### PR TITLE
Fix Ironsmith parse failure: Shivan Sand-Mage

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -440,13 +440,21 @@ pub(super) fn parse_object_filter_inner(
             all_words.join(" ")
         )));
     }
-    if contains_any_filter_phrase(
+    let has_counter_state_or_clause = contains_any_filter_phrase(
         &all_words,
         &[
             &["counter", "on", "it", "or"],
             &["counter", "on", "them", "or"],
         ],
-    ) {
+    );
+    let has_supported_suspended_disjunction = contains_any_filter_phrase(
+        &all_words,
+        &[
+            &["or", "suspended", "card"],
+            &["or", "suspended", "cards"],
+        ],
+    );
+    if has_counter_state_or_clause && !has_supported_suspended_disjunction {
         return Err(CardTextError::ParseError(format!(
             "unsupported counter-state object filter (clause: '{}')",
             all_words.join(" ")

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -12074,6 +12074,22 @@ fn parse_destroy_target_three_or_more_colors_still_fails_loudly() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_time_counter_on_it_or_suspended_card_compiles() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Shivan Sand-Mage Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "When this creature enters, choose one —\n• Remove two time counters from target permanent or suspended card.\n• Put two time counters on target permanent with a time counter on it or suspended card.",
+        )
+        .expect("time-counter or suspended-card clause should parse");
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("put two time counters on target permanent with a time counter on it or suspended card"),
+        "expected rendered text to preserve the counter-state suspended-card disjunction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_ugin_colored_permanent_target_lines() {
     CardDefinitionBuilder::new(CardId::new(), "Ugin Variant")
         .card_types(vec![CardType::Planeswalker])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Shivan Sand-Mage
Initial parse error:
```
unsupported counter-state object filter (clause: 'permanent with time counter on it or suspended card'); oracle-only fallback also failed: unsupported counter-state object filter (clause: 'permanent with time counter on it or suspended card')
```

Worker: i-039d92f108465311b
