### PR TITLE
Fix Ironsmith parse failure: Nettling Nuisance

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -720,6 +720,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         return Ok(EffectAst::subject_verb_clear_suspected(None));
     }
 
+    if let Some(effect) = parse_passive_goad_clause(tokens)? {
+        return Ok(effect);
+    }
+
     let (verb, verb_idx) = find_verb(tokens).ok_or_else(|| {
         let clause = render_lower_words(tokens);
         let known_verbs = [
@@ -1169,6 +1173,56 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         };
     }
     Ok(effect)
+}
+
+fn parse_passive_goad_clause(tokens: &[OwnedLexToken]) -> Result<Option<EffectAst>, CardTextError> {
+    let words = ClauseDispatchCompatWords::new(tokens).to_word_refs();
+    let Some(is_word_idx) = find_word_index(&words, "is") else {
+        return Ok(None);
+    };
+    if !matches!(
+        words.get(is_word_idx + 1).copied(),
+        Some("goaded" | "goad")
+    ) {
+        return Ok(None);
+    }
+
+    let duration_tail = &words[is_word_idx + 2..];
+    let duration_ok = duration_tail.is_empty()
+        || matches!(
+            duration_tail,
+            ["for", "the", "rest", "of", "the", "game"]
+                | ["for", "the", "rest", "of", "this", "game"]
+        );
+    if !duration_ok {
+        return Ok(None);
+    }
+
+    let Some(is_token_idx) = token_index_for_word_index(tokens, is_word_idx) else {
+        return Ok(None);
+    };
+    let subject_tokens = trim_commas(&tokens[..is_token_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let subject_words = ClauseDispatchCompatWords::new(&subject_tokens).to_word_refs();
+    let target = if matches!(subject_words.as_slice(), ["the", "token"] | ["the", "tokens"]) {
+        TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(&subject_tokens))
+    } else {
+        parse_target_phrase(&subject_tokens)?
+    };
+    if matches!(
+        target,
+        TargetAst::Player(_, _) | TargetAst::PlayerOrPlaneswalker(_, _)
+    ) {
+        return Err(CardTextError::ParseError(format!(
+            "goad target must be a creature (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        )));
+    }
+
+    Ok(Some(EffectAst::subject_verb_goad(target)))
 }
 
 fn parse_hexproof_targeting_override_clause(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38590,3 +38590,21 @@ fn parse_suspect_it_clause() {
         "expected suspect-it surface, got {rendered}"
     );
 }
+
+#[test]
+fn parse_passive_goad_designation_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Passive Goad Variant")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Black]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 1))
+        .parse_text(
+            "When one or more Faeries you control deal combat damage to a player, that player creates a 4/2 red Pirate creature token with \"This token can't block.\" The token is goaded for the rest of the game.",
+        )
+        .expect("passive goad clause should parse");
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    assert!(
+        rendered.to_ascii_lowercase().contains("goad that creature"),
+        "expected passive goad surface, got {rendered}"
+    );
+}

--- a/reports/cards/nettling-nuisance-novel-runtime-gap.md
+++ b/reports/cards/nettling-nuisance-novel-runtime-gap.md
@@ -1,0 +1,36 @@
+## Nettling Nuisance single-card pass report
+
+- Card: `Nettling Nuisance`
+- Requested target: semantic similarity `>= 0.99`
+- Current live status: parses strictly, but similarity remains below target.
+
+### What was fixed
+
+- Added parser support for passive goad clauses like `the token is goaded ...` in `clause_dispatch`.
+- Added focused regression coverage for this passive goad pattern.
+
+### Live verification snapshot
+
+Command:
+
+`cargo run -p ironsmith-tools --bin compile_oracle_text -- --name "Nettling Nuisance" --compare-text`
+
+Result:
+
+- Similarity: `0.6852`
+- Parse: successful (no parse error)
+- Compiled text:
+  `Flying`
+  `Whenever one or more Faerie creature you control deal combat damage to a player, that player creates a 4/2 red Pirate creature token with "This token can't block.". Goad that creature.`
+
+### Why the target is blocked
+
+The oracle clause says the created token `is goaded for the rest of the game`.
+
+Current runtime goad execution (`GoadEffect`) hardcodes `Until::YourNextTurn` and does not expose a reusable way to apply a goad designation with a longer duration such as "rest of game". Reaching semantic parity for this card therefore requires a reusable runtime capability upgrade for goad duration modeling, not only parser/lowering text handling.
+
+### Missing reusable capability
+
+- Parameterizable goad duration support in runtime/lowering (for example, allowing goad to use non-default durations including rest-of-game where required by card text).
+
+This goes beyond parser-only single-card scope and should be handled as a reusable effect/runtime enhancement.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nettling Nuisance
Initial parse error:
```
could not find verb in effect clause (clause: 'the token is goaded for the rest of the game'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'the token is goaded for the rest of the game'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0702668408f51f318
