### PR TITLE
Fix Ironsmith parse failure: Pride of the Clouds

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -1585,6 +1585,17 @@ fn parse_reveal_segment_tokens(
         return Ok(ActivationCostSegmentCst::RevealSourceFromHand);
     }
 
+    if lowered.len() == 6
+        && lowered[0] == "reveal"
+        && lowered[1] == "this"
+        && lowered[3] == "from"
+        && lowered[4] == "your"
+        && lowered[5] == "hand"
+        && parse_card_type_word(lowered[2]).is_some()
+    {
+        return Ok(ActivationCostSegmentCst::RevealSourceFromHand);
+    }
+
     Err(CardTextError::ParseError(format!(
         "rewrite reveal-cost parser does not yet support '{raw}'"
     )))

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10634,6 +10634,8 @@ fn rewrite_activation_cost_parses_energy_and_counter_variants() {
         .expect("parser should parse exile-from-hand cost");
     let reveal_source = parse_activation_cost_rewrite("Reveal this card from your hand")
         .expect("parser should parse reveal-source-from-hand cost");
+    let reveal_typed_source = parse_activation_cost_rewrite("Reveal this creature from your hand")
+        .expect("parser should parse typed reveal-source-from-hand cost");
 
     assert!(matches!(
         energy.segments.as_slice(),
@@ -10666,6 +10668,10 @@ fn rewrite_activation_cost_parses_energy_and_counter_variants() {
     ));
     assert!(matches!(
         reveal_source.segments.as_slice(),
+        [super::ActivationCostSegmentCst::RevealSourceFromHand]
+    ));
+    assert!(matches!(
+        reveal_typed_source.segments.as_slice(),
         [super::ActivationCostSegmentCst::RevealSourceFromHand]
     ));
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pride of the Clouds
Initial parse error:
```
unsupported activation cost segment (clause: 'reveal this creature from your hand'): rewrite reveal-cost parser does not yet support 'reveal this creature from your hand'; oracle-only fallback also failed: unsupported activation cost segment (clause: 'reveal this creature from your hand'): rewrite reveal-cost parser does not yet support 'reveal this creature from your hand'
```

Worker: i-0e311e993197816ad
