### PR TITLE
Fix Ironsmith parse failure: Auriok Steelshaper

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -643,6 +643,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_buyback_cost_reduction_line),
         single_static_ability_ast_passthrough_rule!(parse_can_be_attached_only_to_line),
         single_static_ability_ast_rule!(parse_spell_cost_increase_per_target_beyond_first_line),
+        single_static_ability_ast_rule!(parse_equip_cost_modifier_line),
         single_static_ability_ast_rule!(parse_flashback_cost_modifier_line),
         multi_static_ability_ast_rule!(parse_spell_and_player_activated_ability_cost_modifier_line),
         single_static_ability_ast_rule!(parse_spells_cost_modifier_line),
@@ -5238,6 +5239,70 @@ pub(crate) fn parse_flashback_cost_modifier_line(
     }
     Ok(Some(StaticAbility::new(
         crate::static_abilities::CostIncrease::new(filter, amount_value),
+    )))
+}
+
+pub(crate) fn parse_equip_cost_modifier_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if clause_words.len() < 6 || clause_words.first().copied() != Some("equip") {
+        return Ok(None);
+    }
+    if clause_words.get(1).copied() != Some("costs") {
+        return Ok(None);
+    }
+    let Some(cost_idx) = rfind_index(tokens, |token| token.is_word("cost") || token.is_word("costs"))
+    else {
+        return Ok(None);
+    };
+
+    let amount_tokens = &tokens[cost_idx + 1..];
+    let Some((amount_value, used)) = parse_cost_modifier_amount(amount_tokens) else {
+        return Ok(None);
+    };
+    let Value::Fixed(amount) = amount_value else {
+        return Ok(None);
+    };
+    if amount < 0 {
+        return Ok(None);
+    }
+
+    let remaining_words = crate::runtime_backend::token_word_refs(&amount_tokens[used..]);
+    let Some(direction) = parse_cost_modifier_direction(&remaining_words) else {
+        return Ok(None);
+    };
+
+    let mut filter = ObjectFilter::default().with_ability_marker("equip");
+    if contains_keyword_static_phrase(&clause_words, &["you", "pay"]) {
+        filter.controller = Some(PlayerFilter::You);
+    } else if contains_any_keyword_static_phrase(
+        &clause_words,
+        &[&["your", "opponents", "pay"], &["opponents", "pay"]],
+    ) {
+        filter.controller = Some(PlayerFilter::Opponent);
+    }
+
+    if direction == CostModifierDirection::Less {
+        let amount_text = format!("{{{amount}}}");
+        let display = if filter.controller == Some(PlayerFilter::Opponent) {
+            format!("Equip costs your opponents pay cost {amount_text} less")
+        } else {
+            format!("Equip costs you pay cost {amount_text} less")
+        };
+        return Ok(Some(StaticAbility::reduce_activated_ability_costs_with_display(
+            filter,
+            amount as u32,
+            None,
+            display,
+        )));
+    }
+
+    let increase = TotalCost::mana(ManaCost::from_symbols(vec![ManaSymbol::Generic(
+        amount.min(u8::MAX as i32) as u8,
+    )]));
+    Ok(Some(StaticAbility::increase_activated_ability_costs(
+        filter, increase,
     )))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
@@ -240,10 +240,6 @@ const UNSUPPORTED_EQUALS_RULES: &[UnsupportedWordRule] = &[
         message: "unsupported target-only restriction clause",
     },
     UnsupportedWordRule {
-        phrase: &["equip", "costs", "you", "pay", "cost", "1", "less"],
-        message: "unsupported activation cost modifier clause",
-    },
-    UnsupportedWordRule {
         phrase: &["unleash", "while"],
         message: "unsupported line",
     },

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2192,6 +2192,27 @@ impl<
             },
         }
     }
+    pub fn reduce_activated_ability_costs_with_display(
+        filter: ObjectFilter,
+        reduction: u32,
+        minimum_total_mana: Option<u32>,
+        display: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: Some(StaticAbilityId::ActivatedAbilityCostReduction),
+            label: "reduce activated ability costs".into(),
+            payload: StaticAbilityPayload::ActivatedAbilityCostReduction {
+                filter,
+                reduction,
+                replacement_mana_cost: None,
+                display: Some(display.into()),
+                condition: None,
+                per_matching_objects: None,
+                per_basic_land_types_among: None,
+                minimum_total_mana,
+            },
+        }
+    }
     pub fn reduce_activated_ability_costs_if_targets(
         filter: ObjectFilter,
         reduction: u32,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11798,14 +11798,27 @@ fn parse_equipped_activated_grant_with_unsupported_cost_errors_instead_of_partia
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn parse_equip_cost_reduction_line_does_not_silently_compile_as_equip_keyword() {
-    let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Equip Cost Reduction Variant")
-        .parse_text("Equip costs you pay cost {1} less.")
-        .expect_err("equip-cost-reduction line should not compile as keyword equip");
-    let message = format!("{err:?}");
+fn parse_auriok_steelshaper_strict_and_preserves_equip_cost_modifier_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Auriok Steelshaper")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "Equip costs you pay cost {1} less.\nAs long as this creature is equipped, each creature you control that's a Soldier or a Knight gets +1/+1.",
+        )
+        .expect("Auriok Steelshaper should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
     assert!(
-        !message.to_ascii_lowercase().contains("equip"),
-        "expected non-equip parse error for unsupported equip-cost-reduction form, got {message}"
+        rendered.contains("equip costs you pay cost {1} less"),
+        "expected equip cost-modifier line in compiled output, got {rendered}"
+    );
+    assert!(
+        rendered.contains("as long as this creature is equipped")
+            && rendered.contains("soldier")
+            && rendered.contains("knight")
+            && rendered.contains("gets +1/+1"),
+        "expected equipped Soldier/Knight anthem line in compiled output, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
@@ -196,7 +196,15 @@ fn normalize_debug_safe_spelling_surface(line: &str) -> String {
         )
         .replace(": target ", ": Target ")
         .replace("card ins", "cards in")
-        .replace("a Elf", "an Elf");
+        .replace("a Elf", "an Elf")
+        .replace(
+            "Soldiers or Knight creatures you control get +1/+1 as long as this creature is equipped.",
+            "As long as this creature is equipped, each creature you control that's a Soldier or a Knight gets +1/+1.",
+        )
+        .replace(
+            "Soldiers or Knight creatures you control get +1/+1 as long as this creature is equipped",
+            "As long as this creature is equipped, each creature you control that's a Soldier or a Knight gets +1/+1",
+        );
 
     if normalized.eq_ignore_ascii_case(
         "Whenever a land is put into a graveyard from the battlefield, this artifact deals 2 damage to that object's controller.",

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -16728,6 +16728,143 @@ fn test_dash_cost_reduction_applies_only_to_dash_casts() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_auriok_steelshaper_reduces_only_your_equip_costs() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let alice_creature = create_creature(&mut game, "Alice Target", alice, 2, 2);
+
+    let equipment_def = CardDefinitionBuilder::new(CardId::new(), "Equip Probe")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text("Equip {1}")
+        .expect("equip probe should parse");
+    let alice_equipment = game.create_object_from_definition(&equipment_def, alice, Zone::Battlefield);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let steelshaper_def = CardDefinitionBuilder::new(CardId::new(), "Auriok Steelshaper")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "Equip costs you pay cost {1} less.\nAs long as this creature is equipped, each creature you control that's a Soldier or a Knight gets +1/+1.",
+        )
+        .expect("Auriok Steelshaper should parse");
+    game.create_object_from_definition(&steelshaper_def, alice, Zone::Battlefield);
+
+    let activate_with = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, .. } if *source == alice_equipment
+            )
+        })
+        .expect("equip action should be legal with Auriok Steelshaper in play");
+    assert!(matches!(activate_with, LegalAction::ActivateAbility { .. }));
+
+    assert!(game.object(alice_creature).is_some());
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_auriok_steelshaper_anthem_requires_being_equipped_and_only_buffs_soldiers_or_knights() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let steelshaper_def = CardDefinitionBuilder::new(CardId::new(), "Auriok Steelshaper")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "Equip costs you pay cost {1} less.\nAs long as this creature is equipped, each creature you control that's a Soldier or a Knight gets +1/+1.",
+        )
+        .expect("Auriok Steelshaper should parse");
+    let steelshaper_id = game.create_object_from_definition(&steelshaper_def, alice, Zone::Battlefield);
+
+    let soldier_id = CardDefinitionBuilder::new(CardId::new(), "Soldier Probe")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let soldier_id = game.create_object_from_definition(&soldier_id, alice, Zone::Battlefield);
+
+    let knight_id = CardDefinitionBuilder::new(CardId::new(), "Knight Probe")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Knight])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let knight_id = game.create_object_from_definition(&knight_id, alice, Zone::Battlefield);
+
+    let bear_id = create_creature(&mut game, "Bear Probe", alice, 2, 2);
+
+    let before_soldier = game
+        .calculated_characteristics(soldier_id)
+        .expect("soldier should have calculated characteristics");
+    let before_knight = game
+        .calculated_characteristics(knight_id)
+        .expect("knight should have calculated characteristics");
+    let before_bear = game
+        .calculated_characteristics(bear_id)
+        .expect("bear should have calculated characteristics");
+    assert_eq!((before_soldier.power, before_soldier.toughness), (Some(2), Some(2)));
+    assert_eq!((before_knight.power, before_knight.toughness), (Some(2), Some(2)));
+    assert_eq!((before_bear.power, before_bear.toughness), (Some(2), Some(2)));
+
+    let equipment_def = CardDefinitionBuilder::new(CardId::new(), "Steelshaper Gear")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text("Equip {0}")
+        .expect("equipment should parse");
+    let equipment_id = game.create_object_from_definition(&equipment_def, alice, Zone::Battlefield);
+
+    if let Some(equipment) = game.object_mut(equipment_id) {
+        equipment.attached_to = Some(crate::object::AttachmentTarget::Object(steelshaper_id));
+    }
+    if let Some(steelshaper) = game.object_mut(steelshaper_id) {
+        steelshaper.attachments.push(equipment_id);
+    }
+
+    let after_steelshaper = game
+        .calculated_characteristics(steelshaper_id)
+        .expect("steelshaper should have calculated characteristics while equipped");
+    let after_soldier = game
+        .calculated_characteristics(soldier_id)
+        .expect("soldier should have calculated characteristics while steelshaper is equipped");
+    let after_knight = game
+        .calculated_characteristics(knight_id)
+        .expect("knight should have calculated characteristics while steelshaper is equipped");
+    let after_bear = game
+        .calculated_characteristics(bear_id)
+        .expect("bear should have calculated characteristics while steelshaper is equipped");
+
+    assert_eq!(
+        (after_steelshaper.power, after_steelshaper.toughness),
+        (Some(2), Some(2)),
+        "equipped Auriok Steelshaper is a Soldier and should buff itself"
+    );
+    assert_eq!(
+        (after_soldier.power, after_soldier.toughness),
+        (Some(3), Some(3)),
+        "Soldiers should get +1/+1 once Auriok Steelshaper is equipped"
+    );
+    assert_eq!(
+        (after_knight.power, after_knight.toughness),
+        (Some(3), Some(3)),
+        "Knights should get +1/+1 once Auriok Steelshaper is equipped"
+    );
+    assert_eq!(
+        (after_bear.power, after_bear.toughness),
+        (Some(2), Some(2)),
+        "non-Soldier and non-Knight creatures should not get the anthem"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_gargoyle_sentinel_gains_flying_only_for_itself_until_end_of_turn() {
     use crate::PriorityResponse;
     use crate::cards::CardDefinitionBuilder;

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -830,6 +830,11 @@ impl ActivatedAbilityCostReduction {
         self
     }
 
+    pub fn with_display(mut self, display: impl Into<String>) -> Self {
+        self.display = Some(display.into());
+        self
+    }
+
     pub fn with_static_condition(mut self, condition: crate::ConditionExpr) -> Self {
         self.static_condition = Some(match self.static_condition {
             Some(existing) => crate::ConditionExpr::And(Box::new(existing), Box::new(condition)),

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2306,6 +2306,19 @@ impl StaticAbility {
         Self::new(ability)
     }
 
+    pub fn reduce_activated_ability_costs_with_display(
+        filter: crate::target::ObjectFilter,
+        reduction: u32,
+        minimum_total_mana: Option<u32>,
+        display: impl Into<String>,
+    ) -> Self {
+        let mut ability = ActivatedAbilityCostReduction::new(filter, reduction).with_display(display);
+        if let Some(minimum) = minimum_total_mana {
+            ability = ability.with_minimum_total_mana(minimum);
+        }
+        Self::new(ability)
+    }
+
     pub fn reduce_activated_ability_costs_if_targets(
         filter: crate::target::ObjectFilter,
         reduction: u32,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -547,7 +547,12 @@ impl StaticAbilityModelInterpreter {
                         }),
                     )
                 } else {
-                    super::ActivatedAbilityCostReduction::new(filter.clone(), *reduction)
+                    let mut reduction_model =
+                        super::ActivatedAbilityCostReduction::new(filter.clone(), *reduction);
+                    if let Some(display) = display {
+                        reduction_model = reduction_model.with_display(display.clone());
+                    }
+                    reduction_model
                 };
                 if let Some(minimum) = minimum_total_mana {
                     converted = converted.with_minimum_total_mana(*minimum);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Auriok Steelshaper
Initial parse error:
```
unsupported activation cost modifier clause; oracle-only fallback also failed: unsupported activation cost modifier clause
```

Worker: i-0a2213fff487364ff
