### PR TITLE
Fix Ironsmith parse failure: Veteran's Powerblade

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
@@ -547,6 +547,12 @@ pub(crate) fn parse_equip_line(
         return Ok(None);
     }
 
+    let first_mana_idx = tokens
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find_map(|(idx, token)| mana_pips_from_token(token).map(|_| idx));
+
     let (mana_pips, saw_zero, saw_non_symbol) = tokens.iter().skip(1).fold(
         (Vec::new(), false, false),
         |(mut pips, mut saw_zero, mut saw_non_symbol), token| {
@@ -564,6 +570,52 @@ pub(crate) fn parse_equip_line(
     );
 
     if saw_non_symbol {
+        if let Some(cost_start_idx) = first_mana_idx {
+            let qualifier_tokens = trim_commas(&tokens[1..cost_start_idx]);
+            let cost_tokens = trim_commas(&tokens[cost_start_idx..]);
+            if !qualifier_tokens.is_empty() && !cost_tokens.is_empty() {
+                let Some(target_filter) = parse_equip_target_filter_qualifier(&qualifier_tokens)
+                else {
+                    return Ok(None);
+                };
+                let total_cost = parse_activation_cost(&cost_tokens)?;
+                let cost_text = total_cost
+                    .mana_cost()
+                    .map(|mana| mana.to_oracle())
+                    .unwrap_or_else(|| crate::runtime_backend::token_word_refs(&cost_tokens).join(" "));
+                let qualifier_text = keyword_title(
+                    &crate::runtime_backend::token_word_refs(&qualifier_tokens).join(" "),
+                );
+                let equip_text = format!("Equip {qualifier_text} {cost_text}");
+                let target = ChooseSpec::target(ChooseSpec::Object(target_filter));
+
+                return Ok(Some(ParsedAbility {
+                    ability: Ability {
+                        kind: AbilityKind::Activated(crate::ability::ActivatedAbility {
+                            mana_cost: total_cost,
+                            effects: crate::resolution::ResolutionProgram::from_effects(vec![
+                                Effect::attach_to(target.clone()),
+                            ]),
+                            choices: vec![target.clone()],
+                            timing: ActivationTiming::SorcerySpeed,
+                            additional_restrictions: vec![],
+                            activation_restrictions: vec![],
+                            mana_output: None,
+                            activation_condition: None,
+                            mana_usage_restrictions: vec![],
+                            is_loyalty_ability: false,
+                        }),
+                        functional_zones: vec![Zone::Battlefield],
+                    }
+                    .into(),
+                    text: Some(equip_text),
+                    effects_ast: None,
+                    reference_imports: ReferenceImports::default(),
+                    trigger_spec: None,
+                }));
+            }
+        }
+
         let looks_like_cost_prefix = clause_words.get(1).is_some_and(|word| {
             parse_mana_symbol(word).is_ok()
                 || matches!(
@@ -673,6 +725,34 @@ pub(crate) fn parse_equip_line(
         reference_imports: ReferenceImports::default(),
         trigger_spec: None,
     }))
+}
+
+fn parse_equip_target_filter_qualifier(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.is_empty() {
+        return None;
+    }
+    if words.last().copied() == Some("creature") {
+        let subtype_words = &words[..words.len().saturating_sub(1)];
+        if subtype_words.is_empty() {
+            return None;
+        }
+        if subtype_words.len() != 1 {
+            return None;
+        }
+        let subtype = parse_subtype_flexible(subtype_words[0])?;
+        let mut filter = ObjectFilter::creature().you_control();
+        push_unique(&mut filter.subtypes, subtype);
+        return Some(filter);
+    }
+
+    if words.len() != 1 {
+        return None;
+    }
+    let subtype = parse_subtype_flexible(words[0])?;
+    let mut filter = ObjectFilter::creature().you_control();
+    push_unique(&mut filter.subtypes, subtype);
+    Some(filter)
 }
 
 pub(crate) fn parse_equip_line_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1700,6 +1700,27 @@ fn rewrite_document_parser_supports_activate_only_once_each_turn_without_period(
 }
 
 #[test]
+fn rewrite_document_parser_supports_equip_with_subtype_qualifier() {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Subtype Equip Variant")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment]);
+
+    let def = builder
+        .parse_text("Equip Soldier {W}")
+        .expect("expected parser to support subtype-qualified equip");
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("subtypes:") && abilities_debug.contains("Soldier"),
+        "expected equip target filter to include Soldier subtype, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("AttachToEffect"),
+        "expected equip ability to remain an attach activation, got {abilities_debug}"
+    );
+}
+
+#[test]
 fn rewrite_document_parser_splits_activation_cost_on_colon_outside_quotes() {
     let builder = CardDefinitionBuilder::new(CardId::new(), "Quoted Colon Variant")
         .card_types(vec![CardType::Artifact]);

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -8998,6 +8998,28 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_equip_keyword_with_subtype_qualifier() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Veteran Powerblade Equip Variant")
+            .subtypes(vec![Subtype::Equipment])
+            .parse_text("Equip Soldier {W}\nEquip {2}")
+            .expect("parse subtype-qualified equip lines");
+
+        let abilities_debug = format!("{:#?}", def.abilities);
+        assert!(
+            abilities_debug.contains("subtypes:") && abilities_debug.contains("Soldier"),
+            "expected subtype-qualified equip target filter, got {abilities_debug}"
+        );
+
+        let lines = unprocessed_compiled_lines(&def);
+        assert!(
+            lines.iter().any(|line| line == "Equip Soldier {W}"),
+            "expected subtype-qualified equip keyword line, got {:?}",
+            lines
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_skip_turn_from_text() {
         let def = CardDefinitionBuilder::new(CardId::new(), "Meditate")
             .parse_text("You skip your next turn.")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -30775,8 +30775,11 @@ fn describe_structural_equip_keyword(
     }
 
     let cost = describe_cost_list(activated.mana_cost.costs());
+    let qualifier = equip_target_qualifier_text(&attach.target);
     let mut rendered = if cost.trim().is_empty() || cost.eq_ignore_ascii_case("Free") {
         "Equip {0}".to_string()
+    } else if let Some(qualifier) = qualifier {
+        format!("Equip {qualifier} {cost}")
     } else {
         format!("Equip {cost}")
     };
@@ -32247,6 +32250,26 @@ fn is_target_creature_you_control(spec: &ChooseSpec) -> bool {
                 && filter.card_types.contains(&CardType::Creature)
         }
         _ => false,
+    }
+}
+
+fn equip_target_qualifier_text(spec: &ChooseSpec) -> Option<String> {
+    match spec {
+        ChooseSpec::Target(inner) => equip_target_qualifier_text(inner),
+        ChooseSpec::WithCount(inner, count) if count.is_single() => equip_target_qualifier_text(inner),
+        ChooseSpec::Object(filter) => {
+            if filter.zone != Some(Zone::Battlefield)
+                || filter.controller != Some(PlayerFilter::You)
+                || !filter.card_types.contains(&CardType::Creature)
+            {
+                return None;
+            }
+            if filter.subtypes.len() == 1 {
+                return Some(filter.subtypes[0].to_string());
+            }
+            None
+        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Veteran's Powerblade
Initial parse error:
```
parser does not yet support line family: 'Equip Soldier {W}'; oracle-only fallback also failed: parser does not yet support line family: 'Equip Soldier {W}'
```

Worker: i-0116989f725f86c20
