### PR TITLE
Fix Ironsmith parse failure: Trickbind

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -1293,11 +1293,16 @@ pub(crate) fn parse_activated_ability_subject(
         .iter()
         .map(String::as_str)
         .collect::<Vec<_>>();
-    let (owner_word_len, scope) = if slice_ends_with(&subject_words, &["activated", "abilities"]) {
-        (
-            subject_words.len().saturating_sub(2),
-            ActivatedAbilityScope::All,
-        )
+    let word_view = ActivationRestrictionCompatWords::new(tokens);
+    let owner_tokens = if slice_ends_with(&subject_words, &["activated", "abilities"]) {
+        let owner_word_len = subject_words.len().saturating_sub(2);
+        if owner_word_len == 0 {
+            return Ok(None);
+        }
+        let owner_end = word_view
+            .token_index_after_words(owner_word_len)
+            .unwrap_or(tokens.len());
+        trim_commas(&tokens[..owner_end])
     } else if slice_ends_with(
         &subject_words,
         &[
@@ -1310,21 +1315,69 @@ pub(crate) fn parse_activated_ability_subject(
             "costs",
         ],
     ) {
-        (
-            subject_words.len().saturating_sub(7),
-            ActivatedAbilityScope::TapCostOnly,
-        )
+        let owner_word_len = subject_words.len().saturating_sub(7);
+        if owner_word_len == 0 {
+            return Ok(None);
+        }
+        let owner_end = word_view
+            .token_index_after_words(owner_word_len)
+            .unwrap_or(tokens.len());
+        trim_commas(&tokens[..owner_end])
+    } else if slice_starts_with(&subject_words, &["activated", "abilities", "of"]) {
+        let Some(owner_start) = word_view.token_index_for_word_index(3) else {
+            return Ok(None);
+        };
+        trim_commas(&tokens[owner_start..])
+    } else if slice_starts_with(
+        &subject_words,
+        &[
+            "activated",
+            "abilities",
+            "with",
+            "t",
+            "in",
+            "their",
+            "costs",
+            "of",
+        ],
+    ) {
+        let Some(owner_start) = word_view.token_index_for_word_index(8) else {
+            return Ok(None);
+        };
+        trim_commas(&tokens[owner_start..])
     } else {
         return Ok(None);
     };
 
-    if owner_word_len == 0 {
-        return Ok(None);
-    }
-    let owner_end = ActivationRestrictionCompatWords::new(tokens)
-        .token_index_after_words(owner_word_len)
-        .unwrap_or(tokens.len());
-    let owner_tokens = trim_commas(&tokens[..owner_end]);
+    let scope = if slice_ends_with(
+        &subject_words,
+        &[
+            "activated",
+            "abilities",
+            "with",
+            "t",
+            "in",
+            "their",
+            "costs",
+        ],
+    ) || slice_starts_with(
+        &subject_words,
+        &[
+            "activated",
+            "abilities",
+            "with",
+            "t",
+            "in",
+            "their",
+            "costs",
+            "of",
+        ],
+    ) {
+        ActivatedAbilityScope::TapCostOnly
+    } else {
+        ActivatedAbilityScope::All
+    };
+
     if owner_tokens.is_empty() {
         return Ok(None);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -647,6 +647,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_negated_object_restriction_clause_supports_activated_abilities_of_that_permanent() {
+        let tokens = tokenize_line("Activated abilities of that permanent can't be activated.", 0);
+
+        let parsed = parse_negated_object_restriction_clause(&tokens)
+            .expect("parse activated-abilities restriction")
+            .expect("expected restriction");
+
+        assert!(matches!(
+            parsed.restriction,
+            Restriction::ActivateAbilitiesOf(_)
+        ));
+    }
+
+    #[test]
     fn parse_you_choose_objects_clause_supports_bare_card_from_it() {
         let tokens = tokenize_line("You choose a card from it.", 0);
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9163,6 +9163,15 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             let subject = description
                 .strip_prefix("target ")
                 .unwrap_or(description.as_str());
+            let subject = if subject.eq_ignore_ascii_case("permanent")
+                && filter.tagged_constraints.iter().any(|constraint| {
+                    constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+                })
+            {
+                "that permanent"
+            } else {
+                subject
+            };
             format!("activated abilities of {} can't be activated", subject)
         }
         crate::effect::Restriction::ActivateTapAbilitiesOf(filter) => {
@@ -9170,6 +9179,15 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             let subject = description
                 .strip_prefix("target ")
                 .unwrap_or(description.as_str());
+            let subject = if subject.eq_ignore_ascii_case("permanent")
+                && filter.tagged_constraints.iter().any(|constraint| {
+                    constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+                })
+            {
+                "that permanent"
+            } else {
+                subject
+            };
             format!(
                 "activated abilities with {{T}} in their costs of {} can't be activated",
                 subject
@@ -9180,6 +9198,15 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             let subject = description
                 .strip_prefix("target ")
                 .unwrap_or(description.as_str());
+            let subject = if subject.eq_ignore_ascii_case("permanent")
+                && filter.tagged_constraints.iter().any(|constraint| {
+                    constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+                })
+            {
+                "that permanent"
+            } else {
+                subject
+            };
             format!(
                 "non-mana activated abilities of {} can't be activated",
                 subject
@@ -10372,6 +10399,12 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             if let Some(condition) = describe_attached_object_color_condition(tag, filter) {
                 return condition;
             }
+            if tag.as_str().starts_with("countered_")
+                && strip_leading_article(&desc)
+                    .eq_ignore_ascii_case("permanent")
+            {
+                return "a permanent's ability is countered this way".to_string();
+            }
             if is_implicit_reference_tag(tag.as_str()) {
                 // Keep implicit tags oracle-like: use pronouns rather than exposing tag keys.
                 if tag.as_str() == "triggering" && is_aura_only_filter(filter) {
@@ -10558,15 +10591,22 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                     let noun = if card_context { "land card" } else { "land" };
                     return is_clause(noun);
                 }
-	                if stripped == "creature" {
-	                    let noun = if card_context {
-	                        "creature card"
-	                    } else {
-	                        "creature"
-	                    };
-	                    return is_clause(noun);
-	                }
-	                return format!("{subject} matches {desc}");
+                if stripped == "permanent" {
+                    return if subject == "it" {
+                        "it's a permanent".to_string()
+                    } else {
+                        "that object is a permanent".to_string()
+                    };
+                }
+                if stripped == "creature" {
+                    let noun = if card_context {
+                        "creature card"
+                    } else {
+                        "creature"
+                    };
+                    return is_clause(noun);
+                }
+                return format!("{subject} matches {desc}");
                 }
                 format!("the tagged object '{}' matches {desc}", tag.as_str())
             }
@@ -11095,6 +11135,30 @@ mod tests {
         );
 
         assert_eq!(describe_condition(&condition), "equipped creature is green");
+    }
+
+    #[test]
+    fn describe_countered_permanent_condition_uses_countered_this_way_surface() {
+        let condition = Condition::TaggedObjectMatches(TagKey::from("countered_0"), ObjectFilter::permanent());
+
+        assert_eq!(
+            describe_condition(&condition),
+            "a permanent's ability is countered this way"
+        );
+    }
+
+    #[test]
+    fn describe_activate_abilities_of_tagged_permanent_uses_that_permanent() {
+        let mut filter = ObjectFilter::permanent();
+        filter.tagged_constraints.push(TaggedObjectConstraint {
+            tag: TagKey::from("countered_0"),
+            relation: TaggedOpbjectRelation::IsTaggedObject,
+        });
+
+        assert_eq!(
+            describe_restriction(&crate::effect::Restriction::ActivateAbilitiesOf(filter)),
+            "activated abilities of that permanent can't be activated"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Trickbind
Initial parse error:
```
unsupported negated restriction tail (clause: 'activated abilities of that permanent can't be activated'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'activated abilities of that permanent can't be activated')
```

Worker: i-0f5ff9bd24a43adc5
