### PR TITLE
Fix Ironsmith parse failure: Lens of Clarity

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -38,7 +38,9 @@ use super::grammar::abilities::{
     is_shuffle_into_library_from_graveyard_line_lexed, is_skulk_rules_text_line_lexed,
     is_this_creature_cant_attack_alone_line_lexed,
     is_this_creature_cant_attack_its_owner_line_lexed, is_this_subject_reference_lexed,
-    is_you_have_shroud_line_lexed, is_you_may_look_top_card_any_time_line_lexed,
+    is_you_have_shroud_line_lexed,
+    is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed,
+    is_you_may_look_top_card_any_time_line_lexed,
     is_your_opponents_play_with_hands_revealed_line_lexed,
     parse_activated_abilities_cant_be_activated_spec_lexed,
     parse_creatures_assign_combat_damage_using_toughness_line_lexed,
@@ -368,6 +370,10 @@ fn static_ability_rule_head_hints(rule_id: &'static str) -> Vec<StaticAbilityLin
             StaticAbilityLineHeadHint::Pair("you", "may"),
         ],
         "parse_you_may_look_top_card_any_time_line" => vec![
+            StaticAbilityLineHeadHint::Single("you"),
+            StaticAbilityLineHeadHint::Pair("you", "may"),
+        ],
+        "parse_you_may_look_face_down_creatures_you_dont_control_any_time_line" => vec![
             StaticAbilityLineHeadHint::Single("you"),
             StaticAbilityLineHeadHint::Pair("you", "may"),
         ],
@@ -747,6 +753,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_enters_tapped_line),
         multi_static_ability_ast_rule!(parse_additional_land_play_line),
         single_static_ability_ast_rule!(parse_you_may_look_top_card_any_time_line),
+        single_static_ability_ast_rule!(
+            parse_you_may_look_face_down_creatures_you_dont_control_any_time_line
+        ),
         single_static_ability_ast_rule!(parse_players_play_top_card_libraries_revealed_line),
         single_static_ability_ast_rule!(parse_play_top_card_your_library_revealed_line),
         single_static_ability_ast_rule!(parse_your_opponents_play_with_hands_revealed_line),
@@ -6951,6 +6960,17 @@ pub(crate) fn parse_you_may_look_top_card_any_time_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     if is_you_may_look_top_card_any_time_line_lexed(tokens) {
         return Ok(Some(StaticAbility::look_at_top_card_of_library()));
+    }
+    Ok(None)
+}
+
+pub(crate) fn parse_you_may_look_face_down_creatures_you_dont_control_any_time_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::look_at_face_down_creatures_you_dont_control(),
+        ));
     }
     Ok(None)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -3,8 +3,9 @@ use super::line_family_handlers::{
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
     run_combined_static_line_family, run_keyword_line_family, run_labeled_line_family,
     run_learn_line_family, run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
-    run_start_your_engines_line_family, run_statement_line_family, run_statement_probe_line_family,
-    run_static_line_family, run_station_line_family, run_station_threshold_line_family,
+    run_split_top_and_face_down_look_line_family, run_start_your_engines_line_family,
+    run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
+    run_station_line_family, run_station_threshold_line_family,
     run_trailing_keyword_activation_line_family, run_triggered_line_family,
     run_unsupported_line_family, run_ward_or_echo_static_prefix_line_family,
 };
@@ -43,7 +44,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 19] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -93,20 +94,26 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 19] = [
         run: run_learn_line_family,
     },
     LineFamilyRuleDef {
+        id: "split-top-and-face-down-look-line",
+        priority: 38,
+        heads: &["you"],
+        run: run_split_top_and_face_down_look_line_family,
+    },
+    LineFamilyRuleDef {
         id: "champion-line",
-        priority: 37,
+        priority: 39,
         heads: &["champion"],
         run: run_champion_line_family,
     },
     LineFamilyRuleDef {
         id: "station-line",
-        priority: 38,
+        priority: 40,
         heads: &["station"],
         run: run_station_line_family,
     },
     LineFamilyRuleDef {
         id: "station-threshold-line",
-        priority: 39,
+        priority: 41,
         heads: &[],
         run: run_station_threshold_line_family,
     },

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -181,6 +181,47 @@ pub(super) fn run_learn_line_family(
     )))
 }
 
+pub(super) fn run_split_top_and_face_down_look_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let lower = ctx.line.info.raw_line.trim().to_ascii_lowercase();
+    let phrase =
+        "you may look at the top card of your library and at face-down creatures you don't control any time";
+    if lower.trim_end_matches('.') != phrase {
+        return Ok(None);
+    }
+
+    let top_card_line = rewrite_line_normalized(
+        ctx.line,
+        "You may look at the top card of your library any time.",
+    )?;
+    let face_down_line = rewrite_line_normalized(
+        ctx.line,
+        "You may look at face-down creatures you don't control any time.",
+    )?;
+
+    let Some(top_card_static) = parse_static_line_cst(&top_card_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower split top-card line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    let Some(face_down_static) = parse_static_line_cst(&face_down_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower split face-down line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+
+    Ok(Some(LineDispatchResult {
+        lines: vec![
+            RewriteLineCst::Static(top_card_static),
+            RewriteLineCst::Static(face_down_static),
+        ],
+        next_idx: ctx.idx + 1,
+    }))
+}
+
 pub(super) fn run_champion_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2551,6 +2551,39 @@ pub(crate) fn is_you_may_look_top_card_any_time_line_lexed(tokens: &[OwnedLexTok
     )
 }
 
+pub(crate) fn is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    matches_any_exact_phrase_line_lexed(
+        tokens,
+        &[&[
+            "you",
+            "may",
+            "look",
+            "at",
+            "face-down",
+            "creatures",
+            "you",
+            "dont",
+            "control",
+            "any",
+            "time",
+        ], &[
+            "you",
+            "may",
+            "look",
+            "at",
+            "face-down",
+            "creatures",
+            "you",
+            "don't",
+            "control",
+            "any",
+            "time",
+        ]],
+    )
+}
+
 pub(crate) fn is_players_play_top_card_libraries_revealed_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7769,6 +7769,14 @@ fn rewrite_grammar_exact_permission_static_line_probes_match_keyword_static_shap
             crate::static_abilities::StaticAbilityId::LookAtTopCardOfLibrary,
         ),
         (
+            "You may look at face-down creatures you don't control any time.",
+            super::grammar::abilities::is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed
+                as Probe,
+            super::keyword_static::parse_you_may_look_face_down_creatures_you_dont_control_any_time_line
+                as Parser,
+            crate::static_abilities::StaticAbilityId::LookAtFaceDownCreaturesYouDontControl,
+        ),
+        (
             "Players play with the top card of their libraries revealed.",
             super::grammar::abilities::is_players_play_top_card_libraries_revealed_line_lexed
                 as Probe,
@@ -7816,6 +7824,26 @@ fn rewrite_grammar_exact_permission_static_line_probes_match_keyword_static_shap
             "{text}: {parsed:?}"
         );
     }
+}
+
+#[test]
+fn parse_lens_of_clarity_split_look_permissions() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Lens of Clarity Variant")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "You may look at the top card of your library and at face-down creatures you don't control any time.",
+        )
+        .expect("Lens of Clarity text should parse");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("LookAtTopCardOfLibrary"),
+        "expected top-card look permission, got {debug}"
+    );
+    assert!(
+        debug.contains("LookAtFaceDownCreaturesYouDontControl"),
+        "expected face-down look permission, got {debug}"
+    );
 }
 
 #[test]

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -197,6 +197,7 @@ pub enum StaticAbilityId {
     MaximumHandSizeSevenMinusYourGraveyardCardTypes,
     RevealFirstCardYouDrawEachTurn,
     LookAtTopCardOfLibrary,
+    LookAtFaceDownCreaturesYouDontControl,
     AllPlayersLookAtTopCardsOfLibraries,
     AllPlayersLookAtYourTopLibraryCard,
     OpponentsPlayWithHandsRevealed,
@@ -431,6 +432,7 @@ impl StaticAbilityId {
             | MaximumHandSizeSevenMinusYourGraveyardCardTypes
             | RevealFirstCardYouDrawEachTurn
             | LookAtTopCardOfLibrary
+            | LookAtFaceDownCreaturesYouDontControl
             | AllPlayersLookAtTopCardsOfLibraries
             | AllPlayersLookAtYourTopLibraryCard
             | OpponentsPlayWithHandsRevealed

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3041,6 +3041,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn look_at_face_down_creatures_you_dont_control() -> Self {
+        Self {
+            id: Some(StaticAbilityId::LookAtFaceDownCreaturesYouDontControl),
+            label: "You may look at face-down creatures you don't control any time.".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn all_players_look_at_top_cards_of_libraries() -> Self {
         Self {
             id: Some(StaticAbilityId::AllPlayersLookAtTopCardsOfLibraries),

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -180,6 +180,9 @@ impl StaticAbility {
                 Self::exile_would_die_instead(crate::target::ObjectFilter::creature())
             }
             Some(StaticAbilityId::LookAtTopCardOfLibrary) => Self::look_at_top_card_of_library(),
+            Some(StaticAbilityId::LookAtFaceDownCreaturesYouDontControl) => {
+                Self::look_at_face_down_creatures_you_dont_control()
+            }
             Some(StaticAbilityId::AllPlayersLookAtTopCardsOfLibraries) => {
                 Self::all_players_look_at_top_cards_of_libraries()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -4364,6 +4364,20 @@ impl StaticAbilityKind for LookAtTopCardOfLibrary {
     }
 }
 
+/// Allows a player to continuously see face-down creatures they do not control.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookAtFaceDownCreaturesYouDontControl;
+
+impl StaticAbilityKind for LookAtFaceDownCreaturesYouDontControl {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::LookAtFaceDownCreaturesYouDontControl
+    }
+
+    fn display(&self) -> String {
+        "You may look at face-down creatures you don't control any time.".to_string()
+    }
+}
+
 /// Allows every player to continuously see the top card of every library.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AllPlayersLookAtTopCardsOfLibraries;
@@ -4912,6 +4926,19 @@ mod tests {
         assert_eq!(
             ability.display(),
             "You may look at the top card of your library any time."
+        );
+    }
+
+    #[test]
+    fn test_look_at_face_down_creatures_you_dont_control() {
+        let ability = LookAtFaceDownCreaturesYouDontControl;
+        assert_eq!(
+            ability.id(),
+            StaticAbilityId::LookAtFaceDownCreaturesYouDontControl
+        );
+        assert_eq!(
+            ability.display(),
+            "You may look at face-down creatures you don't control any time."
         );
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2834,6 +2834,10 @@ impl StaticAbility {
         Self::new(LookAtTopCardOfLibrary)
     }
 
+    pub fn look_at_face_down_creatures_you_dont_control() -> Self {
+        Self::new(LookAtFaceDownCreaturesYouDontControl)
+    }
+
     pub fn all_players_look_at_top_cards_of_libraries() -> Self {
         Self::new(AllPlayersLookAtTopCardsOfLibraries)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Lens of Clarity
Initial parse error:
```
parser does not yet support line family: 'You may look at the top card of your library and at face-down creatures you don't control any time.'; oracle-only fallback also failed: parser does not yet support line family: 'You may look at the top card of your library and at face-down creatures you don't control any time.'
```

Worker: i-045efa667cf89d793
