### PR TITLE
Fix Ironsmith parse failure: Surge to Victory

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -58,6 +58,13 @@ fn compile_delayed_trigger_spec(
         TriggerSpec::Dies(filter) | TriggerSpec::DiesOneOrMore(filter) => {
             Ok(ironsmith_core::DelayedTriggerSpec::Dies(filter.clone()))
         }
+        TriggerSpec::DealsCombatDamageToPlayer { source, player }
+        | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { source, player } => {
+            Ok(ironsmith_core::DelayedTriggerSpec::DealsCombatDamageToPlayer {
+                source: source.clone(),
+                player: player.clone(),
+            })
+        }
         TriggerSpec::SpellCast {
             filter,
             caster,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9800,6 +9800,25 @@ fn rewrite_lowered_intervening_counter_gate_binds_destroy_to_gate_filter()
 }
 
 #[test]
+fn rewrite_lowered_delayed_combat_damage_player_trigger_this_turn_compiles() -> Result<(), CardTextError>
+{
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Delayed Combat Trigger")
+        .card_types(vec![CardType::Sorcery]);
+    let (definition, _) = parse_text_with_annotations_lowered(
+        builder,
+        "This turn, whenever a creature you control deals combat damage to a player, draw a card."
+            .to_string(),
+        false,
+    )?;
+    let debug = format!("{definition:#?}");
+
+    assert!(debug.contains("ScheduleDelayedTriggerEffect"), "{debug}");
+    assert!(debug.contains("DealsCombatDamageToPlayer"), "{debug}");
+    assert!(debug.contains("DrawCardsEffect"), "{debug}");
+    Ok(())
+}
+
+#[test]
 fn rewrite_sequence_registry_matches_consult_cast_bottom_bundle() {
     let sentences = registry_sentence_inputs(
         "Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Put all cards exiled this way that weren't cast this way on the bottom of your library in a random order.",

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -136,6 +136,10 @@ pub enum DelayedTriggerSpec {
     AttacksOneOrMore(ObjectFilter),
     Blocks(ObjectFilter),
     Dies(ObjectFilter),
+    DealsCombatDamageToPlayer {
+        source: ObjectFilter,
+        player: PlayerFilter,
+    },
     IsDealtDamage(ChooseSpec),
     PutIntoGraveyard(ObjectFilter),
     PutIntoGraveyardFromZone {

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -439,6 +439,9 @@ impl super::Trigger {
             }
             ironsmith_core::DelayedTriggerSpec::Blocks(filter) => Self::blocks(filter),
             ironsmith_core::DelayedTriggerSpec::Dies(filter) => Self::dies(filter),
+            ironsmith_core::DelayedTriggerSpec::DealsCombatDamageToPlayer { source, player } => {
+                Self::deals_combat_damage_to_player(source, player)
+            }
             ironsmith_core::DelayedTriggerSpec::IsDealtDamage(target) => {
                 Self::is_dealt_damage(target)
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Surge to Victory
Initial parse error:
```
unsupported delayed trigger spec: DealsCombatDamageToPlayer { source: ObjectFilter { zone: Some(Battlefield), controller: Some(You), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }, player: Any }; oracle-only fallback also failed: unsupported delayed trigger spec: DealsCombatDamageToPlayer { source: ObjectFilter { zone: Some(Battlefield), controller: Some(You), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }, player: Any }
```

Worker: i-080c9adf3e99b4f74
