### PR TITLE
Fix Ironsmith parse failure: Phyrexian Atlas

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -470,6 +470,13 @@ pub(crate) fn compile_condition_from_predicate_ast(
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerHasMoreCardsInHandThanEachOtherPlayer { player }
         }
+        PredicateAst::PlayerHasPoisonCountersOrMore { player, count } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::PlayerHasPoisonCountersOrMore {
+                player,
+                count: *count,
+            }
+        }
         PredicateAst::PlayerCastSpellsThisTurnOrMore { player, count } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerCastSpellsThisTurnOrMore {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -451,6 +451,10 @@ pub(crate) enum PredicateAst {
     PlayerHasMoreCardsInHandThanEachOtherPlayer {
         player: PlayerAst,
     },
+    PlayerHasPoisonCountersOrMore {
+        player: PlayerAst,
+        count: u32,
+    },
     VoteOptionGetsMoreVotes {
         option: String,
     },

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
@@ -674,6 +674,39 @@ pub(crate) fn parse_for_each_opponent_clause(
             if_false: Vec::new(),
         }])));
     }
+    if inner_words.len() >= 7
+        && inner_words.first().copied() == Some("who")
+        && inner_words.get(1).copied() == Some("has")
+        && let Some((count, used)) = parse_number(&inner_tokens[2..])
+    {
+        let cmp_idx = 2 + used;
+        if inner_words.get(cmp_idx).copied() == Some("or")
+            && inner_words.get(cmp_idx + 1).copied() == Some("more")
+            && inner_words.get(cmp_idx + 2).copied() == Some("poison")
+            && inner_words.get(cmp_idx + 3).is_some_and(|word| *word == "counter" || *word == "counters")
+        {
+            let effect_start = cmp_idx + 4;
+            let effect_token_start =
+                token_index_for_word_index(&inner_tokens, effect_start).unwrap_or(inner_tokens.len());
+            let effect_tokens = trim_commas(&inner_tokens[effect_token_start..]);
+            if effect_tokens.is_empty() {
+                return Err(CardTextError::ParseError(format!(
+                    "missing effect after 'each opponent who has ... poison counters' (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            }
+            let mut branch_effects = parse_effect_chain(&effect_tokens)?;
+            force_implicit_token_controller_you(&mut branch_effects);
+            return Ok(Some(wrap_for_each(vec![EffectAst::Conditional {
+                predicate: PredicateAst::PlayerHasPoisonCountersOrMore {
+                    player: PlayerAst::That,
+                    count,
+                },
+                if_true: branch_effects,
+                if_false: Vec::new(),
+            }])));
+        }
+    }
     if inner_words.first().copied() == Some("who")
         && let Some((negation_idx, negation_len)) = negated_action_word_index(&inner_words)
     {

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -648,6 +648,10 @@ pub enum Condition {
     PlayerHasMoreCardsInHandThanEachOtherPlayer {
         player: PlayerFilter,
     },
+    PlayerHasPoisonCountersOrMore {
+        player: PlayerFilter,
+        count: u32,
+    },
     YouHaveCardInHandMatching(ObjectFilter),
     YourTurn,
     YourFirstTurnsOfTheGameOrFewer(u32),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1824,6 +1824,25 @@ fn test_parse_canonist_style_nonartifact_cast_limit() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_each_opponent_with_poison_counter_threshold() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Corrupted Atlas Variant")
+        .parse_text(
+            "Corrupted - Whenever this artifact becomes tapped, each opponent who has three or more poison counters loses 1 life.",
+        )
+        .expect("parse each-opponent poison threshold trigger");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("each opponent who has three or more poison counters loses 1 life")
+            || rendered.contains("for each opponent, if that player has 3 or more poison counters, that player loses 1 life"),
+        "expected poison-threshold opponent life-loss trigger, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_your_opponents_nonartifact_cast_limit() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Lavinia Variant")
         .parse_text("Your opponents can't cast more than one nonartifact spell each turn.")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10054,6 +10054,13 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 describe_player_filter(player)
             )
         }
+        Condition::PlayerHasPoisonCountersOrMore { player, count } => {
+            format!(
+                "{} has {} or more poison counters",
+                describe_player_filter(player),
+                count
+            )
+        }
         Condition::YouHaveCardInHandMatching(filter) => {
             let object_text = with_indefinite_article(&filter.description());
             format!("you have {object_text} in hand")

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -477,6 +477,12 @@ fn player_has_more_life_than_each_other_player(game: &GameState, player_id: Play
         .all(|candidate| candidate.id == player_id || life > candidate.life)
 }
 
+fn player_poison_counters_or_more(game: &GameState, player_id: PlayerId, count: u32) -> bool {
+    game.player(player_id)
+        .map(|player| player.poison_counters >= count)
+        .unwrap_or(false)
+}
+
 fn player_has_no_opponent_with_more_life_than(game: &GameState, player_id: PlayerId) -> bool {
     let Some(life) = game.player(player_id).map(|p| p.life) else {
         return false;
@@ -944,6 +950,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::PlayerHasMoreLifeThanEachOtherPlayer { .. } => {}
         Condition::PlayerHasMoreCardsInHandThanYou { .. } => {}
         Condition::PlayerHasMoreCardsInHandThanEachOtherPlayer { .. } => {}
+        Condition::PlayerHasPoisonCountersOrMore { .. } => {}
         Condition::PlayerIsMonarch { .. } => {}
         Condition::PlayerHasInitiative { .. } => {}
         Condition::PlayerHasCitysBlessing { .. } => {}
@@ -1191,6 +1198,11 @@ pub fn evaluate_condition_external(
                         .filter(|candidate| candidate.is_in_game())
                         .all(|candidate| candidate.id == player_id || hand > candidate.hand.len())
                 })
+        }
+        Condition::PlayerHasPoisonCountersOrMore { player, count } => {
+            matching_condition_players_external(game, ctx, player)
+                .into_iter()
+                .any(|player_id| player_poison_counters_or_more(game, player_id, *count))
         }
         Condition::PlayerIsMonarch { player } => {
             let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
@@ -2259,6 +2271,11 @@ fn evaluate_condition_simple(
                         .all(|candidate| candidate.id == player_id || hand > candidate.hand.len())
                 })
         }
+        Condition::PlayerHasPoisonCountersOrMore { player, count } => {
+            matching_condition_players_simple(game, controller, player)
+                .into_iter()
+                .any(|player_id| player_poison_counters_or_more(game, player_id, *count))
+        }
         Condition::PlayerCastSpellsThisTurnOrMore { player, count } => {
             let filter_ctx = game.filter_context_for(controller, Some(source));
             let players: Vec<PlayerId> = match player {
@@ -2893,6 +2910,11 @@ fn evaluate_condition(
                         .filter(|candidate| candidate.is_in_game())
                         .all(|candidate| candidate.id == player_id || hand > candidate.hand.len())
                 }))
+        }
+        Condition::PlayerHasPoisonCountersOrMore { player, count } => {
+            Ok(matching_condition_players_exec(game, ctx, player)?
+                .into_iter()
+                .any(|player_id| player_poison_counters_or_more(game, player_id, *count)))
         }
         Condition::PlayerCastSpellsThisTurnOrMore { player, count } => {
             let filter_ctx = ctx.filter_context(game);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Phyrexian Atlas
Initial parse error:
```
unsupported target phrase (clause: 'loses 1 life'); oracle-only fallback also failed: unsupported target phrase (clause: 'loses 1 life')
```

Worker: i-0948e62d4c1c817c4
