### PR TITLE
Fix Ironsmith parse failure: Crush of Tentacles

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -6,6 +6,7 @@ use super::line_family_handlers::{
     run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
     run_partner_with_keyword_line_family, run_split_top_and_face_down_look_line_family,
     run_split_top_look_and_top_land_play_line_family, run_start_your_engines_line_family,
+    run_surge_line_family,
     run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
     run_station_line_family, run_station_threshold_line_family,
     run_trailing_keyword_activation_line_family, run_triggered_line_family,
@@ -46,7 +47,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 23] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 24] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -130,6 +131,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 23] = [
         priority: 42,
         heads: &[],
         run: run_escape_enters_with_counter_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "surge-line",
+        priority: 43,
+        heads: &["surge"],
+        run: run_surge_line_family,
     },
     LineFamilyRuleDef {
         id: "keyword-line",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -556,6 +556,44 @@ pub(super) fn run_escape_enters_with_counter_line_family(
     }))
 }
 
+pub(super) fn run_surge_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let Some(rest) = raw.strip_prefix("Surge ") else {
+        return Ok(None);
+    };
+    let cost_text = rest
+        .split_once('(')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(rest)
+        .trim()
+        .trim_end_matches('.')
+        .trim();
+    if cost_text.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "surge keyword missing cost: '{}'",
+            ctx.line.info.raw_line
+        )));
+    }
+
+    let rewritten = format!(
+        "If you've cast another spell this turn, you may pay {cost_text} rather than pay this spell's mana cost."
+    );
+    let alternative_line = rewrite_line_normalized(ctx.line, rewritten.as_str())?;
+    let Some(keyword) = parse_keyword_line_cst(&alternative_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower surge keyword line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Keyword(keyword),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_keyword_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1625,6 +1625,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_document_cst_rewrites_surge_keyword_line_to_alternative_cost()
+    -> Result<(), CardTextError> {
+        let preprocessed = preprocess_document(
+            CardDefinitionBuilder::new(CardId::new(), "Surge Parse Test")
+                .card_types(vec![CardType::Sorcery]),
+            "Surge {3}{U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)\nReturn all nonland permanents to their owners' hands.",
+        )?;
+        let cst = super::parse_document_cst(&preprocessed, false)?;
+
+        match cst.lines.as_slice() {
+            [super::RewriteLineCst::Keyword(keyword), super::RewriteLineCst::Statement(_)] => {
+                assert_eq!(keyword.kind, KeywordLineKindCst::AlternativeCast);
+                assert_eq!(
+                    render_token_slice(&keyword.parse_tokens),
+                    "If you've cast another spell this turn, you may pay {3}{U}{U} rather than pay this spell's mana cost."
+                );
+            }
+            other => panic!("expected surge keyword plus statement line, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn static_line_cst_recognizes_compound_unblockable_from_tokens() -> Result<(), CardTextError> {
         let line = single_preprocessed_line("Enchanted creature gets +2/+2 and can't be blocked.");
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2225,7 +2225,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         && filtered[0] == "this"
         && matches!(
             filtered[1],
-            "spell's" | "card's" | "creature's" | "permanent's"
+            "spell's" | "spells" | "card's" | "creature's" | "permanent's"
         )
         && filtered[3] == "cost"
         && filtered[4] == "was"
@@ -3109,8 +3109,29 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         }
     }
 
-    Err(CardTextError::ParseError(format!(
+Err(CardTextError::ParseError(format!(
         "unsupported predicate (predicate: '{}')",
         filtered.join(" ")
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_backend::front_end::lexer::lex_line;
+
+    #[test]
+    fn parse_predicate_accepts_unapostrophed_spell_paid_label() -> Result<(), CardTextError> {
+        let tokens = lex_line("If this spells surge cost was paid", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(parsed, PredicateAst::ThisSpellPaidLabel("Surge".to_string()));
+        Ok(())
+    }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Crush of Tentacles
Initial parse error:
```
parser does not yet support line family: 'Surge {3}{U}{U} (You may cast this spell for its surge cost if you or a teammate has cast another spell this turn.)'; oracle-only fallback also failed: parser does not yet support line family: 'Surge {3}{U}{U}'
```

Worker: i-0d0c247986418d069
