### PR TITLE
Fix Ironsmith parse failure: Etali, Primal Conqueror // Etali, Primal Sickness

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -327,6 +327,40 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
 
     let clause_word_view = ClauseDispatchCompatWords::new(tokens);
     let clause_words = clause_word_view.to_word_refs();
+
+    if word_slice_starts_with(
+        &clause_words,
+        &["cast", "any", "number", "of", "spells"],
+    ) && find_word_sequence_index(
+        &clause_words,
+        &["from", "among", "the", "nonland", "cards", "exiled", "this", "way"],
+    )
+    .is_some()
+        && word_slice_ends_with(
+        &clause_words,
+        &["without", "paying", "their", "mana", "costs"],
+    ) {
+        let cast_filter = ObjectFilter::nonland()
+            .in_zone(crate::zone::Zone::Exile)
+            .match_tagged(
+                TagKey::from(IT_TAG),
+                crate::target::TaggedOpbjectRelation::IsTaggedObject,
+            );
+        return Ok(EffectAst::ForEachObject {
+            filter: cast_filter,
+            effects: vec![EffectAst::May {
+                effects: vec![EffectAst::subject_verb_cast_tagged(
+                    TagKey::from(IT_TAG),
+                    PlayerAst::You,
+                    false,
+                    false,
+                    true,
+                    None,
+                )],
+            }],
+        });
+    }
+
     if clause_words.starts_with(&["all", "abilities", "and"])
         && matches!(clause_words.get(3).copied(), Some("gain" | "gains"))
         && let Some(gain_idx) = tokens

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -732,11 +732,20 @@ fn parse_generic_each_player_exile_top_then_cast_any_number_subject_verb(
         exile_words.as_slice(),
         &["exile", "top", "card", "of", "each"],
     );
+    let starts_with_each_player_exile_until_nonland = slice_starts_with(
+        exile_words.as_slice(),
+        &[
+            "each", "player", "exiles", "cards", "from", "the", "top", "of", "their",
+            "library", "until", "they", "exile", "a", "nonland", "card",
+        ],
+    );
     let mentions_player_library = exile_words
         .iter()
         .any(|word| matches!(*word, "player" | "players"))
-        && exile_words.last().is_some_and(|word| *word == "library");
-    if !starts_with_each_player_exile || !mentions_player_library {
+        && slice_contains(&exile_words, &"library");
+    if !(starts_with_each_player_exile || starts_with_each_player_exile_until_nonland)
+        || !mentions_player_library
+    {
         return Ok(None);
     }
 
@@ -750,24 +759,55 @@ fn parse_generic_each_player_exile_top_then_cast_any_number_subject_verb(
             cast_words.as_slice(),
             &["without", "paying", "their", "mana", "costs"],
         );
-    if !casts_any_number_from_those_cards {
+
+    let casts_any_number_from_nonland_exiled_this_way = slice_starts_with(
+        cast_words.as_slice(),
+        &["you", "may", "cast", "any", "number", "of", "spells"],
+    ) && contains_word_window(
+        cast_words.as_slice(),
+        &["from", "among", "the", "nonland", "cards", "exiled", "this", "way"],
+    ) && slice_ends_with(
+        cast_words.as_slice(),
+        &["without", "paying", "their", "mana", "costs"],
+    );
+
+    if !casts_any_number_from_those_cards && !casts_any_number_from_nonland_exiled_this_way {
         return Ok(None);
     }
 
     let exiled_tag = crate::runtime_backend::util::helper_tag_for_tokens(tokens, "exiled");
+    let consult_match_tag = crate::runtime_backend::util::helper_tag_for_tokens(tokens, "match");
+    let consult_filter = ObjectFilter::nonland();
+    let exile_effects = if starts_with_each_player_exile_until_nonland {
+        vec![EffectAst::subject_verb_consult_top_of_library(
+            PlayerAst::That,
+            crate::cards::builders::LibraryConsultModeAst::Exile,
+            consult_filter,
+            crate::cards::builders::LibraryConsultStopRuleAst::MatchCount(Value::Fixed(1)),
+            exiled_tag.clone(),
+            consult_match_tag.clone(),
+        )]
+    } else {
+        vec![EffectAst::subject_verb_exile_top_of_library(
+            PlayerAst::That,
+            Value::Fixed(1),
+            Vec::new(),
+            vec![exiled_tag.clone()],
+        )]
+    };
+
     let cast_filter = ObjectFilter::nonland().in_zone(Zone::Exile).match_tagged(
-        exiled_tag.clone(),
+        if starts_with_each_player_exile_until_nonland {
+            consult_match_tag
+        } else {
+            exiled_tag.clone()
+        },
         TaggedOpbjectRelation::IsTaggedObject,
     );
 
     Ok(Some(vec![
         EffectAst::ForEachPlayer {
-            effects: vec![EffectAst::subject_verb_exile_top_of_library(
-                PlayerAst::That,
-                Value::Fixed(1),
-                Vec::new(),
-                vec![exiled_tag.clone()],
-            )],
+            effects: exile_effects,
         },
         EffectAst::ForEachObject {
             filter: cast_filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9805,6 +9805,20 @@ fn rewrite_lexed_effect_sequence_keeps_reveal_consult_cast_bottom_family_parseab
 }
 
 #[test]
+fn rewrite_lexed_effect_sequence_parses_each_player_exile_top_cast_nonland_exiled_this_way() {
+    let text = "Exile the top card of each player's library, then you may cast any number of spells from among the nonland cards exiled this way without paying their mana costs.";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify each-player exile-top cast text");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&lexed).expect("sequence");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("ForEachPlayer"), "{debug}");
+    assert!(debug.contains("ForEachObject"), "{debug}");
+    assert!(debug.contains("CastTagged"), "{debug}");
+    assert!(debug.contains("without_paying_mana_cost: true"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_effect_sequence_parses_target_opponent_consult_until_eot_cast() {
     let text = "Target opponent exiles cards from the top of their library until they exile a nonland card. Until end of turn, you may cast that card without paying its mana cost.";
     let lexed =


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Etali, Primal Conqueror // Etali, Primal Sickness
Initial parse error:
```
could not find verb in effect clause (clause: 'cast any number of spells from among the nonland cards exiled this way without paying their mana costs'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast any number of spells from among the nonland cards exiled this way without paying their mana costs'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-045bcc0069e67fd85
