### PR TITLE
Fix Ironsmith parse failure: Sorin Markov

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -50,6 +50,7 @@ use super::subject_verb_primitives::{find_unquoted_token_word, try_build_unless}
 use super::verb_dispatch::parse_effect_with_verb;
 use super::zone_counter_helpers::{parse_half_starting_life_total_value, parse_put_counters};
 use super::zone_handlers::{collapse_leading_signed_pt_modifier_tokens, parse_sacrifice};
+use super::verb_handlers::parse_control_duration;
 use super::{
     Verb, bind_implicit_player_context, find_verb, parse_effect_chain_with_subject_verb_primitives,
     parse_simple_gain_ability_clause, parse_simple_lose_ability_clause, parse_subtype_word,
@@ -212,6 +213,61 @@ fn common_player_action_pattern_for(
         return Some(CommonPlayerActionPattern::StateChange);
     }
     None
+}
+
+fn parse_control_player_clause(tokens: &[OwnedLexToken]) -> Result<Option<EffectAst>, CardTextError> {
+    let words = ClauseDispatchCompatWords::new(tokens).to_word_refs();
+    let Some(control_word_idx) = words
+        .iter()
+        .position(|word| matches!(*word, "control" | "controls"))
+    else {
+        return Ok(None);
+    };
+    if control_word_idx == 0 {
+        return Ok(None);
+    }
+
+    let Some(control_token_idx) = token_index_for_word_index(tokens, control_word_idx) else {
+        return Ok(None);
+    };
+    let subject_tokens = trim_commas(&tokens[..control_token_idx]);
+    let subject_words = ClauseDispatchCompatWords::new(&subject_tokens).to_word_refs();
+    let player = match subject_words.as_slice() {
+        ["you"] => PlayerAst::You,
+        ["that", "player"] => PlayerAst::That,
+        ["target", "player"] => PlayerAst::Target,
+        ["each", "opponent"] => PlayerAst::Opponent,
+        _ => return Ok(None),
+    };
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(during_word_idx) = words.iter().position(|word| *word == "during") else {
+        return Ok(None);
+    };
+    if during_word_idx <= control_word_idx + 1 {
+        return Ok(None);
+    }
+
+    let Some(during_token_idx) = token_index_for_word_index(tokens, during_word_idx) else {
+        return Ok(None);
+    };
+    let target_tokens = trim_commas(&tokens[control_token_idx + 1..during_token_idx]);
+    if target_tokens.is_empty() {
+        return Ok(None);
+    }
+    let TargetAst::Player(target_filter, _) = parse_target_phrase(&target_tokens)? else {
+        return Ok(None);
+    };
+
+    let duration_tokens = trim_commas(&tokens[during_token_idx..]);
+    let duration = parse_control_duration(&duration_tokens)?;
+    Ok(Some(EffectAst::subject_verb_control_player(
+        player,
+        PlayerFilter::Target(Box::new(target_filter)),
+        duration,
+    )))
 }
 
 fn is_pronoun_top_or_bottom_library_choice_put_tail(tokens: &[OwnedLexToken]) -> bool {
@@ -788,6 +844,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     }
 
     if let Some(effect) = parse_passive_goad_clause(tokens)? {
+        return Ok(effect);
+    }
+
+    if let Some(effect) = parse_control_player_clause(tokens)? {
         return Ok(effect);
     }
 
@@ -1464,5 +1524,21 @@ mod tests {
             parse_effect_clause(&tokens)
                 .unwrap_or_else(|err| panic!("common player clause should parse: {text}: {err:?}"));
         }
+    }
+
+    #[test]
+    fn parses_control_target_player_during_next_turn_clause() {
+        let tokens = lex_line(
+            "You control target player during that player's next turn.",
+            0,
+        )
+        .expect("lex clause");
+        let effect = parse_effect_clause(&tokens)
+            .expect("control target player during next turn should parse");
+        let debug = format!("{effect:?}").to_ascii_lowercase();
+        assert!(
+            debug.contains("controlplayer") && debug.contains("nextturn"),
+            "expected control-player-next-turn effect, got {debug}"
+        );
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39715,3 +39715,68 @@ fn rayami_first_of_the_fallen_parses_and_renders_blood_counter_replacement() {
         "expected would-die replacement text, got {rendered}"
     );
 }
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sorin_markov_strict_parse_regression_and_compiled_text_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Sorin Markov")
+        .card_types(vec![CardType::Planeswalker])
+        .subtypes(vec![Subtype::Sorin])
+        .loyalty(4)
+        .parse_text(
+            "+2: Sorin Markov deals 2 damage to any target and you gain 2 life.\n−3: Target opponent's life total becomes 10.\n−7: You control target player during that player's next turn.",
+        )
+        .expect("Sorin Markov should parse strictly");
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("control target player during")
+            && rendered_lower.contains("next turn"),
+        "expected control-target-player-next-turn wording in compiled output, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sorin_markov_compiles_control_player_and_life_total_effects() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Sorin Markov")
+        .card_types(vec![CardType::Planeswalker])
+        .subtypes(vec![Subtype::Sorin])
+        .loyalty(4)
+        .parse_text(
+            "+2: Sorin Markov deals 2 damage to any target and you gain 2 life.\n−3: Target opponent's life total becomes 10.\n−7: You control target player during that player's next turn.",
+        )
+        .expect("Sorin Markov should parse strictly");
+
+    let mut has_set_life_to_ten = false;
+    let mut has_control_player_next_turn = false;
+    for ability in &def.abilities {
+        let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+            continue;
+        };
+        for effect in activated.effects.flattened_default_effects() {
+            if let Some(set_life) = effect.downcast_ref::<crate::effects::SetLifeTotalEffect>()
+                && set_life.amount == crate::effect::Value::Fixed(10)
+            {
+                has_set_life_to_ten = true;
+            }
+            if let Some(control_player) = effect.downcast_ref::<crate::effects::ControlPlayerEffect>()
+                && format!("{:?}", control_player.start)
+                    .to_ascii_lowercase()
+                    .contains("nextturn")
+            {
+                has_control_player_next_turn = true;
+            }
+        }
+    }
+
+    assert!(
+        has_set_life_to_ten,
+        "expected Sorin Markov to compile a set-life-total-to-10 effect"
+    );
+    assert!(
+        has_control_player_next_turn,
+        "expected Sorin Markov to compile a control-player-during-next-turn effect"
+    );
+}


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sorin Markov
Initial parse error:
```
could not find verb in effect clause (clause: 'you control target player during that players next turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'you control target player during that players next turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0909a13b95773cef1
