### PR TITLE
Fix Ironsmith parse failure: Thunderous Debut

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -592,6 +592,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_object_filter_lexed_handles_revealed_cards_reference() {
+        let tokens = lex_line("revealed cards", 0).unwrap();
+
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert!(filter.tagged_constraints.iter().any(|constraint| {
+            *constraint
+                == TaggedObjectConstraint {
+                    tag: TagKey::from(IT_TAG),
+                    relation: TaggedOpbjectRelation::IsTaggedObject,
+                }
+        }));
+    }
+
+    #[test]
     fn parse_object_filter_lexed_handles_same_mana_value_as_sacrificed_reference() {
         let tokens = lex_line(
             "creature with same mana value as the sacrificed creature",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
@@ -1023,6 +1023,14 @@ pub(super) fn apply_reference_and_tag_stage(
         all_words.remove(0);
     }
 
+    if starts_with_any_filter_phrase(all_words, &[&["revealed", "card"], &["revealed", "cards"]]) {
+        filter.tagged_constraints.push(TaggedObjectConstraint {
+            tag: IT_TAG.into(),
+            relation: TaggedOpbjectRelation::IsTaggedObject,
+        });
+        all_words.drain(..2);
+    }
+
     let has_share_card_type = (contains_filter_word(all_words, "share")
         || contains_filter_word(all_words, "shares"))
         && (contains_filter_word(all_words, "card")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thunderous Debut
Initial parse error:
```
unsupported target phrase (clause: 'revealed cards'); oracle-only fallback also failed: unsupported target phrase (clause: 'revealed cards')
```

Worker: i-09c53dc56d6fdf279
