### PR TITLE
Fix Ironsmith parse failure: Winota, Joiner of Forces

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/looked_cards_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/looked_cards_family.rs
@@ -323,20 +323,21 @@ pub(crate) fn parse_may_put_filtered_looked_card_onto_battlefield_and_filtered_i
     let after_first_clause = trim_commas(&action_tokens[after_first_from..]);
     let after_words = TokenWordView::new(&after_first_clause);
     let after_refs = after_words.word_refs();
-    let (tapped, second_start_words) =
-        if slice_starts_with(
-            &after_refs,
-            &["onto", "the", "battlefield", "tapped", "and"],
-        ) || slice_starts_with(&after_refs, &["onto", "battlefield", "tapped", "and"])
-        {
-            (true, 5usize)
-        } else if slice_starts_with(&after_refs, &["onto", "the", "battlefield", "and"])
-            || slice_starts_with(&after_refs, &["onto", "battlefield", "and"])
-        {
-            (false, 4usize)
-        } else {
-            return Ok(None);
-        };
+    let (tapped, second_start_words) = if slice_starts_with(
+        &after_refs,
+        &["onto", "the", "battlefield", "tapped", "and", "put"],
+    ) || slice_starts_with(
+        &after_refs,
+        &["onto", "battlefield", "tapped", "and", "put"],
+    ) {
+        (true, 5usize)
+    } else if slice_starts_with(&after_refs, &["onto", "the", "battlefield", "and", "put"])
+        || slice_starts_with(&after_refs, &["onto", "battlefield", "and", "put"])
+    {
+        (false, 4usize)
+    } else {
+        return Ok(None);
+    };
     let second_start = after_words
         .token_index_after_words(second_start_words)
         .unwrap_or(after_first_clause.len());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32000,8 +32000,8 @@ fn parse_oracle_ilharg_tapped_attacking_stays_deferred() {
 }
 
 #[test]
-fn parse_oracle_winota_tapped_attacking_stays_deferred() {
-    assert_oracle_card_fails_strict("Winota, Joiner of Forces");
+fn parse_oracle_winota_tapped_attacking_regression() {
+    assert_oracle_card_parses_strict("Winota, Joiner of Forces");
 }
 
 #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Winota, Joiner of Forces
Initial parse error:
```
unable to parse second looked-card hand filter; oracle-only fallback also failed: unable to parse second looked-card hand filter
```

Worker: i-042bfa8d6b9c56992
