### PR TITLE
Fix Ironsmith parse failure: Repel the Abominable

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1178,6 +1178,18 @@ impl Effect {
         ))
     }
 
+    pub fn prevent_all_damage_from_filter(
+        source_filter: crate::target::ObjectFilter,
+        until: Until,
+    ) -> Self {
+        let mut damage_filter = ironsmith_core::DamageFilter::all();
+        damage_filter.from_source = Some(source_filter);
+        Self::new(crate::effects::PreventAllDamageEffect::all_with_filter(
+            damage_filter,
+            until,
+        ))
+    }
+
     pub fn gain_life(amount: impl Into<Value>) -> Self {
         Self::new(crate::effects::GainLifeEffect::new(
             amount.into(),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1485,6 +1485,19 @@ fn compile_subject_verb_effect(
                 })
             }
         }
+        SubjectVerbActionAst::PreventAllDamageFromSourceFilter {
+            duration,
+            source_filter,
+        } => {
+            let source_filter = resolve_it_tag(source_filter, &current_reference_env(ctx))?;
+            Ok((
+                vec![Effect::prevent_all_damage_from_filter(
+                    source_filter,
+                    duration.clone(),
+                )],
+                Vec::new(),
+            ))
+        }
         SubjectVerbActionAst::PreventDamageToTargetPutCounters {
             amount,
             target,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -666,6 +666,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::PreventNextTimeDamage { .. }
         | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
         | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+        | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
         | SubjectVerbActionAst::PreventDamageToTargetPutCounters { .. }
         | SubjectVerbActionAst::PutOrRemoveCounters { .. }
         | SubjectVerbActionAst::CopySpellForEachTarget { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -932,6 +932,10 @@ pub(crate) enum SubjectVerbActionAst {
         target: TargetAst,
         duration: Until,
     },
+    PreventAllDamageFromSourceFilter {
+        duration: Until,
+        source_filter: ObjectFilter,
+    },
     PreventDamageToTargetPutCounters {
         amount: Option<Value>,
         target: TargetAst,
@@ -2016,6 +2020,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("PreventAllDamageToTarget")
                 .field("target", target)
                 .field("duration", duration)
+                .finish(),
+            Self::PreventAllDamageFromSourceFilter {
+                duration,
+                source_filter,
+            } => f
+                .debug_struct("PreventAllDamageFromSourceFilter")
+                .field("duration", duration)
+                .field("source_filter", source_filter)
                 .finish(),
             Self::PreventDamageToTargetPutCounters {
                 amount,
@@ -3327,6 +3339,20 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::PreventAllDamageToTarget { target, duration },
+        )
+    }
+
+    pub(crate) fn subject_verb_prevent_all_damage_from_source_filter(
+        source_filter: ObjectFilter,
+        duration: Until,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::PreventAllDamageFromSourceFilter {
+                duration,
+                source_filter,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -420,6 +420,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+            | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { amount: None, .. }
             | SubjectVerbActionAst::Meld { .. }
             | SubjectVerbActionAst::SearchLibrarySlotsToHand { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1686,6 +1686,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+            | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { amount: None, .. }
             | SubjectVerbActionAst::Meld { .. }
             | SubjectVerbActionAst::SearchLibrarySlotsToHand { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -975,10 +975,46 @@ pub(crate) fn parse_prevent_all_damage_clause(
     let prefix_duration_then_target = [
         "prevent", "all", "damage", "that", "would", "be", "dealt", "this", "turn", "to",
     ];
+    let prefix_duration_then_source = [
+        "prevent", "all", "damage", "that", "would", "be", "dealt", "this", "turn", "by",
+    ];
     if !word_slice_starts_with(&clause_words, &prefix_target_then_duration)
         && !word_slice_starts_with(&clause_words, &prefix_duration_then_target)
+        && !word_slice_starts_with(&clause_words, &prefix_duration_then_source)
     {
         return Ok(None);
+    }
+    if word_slice_starts_with(&clause_words, &prefix_duration_then_source) {
+        let source_words = &clause_words[prefix_duration_then_source.len()..];
+        if source_words.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing prevent-all damage source filter (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+        if source_words.last().copied() != Some("sources") {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported prevent-all damage source phrase (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+        let source_filter_tokens = source_words[..source_words.len() - 1]
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        let source_filter_target = parse_target_phrase(&source_filter_tokens)?;
+        let TargetAst::Object(source_filter, _, _) = source_filter_target else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported prevent-all damage source filter target (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        };
+        return Ok(Some(
+            EffectAst::subject_verb_prevent_all_damage_from_source_filter(
+                source_filter,
+                Until::EndOfTurn,
+            ),
+        ));
     }
     let target_words = if word_slice_starts_with(&clause_words, &prefix_duration_then_target) {
         &clause_words[prefix_duration_then_target.len()..]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2433,6 +2433,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+            | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { amount: None, .. }
             | SubjectVerbActionAst::Meld { .. }
             | SubjectVerbActionAst::SearchLibrarySlotsToHand { .. }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7884,6 +7884,24 @@ fn test_parse_prevent_all_damage_to_explicit_target_stays_targeted() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_prevent_all_damage_from_non_human_sources_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Repel Probe")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Prevent all damage that would be dealt this turn by non-Human sources.")
+        .expect("prevent-all damage from source filter clause should parse");
+
+    let spell_debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        spell_debug.contains("preventalldamageeffect")
+            && spell_debug.contains("from_source")
+            && spell_debug.contains("excluded_subtypes")
+            && spell_debug.contains("human"),
+        "expected non-Human source-filter prevent-all-damage effect, got {spell_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_cant_be_blocked_as_long_as_defending_player_controls_artifact_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Bouncing Beebles Probe")
         .card_types(vec![CardType::Creature])
@@ -29722,6 +29740,35 @@ fn parse_oracle_liquimetal_coating_type_addition_render_regression() {
     assert!(
         !rendered.contains("unsupported effect"),
         "expected Liquimetal Coating to avoid unsupported markers, got {rendered}"
+    );
+}
+
+#[test]
+fn parse_oracle_repel_the_abominable_prevention_regression() {
+    let def = parse_oracle_card_definition("Repel the Abominable");
+
+    let raw = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        raw.contains("preventalldamageeffect")
+            && raw.contains("from_source")
+            && raw.contains("excluded_subtypes")
+            && raw.contains("human"),
+        "expected Repel the Abominable to keep a non-Human source damage filter, got {raw}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("prevent all damage")
+            && rendered.contains("that would be dealt this turn")
+            && rendered.contains("non-human")
+            && rendered.contains("sources"),
+        "expected Repel the Abominable prevention wording, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported"),
+        "expected Repel the Abominable to avoid unsupported markers, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9028,7 +9028,11 @@ pub(super) fn describe_damage_filter(filter: &crate::prevention::DamageFilter) -
     }
 
     if let Some(source_filter) = &filter.from_source {
-        parts.push(format!("from {}", source_filter.description()));
+        let mut source_text = source_filter.description();
+        if let Some(stripped) = source_text.strip_suffix(" permanent") {
+            source_text = stripped.to_string();
+        }
+        parts.push(format!("from {source_text} sources"));
     }
     if let Some(source_types) = &filter.from_card_types
         && !source_types.is_empty()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28532,6 +28532,15 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 protected
             );
         }
+        if matches!(prevent_all.until, Until::EndOfTurn) {
+            if matches!(prevent_all.target, crate::prevention::PreventionTarget::All) {
+                return format!("Prevent {damage_type} that would be dealt this turn");
+            }
+            return format!(
+                "Prevent {damage_type} that would be dealt to {} this turn",
+                protected
+            );
+        }
         if matches!(prevent_all.target, crate::prevention::PreventionTarget::All) {
             return format!(
                 "Prevent {} {}",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Repel the Abominable
Initial parse error:
```
parser does not yet support line family: 'Prevent all damage that would be dealt this turn by non-Human sources.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all damage that would be dealt this turn by non-Human sources.'
```

Worker: i-015b3b44135b6fdbd
