### PR TITLE
Fix Ironsmith parse failure: Behold the Unspeakable // Vision of the Unspeakable

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1662,7 +1662,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
-        && filtered.get(subject_len).copied() == Some("has")
+        && matches!(filtered.get(subject_len).copied(), Some("has" | "have"))
         && let Some(count_word) = filtered.get(subject_len + 1).copied()
         && let Some(count) = parse_named_number(count_word)
         && filtered.get(subject_len + 2).copied() == Some("or")

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1251,6 +1251,21 @@ fn rewrite_structure_predicate_parse_entrypoint_matches_parser_root_output_for_c
 }
 
 #[test]
+fn rewrite_structure_predicate_parses_you_have_one_or_fewer_cards_in_hand() {
+    let text = "you have one or fewer cards in hand";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify predicate text");
+
+    let predicate =
+        super::parse_predicate_lexed(&lexed).expect("predicate should parse for you-have subject");
+    let debug = format!("{predicate:?}");
+
+    assert!(
+        debug.contains("PlayerCardsInHandOrFewer"),
+        "expected cards-in-hand threshold predicate, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_structure_if_tail_parser_extracts_predicate() {
     let tokens = lex_line("if it's white", 0).expect("rewrite lexer should classify if tail");
     let predicate = super::grammar::structure::parse_trailing_if_predicate_lexed(&tokens)

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10040,12 +10040,20 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::LifeTotalOrGreater(n) => format!("your life total is {n} or greater"),
         Condition::CardsInHandOrMore(n) => format!("you have {n} or more cards in hand"),
         Condition::PlayerCardsInHandOrMore { player, count } => {
-            format!("{} has {} or more cards in hand", describe_player_filter(player), count)
+            let subject = describe_player_filter(player);
+            format!(
+                "{} {} {} or more cards in hand",
+                subject,
+                player_verb(&subject, "have", "has"),
+                count
+            )
         }
         Condition::PlayerCardsInHandOrFewer { player, count } => {
+            let subject = describe_player_filter(player);
             format!(
-                "{} has {} or fewer cards in hand",
-                describe_player_filter(player),
+                "{} {} {} or fewer cards in hand",
+                subject,
+                player_verb(&subject, "have", "has"),
                 count
             )
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Behold the Unspeakable // Vision of the Unspeakable
Initial parse error:
```
unsupported predicate (predicate: 'you have one or fewer cards in hand'); oracle-only fallback also failed: unsupported predicate (predicate: 'you have one or fewer cards in hand')
```

Worker: i-004600f0258160692
