### PR TITLE
Fix Ironsmith parse failure: Lunar Frenzy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -3471,6 +3471,9 @@ pub(crate) fn parse_anthem_and_keyword_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if anthem_contains_word(&clause_words, "target") || contains_until_end_of_turn(&clause_words) {
+        return Ok(None);
+    }
 
     let get_idx = anthem_token_offset(tokens, |token| {
         token.is_word("get") || token.is_word("gets")
@@ -3496,6 +3499,12 @@ pub(crate) fn parse_anthem_and_keyword_line(
     // "until end of turn" in the pump clause indicates a one-shot effect.
     // Ignore timing text that appears only inside a quoted granted ability.
     if contains_until_end_of_turn(&pre_grant_words) {
+        return Ok(None);
+    }
+    if let Some(modifier_word) = tokens.get(get_idx + 1).and_then(OwnedLexToken::as_word)
+        && modifier_word.to_ascii_lowercase().contains('x')
+        && !anthem_has_word_sequence(&clause_words, &["where", "x", "is"])
+    {
         return Ok(None);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10948,6 +10948,28 @@ fn rewrite_lexed_effect_sentence_supports_gain_then_get_for_each_cards_drawn() {
 }
 
 #[test]
+fn rewrite_lexed_effect_sentence_supports_target_get_then_gain_with_spell_x() {
+    let text =
+        "Target creature you control gets +X/+0 and gains first strike and trample until end of turn.";
+    let lexed =
+        lex_line(text, 0).expect("rewrite lexer should classify get-then-gain spell-X sentence");
+
+    let parsed = parse_effect_sentence_lexed(&lexed)
+        .expect("rewrite effect sentence parser should split get-then-gain target pump");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("GrantAbilitiesToTarget") && debug.contains("Pump"),
+        "expected target ability grant plus pump effect, got {debug}"
+    );
+    assert!(
+        debug.contains("first strike") || debug.contains("FirstStrike"),
+        "expected first strike grant, got {debug}"
+    );
+    assert!(debug.contains("Trample"), "expected trample grant, got {debug}");
+}
+
+#[test]
 fn rewrite_lexed_effect_sentence_supports_compound_damage_to_you_and_your_objects() {
     let text = "This deals 2 damage to you and each creature you control.";
     let lexed = lex_line(text, 0)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Lunar Frenzy
Initial parse error:
```
unsupported X power/toughness modifier without count expression (clause: 'target creature you control gets +x/+0 and gains first strike and trample until end of turn'); oracle-only fallback also failed: unsupported X power/toughness modifier without count expression (clause: 'target creature you control gets +x/+0 and gains first strike and trample until end of turn')
```

Worker: i-0d0a715d86df6c1db
