### PR TITLE
Fix Ironsmith parse failure: Eldritch Evolution

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/search_library_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/search_library_support.rs
@@ -401,7 +401,7 @@ pub(crate) fn split_search_library_count_value_clause_lexed(
 
     let count_value_tokens = trim_lexed_commas(&filter_tokens[where_idx..]).to_vec();
     let Some(count_value) =
-        super::grammar::values::parse_players_who_control_more_than_you_value_lexed(
+        crate::runtime_backend::keyword_static::parse_value_binding_clause_lexed(
             count_value_tokens.as_slice(),
         )
     else {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -6814,6 +6814,22 @@ fn rewrite_lexed_search_library_sentence_parses_disjunction_filter_via_grammar_s
 }
 
 #[test]
+fn rewrite_lexed_search_library_sentence_parses_where_x_fixed_plus_sacrificed_mana_value_clause() {
+    let text = "Search your library for a creature card with mana value X or less, where X is 2 plus the sacrificed creature's mana value, put that card onto the battlefield, then shuffle.";
+    let lexed =
+        lex_line(text, 0).expect("rewrite lexer should classify where-x fixed-plus search clause");
+
+    let parsed = super::parse_search_library_sentence_lexed(&lexed)
+        .expect("lexed search-library sentence should parse")
+        .expect("search-library sentence should produce effects");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("Add"), "{debug}");
+    assert!(debug.contains("Fixed(2)"), "{debug}");
+    assert!(debug.contains("ManaValueOf"), "{debug}");
+}
+
+#[test]
 fn rewrite_gain_ability_keyword_lists_route_through_grammar_separator_helpers() {
     let text = "Target creature gains flying and vigilance until end of turn.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify gain-ability keyword list");

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -2378,6 +2378,7 @@ fn describe_filter_static_ability(ability_id: StaticAbilityId) -> Option<&'stati
 fn describe_comparison(cmp: &Comparison) -> String {
     fn describe_value_expr(value: &Value) -> String {
         match value {
+            Value::SurfaceHinted { value, .. } => describe_value_expr(value),
             Value::Fixed(v) => v.to_string(),
             Value::X => "X".to_string(),
             Value::Count(filter) => format!("the number of {}", filter.description()),
@@ -2434,6 +2435,10 @@ fn describe_comparison(cmp: &Comparison) -> String {
                     && tag.as_str() == crate::SOURCE_EXILED_TAG
                 {
                     "the exiled spell's mana value".to_string()
+                } else if let ChooseSpec::Tagged(tag) = spec.base()
+                    && tag.as_str().starts_with("sacrificed")
+                {
+                    "the sacrificed creature's mana value".to_string()
                 } else {
                     "that card's mana value".to_string()
                 }
@@ -2478,7 +2483,11 @@ fn describe_comparison(cmp: &Comparison) -> String {
         }
         Comparison::LessThanExpr(value) => format!("less than {}", describe_value_expr(value)),
         Comparison::LessThanOrEqualExpr(value) => {
-            format!("{} or less", describe_value_expr(value))
+            if value.has_surface_hint(crate::ValueSurfaceHint::WhereXIs) {
+                format!("X or less, where X is {}", describe_value_expr(value.unhinted()))
+            } else {
+                format!("{} or less", describe_value_expr(value))
+            }
         }
         Comparison::GreaterThanExpr(value) => {
             format!("greater than {}", describe_value_expr(value))
@@ -2509,10 +2518,11 @@ fn describe_value_choose_spec_possessive(spec: &ChooseSpec) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ObjectRef, ParityRequirement, PlayerFilter, PtReference, StackObjectKind,
+        ChooseSpec, Comparison, ObjectFilter, ObjectRef, ParityRequirement, PlayerFilter,
+        PtReference, StackObjectKind,
         TaggedObjectConstraint, TaggedOpbjectRelation,
     };
-    use crate::{CardType, ObjectId, TagKey};
+    use crate::{CardType, ObjectId, TagKey, Value};
 
     #[test]
     fn object_ref_helpers_preserve_payloads() {
@@ -2584,6 +2594,29 @@ mod tests {
         assert_eq!(
             ParityRequirement::Chosen.describe_axis("power"),
             "with power of the chosen quality"
+        );
+    }
+
+    #[test]
+    fn mana_value_expr_description_unwraps_surface_hints() {
+        let mut filter = ObjectFilter::creature();
+        filter.mana_value = Some(Comparison::LessThanOrEqualExpr(Box::new(
+            Value::Add(
+                Box::new(Value::Fixed(2)),
+                Box::new(
+                    Value::ManaValueOf(Box::new(ChooseSpec::Tagged(TagKey::from("sacrificed_0"))))
+                    .with_surface_hint(crate::ValueSurfaceHint::WhereXIs),
+                ),
+            )
+            .with_surface_hint(crate::ValueSurfaceHint::WhereXIs),
+        )));
+
+        let rendered = filter.description();
+        assert!(
+            rendered.contains(
+                "with mana value X or less, where X is 2 plus the sacrificed creature's mana value"
+            ),
+            "{rendered}"
         );
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -29217,6 +29217,13 @@ fn parse_eldritch_evolution_sacrifice_scaled_where_x_clause() {
             .contains("put it onto the battlefield, then shuffle"),
         "expected eldritch evolution search destination to survive compilation"
     );
+    assert!(
+        unprocessed_compiled_lines(&def)
+            .join(" ")
+            .to_ascii_lowercase()
+            .contains("mana value 2 plus"),
+        "expected eldritch evolution to preserve fixed-plus mana-value text"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -4596,6 +4596,7 @@ fn describe_comparison(cmp: &Comparison) -> String {
     fn describe_value_expr(value: &crate::effect::Value) -> String {
         use crate::effect::Value;
         match value {
+            Value::SurfaceHinted { value, .. } => describe_value_expr(value),
             Value::Fixed(v) => v.to_string(),
             Value::X => "X".to_string(),
             Value::Count(filter) => format!("the number of {}", filter.description()),
@@ -4643,6 +4644,10 @@ fn describe_comparison(cmp: &Comparison) -> String {
                     && tag.as_str() == crate::tag::SOURCE_EXILED_TAG
                 {
                     "the exiled spell's mana value".to_string()
+                } else if let ChooseSpec::Tagged(tag) = spec.base()
+                    && tag.as_str().starts_with("sacrificed")
+                {
+                    "the sacrificed creature's mana value".to_string()
                 } else {
                     "that card's mana value".to_string()
                 }
@@ -4687,7 +4692,11 @@ fn describe_comparison(cmp: &Comparison) -> String {
         }
         Comparison::LessThanExpr(value) => format!("less than {}", describe_value_expr(value)),
         Comparison::LessThanOrEqualExpr(value) => {
-            format!("{} or less", describe_value_expr(value))
+            if value.has_surface_hint(ironsmith_core::ValueSurfaceHint::WhereXIs) {
+                format!("X or less, where X is {}", describe_value_expr(value.unhinted()))
+            } else {
+                format!("{} or less", describe_value_expr(value))
+            }
         }
         Comparison::GreaterThanExpr(value) => {
             format!("greater than {}", describe_value_expr(value))


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Eldritch Evolution
Initial parse error:
```
unsupported search-library count clause (clause: 'where x is 2 plus the sacrificed creature's mana value'); oracle-only fallback also failed: unsupported search-library count clause (clause: 'where x is 2 plus the sacrificed creature's mana value')
```

Worker: i-019f860ac2a06df8c
