### PR TITLE
Fix Ironsmith parse failure: Geyadrone Dihada

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -23,7 +23,8 @@ use super::grammar::structure::{
 };
 use super::lexer::{OwnedLexToken, TokenKind, render_token_slice, split_lexed_sentences};
 use super::util::{
-    parse_card_type, parse_color, parse_flashback_keyword_line, parse_subtype_flexible, trim_commas,
+    parse_card_type, parse_color, parse_filter_counter_constraint_words,
+    parse_flashback_keyword_line, parse_subtype_flexible, trim_commas,
 };
 
 fn word_slice_starts_with(words: &[&str], expected: &[&str]) -> bool {
@@ -189,6 +190,18 @@ fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if matches!(value, "permanent" | "permanents")
+            && words.get(idx + 2).copied() == Some("with")
+        {
+            let counter_words = &words[idx + 3..];
+            if let Some((with_counter, consumed)) = parse_filter_counter_constraint_words(counter_words)
+                && consumed == counter_words.len()
+            {
+                let mut filter = ObjectFilter::permanent();
+                filter.with_counter = Some(with_counter);
+                return Some(KeywordAction::ProtectionFromFilter(filter));
+            }
+        }
         match value {
             "the"
                 if words.get(idx + 2).copied() == Some("chosen")
@@ -479,6 +492,19 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
 
         let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
             let value = *words.get(idx + 1)?;
+            if matches!(value, "permanent" | "permanents")
+                && words.get(idx + 2).copied() == Some("with")
+            {
+                let counter_words = &words[idx + 3..];
+                if let Some((with_counter, consumed)) =
+                    parse_filter_counter_constraint_words(counter_words)
+                    && consumed == counter_words.len()
+                {
+                    let mut filter = ObjectFilter::permanent();
+                    filter.with_counter = Some(with_counter);
+                    return Some(KeywordAction::ProtectionFromFilter(filter));
+                }
+            }
             match value {
                 "the"
                     if words.get(idx + 2).copied() == Some("chosen")

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
@@ -87,6 +87,18 @@ pub(crate) fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<Key
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if matches!(value, "permanent" | "permanents")
+            && words.get(idx + 2).copied() == Some("with")
+        {
+            let counter_words = &words[idx + 3..];
+            if let Some((with_counter, consumed)) = parse_filter_counter_constraint_words(counter_words)
+                && consumed == counter_words.len()
+            {
+                let mut filter = ObjectFilter::permanent();
+                filter.with_counter = Some(with_counter);
+                return Some(KeywordAction::ProtectionFromFilter(filter));
+            }
+        }
         match value {
             "the"
                 if words.get(idx + 2).copied() == Some("chosen")

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -80,9 +80,9 @@ use super::token_primitives::{
 use super::util::{
     is_source_reference_words, leading_mana_cost_from_tokens, mana_pips_from_token,
     parse_alternative_cast_words, parse_card_type, parse_color, parse_counter_type_from_tokens,
-    parse_counter_type_word, parse_flashback_keyword_line, parse_for_each_count_value_words,
-    parse_number_word_i32, parse_subtype_flexible, parse_value, parse_value_expr_words,
-    parse_zone_word, preserve_keyword_prefix_for_parse,
+    parse_counter_type_word, parse_filter_counter_constraint_words, parse_flashback_keyword_line,
+    parse_for_each_count_value_words, parse_number_word_i32, parse_subtype_flexible,
+    parse_value, parse_value_expr_words, parse_zone_word, preserve_keyword_prefix_for_parse,
     source_reference_surface_for_possessive_words, trim_commas, words,
 };
 use super::util::{source_choose_spec_for_surface, source_reference_surface_for_words};

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -6653,6 +6653,24 @@ fn rewrite_lexed_keyword_line_parses_mixed_protection_chain_targets() {
 }
 
 #[test]
+fn rewrite_lexed_keyword_line_parses_protection_from_permanents_with_named_counters() {
+    let protection_tokens =
+        lex_line("Protection from permanents with corruption counters on them", 0)
+            .expect("rewrite lexer should classify counter-filtered protection");
+
+    let parsed = super::clause_support::parse_ability_line_lexed(&protection_tokens)
+        .expect("counter-filtered protection should parse");
+    assert_eq!(parsed.len(), 1, "{parsed:?}");
+
+    let crate::cards::builders::KeywordAction::ProtectionFromFilter(filter) = &parsed[0] else {
+        panic!("expected protection-from-filter action, got {parsed:?}");
+    };
+    let debug = format!("{filter:?}");
+    assert!(debug.contains("with_counter: Some"), "{debug}");
+    assert!(debug.to_ascii_lowercase().contains("corruption"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_keyword_line_routes_separator_lists_through_grammar_primitives() {
     let keyword_tokens = lex_line("Flying, vigilance; trample and haste", 0)
         .expect("rewrite lexer should classify mixed keyword separator line");

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -134,7 +134,28 @@ fn describe_protection_permanent_filter(filter: &ObjectFilter) -> String {
         return pluralize_subtype_for_protection(filter.subtypes[0]);
     }
 
-    filter.description()
+    let description = filter.description();
+    if let Some(pluralized) = pluralize_permanent_counter_phrase(description.as_str()) {
+        return pluralized;
+    }
+    description
+}
+
+fn pluralize_permanent_counter_phrase(description: &str) -> Option<String> {
+    if let Some(rest) = description.strip_prefix("permanent with a ")
+        && let Some(counter_name) = rest.strip_suffix(" counter on it")
+    {
+        return Some(format!("permanents with {counter_name} counters on them"));
+    }
+    if let Some(rest) = description.strip_prefix("permanent with an ")
+        && let Some(counter_name) = rest.strip_suffix(" counter on it")
+    {
+        return Some(format!("permanents with {counter_name} counters on them"));
+    }
+    if description == "permanent with counter on it" {
+        return Some("permanents with counters on them".to_string());
+    }
+    None
 }
 
 fn pluralize_subtype_for_protection(subtype: crate::types::Subtype) -> String {
@@ -248,6 +269,8 @@ impl StaticAbilityKind for Ward {
 mod tests {
     use super::*;
     use crate::color::Color;
+    use crate::filter::CounterConstraint;
+    use crate::object::CounterType;
 
     #[test]
     fn test_protection_from_color() {
@@ -299,6 +322,17 @@ mod tests {
         let filter = ObjectFilter::artifact();
         let prot = Protection::new(ProtectionFrom::Permanents(filter));
         assert_eq!(prot.display(), "Protection from artifact");
+    }
+
+    #[test]
+    fn test_protection_display_permanents_with_counter_filter_pluralizes() {
+        let mut filter = ObjectFilter::permanent();
+        filter.with_counter = Some(CounterConstraint::Typed(CounterType::Charge));
+        let prot = Protection::new(ProtectionFrom::Permanents(filter));
+        assert_eq!(
+            prot.display(),
+            "Protection from permanents with charge counters on them"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Geyadrone Dihada
Initial parse error:
```
parser does not yet support line family: 'Protection from permanents with corruption counters on them'; oracle-only fallback also failed: parser does not yet support line family: 'Protection from permanents with corruption counters on them'
```

Worker: i-0e892cce5cbbc1b4f
