### PR TITLE
Fix Ironsmith parse failure: Charred Graverobber

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -571,6 +571,10 @@ fn parse_enters_with_counter_condition_clause(
     {
         return Some(crate::ConditionExpr::ThisSpellWasKicked);
     }
+    if condition_words == ["this", "spell", "escaped"] || condition_words == ["it", "escaped"]
+    {
+        return Some(crate::ConditionExpr::ThisSpellEscaped);
+    }
     if condition_words == ["a", "creature", "died", "this", "turn"]
         || condition_words == ["one", "or", "more", "creatures", "died", "this", "turn"]
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -1,8 +1,9 @@
 use super::line_family_handlers::{
     run_activation_line_family, run_champion_line_family,
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
-    run_combined_static_line_family, run_keyword_line_family, run_labeled_line_family,
-    run_learn_line_family, run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
+    run_combined_static_line_family, run_escape_enters_with_counter_line_family,
+    run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
+    run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
     run_split_top_and_face_down_look_line_family, run_start_your_engines_line_family,
     run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
     run_station_line_family, run_station_threshold_line_family,
@@ -44,7 +45,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 21] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -116,6 +117,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
         priority: 41,
         heads: &[],
         run: run_station_threshold_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "escape-enters-with-counter-line",
+        priority: 42,
+        heads: &[],
+        run: run_escape_enters_with_counter_line_family,
     },
     LineFamilyRuleDef {
         id: "keyword-line",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -505,6 +505,45 @@ pub(super) fn run_partner_with_keyword_line_family(
     )))
 }
 
+pub(super) fn run_escape_enters_with_counter_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let lower = raw.to_ascii_lowercase();
+    let Some(with_idx) = lower.find(" escapes with ") else {
+        return Ok(None);
+    };
+
+    let subject = raw[..with_idx].trim();
+    if subject.is_empty() {
+        return Ok(None);
+    }
+    if subject.eq_ignore_ascii_case("this") {
+        return Ok(None);
+    }
+
+    let rest_start = with_idx + " escapes with ".len();
+    let rest = raw[rest_start..].trim().trim_end_matches('.').trim();
+    if rest.is_empty() {
+        return Ok(None);
+    }
+
+    let rewritten = format!(
+        "{subject} enters with {rest} if this spell escaped.",
+    );
+    let rewritten_line = rewrite_line_normalized(ctx.line, rewritten.as_str())?;
+    let Some(static_cst) = parse_static_line_cst(&rewritten_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower escapes-with-counters line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Static(static_cst),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_keyword_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38701,6 +38701,34 @@ fn card_fixer_parse_sacrifice_unless_it_escaped_keeps_escape_condition() {
 }
 
 #[test]
+fn card_fixer_parse_escapes_with_counter_line_lowers_to_escape_condition() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Escape Counter Variant")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 1))
+        .parse_text(
+            "Haste\nEscape-{R}, Exile three other cards from your graveyard.\nThis creature escapes with a +1/+1 counter on it.",
+        )
+        .expect("escape enters-with-counter line should parse");
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("EnterWithCountersIfCondition"),
+        "expected conditional enters-with-counters static ability, got {debug}"
+    );
+    assert!(
+        debug.contains("ThisSpellEscaped"),
+        "expected escape condition to lower through ThisSpellEscaped, got {debug}"
+    );
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    assert!(
+        rendered.contains("enters with a +1/+1 counter on it if this spell escaped"),
+        "expected escaped conditional enters-with-counter surface, got {rendered}"
+    );
+}
+
+#[test]
 fn card_fixer_parse_characteristic_defining_domain_counts_basic_land_types() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Domain Kavu Variant")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Charred Graverobber
Initial parse error:
```
parser does not yet support line family: 'This creature escapes with a +1/+1 counter on it.'; oracle-only fallback also failed: parser does not yet support line family: 'This creature escapes with a +1/+1 counter on it.'
```

Worker: i-0675e7108b48df90a
