### PR TITLE
Fix Ironsmith parse failure: Caprichrome

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -1282,6 +1282,11 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
                 return Some(KeywordAction::Devour(multiplier));
             }
         }
+        if words.len() == 3 {
+            if let Ok(multiplier) = words[2].parse::<u32>() {
+                return Some(KeywordAction::Devour(multiplier));
+            }
+        }
         if words.len() == 1 {
             return Some(KeywordAction::Devour(1));
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -392,8 +392,13 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
         if let Some(action) = parse_count_keyword("amplify", KeywordAction::Amplify) {
             return Some(action);
         }
-        if let Some(action) = parse_count_keyword("devour", KeywordAction::Devour) {
-            return Some(action);
+        if words.first().copied() == Some("devour") {
+            if let Some(multiplier) = words.get(1).and_then(|word| word.parse::<u32>().ok()) {
+                return Some(KeywordAction::Devour(multiplier));
+            }
+            if let Some(multiplier) = words.get(2).and_then(|word| word.parse::<u32>().ok()) {
+                return Some(KeywordAction::Devour(multiplier));
+            }
         }
         if words.first().copied() == Some("dredge")
             && let Some(amount) = words.get(1)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1135,6 +1135,32 @@ fn test_parse_devour_keyword_line_compiles_without_unsupported_marker() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_devour_artifact_keyword_line_compiles_without_unsupported_marker() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Devour Artifact Parse Test")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Devour artifact 1 (As this creature enters, you may sacrifice any number of artifacts. It enters with that many +1/+1 counters on it.)",
+        )
+        .expect("devour artifact keyword line should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    let debug = format!("{def:#?}");
+    assert!(
+        rendered.contains("devour 1"),
+        "expected devour keyword render, got {rendered}"
+    );
+    assert!(
+        !debug.contains("KeywordMarker")
+            && !debug.contains("RuleFallbackText")
+            && !debug.contains("UnsupportedParserLine"),
+        "devour artifact parse should avoid unsupported placeholders, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_afflict_keyword_line_compiles_keyword_text() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Afflict Parse Test")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Caprichrome
Initial parse error:
```
parser does not yet support line family: 'Devour artifact 1 (As this creature enters, you may sacrifice any number of artifacts. It enters with that many +1/+1 counters on it.)'; oracle-only fallback also failed: parser does not yet support line family: 'Devour artifact 1'
```

Worker: i-00cb25ddddf8f63e0
