### PR TITLE
Fix Ironsmith parse failure: Containment Priest

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2135,6 +2135,37 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::TaggedWasCast(TagKey::from(IT_TAG)));
     }
 
+    if let Some(and_idx) = find_index(&filtered, |word| *word == "and")
+        && and_idx >= 3
+        && filtered[and_idx - 2] == "would"
+        && filtered[and_idx - 1] == "enter"
+        && matches!(
+            &filtered[and_idx + 1..],
+            ["it", "wasnt", "cast"]
+                | ["it", "was", "not", "cast"]
+                | ["that", "creature", "wasnt", "cast"]
+                | ["that", "creature", "was", "not", "cast"]
+                | ["that", "permanent", "wasnt", "cast"]
+                | ["that", "permanent", "was", "not", "cast"]
+                | ["that", "object", "wasnt", "cast"]
+                | ["that", "object", "was", "not", "cast"]
+        )
+    {
+        let filter_tokens = filtered[..and_idx - 2]
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        if !filter_tokens.is_empty() {
+            let filter = parse_object_filter(&filter_tokens, false)?;
+            return Ok(PredicateAst::And(
+                Box::new(PredicateAst::TaggedMatches(TagKey::from(IT_TAG), filter)),
+                Box::new(PredicateAst::Not(Box::new(PredicateAst::TaggedWasCast(
+                    TagKey::from(IT_TAG),
+                )))),
+            ));
+        }
+    }
+
     if filtered.len() >= 6
         && filtered[0] == "this"
         && filtered[1] == "spell"
@@ -3135,6 +3166,25 @@ mod tests {
             parsed,
             PredicateAst::ThisSpellPaidLabel("Surge".to_string())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_would_enter_and_wasnt_cast() -> Result<(), CardTextError> {
+        let tokens = lex_line("If a nontoken creature would enter and it wasn't cast", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+        let debug = format!("{parsed:#?}");
+        let debug_lower = debug.to_ascii_lowercase();
+
+        assert!(debug.contains("And("), "{debug}");
+        assert!(debug_lower.contains("nontoken"), "{debug}");
+        assert!(debug.contains("TaggedWasCast"), "{debug}");
         Ok(())
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -166,6 +166,22 @@ fn rewrite_effects_tag_relation(
         .collect()
 }
 
+fn predicate_references_it_tag(predicate: &PredicateAst) -> bool {
+    match predicate {
+        PredicateAst::ItIsLandCard | PredicateAst::ItIsSoulbondPaired | PredicateAst::ItMatches(_) => true,
+        PredicateAst::TaggedMatches(tag, _) | PredicateAst::TaggedWasCast(tag) => {
+            tag.as_str() == IT_TAG
+        }
+        PredicateAst::TargetMatches(filter) => filter_references_tag(filter, IT_TAG),
+        PredicateAst::PlayerTaggedObjectMatches { tag, .. } => tag.as_str() == IT_TAG,
+        PredicateAst::Not(inner) => predicate_references_it_tag(inner),
+        PredicateAst::And(left, right) | PredicateAst::Or(left, right) => {
+            predicate_references_it_tag(left) || predicate_references_it_tag(right)
+        }
+        _ => false,
+    }
+}
+
 pub(super) fn try_compile_timing_and_control_effect(
     effect: &EffectAst,
     ctx: &mut EffectLoweringContext,
@@ -531,6 +547,7 @@ pub(super) fn try_compile_stack_and_condition_effect(
             if_true,
             if_false,
         } => {
+            let predicate_references_it = predicate_references_it_tag(predicate);
             let mut effective_if_true = if_true.clone();
             if let Some(antecedent) = predicate_object_filter_antecedent(predicate) {
                 bind_condition_antecedent_in_effects(
@@ -540,6 +557,9 @@ pub(super) fn try_compile_stack_and_condition_effect(
                 );
             }
             let saved_last_tag = ctx.last_object_tag.clone();
+            if ctx.last_object_tag.is_none() && predicate_references_it {
+                ctx.last_object_tag = Some("triggering".to_string());
+            }
             let saved_source_object_antecedent = ctx.source_object_antecedent;
             ctx.source_object_antecedent |= predicate.establishes_source_object_antecedent();
             let (true_effects, true_choices) = compile_effects(&effective_if_true, ctx)?;
@@ -549,22 +569,6 @@ pub(super) fn try_compile_stack_and_condition_effect(
                 saved_source_object_antecedent || predicate.establishes_source_object_antecedent();
             let (false_effects, false_choices) = compile_effects(if_false, ctx)?;
             ctx.source_object_antecedent = saved_source_object_antecedent;
-            let predicate_references_it = matches!(
-                predicate,
-                PredicateAst::ItIsLandCard
-                    | PredicateAst::ItIsSoulbondPaired
-                    | PredicateAst::ItMatches(_)
-            ) || matches!(predicate, PredicateAst::TaggedMatches(tag, _) if tag.as_str() == IT_TAG)
-                || matches!(predicate, PredicateAst::TaggedWasCast(tag) if tag.as_str() == IT_TAG)
-                || matches!(
-                    predicate,
-                    PredicateAst::TargetMatches(filter) if filter_references_tag(filter, IT_TAG)
-                )
-                || matches!(
-                    predicate,
-                    PredicateAst::PlayerTaggedObjectMatches { tag, .. } if tag.as_str() == IT_TAG
-                );
-
             let antecedent_choice = if saved_last_tag.is_none() && predicate_references_it {
                 let mut antecedent_choice = None;
                 for choice in true_choices.iter().chain(false_choices.iter()) {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -3128,6 +3128,28 @@ fn rewrite_if_clause_binds_it_was_cast_to_tagged_object() {
 }
 
 #[test]
+fn rewrite_if_clause_supports_would_enter_and_wasnt_cast() {
+    let tokens = lex_line(
+        "If a nontoken creature would enter and it wasn't cast, exile it instead.",
+        0,
+    )
+    .expect("rewrite lexer should classify would-enter cast-history predicate");
+
+    let parsed = parse_effect_sentence_lexed(&tokens)
+        .expect("would-enter cast-history conditional should parse");
+    let [crate::cards::builders::EffectAst::Conditional { predicate, .. }] = parsed.as_slice()
+    else {
+        panic!("expected conditional exile clause, got {parsed:?}");
+    };
+
+    let debug = format!("{predicate:#?}");
+    let debug_lower = debug.to_ascii_lowercase();
+    assert!(debug.contains("And("), "{debug}");
+    assert!(debug_lower.contains("nontoken"), "{debug}");
+    assert!(debug.contains("TaggedWasCast"), "{debug}");
+}
+
+#[test]
 fn rewrite_verb_handlers_keep_trailing_instead_if_damage_clause_after_structure_cutover() {
     let tokens = lex_line(
         "This creature deals 5 damage to target creature instead if it's white.",

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -9402,13 +9402,13 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
-    fn parse_rejects_would_enter_replacement_clause() {
+    fn parse_supports_would_enter_replacement_clause() {
         let result = CardDefinitionBuilder::new(CardId::new(), "Mistcaller Variant").parse_text(
             "Sacrifice this creature: Until end of turn, if a nontoken creature would enter and it wasn't cast, exile it instead.",
         );
         assert!(
-            result.is_err(),
-            "unsupported would-enter replacement clause should fail parse instead of collapsing to an immediate exile effect"
+            result.is_ok(),
+            "would-enter replacement clause should parse into a replacement effect"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Containment Priest
Initial parse error:
```
unsupported predicate (predicate: 'nontoken creature would enter and it wasnt cast'); oracle-only fallback also failed: unsupported predicate (predicate: 'nontoken creature would enter and it wasnt cast')
```

Worker: i-0bd108a9b9fcf0db2
