### PR TITLE
Fix Ironsmith parse failure: Herald of Anafenza

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -809,6 +809,20 @@ pub(crate) fn parse_trigger_clause_lexed(
         let subject_words = subject_word_view.to_word_refs();
         if let Some(activator) = parse_trigger_subject_player_filter(&subject_words) {
             let tail_words = &words[activate_idx + 1..];
+            if let Some((owner_filter, marker)) = parse_possessive_ability_trigger_tail_lexed(
+                &tokens[activate_idx + 1..],
+                tail_words,
+            )? {
+                let filter = match marker {
+                    Some(marker) => owner_filter.with_ability_marker(marker),
+                    None => owner_filter,
+                };
+                return Ok(TriggerSpec::AbilityActivated {
+                    activator,
+                    filter,
+                    non_mana_only: false,
+                });
+            }
             if tail_words == ["an", "ability"]
                 || tail_words == ["abilities"]
                 || tail_words == ["an", "ability", "that", "isnt", "a", "mana", "ability"]
@@ -3130,4 +3144,46 @@ pub(crate) fn parse_trigger_clause_lexed(
             words.join(" ")
         ))),
     }
+}
+
+fn parse_possessive_ability_trigger_tail_lexed<'a>(
+    tail_tokens: &'a [OwnedLexToken],
+    tail_words: &[&str],
+) -> Result<Option<(ObjectFilter, Option<String>)>, CardTextError> {
+    let Some(ability_idx) = find_index(tail_tokens, |token| {
+        token.is_word("ability") || token.is_word("abilities")
+    }) else {
+        return Ok(None);
+    };
+    if ability_idx == 0 || ability_idx + 1 != tail_tokens.len() {
+        return Ok(None);
+    }
+
+    let owner_tokens = &tail_tokens[..ability_idx];
+    let owner_words = &tail_words[..ability_idx];
+    let Some(possessive_idx) = owner_words
+        .iter()
+        .rposition(|word| word.ends_with('s') && !matches!(*word, "this" | "its"))
+    else {
+        return Ok(None);
+    };
+
+    let owner_subject_tokens = &owner_tokens[..=possessive_idx];
+    if owner_subject_tokens.is_empty() {
+        return Ok(None);
+    }
+    let owner_filter = parse_object_filter_lexed(owner_subject_tokens, false).map_err(|_| {
+        CardTextError::ParseError(format!(
+            "unsupported activated-ability trigger source filter (clause: '{}')",
+            tail_words.join(" ")
+        ))
+    })?;
+
+    let marker = if possessive_idx + 1 < owner_words.len() {
+        Some(owner_words[possessive_idx + 1].to_string())
+    } else {
+        None
+    };
+
+    Ok(Some((owner_filter, marker)))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7142,6 +7142,22 @@ fn rewrite_lexed_triggered_and_static_entrypoints_work_natively() {
 }
 
 #[test]
+fn rewrite_lexed_trigger_parses_possessive_keyword_ability_activation() {
+    let tokens = lex_line(
+        "Whenever you activate this creature's outlast ability, create a 1/1 white Warrior creature token.",
+        0,
+    )
+    .expect("rewrite lexer should classify possessive keyword-ability trigger");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("trigger should parse through ability-activated shape");
+
+    let debug = format!("{parsed:?}").to_ascii_lowercase();
+    assert!(debug.contains("abilityactivated"), "{debug}");
+    assert!(debug.contains("outlast"), "{debug}");
+}
+
+#[test]
 fn rewrite_grammar_activated_abilities_cant_be_activated_splitter_matches_keyword_static_shape() {
     let tokens = lex_line(
         "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Herald of Anafenza
Initial parse error:
```
unsupported triggered line: 'Whenever you activate this creature's outlast ability, create a 1/1 white Warrior creature token.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever you activate this creature's outlast ability, create a 1/1 white Warrior creature token.'
```

Worker: i-0f7e60bfc82e7d2fd
