### PR TITLE
Fix Ironsmith parse failure: Cloakwood Hermit

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1829,6 +1829,38 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if matches!(
         filtered.as_slice(),
+        [
+            "a",
+            "creature",
+            "card",
+            "was",
+            "put",
+            "into",
+            "your",
+            "graveyard",
+            "from",
+            "anywhere",
+            "this",
+            "turn"
+        ] | [
+            "creature",
+            "card",
+            "was",
+            "put",
+            "into",
+            "your",
+            "graveyard",
+            "from",
+            "anywhere",
+            "this",
+            "turn"
+        ]
+    ) {
+        return Ok(PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn);
+    }
+
+    if matches!(
+        filtered.as_slice(),
         ["no", "permanent", "left", "battlefield", "this", "turn"]
             | ["no", "permanents", "left", "battlefield", "this", "turn"]
     ) {
@@ -3196,6 +3228,25 @@ mod tests {
                 player: PlayerAst::Opponent,
             }
         );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_creature_card_put_into_your_graveyard_this_turn(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line(
+            "If a creature card was put into your graveyard from anywhere this turn",
+            0,
+        )?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(parsed, PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn);
         Ok(())
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -496,6 +496,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
         }
         PredicateAst::YourTurn => Condition::YourTurn,
         PredicateAst::CreatureDiedThisTurn => Condition::CreatureDiedThisTurn,
+        PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn => {
+            Condition::CreatureCardPutIntoYourGraveyardThisTurn
+        }
         PredicateAst::PermanentLeftBattlefieldThisTurn => {
             Condition::PermanentLeftBattlefieldThisTurn
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -518,6 +518,7 @@ pub(crate) enum PredicateAst {
     YouAttackedWithExactlyNOtherCreaturesThisCombat(u32),
     CreatureDiedThisTurn,
     CreatureDiedThisTurnOrMore(u32),
+    CreatureCardPutIntoYourGraveyardThisTurn,
     PermanentLeftBattlefieldThisTurn,
     PermanentLeftBattlefieldUnderYourControlThisTurn,
     ObjectEnteredBattlefieldThisTurn(ObjectFilter),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12891,6 +12891,20 @@ fn rewrite_grammar_land_you_controlled_put_into_graveyard_predicate_parses() {
 }
 
 #[test]
+fn rewrite_grammar_creature_card_put_into_your_graveyard_from_anywhere_predicate_parses() {
+    let tokens = lex_line(
+        "a creature card was put into your graveyard from anywhere this turn",
+        0,
+    )
+    .expect("rewrite lexer should classify creature-card graveyard-history predicate");
+
+    assert_eq!(
+        super::parse_predicate_lexed(&tokens).expect("predicate should parse"),
+        crate::cards::builders::PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn
+    );
+}
+
+#[test]
 fn rewrite_grammar_artifact_entered_under_your_control_predicate_parses() {
     let tokens = lex_line(
         "an artifact entered the battlefield under your control this turn",

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -664,6 +664,7 @@ pub enum Condition {
     YourFirstTurnsOfTheGameOrFewer(u32),
     CreatureDiedThisTurn,
     CreatureDiedThisTurnOrMore(u32),
+    CreatureCardPutIntoYourGraveyardThisTurn,
     CastSpellThisTurn,
     PlayerCastSpellsThisTurnOrMore {
         player: PlayerFilter,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36322,6 +36322,34 @@ fn parse_lulu_loyal_hollyphant_keeps_revolt_gate_and_untap_followup() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_cloakwood_hermit_keeps_creature_card_graveyard_gate() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Cloakwood Hermit")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Background])
+        .parse_text(
+            "Commander creatures you own have \"At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens.\"",
+        )
+        .expect("Cloakwood Hermit should parse");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("CreatureCardPutIntoYourGraveyardThisTurn"),
+        "expected Cloakwood Hermit to keep the creature-card graveyard gate, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("at the beginning of your end step")
+            && rendered.contains("a creature card was put into your graveyard from anywhere this turn")
+            && rendered.contains("create two tapped 1/1 green squirrel creature tokens"),
+        "expected Cloakwood Hermit trigger and gate wording to render, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_choose_background_renders_keyword_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Background Partner Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10241,6 +10241,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::CreatureDiedThisTurnOrMore(count) => {
             format!("{count} or more creatures died this turn")
         }
+        Condition::CreatureCardPutIntoYourGraveyardThisTurn => {
+            "a creature card was put into your graveyard from anywhere this turn".to_string()
+        }
         Condition::CastSpellThisTurn => "a spell was cast this turn".to_string(),
         Condition::PlayerCastSpellsThisTurnOrMore { player, count } => {
             let subject = describe_player_filter(player);

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -525,6 +525,21 @@ fn object_matching_was_put_into_graveyard_from_battlefield_this_turn(
         })
 }
 
+fn creature_card_was_put_into_your_graveyard_this_turn(game: &GameState, player: PlayerId) -> bool {
+    let Some(player_state) = game.player(player) else {
+        return false;
+    };
+    player_state.graveyard.iter().any(|card_id| {
+        game.object(*card_id).is_some_and(|object| {
+            game.object_has_card_type(object.id, crate::types::CardType::Creature)
+                && game
+                    .turn_store
+                    .turn_history
+                    .object_was_put_into_graveyard_this_turn(object.stable_id)
+        })
+    })
+}
+
 fn object_matching_entered_battlefield_this_turn(
     game: &GameState,
     ctx: SharedConditionContext<'_>,
@@ -666,6 +681,9 @@ fn evaluate_condition_shared_core(
                 .turn_history
                 .total_creatures_died_this_turn()
                 >= *count,
+        ),
+        Condition::CreatureCardPutIntoYourGraveyardThisTurn => Some(
+            creature_card_was_put_into_your_graveyard_this_turn(game, ctx.controller),
         ),
         Condition::CastSpellThisTurn => {
             Some(game.turn_store.turn_history.any_spell_was_cast_this_turn())
@@ -851,6 +869,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::YourFirstTurnsOfTheGameOrFewer(..) => {}
         Condition::CreatureDiedThisTurn => {}
         Condition::CreatureDiedThisTurnOrMore(..) => {}
+        Condition::CreatureCardPutIntoYourGraveyardThisTurn => {}
         Condition::CastSpellThisTurn => {}
         Condition::AttackedThisTurn => {}
         Condition::OpponentLostLifeThisTurn => {}
@@ -1115,6 +1134,9 @@ pub fn evaluate_condition_external(
                 .turn_history
                 .total_creatures_died_this_turn()
                 >= *count
+        }
+        Condition::CreatureCardPutIntoYourGraveyardThisTurn => {
+            creature_card_was_put_into_your_graveyard_this_turn(game, ctx.controller)
         }
         Condition::PlayerHadLandEnterBattlefieldThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
@@ -2320,6 +2342,9 @@ fn evaluate_condition_simple(
                 .total_creatures_died_this_turn()
                 >= *count
         }
+        Condition::CreatureCardPutIntoYourGraveyardThisTurn => {
+            creature_card_was_put_into_your_graveyard_this_turn(game, controller)
+        }
         Condition::PlayerHadLandEnterBattlefieldThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
                 return false;
@@ -2957,6 +2982,9 @@ fn evaluate_condition(
             .turn_history
             .total_creatures_died_this_turn()
             >= *count),
+        Condition::CreatureCardPutIntoYourGraveyardThisTurn => Ok(
+            creature_card_was_put_into_your_graveyard_this_turn(game, ctx.controller),
+        ),
         Condition::PlayerHadLandEnterBattlefieldThisTurn { player } => {
             let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
             Ok(player_had_land_enter_battlefield_this_turn(game, player_id))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -935,6 +935,107 @@ fn guild_artisan_does_not_trigger_when_attacked_player_is_not_the_life_leader() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn cloakwood_hermit_triggers_at_end_step_after_creature_card_hits_graveyard() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let cloakwood = CardDefinitionBuilder::new(CardId::from_raw(81_100), "Cloakwood Hermit")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![crate::types::Subtype::Background])
+        .parse_text(
+            "Commander creatures you own have \"At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens.\"",
+        )
+        .expect("Cloakwood Hermit should parse");
+    game.create_object_from_definition(&cloakwood, alice, Zone::Battlefield);
+
+    let commander = CardBuilder::new(CardId::from_raw(81_101), "Cloakwood Commander")
+        .card_types(vec![CardType::Creature])
+        .supertypes(vec![crate::types::Supertype::Legendary])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let commander_id = game.create_object_from_card(&commander, alice, Zone::Battlefield);
+    game.set_as_commander(commander_id, alice);
+    game.refresh_continuous_state();
+
+    let creature_card = CardBuilder::new(CardId::from_raw(81_102), "Fallen Scout")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let creature_card_id = game.create_object_from_card(&creature_card, alice, Zone::Hand);
+    game
+        .move_object_by_effect(creature_card_id, Zone::Graveyard)
+        .expect("creature card should move to graveyard this turn");
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Cloakwood Hermit should grant one end-step trigger when condition is met"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Cloakwood Hermit trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Cloakwood Hermit trigger should resolve");
+
+    let squirrel_ids = game
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|id| game.object(*id).is_some_and(|obj| obj.name == "Squirrel"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        squirrel_ids.len(),
+        2,
+        "Cloakwood Hermit should create two Squirrel tokens"
+    );
+    assert!(
+        squirrel_ids.iter().all(|id| game.is_tapped(*id)),
+        "Cloakwood Hermit tokens should enter tapped"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cloakwood_hermit_does_not_trigger_without_creature_card_in_graveyard_this_turn() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let cloakwood = CardDefinitionBuilder::new(CardId::from_raw(81_103), "Cloakwood Hermit")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![crate::types::Subtype::Background])
+        .parse_text(
+            "Commander creatures you own have \"At the beginning of your end step, if a creature card was put into your graveyard from anywhere this turn, create two tapped 1/1 green Squirrel creature tokens.\"",
+        )
+        .expect("Cloakwood Hermit should parse");
+    game.create_object_from_definition(&cloakwood, alice, Zone::Battlefield);
+
+    let commander = CardBuilder::new(CardId::from_raw(81_104), "Cloakwood Commander")
+        .card_types(vec![CardType::Creature])
+        .supertypes(vec![crate::types::Supertype::Legendary])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let commander_id = game.create_object_from_card(&commander, alice, Zone::Battlefield);
+    game.set_as_commander(commander_id, alice);
+    game.refresh_continuous_state();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Cloakwood Hermit should not trigger without a creature card put into your graveyard this turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn ignite_memories_reveals_a_random_card_from_target_players_hand_and_damages_them() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cloakwood Hermit
Initial parse error:
```
unsupported predicate (predicate: 'creature card was put into your graveyard from anywhere this turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'creature card was put into your graveyard from anywhere this turn')
```

Worker: i-04b0314d7f13cf1df
