### PR TITLE
Fix Ironsmith parse failure: Jenova, Ancient Calamity

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -290,6 +290,19 @@ fn parse_put_counter_count_value(
         if let Some(value) = parse_dynamic_cost_modifier_value(tokens)? {
             return Ok((value, 3));
         }
+        if let Some(equal_idx) = find_token_index(tokens, |token| token.is_word("equal"))
+            && tokens
+                .get(equal_idx + 1)
+                .is_some_and(|token| token.is_word("to"))
+            && let Some(on_idx) = find_token_index(&tokens[equal_idx + 2..], |token| token.is_word("on"))
+        {
+            let value_tokens = trim_commas(&tokens[equal_idx + 2..equal_idx + 2 + on_idx]);
+            if let Some((value, used)) = parse_value(&value_tokens)
+                && used == value_tokens.len()
+            {
+                return Ok((value, 3));
+            }
+        }
         return Err(CardTextError::ParseError(format!(
             "missing counter amount (clause: '{}')",
             clause

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2633,6 +2633,23 @@ fn rewrite_zone_counter_helpers_parse_difference_counter_amount() {
 }
 
 #[test]
+fn rewrite_zone_counter_helpers_parse_equal_to_named_source_power_counter_amount() {
+    let tokens = lex_line(
+        "Put a number of +1/+1 counters equal to Jenova's power on up to one other target creature.",
+        0,
+    )
+    .expect("rewrite lexer should classify source-power counter clause");
+
+    let parsed = parse_effect_sentence_lexed(&tokens)
+        .expect("source-power counter clause should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("PutCounters"), "{debug}");
+    assert!(debug.contains("PowerOf(Source)"), "{debug}");
+    assert!(debug.contains("count: UpTo(1)"), "{debug}");
+}
+
+#[test]
 fn rewrite_triggered_it_damage_source_binds_to_triggering_object() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Warstorm Surge Probe")
         .card_types(vec![CardType::Enchantment])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jenova, Ancient Calamity
Initial parse error:
```
missing counter amount (clause: 'a number of +1/+1 counters equal to jenovas power on up to one other target creature'); oracle-only fallback also failed: missing counter amount (clause: 'a number of +1/+1 counters equal to thiss power on up to one other target creature')
```

Worker: i-08ddb3ce41fe06ea2
