### PR TITLE
Fix Ironsmith parse failure: Radha, Heart of Keld // Radha, Heart of Keld

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -3,7 +3,8 @@ use super::line_family_handlers::{
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
     run_combined_static_line_family, run_keyword_line_family, run_labeled_line_family,
     run_learn_line_family, run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
-    run_split_top_and_face_down_look_line_family, run_start_your_engines_line_family,
+    run_split_top_and_face_down_look_line_family, run_split_top_look_and_top_land_play_line_family,
+    run_start_your_engines_line_family,
     run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
     run_station_line_family, run_station_threshold_line_family,
     run_trailing_keyword_activation_line_family, run_triggered_line_family,
@@ -44,7 +45,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 21] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -100,8 +101,14 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
         run: run_split_top_and_face_down_look_line_family,
     },
     LineFamilyRuleDef {
-        id: "champion-line",
+        id: "split-top-look-and-top-land-play-line",
         priority: 39,
+        heads: &["you"],
+        run: run_split_top_look_and_top_land_play_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "champion-line",
+        priority: 40,
         heads: &["champion"],
         run: run_champion_line_family,
     },

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -221,6 +221,42 @@ pub(super) fn run_split_top_and_face_down_look_line_family(
     }))
 }
 
+pub(super) fn run_split_top_look_and_top_land_play_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let lower = ctx.line.info.raw_line.trim().to_ascii_lowercase();
+    let phrase = "you may look at the top card of your library any time, and you may play lands from the top of your library";
+    if lower.trim_end_matches('.') != phrase {
+        return Ok(None);
+    }
+
+    let top_card_line =
+        rewrite_line_normalized(ctx.line, "You may look at the top card of your library any time.")?;
+    let play_lands_line =
+        rewrite_line_normalized(ctx.line, "You may play lands from the top of your library.")?;
+
+    let Some(top_card_static) = parse_static_line_cst(&top_card_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower split top-card look line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    let Some(play_lands_static) = parse_static_line_cst(&play_lands_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower split top-library land-play line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+
+    Ok(Some(LineDispatchResult {
+        lines: vec![
+            RewriteLineCst::Static(top_card_static),
+            RewriteLineCst::Static(play_lands_static),
+        ],
+        next_idx: ctx.idx + 1,
+    }))
+}
+
 pub(super) fn run_champion_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8154,6 +8154,28 @@ fn parse_lens_of_clarity_split_look_permissions() {
 }
 
 #[test]
+fn parse_radha_split_top_look_and_top_land_play_permissions() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Radha Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "You may look at the top card of your library any time, and you may play lands from the top of your library.",
+        )
+        .expect("Radha static line should parse");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("LookAtTopCardOfLibrary"),
+        "expected top-card look permission, got {debug}"
+    );
+    assert!(
+        debug.contains("PlayFromZone")
+            || debug.contains("lands from the top of your library")
+            || debug.contains("GrantSpec"),
+        "expected top-library land-play grant, got {debug}"
+    );
+}
+
+#[test]
 fn parse_lantern_of_insight_public_top_library_static_and_shuffle() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Lantern of Insight Variant")
         .card_types(vec![CardType::Artifact])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Radha, Heart of Keld // Radha, Heart of Keld
Initial parse error:
```
parser does not yet support line family: 'You may look at the top card of your library any time, and you may play lands from the top of your library.'; oracle-only fallback also failed: parser does not yet support line family: 'You may look at the top card of your library any time, and you may play lands from the top of your library.'
```

Worker: i-045b00310391425c4
