### PR TITLE
Fix Ironsmith parse failure: Rayami, First of the Fallen

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -8019,23 +8019,40 @@ pub(crate) fn parse_exile_would_die_instead_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
     let words = crate::runtime_backend::token_word_refs(tokens);
-    let nontoken_opponent_creature = ObjectFilter::creature()
-        .nontoken()
-        .controlled_by(PlayerFilter::Opponent);
     let nontoken_opponent_prefix = [
         "if", "a", "nontoken", "creature", "an", "opponent", "controls", "would", "die",
     ];
     let nontoken_opponent_prefix_no_article = [
         "if", "nontoken", "creature", "opponent", "controls", "would", "die",
     ];
-    let after_prefix = if slice_starts_with(&words, &nontoken_opponent_prefix) {
-        Some(&words[nontoken_opponent_prefix.len()..])
+    let nontoken_any_prefix = ["if", "a", "nontoken", "creature", "would", "die"];
+    let nontoken_any_prefix_no_article = ["if", "nontoken", "creature", "would", "die"];
+    let matched_nontoken_filter = if slice_starts_with(&words, &nontoken_opponent_prefix) {
+        Some((
+            ObjectFilter::creature()
+                .nontoken()
+                .controlled_by(PlayerFilter::Opponent),
+            nontoken_opponent_prefix.len(),
+        ))
     } else if slice_starts_with(&words, &nontoken_opponent_prefix_no_article) {
-        Some(&words[nontoken_opponent_prefix_no_article.len()..])
+        Some((
+            ObjectFilter::creature()
+                .nontoken()
+                .controlled_by(PlayerFilter::Opponent),
+            nontoken_opponent_prefix_no_article.len(),
+        ))
+    } else if slice_starts_with(&words, &nontoken_any_prefix) {
+        Some((ObjectFilter::creature().nontoken(), nontoken_any_prefix.len()))
+    } else if slice_starts_with(&words, &nontoken_any_prefix_no_article) {
+        Some((
+            ObjectFilter::creature().nontoken(),
+            nontoken_any_prefix_no_article.len(),
+        ))
     } else {
         None
     };
-    if let Some(tail) = after_prefix {
+    if let Some((matched_filter, prefix_len)) = matched_nontoken_filter {
+        let tail = &words[prefix_len..];
         let (exile_with_counters, follow_up) = match tail {
             [
                 "exile",
@@ -8083,11 +8100,20 @@ pub(crate) fn parse_exile_would_die_instead_line(
             ["exile", "that", "card", "instead"] | ["exile", "it", "instead"] => {
                 (Vec::new(), Vec::new())
             }
+            ["instead", "exile", "that", "card", "with", "a", counter_word, "counter", "on", "it"]
+            | ["instead", "exile", "it", "with", "a", counter_word, "counter", "on", "it"]
+            | ["exile", "that", "card", "with", "a", counter_word, "counter", "on", "it", "instead"]
+            | ["exile", "it", "with", "a", counter_word, "counter", "on", "it", "instead"] => {
+                let Some(counter_type) = parse_counter_type_word(counter_word) else {
+                    return Ok(None);
+                };
+                (vec![(counter_type, 1)], Vec::new())
+            }
             _ => return Ok(None),
         };
         return Ok(Some(
             StaticAbility::exile_would_die_instead_with_damage_source_counters_and_follow_up(
-                nontoken_opponent_creature,
+                matched_filter,
                 None,
                 exile_with_counters,
                 follow_up,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -352,6 +352,7 @@ fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "ki" => Some(CounterType::Ki),
         "energy" => Some(CounterType::Energy),
         "age" => Some(CounterType::Age),
+        "blood" => Some(CounterType::Blood),
         "ice" => Some(CounterType::Ice),
         "finality" => Some(CounterType::Finality),
         "time" => Some(CounterType::Time),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1225,6 +1225,7 @@ pub(crate) fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "ki" => Some(CounterType::Ki),
         "energy" => Some(CounterType::Energy),
         "age" => Some(CounterType::Age),
+        "blood" => Some(CounterType::Blood),
         "ice" => Some(CounterType::Ice),
         "finality" => Some(CounterType::Finality),
         "time" => Some(CounterType::Time),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9921,6 +9921,19 @@ fn rewrite_nontoken_opponent_creature_would_die_with_counter_static_replacement(
 }
 
 #[test]
+fn rewrite_rayami_nontoken_creature_would_die_with_blood_counter_static_replacement() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Rayami, First of the Fallen")
+        .card_types(vec![CardType::Creature])
+        .parse_text("If a nontoken creature would die, exile that card with a blood counter on it instead.")
+        .expect("rayami replacement clause should parse");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(debug.contains("ExileWouldDieInstead"), "{debug}");
+    assert!(debug.contains("nontoken: true"), "{debug}");
+    assert!(debug.contains("Blood"), "{debug}");
+}
+
+#[test]
 fn rewrite_exile_counter_cast_permission_with_mana_permission_static_line() {
     let line = "You may cast spells from among cards in exile your opponents own with ice counters on them, and you may spend mana from snow sources as though it were mana of any color to cast those spells.";
     let tokens = lex_line(line, 0).expect("permission line should lex");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39359,3 +39359,29 @@ fn parse_passive_goad_designation_clause() {
         "expected passive goad surface, got {rendered}"
     );
 }
+
+#[test]
+fn rayami_first_of_the_fallen_parses_and_renders_blood_counter_replacement() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Rayami, First of the Fallen")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Vampire])
+        .power_toughness(PowerToughness::fixed(5, 4))
+        .parse_text(
+            "If a nontoken creature would die, exile that card with a blood counter on it instead.\nAs long as an exiled creature card with a blood counter on it has flying, this has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.",
+        )
+        .expect("Rayami, First of the Fallen oracle text should parse");
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("if nontoken creature would die, exile it instead"),
+        "expected would-die replacement text, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/effects/zones/destroy.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/destroy.rs
@@ -253,6 +253,7 @@ mod tests {
     use crate::game_state::GameState;
     use crate::ids::{CardId, ObjectId, PlayerId};
     use crate::mana::{ManaCost, ManaSymbol};
+    use crate::object::CounterType;
     use crate::static_abilities::StaticAbility;
     use crate::target::PlayerFilter;
     use crate::types::CardType;
@@ -356,6 +357,78 @@ mod tests {
             })
             .count();
         assert_eq!(zombie_count, 1);
+    }
+
+    #[test]
+    fn rayami_replacement_exiles_nontoken_creature_with_blood_counter() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let rayami = crate::cards::CardDefinitionBuilder::new(
+            CardId::from_raw(50_210),
+            "Rayami, First of the Fallen",
+        )
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 4))
+        .parse_text("If a nontoken creature would die, exile that card with a blood counter on it instead.")
+        .expect("rayami replacement clause should parse");
+        let source = game.create_object_from_definition(&rayami, alice, Zone::Battlefield);
+        let victim = create_creature(&mut game, bob, "Rayami Victim", 50_211);
+        let victim_stable_id = game.object(victim).expect("victim before destroy").stable_id;
+
+        game.update_replacement_effects();
+        let mut dm = SelectFirstDecisionMaker;
+        let outcome = process_destroy(&mut game, victim, Some(source), &mut dm);
+
+        assert!(
+            matches!(outcome, EventOutcome::Replaced),
+            "expected replacement outcome, got {outcome:?}"
+        );
+        let exiled_victim = game
+            .find_object_by_stable_id(victim_stable_id)
+            .expect("exiled victim should still be findable");
+        assert_eq!(game.object(exiled_victim).expect("exiled victim").zone, Zone::Exile);
+        assert_eq!(
+            game.counter_count(exiled_victim, CounterType::Blood),
+            1,
+            "exiled creature should have one blood counter"
+        );
+    }
+
+    #[test]
+    fn rayami_replacement_does_not_exile_noncreature_permanent() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let rayami = crate::cards::CardDefinitionBuilder::new(
+            CardId::from_raw(50_220),
+            "Rayami, First of the Fallen",
+        )
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 4))
+        .parse_text("If a nontoken creature would die, exile that card with a blood counter on it instead.")
+        .expect("rayami replacement clause should parse");
+        let source = game.create_object_from_definition(&rayami, alice, Zone::Battlefield);
+        let noncreature = CardBuilder::new(CardId::from_raw(50_221), "Rayami Noncreature")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let noncreature_victim = game.create_object_from_card(&noncreature, bob, Zone::Battlefield);
+
+        game.update_replacement_effects();
+        let mut dm = SelectFirstDecisionMaker;
+        let outcome = process_destroy(&mut game, noncreature_victim, Some(source), &mut dm);
+
+        assert!(
+            !matches!(outcome, EventOutcome::Replaced),
+            "noncreature death should not be replaced by Rayami"
+        );
+        assert!(
+            game.object(noncreature_victim)
+                .is_none_or(|obj| obj.zone != Zone::Exile),
+            "noncreature permanent should not be exiled by Rayami replacement"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rayami, First of the Fallen
Initial parse error:
```
unsupported predicate (predicate: 'nontoken creature would die'); oracle-only fallback also failed: unsupported predicate (predicate: 'nontoken creature would die')
```

Worker: i-0cc20add086cbba69
