### PR TITLE
Fix Ironsmith parse failure: Oviya, Automech Artisan

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -299,6 +299,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_object_filter_lexed_handles_attacking_one_of_your_opponents_clause() {
+        let tokens = lex_line("creature attacking one of your opponents", 0).unwrap();
+
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.card_types, vec![CardType::Creature]);
+        assert_eq!(
+            filter.attacking_player_or_planeswalker_controlled_by,
+            Some(PlayerFilter::Opponent)
+        );
+    }
+
+    #[test]
     fn temporal_graveyard_from_battlefield_phrase_parser_matches() {
         assert_eq!(
             parse_graveyard_from_battlefield_this_turn_words(&[

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
@@ -771,6 +771,9 @@ pub(super) fn attacking_player_filter_from_words(
     ) {
         return Some(PlayerFilter::Opponent);
     }
+    if contains_any_filter_phrase(words, &[&["attacking", "one", "of", "your", "opponents"]]) {
+        return Some(PlayerFilter::Opponent);
+    }
 
     None
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10415,6 +10415,30 @@ fn search_reveal_named_card_branch_moves_the_searched_card() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn if_you_put_artifact_this_way_does_not_leak_tagged_object_markers() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Oviya Automech Probe")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. \
+             If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
+        )
+        .expect("parse oviya-like activated line");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("if you put an artifact this way, put two +1/+1 counters on it"),
+        "expected moved-tag conditional to render as put-this-way text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("tagged object") && !rendered.contains("tagged '"),
+        "expected compiled text to avoid internal tag references, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_if_you_do_still_wraps_antecedent_with_with_id() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "If You Do Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9356,6 +9356,7 @@ pub(super) fn tag_action_from_name(tag: &str) -> Option<&'static str> {
         "discarded" => Some("discarded"),
         "died" => Some("died"),
         "milled" => Some("milled"),
+        "moved" => Some("put"),
         _ => None,
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Oviya, Automech Artisan
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Worker: i-0760d07175c4186a4
