### PR TITLE
Fix Ironsmith parse failure: Unforge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2327,6 +2327,25 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::ManaSpentToCastThisSpellAtLeast { amount, symbol });
     }
 
+    if filtered.len() >= 6
+        && filtered[0] == "that"
+        && filtered[1] == "equipment"
+        && filtered[2] == "was"
+        && filtered[3] == "attached"
+        && filtered[4] == "to"
+    {
+        let attachment_tokens = std::iter::once(OwnedLexToken::word(
+            "equipment".to_string(),
+            TextSpan::synthetic(),
+        ))
+        .chain(filtered[3..].iter().map(|word| {
+            OwnedLexToken::word((*word).to_string(), TextSpan::synthetic())
+        }))
+        .collect::<Vec<_>>();
+        let filter = parse_object_filter(&attachment_tokens, false)?;
+        return Ok(PredicateAst::TaggedMatches(TagKey::from(IT_TAG), filter));
+    }
+
     if filtered.len() >= 5
         && matches!(
             filtered.as_slice(),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12607,6 +12607,21 @@ fn rewrite_grammar_no_permanents_left_battlefield_this_turn_predicate_parses() {
 }
 
 #[test]
+fn rewrite_grammar_that_equipment_was_attached_to_creature_predicate_parses() {
+    let tokens = lex_line("that Equipment was attached to a creature", 0)
+        .expect("rewrite lexer should classify attachment-history predicate");
+
+    let parsed = super::parse_predicate_lexed(&tokens).expect("predicate should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("TaggedMatches"), "{debug}");
+    assert!(debug.contains("\"it\""), "{debug}");
+    assert!(debug.contains("Equipment"), "{debug}");
+    assert!(debug.contains("AttachedTo"), "{debug}");
+    assert!(debug.contains("Creature"), "{debug}");
+}
+
+#[test]
 fn rewrite_parse_subject_player_with_most_cards_in_hand() {
     let tokens = lex_line("the player who has the most cards in hand", 0)
         .expect("rewrite lexer should classify most-cards subject");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Unforge
Initial parse error:
```
unsupported predicate (predicate: 'that equipment was attached to creature'); oracle-only fallback also failed: unsupported predicate (predicate: 'that equipment was attached to creature')
```

Worker: i-0ead39e29daf67d57
