### PR TITLE
Fix Ironsmith parse failure: Stranglehold

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1756,6 +1756,17 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if matches!(
         filtered.as_slice(),
+        ["opponent", "would", "begin", "extra", "turn"]
+            | ["an", "opponent", "would", "begin", "an", "extra", "turn"]
+            | ["opponents", "would", "begin", "extra", "turn"]
+    ) {
+        return Ok(PredicateAst::PlayerWouldBeginExtraTurn {
+            player: PlayerAst::Opponent,
+        });
+    }
+
+    if matches!(
+        filtered.as_slice(),
         ["it", "your", "turn"] | ["its", "your", "turn"] | ["your", "turn"]
     ) {
         return Ok(PredicateAst::YourTurn);
@@ -3134,6 +3145,26 @@ mod tests {
         assert_eq!(
             parsed,
             PredicateAst::ThisSpellPaidLabel("Surge".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_opponent_would_begin_extra_turn() -> Result<(), CardTextError> {
+        let tokens = lex_line("If an opponent would begin an extra turn", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::PlayerWouldBeginExtraTurn {
+                player: PlayerAst::Opponent,
+            }
         );
         Ok(())
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -487,6 +487,13 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::YouHaveNoCardsInHand => {
             Condition::Not(Box::new(Condition::CardsInHandOrMore(1)))
         }
+        PredicateAst::PlayerWouldBeginExtraTurn { player } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::Custom(match player {
+                PlayerFilter::Opponent => "opponent_would_begin_extra_turn",
+                _ => "player_would_begin_extra_turn",
+            })
+        }
         PredicateAst::YourTurn => Condition::YourTurn,
         PredicateAst::CreatureDiedThisTurn => Condition::CreatureDiedThisTurn,
         PredicateAst::PermanentLeftBattlefieldThisTurn => {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/iterated_player_validation.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/iterated_player_validation.rs
@@ -57,6 +57,12 @@ fn validate_effect_for_iterated_player(
     iterated_player_bound: bool,
     context: &str,
 ) -> Result<(), CardTextError> {
+    if !iterated_player_bound
+        && let Some(skip_turn) = effect.downcast_ref::<crate::effects::SkipTurnEffect>()
+        && matches!(skip_turn.player, PlayerFilter::IteratedPlayer)
+    {
+        return Ok(());
+    }
     if let Some(sequence) = effect.downcast_ref::<crate::effects::SequenceEffect>() {
         return validate_effects_for_iterated_player(
             &sequence.effects,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -1254,6 +1254,12 @@ fn rewrite_validate_effect_for_iterated_player(
     iterated_player_bound: bool,
     context: &str,
 ) -> Result<(), CardTextError> {
+    if !iterated_player_bound
+        && let Some(skip_turn) = effect.downcast_ref::<crate::effects::SkipTurnEffect>()
+        && matches!(skip_turn.player, PlayerFilter::IteratedPlayer)
+    {
+        return Ok(());
+    }
     if let Some(sequence) = effect.downcast_ref::<crate::effects::SequenceEffect>() {
         return rewrite_validate_effects_for_iterated_player(
             &sequence.effects,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -483,6 +483,9 @@ pub(crate) enum PredicateAst {
         count: u32,
     },
     YouHaveNoCardsInHand,
+    PlayerWouldBeginExtraTurn {
+        player: PlayerAst,
+    },
     SourceIsTapped,
     SourceIsSaddled,
     SourceMatches(ObjectFilter),

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -189,6 +189,20 @@ fn track_effect_player(
     Ok(())
 }
 
+fn predicate_bound_player_filter(predicate: &PredicateAst) -> Option<PlayerFilter> {
+    match predicate {
+        PredicateAst::PlayerWouldBeginExtraTurn { player } => match player {
+            PlayerAst::Opponent => Some(PlayerFilter::Opponent),
+            _ => None,
+        },
+        PredicateAst::And(left, right) | PredicateAst::Or(left, right) => {
+            predicate_bound_player_filter(left).or_else(|| predicate_bound_player_filter(right))
+        }
+        PredicateAst::Not(inner) => predicate_bound_player_filter(inner),
+        _ => None,
+    }
+}
+
 fn track_target_player(target: &TargetAst, frame: &mut ReferenceFrame) {
     match target {
         TargetAst::Player(filter, _) | TargetAst::PlayerOrPlaneswalker(filter, _) => {
@@ -1001,18 +1015,29 @@ fn advance_reference_frame_for_effect(
             track_effect_player(player.clone(), frame, true, true)?;
         }
         EffectAst::Conditional {
-            if_true, if_false, ..
+            predicate,
+            if_true,
+            if_false,
         }
         | EffectAst::SelfReplacement {
-            if_true, if_false, ..
+            predicate,
+            if_true,
+            if_false,
+            ..
         } => {
             let saved = frame.clone();
             let mut true_frame = saved.clone();
+            if let Some(player_filter) = predicate_bound_player_filter(predicate) {
+                true_frame.last_player_filter = Some(player_filter);
+            }
             advance_reference_frames(&if_true, id_gen, &mut true_frame)?;
             if if_false.is_empty() {
                 *frame = true_frame;
             } else {
                 let mut false_frame = saved.clone();
+                if let Some(player_filter) = predicate_bound_player_filter(predicate) {
+                    false_frame.last_player_filter = Some(player_filter);
+                }
                 advance_reference_frames(&if_false, id_gen, &mut false_frame)?;
                 frame.last_object_tag = saved.last_object_tag;
                 frame.last_player_filter = saved.last_player_filter;
@@ -1436,6 +1461,9 @@ fn advance_reference_env_for_effect(
         } => {
             let mut branch_env = env.clone();
             branch_env.source_object_antecedent |= predicate.establishes_source_object_antecedent();
+            if let Some(player_filter) = predicate_bound_player_filter(predicate) {
+                branch_env.last_player_filter = RefState::Known(player_filter);
+            }
             let true_sequence = annotate_effect_sequence_with_env_internal(
                 if_true,
                 branch_env.clone(),

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -5261,6 +5261,10 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             "that player sacrifices an untapped land.",
             "that player sacrifices an untapped land of their choice.",
         )
+        .replace(
+            "If an opponent would begin an extra turn, that player skips that turn.",
+            "If an opponent would begin an extra turn, that player skips that turn instead.",
+        )
         ;
     if normalized.starts_with("At the beginning of each end step, if ")
         && normalized.contains(", that player ")
@@ -10965,7 +10969,13 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             format!("{player:?}'s graveyard has {count} or more cards")
         }
         Condition::XValueAtLeast(min) => format!("X is {min} or more"),
-        Condition::Custom(id) => format!("custom condition {id}"),
+        Condition::Custom(id) => match *id {
+            "opponent_would_begin_extra_turn" => {
+                "an opponent would begin an extra turn".to_string()
+            }
+            "player_would_begin_extra_turn" => "a player would begin an extra turn".to_string(),
+            _ => format!("custom condition {id}"),
+        },
         Condition::Not(inner) => {
             if let Condition::TargetSpellManaSpentToCastAtLeast {
                 amount: 1,

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28206,6 +28206,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(skip_turn) = effect.downcast_ref::<crate::effects::SkipTurnEffect>() {
+        if skip_turn.player == PlayerFilter::IteratedPlayer {
+            return "that player skips that turn instead".to_string();
+        }
         return format!(
             "{} skips their next turn",
             describe_player_filter(&skip_turn.player)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Stranglehold
Initial parse error:
```
unsupported predicate (predicate: 'opponent would begin extra turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'opponent would begin extra turn')
```

Worker: i-0ffc32cee8b79967d
