### PR TITLE
Fix Ironsmith parse failure: Animate Wall

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -6143,6 +6143,45 @@ pub(crate) fn parse_filter_has_granted_ability_line(
         return Ok(None);
     }
 
+    let normalized = clause_words
+        .iter()
+        .map(|word| {
+            if *word == "didn't" {
+                "didnt"
+            } else {
+                *word
+            }
+        })
+        .collect::<Vec<_>>();
+    if let Some(can_idx) = anthem_find_word_sequence_index(
+        &normalized,
+        &["can", "attack", "as", "though", "it", "didnt", "have", "defender"],
+    ) {
+        if can_idx > 0
+            && anthem_word_slice_starts_with(&normalized[can_idx..], &["can", "attack"])
+            && normalized.last().copied() == Some("defender")
+            && let Some(subject_end) = token_index_for_word_index(tokens, can_idx)
+        {
+            let subject_tokens = trim_commas(&tokens[..subject_end]);
+            if !subject_tokens.is_empty() {
+                let subject = parse_anthem_subject(&subject_tokens)?;
+                let granted = match subject {
+                    AnthemSubjectAst::Source => StaticAbilityAst::Static(
+                        StaticAbility::can_attack_as_though_no_defender(),
+                    ),
+                    AnthemSubjectAst::Filter(filter) => StaticAbilityAst::GrantStaticAbility {
+                        filter,
+                        ability: Box::new(StaticAbilityAst::Static(
+                            StaticAbility::can_attack_as_though_no_defender(),
+                        )),
+                        condition: None,
+                    },
+                };
+                return Ok(Some(vec![granted]));
+            }
+        }
+    }
+
     let mut deferred_error: Option<CardTextError> = None;
     let mut inside_quotes = false;
     for (has_idx, token) in tokens.iter().enumerate() {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1064,12 +1064,10 @@ pub(crate) fn parse_can_attack_as_though_no_defender_clause(
     let tail = &clause_words[can_idx..];
     let has_full_core = word_slice_starts_with(tail, &["can", "attack"])
         && word_slice_contains_sequence(tail, &["as", "though"])
-        && word_slice_contains(tail, "turn")
         && word_slice_contains(tail, "have")
         && tail.last().copied() == Some("defender");
     let has_split_core = word_slice_starts_with(tail, &["can", "attack"])
         && word_slice_contains_sequence(tail, &["as", "though"])
-        && word_slice_contains(tail, "turn")
         && matches!(tail.last().copied(), Some("didnt" | "didn't"));
     if !has_full_core && !has_split_core {
         return Ok(None);

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -660,7 +660,6 @@ fn is_can_attack_as_though_no_defender_clause_words_lexed(words: &[&str]) -> boo
     let tail = &words[can_idx..];
     word_slice_starts_with(tail, &["can", "attack"])
         && word_slice_contains_sequence(tail, &["as", "though"])
-        && word_slice_contains(tail, "turn")
         && word_slice_contains(tail, "have")
         && tail.last().copied() == Some("defender")
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35458,6 +35458,23 @@ fn parse_tidal_barracuda_any_player_flash_permission_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_animate_wall_as_though_no_defender_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Animate Wall")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text("Enchanted Wall can attack as though it didn't have defender.")
+        .expect("animate wall as-though clause should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("as though") && rendered.contains("defender"),
+        "expected as-though no-defender wording, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_valley_floodcaller_keeps_flash_grant_and_them_reference_wording() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Valley Floodcaller")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Animate Wall
Initial parse error:
```
compiled text dropped required semantic marker: as-though
```

Worker: i-05a374443ea288528
