### PR TITLE
Fix Ironsmith parse failure: Vela the Night-Clad

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -902,6 +902,65 @@ pub(crate) fn parse_trigger_clause_lexed(
         return Ok(TriggerSpec::ThisLeavesBattlefield);
     }
 
+    if let Some(leaves_word_idx) =
+        find_index(&words, |word| *word == "leaves" || *word == "leave")
+        && words.get(leaves_word_idx + 1).copied() == Some("the")
+        && words.get(leaves_word_idx + 2).copied() == Some("battlefield")
+    {
+        let leaves_token_idx = word_view
+            .token_index_for_word_index(leaves_word_idx)
+            .unwrap_or(tokens.len());
+        let subject_tokens = &tokens[..leaves_token_idx];
+
+        if let Some(or_idx) = find_index(subject_tokens, |token: &OwnedLexToken| token.is_word("or"))
+        {
+            let left_tokens = &subject_tokens[..or_idx];
+            let mut right_tokens = &subject_tokens[or_idx + 1..];
+            let left_words = ActivationRestrictionCompatWords::new(left_tokens)
+                .to_word_refs()
+                .into_iter()
+                .filter(|word| !is_article(word))
+                .collect::<Vec<_>>();
+            if is_source_reference_words(&left_words) && !right_tokens.is_empty() {
+                let mut other = false;
+                if right_tokens
+                    .first()
+                    .is_some_and(|token| token.is_word("another") || token.is_word("other"))
+                {
+                    other = true;
+                    right_tokens = &right_tokens[1..];
+                }
+                let parsed_filter = parse_object_filter_lexed(right_tokens, other)
+                    .ok()
+                    .or_else(|| parse_subtype_list_enters_trigger_filter_lexed(right_tokens, other));
+                if let Some(filter) = parsed_filter {
+                    return Ok(TriggerSpec::Either(
+                        Box::new(TriggerSpec::ThisLeavesBattlefield),
+                        Box::new(TriggerSpec::LeavesBattlefield(filter)),
+                    ));
+                }
+            }
+        }
+
+        let mut filtered_subject_tokens = subject_tokens;
+        let mut other = false;
+        if filtered_subject_tokens
+            .first()
+            .is_some_and(|token| token.is_word("another") || token.is_word("other"))
+        {
+            other = true;
+            filtered_subject_tokens = &filtered_subject_tokens[1..];
+        }
+        let parsed_filter = parse_object_filter_lexed(filtered_subject_tokens, other)
+            .ok()
+            .or_else(|| {
+                parse_subtype_list_enters_trigger_filter_lexed(filtered_subject_tokens, other)
+            });
+        if let Some(filter) = parsed_filter {
+            return Ok(TriggerSpec::LeavesBattlefield(filter));
+        }
+    }
+
     if let Some(dies_word_idx) = find_index(&words, |word| *word == "dies" || *word == "die") {
         let dies_token_idx = word_view
             .token_index_for_word_index(dies_word_idx)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -166,6 +166,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::PlayerSacrifices { player, filter } => {
             Trigger::player_sacrifices(player, filter)
         }
+        TriggerSpec::LeavesBattlefield(filter) => Trigger::leaves_battlefield(filter),
         TriggerSpec::Dies(filter) => Trigger::dies(filter),
         TriggerSpec::DiesOneOrMore(filter) => Trigger::new(
             crate::triggers::zone_changes::ZoneChangeTrigger::new()

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -220,6 +220,7 @@ pub(crate) enum TriggerSpec {
         player: PlayerFilter,
         filter: ObjectFilter,
     },
+    LeavesBattlefield(ObjectFilter),
     Dies(ObjectFilter),
     DiesOneOrMore(ObjectFilter),
     HauntedCreatureDies,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8925,6 +8925,23 @@ fn rewrite_lexed_triggered_line_supports_leave_battlefield_sacrifice_all_non_ogr
 }
 
 #[test]
+fn rewrite_lexed_triggered_line_supports_this_or_another_leaves_battlefield() {
+    let tokens = lex_line(
+        "Whenever this creature or another creature you control leaves the battlefield, each opponent loses 1 life.",
+        0,
+    )
+    .expect("rewrite lexer should classify source-or-another leaves trigger");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("source-or-another leaves trigger should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("ThisLeavesBattlefield"), "{debug}");
+    assert!(debug.contains("LeavesBattlefield"), "{debug}");
+    assert!(debug.contains("LoseLife"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_swindlers_scheme_trigger_keeps_opponent_hand_reveal_and_followup_cast() {
     let text = "Whenever an opponent casts a spell from their hand, you may reveal the top card of your library. If it shares a card type with that spell, counter that spell and that opponent may cast the revealed card without paying its mana cost.";
     let tokens = lex_line(text, 0).expect("rewrite lexer should classify Swindler's Scheme");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -4538,6 +4538,16 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     {
         return format!("Whenever this or another {rest}");
     }
+    if let Some(rest) = normalized.strip_prefix("When this creature leaves the battlefield or another ")
+        && rest.contains(" leaves the battlefield")
+    {
+        return format!("Whenever this creature or another {rest}");
+    }
+    if let Some(rest) = normalized.strip_prefix("When this leaves the battlefield or another ")
+        && rest.contains(" leaves the battlefield")
+    {
+        return format!("Whenever this or another {rest}");
+    }
     if let Some((left, right)) = normalized.split_once(" or Whenever another ") {
         if left.starts_with("Whenever ") {
             return format!("{left} or another {right}");
@@ -4552,6 +4562,17 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
         return format!("Whenever this creature or another {rest}");
     }
     if let Some(rest) = lower.strip_prefix("whenever this or whenever another ") {
+        return format!("Whenever this or another {rest}");
+    }
+    if let Some(rest) =
+        lower.strip_prefix("when this creature leaves the battlefield or another ")
+        && rest.contains(" leaves the battlefield")
+    {
+        return format!("Whenever this creature or another {rest}");
+    }
+    if let Some(rest) = lower.strip_prefix("when this leaves the battlefield or another ")
+        && rest.contains(" leaves the battlefield")
+    {
         return format!("Whenever this or another {rest}");
     }
     if let Some(rest) = normalized


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vela the Night-Clad
Initial parse error:
```
unsupported triggered line: 'Whenever Vela or another creature you control leaves the battlefield, each opponent loses 1 life.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever Vela or another creature you control leaves the battlefield, each opponent loses 1 life.'
```

Worker: i-083e353b3c41a8693
