### PR TITLE
Fix Ironsmith parse failure: Academy Researchers

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -976,55 +976,84 @@ pub(crate) fn parse_put_into_hand(
             )));
         }
 
-        let destination_words: Vec<&str> =
-            crate::runtime_backend::token_word_refs(dest_slice)
-                .into_iter()
-                .filter(|word| !is_article(word))
-                .collect();
-        if destination_words.first() != Some(&"battlefield") {
+        let destination_tokens: Vec<OwnedLexToken> = dest_slice
+            .iter()
+            .filter(|token| !token.as_word().is_some_and(is_article))
+            .cloned()
+            .collect();
+        if !destination_tokens
+            .first()
+            .is_some_and(|token| token.is_word("battlefield"))
+        {
             return Err(CardTextError::ParseError(format!(
                 "unsupported put destination after 'onto' (clause: '{}')",
                 clause_words.join(" ")
             )));
         }
-        let mut destination_tail: Vec<&str> = destination_words[1..].to_vec();
-        let battlefield_attacking = slice_contains(&destination_tail, &"attacking");
-        let battlefield_tapped = slice_contains(&destination_tail, &"tapped");
-        if let Some(from_idx) =
-            find_word_sequence_start(&destination_tail, &["from", "command", "zone"])
+
+        let mut destination_tail: Vec<OwnedLexToken> = destination_tokens[1..].to_vec();
+        let battlefield_attacking = grammar::contains_word(&destination_tail, "attacking");
+        let battlefield_tapped = grammar::contains_word(&destination_tail, "tapped");
+        if let Some(from_idx) = find_index(&destination_tail, |token| token.is_word("from"))
+            && destination_tail
+                .get(from_idx + 1)
+                .is_some_and(|token| token.is_word("command"))
+            && destination_tail
+                .get(from_idx + 2)
+                .is_some_and(|token| token.is_word("zone"))
         {
             destination_tail.drain(from_idx..from_idx + 3);
         }
-        destination_tail.retain(|word| *word != "and");
-        destination_tail.retain(|word| *word != "tapped");
-        destination_tail.retain(|word| *word != "attacking");
+        destination_tail.retain(|token| !token.is_word("and"));
+        destination_tail.retain(|token| !token.is_word("tapped"));
+        destination_tail.retain(|token| !token.is_word("attacking"));
         if battlefield_attacking {
             return Err(CardTextError::ParseError(format!(
                 "unsupported put destination after 'onto' (clause: '{}')",
                 clause_words.join(" ")
             )));
         }
-        let supported_control_tail = destination_tail.is_empty()
-            || destination_tail.as_slice() == ["under", "your", "control"]
-            || destination_tail.as_slice() == ["under", "its", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "his", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "her", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "their", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "that", "players", "control"];
+
+        let mut attached_to_target: Option<TargetAst> = None;
+        if destination_tail
+            .first()
+            .is_some_and(|token| token.is_word("attached"))
+            && destination_tail
+                .get(1)
+                .is_some_and(|token| token.is_word("to"))
+        {
+            let attachment_target_tokens = trim_commas(&destination_tail[2..]);
+            if attachment_target_tokens.is_empty() {
+                return Err(CardTextError::ParseError(format!(
+                    "missing attachment target after 'attached to' (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            }
+            attached_to_target = Some(parse_target_phrase(&attachment_target_tokens)?);
+            destination_tail.clear();
+        }
+
+        let destination_tail_words = crate::runtime_backend::token_word_refs(&destination_tail);
+        let supported_control_tail = destination_tail_words.is_empty()
+            || destination_tail_words.as_slice() == ["under", "your", "control"]
+            || destination_tail_words.as_slice() == ["under", "its", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "his", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "her", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "their", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "that", "players", "control"];
         if !supported_control_tail {
             return Err(CardTextError::ParseError(format!(
                 "unsupported put destination after 'onto' (clause: '{}')",
                 clause_words.join(" ")
             )));
         }
-        let battlefield_controller = if destination_tail.as_slice() == ["under", "your", "control"]
-        {
+        let battlefield_controller = if destination_tail_words.as_slice() == ["under", "your", "control"] {
             ReturnControllerAst::You
-        } else if destination_tail.as_slice() == ["under", "its", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "his", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "her", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "their", "owners", "control"]
-            || destination_tail.as_slice() == ["under", "that", "players", "control"]
+        } else if destination_tail_words.as_slice() == ["under", "its", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "his", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "her", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "their", "owners", "control"]
+            || destination_tail_words.as_slice() == ["under", "that", "players", "control"]
         {
             ReturnControllerAst::Owner
         } else {
@@ -1085,7 +1114,7 @@ pub(crate) fn parse_put_into_hand(
             false,
             battlefield_controller,
             battlefield_tapped,
-            None,
+            attached_to_target,
         ));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5963,6 +5963,23 @@ fn curse_of_misfortunes_search_excludes_names_of_attached_curses() {
 }
 
 #[test]
+fn academy_researchers_puts_aura_from_hand_onto_battlefield_attached() {
+    let text = "When this creature enters, you may put an Aura card from your hand onto the battlefield attached to this creature.";
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Academy Researchers")
+        .card_types(vec![CardType::Creature])
+        .parse_text(text)
+        .expect("Academy Researchers should parse");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(debug.contains("MoveToZoneEffect"), "{debug}");
+    assert!(debug.contains("zone: Some("), "{debug}");
+    assert!(debug.contains("Hand"), "{debug}");
+    assert!(debug.contains("Aura"), "{debug}");
+    assert!(debug.contains("AttachObjectsEffect"), "{debug}");
+    assert!(debug.contains("this creature"), "{debug}");
+}
+
+#[test]
 fn cruel_reality_fallback_life_loss_targets_that_player() {
     let text = "Enchant player\nAt the beginning of enchanted player's upkeep, that player sacrifices a creature or planeswalker of their choice. If the player can't, they lose 5 life.";
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Cruel Reality")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2400,6 +2400,40 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         ))
     }
 
+    fn describe_put_onto_battlefield_attached(effects: &[&Effect]) -> Option<String> {
+        let [move_effect, attach_effect] = effects else {
+            return None;
+        };
+
+        let tagged_move = move_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+        let move_to_zone = tagged_move
+            .effect
+            .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+        let attach = attach_effect.downcast_ref::<crate::effects::AttachObjectsEffect>()?;
+        if move_to_zone.zone != Zone::Battlefield
+            || !choose_spec_references_exact_tag(&attach.objects, &tagged_move.tag)
+        {
+            return None;
+        }
+
+        let move_text = describe_effect(move_effect);
+        if !move_text
+            .to_ascii_lowercase()
+            .contains("onto the battlefield")
+        {
+            return None;
+        }
+
+        Some(format!(
+            "{move_text} attached to {}",
+            describe_choose_spec(&attach.target)
+        ))
+    }
+
+    if let Some(compact) = describe_put_onto_battlefield_attached(&raw_effects) {
+        return compact;
+    }
+
     fn describe_exile_then_incubate_count(effects: &[&Effect]) -> Option<String> {
         let [exile_effect, incubate_effect] = effects else {
             return None;
@@ -14517,6 +14551,40 @@ mod tests {
         assert_eq!(
             describe_effect_list(&effects),
             "Sacrifice this enchantment, then put a creature card exiled with it onto the battlefield under your control with two additional +1/+1 counters on it"
+        );
+    }
+
+    #[test]
+    fn describe_effect_list_compacts_put_onto_battlefield_attached() {
+        let moved_tag = TagKey::from("moved_0");
+        let move_to_zone = crate::effects::MoveToZoneEffect::new(
+            ChooseSpec::Object(
+                ObjectFilter::default()
+                    .with_subtype(Subtype::Aura)
+                    .in_zone(Zone::Hand)
+                    .owned_by(PlayerFilter::You),
+            )
+            .with_count(ChoiceCount::exactly(1)),
+            Zone::Battlefield,
+            false,
+        );
+        let mut moved_filter = ObjectFilter::default();
+        moved_filter.tagged_constraints.push(TaggedObjectConstraint {
+            tag: moved_tag.clone(),
+            relation: TaggedOpbjectRelation::IsTaggedObject,
+        });
+
+        let effects = vec![
+            Effect::new(move_to_zone).tag(moved_tag),
+            Effect::new(crate::effects::AttachObjectsEffect::new(
+                ChooseSpec::All(moved_filter),
+                ChooseSpec::Source,
+            )),
+        ];
+
+        assert_eq!(
+            describe_effect_list(&effects),
+            "Put an Aura card in your hand onto the battlefield attached to this source"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Academy Researchers
Initial parse error:
```
unsupported put destination after 'onto' (clause: 'an aura card from your hand onto the battlefield attached to this creature'); oracle-only fallback also failed: unsupported put destination after 'onto' (clause: 'an aura card from your hand onto the battlefield attached to this creature')
```

Worker: i-06e801195e14f0051
