### PR TITLE
Fix Ironsmith parse failure: Cabaretti Ascendancy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3021,6 +3021,25 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         });
     }
 
+    let didnt_put_into_hand = matches!(
+        filtered.as_slice(),
+        ["you", "dont", "put", "the", "card", "into", "your", "hand"]
+            | ["you", "didnt", "put", "the", "card", "into", "your", "hand"]
+            | ["you", "did", "not", "put", "the", "card", "into", "your", "hand"]
+            | ["you", "dont", "put", "card", "into", "your", "hand"]
+            | ["you", "didnt", "put", "card", "into", "your", "hand"]
+            | ["you", "did", "not", "put", "card", "into", "your", "hand"]
+    );
+    if didnt_put_into_hand {
+        return Ok(PredicateAst::Not(Box::new(
+            PredicateAst::PlayerTaggedObjectMatches {
+                player: PlayerAst::You,
+                tag: TagKey::from(IT_TAG),
+                filter: ObjectFilter::default().in_zone(Zone::Hand),
+            },
+        )));
+    }
+
     if filtered.as_slice() == ["it", "wasnt", "blocking"]
         || filtered.as_slice() == ["it", "was", "not", "blocking"]
         || filtered.as_slice() == ["that", "creature", "wasnt", "blocking"]
@@ -3239,6 +3258,28 @@ mod tests {
             PredicateAst::PlayerWouldBeginExtraTurn {
                 player: PlayerAst::Opponent,
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_if_you_dont_put_card_into_your_hand() -> Result<(), CardTextError> {
+        let tokens = lex_line("If you don't put the card into your hand", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::Not(Box::new(PredicateAst::PlayerTaggedObjectMatches {
+                player: PlayerAst::You,
+                tag: TagKey::from(IT_TAG),
+                filter: ObjectFilter::default().in_zone(Zone::Hand),
+            }))
         );
         Ok(())
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32599,11 +32599,70 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_cabaretti_ascendancy_strict_regression() {
+    assert_oracle_card_parses_strict("Cabaretti Ascendancy");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cabaretti_ascendancy_compiled_text_keeps_hand_or_bottom_branch() {
+    let def = parse_oracle_card_definition("Cabaretti Ascendancy");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("if you don't put the card into your hand")
+            || rendered.contains("if you dont put the card into your hand")
+            || rendered.contains("if not"),
+        "expected hand-branch predicate in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("you may put it on the bottom of your library")
+            || rendered.contains("you may put it on the bottom of its owner's library"),
+        "expected optional bottom-of-library branch in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cabaretti_ascendancy_trigger_keeps_conditional_bottom_branch_runtime_shape() {
+    let def = parse_oracle_card_definition("Cabaretti Ascendancy");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Cabaretti Ascendancy should compile to a triggered upkeep ability");
+
+    let debug = format!("{triggered:#?}").to_ascii_lowercase();
+    assert!(
+        debug.contains("beginningofupkeep"),
+        "expected upkeep trigger, got {debug}"
+    );
+    assert!(
+        debug.contains("condition: not(")
+            && debug.contains("playertaggedobjectmatches")
+            && debug.contains("zone: some(")
+            && debug.contains("hand"),
+        "expected negative hand-placement condition for fallback branch, got {debug}"
+    );
+    assert!(
+        debug.contains("zone: library")
+            && debug.contains("to_top: false")
+            && debug.contains("mayeffect"),
+        "expected optional move-to-bottom effect gated by the condition, got {debug}"
+    );
+}
+
 const STRICT_PARSE_REGRESSION_SUCCESS_CARDS: &[&str] = &[
     "Banefire",
     "Barrowin of Clan Undurr",
     "Biophagus",
     "Blast Zone",
+    "Cabaretti Ascendancy",
     "Boseiju, Who Endures",
     "Cabal Ritual",
     "Caves of Chaos Adventurer",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cabaretti Ascendancy
Initial parse error:
```
unsupported predicate (predicate: 'you dont put card into your hand'); oracle-only fallback also failed: unsupported predicate (predicate: 'you dont put card into your hand')
```

Worker: i-0fe9c3f21c22e2dd1
