### PR TITLE
Fix Ironsmith parse failure: Haldan, Avid Arcanist

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6792,7 +6792,13 @@ pub(crate) fn parse_you_may_cast_exile_counter_cards_with_mana_permission_line(
     let cast_prefix = [
         "you", "may", "cast", "spells", "from", "among", "cards", "in", "exile",
     ];
-    if !words.starts_with(&cast_prefix) {
+    let play_lands_and_cast_prefix = [
+        "you", "may", "play", "lands", "and", "cast", "noncreature", "spells", "from",
+        "among", "cards", "you", "exiled",
+    ];
+    let is_cast_from_exile_family = words.starts_with(&cast_prefix);
+    let is_play_lands_and_cast_noncreature_family = words.starts_with(&play_lands_and_cast_prefix);
+    if !is_cast_from_exile_family && !is_play_lands_and_cast_noncreature_family {
         return Ok(None);
     }
 
@@ -6801,14 +6807,33 @@ pub(crate) fn parse_you_may_cast_exile_counter_cards_with_mana_permission_line(
     else {
         return Ok(None);
     };
-    let Some(with_idx) = words[..and_idx].iter().position(|word| *word == "with") else {
-        return Ok(None);
-    };
-    let Some(counters_idx) = words[with_idx + 1..and_idx]
-        .iter()
-        .position(|word| matches!(*word, "counter" | "counters"))
-        .map(|offset| with_idx + 1 + offset)
-    else {
+    let (counter_start_idx, counters_idx) = if let Some(with_idx) =
+        words[..and_idx].iter().position(|word| *word == "with")
+    {
+        let Some(counters_idx) = words[with_idx + 1..and_idx]
+            .iter()
+            .position(|word| matches!(*word, "counter" | "counters"))
+            .map(|offset| with_idx + 1 + offset)
+        else {
+            return Ok(None);
+        };
+        (with_idx + 1, counters_idx)
+    } else if is_play_lands_and_cast_noncreature_family {
+        let that_have_prefix = ["that", "have"];
+        let Some(that_have_idx) =
+            find_keyword_static_phrase_start(&words[..and_idx], &that_have_prefix)
+        else {
+            return Ok(None);
+        };
+        let Some(counters_idx) = words[that_have_idx + that_have_prefix.len()..and_idx]
+            .iter()
+            .position(|word| matches!(*word, "counter" | "counters"))
+            .map(|offset| that_have_idx + that_have_prefix.len() + offset)
+        else {
+            return Ok(None);
+        };
+        (that_have_idx + that_have_prefix.len(), counters_idx)
+    } else {
         return Ok(None);
     };
     if counters_idx + 3 > and_idx
@@ -6817,18 +6842,21 @@ pub(crate) fn parse_you_may_cast_exile_counter_cards_with_mana_permission_line(
         return Ok(None);
     }
 
-    let owner_words = &words[cast_prefix.len()..with_idx];
-    let owner = match owner_words {
-        [] => None,
-        ["your", "opponents", "own"]
-        | ["your", "opponent", "owns"]
-        | ["opponents", "own"]
-        | ["opponent", "owns"] => Some(PlayerFilter::Opponent),
-        _ => return Ok(None),
+    let owner = if is_play_lands_and_cast_noncreature_family {
+        None
+    } else {
+        let owner_words = &words[cast_prefix.len()..counter_start_idx.saturating_sub(1)];
+        match owner_words {
+            [] => None,
+            ["your", "opponents", "own"]
+            | ["your", "opponent", "owns"]
+            | ["opponents", "own"]
+            | ["opponent", "owns"] => Some(PlayerFilter::Opponent),
+            _ => return Ok(None),
+        }
     };
 
-    let counter_start = with_idx + 1;
-    let counter_tokens = &tokens[counter_start..counters_idx + 1];
+    let counter_tokens = &tokens[counter_start_idx..counters_idx + 1];
     let Some(counter_type) = parse_counter_type_from_tokens(counter_tokens) else {
         return Ok(None);
     };
@@ -6853,12 +6881,40 @@ pub(crate) fn parse_you_may_cast_exile_counter_cards_with_mana_permission_line(
         return Ok(None);
     }
 
-    let mut filter = ObjectFilter {
+    let mut base_filter = ObjectFilter {
         zone: Some(Zone::Exile),
         owner,
-        excluded_card_types: vec![CardType::Land],
         with_counter: Some(crate::filter::CounterConstraint::Typed(counter_type)),
         ..ObjectFilter::default()
+    };
+    if is_play_lands_and_cast_noncreature_family {
+        base_filter
+            .tagged_constraints
+            .push(crate::target::TaggedObjectConstraint {
+                tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+                relation: crate::target::TaggedOpbjectRelation::IsTaggedObject,
+            });
+    }
+
+    let mut filter = if is_play_lands_and_cast_noncreature_family {
+        ObjectFilter {
+            any_of: vec![
+                ObjectFilter {
+                    card_types: vec![CardType::Land],
+                    ..base_filter.clone()
+                },
+                ObjectFilter {
+                    excluded_card_types: vec![CardType::Creature, CardType::Land],
+                    ..base_filter.clone()
+                },
+            ],
+            ..ObjectFilter::default()
+        }
+    } else {
+        ObjectFilter {
+            excluded_card_types: vec![CardType::Land],
+            ..base_filter
+        }
     };
     filter.has_mana_cost = false;
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9317,6 +9317,86 @@ fn rewrite_exile_counter_cast_permission_with_mana_permission_static_line() {
 }
 
 #[test]
+fn rewrite_source_exiled_counter_play_and_cast_permission_static_line() {
+    let line = "You may play lands and cast noncreature spells from among cards you exiled that have fetch counters on them, and you may spend mana as though it were mana of any color to cast those spells.";
+    let tokens = lex_line(line, 0).expect("Haldan-style permission line should lex");
+    let direct =
+        super::keyword_static::parse_you_may_cast_exile_counter_cards_with_mana_permission_line(
+            &tokens,
+        )
+        .expect("direct parser should not error");
+    assert!(
+        direct.is_some(),
+        "expected direct parser to accept {:?}",
+        crate::runtime_backend::token_word_refs(&tokens)
+    );
+
+    let direct_abilities = direct.expect("direct parser should produce abilities");
+    assert_eq!(direct_abilities.len(), 2);
+    let grant = direct_abilities
+        .iter()
+        .find_map(|ability| match &ability.payload {
+            crate::static_abilities::StaticAbilityPayload::Grants(spec) => Some(spec),
+            _ => None,
+        })
+        .expect("expected PlayFrom grant");
+
+    assert!(matches!(&grant.grantable, crate::grant::Grantable::PlayFrom));
+    assert_eq!(grant.zone, crate::zone::Zone::Exile);
+    assert_eq!(grant.beneficiary, crate::filter::PlayerFilter::You);
+    assert_eq!(grant.filter.any_of.len(), 2);
+    assert!(grant.filter.any_of.iter().any(|candidate| {
+        candidate.card_types == vec![CardType::Land]
+            && candidate.zone == Some(crate::zone::Zone::Exile)
+            && candidate
+                .tagged_constraints
+                .iter()
+                .any(|constraint| constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG)
+    }));
+    assert!(grant.filter.any_of.iter().any(|candidate| {
+        candidate.excluded_card_types.contains(&CardType::Creature)
+            && candidate.excluded_card_types.contains(&CardType::Land)
+            && candidate.with_counter
+                == Some(crate::filter::CounterConstraint::Typed(CounterType::Named("fetch")))
+    }));
+
+    let permission = direct_abilities
+        .iter()
+        .find_map(|ability| match &ability.payload {
+            crate::static_abilities::StaticAbilityPayload::ManaSpendPermission {
+                permission,
+                ..
+            } => {
+                assert_eq!(permission.player, crate::filter::PlayerFilter::You);
+                Some(permission)
+            }
+            _ => None,
+        })
+        .expect("expected mana spend permission");
+    let mana_filter = match &permission.scope {
+        ironsmith_core::ManaSpendScope::CastingSpellsMatching(filter) => filter,
+        other => panic!("expected casting mana permission, got {other:?}"),
+    };
+    assert_eq!(mana_filter.any_of.len(), 2);
+    assert!(mana_filter.any_of.iter().all(|candidate| {
+        candidate.zone == Some(crate::zone::Zone::Exile)
+            && candidate
+                .tagged_constraints
+                .iter()
+                .any(|constraint| constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG)
+    }));
+
+    let def = CardDefinitionBuilder::new(CardId::new(), "Haldan Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(line)
+        .expect("Haldan-style line should parse");
+    let debug = format!("{:#?}", def.abilities);
+    assert!(debug.contains("Grantable::PlayFrom") || debug.contains("grantable: PlayFrom"), "{debug}");
+    assert!(debug.contains("fetch"), "{debug}");
+    assert!(debug.contains("ManaSpendPermission"), "{debug}");
+}
+
+#[test]
 fn rewrite_source_you_control_noncombat_damage_to_opponent_creature_as_counters() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Soul-Scar Mage Variant")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Haldan, Avid Arcanist
Initial parse error:
```
parser does not yet support line family: 'You may play lands and cast noncreature spells from among cards you exiled that have fetch counters on them, and you may spend mana as though it were mana of any color to cast those spells.'; oracle-only fallback also failed: parser does not yet support line family: 'You may play lands and cast noncreature spells from among cards you exiled that have fetch counters on them, and you may spend mana as though it were mana of any color to cast those spells.'
```

Worker: i-072821718da07e567
