### PR TITLE
Fix Ironsmith parse failure: Counterpoint

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1213,6 +1213,143 @@ fn clause_is_singular_free_cast_from_hand(clause_words: &[&str]) -> bool {
         || word_slice_has_sequence(clause_words, &["cast", "one", "spell"])
 }
 
+fn parse_cast_with_tagged_mana_value_limit_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    fn parse_simple_spell_type_list_filter(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+        let mut words = token_word_refs(tokens);
+        if matches!(words.first().copied(), Some("a" | "an")) {
+            words.remove(0);
+        }
+        if matches!(words.last().copied(), Some("spell" | "spells")) {
+            words.pop();
+        }
+        if words.is_empty() {
+            return None;
+        }
+
+        let mut card_types = Vec::new();
+        for word in words {
+            let card_type = match word {
+                "or" | "and" => continue,
+                "artifact" => CardType::Artifact,
+                "battle" => CardType::Battle,
+                "creature" => CardType::Creature,
+                "enchantment" => CardType::Enchantment,
+                "instant" => CardType::Instant,
+                "land" => CardType::Land,
+                "planeswalker" => CardType::Planeswalker,
+                "sorcery" => CardType::Sorcery,
+                _ => return None,
+            };
+            if !card_types.contains(&card_type) {
+                card_types.push(card_type);
+            }
+        }
+        if card_types.is_empty() {
+            return None;
+        }
+        Some(ObjectFilter {
+            card_types,
+            ..ObjectFilter::default()
+        })
+    }
+
+    let Some((lead, rest_tokens)) = parse_permission_lead_tokens(tokens) else {
+        return Ok(None);
+    };
+    if lead.allow_land {
+        return Ok(None);
+    }
+
+    let rest_words = token_word_refs(rest_tokens);
+    let normalized_words: Vec<String> = rest_words
+        .iter()
+        .map(|word| {
+            word.to_ascii_lowercase()
+                .replace(['\'', '’'], "")
+                .to_string()
+        })
+        .collect();
+    let Some(from_idx) = normalized_words.iter().position(|word| word == "from") else {
+        return Ok(None);
+    };
+    if from_idx == 0 {
+        return Ok(None);
+    }
+
+    let expected_tail_with_split_possessive = [
+        "from",
+        "your",
+        "graveyard",
+        "with",
+        "mana",
+        "value",
+        "less",
+        "than",
+        "or",
+        "equal",
+        "to",
+        "that",
+        "spell",
+        "s",
+        "mana",
+        "value",
+        "without",
+        "paying",
+        "its",
+        "mana",
+        "cost",
+    ];
+    let expected_tail_with_word_possessive = [
+        "from",
+        "your",
+        "graveyard",
+        "with",
+        "mana",
+        "value",
+        "less",
+        "than",
+        "or",
+        "equal",
+        "to",
+        "that",
+        "spells",
+        "mana",
+        "value",
+        "without",
+        "paying",
+        "its",
+        "mana",
+        "cost",
+    ];
+    let normalized_tail = &normalized_words[from_idx..];
+    if normalized_tail != expected_tail_with_split_possessive
+        && normalized_tail != expected_tail_with_word_possessive
+    {
+        return Ok(None);
+    }
+
+    let Some(filter_end) = token_index_for_word_index(rest_tokens, from_idx) else {
+        return Ok(None);
+    };
+    let filter_tokens = trim_lexed_commas(&rest_tokens[..filter_end]);
+    let Some(mut filter) = parse_simple_spell_type_list_filter(filter_tokens)
+        .or(parse_permission_subject_filter_tokens_lexed(filter_tokens)?)
+    else {
+        return Ok(None);
+    };
+    filter.owner = Some(crate::target::PlayerFilter::You);
+    filter.tagged_constraints.push(crate::filter::TaggedObjectConstraint {
+        tag: TagKey::from(IT_TAG),
+        relation: crate::filter::TaggedOpbjectRelation::ManaValueLteTagged,
+    });
+
+    Ok(Some(
+        EffectAst::may_cast_matching_spell_without_paying_mana_cost(lead.player, filter, Zone::Graveyard),
+    ))
+}
+
 pub(crate) fn parse_cast_or_play_tagged_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
@@ -1243,6 +1380,10 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
                 spec.zone,
             ),
         ));
+    }
+
+    if let Some(effect) = parse_cast_with_tagged_mana_value_limit_clause(&trimmed)? {
+        return Ok(Some(effect));
     }
 
     let conditional_tagged_permission = parse_permission_lead_tokens(&trimmed)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -14,7 +14,8 @@ use super::super::lexer::{OwnedLexToken, TokenKind, token_word_refs, trim_lexed_
 use super::super::object_filters::parse_object_filter;
 use super::super::permission_helpers::{
     PermissionClauseSpec, PermissionLifetime, parse_additional_land_plays_clause_lexed,
-    parse_permission_clause_spec_lexed, parse_unsupported_play_cast_permission_clause_lexed,
+    parse_cast_or_play_tagged_clause, parse_permission_clause_spec_lexed,
+    parse_unsupported_play_cast_permission_clause_lexed,
 };
 use super::super::rule_engine::{LexClauseView, LexRuleDef, LexRuleIndex};
 use super::super::token_primitives::{
@@ -433,6 +434,10 @@ pub(crate) fn parse_effect_chain_lexed(
 
     if let Some(unless_action) = parse_or_action_clause_lexed(tokens)? {
         return Ok(vec![unless_action]);
+    }
+
+    if let Some(effect) = parse_cast_or_play_tagged_clause(tokens)? {
+        return Ok(vec![effect]);
     }
 
     parse_effect_chain_with_subject_verb_primitives_lexed(tokens)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -13,6 +13,7 @@ use super::super::activation_and_restrictions::{
     parse_target_player_choose_objects_clause, parse_you_choose_objects_clause,
     parse_you_choose_player_clause, starts_with_target_indicator,
 };
+use super::super::permission_helpers::parse_cast_or_play_tagged_clause;
 use super::super::grammar::primitives::{self as grammar, TokenWordView};
 use super::super::keyword_static::{
     keyword_action_to_static_ability, parse_ability_line, parse_pt_modifier,
@@ -302,6 +303,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
 
     if let Some(spec) = parse_may_cast_it_sentence(tokens) {
         return Ok(build_may_cast_tagged_effect(&spec));
+    }
+
+    if let Some(effect) = parse_cast_or_play_tagged_clause(tokens)? {
+        return Ok(effect);
     }
 
     if let Some(player) = parse_leading_player_may(tokens) {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4350,6 +4350,71 @@ fn rewrite_lexed_parse_cast_target_graveyard_without_paying_mana_cost() {
 }
 
 #[test]
+fn rewrite_lexed_parse_counterpoint_followup_clause_with_tagged_mana_value_gate() {
+    let tokens = lex_line(
+        "You may cast a creature, instant, sorcery, or planeswalker spell from your graveyard with mana value less than or equal to that spell's mana value without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify Counterpoint follow-up clause");
+
+    let token_words = crate::runtime_backend::token_word_refs(&tokens);
+    assert!(
+        super::permission_helpers::parse_cast_or_play_tagged_clause(&tokens)
+            .expect("Counterpoint follow-up clause should not throw parser errors")
+            .is_some(),
+        "expected cast/play helper to parse Counterpoint follow-up clause; words={token_words:?}"
+    );
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("Counterpoint follow-up clause should parse as a supported effect");
+
+    let (player, filter, zone) = match effects.as_slice() {
+        [crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+            player,
+            filter,
+            zone,
+        }] => (player, filter, zone),
+        [crate::cards::builders::EffectAst::MayByPlayer {
+            player: crate::cards::builders::PlayerAst::You,
+            effects,
+        }] => match effects.as_slice() {
+            [crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+                player,
+                filter,
+                zone,
+            }] => (player, filter, zone),
+            _ => panic!("expected nested free-cast effect, got {effects:#?}"),
+        },
+        _ => panic!("expected free-cast effect, got {effects:#?}"),
+    };
+
+    assert!(matches!(
+        player,
+        crate::cards::builders::PlayerAst::Implicit | crate::cards::builders::PlayerAst::You
+    ));
+    assert_eq!(*zone, crate::zone::Zone::Graveyard);
+    let has_type = |card_type: crate::types::CardType| {
+        filter.card_types.contains(&card_type)
+            || filter
+                .any_of
+                .iter()
+                .any(|branch| branch.card_types.contains(&card_type))
+    };
+    assert!(has_type(crate::types::CardType::Creature), "{filter:#?}");
+    assert!(has_type(crate::types::CardType::Instant), "{filter:#?}");
+    assert!(has_type(crate::types::CardType::Sorcery), "{filter:#?}");
+    assert!(has_type(crate::types::CardType::Planeswalker), "{filter:#?}");
+    assert!(
+        filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag == crate::cards::builders::TagKey::from(crate::cards::builders::IT_TAG)
+                && constraint.relation
+                    == crate::filter::TaggedOpbjectRelation::ManaValueLteTagged
+        }),
+        "expected mana-value-to-tagged constraint, got {filter:#?}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_play() {
     let tokens = lex_line("Until the end of your next turn, you may play that card", 0)
         .expect("rewrite lexer should classify until-next-turn permission clause");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29253,8 +29253,36 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(may_cast_matching) =
         effect.downcast_ref::<crate::effects::MayCastMatchingSpellWithoutPayingManaCostEffect>()
     {
+        fn join_with_or(items: &[String]) -> String {
+            match items.len() {
+                0 => String::new(),
+                1 => items[0].clone(),
+                2 => format!("{} or {}", items[0], items[1]),
+                _ => {
+                    let mut out = items[..items.len() - 1].join(", ");
+                    out.push_str(", or ");
+                    out.push_str(&items[items.len() - 1]);
+                    out
+                }
+            }
+        }
+
         let player = describe_player_filter(&may_cast_matching.player);
+        let has_tagged_mana_value_cap = may_cast_matching.filter.tagged_constraints.iter().any(
+            |constraint| {
+                constraint.relation == crate::filter::TaggedOpbjectRelation::ManaValueLteTagged
+            },
+        );
         let mut spell_text = describe_cast_limit_spell_filter(&may_cast_matching.filter);
+        if has_tagged_mana_value_cap && !may_cast_matching.filter.card_types.is_empty() {
+            let card_type_words: Vec<String> = may_cast_matching
+                .filter
+                .card_types
+                .iter()
+                .map(|card_type| card_type.to_string().to_ascii_lowercase())
+                .collect();
+            spell_text = format!("a {} spell", join_with_or(&card_type_words));
+        }
         if spell_text == "spell" {
             spell_text = "a spell".to_string();
         } else if !spell_text.starts_with("a ")
@@ -29268,7 +29296,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 "from {} hand",
                 describe_possessive_player_filter(&may_cast_matching.player)
             ),
-            Zone::Graveyard => "from a graveyard".to_string(),
+            Zone::Graveyard => {
+                if may_cast_matching.filter.owner == Some(crate::filter::PlayerFilter::You) {
+                    "from your graveyard".to_string()
+                } else {
+                    "from a graveyard".to_string()
+                }
+            }
             Zone::Library => "from a library".to_string(),
             Zone::Exile => "from exile".to_string(),
             Zone::Battlefield => "from the battlefield".to_string(),
@@ -29276,7 +29310,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             Zone::Command => "from the command zone".to_string(),
             Zone::OutsideGame => "from outside the game".to_string(),
         };
-        return format!("{player} may cast {spell_text} {zone_text} without paying its mana cost");
+        let mana_value_limit_text = if has_tagged_mana_value_cap {
+            " with mana value less than or equal to that spell's mana value"
+        } else {
+            ""
+        };
+        return format!(
+            "{player} may cast {spell_text} {zone_text}{mana_value_limit_text} without paying its mana cost"
+        );
     }
     if let Some(grant_next_spell_cost_reduction) =
         effect.downcast_ref::<crate::effects::GrantNextSpellCostReductionEffect>()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Counterpoint
Initial parse error:
```
could not find verb in effect clause (clause: 'cast a creature instant sorcery or planeswalker spell from your graveyard with mana value less than or equal to that spells mana value without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast a creature instant sorcery or planeswalker spell from your graveyard with mana value less than or equal to that spells mana value without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0af22f71ed7d637da
