### PR TITLE
Fix Ironsmith parse failure: Ensoul Artifact

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
@@ -75,6 +75,34 @@ fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
     items.push(item);
 }
 
+fn parse_attached_with_base_power_toughness_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<(i32, i32, bool)>, CardTextError> {
+    let words = token_words(tokens);
+    if words.len() < 5 || !word_slice_starts_with(&words, &["base", "power", "and", "toughness"]) {
+        return Ok(None);
+    }
+
+    let (power, toughness) = parse_pt_modifier(words[4]).map_err(|_| {
+        CardTextError::ParseError(format!(
+            "invalid attached transform base power/toughness value (clause: '{}')",
+            words.join(" ")
+        ))
+    })?;
+
+    let trailing = &words[5..];
+    let preserve_other_types = matches!(
+        trailing,
+        ["in", "addition", "to", "its", "other", "types"]
+            | ["in", "addition", "to", "their", "other", "types"]
+    );
+    if !trailing.is_empty() && !preserve_other_types {
+        return Ok(None);
+    }
+
+    Ok(Some((power, toughness, preserve_other_types)))
+}
+
 pub(crate) fn display_text_for_tokens(
     tokens: &[OwnedLexToken],
     capitalize_effect_start: bool,
@@ -928,18 +956,7 @@ pub(crate) fn parse_attached_type_transform_line(
     }
 
     let mut out = Vec::new();
-    if !set_card_types.is_empty() {
-        out.push(StaticAbility::set_card_types(filter.clone(), set_card_types).into());
-    }
-    if !add_subtypes.is_empty() {
-        out.push(StaticAbility::add_subtypes(filter.clone(), add_subtypes).into());
-    }
-    if !set_colors.is_empty() {
-        out.push(StaticAbility::set_colors(filter.clone(), set_colors).into());
-    }
-    if make_colorless {
-        out.push(StaticAbility::make_colorless(filter.clone()).into());
-    }
+    let mut preserve_other_types = false;
 
     if let Some(with_idx) = with_idx {
         let ability_end = lose_idx.unwrap_or(remainder.len());
@@ -958,7 +975,12 @@ pub(crate) fn parse_attached_type_transform_line(
             )));
         }
 
-        if let Some(parsed) = parse_attached_granted_activated_line(&ability_tokens)? {
+        if let Some((power, toughness, with_preserve_other_types)) =
+            parse_attached_with_base_power_toughness_clause(&ability_tokens)?
+        {
+            preserve_other_types = with_preserve_other_types;
+            out.push(StaticAbility::set_base_power_toughness(filter.clone(), power, toughness).into());
+        } else if let Some(parsed) = parse_attached_granted_activated_line(&ability_tokens)? {
             out.push(StaticAbilityAst::AttachedObjectAbilityGrant {
                 ability: parsed,
                 display: format!(
@@ -981,6 +1003,23 @@ pub(crate) fn parse_attached_type_transform_line(
                 line_words.join(" ")
             )));
         }
+    }
+
+    if !set_card_types.is_empty() {
+        if preserve_other_types {
+            out.push(StaticAbility::add_card_types(filter.clone(), set_card_types).into());
+        } else {
+            out.push(StaticAbility::set_card_types(filter.clone(), set_card_types).into());
+        }
+    }
+    if !add_subtypes.is_empty() {
+        out.push(StaticAbility::add_subtypes(filter.clone(), add_subtypes).into());
+    }
+    if !set_colors.is_empty() {
+        out.push(StaticAbility::set_colors(filter.clone(), set_colors).into());
+    }
+    if make_colorless {
+        out.push(StaticAbility::make_colorless(filter.clone()).into());
     }
 
     if let Some(lose_idx) = lose_idx {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11700,6 +11700,30 @@ fn parse_swift_reconfiguration_vehicle_transform_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_ensoul_artifact_style_transform_line() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Ensoul Artifact")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant artifact\nEnchanted artifact is a creature with base power and toughness 5/5 in addition to its other types.",
+        )
+        .expect("ensoul-artifact-style transform should parse");
+
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains("enchanted artifact is creature"),
+        "expected creature type-setting text, got {compiled}"
+    );
+    assert!(
+        compiled.contains("base power and toughness 5/5"),
+        "expected base power/toughness text, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_equipped_activated_grant_with_unsupported_cost_errors_instead_of_partial_compile() {
     let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Equip Unsupported Grant Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -1466,6 +1466,42 @@ fn normalize_zero_zero_token_with_base_pt(line: &str) -> Option<String> {
     Some(rewritten)
 }
 
+fn normalize_attached_creature_with_base_pt(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let (first, second) = trimmed.split_once(". ")?;
+    let first = first.trim_end_matches('.').trim();
+    let second = second.trim_end_matches('.').trim();
+
+    let first_lower = first.to_ascii_lowercase();
+    let subject = if let Some(subject) = first_lower.strip_suffix(" is creature") {
+        subject
+    } else if let Some(subject) = first_lower.strip_suffix(" is a creature") {
+        subject
+    } else {
+        return None;
+    };
+    if subject.is_empty() {
+        return None;
+    }
+
+    let second_lower = second.to_ascii_lowercase();
+    let marker = " has base power and toughness ";
+    let idx = second_lower.find(marker)?;
+    if second_lower[..idx] != *subject {
+        return None;
+    }
+    let pt = second[idx + marker.len()..].trim();
+    if pt.is_empty() || !pt.contains('/') {
+        return None;
+    }
+
+    Some(format!(
+        "{} is a creature with base power and toughness {} in addition to its other types.",
+        capitalize_first(subject),
+        pt
+    ))
+}
+
 fn split_choose_sacrifice_tail<'a>(rest: &'a str) -> Option<(&'a str, &'a str)> {
     for needle in [
         ". you sacrifice all permanents you control",
@@ -1637,6 +1673,9 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     }
     if let Some(compacted) = compact_repeated_process_once_surface(&normalized) {
         normalized = compacted;
+    }
+    if let Some(attached_with_pt) = normalize_attached_creature_with_base_pt(&normalized) {
+        normalized = attached_with_pt;
     }
     let lower_compact = normalized
         .split_whitespace()
@@ -11211,6 +11250,16 @@ mod tests {
         assert_eq!(
             normalize_common_semantic_phrasing("Draw a card. Draw a card."),
             "Draw a card. Draw a card."
+        );
+    }
+
+    #[test]
+    fn normalize_attached_creature_with_base_pt_combines_sentences() {
+        assert_eq!(
+            normalize_common_semantic_phrasing(
+                "Enchanted artifact is creature. Enchanted artifact has base power and toughness 5/5."
+            ),
+            "Enchanted artifact is a creature with base power and toughness 5/5 in addition to its other types."
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ensoul Artifact
Initial parse error:
```
unsupported attached transform granted ability (clause: 'enchanted artifact is a creature with base power and toughness 5/5 in addition to its other types'); oracle-only fallback also failed: unsupported attached transform granted ability (clause: 'enchanted artifact is a creature with base power and toughness 5/5 in addition to its other types')
```

Worker: i-084bd72f18b8cf6cb
