### PR TITLE
Fix Ironsmith parse failure: Bellowing Saddlebrute

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -58,6 +58,33 @@ pub(crate) fn parse_lose_life(
                 SubjectVerbActionAst::LoseLife { amount },
             ));
         }
+        let base_effect = subject_verb_player_resource_effect(
+            SubjectVerbRoleAst::AffectedPlayer,
+            player,
+            SubjectVerbActionAst::LoseLife { amount },
+        );
+        if let Some(predicate) = parse_trailing_if_predicate_lexed(&trailing) {
+            return Ok(EffectAst::Conditional {
+                predicate,
+                if_true: vec![base_effect],
+                if_false: Vec::new(),
+            });
+        }
+        if trailing
+            .first()
+            .is_some_and(|token| token.is_word("unless"))
+        {
+            let mut unless_as_if_tokens = Vec::with_capacity(trailing.len() + 1);
+            unless_as_if_tokens.push(OwnedLexToken::word("if".to_string(), TextSpan::synthetic()));
+            unless_as_if_tokens.extend_from_slice(&trailing[1..]);
+            if let Some(predicate) = parse_trailing_if_predicate_lexed(&unless_as_if_tokens) {
+                return Ok(EffectAst::Conditional {
+                    predicate,
+                    if_true: Vec::new(),
+                    if_false: vec![base_effect],
+                });
+            }
+        }
         return Err(CardTextError::ParseError(format!(
             "unsupported trailing life-loss clause (clause: '{}')",
             clause_words.join(" ")

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2623,6 +2623,20 @@ fn rewrite_zone_counter_helpers_parse_put_or_remove_counter_modes() {
 }
 
 #[test]
+fn rewrite_parse_lose_life_unless_you_attacked_this_turn_clause() {
+    let tokens = lex_line("You lose 4 life unless you attacked this turn.", 0)
+        .expect("rewrite lexer should classify life-loss unless clause");
+
+    let parsed = parse_effect_sentence_lexed(&tokens)
+        .expect("life-loss unless clause should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("Conditional"), "{debug}");
+    assert!(debug.contains("LoseLife"), "{debug}");
+    assert!(debug.contains("YouAttackedThisTurn"), "{debug}");
+}
+
+#[test]
 fn rewrite_zone_counter_helpers_parse_multiple_counter_sentence() {
     let tokens = lex_line(
         "Put a +1/+1 counter and a flying counter on target creature",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -11785,7 +11785,7 @@ pub(super) fn describe_false_only_conditional(
     }
 
     format!(
-        "If it isn't true that {}, {}",
+        "Unless {}, {}",
         lowercase_first(&describe_condition(condition)),
         false_branch
     )
@@ -13028,6 +13028,17 @@ mod tests {
             PlayerFilter::You,
         ));
         assert_eq!(describe_effect(&scaled), "Add {R} for each creature");
+    }
+
+    #[test]
+    fn describe_false_only_conditional_prefers_unless_surface() {
+        assert_eq!(
+            describe_false_only_conditional(
+                &crate::effect::Condition::AttackedThisTurn,
+                "you lose 4 life"
+            ),
+            "Unless you attacked this turn, you lose 4 life"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Bellowing Saddlebrute
Initial parse error:
```
unsupported trailing life-loss clause (clause: '4 life unless you attacked this turn'); oracle-only fallback also failed: unsupported trailing life-loss clause (clause: '4 life unless you attacked this turn')
```

Worker: i-082199ea5c2cd775a
