### PR TITLE
Fix Ironsmith parse failure: Jade Seedstones // Jadeheart Attendant

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
@@ -226,6 +226,11 @@ fn parse_craft_material_spec(
             ChoiceCount::exactly(1),
             "artifact".to_string(),
         )),
+        ["creature"] => Ok((
+            craft_creature_battlefield_or_graveyard_filter(),
+            ChoiceCount::exactly(1),
+            "creature".to_string(),
+        )),
         ["one", "or", "more"] => {
             let mut filter = ObjectFilter::default();
             filter.any_of = vec![
@@ -300,6 +305,21 @@ fn craft_battlefield_or_graveyard_filter(card_type: CardType) -> ObjectFilter {
             .in_zone(Zone::Graveyard)
             .owned_by(PlayerFilter::You)
             .other(),
+    ];
+    filter
+}
+
+fn craft_creature_battlefield_or_graveyard_filter() -> ObjectFilter {
+    let mut filter = ObjectFilter::default();
+    filter.any_of = vec![
+        ObjectFilter::default()
+            .with_type(CardType::Creature)
+            .in_zone(Zone::Battlefield)
+            .controlled_by(PlayerFilter::You),
+        ObjectFilter::default()
+            .with_type(CardType::Creature)
+            .in_zone(Zone::Graveyard)
+            .owned_by(PlayerFilter::You),
     ];
     filter
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7290,6 +7290,25 @@ fn rewrite_keyword_craft_line_uses_supported_activated_keyword_lowering() {
 }
 
 #[test]
+fn rewrite_keyword_craft_line_supports_creature_material_clause() {
+    let tokens =
+        lex_line("Craft with creature {5}{G}{G}", 0).expect("rewrite lexer should classify craft line");
+
+    let parsed = super::activation_and_restrictions::parse_craft_line_lexed(&tokens)
+        .expect("craft line should parse")
+        .expect("craft line should produce an activated ability");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("Activated")
+            && debug.contains("EmitKeywordActionEffect")
+            && debug.contains("Craft")
+            && debug.contains("Craft with creature {5}{G}{G}"),
+        "{debug}"
+    );
+}
+
+#[test]
 fn rewrite_keyword_static_as_enters_choice_parsers_share_subject_tables() {
     let color_tokens = lex_line("as this aura enters, choose a color.", 0)
         .expect("rewrite lexer should classify choose-color static line");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35797,6 +35797,23 @@ fn parse_craft_keyword_line_as_activated_ability() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_craft_with_creature_keyword_line_as_activated_ability() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Craft Creature Variant")
+        .card_types(vec![CardType::Artifact])
+        .parse_text_allow_unsupported(
+            "Craft with creature {5}{G}{G} ({5}{G}{G}, Exile this artifact, Exile a creature you control or a creature card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+        )
+        .expect("craft with creature should parse as a supported activated keyword ability");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Craft with creature {5}{G}{G}"),
+        "craft with creature should render structurally, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_sphinxs_decree_next_turn_silence() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Sphinx's Decree")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -30704,6 +30704,9 @@ fn describe_craft_material_filter(filter: &ObjectFilter, count: ChoiceCount) -> 
     if count == ChoiceCount::exactly(1) && is_craft_artifact_material_filter(filter) {
         return Some("artifact".to_string());
     }
+    if count == ChoiceCount::exactly(1) && is_craft_creature_material_filter(filter) {
+        return Some("creature".to_string());
+    }
     if count == ChoiceCount::at_least(1) && is_craft_one_or_more_material_filter(filter) {
         return Some("one or more".to_string());
     }
@@ -30728,6 +30731,24 @@ fn is_craft_artifact_material_filter(filter: &ObjectFilter) -> bool {
                 && branch.controller.is_none()
                 && branch.other
                 && branch.card_types == vec![CardType::Artifact]
+        })
+}
+
+fn is_craft_creature_material_filter(filter: &ObjectFilter) -> bool {
+    filter.any_of.len() == 2
+        && filter.any_of.iter().any(|branch| {
+            branch.zone == Some(Zone::Battlefield)
+                && branch.controller == Some(PlayerFilter::You)
+                && branch.owner.is_none()
+                && !branch.other
+                && branch.card_types == vec![CardType::Creature]
+        })
+        && filter.any_of.iter().any(|branch| {
+            branch.zone == Some(Zone::Graveyard)
+                && branch.owner == Some(PlayerFilter::You)
+                && branch.controller.is_none()
+                && !branch.other
+                && branch.card_types == vec![CardType::Creature]
         })
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jade Seedstones // Jadeheart Attendant
Initial parse error:
```
unsupported craft material clause 'creature'; oracle-only fallback also failed: unsupported craft material clause 'creature'
```

Worker: i-0d149a26b71717015
