### PR TITLE
Fix Ironsmith parse failure: Crawlspace

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3400,19 +3400,27 @@ pub(crate) fn parse_no_more_than_creatures_can_attack_or_block_each_combat_line(
     };
 
     let tail = crate::runtime_backend::token_word_refs(&tokens[3 + used..]);
-    if tail.len() != 5 {
+    if tail.len() != 5 && tail.len() != 6 {
         return Ok(None);
     }
 
+    let attack_you = tail.len() == 6;
     if !matches!(tail[0], "creature" | "creatures")
         || tail[1] != "can"
-        || tail[3] != "each"
-        || tail[4] != "combat"
+        || tail[3 + usize::from(attack_you)] != "each"
+        || tail[4 + usize::from(attack_you)] != "combat"
     {
         return Ok(None);
     }
 
+    if attack_you && tail[3] != "you" {
+        return Ok(None);
+    }
+
     let ability = match tail[2] {
+        "attack" if attack_you => {
+            StaticAbility::max_attackers_can_attack_you_each_combat(maximum as usize)
+        }
         "attack" => StaticAbility::max_attackers_each_combat(maximum as usize),
         "block" => StaticAbility::max_blockers_each_combat(maximum as usize),
         _ => return Ok(None),

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -65,6 +65,7 @@ pub enum StaticAbilityId {
     CanBlockOnlyFlying,
     CanBlockAdditionalCreatureEachCombat,
     MaxCreaturesCanAttackEachCombat,
+    MaxCreaturesCanAttackYouEachCombat,
     MaxCreaturesCanBlockEachCombat,
     CantBeBlockedByPowerOrLess,
     CantBeBlockedByPowerOrGreater,
@@ -302,6 +303,7 @@ impl StaticAbilityId {
             | CanBlockOnlyFlying
             | CanBlockAdditionalCreatureEachCombat
             | MaxCreaturesCanAttackEachCombat
+            | MaxCreaturesCanAttackYouEachCombat
             | MaxCreaturesCanBlockEachCombat
             | CantBeBlockedByPowerOrLess
             | CantBeBlockedByPowerOrGreater

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -226,6 +226,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         supertypes: Vec<Supertype>,
     },
     MaxCreaturesCanAttackEachCombat(usize),
+    MaxCreaturesCanAttackYouEachCombat(usize),
     MaxCreaturesCanBlockEachCombat(usize),
     ChooseBasicLandTypeAsEnters(String),
     ChooseLandTypeAsEnters(String),
@@ -880,6 +881,9 @@ where
             }
             StaticAbilityPayload::MaxCreaturesCanAttackEachCombat(maximum) => {
                 StaticAbilityPayload::MaxCreaturesCanAttackEachCombat(maximum)
+            }
+            StaticAbilityPayload::MaxCreaturesCanAttackYouEachCombat(maximum) => {
+                StaticAbilityPayload::MaxCreaturesCanAttackYouEachCombat(maximum)
             }
             StaticAbilityPayload::MaxCreaturesCanBlockEachCombat(maximum) => {
                 StaticAbilityPayload::MaxCreaturesCanBlockEachCombat(maximum)
@@ -2889,6 +2893,13 @@ impl<
             id: Some(StaticAbilityId::MaxCreaturesCanAttackEachCombat),
             label: format!("no more than {n} creatures can attack each combat"),
             payload: StaticAbilityPayload::MaxCreaturesCanAttackEachCombat(n),
+        }
+    }
+    pub fn max_attackers_can_attack_you_each_combat(n: usize) -> Self {
+        Self {
+            id: Some(StaticAbilityId::MaxCreaturesCanAttackYouEachCombat),
+            label: format!("no more than {n} creatures can attack you each combat"),
+            payload: StaticAbilityPayload::MaxCreaturesCanAttackYouEachCombat(n),
         }
     }
     pub fn max_blockers_each_combat(n: usize) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -19973,6 +19973,33 @@ fn parse_no_more_than_creatures_can_attack_or_block_each_combat_lines() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_crawlspace_attack_you_cap_line() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Crawlspace")
+        .parse_text("No more than two creatures can attack you each combat.")
+        .expect("crawlspace attack-you cap line should parse");
+    let ids: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        ids.contains(&crate::static_abilities::StaticAbilityId::MaxCreaturesCanAttackYouEachCombat),
+        "expected attack-you-cap static ability, got {ids:?}"
+    );
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains("no more than 2 creatures can attack you each combat"),
+        "expected compiled text to include attack-you cap, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_opponent_loses_life_trigger_with_that_much_gain() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Life Trigger Variant")
         .parse_text("Whenever an opponent loses life, you gain that much life.")

--- a/crates/ironsmith-runtime/src/combat_state.rs
+++ b/crates/ironsmith-runtime/src/combat_state.rs
@@ -314,6 +314,22 @@ fn max_creatures_can_block_each_combat(game: &GameState) -> Option<usize> {
         .min()
 }
 
+fn max_creatures_can_attack_defending_player_each_combat(
+    game: &GameState,
+    defending_player: PlayerId,
+) -> Option<usize> {
+    let all_effects = game.all_continuous_effects();
+    game.battlefield
+        .iter()
+        .filter_map(|&object_id| {
+            let object = game.object(object_id)?;
+            (game.controller_of(object) == defending_player).then_some(object_id)
+        })
+        .flat_map(|object_id| static_abilities_for_object(game, object_id, &all_effects))
+        .filter_map(|ability| ability.max_creatures_can_attack_you_each_combat())
+        .min()
+}
+
 fn generic_mana_cost(amount: u32) -> crate::mana::ManaCost {
     use crate::mana::ManaSymbol;
 
@@ -468,6 +484,28 @@ pub fn declare_attackers(
             maximum: max_attackers,
             provided: declarations.len(),
         });
+    }
+
+    let mut attackers_per_defender: HashMap<PlayerId, usize> = HashMap::new();
+    for (_attacker, target) in &declarations {
+        let defending_player = match target {
+            AttackTarget::Player(player_id) => *player_id,
+            AttackTarget::Planeswalker(pw_id) => {
+                let pw = game
+                    .object(*pw_id)
+                    .ok_or_else(|| CombatError::InvalidAttackTarget(target.clone()))?;
+                game.controller_of(pw)
+            }
+        };
+        *attackers_per_defender.entry(defending_player).or_insert(0) += 1;
+    }
+
+    for (defending_player, provided) in attackers_per_defender {
+        if let Some(maximum) = max_creatures_can_attack_defending_player_each_combat(game, defending_player)
+            && provided > maximum
+        {
+            return Err(CombatError::TooManyAttackers { maximum, provided });
+        }
     }
 
     // Pay non-mana attacker costs from "can't attack unless ..." restrictions.
@@ -1418,5 +1456,110 @@ mod tests {
             .mana_pool
             .total();
         assert_eq!(remaining, 0, "expected mana attack cost to be paid");
+    }
+
+    #[test]
+    fn declare_attackers_enforces_crawlspace_style_cap_against_its_controller() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let crawlspace_like = enchantment_card("Crawlspace");
+        let crawlspace_id = game.create_object_from_card(&crawlspace_like, bob, Zone::Battlefield);
+        game.object_mut(crawlspace_id)
+            .expect("crawlspace object should exist")
+            .abilities
+            .push(Ability::static_ability(
+                StaticAbility::max_attackers_can_attack_you_each_combat(2),
+            ));
+
+        let attacker_one = game.create_object_from_card(
+            &creature_card("Attacker One", 2, 2),
+            alice,
+            Zone::Battlefield,
+        );
+        let attacker_two = game.create_object_from_card(
+            &creature_card("Attacker Two", 2, 2),
+            alice,
+            Zone::Battlefield,
+        );
+        let attacker_three = game.create_object_from_card(
+            &creature_card("Attacker Three", 2, 2),
+            alice,
+            Zone::Battlefield,
+        );
+        game.remove_summoning_sickness(attacker_one);
+        game.remove_summoning_sickness(attacker_two);
+        game.remove_summoning_sickness(attacker_three);
+
+        let result = declare_attackers(
+            &mut game,
+            &mut CombatState::default(),
+            vec![
+                (attacker_one, AttackTarget::Player(bob)),
+                (attacker_two, AttackTarget::Player(bob)),
+                (attacker_three, AttackTarget::Player(bob)),
+            ],
+        );
+        assert_eq!(
+            result,
+            Err(CombatError::TooManyAttackers {
+                maximum: 2,
+                provided: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn declare_attackers_crawlspace_style_cap_does_not_limit_other_defenders() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Cara".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let cara = PlayerId::from_index(2);
+
+        let crawlspace_like = enchantment_card("Crawlspace");
+        let crawlspace_id = game.create_object_from_card(&crawlspace_like, bob, Zone::Battlefield);
+        game.object_mut(crawlspace_id)
+            .expect("crawlspace object should exist")
+            .abilities
+            .push(Ability::static_ability(
+                StaticAbility::max_attackers_can_attack_you_each_combat(2),
+            ));
+
+        let attacker_one = game.create_object_from_card(
+            &creature_card("Attacker One", 2, 2),
+            alice,
+            Zone::Battlefield,
+        );
+        let attacker_two = game.create_object_from_card(
+            &creature_card("Attacker Two", 2, 2),
+            alice,
+            Zone::Battlefield,
+        );
+        let attacker_three = game.create_object_from_card(
+            &creature_card("Attacker Three", 2, 2),
+            alice,
+            Zone::Battlefield,
+        );
+        game.remove_summoning_sickness(attacker_one);
+        game.remove_summoning_sickness(attacker_two);
+        game.remove_summoning_sickness(attacker_three);
+
+        let result = declare_attackers(
+            &mut game,
+            &mut CombatState::default(),
+            vec![
+                (attacker_one, AttackTarget::Player(cara)),
+                (attacker_two, AttackTarget::Player(cara)),
+                (attacker_three, AttackTarget::Player(cara)),
+            ],
+        );
+        assert!(
+            result.is_ok(),
+            "expected three attackers against another defender to be legal"
+        );
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -313,6 +313,39 @@ impl StaticAbilityKind for MaxCreaturesCanAttackEachCombat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaxCreaturesCanAttackYouEachCombat {
+    pub maximum: usize,
+}
+
+impl MaxCreaturesCanAttackYouEachCombat {
+    pub const fn new(maximum: usize) -> Self {
+        Self { maximum }
+    }
+}
+
+impl StaticAbilityKind for MaxCreaturesCanAttackYouEachCombat {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::MaxCreaturesCanAttackYouEachCombat
+    }
+
+    fn display(&self) -> String {
+        let noun = if self.maximum == 1 {
+            "creature"
+        } else {
+            "creatures"
+        };
+        format!(
+            "No more than {} {} can attack you each combat",
+            self.maximum, noun
+        )
+    }
+
+    fn max_creatures_can_attack_you_each_combat(&self) -> Option<usize> {
+        Some(self.maximum)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MaxCreaturesCanBlockEachCombat {
     pub maximum: usize,
 }
@@ -1827,6 +1860,13 @@ mod tests {
         let cap = MaxCreaturesCanAttackEachCombat::new(2);
         assert_eq!(cap.id(), StaticAbilityId::MaxCreaturesCanAttackEachCombat);
         assert_eq!(cap.max_creatures_can_attack_each_combat(), Some(2));
+    }
+
+    #[test]
+    fn test_max_creatures_can_attack_you_each_combat() {
+        let cap = MaxCreaturesCanAttackYouEachCombat::new(2);
+        assert_eq!(cap.id(), StaticAbilityId::MaxCreaturesCanAttackYouEachCombat);
+        assert_eq!(cap.max_creatures_can_attack_you_each_combat(), Some(2));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -522,6 +522,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Returns the maximum number of creatures that can attack this ability's controller each combat.
+    fn max_creatures_can_attack_you_each_combat(&self) -> Option<usize> {
+        None
+    }
+
     /// Returns the maximum number of creatures that can block in a combat.
     fn max_creatures_can_block_each_combat(&self) -> Option<usize> {
         None
@@ -1245,6 +1250,10 @@ impl StaticAbility {
         self.0.max_creatures_can_attack_each_combat()
     }
 
+    pub fn max_creatures_can_attack_you_each_combat(&self) -> Option<usize> {
+        self.0.max_creatures_can_attack_you_each_combat()
+    }
+
     pub fn max_creatures_can_block_each_combat(&self) -> Option<usize> {
         self.0.max_creatures_can_block_each_combat()
     }
@@ -1733,6 +1742,10 @@ impl StaticAbility {
 
     pub fn max_attackers_each_combat(maximum: usize) -> Self {
         Self::new(MaxCreaturesCanAttackEachCombat::new(maximum))
+    }
+
+    pub fn max_attackers_can_attack_you_each_combat(maximum: usize) -> Self {
+        Self::new(MaxCreaturesCanAttackYouEachCombat::new(maximum))
     }
 
     pub fn max_blockers_each_combat(maximum: usize) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -987,6 +987,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::MaxCreaturesCanAttackEachCombat(maximum) => {
                 StaticAbility::max_attackers_each_combat(*maximum)
             }
+            ironsmith_core::StaticAbilityPayload::MaxCreaturesCanAttackYouEachCombat(maximum) => {
+                StaticAbility::max_attackers_can_attack_you_each_combat(*maximum)
+            }
             ironsmith_core::StaticAbilityPayload::MaxCreaturesCanBlockEachCombat(maximum) => {
                 StaticAbility::max_blockers_each_combat(*maximum)
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Crawlspace
Initial parse error:
```
parser does not yet support line family: 'No more than two creatures can attack you each combat.'; oracle-only fallback also failed: parser does not yet support line family: 'No more than two creatures can attack you each combat.'
```

Worker: i-01c42bdf2e3a0285d
