### PR TITLE
Fix Ironsmith parse failure: Visions of Dread

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -1098,6 +1098,10 @@ pub(crate) fn parse_put_into_hand(
         }
 
         let mut target = parse_target_phrase(&target_tokens)?;
+        if let Some(filter) = crate::runtime_backend::sentences::effect_sentences::zone_counter_helpers::target_object_filter_mut(&mut target)
+        {
+            crate::runtime_backend::sentences::effect_sentences::zone_counter_helpers::apply_exile_subject_owner_context(filter, subject);
+        }
         if super::super::grammar::primitives::contains_phrase(
             dest_slice,
             &["from", "the", "command", "zone"],

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10955,6 +10955,22 @@ fn rewrite_lexed_effect_sentence_preserves_non_vampire_sacrifice_filter() {
 }
 
 #[test]
+fn parse_target_opponent_puts_from_their_graveyard_compiles() {
+    let built = CardDefinitionBuilder::new(CardId::from_raw(98_501), "Target Opponent Put")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Target opponent puts a creature card of their choice from their graveyard onto the battlefield under your control.",
+        )
+        .expect("target-opponent put-from-graveyard sentence should compile");
+
+    let debug = format!("{built:?}");
+    assert!(
+        debug.contains("Target(Opponent)") || debug.contains("target_opponent"),
+        "expected target-opponent ownership context in compiled card, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_entrypoint_supports_create_for_each_creatures_died() {
     let text = "Create a Treasure token for each creature that died this turn.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify create-for-each effect");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Visions of Dread
Initial parse error:
```
spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(MoveToZoneEffect { target: WithCount(Object(ObjectFilter { zone: Some(Graveyard), controller: None, cast_by: None, first_spell_cast_each_turn: false, owner: Some(IteratedPlayer), single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }), ChoiceCount { min: 1, max: Some(1), dynamic_x: false, up_to_x: false, random: false }), zone: Battlefield, to_top: false, battlefield_controller: You, enters_tapped: false, transfer_exiled_with_source_links: false }); oracle-only fallback also failed: spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(MoveToZoneEffect { target: WithCount(Object(ObjectFilter { zone: Some(Graveyard), controller: None, cast_by: None, first_spell_cast_each_turn: false, owner: Some(IteratedPlayer), single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }), ChoiceCount { min: 1, max: Some(1), dynamic_x: false, up_to_x: false, random: false }), zone: Battlefield, to_top: false, battlefield_controller: You, enters_tapped: false, transfer_exiled_with_source_links: false })
```

Worker: i-0a43cb6173f127556
