### PR TITLE
Fix Ironsmith parse failure: Keeper of the Lens

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -38,7 +38,9 @@ use super::grammar::abilities::{
     is_shuffle_into_library_from_graveyard_line_lexed, is_skulk_rules_text_line_lexed,
     is_this_creature_cant_attack_alone_line_lexed,
     is_this_creature_cant_attack_its_owner_line_lexed, is_this_subject_reference_lexed,
-    is_you_have_shroud_line_lexed, is_you_may_look_top_card_any_time_line_lexed,
+    is_you_have_shroud_line_lexed,
+    is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed,
+    is_you_may_look_top_card_any_time_line_lexed,
     is_your_opponents_play_with_hands_revealed_line_lexed,
     parse_activated_abilities_cant_be_activated_spec_lexed,
     parse_creatures_assign_combat_damage_using_toughness_line_lexed,
@@ -747,6 +749,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_enters_tapped_line),
         multi_static_ability_ast_rule!(parse_additional_land_play_line),
         single_static_ability_ast_rule!(parse_you_may_look_top_card_any_time_line),
+        single_static_ability_ast_rule!(
+            parse_you_may_look_face_down_creatures_you_dont_control_any_time_line
+        ),
         single_static_ability_ast_rule!(parse_players_play_top_card_libraries_revealed_line),
         single_static_ability_ast_rule!(parse_play_top_card_your_library_revealed_line),
         single_static_ability_ast_rule!(parse_your_opponents_play_with_hands_revealed_line),
@@ -6951,6 +6956,17 @@ pub(crate) fn parse_you_may_look_top_card_any_time_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     if is_you_may_look_top_card_any_time_line_lexed(tokens) {
         return Ok(Some(StaticAbility::look_at_top_card_of_library()));
+    }
+    Ok(None)
+}
+
+pub(crate) fn parse_you_may_look_face_down_creatures_you_dont_control_any_time_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::look_at_face_down_creatures_you_dont_control_any_time(),
+        ));
     }
     Ok(None)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -1,11 +1,13 @@
 use super::line_family_handlers::{
     run_activation_line_family, run_champion_line_family,
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
-    run_combined_static_line_family, run_keyword_line_family, run_labeled_line_family,
-    run_learn_line_family, run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
-    run_start_your_engines_line_family, run_statement_line_family, run_statement_probe_line_family,
-    run_static_line_family, run_station_line_family, run_station_threshold_line_family,
-    run_trailing_keyword_activation_line_family, run_triggered_line_family,
+    run_combined_static_line_family, run_face_down_look_any_time_line_family,
+    run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
+    run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
+    run_start_your_engines_line_family, run_statement_line_family,
+    run_statement_probe_line_family, run_static_line_family, run_station_line_family,
+    run_station_threshold_line_family, run_trailing_keyword_activation_line_family,
+    run_triggered_line_family,
     run_unsupported_line_family, run_ward_or_echo_static_prefix_line_family,
 };
 use super::*;
@@ -43,7 +45,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 19] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -133,6 +135,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 19] = [
         priority: 70,
         heads: &["as", "if"],
         run: run_combined_static_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "face-down-look-any-time",
+        priority: 75,
+        heads: &["you"],
+        run: run_face_down_look_any_time_line_family,
     },
     LineFamilyRuleDef {
         id: "statement-probe",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -569,6 +569,27 @@ pub(super) fn run_combined_static_line_family(
     }))
 }
 
+pub(super) fn run_face_down_look_any_time_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    if ctx.line.info.normalized.normalized.as_str()
+        != "you may look at face-down creatures you don't control any time."
+    {
+        return Ok(None);
+    }
+
+    let Some(static_line) = parse_static_line_cst(ctx.line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower face-down look static line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Static(static_line),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_statement_probe_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2551,6 +2551,39 @@ pub(crate) fn is_you_may_look_top_card_any_time_line_lexed(tokens: &[OwnedLexTok
     )
 }
 
+pub(crate) fn is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    matches_any_exact_phrase_line_lexed(
+        tokens,
+        &[&[
+            "you",
+            "may",
+            "look",
+            "at",
+            "face-down",
+            "creatures",
+            "you",
+            "dont",
+            "control",
+            "any",
+            "time",
+        ], &[
+            "you",
+            "may",
+            "look",
+            "at",
+            "face-down",
+            "creatures",
+            "you",
+            "don't",
+            "control",
+            "any",
+            "time",
+        ]],
+    )
+}
+
 pub(crate) fn is_players_play_top_card_libraries_revealed_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7769,6 +7769,12 @@ fn rewrite_grammar_exact_permission_static_line_probes_match_keyword_static_shap
             crate::static_abilities::StaticAbilityId::LookAtTopCardOfLibrary,
         ),
         (
+            "You may look at face-down creatures you don't control any time.",
+            super::grammar::abilities::is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed as Probe,
+            super::keyword_static::parse_you_may_look_face_down_creatures_you_dont_control_any_time_line as Parser,
+            crate::static_abilities::StaticAbilityId::LookAtFaceDownCreaturesYouDontControlAnyTime,
+        ),
+        (
             "Players play with the top card of their libraries revealed.",
             super::grammar::abilities::is_players_play_top_card_libraries_revealed_line_lexed
                 as Probe,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -197,6 +197,7 @@ pub enum StaticAbilityId {
     MaximumHandSizeSevenMinusYourGraveyardCardTypes,
     RevealFirstCardYouDrawEachTurn,
     LookAtTopCardOfLibrary,
+    LookAtFaceDownCreaturesYouDontControlAnyTime,
     AllPlayersLookAtTopCardsOfLibraries,
     AllPlayersLookAtYourTopLibraryCard,
     OpponentsPlayWithHandsRevealed,
@@ -431,6 +432,7 @@ impl StaticAbilityId {
             | MaximumHandSizeSevenMinusYourGraveyardCardTypes
             | RevealFirstCardYouDrawEachTurn
             | LookAtTopCardOfLibrary
+            | LookAtFaceDownCreaturesYouDontControlAnyTime
             | AllPlayersLookAtTopCardsOfLibraries
             | AllPlayersLookAtYourTopLibraryCard
             | OpponentsPlayWithHandsRevealed

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3041,6 +3041,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn look_at_face_down_creatures_you_dont_control_any_time() -> Self {
+        Self {
+            id: Some(StaticAbilityId::LookAtFaceDownCreaturesYouDontControlAnyTime),
+            label: "You may look at face-down creatures you don't control any time.".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn all_players_look_at_top_cards_of_libraries() -> Self {
         Self {
             id: Some(StaticAbilityId::AllPlayersLookAtTopCardsOfLibraries),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -27105,6 +27105,23 @@ fn parse_face_down_static_anthem_filter() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_you_may_look_at_face_down_creatures_you_dont_control_any_time() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Keeper of the Lens Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text("You may look at face-down creatures you don't control any time.")
+        .expect("face-down visibility static line should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("you may look at face-down creatures you don't control any time"),
+        "expected face-down visibility line to be preserved, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_player_sacrifices_trigger_preserves_another_qualifier() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Furnace Celebration Variant")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -180,6 +180,9 @@ impl StaticAbility {
                 Self::exile_would_die_instead(crate::target::ObjectFilter::creature())
             }
             Some(StaticAbilityId::LookAtTopCardOfLibrary) => Self::look_at_top_card_of_library(),
+            Some(StaticAbilityId::LookAtFaceDownCreaturesYouDontControlAnyTime) => {
+                Self::look_at_face_down_creatures_you_dont_control_any_time()
+            }
             Some(StaticAbilityId::AllPlayersLookAtTopCardsOfLibraries) => {
                 Self::all_players_look_at_top_cards_of_libraries()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -4364,6 +4364,20 @@ impl StaticAbilityKind for LookAtTopCardOfLibrary {
     }
 }
 
+/// Allows a player to continuously see face-down creatures they do not control.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookAtFaceDownCreaturesYouDontControlAnyTime;
+
+impl StaticAbilityKind for LookAtFaceDownCreaturesYouDontControlAnyTime {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::LookAtFaceDownCreaturesYouDontControlAnyTime
+    }
+
+    fn display(&self) -> String {
+        "You may look at face-down creatures you don't control any time.".to_string()
+    }
+}
+
 /// Allows every player to continuously see the top card of every library.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AllPlayersLookAtTopCardsOfLibraries;
@@ -4912,6 +4926,19 @@ mod tests {
         assert_eq!(
             ability.display(),
             "You may look at the top card of your library any time."
+        );
+    }
+
+    #[test]
+    fn test_look_at_face_down_creatures_you_dont_control_any_time() {
+        let ability = LookAtFaceDownCreaturesYouDontControlAnyTime;
+        assert_eq!(
+            ability.id(),
+            StaticAbilityId::LookAtFaceDownCreaturesYouDontControlAnyTime
+        );
+        assert_eq!(
+            ability.display(),
+            "You may look at face-down creatures you don't control any time."
         );
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2834,6 +2834,10 @@ impl StaticAbility {
         Self::new(LookAtTopCardOfLibrary)
     }
 
+    pub fn look_at_face_down_creatures_you_dont_control_any_time() -> Self {
+        Self::new(LookAtFaceDownCreaturesYouDontControlAnyTime)
+    }
+
     pub fn all_players_look_at_top_cards_of_libraries() -> Self {
         Self::new(AllPlayersLookAtTopCardsOfLibraries)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Keeper of the Lens
Initial parse error:
```
parser does not yet support line family: 'You may look at face-down creatures you don't control any time.'; oracle-only fallback also failed: parser does not yet support line family: 'You may look at face-down creatures you don't control any time.'
```

Worker: i-06de1fae017d94bd0
