### PR TITLE
Fix Ironsmith parse failure: Goldwardens' Gambit

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -1341,6 +1341,10 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
 
     let action = match words.as_slice() {
         ["affinity", "for", "artifacts"] => KeywordAction::AffinityForArtifacts,
+        ["affinity", "for", ..] => {
+            let text = marker_text_from_words(&words)?;
+            KeywordAction::MarkerText(text)
+        }
         ["first", "strike"] => KeywordAction::FirstStrike,
         ["double", "strike"] => KeywordAction::DoubleStrike,
         ["for", "mirrodin"] => KeywordAction::ForMirrodin,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -198,6 +198,7 @@ fn supported_keyword_marker_text(text: &str) -> bool {
     text == "compleated"
         || text.starts_with("prototype ")
         || text.starts_with("splice onto ")
+        || text.starts_with("affinity for ")
         || is_ticket_power_toughness_sticker_marker_line(&text)
         || text.starts_with("dredge ")
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -932,6 +932,7 @@ fn supported_keyword_marker_text(text: &str) -> bool {
     text == "compleated"
         || text.starts_with("prototype ")
         || text.starts_with("splice onto ")
+        || text.starts_with("affinity for ")
         || is_ticket_power_toughness_sticker_marker_line(&text)
         || text.starts_with("dredge ")
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -71,15 +71,6 @@ pub(crate) fn parse_attach_object_phrase(
         return parse_target_phrase(tokens);
     }
 
-    if object_words.len() >= 2
-        && !object_words.contains(&"target")
-        && object_words
-            .iter()
-            .all(|word| word.chars().all(|ch| ch.is_ascii_alphanumeric()))
-    {
-        return Ok(TargetAst::Source(object_span));
-    }
-
     parse_target_phrase(tokens)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5000,6 +5000,11 @@ fn rewrite_lexed_trigger_keeps_look_exile_and_while_exiled_play_permission() {
 fn rewrite_lexed_keyword_line_and_static_cost_probe_work_natively() {
     let flashback_tokens = lex_line("Flashback {2}{R}", 0)
         .expect("rewrite lexer should classify flashback keyword line");
+    let affinity_tokens = lex_line(
+        "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)",
+        0,
+    )
+    .expect("rewrite lexer should classify affinity keyword line");
     let cost_probe_tokens = lex_line("If it is night, this spell costs {2} less to cast.", 0)
         .expect("rewrite lexer should classify this-spell cost probe");
 
@@ -5009,6 +5014,14 @@ fn rewrite_lexed_keyword_line_and_static_cost_probe_work_natively() {
             actions.as_slice(),
             [crate::cards::builders::KeywordAction::MarkerText(text)]
                 if text == "Flashback {2}{R}"
+        )
+    ));
+    assert!(matches!(
+        super::clause_support::parse_ability_line_lexed(&affinity_tokens),
+        Some(actions) if matches!(
+            actions.as_slice(),
+            [crate::cards::builders::KeywordAction::MarkerText(text)]
+                if text.to_ascii_lowercase().starts_with("affinity for equipment")
         )
     ));
     let split = super::grammar::abilities::split_if_this_spell_costs_line_lexed(&cost_probe_tokens)
@@ -6338,6 +6351,21 @@ fn academy_researchers_puts_aura_from_hand_onto_battlefield_attached() {
     assert!(debug.contains("Aura"), "{debug}");
     assert!(debug.contains("AttachObjectsEffect"), "{debug}");
     assert!(debug.contains("this creature"), "{debug}");
+}
+
+#[test]
+fn goldwardens_gambit_attaches_controlled_equipment_to_each_token() {
+    let text = "Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)\nCreate five 2/2 red Rebel creature tokens. They gain haste until end of turn. For each of those tokens, you may attach an Equipment you control to it.";
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Goldwardens' Gambit")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(text)
+        .expect("Goldwardens' Gambit should parse");
+    let debug = format!("{:#?}", def.spell_effect);
+
+    assert!(debug.contains("AttachObjectsEffect"), "{debug}");
+    assert!(debug.contains("subtypes: [\n                                        Equipment"), "{debug}");
+    assert!(debug.contains("controller: Some(\n                                        You"), "{debug}");
+    assert!(!debug.contains("objects: Source"), "{debug}");
 }
 
 #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Goldwardens' Gambit
Initial parse error:
```
parser does not yet support line family: 'Affinity for Equipment (This spell costs {1} less to cast for each Equipment you control.)'; oracle-only fallback also failed: parser does not yet support line family: 'Affinity for Equipment'
```

Worker: i-0ce6c0b74bec646cf
