### PR TITLE
Fix Ironsmith parse failure: Emissary Escort

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2925,6 +2925,9 @@ pub(crate) fn parse_anthem_clause(
             })?;
             scale = Some(match x_value {
                 Value::Count(filter) => AnthemCountExpression::MatchingFilter(filter),
+                Value::GreatestManaValue(filter) => {
+                    AnthemCountExpression::GreatestManaValueAmong(filter)
+                }
                 Value::CountersOnSource(counter_type) => {
                     AnthemCountExpression::CountersOnSource(counter_type)
                 }

--- a/crates/ironsmith-core/src/anthem_model.rs
+++ b/crates/ironsmith-core/src/anthem_model.rs
@@ -3,6 +3,7 @@ use crate::{CounterType, ManaSymbol, ObjectFilter, PlayerFilter};
 #[derive(Debug, Clone, PartialEq)]
 pub enum AnthemCountExpression {
     MatchingFilter(ObjectFilter),
+    GreatestManaValueAmong(ObjectFilter),
     AttachedToSource(ObjectFilter),
     AttachedToAffected(ObjectFilter),
     AffectedAttackedThisTurn,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34429,6 +34429,24 @@ fn parse_oracle_commanders_insignia_commander_cast_count_regression() {
 }
 
 #[test]
+fn parse_oracle_emissary_escort_greatest_mana_value_anthem_regression() {
+    let def = parse_oracle_card_definition("Emissary Escort");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("greatest mana value among other artifacts you control"),
+        "expected greatest-mana-value anthem wording, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("GreatestManaValueAmong"),
+        "expected greatest-mana-value anthem lowering in parsed ability, got {debug}"
+    );
+}
+
+#[test]
 fn parse_oracle_clarion_ultimatum_for_each_chosen_permanent_regression() {
     let def = parse_oracle_card_definition("Clarion Ultimatum");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -13,7 +13,7 @@ use crate::continuous::{
 };
 use crate::effect::{Comparison, Value};
 use crate::filter::ObjectFilterExt as _;
-use crate::filter::{PlayerFilterExt, TaggedOpbjectRelation};
+use crate::filter::{PlayerFilterExt, TaggedConstraintSubject, TaggedOpbjectRelation};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::object::CounterType;
@@ -586,6 +586,9 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
             }
             subject
         }
+        AnthemCountExpression::GreatestManaValueAmong(filter) => {
+            format!("the greatest mana value among {}", pluralized_subject_text(filter))
+        }
         AnthemCountExpression::AttachedToSource(filter) => {
             format!(
                 "{} attached to this creature",
@@ -693,6 +696,15 @@ fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Op
             player.description()
         )),
         _ => None,
+    }
+}
+
+fn describe_anthem_where_x_count_expression(expr: &AnthemCountExpression) -> String {
+    match expr {
+        AnthemCountExpression::GreatestManaValueAmong(filter) => {
+            format!("the greatest mana value among {}", pluralized_subject_text(filter))
+        }
+        _ => format!("the number of {}", describe_anthem_count_expression(expr)),
     }
 }
 
@@ -1224,6 +1236,13 @@ pub(crate) fn resolve_anthem_count_expression(
             .filter_map(|id| game.object(id))
             .filter(|obj| filter.matches_non_recursive(obj, &filter_ctx, game))
             .count() as i32,
+        AnthemCountExpression::GreatestManaValueAmong(filter) => all_game_object_ids(game)
+            .into_iter()
+            .filter_map(|id| game.object(id))
+            .filter(|obj| filter.matches_non_recursive(obj, &filter_ctx, game))
+            .map(|obj| obj.subject_mana_value())
+            .max()
+            .unwrap_or(0) as i32,
         AnthemCountExpression::AttachedToSource(filter)
         | AnthemCountExpression::AttachedToAffected(filter) => game
             .object(source)
@@ -1537,8 +1556,8 @@ impl StaticAbilityKind for Anthem {
                     return format!("{subject} {verb} +1/+1 for each {count_subject}");
                 }
                 format!(
-                    "{subject} {verb} +X/+X, where X is the number of {}",
-                    describe_anthem_count_expression(power_count),
+                    "{subject} {verb} +X/+X, where X is {}",
+                    describe_anthem_where_x_count_expression(power_count),
                 )
             }
             (
@@ -1585,10 +1604,10 @@ impl StaticAbilityKind for Anthem {
                     )
                 } else {
                     format!(
-                        "{subject} {verb} {}/{}, where X is the number of {}",
+                        "{subject} {verb} {}/{}, where X is {}",
                         x_component(*power),
                         signed(*toughness),
-                        describe_anthem_count_expression(count),
+                        describe_anthem_where_x_count_expression(count),
                     )
                 }
             }
@@ -1599,10 +1618,10 @@ impl StaticAbilityKind for Anthem {
                 },
                 AnthemValue::Fixed(toughness),
             ) => format!(
-                "{subject} {verb} {}/{}, where X is the number of {}",
+                "{subject} {verb} {}/{}, where X is {}",
                 x_component(*power),
                 signed(*toughness),
-                describe_anthem_count_expression(count),
+                describe_anthem_where_x_count_expression(count),
             ),
             (
                 AnthemValue::Fixed(power),
@@ -1618,10 +1637,10 @@ impl StaticAbilityKind for Anthem {
                     )
                 } else {
                     format!(
-                        "{subject} {verb} {}/{}, where X is the number of {}",
+                        "{subject} {verb} {}/{}, where X is {}",
                         signed(*power),
                         x_component(*toughness),
-                        describe_anthem_count_expression(count),
+                        describe_anthem_where_x_count_expression(count),
                     )
                 }
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Emissary Escort
Initial parse error:
```
unsupported where-x anthem value (clause: 'this creature gets +x/+0 where x is the greatest mana value among other artifacts you control'); oracle-only fallback also failed: unsupported where-x anthem value (clause: 'this creature gets +x/+0 where x is the greatest mana value among other artifacts you control')
```

Worker: ip-172-31-29-179.us-east-2.compute.internal
