### PR TITLE
Fix Ironsmith parse failure: Absolute Virtue

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -1897,6 +1897,18 @@ pub(crate) fn parse_static_text_marker_line(tokens: &[OwnedLexToken]) -> Option<
         ));
     }
 
+    if crate::runtime_backend::token_word_refs(tokens)
+        == ["you", "have", "protection", "from", "each", "of", "your", "opponents"]
+    {
+        return Some(StaticAbility::restriction(
+            crate::effect::Restriction::be_targeted_player_from(
+                PlayerFilter::You,
+                ObjectFilter::default().controlled_by(PlayerFilter::Opponent),
+            ),
+            "You have protection from each of your opponents".to_string(),
+        ));
+    }
+
     let words = parser_token_word_refs(tokens);
     if words
         == [

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -13140,6 +13140,20 @@ fn witchbane_orb_player_hexproof_and_attached_curse_destroy_parse() {
 }
 
 #[test]
+fn absolute_virtue_player_protection_from_opponents_parses_as_targeting_restriction() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Absolute Virtue")
+        .parse_text("You have protection from each of your opponents.")
+        .expect("Absolute Virtue static line should parse");
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("BeTargetedPlayerFrom")
+            && debug.contains("You")
+            && debug.contains("controller: Some(Opponent)"),
+        "expected player targeting restriction from opponent-controlled sources, got {debug}"
+    );
+}
+
+#[test]
 fn maddening_hex_damage_equal_to_die_result_binds_prior_roll() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Maddening Hex Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39715,3 +39715,20 @@ fn rayami_first_of_the_fallen_parses_and_renders_blood_counter_replacement() {
         "expected would-die replacement text, got {rendered}"
     );
 }
+
+#[test]
+fn absolute_virtue_renders_protection_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Absolute Virtue")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White], vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text("You have protection from each of your opponents.")
+        .expect("Absolute Virtue oracle text should parse");
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("you have protection from each of your opponents"),
+        "expected protection clause in compiled text, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -25900,6 +25900,42 @@ fn test_cephalid_inkshrouder_grants_shroud_and_unblockable_after_discard() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn absolute_virtue_blocks_opponent_controlled_sources_from_targeting_you() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::ids::CardId;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let absolute_virtue = CardDefinitionBuilder::new(CardId::new(), "Absolute Virtue")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White], vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text("You have protection from each of your opponents.")
+        .expect("Absolute Virtue should parse");
+    game.create_object_from_definition(&absolute_virtue, alice, Zone::Battlefield);
+
+    let bob_source = create_creature(&mut game, "Opposing Source", bob, 2, 2);
+    let alice_source = create_creature(&mut game, "Friendly Source", alice, 2, 2);
+
+    game.refresh_continuous_state();
+
+    assert!(
+        !game.can_target_player_from_source(alice, bob_source),
+        "opponent-controlled source should not be able to target Absolute Virtue's controller"
+    );
+    assert!(
+        game.can_target_player_from_source(alice, alice_source),
+        "controller's own source should still be able to target them"
+    );
+    assert!(
+        game.can_target_player_from_source(bob, bob_source),
+        "Absolute Virtue should not prevent targeting opponents"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn giant_solifuge_keywords_apply_to_targeting_haste_and_trample() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::static_abilities::StaticAbilityId;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Absolute Virtue
Initial parse error:
```
parser does not yet support line family: 'You have protection from each of your opponents. (You can't be dealt damage, enchanted, or targeted by anything controlled by your opponents.)'; oracle-only fallback also failed: parser does not yet support line family: 'You have protection from each of your opponents.'
```

Worker: i-0908d9e0feaa324a8
