### PR TITLE
Fix Ironsmith parse failure: Firespout

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
@@ -344,11 +344,6 @@ pub(super) fn diagnose_known_unsupported_rewrite_line(
         } else {
             "unsupported lose-all-abilities static becomes clause"
         }
-    } else if ctx.phrase_count(&["spent", "to", "cast", "this", "spell"]) >= 2
-        && ctx.contains_word("if")
-        && !matches!(ctx.first_word(), Some("if" | "unless" | "when" | "as"))
-    {
-        "unsupported spent-to-cast conditional clause"
     } else if ctx.contains_phrase(&["for", "each", "odd", "result"])
         && ctx.contains_phrase(&["for", "each", "even", "result"])
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9974,6 +9974,27 @@ fn rewrite_lexed_effect_sentence_supports_spent_to_cast_followup_on_that_permane
 }
 
 #[test]
+fn rewrite_lowered_supports_spent_to_cast_conditional_chain() -> Result<(), CardTextError> {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Firespout Variant")
+        .card_types(vec![CardType::Sorcery]);
+    let (definition, _) = parse_text_with_annotations_lowered(
+        builder,
+        "Firespout deals 3 damage to each creature without flying if {R} was spent to cast this spell and 3 damage to each creature with flying if {G} was spent to cast this spell."
+            .to_string(),
+        false,
+    )?;
+
+    let debug = format!("{definition:#?}");
+    assert!(debug.contains("ManaSpentToCastThisSpellAtLeast"), "{debug}");
+    assert!(debug.contains("Red,"), "{debug}");
+    assert!(debug.contains("Green,"), "{debug}");
+    assert!(debug.contains("excluded_static_abilities"), "{debug}");
+    assert!(debug.contains("static_abilities"), "{debug}");
+    assert!(debug.contains("Flying"), "{debug}");
+    Ok(())
+}
+
+#[test]
 fn rewrite_lexed_effect_sentence_supports_radiance_shared_color_fanout() {
     let text = "Radiance — Target creature and each other creature that shares a color with it gain haste until end of turn.";
     let lexed =

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -9266,13 +9266,19 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
-    fn parse_rejects_spent_to_cast_conditional_clause() {
-        let result = CardDefinitionBuilder::new(CardId::new(), "Firespout Variant").parse_text(
+    fn parse_supports_spent_to_cast_conditional_clause_chain() {
+        let definition = CardDefinitionBuilder::new(CardId::new(), "Firespout Variant")
+            .parse_text(
             "Firespout deals 3 damage to each creature without flying if {R} was spent to cast this spell and 3 damage to each creature with flying if {G} was spent to cast this spell.",
-        );
+            )
+            .expect("spent-to-cast conditional chain should parse");
+        let joined = crate::compiled_text::unprocessed_compiled_lines(&definition)
+            .join(" ")
+            .to_ascii_lowercase();
         assert!(
-            result.is_err(),
-            "unsupported spent-to-cast conditional clause should fail parse instead of partially compiling damage effects"
+            joined.contains("if {r} was spent to cast this spell")
+                && joined.contains("if {g} was spent to cast this spell"),
+            "expected both spent-to-cast conditionals in compiled text, got {joined}"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Firespout
Initial parse error:
```
unsupported spent-to-cast conditional clause; oracle-only fallback also failed: unsupported spent-to-cast conditional clause
```

Worker: ip-172-31-26-41.us-east-2.compute.internal
