### PR TITLE
Fix Ironsmith parse failure: Territorial Aetherkite

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -640,6 +640,11 @@ pub(crate) fn parse_pay(
     {
         return Ok(EffectAst::subject_verb_pay_any_energy(player));
     }
+    if grammar::words_match_any_prefix(tokens, &[&["one", "or", "more"]]).is_some()
+        && (grammar::contains_word(tokens, "e") || energy_symbol_count > 0)
+    {
+        return Ok(EffectAst::subject_verb_pay_any_energy(player));
+    }
     let has_for_each = clause_words
         .windows(2)
         .any(|window| window == ["for", "each"]);

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -7495,6 +7495,35 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_one_or_more_energy_pay_clause_includes_pay_any_energy_effect() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Flexible Energy Pay Trigger Variant")
+            .parse_text(
+                "Whenever this creature attacks, you may pay one or more {E}. If you do, put a +1/+1 counter on this creature.",
+            )
+            .expect("one-or-more energy pay trigger line should parse");
+
+        let triggered = def
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered) => Some(triggered),
+                _ => None,
+            })
+            .expect("expected triggered ability");
+
+        let debug = format!("{:?}", triggered.effects);
+        assert!(
+            debug.contains("PayAnyEnergyEffect"),
+            "expected pay any energy effect, got {debug}"
+        );
+        assert!(
+            debug.contains("PutCountersEffect"),
+            "expected +1/+1 counter effect in if-you-do branch, got {debug}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_get_energy_equal_to_tagged_spell_mana_value() {
         let def = CardDefinitionBuilder::new(CardId::new(), "Electrosiphon Variant")
             .parse_text("Counter target spell. You get an amount of {E} (energy counters) equal to its mana value.")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -23872,6 +23872,43 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_until(&gain_control.duration)
             );
         }
+        if for_each.effects.len() == 1 {
+            let deal = if let Some(deal) =
+                for_each.effects[0].downcast_ref::<crate::effects::DealDamageEffect>()
+            {
+                Some(deal)
+            } else if let Some(tagged) =
+                for_each.effects[0].downcast_ref::<crate::effects::TaggedEffect>()
+            {
+                tagged.effect.downcast_ref::<crate::effects::DealDamageEffect>()
+            } else {
+                None
+            };
+            if let Some(deal) = deal
+                && matches!(deal.target, ChooseSpec::Iterated)
+            {
+                let effect_text = describe_effect_list(&for_each.effects);
+                let replacements = [
+                    " to that object",
+                    " to that creature",
+                    " to that permanent",
+                    " to that artifact",
+                    " to that enchantment",
+                    " to that land",
+                    " to that spell",
+                    " to that card",
+                ];
+                if let Some(suffix) = replacements
+                    .iter()
+                    .find(|suffix| effect_text.ends_with(**suffix))
+                {
+                    let subject_text = effect_text.trim_end_matches(*suffix);
+                    let description = for_each.filter.description();
+                    let filter_text = strip_indefinite_article(&description);
+                    return format!("{subject_text} to each {filter_text}");
+                }
+            }
+        }
         let description = for_each.filter.description();
         let filter_text = strip_indefinite_article(&description);
         return format!(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Territorial Aetherkite
Initial parse error:
```
unsupported pay clause token 'one' (clause: 'one or more'); oracle-only fallback also failed: unsupported pay clause token 'one' (clause: 'one or more')
```

Worker: i-0f9b019866543ec1f
