### PR TITLE
Fix Ironsmith parse failure: Khârn the Betrayer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -740,7 +740,11 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_passthrough_rule!(
             parse_source_can_attack_as_though_no_defender_as_long_as_line
         ),
+        multi_static_ability_ast_passthrough_rule!(
+            parse_attacks_or_blocks_each_combat_if_able_line
+        ),
         single_static_ability_ast_passthrough_rule!(parse_attacks_each_combat_if_able_line),
+        single_static_ability_ast_passthrough_rule!(parse_blocks_each_combat_if_able_line),
         single_static_ability_ast_rule!(parse_source_must_be_blocked_if_able_line),
         StaticAbilityLineRuleDef {
             id: stringify!(parse_composed_anthem_effects_line),
@@ -7268,6 +7272,93 @@ pub(crate) fn parse_attacks_each_combat_if_able_line(
             ability: Box::new(StaticAbilityAst::Static(StaticAbility::must_attack())),
             condition: None,
         })),
+    }
+}
+
+pub(crate) fn parse_blocks_each_combat_if_able_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbilityAst>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(block_idx) = find_index(&words, |word| *word == "block" || *word == "blocks")
+    else {
+        return Ok(None);
+    };
+    if words[block_idx..] != ["blocks", "each", "combat", "if", "able"]
+        && words[block_idx..] != ["block", "each", "combat", "if", "able"]
+    {
+        return Ok(None);
+    }
+
+    if block_idx == 0 {
+        return Ok(Some(StaticAbilityAst::Static(StaticAbility::must_block())));
+    }
+
+    let subject_tokens = trim_commas(&tokens[..block_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(Some(StaticAbilityAst::Static(StaticAbility::must_block())));
+    }
+    let subject = parse_anthem_subject(&subject_tokens)?;
+    match subject {
+        AnthemSubjectAst::Source => Ok(Some(StaticAbilityAst::Static(StaticAbility::must_block()))),
+        AnthemSubjectAst::Filter(filter) => Ok(Some(StaticAbilityAst::GrantStaticAbility {
+            filter,
+            ability: Box::new(StaticAbilityAst::Static(StaticAbility::must_block())),
+            condition: None,
+        })),
+    }
+}
+
+pub(crate) fn parse_attacks_or_blocks_each_combat_if_able_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(action_idx) = find_index(&words, |word| *word == "attack" || *word == "attacks")
+    else {
+        return Ok(None);
+    };
+    let tail = &words[action_idx..];
+    if tail != ["attacks", "or", "blocks", "each", "combat", "if", "able"]
+        && tail != ["attack", "or", "block", "each", "combat", "if", "able"]
+        && tail != ["attacks", "or", "block", "each", "combat", "if", "able"]
+        && tail != ["attack", "or", "blocks", "each", "combat", "if", "able"]
+    {
+        return Ok(None);
+    }
+
+    let mk_pair = |subject: Option<ObjectFilter>| {
+        if let Some(filter) = subject {
+            vec![
+                StaticAbilityAst::GrantStaticAbility {
+                    filter: filter.clone(),
+                    ability: Box::new(StaticAbilityAst::Static(StaticAbility::must_attack())),
+                    condition: None,
+                },
+                StaticAbilityAst::GrantStaticAbility {
+                    filter,
+                    ability: Box::new(StaticAbilityAst::Static(StaticAbility::must_block())),
+                    condition: None,
+                },
+            ]
+        } else {
+            vec![
+                StaticAbilityAst::Static(StaticAbility::must_attack()),
+                StaticAbilityAst::Static(StaticAbility::must_block()),
+            ]
+        }
+    };
+
+    if action_idx == 0 {
+        return Ok(Some(mk_pair(None)));
+    }
+
+    let subject_tokens = trim_commas(&tokens[..action_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(Some(mk_pair(None)));
+    }
+    let subject = parse_anthem_subject(&subject_tokens)?;
+    match subject {
+        AnthemSubjectAst::Source => Ok(Some(mk_pair(None))),
+        AnthemSubjectAst::Filter(filter) => Ok(Some(mk_pair(Some(filter)))),
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4011,6 +4011,26 @@ fn semantic_document_supports_next_turn_silence() {
 }
 
 #[test]
+fn semantic_document_supports_attacks_or_blocks_each_combat_if_able() {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Iron Golem")
+        .card_types(vec![CardType::Artifact, CardType::Creature]);
+    let text = "This creature attacks or blocks each combat if able.";
+
+    parse_text_to_semantic_document(builder, text.to_string(), false)
+        .expect("expected attacks-or-blocks-each-combat line to parse");
+}
+
+#[test]
+fn semantic_document_supports_blocks_each_combat_if_able() {
+    let builder =
+        CardDefinitionBuilder::new(CardId::new(), "Watchdog").card_types(vec![CardType::Creature]);
+    let text = "This creature blocks each combat if able.";
+
+    parse_text_to_semantic_document(builder, text.to_string(), false)
+        .expect("expected blocks-each-combat line to parse");
+}
+
+#[test]
 fn rewrite_lexed_restriction_duration_handles_for_as_long_as_token_shapes() {
     let prefix = lex_line(
         "For as long as you control this, target creature can't attack.",

--- a/reports/cards/kharn-the-betrayer-control-loss-trigger-gap.md
+++ b/reports/cards/kharn-the-betrayer-control-loss-trigger-gap.md
@@ -1,0 +1,30 @@
+Card: Kharn the Betrayer
+Date: 2026-05-24
+
+Current strict parse blocker:
+
+- `Sigil of Corruption - When you lose control of this creature, draw two cards.`
+
+What was fixed in this pass:
+
+- Added reusable parser support for static combat requirements:
+  - `attacks or blocks each combat if able`
+  - `blocks each combat if able`
+- Verified this parses on representative cards (for example Iron Golem).
+
+Why Kharn still cannot reach strict parse in this pass:
+
+- The remaining line is a control-loss trigger (`When you lose control of ...`).
+- The current trigger parser/runtime model does not expose a reusable trigger family for
+  source control-loss/control-change events that this clause can lower into.
+- This is broader than a card-local parser tweak and needs reusable trigger modeling
+  (AST + trigger matching/runtime wiring) to support this and similar cards.
+
+Recommended follow-up capability:
+
+- Add reusable trigger support for "you lose control of <object>" / control-change
+  event triggers, then lower named and tagged source forms into that shared model.
+
+Verification command used:
+
+- `cargo run -p ironsmith-tools --bin compile_oracle_text -- --name "Khârn the Betrayer" --compare-text`


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Khârn the Betrayer
Initial parse error:
```
parser does not yet support line family: 'Berzerker — Khârn the Betrayer attacks or blocks each combat if able.'; oracle-only fallback also failed: parser does not yet support line family: 'Berzerker — Khârn the Betrayer attacks or blocks each combat if able.'
```

Worker: i-08748d7222dd074ce
