### PR TITLE
Fix Ironsmith parse failure: Aminatou, Veil Piercer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -518,6 +518,75 @@ pub(crate) fn parse_granted_keyword_static_line(
         Ok(Some(count as u32))
     }
 
+    fn parse_granted_miracle_cost_reduction_tail(
+        trailing_tokens: &[OwnedLexToken],
+    ) -> Result<Option<u32>, CardTextError> {
+        let trailing_words = AnthemNormalizedWords::new(trailing_tokens);
+        let trailing_word_refs = trailing_words.word_refs();
+        let Some(prefix_len) = (match trailing_word_refs.as_slice() {
+            [
+                "the",
+                "miracle",
+                "cost",
+                "is",
+                "equal",
+                "to",
+                "its",
+                "mana",
+                "cost",
+                "reduced",
+                "by",
+                ..,
+            ] => Some(11usize),
+            [
+                "its",
+                "miracle",
+                "cost",
+                "is",
+                "equal",
+                "to",
+                "its",
+                "mana",
+                "cost",
+                "reduced",
+                "by",
+                ..,
+            ] => Some(11usize),
+            _ => None,
+        }) else {
+            return Ok(None);
+        };
+
+        let Some(cost_idx) = trailing_words.token_index_for_word_index(prefix_len) else {
+            return Ok(None);
+        };
+        let cost_tokens = trailing_tokens.get(cost_idx..).unwrap_or_default();
+        let Some((cost, used)) =
+            crate::runtime_backend::front_end::shared::util::leading_mana_cost_from_tokens(
+                cost_tokens,
+            )
+        else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported miracle cost reduction clause (clause: '{}')",
+                trailing_word_refs.join(" ")
+            )));
+        };
+        if used != cost_tokens.len() {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported miracle cost reduction clause (clause: '{}')",
+                trailing_word_refs.join(" ")
+            )));
+        }
+        let generic = cost.generic_mana_total();
+        if generic == 0 || cost.mana_value() != generic {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported miracle cost reduction clause (clause: '{}')",
+                trailing_word_refs.join(" ")
+            )));
+        }
+        Ok(Some(generic))
+    }
+
     fn parse_granted_alternative_cast_static(
         subject_tokens: &[OwnedLexToken],
         keyword_tokens: &[OwnedLexToken],
@@ -560,6 +629,16 @@ pub(crate) fn parse_granted_keyword_static_line(
                     return Ok(None);
                 }
                 return granted_emerge_abilities_from_subject(subject_tokens, condition);
+            }
+            ["miracle"] => {
+                let Some(reduction) = parse_granted_miracle_cost_reduction_tail(trailing_tokens)?
+                else {
+                    return Ok(None);
+                };
+                extract_grant_spec_from_subject(
+                    subject_tokens,
+                    crate::grant::Grantable::miracle_from_cards_mana_cost_reduced_by(reduction),
+                )?
             }
             ["escape"] => {
                 let Some(exile_count) = parse_granted_escape_cost_tail(trailing_tokens)? else {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5135,6 +5135,25 @@ fn rewrite_anthem_grant_static_parses_escape_tail_without_word_view() {
 }
 
 #[test]
+fn rewrite_anthem_grant_static_parses_miracle_reduction_tail_without_word_view() {
+    let tokens = lex_line(
+        "Each enchantment card in your hand has miracle. Its miracle cost is equal to its mana cost reduced by {4}.",
+        0,
+    )
+    .expect("rewrite lexer should classify granted miracle static line");
+
+    let parsed = super::keyword_static::parse_granted_keyword_static_line(&tokens)
+        .expect("granted miracle static line should parse")
+        .expect("granted miracle static line should be recognized");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("MiracleFromCardManaCostReducedBy") && debug.contains("reduction: 4"),
+        "{debug}"
+    );
+}
+
+#[test]
 fn rewrite_anthem_static_condition_normalizes_apostrophe_shapes() {
     let tokens = lex_line("It's enchanted", 0)
         .expect("rewrite lexer should classify static-condition clause");

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -19,6 +19,8 @@ pub enum DerivedAlternativeCast<C> {
     BlitzFromCardManaCost,
     /// Emerge using the card's mana cost and sacrificing a creature.
     EmergeFromCardManaCost,
+    /// Miracle using the card's mana cost reduced by a fixed generic amount.
+    MiracleFromCardManaCostReducedBy { reduction: u32 },
     /// Escape using the card's mana cost and exiling N other graveyard cards.
     EscapeFromCardManaCost { exile_count: u32 },
     /// Cast from hand by paying generic mana equal to the card's mana value.
@@ -37,6 +39,7 @@ impl<C> DerivedAlternativeCast<C> {
             Self::RetraceFromCardManaCost => "Retrace",
             Self::BlitzFromCardManaCost => "Blitz",
             Self::EmergeFromCardManaCost => "Emerge",
+            Self::MiracleFromCardManaCostReducedBy { .. } => "Miracle",
             Self::EscapeFromCardManaCost { .. } => "Escape",
             Self::ManaValueAsGenericFromHand => "Pay mana value",
             Self::GraveyardCastFromCardManaCost { .. } => "Cast from graveyard",
@@ -77,6 +80,10 @@ impl<C: CostComponent> DerivedAlternativeCast<C> {
 
     pub fn escape_from_cards_mana_cost(exile_count: u32) -> Self {
         Self::EscapeFromCardManaCost { exile_count }
+    }
+
+    pub fn miracle_from_cards_mana_cost_reduced_by(reduction: u32) -> Self {
+        Self::MiracleFromCardManaCostReducedBy { reduction }
     }
 
     pub fn once_each_turn_graveyard_cast_from_cards_mana_cost(additional_costs: Vec<C>) -> Self {
@@ -151,6 +158,13 @@ where
     pub fn escape(exile_count: u32) -> Self {
         Self::DerivedAlternativeCast(DerivedAlternativeCast::escape_from_cards_mana_cost(
             exile_count,
+        ))
+    }
+
+    /// Create a grantable for miracle whose cost is the granted card's mana cost reduced by a fixed amount.
+    pub fn miracle_from_cards_mana_cost_reduced_by(reduction: u32) -> Self {
+        Self::DerivedAlternativeCast(DerivedAlternativeCast::miracle_from_cards_mana_cost_reduced_by(
+            reduction,
         ))
     }
 
@@ -572,6 +586,30 @@ where
                 .unwrap_or(cast_desc);
             return format!(
                 "Each {filter_desc} has emerge. The emerge cost is equal to its mana cost"
+            );
+        }
+        if let Grantable::DerivedAlternativeCast(
+            DerivedAlternativeCast::MiracleFromCardManaCostReducedBy { reduction },
+        ) = &self.grantable
+            && self.zone == Zone::Hand
+        {
+            let mut base_filter = self.filter.clone();
+            base_filter.zone = None;
+            if matches!(base_filter.owner, Some(PlayerFilter::You)) {
+                base_filter.owner = None;
+            }
+            let base = castable_filter_description(&base_filter)
+                .strip_suffix(" spells")
+                .unwrap_or("cards")
+                .to_string();
+            let owner_phrase = if matches!(self.filter.owner, Some(PlayerFilter::You)) {
+                "your"
+            } else {
+                "that"
+            };
+            return format!(
+                "Each {base} card in {owner_phrase} hand has miracle. Its miracle cost is equal to its mana cost reduced by {}",
+                format!("{{{reduction}}}")
             );
         }
         if let Grantable::DerivedAlternativeCast(DerivedAlternativeCast::ManaValueAsGenericFromHand) =

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -624,6 +624,9 @@ where
                 DerivedAlternativeCast::EmergeFromCardManaCost => {
                     DerivedAlternativeCast::EmergeFromCardManaCost
                 }
+                DerivedAlternativeCast::MiracleFromCardManaCostReducedBy { reduction } => {
+                    DerivedAlternativeCast::MiracleFromCardManaCostReducedBy { reduction }
+                }
                 DerivedAlternativeCast::ManaValueAsGenericFromHand => {
                     DerivedAlternativeCast::ManaValueAsGenericFromHand
                 }

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -335,6 +335,11 @@ fn convert_derived_alternative_cast(
         compiler::grant::DerivedAlternativeCast::EmergeFromCardManaCost => {
             ironsmith::grant::DerivedAlternativeCast::EmergeFromCardManaCost
         }
+        compiler::grant::DerivedAlternativeCast::MiracleFromCardManaCostReducedBy {
+            reduction,
+        } => ironsmith::grant::DerivedAlternativeCast::MiracleFromCardManaCostReducedBy {
+            reduction,
+        },
         compiler::grant::DerivedAlternativeCast::ManaValueAsGenericFromHand => {
             ironsmith::grant::DerivedAlternativeCast::ManaValueAsGenericFromHand
         }

--- a/crates/ironsmith-runtime/src/grant.rs
+++ b/crates/ironsmith-runtime/src/grant.rs
@@ -124,6 +124,15 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
                     )],
                 ))
             }
+            Self::MiracleFromCardManaCostReducedBy { reduction } => {
+                let mana_cost = card.mana_cost.clone()?;
+                if card.zone != Zone::Hand {
+                    return None;
+                }
+                Some(AlternativeCastingMethod::Miracle {
+                    cost: mana_cost.reduce_generic(*reduction),
+                })
+            }
             Self::EscapeFromCardManaCost { exile_count } => {
                 let mana_cost = card.mana_cost.clone()?;
                 if card.zone != Zone::Graveyard {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aminatou, Veil Piercer
Initial parse error:
```
unsupported trailing granted-keyword clause (clause: 'each enchantment card in your hand has miracle its miracle cost is equal to its mana cost reduced by'); oracle-only fallback also failed: unsupported trailing granted-keyword clause (clause: 'each enchantment card in your hand has miracle its miracle cost is equal to its mana cost reduced by')
```

Worker: i-0e1e62254d0e6db13
