### PR TITLE
Fix Ironsmith parse failure: Dihada's Ploy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -378,6 +378,11 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
     if str_strip_suffix(first, "cycling").is_some() {
         return Some(KeywordDispatchHint::Cycling);
     }
+    if matches!(first, "jumpstart" | "jump-start")
+        || (first == "jump" && word_view.get(1) == Some("start"))
+    {
+        return Some(KeywordDispatchHint::AlternativeOrExertFamily);
+    }
 
     None
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -35,7 +35,8 @@ use super::util::{
     parse_escape_line_lexed, parse_eternalize_line_lexed, parse_evoke_line_lexed,
     parse_flash_with_additional_cost_line_lexed, parse_flashback_line_lexed,
     parse_harmonize_line_lexed, parse_if_conditional_alternative_cost_line_lexed,
-    parse_kicker_line_lexed, parse_madness_line_lexed, parse_morph_keyword_line_lexed,
+    parse_jump_start_line_lexed, parse_kicker_line_lexed, parse_madness_line_lexed,
+    parse_morph_keyword_line_lexed,
     parse_multikicker_line_lexed, parse_offspring_line_lexed, parse_reinforce_line_lexed,
     parse_replicate_line_lexed, parse_retrace_line_lexed,
     parse_self_free_cast_alternative_cost_line_lexed, parse_squad_line_lexed,
@@ -221,6 +222,9 @@ pub(super) fn lower_alternative_cast(
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     if let Some(method) = parse_flash_with_additional_cost_line_lexed(tokens) {
+        return Ok(LineAst::AlternativeCastingMethod(method.into()));
+    }
+    if let Some(method) = parse_jump_start_line_lexed(tokens)? {
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     if let Some(method) =
@@ -874,6 +878,7 @@ fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTex
             || parse_you_may_rather_than_spell_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()
             || parse_flash_with_additional_cost_line_lexed(tokens).is_some()
+            || parse_jump_start_line_lexed(tokens)?.is_some()
             || parse_if_conditional_alternative_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()
             || parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)?.is_some(),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4562,6 +4562,29 @@ pub(crate) fn parse_retrace_line_lexed(
     parse_retrace_line(tokens)
 }
 
+pub(crate) fn parse_jump_start_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let rendered = crate::runtime_backend::front_end::lexer::render_token_slice(tokens)
+        .trim()
+        .to_ascii_lowercase();
+    if rendered.starts_with("jump-start")
+        || rendered.starts_with("jump start")
+        || matches!(words.first().copied(), Some("jumpstart" | "jump-start"))
+        || words.get(..2) == Some(["jump", "start"].as_slice())
+    {
+        return Ok(Some(AlternativeCastingMethod::JumpStart));
+    }
+    Ok(None)
+}
+
+pub(crate) fn parse_jump_start_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    parse_jump_start_line(tokens)
+}
+
 pub(crate) fn parse_harmonize_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/value_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/value_helpers.rs
@@ -261,6 +261,43 @@ fn parse_creatures_died_this_turn_count_value(tokens: &[OwnedLexToken]) -> Optio
     }
 }
 
+fn parse_cards_discarded_this_turn_count_value(tokens: &[OwnedLexToken]) -> Option<Value> {
+    let words = ValueHelperCompatWords::new(tokens);
+    if !lower_words_have(&words, "cards")
+        || !lower_words_have(&words, "discarded")
+        || !lower_words_have(&words, "this")
+        || !lower_words_have(&words, "turn")
+    {
+        return None;
+    }
+
+    if words
+        .to_word_refs()
+        .iter()
+        .any(|word| matches!(*word, "you" | "your" | "youve"))
+    {
+        return Some(Value::CardsDiscardedThisTurn(PlayerFilter::You));
+    }
+    if words
+        .to_word_refs()
+        .iter()
+        .any(|word| matches!(*word, "opponent" | "opponents"))
+    {
+        return Some(Value::CardsDiscardedThisTurn(PlayerFilter::Opponent));
+    }
+    if word_refs_find_sequence(&words.to_word_refs(), &["that", "player"]).is_some()
+        || word_refs_find_sequence(&words.to_word_refs(), &["that", "players"]).is_some()
+        || words
+            .to_word_refs()
+            .iter()
+            .any(|word| matches!(*word, "they" | "their" | "theyve" | "each"))
+    {
+        return Some(Value::CardsDiscardedThisTurn(PlayerFilter::IteratedPlayer));
+    }
+
+    Some(Value::CardsDiscardedThisTurn(PlayerFilter::Any))
+}
+
 pub(crate) fn parse_commander_cast_count_player(tokens: &[OwnedLexToken]) -> Option<PlayerFilter> {
     let word_view = ValueHelperCompatWords::new(tokens);
     let words = word_view.to_word_refs();
@@ -350,6 +387,9 @@ pub(crate) fn parse_equal_to_number_of_filter_value(tokens: &[OwnedLexToken]) ->
     let filter_word_view = ValueHelperCompatWords::new(&filter_tokens);
     let filter_words = filter_word_view.to_word_refs();
     if let Some(value) = parse_creatures_died_this_turn_count_value(&filter_tokens) {
+        return Some(value);
+    }
+    if let Some(value) = parse_cards_discarded_this_turn_count_value(&filter_tokens) {
         return Some(value);
     }
     if lower_words_have(&filter_word_view, "cards")
@@ -710,6 +750,9 @@ pub(crate) fn parse_equal_to_number_of_filter_value_lexed(
     let filter_tokens = trim_lexed_edge_punctuation(&tokens[filter_start_token_idx..]);
     let filter_words = ValueHelperCompatWords::new(filter_tokens).to_word_refs();
     if let Some(value) = parse_spells_cast_this_turn_matching_count_value_lexed(filter_tokens) {
+        return Some(value);
+    }
+    if let Some(value) = parse_cards_discarded_this_turn_count_value(filter_tokens) {
         return Some(value);
     }
     if word_refs_have_prefix(&filter_words, &["basic", "land", "type", "among"])

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4989,6 +4989,40 @@ fn flashback_keyword_accepts_non_mana_total_cost() {
 }
 
 #[test]
+fn jump_start_keyword_line_is_classified_as_alternative_cast() {
+    let tokens = lex_line(
+        "Jump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",
+        0,
+    )
+    .expect("rewrite lexer should classify jump-start keyword line");
+
+    assert!(matches!(
+        super::families::keyword_families::parse_keyword_dispatch_hint(&tokens),
+        Some(super::families::keyword_families::KeywordDispatchHint::AlternativeOrExertFamily)
+    ));
+
+    let parsed = super::front_end::shared::util::parse_jump_start_line_lexed(&tokens)
+        .expect("jump-start parse should not error")
+        .expect("jump-start keyword line should parse");
+    assert!(format!("{parsed:?}").contains("JumpStart"));
+}
+
+#[test]
+fn equal_to_number_of_cards_you_ve_discarded_this_turn_parses() {
+    let tokens = lex_line("equal to the number of cards you've discarded this turn", 0)
+        .expect("rewrite lexer should classify value clause");
+
+    let parsed =
+        super::front_end::shared::value_helpers::parse_equal_to_number_of_filter_value(&tokens)
+            .expect("discarded this turn count should parse");
+
+    assert!(matches!(
+        parsed,
+        crate::Value::CardsDiscardedThisTurn(crate::PlayerFilter::You)
+    ));
+}
+
+#[test]
 fn rewrite_lower_routes_next_spell_cost_reduction_filters_through_grammar_entrypoint() {
     let text = "{T}: The next noncreature spell you cast this turn costs {2} less to cast.";
     let builder = CardDefinitionBuilder::new(CardId::new(), "Cost Reducer")

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -92,6 +92,7 @@ pub enum Value {
     DevotionToChosenColor(PlayerFilter),
     LifeGainedThisTurn(PlayerFilter),
     LifeLostThisTurn(PlayerFilter),
+    CardsDiscardedThisTurn(PlayerFilter),
     NoncombatDamageDealtToPlayersThisTurn(PlayerFilter),
     NoncombatDamageDealtBySourcesControlledThisTurn {
         player: PlayerFilter,

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7515,6 +7515,17 @@ pub(crate) fn describe_value(value: &Value) -> String {
                 describe_player_filter(filter)
             ),
         },
+        Value::CardsDiscardedThisTurn(filter) => match filter {
+            PlayerFilter::You => "the number of cards you've discarded this turn".to_string(),
+            PlayerFilter::Opponent => {
+                "the number of cards your opponents have discarded this turn".to_string()
+            }
+            PlayerFilter::Any => "the number of cards discarded this turn".to_string(),
+            _ => format!(
+                "the number of cards {} discarded this turn",
+                describe_player_filter(filter)
+            ),
+        },
         Value::NoncombatDamageDealtToPlayersThisTurn(filter) => match filter {
             PlayerFilter::You => {
                 "the total amount of noncombat damage dealt to you this turn".to_string()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -25531,6 +25531,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 | Value::Speed(_)
                 | Value::LifeGainedThisTurn(_)
                 | Value::LifeLostThisTurn(_)
+                | Value::CardsDiscardedThisTurn(_)
                 | Value::EffectMetric { .. }
                 | Value::EffectMetricOffset { .. }
                 | Value::PendingEffectMetric { .. }

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4355,6 +4355,7 @@ fn resolve_value_with_context(
         | Value::CardsInHand(_)
         | Value::LifeGainedThisTurn(_)
         | Value::LifeLostThisTurn(_)
+        | Value::CardsDiscardedThisTurn(_)
         | Value::NoncombatDamageDealtToPlayersThisTurn(_)
         | Value::NoncombatDamageDealtBySourcesControlledThisTurn { .. }
         | Value::MaxCardsDrawnThisTurn(_)

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1353,6 +1353,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::CardsInLibrary(_)
         | Value::LifeGainedThisTurn(_)
         | Value::LifeLostThisTurn(_)
+        | Value::CardsDiscardedThisTurn(_)
         | Value::NoncombatDamageDealtToPlayersThisTurn(_)
         | Value::NoncombatDamageDealtBySourcesControlledThisTurn { .. }
         | Value::MaxCardsDrawnThisTurn(_)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1164,6 +1164,16 @@ pub fn resolve_value(
             Ok(total as i32)
         }
 
+        Value::CardsDiscardedThisTurn(player_spec) => {
+            let player_ids =
+                resolve_player_filter_to_list(game, player_spec, &ctx.filter_context(game), ctx)?;
+            let total = game
+                .turn_store
+                .turn_history
+                .total_cards_discarded_for_players(&player_ids);
+            Ok(total as i32)
+        }
+
         Value::NoncombatDamageDealtToPlayersThisTurn(player_spec) => {
             let player_ids =
                 resolve_player_filter_to_list(game, player_spec, &ctx.filter_context(game), ctx)?;

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -4,7 +4,8 @@ use crate::color::ColorSet;
 use crate::events::EnterBattlefieldEvent;
 use crate::events::combat::{CreatureBecameBlockedEvent, CreatureBlockedEvent};
 use crate::events::other::{
-    CardsDrawnEvent, ControlChangedEvent, KeywordActionEvent, KeywordActionKind, SearchLibraryEvent,
+    CardDiscardedEvent, CardsDrawnEvent, ControlChangedEvent, KeywordActionEvent,
+    KeywordActionKind, SearchLibraryEvent,
 };
 use crate::events::permanents::SacrificeEvent;
 use crate::events::spells::SpellCastEvent;
@@ -163,6 +164,20 @@ impl TurnHistory {
             .filter_map(|record| record.event.downcast::<CardsDrawnEvent>())
             .filter(|event| event.player == player)
             .map(CardsDrawnEvent::amount)
+            .sum()
+    }
+
+    pub fn cards_discarded_by_player(&self, player: PlayerId) -> u32 {
+        self.projected_records()
+            .filter_map(|record| record.event.downcast::<CardDiscardedEvent>())
+            .filter(|event| event.player == player)
+            .count() as u32
+    }
+
+    pub fn total_cards_discarded_for_players(&self, players: &[PlayerId]) -> u32 {
+        players
+            .iter()
+            .map(|player| self.cards_discarded_by_player(*player))
             .sum()
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dihada's Ploy
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to the number of cards you've discarded this turn'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to the number of cards you've discarded this turn')
```

Worker: i-062740f575c384c34
