### PR TITLE
Fix Ironsmith parse failure: Feed the Swarm

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1769,6 +1769,12 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         &["that", "spell", "mana", "value"],
         &["that", "spell's", "mana", "value"],
         &["that", "spells", "mana", "value"],
+        &["that", "permanent", "mana", "value"],
+        &["that", "permanent's", "mana", "value"],
+        &["that", "permanents", "mana", "value"],
+        &["that", "object", "mana", "value"],
+        &["that", "object's", "mana", "value"],
+        &["that", "objects", "mana", "value"],
     ]) {
         return Some((
             Value::ManaValueOf(Box::new(ChooseSpec::Tagged(TagKey::from(IT_TAG)))),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5491,6 +5491,26 @@ fn incubate_its_controller_binds_controller_and_mana_value() {
 }
 
 #[test]
+fn destroy_target_nonland_permanent_with_life_equal_to_mana_value_parses() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Feed the Swarm Variant")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Destroy target creature or enchantment an opponent controls. You lose life equal to that permanent's mana value.",
+        )
+        .expect("life-loss equal to that permanent's mana value should parse");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("DestroyEffect")
+            && debug.contains("LoseLifeEffect")
+            && debug.contains("ManaValueOf")
+            && debug.contains("Tagged")
+            && debug.contains("it"),
+        "expected lose-life amount to use the destroyed permanent's mana value, got {debug}"
+    );
+}
+
+#[test]
 fn equal_to_dynamic_token_count_can_use_opponent_count() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Opponent Count Token Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -174,6 +174,22 @@ fn finalize_ast_surface_line(line: String) -> String {
         "Target creature or planeswalker an opponent controls",
     );
     line = line.replace(
+        "target creature an opponent controls or enchantment",
+        "target creature or enchantment an opponent controls",
+    );
+    line = line.replace(
+        "Target creature an opponent controls or enchantment",
+        "Target creature or enchantment an opponent controls",
+    );
+    line = line.replace(
+        "lose life equal to its mana value",
+        "lose life equal to that permanent's mana value",
+    );
+    line = line.replace(
+        "Lose life equal to its mana value",
+        "Lose life equal to that permanent's mana value",
+    );
+    line = line.replace(
         "At the beginning of the next end step, you lose 1 life. Return this card to its owner's hand",
         "At the beginning of the next end step, you lose 1 life and return this card to your hand",
     );
@@ -743,6 +759,24 @@ mod tests {
                     .to_string()
             ),
             "When an opponent casts a spell, sacrifice this enchantment and counter that spell."
+        );
+    }
+
+    #[test]
+    fn target_type_disjunction_keeps_shared_opponent_controller_clause() {
+        assert_eq!(
+            finalize_ast_surface_line(
+                "Destroy target creature an opponent controls or enchantment".to_string()
+            ),
+            "Destroy target creature or enchantment an opponent controls."
+        );
+    }
+
+    #[test]
+    fn life_loss_mana_value_uses_that_permanent_surface() {
+        assert_eq!(
+            finalize_ast_surface_line("You lose life equal to its mana value".to_string()),
+            "You lose life equal to that permanent's mana value."
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Feed the Swarm
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to that permanent's mana value'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to that permanent's mana value')
```

Worker: i-0ce5e72655419f53e
