### PR TITLE
Fix Ironsmith parse failure: Crystal Barricade

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -30,6 +30,7 @@ use super::grammar::abilities::{
     is_players_cant_pay_life_or_sacrifice_line_lexed,
     is_players_play_top_card_libraries_revealed_line_lexed, is_players_skip_upkeep_line_lexed,
     is_prevent_all_combat_damage_to_source_line_lexed,
+    is_prevent_all_noncombat_damage_to_other_creatures_you_control_line_lexed,
     is_prevent_all_damage_dealt_to_creatures_line_lexed,
     is_prevent_all_damage_to_source_by_creatures_line_lexed,
     is_prevent_damage_to_other_creature_you_control_put_counters_line_lexed,
@@ -763,6 +764,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_grant_flash_to_noncreature_spells_line),
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
         single_static_ability_ast_rule!(parse_prevent_all_combat_damage_to_source_line),
+        single_static_ability_ast_rule!(
+            parse_prevent_all_noncombat_damage_to_other_creatures_you_control_line
+        ),
         single_static_ability_ast_rule!(parse_prevent_all_damage_to_source_by_creatures_line),
         single_static_ability_ast_rule!(
             parse_prevent_damage_to_other_creature_you_control_put_counters_line
@@ -6542,6 +6546,18 @@ pub(crate) fn parse_prevent_all_combat_damage_to_source_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     if is_prevent_all_combat_damage_to_source_line_lexed(tokens) {
         return Ok(Some(StaticAbility::prevent_all_combat_damage_to_self()));
+    }
+
+    Ok(None)
+}
+
+pub(crate) fn parse_prevent_all_noncombat_damage_to_other_creatures_you_control_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_prevent_all_noncombat_damage_to_other_creatures_you_control_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::prevent_all_noncombat_damage_to_other_creatures_you_control(),
+        ));
     }
 
     Ok(None)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2498,6 +2498,29 @@ pub(crate) fn is_prevent_all_combat_damage_to_source_line_lexed(tokens: &[OwnedL
     )
 }
 
+pub(crate) fn is_prevent_all_noncombat_damage_to_other_creatures_you_control_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    matches_exact_phrase_line_lexed(
+        tokens,
+        &[
+            "prevent",
+            "all",
+            "noncombat",
+            "damage",
+            "that",
+            "would",
+            "be",
+            "dealt",
+            "to",
+            "other",
+            "creatures",
+            "you",
+            "control",
+        ],
+    )
+}
+
 pub(crate) fn is_prevent_all_damage_to_source_by_creatures_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7866,6 +7866,12 @@ fn rewrite_grammar_prevention_static_line_probes_match_keyword_static_shapes() {
             crate::static_abilities::StaticAbilityId::PreventAllCombatDamageToSelf,
         ),
         (
+            "Prevent all noncombat damage that would be dealt to other creatures you control.",
+            super::grammar::abilities::is_prevent_all_noncombat_damage_to_other_creatures_you_control_line_lexed as Probe,
+            super::keyword_static::parse_prevent_all_noncombat_damage_to_other_creatures_you_control_line as Parser,
+            crate::static_abilities::StaticAbilityId::PreventAllNoncombatDamageToOtherCreaturesYouControl,
+        ),
+        (
             "Prevent all damage that would be dealt to this permanent by creatures.",
             super::grammar::abilities::is_prevent_all_damage_to_source_by_creatures_line_lexed as Probe,
             super::keyword_static::parse_prevent_all_damage_to_source_by_creatures_line as Parser,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -170,6 +170,7 @@ pub enum StaticAbilityId {
     PreventConstrainedDamageToSelfPutCountersInstead,
     ReplaceDamageWithCountersInstead,
     PreventDamageToOtherCreatureYouControlPutCountersInstead,
+    PreventAllNoncombatDamageToOtherCreaturesYouControl,
     DoesntUntap,
     UntapDuringEachOtherPlayersUntapStep,
     MayChooseNotToUntapDuringUntapStep,
@@ -405,6 +406,7 @@ impl StaticAbilityId {
             | PreventConstrainedDamageToSelfPutCountersInstead
             | ReplaceDamageWithCountersInstead
             | PreventDamageToOtherCreatureYouControlPutCountersInstead
+            | PreventAllNoncombatDamageToOtherCreaturesYouControl
             | DoesntUntap
             | UntapDuringEachOtherPlayersUntapStep
             | MayChooseNotToUntapDuringUntapStep

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2988,6 +2988,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn prevent_all_noncombat_damage_to_other_creatures_you_control() -> Self {
+        Self {
+            id: Some(StaticAbilityId::PreventAllNoncombatDamageToOtherCreaturesYouControl),
+            label: "prevent all noncombat damage to other creatures you control".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn prevent_all_damage_to_self_by_creatures() -> Self {
         Self {
             id: Some(StaticAbilityId::PreventAllDamageToSelfByCreatures),

--- a/crates/ironsmith-runtime/src/events/damage/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/damage/matchers.rs
@@ -670,7 +670,23 @@ impl ReplacementMatcher for DamageToSelfCombatMatcher {
 
 /// Matches damage events dealt to another creature you control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct DamageToOtherCreatureYouControlMatcher;
+pub struct DamageToOtherCreatureYouControlMatcher {
+    noncombat_only: bool,
+}
+
+impl DamageToOtherCreatureYouControlMatcher {
+    pub fn new() -> Self {
+        Self {
+            noncombat_only: false,
+        }
+    }
+
+    pub fn noncombat_only() -> Self {
+        Self {
+            noncombat_only: true,
+        }
+    }
+}
 
 impl ReplacementMatcher for DamageToOtherCreatureYouControlMatcher {
     fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
@@ -682,7 +698,7 @@ impl ReplacementMatcher for DamageToOtherCreatureYouControlMatcher {
             return false;
         };
 
-        if damage.is_unpreventable {
+        if damage.is_unpreventable || (self.noncombat_only && damage.is_combat) {
             return false;
         }
 

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -121,6 +121,9 @@ impl StaticAbility {
             Some(StaticAbilityId::PreventAllDamageToSelfByCreatures) => {
                 Self::prevent_all_damage_to_self_by_creatures()
             }
+            Some(StaticAbilityId::PreventAllNoncombatDamageToOtherCreaturesYouControl) => {
+                Self::prevent_all_noncombat_damage_to_other_creatures_you_control()
+            }
             Some(StaticAbilityId::RedirectDamageToSource) => {
                 Self::redirect_damage_from_you_and_other_permanents_to_source()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -2014,12 +2014,40 @@ impl StaticAbilityKind for PreventDamageToOtherCreatureYouControlPutCountersInst
         Some(ReplacementEffect::with_matcher(
             source,
             controller,
-            DamageToOtherCreatureYouControlMatcher,
+            DamageToOtherCreatureYouControlMatcher::new(),
             ReplacementAction::Instead(vec![Effect::put_counters(
                 self.counter_type,
                 Value::EventValue(EventValueSpec::Amount),
                 ChooseSpec::AnyTarget,
             )]),
+        ))
+    }
+}
+
+/// "Prevent all noncombat damage that would be dealt to other creatures you control."
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreventAllNoncombatDamageToOtherCreaturesYouControl;
+
+impl StaticAbilityKind for PreventAllNoncombatDamageToOtherCreaturesYouControl {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::PreventAllNoncombatDamageToOtherCreaturesYouControl
+    }
+
+    fn display(&self) -> String {
+        "Prevent all noncombat damage that would be dealt to other creatures you control."
+            .to_string()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            DamageToOtherCreatureYouControlMatcher::noncombat_only(),
+            ReplacementAction::Prevent,
         ))
     }
 }
@@ -5556,6 +5584,67 @@ mod tests {
             crate::events::cause::EventCause::combat_damage(source),
         );
         assert!(!matcher.matches_event(&unpreventable, &ctx));
+    }
+
+    #[test]
+    fn test_prevent_all_noncombat_damage_to_other_creatures_you_control() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let source = CardBuilder::new(CardId::new(), "Crystal Barricade")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source_id = game.create_object_from_card(&source, alice, Zone::Battlefield);
+
+        let other = CardBuilder::new(CardId::new(), "Ally")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let other_id = game.create_object_from_card(&other, alice, Zone::Battlefield);
+
+        let opponent = CardBuilder::new(CardId::new(), "Opponent Creature")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let opponent_id = game.create_object_from_card(&opponent, bob, Zone::Battlefield);
+
+        let ability = PreventAllNoncombatDamageToOtherCreaturesYouControl;
+        let replacement = ability
+            .generate_replacement_effect(source_id, alice)
+            .expect("should generate replacement effect");
+        assert_eq!(replacement.replacement, ReplacementAction::Prevent);
+
+        let matcher = replacement
+            .matcher
+            .as_ref()
+            .expect("replacement must have a matcher");
+        let ctx = EventContext::for_replacement_effect(alice, source_id, &game);
+
+        let noncombat_to_other = DamageEvent::with_cause(
+            opponent_id,
+            DamageTarget::Object(other_id),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(matcher.matches_event(&noncombat_to_other, &ctx));
+
+        let combat_to_other = DamageEvent::with_cause(
+            opponent_id,
+            DamageTarget::Object(other_id),
+            2,
+            true,
+            crate::events::cause::EventCause::combat_damage(opponent_id),
+        );
+        assert!(!matcher.matches_event(&combat_to_other, &ctx));
+
+        let noncombat_to_source = DamageEvent::with_cause(
+            opponent_id,
+            DamageTarget::Object(source_id),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(!matcher.matches_event(&noncombat_to_source, &ctx));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2356,6 +2356,10 @@ impl StaticAbility {
         ))
     }
 
+    pub fn prevent_all_noncombat_damage_to_other_creatures_you_control() -> Self {
+        Self::new(PreventAllNoncombatDamageToOtherCreaturesYouControl)
+    }
+
     pub fn increase_activated_ability_costs(
         filter: crate::target::ObjectFilter,
         increase: crate::cost::TotalCost,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Crystal Barricade
Initial parse error:
```
parser does not yet support line family: 'Prevent all noncombat damage that would be dealt to other creatures you control.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all noncombat damage that would be dealt to other creatures you control.'
```

Worker: i-02e077d3806ee8247
