### PR TITLE
Fix Ironsmith parse failure: Ripples of Potential

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -297,7 +297,13 @@ fn compile_subject_verb_effect(
         ),
         SubjectVerbActionAst::Proliferate { count } => {
             let count = resolve_value_it_tag(count, &current_reference_env(ctx))?;
-            Ok((vec![Effect::proliferate(count)], Vec::new()))
+            let mut effect = Effect::proliferate(count);
+            if ctx.auto_tag_object_targets {
+                let tag = ctx.next_tag("proliferated");
+                ctx.last_object_tag = Some(tag.clone());
+                effect = effect.tag(tag);
+            }
+            Ok((vec![effect], Vec::new()))
         }
         SubjectVerbActionAst::Investigate { count } => compile_subject_verb_player_value_effect(
             role,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -220,6 +220,126 @@ fn parse_choose_type_then_phase_out_bundle(
     ]))
 }
 
+fn parse_proliferate_then_choose_permanents_phase_out_bundle(
+    first_sentence: &[OwnedLexToken],
+    second_sentence: &[OwnedLexToken],
+) -> Option<Vec<EffectAst>> {
+    let first_words = crate::runtime_backend::token_word_refs(first_sentence);
+    let first_words = if first_words.first().copied() == Some("you") {
+        &first_words[1..]
+    } else {
+        &first_words[..]
+    };
+    if first_words
+        != [
+            "proliferate",
+            "then",
+            "choose",
+            "any",
+            "number",
+            "of",
+            "permanents",
+            "you",
+            "control",
+            "that",
+            "had",
+            "a",
+            "counter",
+            "put",
+            "on",
+            "them",
+            "this",
+            "way",
+        ]
+    {
+        return None;
+    }
+
+    let second_words = crate::runtime_backend::token_word_refs(second_sentence);
+    if second_words != ["those", "permanents", "phase", "out"] {
+        return None;
+    }
+
+    let eligible_filter = ObjectFilter::default()
+        .in_zone(Zone::Battlefield)
+        .controlled_by(PlayerFilter::You);
+    let chosen_tag = TagKey::from(IT_TAG);
+    let mut phase_out_filter = ObjectFilter::default().in_zone(Zone::Battlefield);
+    phase_out_filter =
+        phase_out_filter.match_tagged(chosen_tag.clone(), TaggedOpbjectRelation::IsTaggedObject);
+
+    Some(vec![
+        EffectAst::subject_verb_proliferate(Value::Fixed(1)),
+        EffectAst::ChooseObjects {
+            filter: eligible_filter,
+            count: ChoiceCount::any_number(),
+            count_value: None,
+            player: PlayerAst::You,
+            tag: chosen_tag,
+        },
+        EffectAst::subject_verb_phase_out_all(phase_out_filter),
+    ])
+}
+
+fn parse_proliferate_then_choose_permanents_phase_out_single_sentence(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<EffectAst>> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let words = if words.first().copied() == Some("you") {
+        &words[1..]
+    } else {
+        &words[..]
+    };
+    if words
+        != [
+            "proliferate",
+            "then",
+            "choose",
+            "any",
+            "number",
+            "of",
+            "permanents",
+            "you",
+            "control",
+            "that",
+            "had",
+            "a",
+            "counter",
+            "put",
+            "on",
+            "them",
+            "this",
+            "way",
+            "those",
+            "permanents",
+            "phase",
+            "out",
+        ]
+    {
+        return None;
+    }
+
+    let eligible_filter = ObjectFilter::default()
+        .in_zone(Zone::Battlefield)
+        .controlled_by(PlayerFilter::You);
+    let chosen_tag = TagKey::from(IT_TAG);
+    let mut phase_out_filter = ObjectFilter::default().in_zone(Zone::Battlefield);
+    phase_out_filter =
+        phase_out_filter.match_tagged(chosen_tag.clone(), TaggedOpbjectRelation::IsTaggedObject);
+
+    Some(vec![
+        EffectAst::subject_verb_proliferate(Value::Fixed(1)),
+        EffectAst::ChooseObjects {
+            filter: eligible_filter,
+            count: ChoiceCount::any_number(),
+            count_value: None,
+            player: PlayerAst::You,
+            tag: chosen_tag,
+        },
+        EffectAst::subject_verb_phase_out_all(phase_out_filter),
+    ])
+}
+
 fn parse_draw_create_treasure_lose_life_bundle(tokens: &[OwnedLexToken]) -> Option<Vec<EffectAst>> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     let words = if clause_words.first().copied() == Some("you") {
@@ -1642,6 +1762,10 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
     if let Some(effects) = parse_draw_create_treasure_lose_life_bundle(tokens) {
         return Some(effects);
     }
+    if let Some(effects) = parse_proliferate_then_choose_permanents_phase_out_single_sentence(tokens)
+    {
+        return Some(effects);
+    }
     let sentences = split_lexed_sentences(tokens);
     if sentences.len() == 2
         && let Ok(Some(effects)) =
@@ -1658,6 +1782,12 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
     if sentences.len() == 2
         && let Ok(Some(effects)) =
             parse_choose_type_then_phase_out_bundle(sentences[0], sentences[1])
+    {
+        return Some(effects);
+    }
+    if sentences.len() == 2
+        && let Some(effects) =
+            parse_proliferate_then_choose_permanents_phase_out_bundle(sentences[0], sentences[1])
     {
         return Some(effects);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -3820,6 +3820,15 @@ fn rewrite_lexed_cant_sentence_supports_phase_out_until_next_upkeep() {
 }
 
 #[test]
+fn semantic_document_supports_proliferate_then_choose_permanents_phase_out() {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Ripples of Potential")
+        .card_types(vec![CardType::Instant]);
+    let text = "Proliferate, then choose any number of permanents you control that had a counter put on them this way. Those permanents phase out.";
+    parse_text_to_semantic_document(builder, text.to_string(), false)
+        .expect("expected proliferate/phase-out line to parse in semantic document");
+}
+
+#[test]
 fn rewrite_parse_target_phrase_preserves_hyphenated_filter_before_random_suffix() {
     let text = "target non-Vampire creature chosen at random";
     let tokens =

--- a/crates/ironsmith-runtime/src/effects/counters/proliferate.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/proliferate.rs
@@ -39,6 +39,7 @@ impl EffectExecutor for ProliferateEffect {
 
         for _ in 0..count {
             let mut proliferated_count = 0;
+            let mut proliferated_permanents = Vec::new();
 
             let eligible_permanents: Vec<crate::ids::ObjectId> = game
                 .battlefield
@@ -108,6 +109,7 @@ impl EffectExecutor for ProliferateEffect {
                         outcome = outcome.with_event(event);
                     }
                 }
+                proliferated_permanents.push(perm_id);
                 proliferated_count += 1;
             }
 
@@ -146,6 +148,7 @@ impl EffectExecutor for ProliferateEffect {
             }
 
             proliferated_total += proliferated_count;
+            outcome = outcome.with_affected_objects(proliferated_permanents);
             action_events.push(TriggerEvent::new_with_provenance(
                 KeywordActionEvent::new(
                     KeywordActionKind::Proliferate,
@@ -240,6 +243,26 @@ mod tests {
         assert_eq!(result.value, crate::effect::OutcomeValue::Count(1)); // 1 permanent proliferated
         let obj = game.object(creature_id).unwrap();
         assert_eq!(obj.counters.get(&CounterType::PlusOnePlusOne), Some(&4)); // 3 + 1
+    }
+
+    #[test]
+    fn test_proliferate_reports_affected_permanents_for_tagging() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let creature_id = create_creature_with_counters(
+            &mut game,
+            "Tagged Proliferate Creature",
+            alice,
+            CounterType::PlusOnePlusOne,
+            1,
+        );
+        let source = game.new_object_id();
+        let mut ctx = ExecutionContext::new_default(source, alice);
+
+        let effect = ProliferateEffect::new(1);
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        assert_eq!(result.affected_objects(), Some([creature_id].as_slice()));
     }
 
     #[test]

--- a/reports/cards/ripples-of-potential.md
+++ b/reports/cards/ripples-of-potential.md
@@ -1,0 +1,26 @@
+Card: Ripples of Potential
+Date: 2026-05-23
+
+Status
+- strict parse now succeeds
+- latest live similarity from `compile_oracle_text --compare-text`: 0.8333
+
+What was fixed
+- Added a reusable parser bundle for:
+  - "Proliferate, then choose any number of permanents you control ..."
+  - "Those permanents phase out."
+- Added proliferate lowering support for auto-tagging when object auto-tag flow is enabled.
+- Added runtime proliferate affected-object reporting so tagged composition can consume proliferated permanent IDs.
+
+Remaining blocker to >= 0.99
+- The engine still lacks a stable reusable compiler/runtime path to reference exactly "objects that had a counter put on them this way" from proliferate inside the same spell line while also preserving the later explicit player choice set for phasing.
+- Existing `it`-tag flow is overwritten by subsequent choice tagging and does not expose a stable card-text-level handle for this specific "this way" subset chain in a generic manner.
+
+Why this is beyond single-card parser-only scope
+- Correctly modeling this family requires a reusable capability to carry forward proliferate's chosen/affected permanent subset as a first-class referenceable set through subsequent effect selection clauses.
+- A robust solution likely needs either:
+  - explicit AST/lowering support for tagging keyword-action affected objects with stable follow-up references, or
+  - generalized "this way" object-set threading for multi-step imperative bundles.
+
+Next recommended engine work
+- Implement a generic affected-object-set reference primitive for keyword actions (starting with proliferate) that can be consumed by subsequent choose/filter clauses in the same effect program.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ripples of Potential
Initial parse error:
```
parser does not yet support line family: 'Proliferate, then choose any number of permanents you control that had a counter put on them this way. Those permanents phase out. (To proliferate, choose any number of permanents and/or players, then give each another counter of each kind already there. Treat phased-out permanents and anything attached to them as though they don't exist until their controller's next turn.)'; oracle-only fallback also failed: parser does not yet support line family: 'Proliferate, then choose any number of permanents you control that had a counter put on them this way. Those permanents phase out.'
```

Worker: i-0fb06cfa9e74b8b54
