### PR TITLE
Fix Ironsmith parse failure: Overclocked Electromancer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1552,6 +1552,9 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
     if matches!(words.get(..4), Some(["that", "much", "excess", "damage"])) {
         return Some((Value::EventValue(EventValueSpec::Amount), 4));
     }
+    if matches!(words.get(..3), Some(["that", "excess", "damage"])) {
+        return Some((Value::EventValue(EventValueSpec::Amount), 3));
+    }
     if matches!(words.get(..2), Some(["damage", "dealt"])) {
         return Some((Value::EventValue(EventValueSpec::Amount), 2));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_special_recognizers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_special_recognizers.rs
@@ -401,7 +401,14 @@ pub(crate) fn parse_scaled_target_power_sentence(
         )]));
     }
 
-    let target = parse_target_phrase_lexed(&target_tokens)?;
+    let target = {
+        let target_words = crate::runtime_backend::token_word_refs(&target_tokens);
+        if matches!(target_words.as_slice(), ["its"] | ["their"]) {
+            TargetAst::Tagged(TagKey::from(IT_TAG), None)
+        } else {
+            parse_target_phrase_lexed(&target_tokens)?
+        }
+    };
     Ok(Some(vec![scale_pt_from_value_spec(
         &target,
         include_power,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8832,6 +8832,50 @@ fn rewrite_lexed_effect_sentence_parses_triple_target_pt_body() {
 }
 
 #[test]
+fn rewrite_lexed_effect_sentence_parses_double_its_power_body() {
+    let tokens = lex_line("double its power until end of turn", 0)
+        .expect("rewrite lexer should classify double its power effect");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&tokens)
+        .expect("double its power effect should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("Pump"), "{debug}");
+    assert!(debug.contains("__it__"), "{debug}");
+    assert!(debug.contains("PowerOf"), "{debug}");
+}
+
+#[test]
+fn rewrite_lexed_triggered_line_parses_double_its_power_body() {
+    let tokens = lex_line(
+        "Whenever this creature attacks, double its power until end of turn.",
+        0,
+    )
+    .expect("rewrite lexer should classify attack trigger with double its power");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("attack trigger with double its power should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("Attacks"), "{debug}");
+    assert!(debug.contains("__it__"), "{debug}");
+    assert!(debug.contains("PowerOf"), "{debug}");
+}
+
+#[test]
+fn rewrite_etb_where_x_that_excess_damage_clause_binds_event_amount() {
+    let tokens = lex_line("where x is that excess damage", 0)
+        .expect("rewrite lexer should classify where-x excess damage clause");
+
+    let parsed = super::keyword_static::parse_value_binding_clause(&tokens)
+        .expect("where-x excess damage clause should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("EventValue"), "{debug}");
+    assert!(debug.contains("Amount"), "{debug}");
+}
+
+#[test]
 fn rewrite_effect_entrypoint_keeps_exact_bundle_graveyard_copy_shape_without_lowering() {
     let tokens = lex_line(
         "If this spell was cast from a graveyard, copy this spell and you may choose a new target for the copy.",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Overclocked Electromancer
Initial parse error:
```
unsupported target phrase (clause: 'its'); oracle-only fallback also failed: unsupported target phrase (clause: 'its')
```

Worker: i-09149060cf173f4ce
