### PR TITLE
Fix Ironsmith parse failure: Azor's Elocutors

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2412,6 +2412,11 @@ pub(crate) fn parse_trigger_clause_lexed(
             {
                 return Ok(TriggerSpec::DealsNoncombatDamageToPlayer { source, player });
             }
+            if let Some(player) = parse_trigger_subject_player_filter(&target_words)
+                && let Some(source) = parse_trigger_subject_filter_lexed(subject_tokens)?
+            {
+                return Ok(TriggerSpec::DealsDamageToPlayer { source, player });
+            }
         }
         return Ok(match parse_trigger_subject_filter_lexed(subject_tokens)? {
             Some(filter) => TriggerSpec::DealsDamage(filter),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
@@ -371,6 +371,9 @@ pub(crate) fn parse_trigger_subject_filter(
         filter.controller = Some(PlayerFilter::You);
         return Ok(Some(filter));
     }
+    if matches!(subject_words.as_slice(), ["a", "source"] | ["source"] | ["any", "source"]) {
+        return Ok(Some(ObjectFilter::default()));
+    }
     if matches!(
         subject_words.as_slice(),
         ["a", "source", "an", "opponent", "controls"] | ["source", "an", "opponent", "controls"]
@@ -528,6 +531,9 @@ pub(crate) fn parse_trigger_subject_filter_lexed(
         let mut filter = ObjectFilter::default();
         filter.controller = Some(PlayerFilter::You);
         return Ok(Some(filter));
+    }
+    if matches!(subject_words.as_slice(), ["a", "source"] | ["source"] | ["any", "source"]) {
+        return Ok(Some(ObjectFilter::default()));
     }
     if matches!(
         subject_words.as_slice(),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1200,6 +1200,8 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if let Some(prefix_len) = source_has_counter_prefix_len
         && raw_words.len() >= prefix_len + 4
+        && !(raw_words.get(prefix_len + 1) == Some(&"or")
+            && raw_words.get(prefix_len + 2) == Some(&"more"))
         && let Some(counter_idx) = find_index(&raw_words[prefix_len..], |word| {
             *word == "counter" || *word == "counters"
         })

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -88,6 +88,9 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             Trigger::this_deals_combat_damage_to(filter)
         }
         TriggerSpec::DealsDamage(filter) => Trigger::deals_damage(filter),
+        TriggerSpec::DealsDamageToPlayer { source, player } => {
+            Trigger::deals_damage_to_player(source, player)
+        }
         TriggerSpec::DealsNoncombatDamageToPlayer { source, player } => {
             Trigger::deals_noncombat_damage_to_player(source, player)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -154,6 +154,10 @@ pub(crate) enum TriggerSpec {
     ThisDealsCombatDamage,
     ThisDealsCombatDamageTo(ObjectFilter),
     DealsDamage(ObjectFilter),
+    DealsDamageToPlayer {
+        source: ObjectFilter,
+        player: PlayerFilter,
+    },
     DealsNoncombatDamageToPlayer {
         source: ObjectFilter,
         player: PlayerFilter,

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -115,6 +115,10 @@ pub enum TriggerKind {
     DealsDamage {
         filter: ObjectFilter,
     },
+    DealsDamageToPlayer {
+        source: ObjectFilter,
+        player: PlayerFilter,
+    },
     DealsNoncombatDamageToPlayer {
         source: ObjectFilter,
         player: PlayerFilter,
@@ -536,6 +540,12 @@ impl Trigger {
     }
     pub fn deals_damage(filter: ObjectFilter) -> Self {
         Self::typed("deals_damage", TriggerKind::DealsDamage { filter })
+    }
+    pub fn deals_damage_to_player(source: ObjectFilter, player: PlayerFilter) -> Self {
+        Self::typed(
+            "deals_damage_to_player",
+            TriggerKind::DealsDamageToPlayer { source, player },
+        )
     }
     pub fn deals_noncombat_damage_to_player(source: ObjectFilter, player: PlayerFilter) -> Self {
         Self::typed(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -4393,6 +4393,45 @@ fn test_parse_nest_of_scarabs_style_trigger_and_token_amount() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_damage_trigger_with_source_subject() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Source Subject Damage Probe")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Whenever a source deals damage to you, put a filibuster counter on this creature.",
+        )
+        .expect("source-subject damage trigger should parse");
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("DealsDamageTrigger")
+            && debug.contains("filter: ObjectFilter")
+            && debug.contains("damaged_player: Some(")
+            && debug.contains("You")
+            && debug.contains("PutCountersEffect")
+            && debug.contains("filibuster"),
+        "expected a generic source-damage trigger with filibuster counter effect, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_parse_source_has_five_or_more_counters_condition() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Source Counter Threshold Probe")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "At the beginning of your upkeep, put a filibuster counter on this creature. Then if this creature has five or more filibuster counters on it, you win the game.",
+        )
+        .expect("source counter threshold condition should parse");
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("SourceHasCounterAtLeast") && debug.contains("count: 5"),
+        "expected five-or-more source counter threshold, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_unknown_non_source_subject_fails() {
     let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Unknown Subject Probe")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/triggers/combat/deals_damage.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/deals_damage.rs
@@ -76,22 +76,30 @@ impl TriggerMatcher for DealsDamageTrigger {
     }
 
     fn display(&self) -> String {
+        let source_description = if self.filter == ObjectFilter::default() {
+            "a source".to_string()
+        } else {
+            self.filter.description()
+        };
         if self.combat_only {
-            format!("Whenever {} deals combat damage", self.filter.description())
+            format!("Whenever {} deals combat damage", source_description)
         } else if self.noncombat_only {
             if self.damaged_player.is_some() {
                 format!(
                     "Whenever {} deals noncombat damage to a player",
-                    self.filter.description()
+                    source_description
                 )
             } else {
-                format!(
-                    "Whenever {} deals noncombat damage",
-                    self.filter.description()
-                )
+                format!("Whenever {} deals noncombat damage", source_description)
             }
+        } else if let Some(player) = &self.damaged_player {
+            format!(
+                "Whenever {} deals damage to {}",
+                source_description,
+                player.description()
+            )
         } else {
-            format!("Whenever {} deals damage", self.filter.description())
+            format!("Whenever {} deals damage", source_description)
         }
     }
 }

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -176,6 +176,11 @@ pub(crate) fn interpret_trigger_model(
             crate::triggers::Trigger::this_deals_combat_damage_to_player()
         }
         TriggerKind::DealsDamage { filter } => crate::triggers::Trigger::deals_damage(filter),
+        TriggerKind::DealsDamageToPlayer { source, player } => {
+            let mut trigger = crate::triggers::combat::DealsDamageTrigger::new(source);
+            trigger.damaged_player = Some(player);
+            crate::triggers::Trigger::new(trigger)
+        }
         TriggerKind::DealsNoncombatDamageToPlayer { source, player } => {
             crate::triggers::Trigger::deals_noncombat_damage_to_player(source, player)
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Azor's Elocutors
Initial parse error:
```
unsupported trigger subject filter (clause: 'a source'); oracle-only fallback also failed: unsupported trigger subject filter (clause: 'a source')
```

Worker: i-0555518f43c0cd2af
