### PR TITLE
Fix Ironsmith parse failure: Flash of Defiance

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
@@ -114,17 +114,30 @@ pub(crate) fn parse_cant_clauses(
         if segments.is_empty() {
             return Ok(None);
         }
+        let negated_anchor = segments
+            .iter()
+            .position(|segment| find_negation_span(segment).is_some());
+        let shared_negated_tail = negated_anchor.and_then(|anchor_idx| {
+            find_negation_span(&segments[anchor_idx])
+                .map(|(neg_start, _)| segments[anchor_idx][neg_start..].to_vec())
+        });
         let shared_subject = find_negation_span(&segments[0])
             .map(|(neg_start, _)| trim_commas(&segments[0][..neg_start]))
             .unwrap_or_default();
 
         let mut abilities = Vec::new();
         for (idx, segment) in segments.iter().enumerate() {
-            if find_negation_span(segment).is_none() {
-                continue;
-            }
             let mut expanded = segment.to_vec();
-            if idx > 0
+            if find_negation_span(segment).is_none() {
+                if let Some(anchor_idx) = negated_anchor
+                    && idx < anchor_idx
+                    && let Some(tail) = &shared_negated_tail
+                {
+                    expanded.extend(tail.iter().cloned());
+                } else {
+                    continue;
+                }
+            } else if idx > 0
                 && !shared_subject.is_empty()
                 && matches!(find_negation_span(segment), Some((0, _)))
             {
@@ -231,13 +244,6 @@ pub(crate) fn parse_cant_clause(
             return Ok(conditioned);
         }
     }
-    if let Some((_, remainder)) = parse_restriction_duration(tokens)?
-        && !remainder.is_empty()
-        && remainder.len() < tokens.len()
-    {
-        return Ok(None);
-    }
-
     let normalized_storage = normalize_cant_words(tokens);
     let normalized = normalized_storage
         .iter()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1947,6 +1947,27 @@ fn test_parse_nonsource_cant_block_specific_attacker_restriction() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_multi_color_cant_block_this_turn_restriction() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Flash of Defiance Test")
+        .parse_text("Green creatures and white creatures can't block this turn.")
+        .expect("parse multicolor cant-block-this-turn restriction");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("green creatures can't block this turn")
+            || rendered.contains("white creatures can't block this turn"),
+        "expected at least one parsed color cant-block-this-turn clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("green creatures") && rendered.contains("white creatures"),
+        "expected both colors in parsed restriction output, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_bare_cant_be_blocked_by_more_than_one_creature() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Bare Unblockable Limit")
         .parse_text("Can't be blocked by more than one creature.")

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -751,6 +751,7 @@ pub(super) fn merge_adjacent_subject_predicate_lines(lines: Vec<String>) -> Vec<
 pub(super) fn merge_blockability_lines(lines: Vec<String>) -> Vec<String> {
     let mut merged = Vec::with_capacity(lines.len());
     let mut idx = 0usize;
+    let block_this_turn_tail = " creatures can't block this turn";
     while idx < lines.len() {
         if idx + 1 < lines.len() {
             let left = lines[idx].trim();
@@ -761,6 +762,20 @@ pub(super) fn merge_blockability_lines(lines: Vec<String>) -> Vec<String> {
                 merged.push("This creature can't block and can't be blocked".to_string());
                 idx += 2;
                 continue;
+            }
+            let left_no_period = left.trim_end_matches('.');
+            let right_no_period = right.trim_end_matches('.');
+            if let (Some(left_subject), Some(right_subject)) = (
+                left_no_period.strip_suffix(block_this_turn_tail),
+                right_no_period.strip_suffix(block_this_turn_tail),
+            ) {
+                if !left_subject.is_empty() && !right_subject.is_empty() {
+                    merged.push(format!(
+                        "{left_subject} creatures and {right_subject} creatures can't block this turn"
+                    ));
+                    idx += 2;
+                    continue;
+                }
             }
         }
         merged.push(lines[idx].clone());


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Flash of Defiance
Initial parse error:
```
unsupported cant clause segment (clause: 'white creatures can't block this turn'); oracle-only fallback also failed: unsupported cant clause segment (clause: 'white creatures can't block this turn')
```

Worker: i-054fe92e2f889ec3b
