### PR TITLE
Fix Ironsmith parse failure: Zealous Display

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -3,6 +3,7 @@ use super::line_family_handlers::{
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
     run_combined_static_line_family, run_keyword_line_family, run_labeled_line_family,
     run_learn_line_family, run_max_speed_labeled_line_family, run_partner_with_keyword_line_family,
+    run_non_turn_conditional_untap_line_family,
     run_split_top_and_face_down_look_line_family, run_start_your_engines_line_family,
     run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
     run_station_line_family, run_station_threshold_line_family,
@@ -44,7 +45,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 21] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -140,6 +141,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 20] = [
         priority: 70,
         heads: &["as", "if"],
         run: run_combined_static_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "non-turn-conditional-untap",
+        priority: 75,
+        heads: &["creatures"],
+        run: run_non_turn_conditional_untap_line_family,
     },
     LineFamilyRuleDef {
         id: "statement-probe",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -609,6 +609,55 @@ pub(super) fn run_combined_static_line_family(
     }))
 }
 
+pub(super) fn run_non_turn_conditional_untap_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let lower = raw.to_ascii_lowercase();
+    const SUFFIX: &str = "if it's not your turn, untap those creatures.";
+    if !lower.ends_with(SUFFIX) {
+        return Ok(None);
+    }
+
+    let marker = format!(". {SUFFIX}");
+    let Some(split_idx) = lower.rfind(marker.as_str()) else {
+        return Ok(None);
+    };
+    let Some(prefix) = raw.get(..split_idx) else {
+        return Ok(None);
+    };
+
+    let first_sentence = prefix.trim();
+    if first_sentence.is_empty() {
+        return Ok(None);
+    }
+
+    if !first_sentence
+        .to_ascii_lowercase()
+        .starts_with("creatures you control get ")
+    {
+        return Ok(None);
+    }
+
+    let first_line = rewrite_line_normalized(ctx.line, first_sentence.trim_end_matches('.'))?;
+    let Some(first_statement) = parse_statement_line_cst(&first_line)? else {
+        return Ok(None);
+    };
+
+    let second_line = rewrite_line_normalized(ctx.line, "If it's not your turn, untap them")?;
+    let Some(second_statement) = parse_statement_line_cst(&second_line)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(LineDispatchResult {
+        lines: vec![
+            RewriteLineCst::Statement(first_statement),
+            RewriteLineCst::Statement(second_statement),
+        ],
+        next_idx: ctx.idx + 1,
+    }))
+}
+
 pub(super) fn run_statement_probe_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1763,6 +1763,17 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if matches!(
         filtered.as_slice(),
+        ["it", "not", "your", "turn"]
+            | ["its", "not", "your", "turn"]
+            | ["it", "is", "not", "your", "turn"]
+            | ["its", "is", "not", "your", "turn"]
+            | ["not", "your", "turn"]
+    ) {
+        return Ok(PredicateAst::Not(Box::new(PredicateAst::YourTurn)));
+    }
+
+    if matches!(
+        filtered.as_slice(),
         ["creature", "died", "this", "turn"] | ["creatures", "died", "this", "turn"]
     ) {
         return Ok(PredicateAst::CreatureDiedThisTurn);

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1232,6 +1232,24 @@ fn rewrite_structure_predicate_parse_entrypoint_matches_parser_root_output() {
 }
 
 #[test]
+fn rewrite_structure_predicate_parse_entrypoint_parses_not_your_turn() {
+    let text = "it's not your turn";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify predicate text");
+
+    let grammar = super::grammar::structure::parse_predicate_with_grammar_entrypoint_lexed(&lexed)
+        .expect("grammar predicate entrypoint should parse");
+    let parser_root = super::parse_predicate_lexed(&lexed)
+        .expect("parser-root predicate entrypoint should parse");
+    let debug = format!("{grammar:?}");
+
+    assert_eq!(grammar, parser_root);
+    assert!(
+        debug.contains("Not") && debug.contains("YourTurn"),
+        "expected negated your-turn predicate AST, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_structure_predicate_parse_entrypoint_matches_parser_root_output_for_conjoined_predicate()
 {
     let text = "it's your turn and you have no cards in hand";

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35468,6 +35468,47 @@ fn valley_floodcaller_compiled_lines_meet_strict_semantic_threshold() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_zealous_display_non_turn_conditional_untap_clause() {
+    let oracle =
+        "Creatures you control get +2/+0 until end of turn. If it's not your turn, untap those creatures.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "Zealous Display")
+        .card_types(vec![CardType::Instant])
+        .parse_text(oracle)
+        .expect("Zealous Display conditional untap clause should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        (rendered_lower.contains("creatures you control get +2/+0 until end of turn")
+            || rendered_lower.contains("each creature you control gets +2/+0 until end of turn"))
+            && rendered_lower.contains("if it's not your turn")
+            && rendered_lower.contains("untap those creatures"),
+        "expected Zealous Display wording to preserve conditional untap follow-up, got {rendered}"
+    );
+
+    let compiled = crate::compiled_text::unprocessed_compiled_lines(&def);
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            oracle,
+            &compiled,
+            Some(crate::semantic_compare::EmbeddingConfig {
+                dims: 384,
+                mismatch_threshold: 0.99,
+            }),
+        );
+
+    assert!(
+        similarity >= 0.99,
+        "expected Zealous Display to clear strict semantic threshold, got score={similarity}, lines={compiled:?}"
+    );
+    assert!(
+        !mismatch,
+        "expected Zealous Display to avoid semantic mismatch, got lines={compiled:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_choose_color_then_add_devotion_to_that_color() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Nykthos Variant")
         .card_types(vec![CardType::Land])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -2340,8 +2340,18 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             ". Then that player shuffles.",
         );
     }
-    let preserve_plural_creatures_you_control =
-        normalized.contains("from the command zone this game");
+    if normalized.starts_with("Creatures you control get ")
+        && normalized.contains(" until end of turn. If it is not your turn, untap them.")
+    {
+        normalized = normalized.replace(
+            " until end of turn. If it is not your turn, untap them.",
+            " until end of turn. If it's not your turn, untap those creatures.",
+        );
+    }
+    let preserve_plural_creatures_you_control = normalized.contains("from the command zone this game")
+        || normalized
+            .to_ascii_lowercase()
+            .contains("if it is not your turn, untap them");
     if !preserve_plural_creatures_you_control {
         if normalized.starts_with("creatures you control get ") {
             normalized = normalized.replacen(
@@ -10863,6 +10873,8 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             } = inner.as_ref()
             {
                 "no mana was spent to cast the target spell".to_string()
+            } else if let Condition::YourTurn = inner.as_ref() {
+                "it is not your turn".to_string()
             } else if let Condition::PermanentLeftBattlefieldThisTurn = inner.as_ref() {
                 "no permanents left the battlefield this turn".to_string()
             } else if let Condition::CardsInHandOrMore(1) = inner.as_ref() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Zealous Display
Initial parse error:
```
parser does not yet support line family: 'Creatures you control get +2/+0 until end of turn. If it's not your turn, untap those creatures.'; oracle-only fallback also failed: parser does not yet support line family: 'Creatures you control get +2/+0 until end of turn. If it's not your turn, untap those creatures.'
```

Worker: i-06dc103e23b50d93c
