### PR TITLE
Fix Ironsmith parse failure: Gwen Stacy // Ghost-Spider

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -31,6 +31,7 @@ pub(crate) enum PermissionLifetime {
     UntilEndOfTurn,
     UntilYourNextTurn,
     ForAsLongAsExiled,
+    ForAsLongAsYouControlSource,
     Static,
 }
 
@@ -467,6 +468,24 @@ fn parse_permission_tail_tokens(
         return Some((PermissionLifetime::ForAsLongAsExiled, false));
     }
 
+    if strip_prefix_phrase(
+        tokens,
+        &[
+            "for",
+            "as",
+            "long",
+            "as",
+            "you",
+            "control",
+            "this",
+            "creature",
+        ],
+    )
+    .is_some_and(|rest| rest.is_empty())
+    {
+        return Some((PermissionLifetime::ForAsLongAsYouControlSource, false));
+    }
+
     if let Some((duration, rest)) = parse_turn_duration_prefix(tokens) {
         if rest.is_empty() {
             return Some((permission_lifetime_from_turn_duration(duration), false));
@@ -768,11 +787,15 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                 | PermissionLifetime::UntilEndOfTurn
                 | PermissionLifetime::UntilYourNextTurn
                 | PermissionLifetime::ForAsLongAsExiled
+                | PermissionLifetime::ForAsLongAsYouControlSource
         ) && target_ref.as_copy
         {
             let label = match lifetime {
                 PermissionLifetime::UntilYourNextTurn => "until-next-turn",
                 PermissionLifetime::ForAsLongAsExiled => "for-as-long-as-exiled",
+                PermissionLifetime::ForAsLongAsYouControlSource => {
+                    "for-as-long-as-you-control-source"
+                }
                 _ => "until-end-of-turn",
             };
             return Err(CardTextError::ParseError(format!(
@@ -802,6 +825,13 @@ pub(crate) fn parse_permission_clause_spec_lexed(
         if lifetime == PermissionLifetime::ForAsLongAsExiled && without_paying_mana_cost {
             return Err(CardTextError::ParseError(format!(
                 "unsupported for-as-long-as-exiled play target with alternative cost (clause: '{}')",
+                clause_refs.join(" ")
+            )));
+        }
+
+        if lifetime == PermissionLifetime::ForAsLongAsYouControlSource && without_paying_mana_cost {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported for-as-long-as-you-control-source play target with alternative cost (clause: '{}')",
                 clause_refs.join(" ")
             )));
         }
@@ -1552,6 +1582,21 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             lifetime: PermissionLifetime::ForAsLongAsExiled,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+                tag,
+                PlayerAst::Implicit,
+                allow_land,
+                allow_any_color_for_cast,
+            ),
+        )),
+        Some(PermissionClauseSpec::Tagged {
+            tag,
+            player,
+            allow_land,
+            as_copy: false,
+            without_paying_mana_cost: false,
+            lifetime: PermissionLifetime::ForAsLongAsYouControlSource,
+        }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
+            EffectAst::subject_verb_grant_play_tagged_for_as_long_as_you_control_source(
                 tag,
                 PlayerAst::Implicit,
                 allow_land,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1888,6 +1888,34 @@ fn compile_subject_verb_effect(
                 Vec::new(),
             ))
         }
+        SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource {
+            tag,
+            player,
+            allow_land,
+            allow_any_color_for_cast,
+        } => {
+            let player_filter =
+                resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
+            let resolved_tag = if tag.as_str() == IT_TAG {
+                TagKey::from(ctx.last_object_tag.clone().ok_or_else(|| {
+                    CardTextError::ParseError(
+                        "unable to resolve 'it' without prior reference".to_string(),
+                    )
+                })?)
+            } else {
+                tag.clone()
+            };
+            Ok((
+                vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+                    resolved_tag,
+                    player_filter,
+                    crate::effects::GrantPlayTaggedDuration::ForAsLongAsYouControlSource,
+                    *allow_land,
+                    *allow_any_color_for_cast,
+                ))],
+                Vec::new(),
+            ))
+        }
         SubjectVerbActionAst::ExileUntilSourceLeaves { target, face_down } => {
             let (spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -676,6 +676,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn { .. }
         | SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn { .. }
         | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { .. }
+        | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource { .. }
         | SubjectVerbActionAst::ReturnToBattlefield { .. }
         | SubjectVerbActionAst::ReturnAllToBattlefield { .. }
         | SubjectVerbActionAst::ExileUntilSourceLeaves { .. }
@@ -1004,7 +1005,8 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
                 ..
             }
             | SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn { tag, .. }
-            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { tag, .. } => {
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { tag, .. }
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource { tag, .. } => {
                 tag.as_str() == IT_TAG
             }
             SubjectVerbActionAst::PutRestOnBottomOfLibrary => true,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1012,6 +1012,12 @@ pub(crate) enum SubjectVerbActionAst {
         allow_land: bool,
         allow_any_color_for_cast: bool,
     },
+    GrantPlayTaggedForAsLongAsYouControlSource {
+        tag: TagKey,
+        player: PlayerAst,
+        allow_land: bool,
+        allow_any_color_for_cast: bool,
+    },
     ReturnToBattlefield {
         target: TargetAst,
         tapped: bool,
@@ -2163,6 +2169,18 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 allow_any_color_for_cast,
             } => f
                 .debug_struct("GrantPlayTaggedForAsLongAsExiled")
+                .field("tag", tag)
+                .field("player", player)
+                .field("allow_land", allow_land)
+                .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .finish(),
+            Self::GrantPlayTaggedForAsLongAsYouControlSource {
+                tag,
+                player,
+                allow_land,
+                allow_any_color_for_cast,
+            } => f
+                .debug_struct("GrantPlayTaggedForAsLongAsYouControlSource")
                 .field("tag", tag)
                 .field("player", player)
                 .field("allow_land", allow_land)
@@ -3559,6 +3577,24 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled {
+                tag,
+                player,
+                allow_land,
+                allow_any_color_for_cast,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_grant_play_tagged_for_as_long_as_you_control_source(
+        tag: TagKey,
+        player: PlayerAst,
+        allow_land: bool,
+        allow_any_color_for_cast: bool,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource {
                 tag,
                 player,
                 allow_land,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -454,6 +454,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn { .. }
             | SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn { .. }
             | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { .. }
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource { .. }
             | SubjectVerbActionAst::ReturnToBattlefield { .. }
             | SubjectVerbActionAst::ReturnAllToBattlefield { .. }
             | SubjectVerbActionAst::ExileUntilSourceLeaves { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -729,6 +729,12 @@ fn advance_reference_frame_for_effect(
                 | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { player, .. } => {
                     track_effect_player(*player, frame, true, true)?;
                 }
+                SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource {
+                    player,
+                    ..
+                } => {
+                    track_effect_player(*player, frame, true, true)?;
+                }
                 SubjectVerbActionAst::RevealHand => {
                     frame.last_object_tag = None;
                 }
@@ -1747,6 +1753,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn { .. }
             | SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn { .. }
             | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { .. }
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource { .. }
             | SubjectVerbActionAst::ReturnAllToBattlefield { .. }
             | SubjectVerbActionAst::ExileUntilSourceLeaves { .. }
             | SubjectVerbActionAst::MoveToZone { .. }
@@ -2544,7 +2551,8 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 ..
             }
             | SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn { tag, .. }
-            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { tag, .. } => {
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { tag, .. }
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource { tag, .. } => {
                 bind_unresolved_it_in_tag(tag, seed_tag)
             }
             SubjectVerbActionAst::ReturnToBattlefield {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2466,6 +2466,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn { .. }
             | SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn { .. }
             | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled { .. }
+            | SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource { .. }
             | SubjectVerbActionAst::ReturnToBattlefield { .. }
             | SubjectVerbActionAst::ReturnAllToBattlefield { .. }
             | SubjectVerbActionAst::ExileUntilSourceLeaves { .. }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -90,6 +90,7 @@ pub enum GrantPlayTaggedDuration {
     UntilEndOfTurn,
     UntilYourNextTurnEnd,
     ForAsLongAsExiled,
+    ForAsLongAsYouControlSource,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32340,6 +32340,7 @@ const STRICT_PARSE_REGRESSION_SUCCESS_CARDS: &[&str] = &[
     "Orcish Bowmasters",
     "Pawn of Ulamog",
     "Genesis Chamber",
+    "Gwen Stacy // Ghost-Spider",
     "Sacrifice",
     "Sefris of the Hidden Ways",
     "Sephiroth, Fabled SOLDIER",
@@ -32394,6 +32395,10 @@ strict_parse_card_test!(strict_parse_gemstone_caverns, "Gemstone Caverns");
 strict_parse_card_test!(strict_parse_golgari_thug, "Golgari Thug");
 strict_parse_card_expected_fail_test!(strict_parse_gravecrawler, "Gravecrawler");
 strict_parse_card_test!(strict_parse_grief, "Grief");
+strict_parse_card_test!(
+    strict_parse_gwen_stacy_ghost_spider,
+    "Gwen Stacy // Ghost-Spider"
+);
 strict_parse_card_expected_fail_test!(
     strict_parse_hancock_ghoulish_mayor,
     "Hancock, Ghoulish Mayor"
@@ -32478,6 +32483,19 @@ fn strict_parse_shared_parser_regression_cards() {
     ] {
         assert_oracle_card_parses_strict(name);
     }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_gwen_stacy_ghost_spider_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Gwen Stacy // Ghost-Spider");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("play that card for as long as you control this creature"),
+        "expected Gwen Stacy // Ghost-Spider permission duration clause, got {rendered}"
+    );
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29502,6 +29502,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled => {
                 "for as long as it remains exiled"
             }
+            crate::effects::GrantPlayTaggedDuration::ForAsLongAsYouControlSource => {
+                "for as long as you control this source"
+            }
         };
         let verb = if grant_play_tagged.allow_land {
             "play"

--- a/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
@@ -129,6 +129,7 @@ impl GrantPlayTaggedEffect {
                 Self::next_turn_number_for_player(game, player)
             }
             GrantPlayTaggedDuration::ForAsLongAsExiled => u32::MAX,
+            GrantPlayTaggedDuration::ForAsLongAsYouControlSource => u32::MAX,
         }
     }
 }
@@ -169,9 +170,16 @@ impl EffectExecutor for GrantPlayTaggedEffect {
                 mana_permission_stable_ids.push(object.stable_id);
             }
 
-            let source = GrantSource::Effect {
-                source_id: ctx.source,
-                expires_end_of_turn,
+            let source = if self.duration == GrantPlayTaggedDuration::ForAsLongAsYouControlSource {
+                GrantSource::EffectWhileControlled {
+                    source_id: ctx.source,
+                    controller: player_id,
+                }
+            } else {
+                GrantSource::Effect {
+                    source_id: ctx.source,
+                    expires_end_of_turn,
+                }
             };
             if self.duration == GrantPlayTaggedDuration::ForAsLongAsExiled {
                 game.effect_store.grant_registry.grant_to_stable_card(
@@ -432,6 +440,101 @@ mod tests {
                 alice
             ),
             "grant remains tied to the exile zone"
+        );
+    }
+
+    #[test]
+    fn gwen_stacy_grant_play_permission_ends_when_you_lose_control_of_source() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let source_card = CardBuilder::new(CardId::from_raw(10), "Gwen Stacy source").build();
+        let source_id = game.create_object_from_card(&source_card, alice, Zone::Battlefield);
+
+        let card = CardBuilder::new(CardId::from_raw(11), "Exiled Card").build();
+        let exiled_id = game.create_object_from_card(&card, alice, Zone::Exile);
+        let snapshot =
+            ObjectSnapshot::from_object(game.object(exiled_id).expect("exiled card"), &game);
+
+        let mut tags = std::collections::HashMap::new();
+        tags.insert(TagKey::from("it"), vec![snapshot]);
+
+        let mut dm = SelectFirstDecisionMaker;
+        let mut ctx = ExecutionContext::new(source_id, alice, &mut dm).with_tagged_objects(tags);
+
+        let effect = GrantPlayTaggedEffect::new(
+            "it",
+            PlayerFilter::You,
+            GrantPlayTaggedDuration::ForAsLongAsYouControlSource,
+            true,
+            false,
+        );
+        effect
+            .execute(&mut game, &mut ctx)
+            .expect("effect should resolve");
+
+        assert!(
+            game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice
+            ),
+            "Gwen Stacy permission should apply while you control the source"
+        );
+
+        game.set_current_controller(source_id, bob);
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice
+            ),
+            "Gwen Stacy permission should end once you lose control of the source"
+        );
+    }
+
+    #[test]
+    fn gwen_stacy_grant_play_permission_survives_turn_changes_while_controlled() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+
+        let source_card = CardBuilder::new(CardId::from_raw(12), "Gwen Stacy source").build();
+        let source_id = game.create_object_from_card(&source_card, alice, Zone::Battlefield);
+
+        let card = CardBuilder::new(CardId::from_raw(13), "Exiled Card").build();
+        let exiled_id = game.create_object_from_card(&card, alice, Zone::Exile);
+        let snapshot =
+            ObjectSnapshot::from_object(game.object(exiled_id).expect("exiled card"), &game);
+
+        let mut tags = std::collections::HashMap::new();
+        tags.insert(TagKey::from("it"), vec![snapshot]);
+
+        let mut dm = SelectFirstDecisionMaker;
+        let mut ctx = ExecutionContext::new(source_id, alice, &mut dm).with_tagged_objects(tags);
+
+        let effect = GrantPlayTaggedEffect::new(
+            "it",
+            PlayerFilter::You,
+            GrantPlayTaggedDuration::ForAsLongAsYouControlSource,
+            true,
+            false,
+        );
+        effect
+            .execute(&mut game, &mut ctx)
+            .expect("effect should resolve");
+
+        game.turn.turn_number = game.turn.turn_number.saturating_add(5);
+        assert!(
+            game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice
+            ),
+            "Gwen Stacy permission should not expire by turn count while source stays controlled"
         );
     }
 }

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -29,6 +29,11 @@ pub enum GrantSource {
         /// Turn number when this grant expires (at end of that turn).
         expires_end_of_turn: u32,
     },
+    /// From a resolving effect that lasts while the source remains controlled by a player.
+    EffectWhileControlled {
+        source_id: ObjectId,
+        controller: PlayerId,
+    },
     /// From a static ability on a permanent.
     /// The grant exists only while the source is on the battlefield.
     StaticAbility {
@@ -50,6 +55,7 @@ impl GrantSource {
     pub fn source_id(&self) -> ObjectId {
         match self {
             GrantSource::Effect { source_id, .. } => *source_id,
+            GrantSource::EffectWhileControlled { source_id, .. } => *source_id,
             GrantSource::StaticAbility { source_id } => *source_id,
         }
     }
@@ -68,6 +74,12 @@ impl GrantSource {
                 // Valid only while source is on battlefield
                 game.battlefield.contains(source_id)
             }
+            GrantSource::EffectWhileControlled {
+                source_id,
+                controller,
+            } => game.object(*source_id).is_some_and(|source| {
+                source.zone == Zone::Battlefield && game.controller_of(source) == *controller
+            }),
         }
     }
 
@@ -85,6 +97,7 @@ impl GrantSource {
                 // Valid only while source is on battlefield
                 battlefield.contains(source_id)
             }
+            GrantSource::EffectWhileControlled { source_id, .. } => battlefield.contains(source_id),
         }
     }
 }
@@ -96,6 +109,10 @@ pub enum GrantLifetime {
     UntilEndOfTurn { source_id: ObjectId, turn: u32 },
     /// Valid while the source remains on the battlefield.
     WhileSourceOnBattlefield(ObjectId),
+    WhileSourceControlledBy {
+        source_id: ObjectId,
+        controller: PlayerId,
+    },
 }
 
 impl GrantLifetime {
@@ -103,6 +120,7 @@ impl GrantLifetime {
         match self {
             GrantLifetime::UntilEndOfTurn { source_id, .. } => *source_id,
             GrantLifetime::WhileSourceOnBattlefield(source_id) => *source_id,
+            GrantLifetime::WhileSourceControlledBy { source_id, .. } => *source_id,
         }
     }
 }
@@ -120,6 +138,13 @@ impl GrantSource {
             GrantSource::StaticAbility { source_id } => {
                 GrantLifetime::WhileSourceOnBattlefield(*source_id)
             }
+            GrantSource::EffectWhileControlled {
+                source_id,
+                controller,
+            } => GrantLifetime::WhileSourceControlledBy {
+                source_id: *source_id,
+                controller: *controller,
+            },
         }
     }
 }
@@ -483,6 +508,7 @@ impl GrantRegistry {
         self.grants.retain(|grant| {
             !matches!(&grant.source,
                 GrantSource::Effect { source_id: sid, .. } |
+                GrantSource::EffectWhileControlled { source_id: sid, .. } |
                 GrantSource::StaticAbility { source_id: sid }
                 if *sid == source_id
             )


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gwen Stacy // Ghost-Spider
Initial parse error:
```
could not find verb in effect clause (clause: 'play that card for as long as you control this creature'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'play that card for as long as you control this creature'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0a13b0a752e26837a
