### PR TITLE
Fix Ironsmith parse failure: Scholar of the Lost Trove

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -720,6 +720,32 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         return Ok(EffectAst::subject_verb_clear_suspected(None));
     }
 
+    if clause_words.first() == Some(&"cast")
+        && clause_words.get(1) == Some(&"target")
+        && let Some(without_word_idx) = clause_words
+            .windows(5)
+            .position(|window| window == ["without", "paying", "its", "mana", "cost"])
+        && let Some(target_token_end) = token_index_for_word_index(tokens, without_word_idx)
+    {
+        let _ = parse_target_phrase(&tokens[1..target_token_end])?;
+        return Ok(EffectAst::SubjectVerb(
+            crate::runtime_backend::ast::SubjectVerbEffectAst {
+                subject: crate::runtime_backend::ast::SubjectVerbSubjectAst {
+                    role: SubjectVerbRoleAst::Actor,
+                    player: PlayerAst::Implicit,
+                },
+                action: SubjectVerbActionAst::CastTagged {
+                    tag: TagKey::from(IT_TAG),
+                    player: PlayerAst::Implicit,
+                    allow_land: false,
+                    as_copy: false,
+                    without_paying_mana_cost: true,
+                    cost_reduction: None,
+                },
+            },
+        ));
+    }
+
     let (verb, verb_idx) = find_verb(tokens).ok_or_else(|| {
         let clause = render_lower_words(tokens);
         let known_verbs = [

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -575,25 +575,22 @@ pub(crate) fn parse_may_cast_target_graveyard_spell_then_exile_replacement(
     let first_words = sentence_words(&first);
     let second_words = sentence_words(&second);
 
-    if first_words.as_slice()
-        != [
-            "you",
-            "may",
-            "cast",
-            "target",
-            "instant",
-            "or",
-            "sorcery",
-            "card",
-            "from",
-            "your",
-            "graveyard",
-        ]
-    {
+    let has_from_graveyard = first_words
+        .windows(3)
+        .any(|window| window == ["from", "your", "graveyard"]);
+    let without_paying_mana_cost = first_words
+        .windows(5)
+        .any(|window| window == ["without", "paying", "its", "mana", "cost"]);
+    let first_is_targeted_graveyard_cast = first_words.starts_with(&["you", "may", "cast", "target"])
+        && has_from_graveyard
+        && first_words.contains(&"instant")
+        && first_words.contains(&"sorcery")
+        && first_words.contains(&"card");
+    if !first_is_targeted_graveyard_cast {
         return Ok(None);
     }
-    if second_words.as_slice()
-        != [
+    let second_is_that_spell_replacement = second_words.as_slice()
+        == [
             "if",
             "that",
             "spell",
@@ -606,16 +603,50 @@ pub(crate) fn parse_may_cast_target_graveyard_spell_then_exile_replacement(
             "exile",
             "it",
             "instead",
-        ]
-    {
+        ];
+    let second_is_cast_this_way_replacement = second_words.as_slice()
+        == [
+            "if",
+            "an",
+            "instant",
+            "or",
+            "sorcery",
+            "spell",
+            "cast",
+            "this",
+            "way",
+            "would",
+            "be",
+            "put",
+            "into",
+            "your",
+            "graveyard",
+            "exile",
+            "it",
+            "instead",
+        ];
+    if !second_is_that_spell_replacement && !second_is_cast_this_way_replacement {
         return Ok(None);
     }
 
-    let tag = TagKey::from("target_instant_or_sorcery_card");
+    let tag = TagKey::from(crate::cards::builders::IT_TAG);
     let mut filter = ObjectFilter::default();
     filter.zone = Some(Zone::Graveyard);
     filter.owner = Some(PlayerFilter::You);
     filter.card_types = vec![CardType::Instant, CardType::Sorcery];
+    if first_words.contains(&"artifact") {
+        filter.card_types.push(CardType::Artifact);
+    }
+
+    let replacement_filter = ObjectFilter {
+        zone: Some(Zone::Stack),
+        card_types: vec![CardType::Instant, CardType::Sorcery],
+        tagged_constraints: vec![TaggedObjectConstraint {
+            tag: tag.clone(),
+            relation: TaggedOpbjectRelation::IsTaggedObject,
+        }],
+        ..ObjectFilter::default()
+    };
 
     Ok(Some(vec![
         EffectAst::ChooseObjects {
@@ -631,12 +662,12 @@ pub(crate) fn parse_may_cast_target_graveyard_spell_then_exile_replacement(
                 PlayerAst::You,
                 false,
                 false,
-                false,
+                without_paying_mana_cost,
                 None,
             )],
         },
-        EffectAst::subject_verb_register_zone_replacement(
-            TargetAst::Tagged(tag, None),
+        EffectAst::subject_verb_register_future_zone_replacement(
+            replacement_filter,
             Some(Zone::Stack),
             Some(Zone::Graveyard),
             Zone::Exile,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4254,6 +4254,37 @@ fn rewrite_lexed_permission_helpers_route_singular_hand_free_casts_to_one_shot_e
 }
 
 #[test]
+fn rewrite_lexed_parse_cast_target_graveyard_without_paying_mana_cost() {
+    let tokens = lex_line(
+        "Cast target instant, sorcery, or artifact card from your graveyard without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify targeted graveyard free-cast clause");
+
+    let effects =
+        parse_effect_sentence_lexed(&tokens).expect("targeted graveyard free-cast should parse");
+
+    assert!(matches!(
+        effects.as_slice(),
+        [crate::cards::builders::EffectAst::SubjectVerb(
+            crate::cards::builders::SubjectVerbEffectAst {
+                subject: crate::cards::builders::SubjectVerbSubjectAst {
+                    role: crate::cards::builders::SubjectVerbRoleAst::Actor,
+                    player: crate::cards::builders::PlayerAst::Implicit,
+                },
+                action: crate::cards::builders::SubjectVerbActionAst::CastTagged {
+                    player: crate::cards::builders::PlayerAst::Implicit,
+                    allow_land: false,
+                    as_copy: false,
+                    without_paying_mana_cost: true,
+                    ..
+                },
+            },
+        )]
+    ));
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_play() {
     let tokens = lex_line("Until the end of your next turn, you may play that card", 0)
         .expect("rewrite lexer should classify until-next-turn permission clause");
@@ -9167,6 +9198,28 @@ fn rewrite_sequence_registry_matches_may_cast_target_graveyard_spell_replacement
     );
     assert_eq!(matched.consumed_sentences, 2);
     assert!(debug.contains("ChooseObjects"), "{debug}");
+    assert!(debug.contains("CastTagged"), "{debug}");
+    assert!(debug.contains("RegisterZoneReplacement"), "{debug}");
+}
+
+#[test]
+fn rewrite_sequence_registry_matches_may_cast_target_graveyard_artifact_or_spell_replacement() {
+    let sentences = registry_sentence_inputs(
+        "You may cast target instant, sorcery, or artifact card from your graveyard without paying its mana cost. If an instant or sorcery spell cast this way would be put into your graveyard, exile it instead.",
+    );
+
+    let matched = super::effect_sentences::try_parse_subject_verb_sequence_rule(&sentences, 0)
+        .expect("registry lookup should not error")
+        .expect("registry should match targeted graveyard free-cast/replacement bundle");
+    let debug = format!("{:#?}", matched.effects);
+
+    assert_eq!(
+        matched.name,
+        "may-cast-target-graveyard-spell-then-exile-replacement"
+    );
+    assert_eq!(matched.consumed_sentences, 2);
+    assert!(debug.contains("ChooseObjects"), "{debug}");
+    assert!(debug.contains("Artifact"), "{debug}");
     assert!(debug.contains("CastTagged"), "{debug}");
     assert!(debug.contains("RegisterZoneReplacement"), "{debug}");
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Scholar of the Lost Trove
Initial parse error:
```
could not find verb in effect clause (clause: 'cast target instant sorcery or artifact card from your graveyard without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast target instant sorcery or artifact card from your graveyard without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-021ece9cc6804cfe7
