### PR TITLE
Fix Ironsmith parse failure: Transforming Flourish

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -56,6 +56,7 @@ pub(super) enum KeywordDispatchHint {
     Transmute,
     CastThisSpellOnly,
     Gift,
+    Demonstrate,
     Warp,
     Exploit,
 }
@@ -241,6 +242,12 @@ mod spell_keywords {
             lower: registry::lower_evoke,
         },
         KeywordLineRule {
+            cst_kind: super::super::cst::KeywordLineKindCst::Demonstrate,
+            hints: &[KeywordDispatchHint::Demonstrate],
+            matches: registry::matches_demonstrate,
+            lower: registry::lower_demonstrate,
+        },
+        KeywordLineRule {
             cst_kind: super::super::cst::KeywordLineKindCst::Epic,
             hints: &[KeywordDispatchHint::Epic],
             matches: registry::matches_epic,
@@ -353,6 +360,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
             )),
             winnow::combinator::alt((
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),
+                grammar::kw("demonstrate").value(KeywordDispatchHint::Demonstrate),
                 grammar::kw("warp").value(KeywordDispatchHint::Warp),
                 grammar::kw("escalate").value(KeywordDispatchHint::Escalate),
                 grammar::kw("evoke").value(KeywordDispatchHint::Evoke),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -587,6 +587,15 @@ pub(super) fn lower_gift(
     lower_gift_keyword_line(line)
 }
 
+pub(super) fn lower_demonstrate(
+    _line: &RewriteKeywordLine,
+    _tokens: &[OwnedLexToken],
+) -> Result<LineAst, CardTextError> {
+    Ok(LineAst::StaticAbility(
+        crate::static_abilities::StaticAbility::keyword_marker("Demonstrate").into(),
+    ))
+}
+
 pub(super) fn lower_warp(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
@@ -844,6 +853,13 @@ pub(super) fn matches_gift(
     _tokens: &[OwnedLexToken],
 ) -> Result<bool, CardTextError> {
     Ok(is_standard_gift_keyword_line(line.info.raw_line.as_str()))
+}
+
+pub(super) fn matches_demonstrate(
+    _line: &PreprocessedLine,
+    tokens: &[OwnedLexToken],
+) -> Result<bool, CardTextError> {
+    Ok(token_words_have_prefix(tokens, &["demonstrate"]))
 }
 
 pub(super) fn matches_warp(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -68,6 +68,7 @@ pub(crate) enum KeywordLineKindCst {
     Evoke,
     CastThisSpellOnly,
     Gift,
+    Demonstrate,
     Epic,
     Warp,
     ExertAttack,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1608,6 +1608,20 @@ mod tests {
     }
 
     #[test]
+    fn keyword_line_cst_recognizes_demonstrate_from_tokens() -> Result<(), CardTextError> {
+        let line = single_preprocessed_line(
+            "Demonstrate (When you cast this spell, you may copy it. If you do, choose an opponent to also copy it. Players may choose new targets for their copies.)",
+        );
+
+        let parsed =
+            parse_keyword_line_cst(&line)?.expect("expected demonstrate line to parse as keyword");
+
+        assert!(matches!(parsed.kind, super::KeywordLineKindCst::Demonstrate));
+
+        Ok(())
+    }
+
+    #[test]
     fn keyword_line_cst_recognizes_exert_attack_from_tokens() -> Result<(), CardTextError> {
         let line = single_preprocessed_line(
             "You may exert this creature as it attacks. (An exerted creature won't untap during your next untap step.)",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Transforming Flourish
Initial parse error:
```
parser does not yet support line family: 'Demonstrate (When you cast this spell, you may copy it. If you do, choose an opponent to also copy it. Players may choose new targets for their copies.)'; oracle-only fallback also failed: parser does not yet support line family: 'Demonstrate'
```

Worker: i-059643ca95ee88de8
