### PR TITLE
Fix Ironsmith parse failure: Feudkiller's Verdict

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1604,6 +1604,18 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::PlayerHasMoreLifeThanYou { player });
     }
 
+    if filtered[0] == "you"
+        && matches!(filtered.get(1).copied(), Some("have" | "has"))
+        && filtered.get(2).copied() == Some("more")
+        && filtered.get(3).copied() == Some("life")
+        && filtered.get(4).copied() == Some("than")
+        && matches!(filtered.get(5).copied(), Some("opponent" | "opponents"))
+    {
+        return Ok(PredicateAst::PlayerHasLessLifeThanYou {
+            player: PlayerAst::Opponent,
+        });
+    }
+
     if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
         && matches!(filtered.get(subject_len).copied(), Some("has" | "have"))
         && filtered.len() == subject_len + 5
@@ -3193,6 +3205,26 @@ mod tests {
         assert_eq!(
             parsed,
             PredicateAst::PlayerWouldBeginExtraTurn {
+                player: PlayerAst::Opponent,
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_you_have_more_life_than_opponent() -> Result<(), CardTextError> {
+        let tokens = lex_line("if you have more life than an opponent", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::PlayerHasLessLifeThanYou {
                 player: PlayerAst::Opponent,
             }
         );

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32390,6 +32390,7 @@ strict_parse_card_test!(strict_parse_cavern_of_souls, "Cavern of Souls");
 strict_parse_card_expected_fail_test!(strict_parse_clown_car, "Clown Car");
 strict_parse_card_test!(strict_parse_encroaching_mycosynth, "Encroaching Mycosynth");
 strict_parse_card_test!(strict_parse_fatal_push, "Fatal Push");
+strict_parse_card_test!(strict_parse_feudkillers_verdict, "Feudkiller's Verdict");
 strict_parse_card_test!(strict_parse_gemstone_caverns, "Gemstone Caverns");
 strict_parse_card_test!(strict_parse_golgari_thug, "Golgari Thug");
 strict_parse_card_expected_fail_test!(strict_parse_gravecrawler, "Gravecrawler");
@@ -32453,6 +32454,19 @@ fn strict_parse_regression_batch_target_cards() {
         failures.is_empty(),
         "strict parse regression batch failures:\n{}",
         failures.join("\n")
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn feudkillers_verdict_compiled_text_mentions_life_lead_condition() {
+    let def = parse_oracle_card_definition("Feudkiller's Verdict");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("You gain 10 life")
+            && rendered.contains("If you have more life than an opponent")
+            && rendered.contains("create a 5/5 white Giant Warrior creature token"),
+        "expected compiled text to preserve Feudkiller's Verdict condition and token clause, got: {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10144,7 +10144,11 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             )
         }
         Condition::PlayerHasLessLifeThanYou { player } => {
-            format!("{} has less life than you", describe_player_filter(player))
+            if *player == PlayerFilter::Opponent {
+                "you have more life than an opponent".to_string()
+            } else {
+                format!("{} has less life than you", describe_player_filter(player))
+            }
         }
         Condition::PlayerHasMoreLifeThanYou { player } => {
             format!("{} has more life than you", describe_player_filter(player))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -873,6 +873,103 @@ fn bought_back_instant_returns_to_owners_hand_after_resolution() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn feudkillers_verdict_creates_token_when_you_have_more_life_than_an_opponent() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.player_mut(alice).expect("alice should exist").life = 21;
+    game.player_mut(bob).expect("bob should exist").life = 20;
+
+    let verdict = CardDefinitionBuilder::new(CardId::new(), "Feudkiller's Verdict")
+        .card_types(vec![CardType::Kindred, CardType::Sorcery])
+        .parse_text(
+            "You gain 10 life. Then if you have more life than an opponent, create a 5/5 white Giant Warrior creature token.",
+        )
+        .expect("Feudkiller's Verdict should parse");
+    let permanents_before = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id)
+                .is_some_and(|obj| game.controller_of(obj) == alice)
+        })
+        .count();
+    let spell_id = game.create_object_from_definition(&verdict, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice));
+
+    resolve_stack_entry(&mut game).expect("Feudkiller's Verdict should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice should exist").life,
+        31,
+        "Feudkiller's Verdict should gain 10 life before checking the condition"
+    );
+
+    let permanents_after = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id)
+                .is_some_and(|obj| game.controller_of(obj) == alice)
+        })
+        .count();
+    assert_eq!(
+        permanents_after,
+        permanents_before + 1,
+        "Feudkiller's Verdict should add one permanent when the condition is true"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn feudkillers_verdict_skips_token_when_no_opponent_has_less_life() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.player_mut(alice).expect("alice should exist").life = 5;
+    game.player_mut(bob).expect("bob should exist").life = 20;
+
+    let verdict = CardDefinitionBuilder::new(CardId::new(), "Feudkiller's Verdict")
+        .card_types(vec![CardType::Kindred, CardType::Sorcery])
+        .parse_text(
+            "You gain 10 life. Then if you have more life than an opponent, create a 5/5 white Giant Warrior creature token.",
+        )
+        .expect("Feudkiller's Verdict should parse");
+    let permanents_before = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id)
+                .is_some_and(|obj| game.controller_of(obj) == alice)
+        })
+        .count();
+    let spell_id = game.create_object_from_definition(&verdict, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice));
+
+    resolve_stack_entry(&mut game).expect("Feudkiller's Verdict should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice should exist").life,
+        15,
+        "Feudkiller's Verdict should still gain 10 life even if token clause fails"
+    );
+
+    let permanents_after = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id)
+                .is_some_and(|obj| game.controller_of(obj) == alice)
+        })
+        .count();
+    assert_eq!(
+        permanents_after, permanents_before,
+        "Feudkiller's Verdict should not add a permanent when no opponent has less life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn guild_artisan_does_not_trigger_when_attacked_player_is_not_the_life_leader() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Feudkiller's Verdict
Initial parse error:
```
unsupported predicate (predicate: 'you have more life than opponent'); oracle-only fallback also failed: unsupported predicate (predicate: 'you have more life than opponent')
```

Worker: i-0f4da23a9846c2fa3
