### PR TITLE
Fix Ironsmith parse failure: Waterbender's Restoration

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -159,7 +159,22 @@ pub(super) fn lower_additional_cost(
             ))
         })?
     };
-    let effects = parse_effect_sentences_lexed(effect_tokens)?;
+    let effects = match parse_effect_sentences_lexed(effect_tokens) {
+        Ok(effects) => effects,
+        Err(parse_err) => {
+            let total_cost = parse_activation_cost(effect_tokens).map_err(|_| parse_err.clone())?;
+            if total_cost.non_mana_costs().next().is_some() {
+                return Err(parse_err);
+            }
+            let Some(mana_cost) = total_cost.mana_cost() else {
+                return Err(parse_err);
+            };
+            vec![EffectAst::subject_verb_pay_mana(
+                PlayerAst::You,
+                mana_cost.clone(),
+            )]
+        }
+    };
     Ok(LineAst::AdditionalCost { effects })
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1881,6 +1881,30 @@ fn rewrite_keyword_lowering_reuses_token_sentences_for_optional_cost_cast_trigge
 }
 
 #[test]
+fn rewrite_keyword_lowering_parses_additional_cost_activation_clause_without_effect_verb()
+-> Result<(), CardTextError> {
+    let text = "as an additional cost to cast this spell, waterbend {x}.";
+    let tokens = lex_line(text, 0)
+        .expect("rewrite lexer should classify additional-cost activation clause");
+
+    let parsed = super::lower_rewrite_keyword_to_chunk(
+        rewrite_line_info(text),
+        text,
+        &tokens,
+        RewriteKeywordLineKind::AdditionalCost,
+    )?;
+
+    match parsed {
+        crate::cards::builders::LineAst::AdditionalCost { effects } => {
+            assert!(!effects.is_empty());
+        }
+        other => panic!("expected additional cost line, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
 fn rewrite_statement_lowering_reuses_full_token_slice_for_pact_line() -> Result<(), CardTextError> {
     let text = "search your library for a green creature card, reveal it, put it into your hand, then shuffle. at the beginning of your next upkeep, pay {2}{G}{G}. if you don't, you lose the game.";
     let tokens = lex_line(text, 0).expect("rewrite lexer should classify pact statement line");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -9997,6 +9997,49 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         }
 
         if idx + 1 < filtered.len()
+            && let Some(tagged_exile) =
+                filtered[idx].downcast_ref::<crate::effects::TaggedEffect>()
+            && let Some(exile) = tagged_exile
+                .effect
+                .downcast_ref::<crate::effects::ExileEffect>()
+            && tagged_exile
+                .tag
+                .as_str()
+                .starts_with("__sentence_helper_exiled")
+            && let Some(schedule) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()
+            && schedule.one_shot
+            && schedule
+                .trigger
+                .display()
+                .to_ascii_lowercase()
+                .contains("end step")
+            && schedule.effects.len() == 1
+            && let Some(move_to_zone) = unwrap_tag_wrappers(&schedule.effects[0])
+                .downcast_ref::<crate::effects::MoveToZoneEffect>()
+            && move_to_zone.zone == Zone::Battlefield
+            && matches!(&move_to_zone.target, ChooseSpec::Tagged(tag) if tag == &tagged_exile.tag)
+            && move_to_zone.battlefield_controller == crate::effects::BattlefieldController::Owner
+        {
+            let target = describe_choose_spec(&exile.spec);
+            let return_object = if choose_spec_allows_multiple(&exile.spec) {
+                "those cards"
+            } else {
+                "that card"
+            };
+            let owner_control_suffix = if choose_spec_allows_multiple(&exile.spec) {
+                " under their owner's control"
+            } else {
+                " under its owner's control"
+            };
+            parts.push(format!(
+                "Exile {target}. At the beginning of the next end step, return {return_object} to the battlefield{owner_control_suffix}"
+            ));
+            idx += 2;
+            continue;
+        }
+
+        if idx + 1 < filtered.len()
             && let Some(choose) =
                 filtered[idx].downcast_ref::<crate::effects::ChooseObjectsEffect>()
             && let Some(schedule) =


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Waterbender's Restoration
Initial parse error:
```
could not find verb in effect clause (clause: 'waterbend x'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'waterbend x'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-09b60114927431747
