### PR TITLE
Fix Ironsmith parse failure: Agonizing Demise

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -3239,6 +3239,36 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
             target_count,
         ));
     }
+    if remaining_words.len() >= 2 {
+        let object_head = strip_possessive_suffix(remaining_words[0]);
+        if matches!(remaining_words[1], "controller" | "controllers" | "owner" | "owners")
+            && (matches!(
+                object_head,
+                "creature"
+                    | "creatures"
+                    | "permanent"
+                    | "permanents"
+                    | "spell"
+                    | "spells"
+                    | "source"
+                    | "sources"
+                    | "card"
+                    | "cards"
+            ) || parse_card_type(object_head).is_some()
+                || str_strip_suffix(object_head, "s")
+                    .is_some_and(|singular| parse_card_type(singular).is_some()))
+        {
+            let player = if str_starts_with(remaining_words[1], "owner") {
+                PlayerFilter::OwnerOf(crate::filter::ObjectRef::tagged(IT_TAG))
+            } else {
+                PlayerFilter::ControllerOf(crate::filter::ObjectRef::tagged(IT_TAG))
+            };
+            return Ok(wrap_target_count(
+                TargetAst::Player(player, target_span),
+                target_count,
+            ));
+        }
+    }
     if words_have_prefix(&remaining_words, &["its", "owner"])
         || words_have_prefix(&remaining_words, &["its", "owners"])
         || words_have_prefix(&remaining_words, &["their", "owner"])

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -343,7 +343,8 @@ pub(crate) fn parse_deal_damage_equal_to_clause(
                         | "creature"
                         | "planeswalker"
                 )
-            );
+            )
+            || parse_target_phrase(&tokens[idx + 1..]).is_ok();
         if looks_like_target {
             target_to_idx = Some(idx);
             break;

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10683,6 +10683,23 @@ fn rewrite_lexed_effect_sentence_supports_equal_to_compound_damage_to_objects_an
 }
 
 #[test]
+fn rewrite_lexed_effect_sentence_supports_equal_to_damage_to_controller_phrase_target() {
+    let text = "It deals damage equal to that creature's power to the creature's controller.";
+    let lexed = lex_line(text, 0)
+        .expect("rewrite lexer should classify equal-to damage with controller phrase target");
+
+    let parsed = parse_effect_sentence_lexed(&lexed)
+        .expect("rewrite effect sentence parser should accept controller phrase target");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("PowerOf(Tagged(TagKey(\"__it__\")))"), "{debug}");
+    assert!(
+        debug.contains("target: Player(ControllerOf(Tagged(TagKey(\"__it__\"))), None)"),
+        "{debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_sentence_supports_target_gain_then_get_where_x() {
     let text = "Target creature gains trample and gets +X/+0 until end of turn, where X is the number of creatures you control.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify gain-then-get sentence");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12001,6 +12001,13 @@ pub(super) fn describe_tagged_target_then_power_damage(
         return None;
     }
 
+    if let ChooseSpec::Player(PlayerFilter::ControllerOf(controller_ref) | PlayerFilter::OwnerOf(controller_ref)) =
+        deal.target.base()
+        && matches!(controller_ref, crate::filter::ObjectRef::Tagged(tag) if tag.as_str() == source_tag.as_str())
+    {
+        return None;
+    }
+
     let source_text = describe_choose_spec(&target_only.target);
     if matches!(
         deal.target,
@@ -12999,6 +13006,22 @@ mod tests {
         assert_eq!(
             describe_effect(&effect),
             "this creature deals damage equal to the number of artifacts they control to that player"
+        );
+    }
+
+    #[test]
+    fn power_damage_to_tagged_controllers_keeps_spell_source_surface() {
+        let tagged = TagKey::from("destroyed_0");
+        let effect = Effect::deal_damage(
+            Value::PowerOf(Box::new(ChooseSpec::Tagged(tagged.clone()))),
+            ChooseSpec::Player(PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(
+                tagged,
+            ))),
+        );
+
+        assert_eq!(
+            describe_effect(&effect),
+            "Deal damage equal to that creature's power to that object's controller"
         );
     }
 
@@ -24849,6 +24872,28 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(deal_damage) = effect.downcast_ref::<crate::effects::DealDamageEffect>() {
         if let Value::PowerOf(source) | Value::ToughnessOf(source) = &deal_damage.amount {
+            let target_matches_power_source = matches!(
+                (source.base(), deal_damage.target.base()),
+                (
+                    ChooseSpec::Tagged(source_tag),
+                    ChooseSpec::Player(
+                        PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(target_tag))
+                            | PlayerFilter::OwnerOf(crate::target::ObjectRef::Tagged(target_tag))
+                    )
+                ) if source_tag.as_str() == target_tag.as_str()
+            );
+            if target_matches_power_source {
+                let stat = if matches!(&deal_damage.amount, Value::ToughnessOf(_)) {
+                    "toughness"
+                } else {
+                    "power"
+                };
+                let amount_text = describe_dynamic_counter_basis(source, stat);
+                return format!(
+                    "Deal damage equal to {amount_text} to {}",
+                    describe_choose_spec(&deal_damage.target)
+                );
+            }
             let mut subject = describe_choose_spec(source);
             if subject == "this source" {
                 subject = "this creature".to_string();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Agonizing Demise
Initial parse error:
```
missing damage target in equal-to clause (clause: 'damage equal to that creature's power to the creature's controller'); oracle-only fallback also failed: missing damage target in equal-to clause (clause: 'damage equal to that creature's power to the creature's controller')
```

Worker: i-00664a0718dc07c6f
