### PR TITLE
Fix Ironsmith parse failure: Trial of Agony

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -31,7 +31,7 @@ pub(crate) fn parse_target_player_choose_objects_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<(PlayerAst, ObjectFilter, ChoiceCount)>, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
-    let (chooser, choose_start_idx) =
+    let (mut chooser, choose_start_idx) =
         if clause_words.first().copied() == Some("target") && clause_words.len() >= 4 {
             let chooser = match clause_words.get(1).copied() {
                 Some("player") => PlayerAst::Target,
@@ -133,6 +133,16 @@ pub(crate) fn parse_target_player_choose_objects_clause(
         ))
     })?;
     choose_filter = expand_graveyard_or_hand_disjunction_filter(choose_filter, &clause_words);
+    if chooser == PlayerAst::That
+        && choose_filter.controller.is_none()
+        && choose_filter.owner.is_none()
+        && choose_filter
+            .tagged_constraints
+            .iter()
+            .any(|constraint| constraint.relation == TaggedOpbjectRelation::IsTaggedObject)
+    {
+        chooser = PlayerAst::ItsController;
+    }
     if matches!(
         choose_filter.zone,
         Some(Zone::Graveyard | Zone::Hand | Zone::Library | Zone::Exile)
@@ -143,6 +153,7 @@ pub(crate) fn parse_target_player_choose_objects_clause(
         choose_filter.controller = Some(match chooser {
             PlayerAst::TargetOpponent => PlayerFilter::target_opponent(),
             PlayerAst::That => PlayerFilter::IteratedPlayer,
+            PlayerAst::ItsController => PlayerFilter::ControllerOf(crate::filter::ObjectRef::tagged(IT_TAG)),
             _ => PlayerFilter::target_player(),
         });
     }
@@ -775,6 +786,25 @@ mod tests {
         assert!(
             filter.controller.is_none(),
             "implicit choose should let lowering bind the controller to the chooser, got {filter:?}"
+        );
+    }
+
+    #[test]
+    fn parse_that_player_chooses_one_of_those_uses_last_object_controller() {
+        let tokens = tokenize_line("That player chooses one of those creatures.", 0);
+
+        let (chooser, filter, count) = parse_target_player_choose_objects_clause(&tokens)
+            .expect("parse that-player chooses one-of-those clause")
+            .expect("expected target-player choose clause");
+
+        assert_eq!(chooser, PlayerAst::ItsController);
+        assert_eq!(count, ChoiceCount::exactly(1));
+        assert!(
+            filter
+                .tagged_constraints
+                .iter()
+                .any(|constraint| constraint.relation == TaggedOpbjectRelation::IsTaggedObject),
+            "expected one-of-those choice to stay tied to tagged objects, got {filter:?}"
         );
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -12,6 +12,7 @@ pub(crate) fn target_ast_to_object_filter(target: TargetAst) -> Option<ObjectFil
         TargetAst::Object(filter, _, _) => Some(filter),
         TargetAst::Spell(_) => Some(ObjectFilter::spell()),
         TargetAst::Tagged(tag, _) => Some(ObjectFilter::tagged(tag)),
+        TargetAst::AnyOtherTarget(_) => Some(ObjectFilter::default().not_tagged(TagKey::from(IT_TAG))),
         TargetAst::WithCount(inner, _) => target_ast_to_object_filter(*inner),
         _ => None,
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2401,6 +2401,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_target_phrase_recognizes_bare_the_other_reference() {
+        let tokens = lex_line("the other", 0).unwrap();
+        let target = parse_target_phrase(&tokens).expect("the other should parse as other target");
+
+        assert!(
+            matches!(target, TargetAst::AnyOtherTarget(_)),
+            "expected AnyOtherTarget, got {target:?}"
+        );
+    }
+
+    #[test]
     fn parse_for_each_count_value_words_binds_revealed_this_way_to_it_tag() {
         let words = ["for", "each", "card", "revealed", "this", "way"];
 
@@ -2591,6 +2602,9 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
         all_words.as_slice(),
         ["any", "other"] | ["any", "other", "target"] | ["any", "other", "targets"]
     ) {
+        return Ok(TargetAst::AnyOtherTarget(span));
+    }
+    if matches!(all_words.as_slice(), ["other"] | ["the", "other"]) {
         return Ok(TargetAst::AnyOtherTarget(span));
     }
     if words_have_prefix(all_words.as_slice(), &["up", "to"])

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11669,6 +11669,31 @@ fn rewrite_lowered_former_section9_cases_parse_without_fallback_text() -> Result
 }
 
 #[test]
+fn rewrite_trial_of_agony_other_clause_parses_as_other_tagged_restriction() -> Result<(), CardTextError>
+{
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Trial of Agony")
+        .card_types(vec![CardType::Sorcery]);
+    let (definition, _) = parse_text_with_annotations_lowered(
+        builder,
+        "Choose two target creatures controlled by the same opponent. That player chooses one of those creatures. Trial of Agony deals 5 damage to that creature, and the other can't block this turn.".to_string(),
+        false,
+    )?;
+    let debug = format!("{definition:#?}");
+
+    assert!(debug.contains("CantEffect"), "expected can't effect, got {debug}");
+    assert!(
+        debug.contains("restriction: Block"),
+        "expected block restriction, got {debug}"
+    );
+    assert!(
+        debug.contains("IsNotTaggedObject"),
+        "expected other-reference tagging, got {debug}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn parse_subject_first_exile_top_library_then_play_permission_bundle() {
     let builder = CardDefinitionBuilder::new(CardId::from_raw(1), "Bundle Probe")
         .card_types(vec![CardType::Sorcery]);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Trial of Agony
Initial parse error:
```
unsupported subject target phrase (clause: 'the other'); oracle-only fallback also failed: unsupported subject target phrase (clause: 'the other')
```

Worker: i-0231bf49650c12133
