### PR TITLE
Fix Ironsmith parse failure: Guardian Naga // Banishing Coils

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -17,6 +17,7 @@ use super::grammar::abilities::{
     is_discard_or_redirect_replacement_line_lexed, is_doctors_companion_marker_line_lexed,
     is_double_damage_from_sources_you_control_of_chosen_type_line_lexed,
     is_draw_replace_exile_top_face_down_line_lexed, is_draw_replacement_double_line_lexed,
+    is_during_your_turn_prevent_all_damage_to_source_line_lexed,
     is_effect_discard_to_library_replacement_line_lexed,
     is_enchanted_land_is_chosen_type_line_lexed,
     is_if_source_you_control_with_mana_value_double_instead_marker_line_lexed,
@@ -763,6 +764,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_you_may_static_grant_line),
         single_static_ability_ast_rule!(parse_grant_flash_to_noncreature_spells_line),
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
+        single_static_ability_ast_rule!(parse_during_your_turn_prevent_all_damage_to_source_line),
         single_static_ability_ast_rule!(parse_prevent_all_combat_damage_to_source_line),
         single_static_ability_ast_rule!(
             parse_prevent_all_noncombat_damage_to_other_creatures_you_control_line
@@ -6546,6 +6548,18 @@ pub(crate) fn parse_prevent_all_combat_damage_to_source_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     if is_prevent_all_combat_damage_to_source_line_lexed(tokens) {
         return Ok(Some(StaticAbility::prevent_all_combat_damage_to_self()));
+    }
+
+    Ok(None)
+}
+
+pub(crate) fn parse_during_your_turn_prevent_all_damage_to_source_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_during_your_turn_prevent_all_damage_to_source_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::prevent_all_damage_to_self().with_condition(crate::ConditionExpr::YourTurn),
+        ));
     }
 
     Ok(None)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2498,6 +2498,50 @@ pub(crate) fn is_prevent_all_combat_damage_to_source_line_lexed(tokens: &[OwnedL
     )
 }
 
+pub(crate) fn is_during_your_turn_prevent_all_damage_to_source_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    primitives::parse_prefix(
+        tokens,
+        (
+            primitives::phrase(&["during", "your", "turn"]),
+            opt(primitives::comma()),
+            primitives::phrase(&[
+                "prevent", "all", "damage", "that", "would", "be", "dealt", "to",
+            ]),
+            primitives::phrase(&["this", "creature"]),
+            primitives::sentence_end(),
+        ),
+    )
+    .is_some()
+        || primitives::parse_prefix(
+            tokens,
+            (
+                primitives::phrase(&["during", "your", "turn"]),
+                opt(primitives::comma()),
+                primitives::phrase(&[
+                    "prevent", "all", "damage", "that", "would", "be", "dealt", "to",
+                ]),
+                primitives::phrase(&["this", "permanent"]),
+                primitives::sentence_end(),
+            ),
+        )
+        .is_some()
+        || primitives::parse_prefix(
+            tokens,
+            (
+                primitives::phrase(&["during", "your", "turn"]),
+                opt(primitives::comma()),
+                primitives::phrase(&[
+                    "prevent", "all", "damage", "that", "would", "be", "dealt", "to",
+                ]),
+                primitives::phrase(&["it"]),
+                primitives::sentence_end(),
+            ),
+        )
+        .is_some()
+}
+
 pub(crate) fn is_prevent_all_noncombat_damage_to_other_creatures_you_control_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8057,6 +8057,14 @@ fn rewrite_grammar_prevention_static_line_probes_match_keyword_static_shapes() {
             crate::static_abilities::StaticAbilityId::PreventDamageToOtherCreatureYouControlPutCountersInstead,
         ),
         (
+            "During your turn, prevent all damage that would be dealt to this creature.",
+            super::grammar::abilities::is_during_your_turn_prevent_all_damage_to_source_line_lexed
+                as Probe,
+            super::keyword_static::parse_during_your_turn_prevent_all_damage_to_source_line
+                as Parser,
+            crate::static_abilities::StaticAbilityId::PreventAllDamageToSelf,
+        ),
+        (
             "Prevent all combat damage that would be dealt to this creature.",
             super::grammar::abilities::is_prevent_all_combat_damage_to_source_line_lexed as Probe,
             super::keyword_static::parse_prevent_all_combat_damage_to_source_line as Parser,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -163,6 +163,7 @@ pub enum StaticAbilityId {
     RedirectDamageToSource,
     PreventAllDamageDealtByThisPermanent,
     PreventAllDamageDealtToCreatures,
+    PreventAllDamageToSelf,
     PreventAllCombatDamageToSelf,
     PreventAllDamageToSelfByCreatures,
     PreventDamageToSelfRemoveCounter,
@@ -399,6 +400,7 @@ impl StaticAbilityId {
             | RedirectDamageToSource
             | PreventAllDamageDealtByThisPermanent
             | PreventAllDamageDealtToCreatures
+            | PreventAllDamageToSelf
             | PreventAllCombatDamageToSelf
             | PreventAllDamageToSelfByCreatures
             | PreventDamageToSelfRemoveCounter

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2991,6 +2991,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn prevent_all_damage_to_self() -> Self {
+        Self {
+            id: Some(StaticAbilityId::PreventAllDamageToSelf),
+            label: "prevent all damage to self".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn prevent_all_noncombat_damage_to_other_creatures_you_control() -> Self {
         Self {
             id: Some(StaticAbilityId::PreventAllNoncombatDamageToOtherCreaturesYouControl),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36023,6 +36023,44 @@ fn parse_traveling_chocobo_top_library_lines_compile() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_guardian_naga_banishing_coils_creature_face_strict() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Guardian Naga // Banishing Coils")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Vigilance\nDuring your turn, prevent all damage that would be dealt to this creature.",
+        )
+        .expect("guardian naga creature face should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("vigilance")
+            && rendered.contains("during your turn")
+            && rendered.contains("prevent all damage that would be dealt to this creature"),
+        "expected guardian naga prevention clause to compile, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_guardian_naga_banishing_coils_adventure_face_strict() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Guardian Naga // Banishing Coils")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Exile target artifact or enchantment.")
+        .expect("banishing coils adventure face should parse");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("exile target artifact or enchantment"),
+        "expected banishing coils exile clause to compile, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_starfield_vocalist_with_warp_keyword() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Starfield Vocalist")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -86,6 +86,11 @@ fn normalize_ast_surface_lines(lines: Vec<String>) -> Vec<String> {
 
 fn finalize_ast_surface_line(line: String) -> String {
     let mut line = line;
+    if let Some(rest) = line.strip_prefix("During your turn, this creature has ") {
+        if rest.to_ascii_lowercase().starts_with("prevent ") {
+            line = format!("During your turn, {}", lowercase_first(rest));
+        }
+    }
     line = line
         .replace(
             "Choose target creature you control. Choose target creature an opponent controls. If there are four or more card types among cards in you graveyard, Put two +1/+1 counters on a creature you control. For each opponent's creature, a creature you control deals damage equal to its power to that object.",
@@ -817,6 +822,17 @@ mod tests {
                 "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying and vigilance."
                     .to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn during_your_turn_prevent_clause_drops_extra_has() {
+        assert_eq!(
+            finalize_ast_surface_line(
+                "During your turn, this creature has Prevent all damage that would be dealt to this creature."
+                    .to_string()
+            ),
+            "During your turn, prevent all damage that would be dealt to this creature."
         );
     }
 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12533,6 +12533,11 @@ fn describe_static_ability_with_subject(
             lowercase_first(keyword)
         );
     }
+    if let Some(rest) = line.strip_prefix("During your turn, this creature has ")
+        && rest.to_ascii_lowercase().starts_with("prevent ")
+    {
+        return format!("During your turn, {}", lowercase_first(rest));
+    }
     if let Some(rest) = line.strip_prefix("This creature gets ")
         && let Some(pump) = rest.strip_suffix(" as long as it's your turn")
     {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -115,6 +115,7 @@ impl StaticAbility {
             Some(StaticAbilityId::PreventAllDamageDealtToCreatures) => {
                 Self::prevent_all_damage_dealt_to_creatures()
             }
+            Some(StaticAbilityId::PreventAllDamageToSelf) => Self::prevent_all_damage_to_self(),
             Some(StaticAbilityId::PreventAllCombatDamageToSelf) => {
                 Self::prevent_all_combat_damage_to_self()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1751,6 +1751,33 @@ impl StaticAbilityKind for PreventAllCombatDamageToSelf {
     }
 }
 
+/// "Prevent all damage that would be dealt to this creature."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PreventAllDamageToSelf;
+
+impl StaticAbilityKind for PreventAllDamageToSelf {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::PreventAllDamageToSelf
+    }
+
+    fn display(&self) -> String {
+        "Prevent all damage that would be dealt to this creature.".to_string()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            crate::events::DamageToSelfMatcher::new(),
+            ReplacementAction::Prevent,
+        ))
+    }
+}
+
 /// "Prevent all damage that would be dealt to this creature by creatures."
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct PreventAllDamageToSelfByCreatures;
@@ -5590,6 +5617,54 @@ mod tests {
             crate::events::cause::EventCause::combat_damage(source),
         );
         assert!(!matcher.matches_event(&unpreventable, &ctx));
+    }
+
+    #[test]
+    fn test_prevent_all_damage_to_self_generates_replacement() {
+        let game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let protected = ObjectId::from_raw(42);
+        let source = ObjectId::from_raw(7);
+
+        let ability = PreventAllDamageToSelf;
+        let replacement = ability
+            .generate_replacement_effect(protected, alice)
+            .expect("should generate replacement effect");
+        assert_eq!(replacement.replacement, ReplacementAction::Prevent);
+
+        let matcher = replacement
+            .matcher
+            .as_ref()
+            .expect("replacement must have a matcher");
+        let ctx = EventContext::for_replacement_effect(alice, protected, &game);
+
+        let combat_damage = DamageEvent::with_cause(
+            source,
+            DamageTarget::Object(protected),
+            3,
+            true,
+            crate::events::cause::EventCause::combat_damage(source),
+        );
+        assert!(matcher.matches_event(&combat_damage, &ctx));
+
+        let noncombat_damage = DamageEvent::with_cause(
+            source,
+            DamageTarget::Object(protected),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(matcher.matches_event(&noncombat_damage, &ctx));
+
+        let wrong_target = DamageEvent::with_cause(
+            source,
+            DamageTarget::Player(alice),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(!matcher.matches_event(&wrong_target, &ctx));
+
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2214,6 +2214,10 @@ impl StaticAbility {
         Self::new(PreventAllCombatDamageToSelf)
     }
 
+    pub fn prevent_all_damage_to_self() -> Self {
+        Self::new(PreventAllDamageToSelf)
+    }
+
     pub fn prevent_all_damage_to_self_by_creatures() -> Self {
         Self::new(PreventAllDamageToSelfByCreatures)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Guardian Naga // Banishing Coils
Initial parse error:
```
parser does not yet support line family: 'During your turn, prevent all damage that would be dealt to this creature.'; oracle-only fallback also failed: parser does not yet support line family: 'During your turn, prevent all damage that would be dealt to this creature.'
```

Worker: i-00ae40e164a6d7a94
