### PR TITLE
Fix Ironsmith parse failure: Tajuru Paragon

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -657,6 +657,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(
             parse_subject_are_card_types_in_addition_to_their_other_types_line
         ),
+        single_static_ability_ast_rule!(parse_subject_is_also_subtype_list_line),
         single_static_ability_ast_rule!(parse_all_permanents_colorless_line),
         single_static_ability_ast_rule!(parse_all_cards_spells_permanents_colorless_line),
         multi_static_ability_ast_rule!(parse_all_are_color_and_type_addition_line),
@@ -5765,6 +5766,64 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
     let filter = parse_object_filter(subject_tokens, false)?;
 
     Ok(Some(StaticAbility::add_card_types(filter, card_types)))
+}
+
+pub(crate) fn parse_subject_is_also_subtype_list_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.len() < 5 {
+        return Ok(None);
+    }
+
+    let Some(be_idx) = find_index(&words, |word| matches!(*word, "is" | "are")) else {
+        return Ok(None);
+    };
+    if be_idx == 0 || be_idx + 3 >= words.len() {
+        return Ok(None);
+    }
+    if words.get(be_idx + 1) != Some(&"also") {
+        return Ok(None);
+    }
+
+    let descriptors = &words[be_idx + 2..];
+    let mut subtypes = Vec::new();
+    for descriptor in descriptors {
+        if is_article(descriptor) || matches!(*descriptor, "and" | "or" | "and/or") {
+            continue;
+        }
+
+        let Some(subtype) = parse_subtype_word(descriptor)
+            .or_else(|| str_strip_suffix(descriptor, "s").and_then(parse_subtype_word))
+        else {
+            return Ok(None);
+        };
+
+        if !slice_contains(&subtypes, &subtype) {
+            subtypes.push(subtype);
+        }
+    }
+
+    if subtypes.is_empty() {
+        return Ok(None);
+    }
+
+    let subject_tokens = &tokens[..be_idx];
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+    let filter = parse_object_filter(subject_tokens, false).or_else(|_| {
+        let subject_words = crate::runtime_backend::token_word_refs(subject_tokens);
+        if is_source_reference_words(&subject_words) || !subject_words.is_empty() {
+            Ok(ObjectFilter::source())
+        } else {
+            Err(CardTextError::ParseError(
+                "unsupported subtype-addition subject".to_string(),
+            ))
+        }
+    })?;
+
+    Ok(Some(StaticAbility::add_subtypes(filter, subtypes)))
 }
 
 pub(crate) fn parse_all_cards_spells_permanents_colorless_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12951,3 +12951,29 @@ fn maddening_hex_damage_equal_to_die_result_binds_prior_roll() {
         "that player in this non-loop trigger must not lower to an unbound iterated player, got {debug}"
     );
 }
+
+#[test]
+fn static_line_parses_is_also_subtype_list() {
+    let tokens = lex_line(
+        "Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.",
+        0,
+    )
+    .expect("rewrite lexer should classify subtype-addition line");
+
+    let direct = super::keyword_static::parse_subject_is_also_subtype_list_line(&tokens)
+        .expect("subtype-addition rule should not error")
+        .expect("subtype-addition rule should match");
+    let direct_debug = format!("{direct:?}");
+    assert!(direct_debug.contains("AddSubtypes"), "{direct_debug}");
+
+    let parsed = super::clause_support::parse_static_ability_ast_line_lexed(&tokens)
+        .expect("subtype-addition static line should parse")
+        .expect("subtype-addition static line should produce ability");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("AddSubtypes"), "{debug}");
+    assert!(debug.contains("Cleric"), "{debug}");
+    assert!(debug.contains("Rogue"), "{debug}");
+    assert!(debug.contains("Warrior"), "{debug}");
+    assert!(debug.contains("Wizard"), "{debug}");
+}

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -113,6 +113,25 @@ fn parse_clash_repeat_process_spell_effect() {
     );
 }
 
+#[test]
+fn tajuru_paragon_render_avoids_tagged_object_markers() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(4), "Tajuru Paragon Probe")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "This creature is also a Cleric, Rogue, Warrior, and Wizard.\nKicker {3}\nWhen this creature enters, if it was kicked, reveal the top six cards of your library. You may put a card that shares a creature type with it from among them into your hand. Put the rest on the bottom of your library in a random order.",
+        )
+        .expect("Tajuru Paragon-style rules text should parse");
+
+    let compiled = crate::compiled_text::compiled_text_lines(&def).join(" ");
+    let lower = compiled.to_ascii_lowercase();
+    assert!(
+        !lower.contains("tagged object '") && !lower.contains("tagged '"),
+        "compiled text leaked tagged-object marker: {compiled}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -5114,6 +5114,9 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
         .replace("controlss", "controls")
         .replace("the tagged object 'enchanted'", "enchanted creature")
         .replace("the tagged object '__it__'", "that creature")
+        .replace("the tagged object 'it'", "that creature")
+        .replace("tagged object '__it__'", "that creature")
+        .replace("tagged object 'it'", "that creature")
         .replace(
             "the tagged object 'exiled_0' matches creature",
             "that card is a creature card",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tajuru Paragon
Initial parse error:
```
parser does not yet support line family: 'Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.'; oracle-only fallback also failed: parser does not yet support line family: 'Tajuru Paragon is also a Cleric, Rogue, Warrior, and Wizard.'
```

Worker: i-0cd4d731d7b700c1b
