### PR TITLE
Fix Ironsmith parse failure: Aunt May

### DIFF
--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -5161,6 +5161,7 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             "the tagged object 'triggering' matches creature",
             "that object is a creature",
         )
+        .replace("If that object is a ", "If it's a ")
         .replace("the tagged object 'triggering'", "that object")
         .replace(" that player controls of their choice", " of their choice")
         .replace(" that player controls unless that player pays ", " unless that player pays ")
@@ -10686,6 +10687,39 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                     };
                     return is_clause(noun);
                 }
+                if filter.subtypes.len() == 1
+                    && filter.zone.is_none()
+                    && filter.controller.is_none()
+                    && filter.owner.is_none()
+                    && !filter.single_graveyard
+                    && filter.card_types.is_empty()
+                    && filter.all_card_types.is_empty()
+                    && filter.excluded_card_types.is_empty()
+                    && filter.excluded_subtypes.is_empty()
+                    && filter.supertypes.is_empty()
+                    && filter.excluded_supertypes.is_empty()
+                    && filter.colors.is_none()
+                    && filter.excluded_colors.is_empty()
+                    && !filter.colorless
+                    && !filter.multicolored
+                    && !filter.monocolored
+                    && filter.all_colors.is_none()
+                    && filter.exactly_two_colors.is_none()
+                    && filter.power.is_none()
+                    && filter.toughness.is_none()
+                    && filter.total_power_toughness.is_none()
+                    && filter.mana_value.is_none()
+                    && filter.with_counter.is_none()
+                    && filter.without_counter.is_none()
+                    && filter.name.is_none()
+                    && filter.excluded_name.is_none()
+                    && filter.tagged_constraints.is_empty()
+                    && filter.any_of.is_empty()
+                    && !filter.source
+                {
+                    let subtype = filter.subtypes[0].to_string();
+                    return is_clause(&subtype);
+                }
                 return format!("{subject} matches {desc}");
                 }
                 format!("the tagged object '{}' matches {desc}", tag.as_str())
@@ -11358,6 +11392,18 @@ mod tests {
             ),
             "Whenever another creature enters under your control, you gain 1 life"
         );
+    }
+
+    #[test]
+    fn describe_tagged_object_matches_simple_subtype_uses_is_clause() {
+        let mut filter = ObjectFilter::default();
+        filter.subtypes = vec![Subtype::Spider];
+        let condition = Condition::TaggedObjectMatches(
+            TagKey::from("triggering"),
+            filter,
+        );
+
+        assert_eq!(describe_condition(&condition), "that object is a Spider");
     }
 
     #[test]

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -955,6 +955,40 @@ fn compile_oracle_text_compare_text_outputs_only_text_and_score() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_aunt_may_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(cards_path.exists(), "expected workspace cards.json at {cards_path:?}");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Aunt May")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Aunt May --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Aunt May should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Aunt May"), "{stdout}");
+    assert!(
+        stdout.contains("If it's a Spider, put a +1/+1 counter on it."),
+        "expected Spider conditional clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_outputs_original_oracle_text() {
     let dir = tempdir().expect("tempdir");
     let cards_path = dir.path().join("cards.json");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aunt May
Initial parse error:
```
compiled text contains internal marker: object-predicate-debug
```

Worker: i-01d058db8ef688e55
