### PR TITLE
Fix Ironsmith parse failure: Rakdos, the Muscle

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -360,6 +360,10 @@ fn strip_allow_any_color_for_cast_suffix_tokens<'a>(
                 "spell",
             ][..],
             &[
+                "and", "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "those",
+                "spells",
+            ][..],
+            &[
                 "and", "you", "may", "spend", "mana", "as", "though", "it", "were", "mana", "of",
                 "any", "color", "to", "cast", "it",
             ][..],

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/token_primitives.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/token_primitives.rs
@@ -628,6 +628,8 @@ fn parse_turn_duration_phrase_inner<'a>(input: &mut LexedInput<'a>) -> WResult<T
         "until" => alt((
             grammar::phrase(&["until", "your", "next", "turn"])
                 .value(TurnDurationPhrase::UntilYourNextTurn),
+            grammar::phrase(&["until", "your", "next", "end", "step"])
+                .value(TurnDurationPhrase::UntilYourNextTurn),
             grammar::phrase(&["until", "the", "end", "of", "your", "next", "turn"])
                 .value(TurnDurationPhrase::UntilYourNextTurn),
             grammar::phrase(&["until", "end", "of", "your", "next", "turn"])
@@ -646,6 +648,7 @@ fn parse_turn_duration_phrase_inner<'a>(input: &mut LexedInput<'a>) -> WResult<T
 fn turn_duration_from_suffix_phrase(phrase: &[&str]) -> Option<TurnDurationPhrase> {
     match phrase {
         ["until", "your", "next", "turn"]
+        | ["until", "your", "next", "end", "step"]
         | ["until", "the", "end", "of", "your", "next", "turn"]
         | ["until", "end", "of", "your", "next", "turn"] => {
             Some(TurnDurationPhrase::UntilYourNextTurn)
@@ -669,6 +672,7 @@ pub(crate) fn parse_turn_duration_suffix<'a>(
 ) -> Option<(&'a [OwnedLexToken], TurnDurationPhrase)> {
     let phrases = [
         &["until", "your", "next", "turn"][..],
+        &["until", "your", "next", "end", "step"][..],
         &["until", "the", "end", "of", "your", "next", "turn"][..],
         &["until", "end", "of", "your", "next", "turn"][..],
         &["until", "the", "end", "of", "turn"][..],

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4515,6 +4515,8 @@ fn rewrite_token_primitives_cover_count_range_prefixes() {
 fn rewrite_token_primitives_cover_turn_duration_prefix_and_suffix_phrases() {
     let prefixed = lex_line("Until the end of your next turn, you may play that card", 0)
         .expect("rewrite lexer should classify prefixed duration phrase");
+    let prefixed_next_end_step = lex_line("Until your next end step, you may play that card", 0)
+        .expect("rewrite lexer should classify next-end-step duration phrase");
     let suffixed = lex_line("Target creature can't attack this turn", 0)
         .expect("rewrite lexer should classify suffixed duration phrase");
 
@@ -4524,6 +4526,9 @@ fn rewrite_token_primitives_cover_turn_duration_prefix_and_suffix_phrases() {
     let (suffix_remainder, suffix_duration) =
         super::token_primitives::parse_turn_duration_suffix(&suffixed)
             .expect("suffixed duration should parse");
+    let (next_end_step_duration, next_end_step_remainder) =
+        super::token_primitives::parse_turn_duration_prefix(&prefixed_next_end_step)
+            .expect("next-end-step prefix should parse");
 
     assert_eq!(
         prefix_duration,
@@ -4538,8 +4543,16 @@ fn rewrite_token_primitives_cover_turn_duration_prefix_and_suffix_phrases() {
         super::token_primitives::TurnDurationPhrase::ThisTurn
     );
     assert_eq!(
+        next_end_step_duration,
+        super::token_primitives::TurnDurationPhrase::UntilYourNextTurn
+    );
+    assert_eq!(
         TokenWordView::new(suffix_remainder).to_word_refs(),
         vec!["target", "creature", "cant", "attack"]
+    );
+    assert_eq!(
+        TokenWordView::new(next_end_step_remainder).to_word_refs(),
+        vec!["you", "may", "play", "that", "card"]
     );
 }
 
@@ -4757,6 +4770,22 @@ fn rewrite_lexed_permission_helpers_preserve_any_color_cast_suffix() {
     let debug = format!("{parsed:?}");
 
     assert!(debug.contains("GrantPlayTaggedUntilEndOfTurn"), "{debug}");
+    assert!(debug.contains("allow_any_color_for_cast: true"), "{debug}");
+}
+
+#[test]
+fn rewrite_lexed_permission_helpers_parse_next_end_step_and_those_spells_suffix() {
+    let tokens = lex_line(
+        "Until your next end step, you may play those cards and mana of any type can be spent to cast those spells",
+        0,
+    )
+    .expect("rewrite lexer should classify next-end-step tagged permission with mana-spend suffix");
+
+    let parsed = super::permission_helpers::parse_cast_or_play_tagged_clause(&tokens)
+        .expect("next-end-step tagged permission clause should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("GrantPlayTaggedUntilYourNextTurn"), "{debug}");
     assert!(debug.contains("allow_any_color_for_cast: true"), "{debug}");
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rakdos, the Muscle
Initial parse error:
```
could not find verb in effect clause (clause: 'until your next end step you may play those cards and mana of any type can be spent to cast those spells'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'until your next end step you may play those cards and mana of any type can be spent to cast those spells'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0e365353db51a5b24
