### PR TITLE
Fix Ironsmith parse failure: Mogis, God of Slaughter

### DIFF
--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -3668,6 +3668,19 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     {
         return "Target player sacrifices a creature of their choice".to_string();
     }
+    if let Some(rest) = normalized.strip_prefix("This creature source is no longer creature as long as ")
+    {
+        return format!("This card isn't a creature as long as {rest}");
+    }
+    if let Some(rest) = normalized.strip_prefix("This source is no longer creature as long as ") {
+        return format!("This card isn't a creature as long as {rest}");
+    }
+    if normalized.contains(" to that player unless target player sacrifices a creature") {
+        return normalized.replace(
+            " to that player unless target player sacrifices a creature",
+            " to that player unless that player sacrifices a creature of their choice",
+        );
+    }
     if lower_normalized
         == "target player sacrifices target player's creature. target player loses 1 life"
     {
@@ -11161,6 +11174,26 @@ mod tests {
                 "Strax fights another target that player's creature."
             ),
             "Strax fights another target creature that player controls."
+        );
+    }
+
+    #[test]
+    fn normalize_as_long_as_no_longer_creature_source_clause() {
+        assert_eq!(
+            normalize_common_semantic_phrasing(
+                "This creature source is no longer creature as long as your devotion to black plus your devotion to red is less than seven."
+            ),
+            "This card isn't a creature as long as your devotion to black plus your devotion to red is less than seven."
+        );
+    }
+
+    #[test]
+    fn normalize_unless_target_player_sacrifice_clause() {
+        assert_eq!(
+            normalize_common_semantic_phrasing(
+                "At the beginning of each opponent's upkeep, this creature deals 2 damage to that player unless target player sacrifices a creature."
+            ),
+            "At the beginning of each opponent's upkeep, this creature deals 2 damage to that player unless that player sacrifices a creature of their choice."
         );
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -739,6 +739,44 @@ fn comparison_display(cmp: &Comparison) -> String {
     }
 }
 
+fn describe_static_condition_value(value: &Value) -> String {
+    match value {
+        Value::Fixed(n) => number_word_u32(*n as u32).unwrap_or_else(|| n.to_string()),
+        Value::Add(left, right)
+            if matches!(left.as_ref(), Value::Devotion { .. })
+                && matches!(right.as_ref(), Value::Devotion { .. }) =>
+        {
+            let (Value::Devotion { player: left_player, color: left_color }, Value::Devotion { player: right_player, color: right_color }) =
+                (left.as_ref(), right.as_ref())
+            else {
+                unreachable!();
+            };
+            if left_player == right_player {
+                return format!(
+                    "{} devotion to {} and {}",
+                    describe_static_possessive_player(left_player),
+                    left_color.name(),
+                    right_color.name()
+                );
+            }
+            format!(
+                "{} plus {}",
+                describe_static_condition_value(left),
+                describe_static_condition_value(right)
+            )
+        }
+        Value::Devotion { player, color } => {
+            format!("{} devotion to {}", describe_static_possessive_player(player), color.name())
+        }
+        Value::Add(left, right) => format!(
+            "{} plus {}",
+            describe_static_condition_value(left),
+            describe_static_condition_value(right)
+        ),
+        other => format!("{other:?}"),
+    }
+}
+
 fn flatten_static_condition_and(
     condition: &crate::ConditionExpr,
     out: &mut Vec<crate::ConditionExpr>,
@@ -955,6 +993,30 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             format!(
                 "as long as there are {comparison} cards in {} graveyard",
                 describe_static_possessive_player(player)
+            )
+        }
+        crate::ConditionExpr::ValueComparison {
+            left,
+            operator,
+            right,
+        } => {
+            let operator_text = match operator {
+                crate::effect::ValueComparisonOperator::GreaterThan => "is greater than",
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual => {
+                    "is greater than or equal to"
+                }
+                crate::effect::ValueComparisonOperator::Equal => "is equal to",
+                crate::effect::ValueComparisonOperator::LessThan => "is less than",
+                crate::effect::ValueComparisonOperator::LessThanOrEqual => {
+                    "is less than or equal to"
+                }
+                crate::effect::ValueComparisonOperator::NotEqual => "is not equal to",
+            };
+            format!(
+                "as long as {} {} {}",
+                describe_static_condition_value(left),
+                operator_text,
+                describe_static_condition_value(right)
             )
         }
         crate::ConditionExpr::PlayerIsMonarch { player } => match player {
@@ -3956,6 +4018,7 @@ mod tests {
     use super::*;
     use crate::card::{CardBuilder, PowerToughness};
     use crate::cards::builders::CardDefinitionBuilder;
+    use crate::color::Color;
     use crate::filter::StackObjectKind;
     use crate::ids::CardId;
     use crate::mana::{ManaCost, ManaSymbol};
@@ -4012,6 +4075,53 @@ mod tests {
                 }
             ),
             "as long as your life total is less than or equal to half your starting life total"
+        );
+    }
+
+    #[test]
+    fn describe_static_condition_displays_devotion_value_comparison() {
+        assert_eq!(
+            describe_static_condition(&crate::ConditionExpr::ValueComparison {
+                left: Value::Add(
+                    Box::new(Value::Devotion {
+                        player: PlayerFilter::You,
+                        color: Color::Black,
+                    }),
+                    Box::new(Value::Devotion {
+                        player: PlayerFilter::You,
+                        color: Color::Red,
+                    }),
+                ),
+                operator: crate::effect::ValueComparisonOperator::LessThan,
+                right: Value::Fixed(7),
+            }),
+            "as long as your devotion to black and red is less than seven"
+        );
+    }
+
+    #[test]
+    fn remove_card_types_display_keeps_source_creature_subject() {
+        let remove = RemoveCardTypesForFilter::new(
+            ObjectFilter::source().with_type(CardType::Creature),
+            vec![CardType::Creature],
+        )
+        .with_condition(crate::ConditionExpr::ValueComparison {
+            left: Value::Add(
+                Box::new(Value::Devotion {
+                    player: PlayerFilter::You,
+                    color: Color::Black,
+                }),
+                Box::new(Value::Devotion {
+                    player: PlayerFilter::You,
+                    color: Color::Red,
+                }),
+            ),
+            operator: crate::effect::ValueComparisonOperator::LessThan,
+            right: Value::Fixed(7),
+        });
+        assert_eq!(
+            remove.display(),
+            "this creature is no longer creature as long as your devotion to black and red is less than seven"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mogis, God of Slaughter
Initial parse error:
```
compiled text contains internal marker: value-comparison-debug
```

Worker: i-0b1c5eb8e0fc099ec
