### PR TITLE
Fix Ironsmith parse failure: Razorfield Ripper

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1544,6 +1544,27 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         return Some((Value::EventValue(EventValueSpec::Amount), 6));
     }
     if matches!(
+        words.get(..6),
+        Some(["the", "amount", "of", "e", "you", "have"])
+    ) {
+        return Some((
+            Value::CountersOn(
+                Box::new(ChooseSpec::Player(PlayerFilter::You)),
+                Some(CounterType::Energy),
+            ),
+            6,
+        ));
+    }
+    if matches!(words.get(..5), Some(["amount", "of", "e", "you", "have"])) {
+        return Some((
+            Value::CountersOn(
+                Box::new(ChooseSpec::Player(PlayerFilter::You)),
+                Some(CounterType::Energy),
+            ),
+            5,
+        ));
+    }
+    if matches!(
         words.get(..5),
         Some(["that", "amount", "of", "excess", "damage"])
     ) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33204,6 +33204,21 @@ fn parse_skyclave_apparition_where_x_uses_exiled_card_mana_value() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_where_x_amount_of_energy_you_have() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Razorfield Ripper Variant")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Target creature gets +X/+X until end of turn, where X is the amount of {E} you have.")
+        .expect("where-x energy amount clause should parse");
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("CountersOn(Player(You), Some(Energy))"),
+        "expected where-x binding to use your energy counters, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn where_x_exiled_card_plus_one_still_fails_loudly() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Broken Skyclave Variant")
         .parse_text(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Razorfield Ripper
Initial parse error:
```
unsupported where-x clause (clause: 'you get e then it gets +x/+x until end of turn where x is the amount of e you have'); oracle-only fallback also failed: unsupported where-x clause (clause: 'you get e then it gets +x/+x until end of turn where x is the amount of e you have')
```

Worker: i-0047aca04f3afb83f
