### PR TITLE
Fix Ironsmith parse failure: Stormwing Entity

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -4162,7 +4162,9 @@ pub(crate) fn parse_this_spell_cost_condition(
         return Some(ThisSpellCostCondition::CreatureLeftBattlefieldUnderYourControlThisTurn);
     }
     if (slice_starts_with(&w, &["youve", "cast", "another"])
-        || slice_starts_with(&w, &["you", "cast", "another"]))
+        || slice_starts_with(&w, &["you've", "cast", "another"])
+        || slice_starts_with(&w, &["you", "cast", "another"])
+        || slice_starts_with(&w, &["you", "ve", "cast", "another"]))
         && slice_ends_with(&w, &["this", "turn"])
     {
         if slice_contains(&w, &"instant") || slice_contains(&w, &"sorcery") {
@@ -4183,7 +4185,10 @@ pub(crate) fn parse_this_spell_cost_condition(
             card_types: Vec::new(),
         });
     }
-    if (slice_starts_with(&w, &["youve", "cast"]) || slice_starts_with(&w, &["you", "cast"]))
+    if (slice_starts_with(&w, &["youve", "cast"])
+        || slice_starts_with(&w, &["you've", "cast"])
+        || slice_starts_with(&w, &["you", "cast"])
+        || slice_starts_with(&w, &["you", "ve", "cast"]))
         && slice_ends_with(&w, &["this", "turn"])
         && (slice_contains(&w, &"instant") || slice_contains(&w, &"sorcery"))
     {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -9443,6 +9443,25 @@ fn parse_conditional_spell_cost_if_it_targets_compiles_target_filter() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_conditional_spell_cost_if_you_ve_cast_instant_or_sorcery_this_turn() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Storm Condition Probe")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "This spell costs {2} less to cast if you've cast an instant or sorcery spell this turn.\nFlying",
+        )
+        .expect("cast-history conditional spell-cost clause should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("if you've cast an instant or sorcery spell this turn"),
+        "expected instant-or-sorcery cast-history condition in rendered text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_madness_keyword_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Madness Probe")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -49,6 +49,20 @@ fn describe_card_type(card_type: CardType) -> &'static str {
     card_type.name()
 }
 
+fn join_with_or(items: &[String]) -> String {
+    match items.len() {
+        0 => String::new(),
+        1 => items[0].clone(),
+        2 => format!("{} or {}", items[0], items[1]),
+        _ => {
+            let mut out = items[..items.len() - 1].join(", ");
+            out.push_str(", or ");
+            out.push_str(items.last().map(String::as_str).unwrap_or_default());
+            out
+        }
+    }
+}
+
 fn describe_colors(colors: ColorSet) -> String {
     let mut words = Vec::new();
     if colors.contains(Color::White) {
@@ -1120,11 +1134,6 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
             Some(format!("it targets {}", filter.description()))
         }
         ThisSpellCostCondition::YouCastSpellsThisTurnOrMore { count, card_types } => {
-            let amount = if *count <= 1 {
-                "another".to_string()
-            } else {
-                format!("{count} or more")
-            };
             let type_prefix = if card_types.is_empty() {
                 String::new()
             } else {
@@ -1132,7 +1141,21 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
                     .iter()
                     .map(|card_type| describe_card_type(*card_type).to_string())
                     .collect::<Vec<_>>();
-                format!("{} ", join_with_and(&names))
+                format!("{} ", join_with_or(&names))
+            };
+            let amount = if *count <= 1 {
+                if !card_types.is_empty()
+                    && matches!(
+                        card_types.first(),
+                        Some(CardType::Artifact | CardType::Enchantment | CardType::Instant)
+                    )
+                {
+                    "an".to_string()
+                } else {
+                    "a".to_string()
+                }
+            } else {
+                format!("{count} or more")
             };
             Some(format!(
                 "you've cast {amount} {type_prefix}spell{} this turn",
@@ -1621,7 +1644,7 @@ impl StaticAbilityKind for ThisSpellCostReduction {
             return line;
         };
 
-        format!("If {condition_text}, {line}")
+        format!("{line} if {condition_text}")
     }
 
     fn modifies_costs(&self) -> bool {
@@ -1665,7 +1688,7 @@ impl StaticAbilityKind for ThisSpellCostReductionManaCost {
             return format!("This spell costs {amount_text} less to cast");
         };
 
-        format!("If {condition_text}, this spell costs {amount_text} less to cast")
+        format!("This spell costs {amount_text} less to cast if {condition_text}")
     }
 
     fn modifies_costs(&self) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Stormwing Entity
Initial parse error:
```
unsupported this-spell cost condition (clause: 'this spell costs less to cast if you've cast an instant or sorcery spell this turn'); oracle-only fallback also failed: unsupported this-spell cost condition (clause: 'this spell costs less to cast if you've cast an instant or sorcery spell this turn')
```

Worker: i-07d1fbcb05be0856e
