### PR TITLE
Tighten power-damage marker guard

### DIFF
--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -5301,10 +5301,7 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             "Choose target creature you control. Choose target creature an opponent controls. If there are four or more card types among cards in you graveyard, Put two +1/+1 counters on a creature you control. For each opponent's creature, a creature you control deals damage equal to its power to that object.",
             "Choose target creature you control and target creature an opponent controls. If there are four or more card types among cards in your graveyard, put two +1/+1 counters on the creature you control. The creature you control deals damage equal to its power to the creature an opponent controls.",
         )
-        .replace(
-            "a creature you control deals damage equal to its power to up to one target creature you don't control",
-            "target creature you control deals damage equal to its power to up to one target creature you don't control",
-        );
+        ;
     normalized
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12001,14 +12001,7 @@ pub(super) fn describe_tagged_target_then_power_damage(
         return None;
     }
 
-    let mut source_text = describe_choose_spec(&target_only.target);
-    if source_text != "it"
-        && !source_text.starts_with("this ")
-        && !source_text.starts_with("that ")
-        && !source_text.starts_with("target ")
-    {
-        source_text = format!("target {}", strip_leading_article(&source_text));
-    }
+    let source_text = describe_choose_spec(&target_only.target);
     if matches!(
         deal.target,
         ChooseSpec::Tagged(ref target_tag) if target_tag == source_tag

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -589,11 +589,7 @@ fn authoritative_semantic_marker_parse_error(snapshot: &CompilationSnapshot) -> 
         ),
         (
             ["target creature you control deals damage equal to its power"].as_slice(),
-            [
-                "target creature you control deals damage equal to its power",
-                "a creature you control deals damage equal to its power",
-            ]
-            .as_slice(),
+            ["target creature you control deals damage equal to its power"].as_slice(),
             "target-creature-power-damage-source",
         ),
         (
@@ -2955,16 +2951,6 @@ CardDefinition {
             authoritative_semantic_marker_parse_error(&snapshot).as_deref(),
             Some("compiled text contains internal marker: object-predicate-debug")
         );
-
-        snapshot.compiled_text = Some(
-            "A creature you control deals damage equal to its power to target creature."
-                .to_string(),
-        );
-        assert_eq!(
-            authoritative_semantic_marker_parse_error(&snapshot),
-            None,
-            "generic source-creature power-damage phrasing should satisfy marker requirements"
-        );
     }
 
     #[test]
@@ -3131,6 +3117,11 @@ CardDefinition {
             (
                 "Target creature you control deals damage equal to its power to each other creature.",
                 "For each other creature, this spell deals X damage to that object, where X is this creature's power.",
+                "compiled text dropped required semantic marker: target-creature-power-damage-source",
+            ),
+            (
+                "Target creature you control deals damage equal to its power to up to one target creature you don't control.",
+                "A creature you control deals damage equal to its power to up to one target creature you don't control.",
                 "compiled text dropped required semantic marker: target-creature-power-damage-source",
             ),
             (


### PR DESCRIPTION
This is a quality-gate follow-up for the merged Feral Encounter worker PR.\n\nIt removes renderer/status-DB guard broadening that allowed non-targeted wording like "a creature you control deals damage..." to satisfy oracle text requiring "target creature you control...". The card may still need a real parser/runtime fix for its targeting/delayed trigger semantics, but the DB guard should not hide that gap.\n\nVerification:\n- cargo test -p ironsmith-tools authoritative_marker_guard_rejects_dropped_required_words\n- cargo test -p ironsmith-runtime test_parse_feral_encounter_avoids_tagged_play_marker_text