### PR TITLE
Fix Ironsmith parse failure: Dig Up

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -439,6 +439,7 @@ pub(crate) fn marker_keyword_id(keyword: &str) -> Option<&'static str> {
         "foretell" => Some("foretell"),
         "bestow" => Some("bestow"),
         "dash" => Some("dash"),
+        "cleave" => Some("cleave"),
         "overload" => Some("overload"),
         "soulshift" => Some("soulshift"),
         "adapt" => Some("adapt"),
@@ -486,7 +487,7 @@ pub(crate) fn marker_keyword_display(words: &[&str]) -> Option<String> {
         }
         "bestow" | "dash" | "disturb" | "embalm" | "emerge" | "ninjutsu" | "outlast"
         | "scavenge" | "unearth" | "specialize" | "spectacle" | "plot" | "disguise"
-        | "flashback" | "foretell" | "overload" => {
+        | "flashback" | "foretell" | "overload" | "cleave" => {
             let (cost, _) = leading_mana_symbols_to_oracle(&words[1..])?;
             Some(format!("{title} {cost}"))
         }
@@ -1295,6 +1296,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
                 | "foretell"
                 | "bestow"
                 | "dash"
+                | "cleave"
                 | "overload"
                 | "soulshift"
                 | "adapt"

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -369,6 +369,9 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
 
     let word_view = TokenWordView::new(tokens);
     let first = word_view.get(0)?;
+    if first == "cleave" {
+        return Some(KeywordDispatchHint::AlternativeOrExertFamily);
+    }
     if first == "basic" {
         if word_view.get(1) == Some("landcycling") {
             return Some(KeywordDispatchHint::Cycling);

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -40,6 +40,7 @@ use super::util::{
     parse_replicate_line_lexed, parse_retrace_line_lexed,
     parse_self_free_cast_alternative_cost_line_lexed, parse_squad_line_lexed,
     parse_transmute_line_lexed, parse_warp_line_lexed,
+    parse_cleave_line_lexed,
     parse_you_may_rather_than_spell_cost_line_lexed, preserve_keyword_prefix_for_parse,
 };
 
@@ -221,6 +222,9 @@ pub(super) fn lower_alternative_cast(
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     if let Some(method) = parse_flash_with_additional_cost_line_lexed(tokens) {
+        return Ok(LineAst::AlternativeCastingMethod(method.into()));
+    }
+    if let Some(method) = parse_cleave_line_lexed(tokens)? {
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     if let Some(method) =
@@ -874,6 +878,7 @@ fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTex
             || parse_you_may_rather_than_spell_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()
             || parse_flash_with_additional_cost_line_lexed(tokens).is_some()
+            || parse_cleave_line_lexed(tokens)?.is_some()
             || parse_if_conditional_alternative_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()
             || parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)?.is_some(),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1625,6 +1625,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_document_cst_recognizes_cleave_keyword_line() -> Result<(), CardTextError> {
+        let preprocessed = preprocess_document(
+            CardDefinitionBuilder::new(CardId::new(), "Dig Up").card_types(vec![CardType::Sorcery]),
+            "Cleave {1}{B}{B}{G} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nSearch your library for a [basic land] card, [reveal it,] put it into your hand, then shuffle.",
+        )?;
+        let cst = super::parse_document_cst(&preprocessed, false)?;
+
+        assert!(
+            matches!(
+                cst.lines.as_slice(),
+                [super::RewriteLineCst::Keyword(_), super::RewriteLineCst::Statement(_)]
+            ),
+            "expected cleave line to parse as keyword and body as statement, got {:?}",
+            cst.lines
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn static_line_cst_recognizes_compound_unblockable_from_tokens() -> Result<(), CardTextError> {
         let line = single_preprocessed_line("Enchanted creature gets +2/+2 and can't be blocked.");
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4613,6 +4613,28 @@ pub(crate) fn parse_warp_line_lexed(
     parse_warp_line(tokens)
 }
 
+pub(crate) fn parse_cleave_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    if !tokens.first().is_some_and(|token| token.is_word("cleave")) {
+        return Ok(None);
+    }
+
+    let (cost, _) = leading_mana_cost_from_tokens(tokens.get(1..).unwrap_or_default())
+        .ok_or_else(|| CardTextError::ParseError("cleave keyword missing mana cost".to_string()))?;
+    Ok(Some(AlternativeCastingMethod::Composed {
+        name: "Cleave",
+        total_cost: TotalCost::mana(cost),
+        condition: None,
+    }))
+}
+
+pub(crate) fn parse_cleave_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    parse_cleave_line(tokens)
+}
+
 pub(crate) fn parse_bestow_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1745,6 +1745,12 @@ pub(super) fn describe_alternative_cast_line(
                 .map(|cost| format!("Emerge {}", cost.to_oracle()))
                 .unwrap_or_else(|| "Emerge".to_string())
         }
+        method if method.is_composed_cost() && method.name().eq_ignore_ascii_case("Cleave") => {
+            method
+                .mana_cost()
+                .map(|cost| format!("Cleave {}", cost.to_oracle()))
+                .unwrap_or_else(|| "Cleave".to_string())
+        }
         method if method.is_composed_cost() => {
             let name = method.name();
             let mana_cost = method.mana_cost();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dig Up
Initial parse error:
```
parser does not yet support line family: 'Cleave {1}{B}{B}{G} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)'; oracle-only fallback also failed: parser does not yet support line family: 'Cleave {1}{B}{B}{G}'
```

Worker: i-0a292c7864e35d652
