### PR TITLE
Fix Ironsmith parse failure: Hurl Through Hell

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -448,6 +448,9 @@ fn parse_permission_tail_tokens(
     tokens: &[OwnedLexToken],
     default_lifetime: PermissionLifetime,
 ) -> Option<(PermissionLifetime, bool)> {
+    if let Some(stripped) = strip_allow_any_color_for_cast_suffix_tokens(tokens) {
+        return parse_permission_tail_tokens(stripped, default_lifetime);
+    }
     if tokens.is_empty() {
         return Some((default_lifetime, false));
     }
@@ -790,9 +793,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                 clause_refs.join(" ")
             )));
         }
-        if lifetime == PermissionLifetime::UntilYourNextTurn
-            && (!allow_land || without_paying_mana_cost)
-        {
+        if lifetime == PermissionLifetime::UntilYourNextTurn && without_paying_mana_cost {
             return Err(CardTextError::ParseError(format!(
                 "unsupported until-next-turn play target (clause: '{}')",
                 clause_refs.join(" ")
@@ -1119,6 +1120,7 @@ pub(crate) fn parse_until_your_next_turn_may_play_tagged_clause(
                 tag,
                 PlayerAst::You,
                 true,
+                false,
             ),
         )),
         _ => Ok(None),
@@ -1343,6 +1345,21 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
                 PlayerAst::Implicit,
                 allow_land,
                 without_paying_mana_cost,
+                allow_any_color_for_cast,
+            ),
+        )),
+        Some(PermissionClauseSpec::Tagged {
+            tag,
+            player,
+            allow_land,
+            as_copy: false,
+            without_paying_mana_cost: false,
+            lifetime: PermissionLifetime::UntilYourNextTurn,
+        }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
+            EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
+                tag,
+                PlayerAst::Implicit,
+                allow_land,
                 allow_any_color_for_cast,
             ),
         )),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1816,6 +1816,7 @@ fn compile_subject_verb_effect(
             tag,
             player,
             allow_land,
+            allow_any_color_for_cast,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -1834,7 +1835,7 @@ fn compile_subject_verb_effect(
                     player_filter,
                     crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd,
                     *allow_land,
-                    false,
+                    *allow_any_color_for_cast,
                 ))],
                 Vec::new(),
             ))

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -975,6 +975,7 @@ pub(crate) enum SubjectVerbActionAst {
         tag: TagKey,
         player: PlayerAst,
         allow_land: bool,
+        allow_any_color_for_cast: bool,
     },
     GrantPlayTaggedForAsLongAsExiled {
         tag: TagKey,
@@ -2110,11 +2111,13 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 tag,
                 player,
                 allow_land,
+                allow_any_color_for_cast,
             } => f
                 .debug_struct("GrantPlayTaggedUntilYourNextTurn")
                 .field("tag", tag)
                 .field("player", player)
                 .field("allow_land", allow_land)
+                .field("allow_any_color_for_cast", allow_any_color_for_cast)
                 .finish(),
             Self::GrantPlayTaggedForAsLongAsExiled {
                 tag,
@@ -3481,6 +3484,7 @@ impl EffectAst {
         tag: TagKey,
         player: PlayerAst,
         allow_land: bool,
+        allow_any_color_for_cast: bool,
     ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
@@ -3489,6 +3493,7 @@ impl EffectAst {
                 tag,
                 player,
                 allow_land,
+                allow_any_color_for_cast,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -125,7 +125,12 @@ fn parse_exile_top_library_then_play_bundle(
                 },
             ..
         }) => {
-            EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(tag, player, allow_land)
+            EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
+                tag,
+                player,
+                allow_land,
+                false,
+            )
         }
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
             action:

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -1353,6 +1353,7 @@ pub(crate) fn parse_delayed_dies_exile_top_power_choose_play(
                 chosen_tag,
                 PlayerAst::You,
                 true,
+                false,
             ),
         ],
     }]))

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4272,6 +4272,74 @@ fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_play() {
 }
 
 #[test]
+fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_cast() {
+    let tokens = lex_line(
+        "Until the end of your next turn, you may cast that card",
+        0,
+    )
+    .expect("rewrite lexer should classify until-next-turn cast permission clause");
+
+    assert!(matches!(
+        super::permission_helpers::parse_permission_clause_spec_lexed(&tokens),
+        Ok(Some(super::PermissionClauseSpec::Tagged {
+            player: crate::cards::builders::PlayerAst::You,
+            allow_land: false,
+            as_copy: false,
+            without_paying_mana_cost: false,
+            lifetime: super::PermissionLifetime::UntilYourNextTurn,
+            ..
+        }))
+    ));
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("until-next-turn tagged cast permission should parse as an effect");
+    assert!(
+        effects.iter().any(|effect| matches!(
+            effect,
+            crate::cards::builders::EffectAst::SubjectVerb(subject_verb)
+                if matches!(
+                    &subject_verb.action,
+                    crate::cards::builders::SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn {
+                        player:
+                            crate::cards::builders::PlayerAst::You
+                            | crate::cards::builders::PlayerAst::Implicit,
+                        allow_land: false,
+                        ..
+                    }
+                )
+        )),
+        "expected until-next-turn tagged cast permission effect, got {effects:#?}"
+    );
+}
+
+#[test]
+fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_cast_with_any_color_mana() {
+    let tokens = lex_line(
+        "Until the end of your next turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell",
+        0,
+    )
+    .expect("rewrite lexer should classify until-next-turn cast permission with any-color mana");
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("until-next-turn tagged cast permission with any-color mana should parse as an effect");
+    assert!(
+        effects.iter().any(|effect| matches!(
+            effect,
+            crate::cards::builders::EffectAst::SubjectVerb(subject_verb)
+                if matches!(
+                    &subject_verb.action,
+                    crate::cards::builders::SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn {
+                        allow_land: false,
+                        allow_any_color_for_cast: true,
+                        ..
+                    }
+                )
+        )),
+        "expected until-next-turn tagged cast permission effect with any-color mana, got {effects:#?}"
+    );
+}
+
+#[test]
 fn rewrite_token_primitives_cover_count_range_prefixes() {
     let up_to = lex_line("up to three target creatures", 0)
         .expect("rewrite lexer should classify up-to count range");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29063,8 +29063,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     describe_player_filter(&grant_play_tagged.player),
                 );
             }
+            if helper_tag
+                && !grant_play_tagged.allow_land
+                && grant_play_tagged.duration
+                    == crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd
+            {
+                return format!(
+                    "Until the end of your next turn, {} may cast that card and you may spend mana as though it were mana of any color to cast that spell",
+                    describe_player_filter(&grant_play_tagged.player),
+                );
+            }
             let pronoun = if object_text == "that card" {
-                "it"
+                "that spell"
             } else {
                 "them"
             };


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hurl Through Hell
Initial parse error:
```
unsupported until-next-turn play target (clause: 'until the end of your next turn you may cast that card'); oracle-only fallback also failed: unsupported until-next-turn play target (clause: 'until the end of your next turn you may cast that card')
```

Worker: i-0e62214707ee4ec03
