### PR TITLE
Fix Ironsmith parse failure: Shagrat, Loot Bearer

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1592,7 +1592,7 @@ impl Effect {
         Self::new(crate::effects::LearnEffect::new())
     }
 
-    pub fn amass(subtype: Option<crate::types::Subtype>, amount: u32) -> Self {
+    pub fn amass(subtype: Option<crate::types::Subtype>, amount: impl Into<Value>) -> Self {
         Self::new(crate::effects::AmassEffect::new(subtype, amount))
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
@@ -417,6 +417,19 @@ fn replace_names_with_map(
             return false;
         }
 
+        if prev.is_some_and(|word| word == b"to") {
+            let mut word_start = idx;
+            while word_start > 0 && !bytes[word_start - 1].is_ascii_alphanumeric() {
+                word_start -= 1;
+            }
+            while word_start > 0 && bytes[word_start - 1].is_ascii_alphanumeric() {
+                word_start -= 1;
+            }
+            if previous_word(bytes, word_start).is_some_and(|word| word == b"attached") {
+                return false;
+            }
+        }
+
         apostrophe_s
             || prev.is_some_and(|word| {
                 matches!(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -4059,7 +4059,7 @@ mod parse_compile_tests {
         ctx.auto_tag_object_targets = true;
 
         let (effects, choices) = compile_effect(
-            &EffectAst::subject_verb_amass(Some(Subtype::Orc), 2),
+            &EffectAst::subject_verb_amass(Some(Subtype::Orc), Value::Fixed(2)),
             &mut ctx,
         )
         .expect("compile amass");

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -334,7 +334,8 @@ fn compile_subject_verb_effect(
             Ok((vec![Effect::emit_keyword_action(*action, *amount)], Vec::new()))
         }
         SubjectVerbActionAst::Amass { subtype, amount } => {
-            let mut effect = Effect::amass(*subtype, *amount);
+            let amount = resolve_value_it_tag(amount, &current_reference_env(ctx))?;
+            let mut effect = Effect::amass(*subtype, amount);
             if ctx.auto_tag_object_targets {
                 let tag = ctx.next_tag("amassed");
                 ctx.last_object_tag = Some(tag.clone());

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -637,7 +637,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     Amass {
         subtype: Option<Subtype>,
-        amount: u32,
+        amount: Value,
     },
     Bolster {
         amount: u32,
@@ -4580,7 +4580,7 @@ impl EffectAst {
         )
     }
 
-    pub(crate) fn subject_verb_amass(subtype: Option<Subtype>, amount: u32) -> Self {
+    pub(crate) fn subject_verb_amass(subtype: Option<Subtype>, amount: Value) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -3215,7 +3215,7 @@ mod tests {
     #[test]
     fn annotate_effect_sequence_sets_followup_in_env_from_amassed_tag() {
         let effects = vec![
-            EffectAst::subject_verb_amass(Some(Subtype::Orc), 2),
+            EffectAst::subject_verb_amass(Some(Subtype::Orc), Value::Fixed(2)),
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 TagKey::from(IT_TAG),
                 PlayerAst::You,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1596,17 +1596,25 @@ pub(crate) fn parse_keyword_mechanic_clause(
             amount_start += 1;
         }
 
-        let (amount, used) = parse_number(&clause_tokens[amount_start..]).ok_or_else(|| {
+        let (mut amount, used) = parse_value(&clause_tokens[amount_start..]).ok_or_else(|| {
             CardTextError::ParseError(format!(
                 "missing numeric amount for amass clause (clause: '{}')",
                 clause_words.join(" ")
             ))
         })?;
-        if amount_start + used != clause_tokens.len() {
-            return Err(CardTextError::ParseError(format!(
-                "unsupported trailing amass clause (clause: '{}')",
-                clause_words.join(" ")
-            )));
+        let trailing_tokens = trim_commas(&clause_tokens[amount_start + used..]);
+        if !trailing_tokens.is_empty() {
+            let Some(where_value) = parse_value_binding_clause(&trailing_tokens) else {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported trailing amass clause (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            };
+            amount = super::super::util::replace_unbound_x_with_value(
+                amount,
+                &where_value,
+                &crate::runtime_backend::token_word_refs(&trailing_tokens).join(" "),
+            )?;
         }
 
         return Ok(Some(EffectAst::subject_verb_amass(subtype, amount)));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2240,6 +2240,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::Surveil { count: amount }
             | SubjectVerbActionAst::Proliferate { count: amount }
             | SubjectVerbActionAst::Investigate { count: amount }
+            | SubjectVerbActionAst::Amass { amount, .. }
             | SubjectVerbActionAst::Monstrosity { amount }
             | SubjectVerbActionAst::Discover { count: amount }
             | SubjectVerbActionAst::Fateseal { count: amount }
@@ -2322,7 +2323,6 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::EmitKeywordAction { .. }
-            | SubjectVerbActionAst::Amass { .. }
             | SubjectVerbActionAst::Bolster { .. }
             | SubjectVerbActionAst::Support { .. }
             | SubjectVerbActionAst::Adapt { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -72,6 +72,7 @@ pub(crate) fn parse_attach_object_phrase(
     }
 
     if object_words.len() >= 2
+        && !object_words.contains(&"target")
         && object_words
             .iter()
             .all(|word| word.chars().all(|ch| ch.is_ascii_alphanumeric()))

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2808,6 +2808,58 @@ fn rewrite_if_clause_binds_that_enchantment_and_created_token_references() {
 }
 
 #[test]
+fn attach_up_to_one_target_equipment_to_it_parses_target_object() {
+    let tokens = lex_line("Attach up to one target Equipment to it.", 0)
+        .expect("rewrite lexer should classify attach clause");
+    let parsed = parse_effect_sentence_lexed(&tokens).expect("attach clause should parse");
+
+    let [crate::cards::builders::EffectAst::SubjectVerb(
+        crate::cards::builders::SubjectVerbEffectAst {
+            action: crate::cards::builders::SubjectVerbActionAst::Attach { object, target },
+            ..
+        },
+    )] = parsed.as_slice()
+    else {
+        panic!("expected attach effect, got {parsed:?}");
+    };
+
+    assert!(
+        !matches!(object, crate::cards::builders::TargetAst::Source(_)),
+        "expected object side to remain a targetable attachment object"
+    );
+    assert!(matches!(
+        target,
+        crate::cards::builders::TargetAst::Tagged(tag, _)
+            if tag.as_str() == crate::cards::builders::IT_TAG
+    ));
+}
+
+#[test]
+fn amass_where_x_clause_replaces_unbound_x() {
+    let tokens = lex_line(
+        "Amass Orcs X, where X is the number of Equipment attached to this creature.",
+        0,
+    )
+    .expect("rewrite lexer should classify amass where-x clause");
+    let parsed = parse_effect_sentence_lexed(&tokens).expect("amass clause should parse");
+
+    let [crate::cards::builders::EffectAst::SubjectVerb(
+        crate::cards::builders::SubjectVerbEffectAst {
+            action: crate::cards::builders::SubjectVerbActionAst::Amass { amount, .. },
+            ..
+        },
+    )] = parsed.as_slice()
+    else {
+        panic!("expected amass effect, got {parsed:?}");
+    };
+
+    assert!(
+        !matches!(amount, crate::effect::Value::X),
+        "expected where-X clause to bind amass amount"
+    );
+}
+
+#[test]
 fn rewrite_triggered_attach_it_to_target_seeds_triggering_object_reference() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Attach Source Variant")
         .parse_text("When this Equipment enters, attach it to target creature you control.")

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1774,12 +1774,15 @@ impl PayManaEffect {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AmassEffect {
     pub subtype: Option<crate::types::Subtype>,
-    pub amount: u32,
+    pub amount: Value,
 }
 
 impl AmassEffect {
-    pub fn new(subtype: Option<crate::types::Subtype>, amount: u32) -> Self {
-        Self { subtype, amount }
+    pub fn new(subtype: Option<crate::types::Subtype>, amount: impl Into<Value>) -> Self {
+        Self {
+            subtype,
+            amount: amount.into(),
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27664,11 +27664,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(amass) = effect.downcast_ref::<crate::effects::AmassEffect>() {
+        let amount = describe_value(&amass.amount);
         if let Some(subtype) = amass.subtype {
             let subtype_name = subtype.to_string().to_ascii_lowercase();
-            return format!("Amass {} {}", pluralize_word(&subtype_name), amass.amount);
+            return format!("Amass {} {amount}", pluralize_word(&subtype_name));
         }
-        return format!("Amass {}", amass.amount);
+        return format!("Amass {amount}");
     }
     if let Some(poison) = effect.downcast_ref::<crate::effects::PoisonCountersEffect>() {
         let amount = match poison.count {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -1580,7 +1580,7 @@ impl Effect {
     }
 
     /// Create an "amass" effect.
-    pub fn amass(subtype: Option<crate::types::Subtype>, amount: u32) -> Self {
+    pub fn amass(subtype: Option<crate::types::Subtype>, amount: impl Into<Value>) -> Self {
         use crate::effects::AmassEffect;
         Self::new(AmassEffect::new(subtype, amount))
     }

--- a/crates/ironsmith-runtime/src/effects/tokens/amass.rs
+++ b/crates/ironsmith-runtime/src/effects/tokens/amass.rs
@@ -6,7 +6,7 @@ use crate::color::ColorSet;
 use crate::decisions::make_decision;
 use crate::decisions::specs::ChooseObjectsSpec;
 use crate::effect::{EffectOutcome, ExecutionFact};
-use crate::effects::helpers::normalize_object_selection;
+use crate::effects::helpers::{normalize_object_selection, resolve_value};
 use crate::effects::{CreateTokenEffect, EffectExecutor, PutCountersEffect};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::{KeywordActionEvent, KeywordActionKind};
@@ -61,6 +61,7 @@ impl EffectExecutor for AmassEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let amass_subtype = amass_token_subtype(self);
+        let amount = resolve_value(game, &self.amount, ctx)?.max(0) as u32;
         let mut outcomes = Vec::new();
 
         let mut army_candidates = army_creature_candidates(game, ctx.controller);
@@ -77,7 +78,7 @@ impl EffectExecutor for AmassEffect {
                     KeywordActionKind::Amass,
                     ctx.controller,
                     ctx.source,
-                    self.amount,
+                    amount,
                 ),
                 ctx.provenance,
             );
@@ -118,7 +119,7 @@ impl EffectExecutor for AmassEffect {
 
         let counters_outcome = PutCountersEffect::new(
             CounterType::PlusOnePlusOne,
-            self.amount,
+            amount,
             ChooseSpec::SpecificObject(chosen_army),
         )
         .execute(game, ctx)?;
@@ -129,7 +130,7 @@ impl EffectExecutor for AmassEffect {
                 KeywordActionKind::Amass,
                 ctx.controller,
                 ctx.source,
-                self.amount,
+                amount,
             ),
             ctx.provenance,
         );


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Shagrat, Loot Bearer
Initial parse error:
```
missing numeric amount for amass clause (clause: 'amass orcs x'); oracle-only fallback also failed: missing numeric amount for amass clause (clause: 'amass orcs x')
```

Worker: i-0b4462528377a4dde
