### PR TITLE
Fix Ironsmith parse failure: Regal Leosaur

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -50,6 +50,7 @@ pub(super) enum KeywordDispatchHint {
     Epic,
     Offspring,
     Madness,
+    Mutate,
     Escape,
     MorphFamily,
     Squad,
@@ -259,6 +260,12 @@ mod spell_keywords {
             lower: registry::lower_madness,
         },
         KeywordLineRule {
+            cst_kind: super::super::cst::KeywordLineKindCst::Mutate,
+            hints: &[KeywordDispatchHint::Mutate],
+            matches: registry::matches_mutate,
+            lower: registry::lower_mutate,
+        },
+        KeywordLineRule {
             cst_kind: super::super::cst::KeywordLineKindCst::Escape,
             hints: &[KeywordDispatchHint::Escape],
             matches: registry::matches_escape,
@@ -338,18 +345,21 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
             winnow::combinator::alt((
                 grammar::kw("retrace").value(KeywordDispatchHint::Retrace),
                 grammar::kw("madness").value(KeywordDispatchHint::Madness),
+                grammar::kw("mutate").value(KeywordDispatchHint::Mutate),
                 grammar::kw("escape").value(KeywordDispatchHint::Escape),
                 winnow::combinator::alt((
-                    grammar::kw("morph").value(KeywordDispatchHint::MorphFamily),
-                    grammar::kw("megamorph").value(KeywordDispatchHint::MorphFamily),
-                    grammar::kw("disguise").value(KeywordDispatchHint::MorphFamily),
+                    winnow::combinator::alt((
+                        grammar::kw("morph").value(KeywordDispatchHint::MorphFamily),
+                        grammar::kw("megamorph").value(KeywordDispatchHint::MorphFamily),
+                        grammar::kw("disguise").value(KeywordDispatchHint::MorphFamily),
+                    )),
+                    grammar::kw("squad").value(KeywordDispatchHint::Squad),
+                    grammar::kw("transmute").value(KeywordDispatchHint::Transmute),
+                    grammar::kw("reconfigure").value(KeywordDispatchHint::Reconfigure),
+                    grammar::kw("eternalize").value(KeywordDispatchHint::Eternalize),
+                    grammar::phrase(&["cast", "this", "spell", "only"])
+                        .value(KeywordDispatchHint::CastThisSpellOnly),
                 )),
-                grammar::kw("squad").value(KeywordDispatchHint::Squad),
-                grammar::kw("transmute").value(KeywordDispatchHint::Transmute),
-                grammar::kw("reconfigure").value(KeywordDispatchHint::Reconfigure),
-                grammar::kw("eternalize").value(KeywordDispatchHint::Eternalize),
-                grammar::phrase(&["cast", "this", "spell", "only"])
-                    .value(KeywordDispatchHint::CastThisSpellOnly),
             )),
             winnow::combinator::alt((
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -36,7 +36,8 @@ use super::util::{
     parse_flash_with_additional_cost_line_lexed, parse_flashback_line_lexed,
     parse_harmonize_line_lexed, parse_if_conditional_alternative_cost_line_lexed,
     parse_jump_start_line_lexed, parse_kicker_line_lexed, parse_madness_line_lexed,
-    parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_offspring_line_lexed,
+    parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_mutate_line_lexed,
+    parse_offspring_line_lexed,
     parse_reinforce_line_lexed, parse_replicate_line_lexed, parse_retrace_line_lexed,
     parse_self_free_cast_alternative_cost_line_lexed, parse_squad_line_lexed,
     parse_transmute_line_lexed, parse_warp_line_lexed,
@@ -384,6 +385,15 @@ pub(super) fn lower_madness(
 ) -> Result<LineAst, CardTextError> {
     Ok(LineAst::AlternativeCastingMethod(
         require_keyword_parse(line, "madness", parse_madness_line_lexed(tokens)?)?.into(),
+    ))
+}
+
+pub(super) fn lower_mutate(
+    line: &RewriteKeywordLine,
+    tokens: &[OwnedLexToken],
+) -> Result<LineAst, CardTextError> {
+    Ok(LineAst::StaticAbility(
+        require_keyword_parse(line, "mutate", parse_mutate_line_lexed(tokens)?)?.into(),
     ))
 }
 
@@ -773,6 +783,13 @@ pub(super) fn matches_madness(
     Ok(parse_madness_line_lexed(tokens)?.is_some())
 }
 
+pub(super) fn matches_mutate(
+    _line: &PreprocessedLine,
+    tokens: &[OwnedLexToken],
+) -> Result<bool, CardTextError> {
+    Ok(parse_mutate_line_lexed(tokens)?.is_some())
+}
+
 pub(super) fn matches_escape(
     _line: &PreprocessedLine,
     tokens: &[OwnedLexToken],
@@ -878,6 +895,7 @@ fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTex
                 .is_some()
             || parse_flash_with_additional_cost_line_lexed(tokens).is_some()
             || parse_jump_start_line_lexed(tokens)?.is_some()
+            || parse_mutate_line_lexed(tokens)?.is_some()
             || parse_if_conditional_alternative_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()
             || parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)?.is_some(),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -53,6 +53,7 @@ pub(crate) enum KeywordLineKindCst {
     Harmonize,
     Kicker,
     Madness,
+    Mutate,
     Morph,
     Multikicker,
     Replicate,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4668,6 +4668,21 @@ pub(crate) fn parse_warp_line_lexed(
     parse_warp_line(tokens)
 }
 
+pub(crate) fn parse_mutate_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if !tokens.first().is_some_and(|token| token.is_word("mutate")) {
+        return Ok(None);
+    }
+
+    let (cost, _) = leading_mana_cost_from_tokens(tokens.get(1..).unwrap_or_default())
+        .ok_or_else(|| CardTextError::ParseError("mutate keyword missing mana cost".to_string()))?;
+    Ok(Some(StaticAbility::keyword_marker(format!(
+        "Mutate {}",
+        cost.to_oracle()
+    ))))
+}
+
 pub(crate) fn parse_bestow_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5008,6 +5008,26 @@ fn jump_start_keyword_line_is_classified_as_alternative_cast() {
 }
 
 #[test]
+fn mutate_keyword_line_is_classified_and_lowered_to_marker_static_ability() {
+    let tokens = lex_line(
+        "Mutate {1}{R/W}{R/W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own.)",
+        0,
+    )
+    .expect("rewrite lexer should classify mutate keyword line");
+
+    assert!(matches!(
+        super::families::keyword_families::parse_keyword_dispatch_hint(&tokens),
+        Some(super::families::keyword_families::KeywordDispatchHint::Mutate)
+    ));
+
+    let parsed = super::front_end::shared::util::parse_mutate_line_lexed(&tokens)
+        .expect("mutate parse should not error")
+        .expect("mutate keyword line should parse");
+    let debug = format!("{parsed:?}");
+    assert!(debug.contains("Mutate {1}{R/W}{R/W}"), "{debug}");
+}
+
+#[test]
 fn equal_to_number_of_cards_you_ve_discarded_this_turn_parses() {
     let tokens = lex_line("equal to the number of cards you've discarded this turn", 0)
         .expect("rewrite lexer should classify value clause");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Regal Leosaur
Initial parse error:
```
parser does not yet support line family: 'Mutate {1}{R/W}{R/W} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)'; oracle-only fallback also failed: parser does not yet support line family: 'Mutate {1}{R/W}{R/W}'
```

Worker: i-0d943412f53e36d33
