### PR TITLE
Fix Ironsmith parse failure: Spiny Starfish

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -458,6 +458,10 @@ pub(crate) fn parse_for_each_count_value_words(words: &[&str]) -> Option<(Value,
     }
 
     match &words[idx..filter_end] {
+        ["time", "it", "regenerated", "this", "turn"]
+        | ["times", "it", "regenerated", "this", "turn"] => {
+            return Some((Value::SourceRegeneratedThisTurnCount, filter_end));
+        }
         [
             "card" | "cards",
             "youve" | "you've",

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1213,6 +1213,16 @@ pub(crate) fn parse_create_for_each_dynamic_count(tokens: &[OwnedLexToken]) -> O
     {
         return Some(Value::CreaturesDiedThisTurn.with_surface_hint(ValueSurfaceHint::ForEach));
     }
+    if grammar::words_match_prefix(tokens, &["time", "it", "regenerated", "this", "turn"])
+        .is_some()
+        || grammar::words_match_prefix(
+            tokens,
+            &["times", "it", "regenerated", "this", "turn"],
+        )
+        .is_some()
+    {
+        return Some(Value::SourceRegeneratedThisTurnCount.with_surface_hint(ValueSurfaceHint::ForEach));
+    }
     let clause_words = token_word_refs(tokens);
     if (grammar::contains_word(tokens, "spell") || grammar::contains_word(tokens, "spells"))
         && (grammar::contains_word(tokens, "cast") || grammar::contains_word(tokens, "casts"))

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -110,6 +110,7 @@ pub enum Value {
     },
     CommanderCastCount(PlayerFilter),
     ThisAbilityResolvedThisTurnCount,
+    SourceRegeneratedThisTurnCount,
     DamageDealtThisTurnByTaggedSpellCast(TagKey),
     CardTypesInGraveyard(PlayerFilter),
     Devotion {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8474,6 +8474,27 @@ fn parse_enters_with_counter_for_each_time_it_was_kicked_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_create_token_for_each_time_it_regenerated_this_turn_line() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Spiny Starfish Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "At the beginning of each end step, if this creature regenerated this turn, create a 0/1 blue Starfish creature token for each time it regenerated this turn.",
+        )
+        .expect("for-each-regenerated-this-turn token clause should parse");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        !debug.contains("RuleFallbackText"),
+        "for-each-regenerated-this-turn variant should not use placeholder fallback: {debug}"
+    );
+    assert!(
+        debug.contains("SourceRegeneratedThisTurnCount"),
+        "expected regenerated-this-turn value in triggered ability, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_enters_with_counter_for_each_creature_card_in_your_graveyard_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Golgari Raiders Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7595,6 +7595,9 @@ pub(crate) fn describe_value(value: &Value) -> String {
         Value::ThisAbilityResolvedThisTurnCount => {
             "the number of times this ability has resolved this turn".to_string()
         }
+        Value::SourceRegeneratedThisTurnCount => {
+            "the number of times this permanent regenerated this turn".to_string()
+        }
         Value::SpellsCastThisTurnMatching {
             player,
             filter,

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17603,6 +17603,7 @@ pub(super) fn describe_create_for_each_count(value: &Value) -> Option<String> {
             Some("color of mana spent to cast this spell".to_string())
         }
         Value::CreaturesDiedThisTurn => Some("creature that died this turn".to_string()),
+        Value::SourceRegeneratedThisTurnCount => Some("time it regenerated this turn".to_string()),
         _ => None,
     }
 }
@@ -17704,6 +17705,7 @@ pub(super) fn should_render_token_count_with_where_x(value: &Value) -> bool {
             | Value::TimesPaid(_)
             | Value::TimesPaidLabel(_)
             | Value::KickCount
+            | Value::SourceRegeneratedThisTurnCount
             | Value::MagicGamesLostToOpponentsSinceLastWin
     ) {
         return false;
@@ -17776,6 +17778,9 @@ pub(super) fn describe_compact_token_count(value: &Value, token_name: &str) -> S
         }
         Value::ColorsOfManaSpentToCastThisSpell => {
             format!("a {token_name} token for each color of mana spent to cast this spell")
+        }
+        Value::SourceRegeneratedThisTurnCount => {
+            format!("a {token_name} token for each time it regenerated this turn")
         }
         _ => format!("{} {token_name} token(s)", describe_value(value)),
     }
@@ -27136,7 +27141,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             );
             text = append_token_entry_flags(text, true);
             text = append_token_ability_sentence(text, token_ability);
-            return append_token_cleanup_sentences(text, true);
+            text = append_token_cleanup_sentences(text, true);
+            if matches!(create_token.count.unhinted(), Value::SourceRegeneratedThisTurnCount) {
+                return format!("if this creature regenerated this turn, {}", lowercase_first(&text));
+            }
+            return text;
         }
         let use_where_x = should_render_token_count_with_where_x(&create_token.count);
         let singular_count = matches!(create_token.count, Value::Fixed(1)) && !use_where_x;

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4363,6 +4363,7 @@ fn resolve_value_with_context(
         | Value::SpellsCastBeforeThisTurn(_)
         | Value::SpellsCastThisTurnMatching { .. }
         | Value::ThisAbilityResolvedThisTurnCount
+        | Value::SourceRegeneratedThisTurnCount
         | Value::DamageDealtThisTurnByTaggedSpellCast(_)
         | Value::CardTypesInGraveyard(_)
         | Value::EffectValue(_)

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1363,6 +1363,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::SpellsCastBeforeThisTurn(_)
         | Value::CommanderCastCount(_)
         | Value::ThisAbilityResolvedThisTurnCount
+        | Value::SourceRegeneratedThisTurnCount
         | Value::SpellsCastThisTurnMatching { .. }
         | Value::DamageDealtThisTurnByTaggedSpellCast(_)
         | Value::CardTypesInGraveyard(_)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1299,6 +1299,10 @@ pub fn resolve_value(
             ))
         }
 
+        Value::SourceRegeneratedThisTurnCount => {
+            Ok(game.regenerated_this_turn_count(ctx.source) as i32)
+        }
+
         Value::DamageDealtThisTurnByTaggedSpellCast(tag) => {
             let snapshot = ctx.get_tagged(tag.as_str()).ok_or_else(|| {
                 ExecutionError::UnresolvableValue(format!(

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -1960,6 +1960,9 @@ pub struct GameState {
     /// Regeneration shields on permanents (expires at end of turn).
     pub regeneration_shields: HashMap<ObjectId, u32>,
 
+    /// Number of times each permanent successfully regenerated this turn.
+    pub regenerated_this_turn: HashMap<ObjectId, u32>,
+
     /// Creatures that are monstrous (from monstrosity ability).
     pub monstrous: HashSet<ObjectId>,
 
@@ -2121,6 +2124,7 @@ impl GameState {
             dealt_deathtouch_damage_since_sba: HashSet::new(),
             damage_persists: HashSet::new(),
             regeneration_shields: HashMap::new(),
+            regenerated_this_turn: HashMap::new(),
             monstrous: HashSet::new(),
             renowned: HashSet::new(),
             devoured_counts: HashMap::new(),
@@ -7835,9 +7839,20 @@ impl GameState {
             if *shields == 0 {
                 self.regeneration_shields.remove(&id);
             }
+            *self.regenerated_this_turn.entry(id).or_insert(0) += 1;
             return true;
         }
         false
+    }
+
+    /// Get how many times an object regenerated this turn.
+    pub fn regenerated_this_turn_count(&self, id: ObjectId) -> u32 {
+        self.regenerated_this_turn.get(&id).copied().unwrap_or(0)
+    }
+
+    /// Clear all per-object regeneration counts for this turn.
+    pub fn clear_regenerated_this_turn(&mut self) {
+        self.regenerated_this_turn.clear();
     }
 
     /// Clear all regeneration shields from an object.

--- a/crates/ironsmith-runtime/src/turn.rs
+++ b/crates/ironsmith-runtime/src/turn.rs
@@ -600,6 +600,7 @@ pub fn execute_cleanup_step(game: &mut GameState) {
         }
         game.clear_regeneration_shields(id);
     }
+    game.clear_regenerated_this_turn();
 
     // Clear one-shot replacement effects (like regeneration shields)
     // These only last "until end of turn" per MTG rules


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Spiny Starfish
Initial parse error:
```
unsupported target phrase (clause: 'time it regenerated this turn'); oracle-only fallback also failed: unsupported target phrase (clause: 'time it regenerated this turn')
```

Worker: i-00c506293235b2f0c
