### PR TITLE
Fix Ironsmith parse failure: Maelstrom Muse

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -5295,12 +5295,10 @@ pub(crate) fn parse_cost_modifier_mana_cost(
         let Some(group) = mana_pips_from_token(token) else {
             break;
         };
-        if group.iter().any(|symbol| {
-            matches!(
-                symbol,
-                ManaSymbol::X | ManaSymbol::Snow | ManaSymbol::Life(_)
-            )
-        }) {
+        if group
+            .iter()
+            .any(|symbol| matches!(symbol, ManaSymbol::Snow | ManaSymbol::Life(_)))
+        {
             break;
         }
         pips.push(group);

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -14,8 +14,10 @@ use super::super::activation_and_restrictions::{
     parse_you_choose_player_clause, starts_with_target_indicator,
 };
 use super::super::grammar::primitives::{self as grammar, TokenWordView};
+use super::super::grammar::filters::spell_filters::parse_spell_filter_with_grammar_entrypoint;
 use super::super::keyword_static::{
-    keyword_action_to_static_ability, parse_ability_line, parse_pt_modifier,
+    keyword_action_to_static_ability, parse_ability_line, parse_cost_modifier_mana_cost,
+    parse_pt_modifier,
     parse_pt_modifier_values,
 };
 use super::super::lexer::OwnedLexToken;
@@ -290,6 +292,46 @@ impl<'a> CommonPlayerActionClause<'a> {
             Self::State(clause) => clause.lower(),
         }
     }
+}
+
+fn parse_next_spell_cost_reduction_clause(tokens: &[OwnedLexToken]) -> Option<EffectAst> {
+    let words = TokenWordView::new(tokens);
+    let clause_words = words.to_word_refs();
+    if grammar::words_match_prefix(tokens, &["the", "next"]).is_none() {
+        return None;
+    }
+
+    let spell_idx = clause_words.iter().position(|word| *word == "spell")?;
+    let costs_idx = clause_words.iter().position(|word| *word == "costs")?;
+    let less_idx = clause_words.iter().position(|word| *word == "less")?;
+    if clause_words.get(spell_idx + 1).copied() != Some("you")
+        || clause_words.get(spell_idx + 2).copied() != Some("cast")
+        || clause_words.get(spell_idx + 3).copied() != Some("this")
+        || clause_words.get(spell_idx + 4).copied() != Some("turn")
+        || clause_words.get(less_idx + 1).copied() != Some("to")
+        || clause_words.get(less_idx + 2).copied() != Some("cast")
+        || costs_idx <= spell_idx
+    {
+        return None;
+    }
+
+    let filter_start = words.token_index_after_words(2).unwrap_or(spell_idx);
+    let spell_token_idx = words.token_index_for_word_index(spell_idx)?;
+    let costs_token_idx = words.token_index_for_word_index(costs_idx)?;
+    let less_token_idx = words.token_index_for_word_index(less_idx)?;
+    let spell_filter_tokens = trim_commas(&tokens[filter_start..spell_token_idx]).to_vec();
+    let reduction_tokens = trim_commas(&tokens[costs_token_idx + 1..less_token_idx]).to_vec();
+    let filter = parse_spell_filter_with_grammar_entrypoint(&spell_filter_tokens);
+    let (reduction, consumed) = parse_cost_modifier_mana_cost(&reduction_tokens)?;
+    if consumed != reduction_tokens.len() {
+        return None;
+    }
+
+    Some(EffectAst::subject_verb_reduce_next_spell_cost_this_turn(
+        PlayerAst::You,
+        filter,
+        reduction,
+    ))
 }
 
 pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
@@ -782,6 +824,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     }
 
     if let Some(effect) = parse_passive_goad_clause(tokens)? {
+        return Ok(effect);
+    }
+
+    if let Some(effect) = parse_next_spell_cost_reduction_clause(tokens) {
         return Ok(effect);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4933,6 +4933,25 @@ fn rewrite_lower_routes_next_spell_cost_reduction_filters_through_grammar_entryp
 }
 
 #[test]
+fn rewrite_lower_parses_next_spell_cost_reduction_inside_triggered_clause() {
+    let text = "Whenever this creature attacks, the next instant or sorcery spell you cast this turn costs {X} less to cast, where X is this creature's power as this ability resolves.";
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Triggered Cost Reducer")
+        .card_types(vec![CardType::Creature]);
+
+    let (doc, _) = parse_text_to_semantic_document(builder, text.to_string(), false)
+        .expect("triggered next-spell cost reduction should parse");
+    let parsed = super::pipeline::parse_semantic_document(doc)
+        .expect("triggered next-spell cost reduction should lower to semantic AST");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("ReduceNextSpellCostThisTurn"), "{debug}");
+    assert!(
+        debug.contains("card_types: [Instant, Sorcery]"),
+        "{debug}"
+    );
+}
+
+#[test]
 fn rewrite_anthem_grant_static_parses_flashback_tail_without_word_view() {
     let tokens = lex_line(
         "During your turn, each instant and sorcery card in your graveyard has flashback. Its flashback cost is equal to its mana cost.",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Maelstrom Muse
Initial parse error:
```
could not find verb in effect clause (clause: 'the next instant or sorcery spell you cast this turn costs x less to cast'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'the next instant or sorcery spell you cast this turn costs x less to cast'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0fc2b4600cd96ded5
