### PR TITLE
Fix Ironsmith parse failure: Wild Defiance

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2262,6 +2262,27 @@ pub(crate) fn parse_trigger_clause_lexed(
                     stack_object: ability_filter,
                 });
             }
+            if tail_words
+                .last()
+                .is_some_and(|word| *word == "spell" || *word == "spells")
+                && let Some(filter) = subject_filter
+            {
+                let tail_token_start = ActivationRestrictionCompatWords::new(tokens)
+                    .token_index_for_word_index(tail_word_start)
+                    .unwrap_or(tokens.len());
+                let spell_filter_tokens = trim_commas(&tokens[tail_token_start..]);
+                let spell_filter =
+                    parse_object_filter_lexed(&spell_filter_tokens, false).map_err(|_| {
+                        CardTextError::ParseError(format!(
+                            "unsupported spell filter in becomes-targeted trigger clause (clause: '{}')",
+                            words.join(" ")
+                        ))
+                    })?;
+                return Ok(TriggerSpec::BecomesTargetedByStackObject {
+                    target: filter,
+                    stack_object: spell_filter,
+                });
+            }
         }
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12399,6 +12399,34 @@ fn rewrite_semantic_parse_keeps_intervening_if_trigger_split() -> Result<(), Car
 }
 
 #[test]
+fn rewrite_semantic_parse_accepts_becomes_targeted_by_spell_filter_trigger()
+-> Result<(), CardTextError> {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Wild Defiance Variant")
+        .card_types(vec![CardType::Enchantment]);
+    let (doc, _) = parse_text_to_semantic_document(
+        builder,
+        "Whenever a creature you control becomes the target of an instant or sorcery spell, that creature gets +3/+3 until end of turn.".to_string(),
+        false,
+    )?;
+
+    match doc.items.as_slice() {
+        [RewriteSemanticItem::Triggered(triggered)] => {
+            assert_eq!(
+                triggered.trigger_text,
+                "a creature you control becomes the target of an instant or sorcery spell"
+            );
+            assert_eq!(
+                triggered.effect_text,
+                "that creature gets +3/+3 until end of turn."
+            );
+        }
+        other => panic!("expected one triggered semantic item, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
 fn rewrite_semantic_parse_marks_plumb_additional_cost_as_non_choice() -> Result<(), CardTextError> {
     let builder = CardDefinitionBuilder::new(CardId::new(), "Plumb Variant")
         .card_types(vec![CardType::Instant]);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wild Defiance
Initial parse error:
```
unsupported triggered line: 'Whenever a creature you control becomes the target of an instant or sorcery spell, that creature gets +3/+3 until end of turn.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever a creature you control becomes the target of an instant or sorcery spell, that creature gets +3/+3 until end of turn.'
```

Worker: i-0534010f848abe7f0
