### PR TITLE
fix: improve Windows startup and local dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,17 @@ scripts/__pycache__*
 *.json
 *.csv
 web/ui/node_modules
+web/ui/.pnpm
+web/ui/dist
+web/ui/.vite
+web/wasm_demo/dist
+web/wasm_demo/.vite
+pkg/
+.pnpm-store
+.env
+.env.local
+*.log
+.DS_Store
+.turbo
+*.swp
+*.swo

--- a/src/main.rs
+++ b/src/main.rs
@@ -616,7 +616,10 @@ fn default_replay_path() -> Option<String> {
     Some(dir.join(file_name).to_string_lossy().into_owned())
 }
 
-fn main() {
+// Loading the handwritten registry can exceed the default Windows main-thread stack.
+const CLI_STACK_SIZE: usize = 64 * 1024 * 1024;
+
+fn run_cli() {
     let args = parse_args();
 
     if !args.meta_cards.is_empty() {
@@ -856,4 +859,16 @@ fn main() {
 
     // Run the game (pass whether players have custom hands to skip drawing)
     run_game_with_custom_hands(&mut game, !hand1.is_empty(), !hand2.is_empty());
+}
+
+fn main() {
+    let handle = std::thread::Builder::new()
+        .name("ironsmith-cli".to_string())
+        .stack_size(CLI_STACK_SIZE)
+        .spawn(run_cli)
+        .expect("failed to spawn ironsmith CLI thread");
+
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
 }

--- a/web/ui/src/workers/wasmGameWorker.js
+++ b/web/ui/src/workers/wasmGameWorker.js
@@ -1,5 +1,5 @@
-import initWasm, { WasmGame } from "../../../../pkg/ironsmith.js";
-import wasmUrl from "../../../../pkg/ironsmith_bg.wasm?url";
+import initWasm, { WasmGame } from "../../../wasm_demo/pkg/ironsmith.js";
+import wasmUrl from "../../../wasm_demo/pkg/ironsmith_bg.wasm?url";
 
 const WASM_ESTIMATED_SIZE = 12_500_000; // ~12MB fallback estimate
 


### PR DESCRIPTION
This PR improves the Windows development experience and fixes two local setup issues.

Changes:
- run the CLI on a larger-stack thread to avoid a stack overflow during startup on Windows
- update the WASM worker to load the checked-in package from web/wasm_demo/pkg instead of a missing root-level pkg/ directory
