### PR TITLE
Fix Ironsmith parse failure: Panoptic Mirror

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -61,6 +61,7 @@ use crate::cards::builders::{
 use crate::effect::{Until, Value};
 use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype};
+use crate::zone::Zone;
 
 mod become_clause;
 mod helpers;
@@ -783,6 +784,19 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
 
     if let Some(effect) = parse_passive_goad_clause(tokens)? {
         return Ok(effect);
+    }
+
+    if clause_words.as_slice() == ["copy", "a", "card", "exiled", "with", "this", "artifact"]
+    {
+        let filter = ObjectFilter::default().in_zone(Zone::Exile).match_tagged(
+            TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+            crate::target::TaggedOpbjectRelation::IsTaggedObject,
+        );
+        return Ok(EffectAst::subject_verb_target_only(TargetAst::Object(
+            filter,
+            span_from_tokens(tokens),
+            None,
+        )));
     }
 
     let (verb, verb_idx) = find_verb(tokens).ok_or_else(|| {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10293,6 +10293,21 @@ fn rewrite_lexed_effect_sequence_parses_copy_cast_cost_reduction_followup() {
 }
 
 #[test]
+fn rewrite_lexed_effect_sequence_parses_copy_exiled_card_then_cast_copy() {
+    let text = "You may copy a card exiled with this artifact. If you do, you may cast the copy without paying its mana cost.";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify copy exiled card text");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&lexed).expect("sequence");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("TargetOnly"), "{debug}");
+    assert!(debug.contains("\"__source_exiled__\""), "{debug}");
+    assert!(debug.contains("CastTagged"), "{debug}");
+    assert!(debug.contains("as_copy: true"), "{debug}");
+    assert!(debug.contains("without_paying_mana_cost: true"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_return_all_not_chosen_this_way_tracks_it_tag_exclusion() {
     let text = "Return all nonland permanents not chosen this way to their owners' hands.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify chosen-this-way return");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Panoptic Mirror
Initial parse error:
```
could not find verb in effect clause (clause: 'copy a card exiled with this artifact'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'copy a card exiled with this artifact'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0de856cc5595c5be5
