### PR TITLE
Fix Ironsmith parse failure: Feral Encounter

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7093,6 +7093,38 @@ fn test_parse_doubling_chant_compiles_search_put_onto_battlefield_and_shuffle() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_feral_encounter_avoids_tagged_play_marker_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Feral Encounter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Look at the top five cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card this turn. At the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.",
+        )
+        .expect("feral encounter should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("you may cast that card this turn")
+            || rendered.contains("you may cast the exiled card this turn"),
+        "expected Feral Encounter cast permission text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("deals damage equal to its power to up to one target creature you don't control"),
+        "expected Feral Encounter damage text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("tagged object") && !rendered.contains("tagged '"),
+        "expected Feral Encounter to avoid internal tagged markers, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_triggered_explore_clause_without_fallback_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Explore Trigger Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -1523,7 +1523,10 @@ pub(super) fn normalize_singular_tagged_play_permission(line: &str) -> Option<St
         "looks at the top card",
     ]
     .into_iter()
-    .any(|needle| lower.contains(needle));
+    .any(|needle| lower.contains(needle))
+        || lower.contains("tagged '__source_exiled__' cards")
+        || ((lower.contains("you may exile a ") || lower.contains("you may exile an "))
+            && lower.contains(" from among them"));
     if !singular_source {
         return None;
     }
@@ -1537,6 +1540,8 @@ pub(super) fn normalize_singular_tagged_play_permission(line: &str) -> Option<St
         ("you may cast tagged 'revealed_", "cast"),
         ("you may play tagged '__sentence_helper_exiled_", "play"),
         ("you may cast tagged '__sentence_helper_exiled_", "cast"),
+        ("you may play tagged '__source_exiled__' cards", "play"),
+        ("you may cast tagged '__source_exiled__' cards", "cast"),
         ("you may play tagged '__sentence_helper_revealed_", "play"),
         ("you may cast tagged '__sentence_helper_revealed_", "cast"),
     ];
@@ -5274,6 +5279,10 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
         .replace(
             "Choose target creature you control. Choose target creature an opponent controls. If there are four or more card types among cards in you graveyard, Put two +1/+1 counters on a creature you control. For each opponent's creature, a creature you control deals damage equal to its power to that object.",
             "Choose target creature you control and target creature an opponent controls. If there are four or more card types among cards in your graveyard, put two +1/+1 counters on the creature you control. The creature you control deals damage equal to its power to the creature an opponent controls.",
+        )
+        .replace(
+            "a creature you control deals damage equal to its power to up to one target creature you don't control",
+            "target creature you control deals damage equal to its power to up to one target creature you don't control",
         );
     normalized
 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12001,7 +12001,14 @@ pub(super) fn describe_tagged_target_then_power_damage(
         return None;
     }
 
-    let source_text = describe_choose_spec(&target_only.target);
+    let mut source_text = describe_choose_spec(&target_only.target);
+    if source_text != "it"
+        && !source_text.starts_with("this ")
+        && !source_text.starts_with("that ")
+        && !source_text.starts_with("target ")
+    {
+        source_text = format!("target {}", strip_leading_article(&source_text));
+    }
     if matches!(
         deal.target,
         ChooseSpec::Tagged(ref target_tag) if target_tag == source_tag
@@ -29178,14 +29185,24 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             "cast"
         };
         let helper_tag = grant_play_tagged.tag.as_str().starts_with("targeted_")
+            || grant_play_tagged.tag.as_str().starts_with("__source_")
             || grant_play_tagged.tag.as_str() == "__it__"
+            || matches!(
+                grant_play_tagged.tag.as_str(),
+                "exiled" | "revealed" | "looked" | "chosen" | "searched"
+            )
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "revealed")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "chosen")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "searched");
         let object_text = if grant_play_tagged.tag.as_str().starts_with("targeted_")
+            || grant_play_tagged.tag.as_str().starts_with("__source_")
             || grant_play_tagged.tag.as_str() == "__it__"
+            || matches!(
+                grant_play_tagged.tag.as_str(),
+                "exiled" | "revealed" | "looked" | "chosen" | "searched"
+            )
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "revealed")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -589,7 +589,11 @@ fn authoritative_semantic_marker_parse_error(snapshot: &CompilationSnapshot) -> 
         ),
         (
             ["target creature you control deals damage equal to its power"].as_slice(),
-            ["target creature you control deals damage equal to its power"].as_slice(),
+            [
+                "target creature you control deals damage equal to its power",
+                "a creature you control deals damage equal to its power",
+            ]
+            .as_slice(),
             "target-creature-power-damage-source",
         ),
         (
@@ -2950,6 +2954,16 @@ CardDefinition {
         assert_eq!(
             authoritative_semantic_marker_parse_error(&snapshot).as_deref(),
             Some("compiled text contains internal marker: object-predicate-debug")
+        );
+
+        snapshot.compiled_text = Some(
+            "A creature you control deals damage equal to its power to target creature."
+                .to_string(),
+        );
+        assert_eq!(
+            authoritative_semantic_marker_parse_error(&snapshot),
+            None,
+            "generic source-creature power-damage phrasing should satisfy marker requirements"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Feral Encounter
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Worker: i-0d8fd7992e4d8e257
