### PR TITLE
Fix Ironsmith parse failure: Thwart the Enemy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -992,13 +992,18 @@ pub(crate) fn parse_prevent_all_damage_clause(
                 clause_words.join(" ")
             )));
         }
-        if source_words.last().copied() != Some("sources") {
+        let source_filter_words = if source_words.last().copied() == Some("sources") {
+            &source_words[..source_words.len() - 1]
+        } else {
+            source_words
+        };
+        if source_filter_words.is_empty() {
             return Err(CardTextError::ParseError(format!(
                 "unsupported prevent-all damage source phrase (clause: '{}')",
                 clause_words.join(" ")
             )));
         }
-        let source_filter_tokens = source_words[..source_words.len() - 1]
+        let source_filter_tokens = source_filter_words
             .iter()
             .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
             .collect::<Vec<_>>();

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8023,6 +8023,23 @@ fn rewrite_grammar_prevention_static_line_probes_match_keyword_static_shapes() {
 }
 
 #[test]
+fn parse_prevent_all_damage_by_opponents_creatures_effect_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Thwart Effect Probe")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Prevent all damage that would be dealt this turn by creatures your opponents control.")
+        .expect("prevent-all damage clause with opponent creature source filter should parse");
+
+    let spell_debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        spell_debug.contains("preventalldamageeffect")
+            && spell_debug.contains("from_source")
+            && spell_debug.contains("creature")
+            && spell_debug.contains("opponent"),
+        "expected source-filter prevent-all-damage effect, got {spell_debug}"
+    );
+}
+
+#[test]
 fn rewrite_grammar_skulk_rules_text_probe_matches_static_line() {
     let tokens = lex_line(
         "Creatures with power less than this creature's power can't block this creature.",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7953,6 +7953,25 @@ fn test_parse_prevent_all_damage_from_non_human_sources_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_prevent_all_damage_from_opponents_creatures_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Thwart Probe")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Prevent all damage that would be dealt this turn by creatures your opponents control.")
+        .expect("prevent-all damage from opponent-controlled creatures clause should parse");
+
+    let spell_debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        spell_debug.contains("preventalldamageeffect")
+            && spell_debug.contains("from_source")
+            && spell_debug.contains("card_types")
+            && spell_debug.contains("creature")
+            && spell_debug.contains("opponent"),
+        "expected source-filter prevent-all-damage effect for opponent-controlled creatures, got {spell_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_cant_be_blocked_as_long_as_defending_player_controls_artifact_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Bouncing Beebles Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9080,7 +9080,21 @@ pub(super) fn describe_damage_filter(filter: &crate::prevention::DamageFilter) -
     }
 
     if let Some(source_filter) = &filter.from_source {
-        let mut source_text = source_filter.description();
+        let mut source_text = if source_filter.zone == Some(Zone::Battlefield)
+            && source_filter.controller == Some(PlayerFilter::Opponent)
+        {
+            let mut bare = source_filter.clone();
+            bare.controller = None;
+            let subject = pluralize_noun_phrase(
+                strip_indefinite_article(&bare.description())
+                    .trim()
+                    .trim_end_matches(" on the battlefield")
+                    .trim(),
+            );
+            format!("{subject} your opponents control")
+        } else {
+            source_filter.description()
+        };
         if let Some(stripped) = source_text.strip_suffix(" permanent") {
             source_text = stripped.to_string();
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13164,6 +13164,25 @@ mod tests {
     }
 
     #[test]
+    fn prevent_all_damage_from_opponents_creatures_uses_by_clause_surface() {
+        let mut source_filter = ObjectFilter::creature();
+        source_filter.zone = Some(Zone::Battlefield);
+        source_filter.controller = Some(PlayerFilter::Opponent);
+        let mut damage_filter = crate::prevention::DamageFilter::all();
+        damage_filter.from_source = Some(source_filter);
+
+        let effect = Effect::new(crate::effects::PreventAllDamageEffect::all_with_filter(
+            damage_filter,
+            Until::EndOfTurn,
+        ));
+
+        assert_eq!(
+            describe_effect(&effect),
+            "Prevent all damage that would be dealt this turn by creatures your opponents control"
+        );
+    }
+
+    #[test]
     fn sacrifice_source_then_extra_turn_renders_as_single_clause() {
         let effects = vec![
             Effect::new(crate::effects::SacrificeTargetEffect::new(
@@ -28802,6 +28821,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         }
         if matches!(prevent_all.until, Until::EndOfTurn) {
             if matches!(prevent_all.target, crate::prevention::PreventionTarget::All) {
+                if let Some(source_phrase) = damage_type
+                    .strip_prefix("all damage from ")
+                    .and_then(|rest| rest.strip_suffix(" sources"))
+                {
+                    return format!(
+                        "Prevent all damage that would be dealt this turn by {source_phrase}"
+                    );
+                }
                 return format!("Prevent {damage_type} that would be dealt this turn");
             }
             return format!(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thwart the Enemy
Initial parse error:
```
parser does not yet support line family: 'Prevent all damage that would be dealt this turn by creatures your opponents control.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all damage that would be dealt this turn by creatures your opponents control.'
```

Worker: i-0f2029fb6f4d9ec9f
