### PR TITLE
Fix Ironsmith parse failure: Fork in the Road

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2422,6 +2422,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_target_phrase_recognizes_bare_numeric_reference_as_it_tag() {
+        let tokens = lex_line("one", 0).unwrap();
+        let target = parse_target_phrase(&tokens).expect("bare one should parse");
+
+        let TargetAst::WithCount(inner, count) = target else {
+            panic!("expected counted IT-tag object target, got {target:?}");
+        };
+        let TargetAst::Object(filter, _, _) = *inner else {
+            panic!("expected inner object target, got {inner:?}");
+        };
+
+        assert_eq!(count.min, 1, "expected one selected object");
+        assert_eq!(count.max, Some(1), "expected exactly one selected object");
+        assert!(
+            filter.tagged_constraints.iter().any(|constraint| {
+                constraint.tag.as_str() == IT_TAG
+                    && constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+            }),
+            "expected bare numeric target to bind IT tag, got {filter:?}"
+        );
+    }
+
+    #[test]
     fn parse_for_each_count_value_words_binds_revealed_this_way_to_it_tag() {
         let words = ["for", "each", "card", "revealed", "this", "way"];
 
@@ -2602,6 +2625,18 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
     let mut explicit_target = false;
 
     let all_words = crate::runtime_backend::token_word_refs(tokens);
+    if all_words.len() == 1
+        && let Some(count) = parse_number_word_u32(all_words[0])
+    {
+        let mut chosen_count = ChoiceCount::exactly(count as usize);
+        if random_choice {
+            chosen_count = chosen_count.at_random();
+        }
+        return Ok(wrap_target_count(
+            TargetAst::Object(ObjectFilter::tagged(TagKey::from(IT_TAG)), None, span),
+            Some(chosen_count),
+        ));
+    }
     if matches!(
         all_words.as_slice(),
         ["any"] | ["any", "target"] | ["any", "targets"]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -470,7 +470,15 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
     let first_tokens = trim_commas(sentences[sentence_idx].lowered());
     let first_effects = effect_sentences::parse_effect_chain(&first_tokens)?;
-    let (mut search_filter, count, count_value, chooser, library_player, search_mode) =
+    let (
+        mut search_filter,
+        count,
+        count_value,
+        chooser,
+        library_player,
+        search_mode,
+        preserve_reveal,
+    ) =
         match first_effects.as_slice() {
             [
                 EffectAst::SubjectVerb(SubjectVerbEffectAst {
@@ -493,6 +501,7 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
                 *chooser,
                 *player,
                 *search_mode,
+                false,
             ),
             [
                 EffectAst::ChooseObjectsAcrossZones {
@@ -511,10 +520,37 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
                 *player,
                 *player,
                 search_mode.unwrap_or(crate::effect::SearchSelectionMode::Exact),
+                false,
+            ),
+            [
+                EffectAst::ChooseObjectsAcrossZones {
+                    filter,
+                    count,
+                    count_value,
+                    player,
+                    tag,
+                    zones,
+                    search_mode,
+                    ..
+                },
+                EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                    action: SubjectVerbActionAst::RevealTagged { tag: reveal_tag },
+                    ..
+                }),
+            ] if zones.as_slice() == [Zone::Library] && reveal_tag == tag => (
+                filter.clone(),
+                *count,
+                count_value.clone(),
+                *player,
+                *player,
+                search_mode.unwrap_or(crate::effect::SearchSelectionMode::Exact),
+                true,
             ),
             _ => return Ok(None),
         };
-    if count.min != 2 || count.max != Some(2) || count_value.is_some() {
+    let is_exactly_two = count.min == 2 && count.max == Some(2) && count_value.is_none();
+    let is_up_to_two = count.min == 0 && count.max == Some(2) && count_value.is_none();
+    if !is_exactly_two && !is_up_to_two {
         return Ok(None);
     }
 
@@ -548,10 +584,15 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
     let hand_tag = helper_tag_for_tokens(&second_tokens, "hand");
     let mut hand_filter = ObjectFilter::tagged(searched_tag.clone());
     hand_filter.zone = Some(Zone::Library);
+    let hand_count = if is_up_to_two {
+        ChoiceCount::up_to(1)
+    } else {
+        ChoiceCount::exactly(1)
+    };
     let iterated_is_hand_card =
         ObjectFilter::default().same_stable_id_as_tagged(TagKey::from(IT_TAG));
 
-    Ok(Some(vec![
+    let mut effects = vec![
         EffectAst::ChooseObjectsAcrossZones {
             filter: search_filter,
             count,
@@ -561,9 +602,14 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
             zones: vec![Zone::Library],
             search_mode: Some(search_mode),
         },
+    ];
+    if preserve_reveal {
+        effects.push(EffectAst::subject_verb_reveal_tagged(searched_tag.clone()));
+    }
+    effects.extend([
         EffectAst::ChooseObjects {
             filter: hand_filter,
-            count: ChoiceCount::exactly(1),
+            count: hand_count,
             count_value: None,
             player: chooser,
             tag: hand_tag.clone(),
@@ -596,7 +642,8 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
             library_player,
             SubjectVerbActionAst::ShuffleLibrary,
         ),
-    ]))
+    ]);
+    Ok(Some(effects))
 }
 
 pub(crate) fn parse_search_face_down_exile_conditional_cast_else_hand(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8442,6 +8442,24 @@ fn parse_final_parting_search_two_split_destinations() {
 }
 
 #[test]
+fn parse_search_up_to_two_reveal_split_hand_and_graveyard_then_shuffle() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Fork in the Road Variant")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Search your library for up to two basic land cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle.",
+        )
+        .expect("up-to-two search split should parse");
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(debug.contains("is_search: true"), "{debug}");
+    assert!(debug.contains("RevealTaggedEffect"), "{debug}");
+    assert!(debug.contains("Basic"), "{debug}");
+    assert!(debug.contains("zone: Hand"), "{debug}");
+    assert!(debug.contains("zone: Graveyard"), "{debug}");
+    assert!(debug.contains("ShuffleLibraryEffect"), "{debug}");
+}
+
+#[test]
 fn rewrite_grammar_chosen_type_static_line_probes_match_keyword_static_shapes() {
     type Probe = fn(&[crate::runtime_backend::lexer::OwnedLexToken]) -> bool;
     type Parser = fn(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Fork in the Road
Initial parse error:
```
unsupported target phrase (clause: 'one'); oracle-only fallback also failed: unsupported target phrase (clause: 'one')
```

Worker: i-09660a9ceaa34f0bf
