### PR TITLE
Fix Ironsmith parse failure: Anthropede

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -542,6 +542,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_object_filter_lexed_handles_room_subtype_target() {
+        let tokens = lex_line("room", 0).unwrap();
+
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.subtypes, vec![Subtype::Room]);
+    }
+
+    #[test]
     fn parse_object_filter_lexed_handles_its_attached_to_reference_alias() {
         let tokens = lex_line("creature its attached to", 0).unwrap();
 

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -383,6 +383,7 @@ pub enum Subtype {
     Cartouche,
     Class,
     Curse,
+    Room,
     Role,
     Rune,
     Saga,
@@ -662,6 +663,7 @@ impl Subtype {
             Subtype::Cartouche,
             Subtype::Class,
             Subtype::Curse,
+            Subtype::Room,
             Subtype::Role,
             Subtype::Rune,
             Subtype::Saga,
@@ -979,6 +981,7 @@ impl Subtype {
                 | Subtype::Cartouche
                 | Subtype::Class
                 | Subtype::Curse
+                | Subtype::Room
                 | Subtype::Role
                 | Subtype::Rune
                 | Subtype::Saga

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14798,6 +14798,28 @@ mod tests {
     }
 
     #[test]
+    fn describe_may_unless_pay_mana_uses_or_surface() {
+        let effect = Effect::may_single(Effect::unless_action(
+            vec![Effect::discard_player_filtered(
+                Value::Fixed(1),
+                PlayerFilter::You,
+                false,
+                None,
+            )],
+            vec![Effect::new(crate::effects::PayManaEffect::new(
+                crate::mana::ManaCost::from_symbols(vec![ManaSymbol::Generic(2)]),
+                ChooseSpec::Player(PlayerFilter::You),
+            ))],
+            PlayerFilter::You,
+        ));
+
+        assert_eq!(
+            describe_effect(&effect),
+            "You may discard a card or pay {2}"
+        );
+    }
+
+    #[test]
     fn describe_become_creature_type_choice_uses_each_for_all_creatures() {
         let effect = Effect::new(crate::effects::BecomeCreatureTypeChoiceEffect::new(
             ChooseSpec::Object(ObjectFilter::creature()),
@@ -21843,7 +21865,7 @@ pub(super) fn describe_with_id_then_reflexive_trigger(
     }
 
     let setup = describe_effect(&with_id.effect);
-    let triggered = describe_effect_list(&reflexive.effects);
+    let triggered = lowercase_first(&describe_effect_list(&reflexive.effects));
     let condition = if let Some(may) = with_id.effect.downcast_ref::<crate::effects::MayEffect>() {
         let who = may
             .decider
@@ -24906,6 +24928,15 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(unless_action) = effect.downcast_ref::<crate::effects::UnlessActionEffect>() {
         let inner_text = describe_effect_list(&unless_action.effects);
+        if unless_action.alternative.len() == 1
+            && let Some(pay_mana) =
+                unless_action.alternative[0].downcast_ref::<crate::effects::PayManaEffect>()
+            && let ChooseSpec::Player(alternative_player) = &pay_mana.player
+            && *alternative_player == unless_action.player
+        {
+            let payment_text = pay_mana.cost.to_oracle();
+            return format!("{} or pay {}", inner_text, payment_text);
+        }
         if unless_action.alternative.len() == 1
             && let Some(lose_life) =
                 unless_action.alternative[0].downcast_ref::<crate::effects::LoseLifeEffect>()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Anthropede
Initial parse error:
```
unsupported target phrase (clause: 'room'); oracle-only fallback also failed: unsupported target phrase (clause: 'room')
```

Worker: i-0e20448f81410690d
