### PR TITLE
Fix Ironsmith parse failure: Oko, the Trickster

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
@@ -373,7 +373,11 @@ pub(crate) fn parse_has_base_power_toughness_clause(
             return Ok(None);
         }
     }
-    if !tail.is_empty() && !is_until_end_of_turn(tail) {
+    if !tail.is_empty()
+        && !is_until_end_of_turn(tail)
+        && !word_slice_starts_with(tail, &["and", "gain"])
+        && !word_slice_starts_with(tail, &["and", "gains"])
+    {
         return Err(CardTextError::ParseError(format!(
             "unsupported trailing base power/toughness clause (clause: '{}')",
             words_all.join(" ")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Oko, the Trickster
Initial parse error:
```
unsupported trailing base power/toughness clause (clause: 'until end of turn each creature you control has base power and toughness 10/10 and gains trample'); oracle-only fallback also failed: unsupported trailing base power/toughness clause (clause: 'until end of turn each creature you control has base power and toughness 10/10 and gains trample')
```

Worker: i-0e3c9e4dbf3ae222d
