### PR TITLE
Fix Ironsmith parse failure: War Elemental

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2320,6 +2320,12 @@ pub(crate) fn parse_trigger_clause_lexed(
             .token_index_for_word_index(is_word_idx)
             .unwrap_or(tokens.len());
         let subject_tokens = &tokens[..is_token_idx];
+        if let Some(player) = trigger_subject_player_selector_lexed(subject_tokens) {
+            return Ok(TriggerSpec::DealsDamageToPlayer {
+                source: ObjectFilter::default(),
+                player,
+            });
+        }
         if let Some(filter) = parse_trigger_subject_filter_lexed(subject_tokens)? {
             if slice_ends_with(&words, &["is", "dealt", "combat", "damage"]) {
                 return Ok(TriggerSpec::IsDealtCombatDamage(filter));

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -484,6 +484,7 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 count: *count,
             }
         }
+        PredicateAst::OpponentLostLifeThisTurn => Condition::OpponentLostLifeThisTurn,
         PredicateAst::YouHaveNoCardsInHand => {
             Condition::Not(Box::new(Condition::CardsInHandOrMore(1)))
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -558,7 +558,9 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             | TriggerSpec::IsDealtCombatDamage(_)
             | TriggerSpec::ThisDealsDamage
             | TriggerSpec::ThisDealsDamageTo(_)
+            | TriggerSpec::ThisDealsDamageToPlayer { .. }
             | TriggerSpec::DealsDamage(_)
+            | TriggerSpec::DealsDamageToPlayer { .. }
             | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
             | TriggerSpec::ThisDealsCombatDamage
             | TriggerSpec::ThisDealsCombatDamageTo(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -486,6 +486,7 @@ pub(crate) enum PredicateAst {
         player: PlayerAst,
         count: u32,
     },
+    OpponentLostLifeThisTurn,
     YouHaveNoCardsInHand,
     PlayerWouldBeginExtraTurn {
         player: PlayerAst,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -72,6 +72,9 @@ fn trigger_supports_event_amount(trigger: &TriggerSpec) -> bool {
             | TriggerSpec::ThisDealsDamage
             | TriggerSpec::ThisDealsDamageTo(_)
             | TriggerSpec::DealsDamage(_)
+            | TriggerSpec::ThisDealsDamageToPlayer { .. }
+            | TriggerSpec::DealsDamageToPlayer { .. }
+            | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
             | TriggerSpec::ThisDealsCombatDamage
             | TriggerSpec::ThisDealsCombatDamageTo(_)
             | TriggerSpec::DealsCombatDamage(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -97,6 +97,14 @@ pub(crate) fn parse_sacrifice(
                     if_false: vec![base],
                 });
             }
+            let unless_words = crate::runtime_backend::token_word_refs(&tokens[unless_token_idx + 1..]);
+            if unless_words.as_slice() == ["an", "opponent", "was", "dealt", "damage", "this", "turn"] {
+                return Ok(EffectAst::Conditional {
+                    predicate: PredicateAst::OpponentLostLifeThisTurn,
+                    if_true: Vec::new(),
+                    if_false: vec![base],
+                });
+            }
             if let Some(unless_effect) = try_build_unless(vec![base], tokens, unless_token_idx)? {
                 return Ok(unless_effect);
             }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -12301,6 +12301,65 @@ fn parse_sacrifice_unless_clause_fails_instead_of_ignoring_unless_tail() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_war_elemental_strictly_parses_etb_sacrifice_unless_opponent_damage_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "War Elemental")
+        .parse_text(
+            "When this creature enters, sacrifice it unless an opponent was dealt damage this turn.\nWhenever an opponent is dealt damage, put that many +1/+1 counters on this creature.",
+        )
+        .expect("War Elemental should parse");
+    let joined = crate::compiled_text::unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains("unless an opponent was dealt damage this turn, sacrifice it"),
+        "expected compiled text to preserve ETB unless-opponent-damage semantics, got {joined}"
+    );
+    assert!(
+        joined.contains("whenever an opponent is dealt damage, put that many +1/+1 counters on this creature"),
+        "expected damage-counter trigger to remain intact, got {joined}"
+    );
+}
+
+#[test]
+fn war_elemental_runtime_condition_matches_when_opponent_lost_life_this_turn() {
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = crate::ObjectId::from_raw(77);
+    let bob = crate::PlayerId::from_index(1);
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::life::LifeLossEvent::from_effect(bob, 2),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.stage_turn_history_event(&damage_event);
+
+    assert!(
+        crate::condition_eval::evaluate_condition_cast_time(
+            &game,
+            &crate::effect::Condition::OpponentLostLifeThisTurn,
+            crate::PlayerId::from_index(0),
+            source,
+        ),
+        "War Elemental ETB unless-condition should pass when an opponent lost life this turn"
+    );
+}
+
+#[test]
+fn war_elemental_runtime_condition_fails_when_no_opponent_lost_life_this_turn() {
+    let game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = crate::ObjectId::from_raw(77);
+
+    assert!(
+        !crate::condition_eval::evaluate_condition_cast_time(
+            &game,
+            &crate::effect::Condition::OpponentLostLifeThisTurn,
+            crate::PlayerId::from_index(0),
+            source,
+        ),
+        "War Elemental ETB unless-condition should fail when no opponent lost life this turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_power_or_toughness_cant_be_blocked_subject_fails_loudly() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Tetsuko Variant")
         .parse_text("Creatures you control with power or toughness 1 or less can't be blocked.")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10254,7 +10254,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             )
         }
         Condition::AttackedThisTurn => "you attacked this turn".to_string(),
-        Condition::OpponentLostLifeThisTurn => "an opponent lost life this turn".to_string(),
+        Condition::OpponentLostLifeThisTurn => {
+            "an opponent was dealt damage this turn".to_string()
+        }
         Condition::PermanentLeftBattlefieldThisTurn => {
             "a permanent left the battlefield this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/triggers/combat/deals_damage.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/deals_damage.rs
@@ -93,6 +93,9 @@ impl TriggerMatcher for DealsDamageTrigger {
                 format!("Whenever {} deals noncombat damage", source_description)
             }
         } else if let Some(player) = &self.damaged_player {
+            if self.filter == ObjectFilter::default() {
+                return format!("Whenever {} is dealt damage", player.description());
+            }
             format!(
                 "Whenever {} deals damage to {}",
                 source_description,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: War Elemental
Initial parse error:
```
unsupported sacrifice-unless clause (clause: 'it unless an opponent was dealt damage this turn'); oracle-only fallback also failed: unsupported sacrifice-unless clause (clause: 'it unless an opponent was dealt damage this turn')
```

Worker: i-0b4cb296eda0a9029
