### PR TITLE
Fix Ironsmith parse failure: Heaven Sent

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1602,6 +1602,34 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::PlayerHasMoreLifeThanYou { player });
     }
 
+    if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
+        && matches!(filtered.get(subject_len).copied(), Some("has" | "have"))
+        && filtered.len() == subject_len + 5
+        && filtered.get(subject_len + 2).copied() == Some("or")
+        && matches!(filtered.get(subject_len + 3).copied(), Some("less" | "fewer"))
+        && filtered.get(subject_len + 4).copied() == Some("life")
+        && let Some(amount) = filtered[subject_len + 1]
+            .parse::<i32>()
+            .ok()
+            .or_else(|| parse_named_number(filtered[subject_len + 1]).map(|n| n as i32))
+    {
+        let player_filter = match player {
+            PlayerAst::You => Some(PlayerFilter::You),
+            PlayerAst::Opponent => Some(PlayerFilter::Opponent),
+            PlayerAst::Any => Some(PlayerFilter::Any),
+            PlayerAst::Defending => Some(PlayerFilter::Defending),
+            PlayerAst::Attacking => Some(PlayerFilter::Attacking),
+            _ => None,
+        };
+        if let Some(player_filter) = player_filter {
+            return Ok(PredicateAst::ValueComparison {
+                left: crate::effect::Value::LifeTotal(player_filter),
+                operator: crate::effect::ValueComparisonOperator::LessThanOrEqual,
+                right: crate::effect::Value::Fixed(amount),
+            });
+        }
+    }
+
     if filtered.len() >= 8
         && filtered[0] == "no"
         && matches!(filtered[1], "opponent" | "opponents")

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12685,6 +12685,36 @@ fn rewrite_grammar_no_opponent_has_more_life_than_that_player_predicate_parses()
 }
 
 #[test]
+fn rewrite_grammar_opponent_has_zero_or_less_life_predicate_parses() {
+    let tokens = lex_line("opponent has 0 or less life", 0)
+        .expect("rewrite lexer should classify opponent life-threshold predicate");
+
+    assert_eq!(
+        super::parse_predicate_lexed(&tokens).expect("predicate should parse"),
+        crate::cards::builders::PredicateAst::ValueComparison {
+            left: crate::effect::Value::LifeTotal(crate::filter::PlayerFilter::Opponent),
+            operator: crate::effect::ValueComparisonOperator::LessThanOrEqual,
+            right: crate::effect::Value::Fixed(0),
+        }
+    );
+}
+
+#[test]
+fn heaven_sent_strict_compile_succeeds() {
+    let oracle_text = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II - Investigate.\nIII - This Saga deals 1 damage to each opponent. Then if an opponent has 0 or less life, draw seven cards. Otherwise, exile this Saga and you may cast it this turn.";
+
+    let def = CardDefinitionBuilder::new(CardId::new(), "Heaven Sent Variant")
+        .parse_text(oracle_text)
+        .expect("Heaven Sent text should parse");
+    let debug = format!("{:?}", def.abilities);
+
+    assert!(debug.contains("ValueComparison"), "{debug}");
+    assert!(debug.contains("LifeTotal(Opponent)"), "{debug}");
+    assert!(debug.contains("LessThanOrEqual"), "{debug}");
+    assert!(debug.contains("Fixed(0)"), "{debug}");
+}
+
+#[test]
 fn rewrite_grammar_battlefield_count_predicate_parses_other_creatures() {
     let tokens = lex_line(
         "there are two or more other creatures on the battlefield",

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10821,12 +10821,17 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 );
             }
             if let (
-                Value::LifeTotal(PlayerFilter::You),
+                Value::LifeTotal(player),
                 crate::effect::ValueComparisonOperator::LessThanOrEqual,
                 Value::Fixed(count),
             ) = (left, operator, right)
             {
-                return format!("you have {count} or less life");
+                let subject = describe_player_filter(player);
+                return format!(
+                    "{} {} {count} or less life",
+                    subject,
+                    player_verb(&subject, "have", "has")
+                );
             }
             if let (
                 Value::Count(filter),
@@ -11205,6 +11210,18 @@ mod tests {
                 right: Value::Fixed(5),
             }),
             "you have 5 or less life"
+        );
+    }
+
+    #[test]
+    fn describe_opponent_life_total_at_most_condition_uses_or_less_life_surface() {
+        assert_eq!(
+            describe_condition(&Condition::ValueComparison {
+                left: Value::LifeTotal(PlayerFilter::Opponent),
+                operator: crate::effect::ValueComparisonOperator::LessThanOrEqual,
+                right: Value::Fixed(0),
+            }),
+            "an opponent has 0 or less life"
         );
     }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13091,6 +13091,19 @@ mod tests {
     }
 
     #[test]
+    fn sentence_helper_exiled_grant_play_renders_singular_card_reference() {
+        let effect = Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+            TagKey::from("__sentence_helper_exiled_l0_s0_e0"),
+            PlayerFilter::You,
+            crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn,
+            false,
+            false,
+        ));
+
+        assert_eq!(describe_effect(&effect), "you may cast that card this turn");
+    }
+
+    #[test]
     fn each_player_may_discard_draw_commander_value_compaction_preserves_equal_to_hint() {
         let mut commanders = ObjectFilter::default();
         commanders.any_of = vec![
@@ -29466,26 +29479,23 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "chosen")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "searched");
-        let object_text =
-            if crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled") {
-                "those cards".to_string()
-            } else if grant_play_tagged.tag.as_str().starts_with("targeted_")
-                || grant_play_tagged.tag.as_str().starts_with("__source_")
-                || grant_play_tagged.tag.as_str() == "__it__"
-                || matches!(
-                    grant_play_tagged.tag.as_str(),
-                    "exiled" | "revealed" | "looked" | "chosen" | "searched"
-                )
-                || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled")
-                || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "revealed")
-                || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")
-                || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "chosen")
-                || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "searched")
-            {
-                "that card".to_string()
-            } else {
-                format!("tagged '{}' cards", grant_play_tagged.tag.as_str())
-            };
+        let object_text = if grant_play_tagged.tag.as_str().starts_with("targeted_")
+            || grant_play_tagged.tag.as_str().starts_with("__source_")
+            || grant_play_tagged.tag.as_str() == "__it__"
+            || matches!(
+                grant_play_tagged.tag.as_str(),
+                "exiled" | "revealed" | "looked" | "chosen" | "searched"
+            )
+            || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled")
+            || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "revealed")
+            || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")
+            || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "chosen")
+            || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "searched")
+        {
+            "that card".to_string()
+        } else {
+            format!("tagged '{}' cards", grant_play_tagged.tag.as_str())
+        };
         if grant_play_tagged.allow_any_color_for_cast {
             if helper_tag
                 && !grant_play_tagged.allow_land


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Heaven Sent
Initial parse error:
```
unsupported predicate (predicate: 'opponent has 0 or less life'); oracle-only fallback also failed: unsupported predicate (predicate: 'opponent has 0 or less life')
```

Worker: i-002fcec80607eb82a
