### PR TITLE
Fix Ironsmith parse failure: Nesting Grounds

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -577,6 +577,9 @@ impl Effect {
         if let Some(payload) = self.downcast_ref::<crate::effects::MoveAllCountersEffect>() {
             return Some(&payload.from);
         }
+        if let Some(payload) = self.downcast_ref::<crate::effects::MoveOneCounterEffect>() {
+            return Some(&payload.from);
+        }
         if let Some(payload) = self.downcast_ref::<crate::effects::TransformEffect>() {
             return Some(&payload.target);
         }
@@ -1970,6 +1973,13 @@ impl Effect {
         to: crate::target::ChooseSpec,
     ) -> Self {
         Self::new(crate::effects::MoveAllCountersEffect::new(from, to))
+    }
+
+    pub fn move_one_counter(
+        from: crate::target::ChooseSpec,
+        to: crate::target::ChooseSpec,
+    ) -> Self {
+        Self::new(crate::effects::MoveOneCounterEffect::new(from, to))
     }
 
     pub fn pump_for_each(

--- a/crates/ironsmith-compiler/src/effects/mod.rs
+++ b/crates/ironsmith-compiler/src/effects/mod.rs
@@ -40,7 +40,7 @@ pub use ironsmith_core::{
     ManifestDreadEffect, ManifestTopCardOfLibraryEffect,
     MayCastMatchingSpellWithoutPayingManaCostEffect, MayEffect, MayMoveToZoneEffect, MeldEffect,
     MillEffect, ModifyPowerToughnessEffect, ModifyPowerToughnessForEachEffect, MonstrosityEffect,
-    MoveAllCountersEffect, MoveCountersEffect, MoveToLibraryNthFromTopEffect,
+    MoveAllCountersEffect, MoveCountersEffect, MoveOneCounterEffect, MoveToLibraryNthFromTopEffect,
     MoveToLibraryTopOrBottomChoiceEffect, MoveToZoneEffect, NewTargetRestriction,
     NinjutsuCostEffect, NinjutsuEffect, OpenAttractionEffect, PayAnyEnergyEffect, PayEnergyEffect,
     PayManaEffect, PhaseInEffect, PhaseOutEffect, PoisonCountersEffect, PopulateEffect,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4503,6 +4503,27 @@ fn compile_subject_verb_effect(
             );
             Ok((vec![effect], choices))
         }
+        SubjectVerbActionAst::MoveOneCounter { from, to } => {
+            let (from_spec, mut choices) =
+                resolve_target_spec_with_choices(from, &current_reference_env(ctx))?;
+            let (to_spec, to_choices) =
+                resolve_target_spec_with_choices(to, &current_reference_env(ctx))?;
+            for choice in to_choices {
+                push_choice(&mut choices, choice);
+            }
+            let effect = tag_object_target_effect(
+                tag_object_target_effect(
+                    Effect::move_one_counter(from_spec.clone(), to_spec.clone()),
+                    &from_spec,
+                    ctx,
+                    "from",
+                ),
+                &to_spec,
+                ctx,
+                "to",
+            );
+            Ok((vec![effect], choices))
+        }
         SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {
             let (spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -109,7 +109,8 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
                     visit(fixed);
                 }
             }
-            SubjectVerbActionAst::MoveAllCounters { from, to } => {
+            SubjectVerbActionAst::MoveAllCounters { from, to }
+            | SubjectVerbActionAst::MoveOneCounter { from, to } => {
                 visit(from);
                 visit(to);
             }
@@ -645,6 +646,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::Counter { .. }
         | SubjectVerbActionAst::CounterUnlessPays { .. }
         | SubjectVerbActionAst::MoveAllCounters { .. }
+        | SubjectVerbActionAst::MoveOneCounter { .. }
         | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { .. }
         | SubjectVerbActionAst::ReturnToHand { .. }
         | SubjectVerbActionAst::ReturnAllToHand { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1462,6 +1462,10 @@ pub(crate) enum SubjectVerbActionAst {
         from: TargetAst,
         to: TargetAst,
     },
+    MoveOneCounter {
+        from: TargetAst,
+        to: TargetAst,
+    },
     ForEachCounterKindPutOrRemove {
         target: TargetAst,
     },
@@ -2830,6 +2834,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .finish(),
             Self::MoveAllCounters { from, to } => f
                 .debug_struct("MoveAllCounters")
+                .field("from", from)
+                .field("to", to)
+                .finish(),
+            Self::MoveOneCounter { from, to } => f
+                .debug_struct("MoveOneCounter")
                 .field("from", from)
                 .field("to", to)
                 .finish(),
@@ -5559,6 +5568,14 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::MoveAllCounters { from, to },
+        )
+    }
+
+    pub(crate) fn subject_verb_move_one_counter(from: TargetAst, to: TargetAst) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::MoveOneCounter { from, to },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -402,6 +402,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::ReturnAllToHandOfChosenColor { .. }
             | SubjectVerbActionAst::DoubleCountersOnEach { .. }
             | SubjectVerbActionAst::MoveAllCounters { .. }
+            | SubjectVerbActionAst::MoveOneCounter { .. }
             | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { .. }
             | SubjectVerbActionAst::Sacrifice { .. }
             | SubjectVerbActionAst::SacrificeAll { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -493,7 +493,8 @@ fn advance_reference_frame_for_effect(
                 | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {
                     maybe_tag_target(target, frame, id_gen, "counters")?;
                 }
-                SubjectVerbActionAst::MoveAllCounters { from, to } => {
+                SubjectVerbActionAst::MoveAllCounters { from, to }
+                | SubjectVerbActionAst::MoveOneCounter { from, to } => {
                     if frame.auto_tag_object_targets {
                         let _ = next_reference_tag(id_gen, "from");
                         frame.last_object_tag = Some(next_reference_tag(id_gen, "to"));
@@ -1696,6 +1697,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::ReturnAllToHandOfChosenColor { .. }
             | SubjectVerbActionAst::DoubleCountersOnEach { .. }
             | SubjectVerbActionAst::MoveAllCounters { .. }
+            | SubjectVerbActionAst::MoveOneCounter { .. }
             | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { .. }
             | SubjectVerbActionAst::Sacrifice { .. }
             | SubjectVerbActionAst::SacrificeAll { .. }
@@ -2278,7 +2280,8 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 bind_unresolved_it_in_value(amount, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
             }
-            SubjectVerbActionAst::MoveAllCounters { from, to } => {
+            SubjectVerbActionAst::MoveAllCounters { from, to }
+            | SubjectVerbActionAst::MoveOneCounter { from, to } => {
                 bind_unresolved_it_in_target(from, seed_tag)
                     + bind_unresolved_it_in_target(to, seed_tag)
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2412,6 +2412,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::ReturnAllToHandOfChosenColor { .. }
             | SubjectVerbActionAst::DoubleCountersOnEach { .. }
             | SubjectVerbActionAst::MoveAllCounters { .. }
+            | SubjectVerbActionAst::MoveOneCounter { .. }
             | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { .. }
             | SubjectVerbActionAst::Sacrifice { .. }
             | SubjectVerbActionAst::SacrificeAll { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
@@ -3,9 +3,16 @@ pub(crate) fn parse_move(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardText
     use winnow::Parser as _;
 
     // "all counters from <source> onto/to <destination>"
-    let Some(after_prefix) =
+    // "a counter from <source> onto/to <destination>"
+    let (after_prefix, move_all) = if let Some(rest) =
         grammar::strip_lexed_prefix_phrase(tokens, &["all", "counters", "from"])
-    else {
+    {
+        (rest, true)
+    } else if let Some(rest) =
+        grammar::strip_lexed_prefix_phrase(tokens, &["a", "counter", "from"])
+    {
+        (rest, false)
+    } else {
         return Err(CardTextError::ParseError(format!(
             "unsupported move clause (clause: '{}')",
             crate::runtime_backend::token_word_refs(tokens).join(" ")
@@ -26,7 +33,11 @@ pub(crate) fn parse_move(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardText
     let from = parse_target_phrase(from_tokens)?;
     let to = parse_target_phrase(to_tokens)?;
 
-    Ok(EffectAst::subject_verb_move_all_counters(from, to))
+    Ok(if move_all {
+        EffectAst::subject_verb_move_all_counters(from, to)
+    } else {
+        EffectAst::subject_verb_move_one_counter(from, to)
+    })
 }
 
 pub(crate) fn parse_draw(

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -4346,6 +4346,18 @@ impl MoveAllCountersEffect {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct MoveOneCounterEffect {
+    pub from: ChooseSpec,
+    pub to: ChooseSpec,
+}
+
+impl MoveOneCounterEffect {
+    pub fn new(from: ChooseSpec, to: ChooseSpec) -> Self {
+        Self { from, to }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct MoveCountersEffect {
     pub counter_type: crate::counter::CounterType,
     pub count: Value,

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -101,7 +101,7 @@ pub use effect::{
     ManaRestrictedEffect, ManifestDreadEffect, ManifestTopCardOfLibraryEffect,
     MayCastMatchingSpellWithoutPayingManaCostEffect, MayEffect, MayMoveToZoneEffect, MeldEffect,
     MillEffect, ModifyPowerToughnessEffect, ModifyPowerToughnessForEachEffect, MonstrosityEffect,
-    MoveAllCountersEffect, MoveCountersEffect, MoveToLibraryNthFromTopEffect,
+    MoveAllCountersEffect, MoveCountersEffect, MoveOneCounterEffect, MoveToLibraryNthFromTopEffect,
     MoveToLibraryTopOrBottomChoiceEffect, MoveToZoneEffect, NewTargetRestriction,
     NinjutsuCostEffect, NinjutsuEffect, OpenAttractionEffect, PayAnyEnergyEffect, PayEnergyEffect,
     PayManaEffect, PhaseInEffect, PhaseOutEffect, PlayerControlDuration, PlayerControlStart,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32333,6 +32333,7 @@ const STRICT_PARSE_REGRESSION_SUCCESS_CARDS: &[&str] = &[
     "Imoen, Mystic Trickster",
     "Maskwood Nexus",
     "Mox Amber",
+    "Nesting Grounds",
     "Nexus of Fate",
     "Nykthos, Shrine to Nyx",
     "Nine-Lives Familiar",
@@ -32401,6 +32402,7 @@ strict_parse_card_expected_fail_test!(
 strict_parse_card_expected_fail_test!(strict_parse_lake_of_the_dead, "Lake of the Dead");
 strict_parse_card_test!(strict_parse_maskwood_nexus, "Maskwood Nexus");
 strict_parse_card_test!(strict_parse_mox_amber, "Mox Amber");
+strict_parse_card_test!(strict_parse_nesting_grounds, "Nesting Grounds");
 strict_parse_card_test!(strict_parse_nine_lives_familiar, "Nine-Lives Familiar");
 strict_parse_card_test!(strict_parse_nykthos_shrine_to_nyx, "Nykthos, Shrine to Nyx");
 strict_parse_card_test!(strict_parse_orcish_bowmasters, "Orcish Bowmasters");
@@ -32415,6 +32417,84 @@ strict_parse_card_test!(strict_parse_susurian_voidborn, "Susurian Voidborn");
 strict_parse_card_test!(strict_parse_talon_gates_of_madara, "Talon Gates of Madara");
 strict_parse_card_expected_fail_test!(strict_parse_the_soul_stone, "The Soul Stone");
 strict_parse_card_test!(strict_parse_unmarked_grave, "Unmarked Grave");
+
+#[test]
+fn nesting_grounds_compiled_text_matches_counter_move_clause() {
+    let def = parse_oracle_card_definition("Nesting Grounds");
+    let rendered = debug_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains(
+            "{1}, {T}: Move a counter from target permanent you control onto a second target permanent. Activate only as a sorcery."
+        ),
+        "expected Nesting Grounds counter-move clause in compiled text, got {rendered}"
+    );
+}
+
+#[test]
+fn nesting_grounds_move_counter_effect_moves_exactly_one_counter() {
+    let def = parse_oracle_card_definition("Nesting Grounds");
+    let move_effect = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .segments
+                .iter()
+                .flat_map(|segment| segment.default_effects.iter())
+                .find_map(|effect| effect.downcast_ref::<crate::effects::MoveOneCounterEffect>()),
+            _ => None,
+        })
+        .expect("Nesting Grounds should compile to a move-one-counter activated effect");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let controller = PlayerId::from_index(0);
+    let source = game.new_object_id();
+    let from_id = game.new_object_id();
+    let to_id = game.new_object_id();
+    let mut from_obj = crate::object::Object::new_token(
+        from_id,
+        controller,
+        "From Permanent".to_string(),
+        vec![CardType::Creature],
+        Vec::new(),
+        Some(2),
+        Some(2),
+        crate::color::ColorSet::COLORLESS,
+    );
+    from_obj
+        .counters
+        .insert(crate::object::CounterType::PlusOnePlusOne, 2);
+    let to_obj = crate::object::Object::new_token(
+        to_id,
+        controller,
+        "To Permanent".to_string(),
+        vec![CardType::Creature],
+        Vec::new(),
+        Some(2),
+        Some(2),
+        crate::color::ColorSet::COLORLESS,
+    );
+    game.add_object(from_obj);
+    game.add_object(to_obj);
+
+    let mut ctx = crate::effects::EffectContext::new_default(source, controller).with_targets(vec![
+        crate::effects::ResolvedTarget::Object(from_id),
+        crate::effects::ResolvedTarget::Object(to_id),
+    ]);
+    let result = move_effect
+        .execute(&mut game, &mut ctx)
+        .expect("Nesting Grounds move-counter effect should execute");
+    assert_eq!(result.value, crate::effect::OutcomeValue::Count(1));
+    assert_eq!(
+        game.counter_count(from_id, crate::object::CounterType::PlusOnePlusOne),
+        1
+    );
+    assert_eq!(
+        game.counter_count(to_id, crate::object::CounterType::PlusOnePlusOne),
+        1
+    );
+}
 
 #[test]
 fn strict_parse_regression_batch_target_cards() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29763,6 +29763,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             describe_choose_spec(&move_counters.to)
         );
     }
+    if let Some(move_counter) = effect.downcast_ref::<crate::effects::MoveOneCounterEffect>() {
+        let mut to_text = describe_choose_spec(&move_counter.to);
+        if let Some(rest) = to_text.strip_prefix("another target ") {
+            to_text = format!("a second target {rest}");
+        }
+        return format!(
+            "Move a counter from {} onto {}",
+            describe_choose_spec(&move_counter.from),
+            to_text
+        );
+    }
     if effect
         .downcast_ref::<crate::effects::NinjutsuCostEffect>()
         .is_some()

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -2234,6 +2234,12 @@ impl Effect {
         Self::new(MoveAllCountersEffect::new(from, to))
     }
 
+    /// Create a "move one counter from one permanent to another" effect.
+    pub fn move_one_counter(from: ChooseSpec, to: ChooseSpec) -> Self {
+        use crate::effects::MoveOneCounterEffect;
+        Self::new(MoveOneCounterEffect::new(from, to))
+    }
+
     /// Create a "proliferate" effect.
     pub fn proliferate(count: impl Into<Value>) -> Self {
         use crate::effects::ProliferateEffect;

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -870,6 +870,10 @@ where
     if let Some(converted) = clone_direct_effect::<M, crate::effects::MoveCountersEffect>(&effect) {
         return Ok(converted);
     }
+    if let Some(converted) = clone_direct_effect::<M, crate::effects::MoveOneCounterEffect>(&effect)
+    {
+        return Ok(converted);
+    }
     if let Some(converted) = clone_direct_effect::<M, crate::effects::ProliferateEffect>(&effect) {
         return Ok(converted);
     }

--- a/crates/ironsmith-runtime/src/effects/counters/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/mod.rs
@@ -6,6 +6,7 @@
 mod for_each_counter_kind_put_or_remove;
 mod move_all_counters;
 mod move_counters;
+mod move_one_counter;
 mod proliferate;
 mod put_counters;
 mod remove_any_counters_among;
@@ -17,6 +18,7 @@ mod remove_up_to_counters;
 pub use for_each_counter_kind_put_or_remove::ForEachCounterKindPutOrRemoveEffect;
 pub use move_all_counters::MoveAllCountersEffect;
 pub use move_counters::MoveCountersEffect;
+pub use move_one_counter::MoveOneCounterEffect;
 pub use proliferate::ProliferateEffect;
 pub use put_counters::PutCountersEffect;
 pub use remove_any_counters_among::RemoveAnyCountersAmongEffect;

--- a/crates/ironsmith-runtime/src/effects/counters/move_one_counter.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/move_one_counter.rs
@@ -1,0 +1,162 @@
+use crate::decision::FallbackStrategy;
+use crate::decisions::{CounterRemovalSpec, make_decision_with_fallback};
+use crate::effect::EffectOutcome;
+use crate::effects::EffectExecutor;
+use crate::effects::helpers::resolve_objects_for_effect;
+use crate::effects::{ExecutionContext, ExecutionError};
+use crate::game_state::GameState;
+pub use ironsmith_core::MoveOneCounterEffect;
+
+impl EffectExecutor for MoveOneCounterEffect {
+    fn execute(
+        &self,
+        game: &mut GameState,
+        ctx: &mut ExecutionContext,
+    ) -> Result<EffectOutcome, ExecutionError> {
+        let target_pair = if ctx.target_assignments.is_empty() && ctx.targets.len() >= 2 {
+            ctx.resolve_two_object_targets()
+        } else {
+            let from = resolve_objects_for_effect(game, ctx, &self.from)?;
+            let to = resolve_objects_for_effect(game, ctx, &self.to)?;
+            from.first().copied().zip(to.first().copied())
+        };
+        let Some((from_id, to_id)) = target_pair else {
+            return Ok(EffectOutcome::target_invalid());
+        };
+
+        let available_counters = game
+            .object(from_id)
+            .map(|obj| {
+                obj.counters
+                    .iter()
+                    .filter(|(_, count)| **count > 0)
+                    .map(|(ct, count)| (*ct, *count))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if available_counters.is_empty() {
+            return Ok(EffectOutcome::count(0));
+        }
+
+        let spec = CounterRemovalSpec::new(ctx.source, from_id, 1, available_counters);
+        let selections = make_decision_with_fallback(
+            game,
+            &mut ctx.decision_maker,
+            ctx.controller,
+            Some(ctx.source),
+            spec,
+            FallbackStrategy::Maximum,
+        );
+
+        for (counter_type, to_remove) in selections {
+            if to_remove == 0 {
+                continue;
+            }
+            let Some((removed, remove_event)) = game.remove_counters(
+                from_id,
+                counter_type,
+                1,
+                Some(ctx.source),
+                Some(ctx.controller),
+            ) else {
+                continue;
+            };
+            if removed == 0 {
+                continue;
+            }
+            let mut outcome = EffectOutcome::count(1).with_event(remove_event);
+            if let Some(add_event) =
+                game.add_counters_with_source(to_id, counter_type, 1, Some(ctx.source), Some(ctx.controller))
+            {
+                outcome = outcome.with_event(add_event);
+            }
+            return Ok(outcome);
+        }
+
+        Ok(EffectOutcome::count(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card::{CardBuilder, PowerToughness};
+    use crate::effects::ResolvedTarget;
+    use crate::effect::OutcomeValue;
+    use crate::ids::{CardId, PlayerId};
+    use crate::mana::{ManaCost, ManaSymbol};
+    use crate::object::{CounterType, Object};
+    use crate::target::ChooseSpec;
+    use crate::types::CardType;
+    use crate::zone::Zone;
+
+    fn make_creature_card(card_id: u32, name: &str) -> crate::card::Card {
+        CardBuilder::new(CardId::from_raw(card_id), name)
+            .mana_cost(ManaCost::from_pips(vec![
+                vec![ManaSymbol::Generic(1)],
+                vec![ManaSymbol::Green],
+            ]))
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    }
+
+    #[test]
+    fn move_one_counter_moves_single_chosen_counter() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let controller = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let from_id = game.new_object_id();
+        let to_id = game.new_object_id();
+        let source_card = make_creature_card(from_id.0 as u32, "Source");
+        let mut from_obj = Object::from_card(from_id, &source_card, controller, Zone::Battlefield);
+        from_obj.counters.insert(CounterType::PlusOnePlusOne, 2);
+        let target_card = make_creature_card(to_id.0 as u32, "Dest");
+        let to_obj = Object::from_card(to_id, &target_card, controller, Zone::Battlefield);
+        game.add_object(from_obj);
+        game.add_object(to_obj);
+
+        let mut ctx = ExecutionContext::new_default(source, controller).with_targets(vec![
+            ResolvedTarget::Object(from_id),
+            ResolvedTarget::Object(to_id),
+        ]);
+        let effect = MoveOneCounterEffect::new(ChooseSpec::permanent(), ChooseSpec::permanent());
+        let result = effect.execute(&mut game, &mut ctx).expect("execute move one");
+
+        assert_eq!(result.value, OutcomeValue::Count(1));
+        assert_eq!(game.counter_count(from_id, CounterType::PlusOnePlusOne), 1);
+        assert_eq!(game.counter_count(to_id, CounterType::PlusOnePlusOne), 1);
+    }
+
+    #[test]
+    fn move_one_counter_with_no_available_counters_returns_zero() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let controller = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let from_id = game.new_object_id();
+        let to_id = game.new_object_id();
+        let source_card = make_creature_card(from_id.0 as u32, "Source");
+        let target_card = make_creature_card(to_id.0 as u32, "Dest");
+        game.add_object(Object::from_card(
+            from_id,
+            &source_card,
+            controller,
+            Zone::Battlefield,
+        ));
+        game.add_object(Object::from_card(
+            to_id,
+            &target_card,
+            controller,
+            Zone::Battlefield,
+        ));
+
+        let mut ctx = ExecutionContext::new_default(source, controller).with_targets(vec![
+            ResolvedTarget::Object(from_id),
+            ResolvedTarget::Object(to_id),
+        ]);
+        let effect = MoveOneCounterEffect::new(ChooseSpec::permanent(), ChooseSpec::permanent());
+        let result = effect.execute(&mut game, &mut ctx).expect("execute move one");
+
+        assert_eq!(result.value, OutcomeValue::Count(0));
+    }
+}

--- a/crates/ironsmith-runtime/src/effects/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/mod.rs
@@ -122,6 +122,7 @@ pub use continuous::{ApplyContinuousEffect, ExchangeTextBoxesEffect, RuntimeModi
 pub use control::{ExchangeControlEffect, GainControlEffect, SharedTypeConstraint};
 pub use counters::{
     ForEachCounterKindPutOrRemoveEffect, MoveAllCountersEffect, MoveCountersEffect,
+    MoveOneCounterEffect,
     ProliferateEffect, PutCountersEffect, RemoveAnyCountersAmongEffect,
     RemoveAnyCountersFromSourceEffect, RemoveCountersEffect, RemoveUpToAnyCountersEffect,
     RemoveUpToCountersEffect,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nesting Grounds
Initial parse error:
```
unsupported move clause (clause: 'a counter from target permanent you control onto a second target permanent'); oracle-only fallback also failed: unsupported move clause (clause: 'a counter from target permanent you control onto a second target permanent')
```

Worker: i-09d064cacb0b4f562
