### PR TITLE
Fix Ironsmith parse failure: Wall of Reverence

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -780,10 +780,78 @@ pub(crate) fn parse_life_equal_to_value(
     }
     if matches!(amount_words.get(..2), Some(["equal", "to"])) {
         let value_tokens = &amount_tokens[2..];
+        let mut value_words = crate::runtime_backend::token_word_refs(value_tokens);
+
+        let parse_stat_of_target =
+            |stat_words: &[&str], constructor: fn(Box<ChooseSpec>) -> Value| {
+                if value_words.starts_with(stat_words) {
+                    let target_tokens = &value_tokens[stat_words.len()..];
+                    if let Ok(target) = parse_target_phrase(target_tokens) {
+                        let spec = crate::runtime_backend::references::reference_helpers::choose_spec_for_target(&target);
+                        return Some(constructor(Box::new(spec)));
+                    }
+                }
+                None
+            };
+        if let Some(value) = parse_stat_of_target(&["power", "of"], Value::PowerOf) {
+            return Ok(Some(value));
+        }
+        if let Some(value) = parse_stat_of_target(&["the", "power", "of"], Value::PowerOf) {
+            return Ok(Some(value));
+        }
+        if let Some(value) = parse_stat_of_target(&["toughness", "of"], Value::ToughnessOf) {
+            return Ok(Some(value));
+        }
+        if let Some(value) = parse_stat_of_target(&["the", "toughness", "of"], Value::ToughnessOf)
+        {
+            return Ok(Some(value));
+        }
+        if let Some(value) =
+            parse_stat_of_target(&["mana", "value", "of"], Value::ManaValueOf)
+        {
+            return Ok(Some(value));
+        }
+        if let Some(value) =
+            parse_stat_of_target(&["the", "mana", "value", "of"], Value::ManaValueOf)
+        {
+            return Ok(Some(value));
+        }
+
         if let Some((value, used)) = parse_value(value_tokens)
             && used == value_tokens.len()
         {
             return Ok(Some(value));
+        }
+        if value_tokens
+            .first()
+            .and_then(OwnedLexToken::as_word)
+            .is_some_and(|word| word == "the")
+        {
+            let stripped_tokens = &value_tokens[1..];
+            if let Some((value, used)) = parse_value(stripped_tokens)
+                && used == stripped_tokens.len()
+            {
+                return Ok(Some(value));
+            }
+            value_words = crate::runtime_backend::token_word_refs(stripped_tokens);
+        }
+        for (prefix, stat_words) in [
+            (&["power", "of"][..], &["power"][..]),
+            (&["toughness", "of"][..], &["toughness"][..]),
+            (&["mana", "value", "of"][..], &["mana", "value"][..]),
+        ] {
+            if value_words.starts_with(prefix) {
+                let mut reordered = value_words[prefix.len()..].to_vec();
+                reordered.extend_from_slice(stat_words);
+                if let Some((value, used)) =
+                    crate::runtime_backend::front_end::shared::util::parse_value_expr_words(
+                        &reordered,
+                    )
+                    && used == reordered.len()
+                {
+                    return Ok(Some(value));
+                }
+            }
         }
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5813,6 +5813,24 @@ fn life_lost_this_way_lowers_to_prior_effect_metric() {
 }
 
 #[test]
+fn gain_life_equal_to_the_power_of_target_creature_you_control_parses() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Wall of Reverence Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Flying\nAt the beginning of your end step, you may gain life equal to the power of target creature you control.",
+        )
+        .expect("target creature power life gain should parse");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("GainLifeEffect")
+            && debug.contains("PowerOf")
+            && debug.contains("Target("),
+        "expected life gain amount to use target creature power, got {debug}"
+    );
+}
+
+#[test]
 fn dynamic_return_count_lowers_to_prior_effect_metric_choice() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Dynamic Return Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11861,6 +11861,25 @@ fn parse_gain_life_equal_to_devotion_value() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_gain_life_equal_to_the_power_of_target_creature_you_control() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Wall of Reverence Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Flying\nAt the beginning of your end step, you may gain life equal to the power of target creature you control.",
+        )
+        .expect("target-creature power life gain should parse");
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("GainLifeEffect")
+            && abilities_debug.contains("PowerOf")
+            && abilities_debug.contains("Target("),
+        "expected gain-life amount to use target creature power, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_gain_life_equal_to_your_speed() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Momentum Breaker Variant")
         .card_types(vec![CardType::Enchantment])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wall of Reverence
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to the power of target creature you control'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to the power of target creature you control')
```

Worker: i-0e10a47179d525b16
