### PR TITLE
Fix Ironsmith parse failure: Glowering Rogon

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -675,10 +675,16 @@ impl CardDefinitionBuilder {
     }
 
     pub fn amplify(self, amount: u32) -> Self {
-        self.with_ability(crate::ability::Ability::triggered(
-            crate::triggers::Trigger::this_enters_battlefield(),
-            vec![crate::effect::Effect::amplify(amount)],
-        ))
+        self.with_ability(crate::ability::Ability {
+            kind: crate::ability::AbilityKind::Triggered(crate::ability::TriggeredAbility {
+                trigger: crate::triggers::Trigger::this_enters_battlefield(),
+                effects: vec![crate::effect::Effect::amplify(amount)].into(),
+                choices: vec![],
+                intervening_if: None,
+                presentation_label: Some(format!("keyword:amplify {amount}")),
+            }),
+            functional_zones: vec![crate::zone::Zone::Battlefield],
+        })
     }
 
     pub fn devour(self, multiplier: u32) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -3025,10 +3025,16 @@ impl CardDefinitionBuilder {
     /// that share a creature type with it. This creature enters with N times that many
     /// +1/+1 counters on it."
     pub fn amplify(self, amount: u32) -> Self {
-        self.with_ability(Ability::triggered(
-            Trigger::this_enters_battlefield(),
-            vec![Effect::amplify(amount)],
-        ))
+        self.with_ability(Ability {
+            kind: AbilityKind::Triggered(TriggeredAbility {
+                trigger: Trigger::this_enters_battlefield(),
+                effects: vec![Effect::amplify(amount)].into(),
+                choices: vec![],
+                intervening_if: None,
+                presentation_label: Some(format!("keyword:amplify {amount}")),
+            }),
+            functional_zones: vec![Zone::Battlefield],
+        })
     }
 
     /// Add ravenous.

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32342,6 +32342,20 @@ fn vote_regression_truth_or_consequences_keeps_random_choice_before_consequences
 }
 
 #[test]
+fn amplify_regression_glowering_rogon_renders_keyword_without_unsupported_placeholder() {
+    let def = parse_oracle_card_definition("Glowering Rogon");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Amplify 1"),
+        "expected Glowering Rogon to render amplify keyword, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported effect"),
+        "expected Glowering Rogon to avoid unsupported placeholder, got {rendered}"
+    );
+}
+
+#[test]
 fn vote_regression_elrond_preserves_voter_choice_branch_and_owner_attack_restriction() {
     let def = parse_oracle_card_definition("Elrond of the White Council");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28896,6 +28896,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     {
         return "Evolve".to_string();
     }
+    if let Some(amplify) = effect.downcast_ref::<crate::effects::AmplifyEffect>() {
+        return format!("Amplify {}", amplify.amount);
+    }
     if let Some(devour) = effect.downcast_ref::<crate::effects::DevourEffect>() {
         return format!("Devour {}", devour.multiplier);
     }
@@ -29977,6 +29980,11 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
         return Some(afflict);
     }
     if let AbilityKind::Triggered(triggered) = &ability.kind
+        && let Some(amplify) = describe_structural_amplify_keyword(triggered)
+    {
+        return Some(amplify);
+    }
+    if let AbilityKind::Triggered(triggered) = &ability.kind
         && let Some(devour) = describe_structural_devour_keyword(triggered)
     {
         return Some(devour);
@@ -31039,6 +31047,29 @@ fn describe_structural_devour_keyword(
     };
     let devour = effect.downcast_ref::<crate::effects::DevourEffect>()?;
     Some(format!("Devour {}", devour.multiplier))
+}
+
+fn describe_structural_amplify_keyword(
+    triggered: &crate::ability::TriggeredAbility,
+) -> Option<String> {
+    if !triggered
+        .presentation_label
+        .as_deref()
+        .is_some_and(|label| label.starts_with("keyword:amplify"))
+    {
+        return None;
+    }
+    if triggered.intervening_if.is_some()
+        || !triggered.choices.is_empty()
+        || !trigger_is_this_enters_battlefield(&triggered.trigger)
+    {
+        return None;
+    }
+    let [effect] = triggered.effects.flattened_default_effects() else {
+        return None;
+    };
+    let amplify = effect.downcast_ref::<crate::effects::AmplifyEffect>()?;
+    Some(format!("Amplify {}", amplify.amount))
 }
 
 fn describe_structural_mentor_keyword(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Glowering Rogon
Initial parse error:
```
generated definition still contains unimplemented content
```

Worker: i-09c74451262daaa51
