### PR TITLE
Fix Ironsmith parse failure: Cinder Strike

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -98,6 +98,9 @@ pub(crate) enum ActivationCostSegmentCst {
         count: u32,
         filter_text: String,
     },
+    Blight {
+        count: u32,
+    },
     RemoveCounters {
         counter_type: CounterType,
         count: u32,
@@ -1336,6 +1339,7 @@ fn parse_activation_cost_segment_tokens(
             Some(parse_tap_chosen_segment_tokens(tokens))
         }
         "behold" => Some(parse_behold_segment_tokens(tokens)),
+        "blight" => Some(parse_blight_segment_tokens(tokens)),
         "exile" => Some(parse_exile_segment_tokens(tokens)),
         "reveal" => Some(parse_reveal_segment_tokens(tokens)),
         "return" => Some(parse_return_segment_tokens(tokens)),
@@ -1574,6 +1578,37 @@ fn parse_behold_segment_tokens(
     }
 
     Ok(ActivationCostSegmentCst::Behold { subtype, count })
+}
+
+fn parse_blight_segment_tokens(
+    tokens: &[OwnedLexToken],
+) -> Result<ActivationCostSegmentCst, CardTextError> {
+    let raw = render_lower_lexed_tokens(tokens);
+    let words = LeafCompatWords::new(tokens);
+    let lowered = words.to_word_refs();
+    if lowered.first().copied() != Some("blight") {
+        return Err(CardTextError::ParseError(
+            "rewrite blight parser expected leading 'blight'".to_string(),
+        ));
+    }
+
+    let tail = lowered.get(1..).unwrap_or_default();
+    let (count, consumed_words) =
+        if let Some((count, consumed_words)) = parse_count_prefix_words(tail) {
+            (count, consumed_words)
+        } else {
+            return Err(CardTextError::ParseError(format!(
+                "rewrite blight parser expected amount in '{raw}'"
+            )));
+        };
+
+    if consumed_words != tail.len() {
+        return Err(CardTextError::ParseError(format!(
+            "rewrite blight parser does not yet support trailing clause in '{raw}'"
+        )));
+    }
+
+    Ok(ActivationCostSegmentCst::Blight { count })
 }
 
 fn parse_reveal_segment_tokens(
@@ -1902,6 +1937,22 @@ pub(crate) fn lower_activation_cost_cst(
             ActivationCostSegmentCst::Behold { subtype, count } => {
                 flush_pending_mana(&mut costs, &mut pending_mana_pips);
                 costs.push(Cost::validated_effect(Effect::behold(*subtype, *count)));
+            }
+            ActivationCostSegmentCst::Blight { count } => {
+                flush_pending_mana(&mut costs, &mut pending_mana_pips);
+                let tag = format!("blight_cost_{tap_tag_id}");
+                tap_tag_id += 1;
+                costs.push(Cost::validated_effect(Effect::choose_objects(
+                    ObjectFilter::creature().you_control(),
+                    ChoiceCount::exactly(1),
+                    PlayerFilter::You,
+                    tag.clone(),
+                )));
+                costs.push(Cost::validated_effect(Effect::put_counters(
+                    CounterType::MinusOneMinusOne,
+                    *count as i32,
+                    crate::target::ChooseSpec::tagged(tag),
+                )));
             }
             ActivationCostSegmentCst::SacrificeSelf => {
                 flush_pending_mana(&mut costs, &mut pending_mana_pips);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -2046,7 +2046,9 @@ pub(crate) fn try_lower_optional_behold_additional_cost(
     };
     let stripped = trim_lexed_commas(effect_tokens);
     let words = token_word_refs(stripped);
-    if !slice_starts_with(&words, &["you", "may", "behold"]) {
+    if !slice_starts_with(&words, &["you", "may", "behold"])
+        && !slice_starts_with(&words, &["you", "may", "blight"])
+    {
         return Ok(None);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1825,6 +1825,28 @@ pub(crate) fn parse_keyword_mechanic_clause(
         return Ok(Some(EffectAst::subject_verb_behold(subtype, count)));
     }
 
+    if clause_words.first() == Some(&"blight") {
+        let (amount, used) = parse_number(&clause_tokens[1..]).ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "missing numeric amount for blight clause (clause: '{}')",
+                clause_words.join(" ")
+            ))
+        })?;
+        if 1 + used != clause_tokens.len() {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported trailing blight clause (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+        return Ok(Some(EffectAst::subject_verb_put_counters(
+            crate::object::CounterType::MinusOneMinusOne,
+            Value::Fixed(amount as i32),
+            TargetAst::Object(ObjectFilter::creature().you_control(), None, None),
+            None,
+            false,
+        )));
+    }
+
     if clause_words == ["manifest", "dread"] {
         return Ok(Some(EffectAst::subject_verb_manifest_dread(
             PlayerAst::Implicit,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11942,6 +11942,34 @@ fn rewrite_activation_cost_shared_parser_supports_behold_costs() {
 }
 
 #[test]
+fn rewrite_activation_cost_shared_parser_supports_blight_costs() {
+    let cst = parse_activation_cost_rewrite("Blight 1")
+        .expect("shared activation-cost parser should support blight costs");
+    assert!(matches!(
+        cst.segments.as_slice(),
+        [super::ActivationCostSegmentCst::Blight { count: 1 }]
+    ));
+
+    let tokens = lex_line("Blight 1", 0).expect("lexer should classify blight activation cost");
+    let lowered = super::parse_activation_cost(&tokens)
+        .expect("activated ability entrypoint should use shared blight cost parser");
+    assert!(
+        !lowered.is_free(),
+        "blight costs should survive lowering as a non-free activation cost"
+    );
+    assert_eq!(
+        lowered.costs().len(),
+        2,
+        "blight cost should lower to choose-then-put-counter costs"
+    );
+    let lowered_raw = format!("{lowered:#?}");
+    assert!(
+        lowered_raw.contains("ChooseObjects") && lowered_raw.contains("MinusOneMinusOne"),
+        "blight cost should choose your creature and apply -1/-1 counters, got {lowered_raw}"
+    );
+}
+
+#[test]
 fn rewrite_activation_cost_shared_parser_supports_mill_costs() {
     let cst = parse_activation_cost_rewrite("Mill two cards")
         .expect("shared activation-cost parser should support mill costs");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31088,6 +31088,26 @@ fn parse_oracle_caustic_exhale_behold_or_pay_regression() {
 }
 
 #[test]
+fn parse_oracle_cinder_strike_blight_additional_cost_regression() {
+    let def = parse_oracle_card_definition("Cinder Strike");
+    let raw = format!("{def:#?}");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        raw.contains("ThisSpellPaidLabel")
+            && raw.contains("Additional")
+            && raw.contains("MinusOneMinusOne"),
+        "expected Cinder Strike to preserve additional-cost-paid gating and blight counters, got {raw}"
+    );
+    assert!(
+        rendered.contains("As an additional cost to cast this spell")
+            && rendered.contains("-1/-1 counter on a creature you control")
+            && rendered.contains("additional cost was paid"),
+        "expected Cinder Strike compiled text to keep blight cost and payoff wiring, got {rendered}"
+    );
+}
+
+#[test]
 fn parse_oracle_perch_protection_gift_extra_turn_regression() {
     let def = parse_oracle_card_definition("Perch Protection");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33584,6 +33584,39 @@ pub(super) fn describe_enchant_filter(filter: &crate::object::AuraAttachmentFilt
 
 pub(super) fn describe_additional_costs(costs: &[crate::costs::Cost]) -> String {
     if costs.len() == 1
+        && let Some(may) = costs[0]
+            .effect_ref()
+            .and_then(|effect| effect.downcast_ref::<crate::effects::MayEffect>())
+        && may.effects.len() == 1
+        && let Some(put_counters) = may.effects[0]
+            .downcast_ref::<crate::effects::PutCountersEffect>()
+        && put_counters.counter_type == crate::object::CounterType::MinusOneMinusOne
+        && put_counters.target
+            == ChooseSpec::Object(crate::filter::ObjectFilter::creature().you_control())
+        && put_counters.target_count.is_none()
+        && !put_counters.distributed
+    {
+        return format!("you may blight {}", describe_value(&put_counters.amount));
+    }
+
+    if costs.len() == 2
+        && let Some(choose) = costs[0]
+            .effect_ref()
+            .and_then(|effect| effect.downcast_ref::<crate::effects::ChooseObjectsEffect>())
+        && let Some(put_counters) = costs[1]
+            .effect_ref()
+            .and_then(|effect| effect.downcast_ref::<crate::effects::PutCountersEffect>())
+        && choose.filter == crate::filter::ObjectFilter::creature().you_control()
+        && choose.count.min == 1
+        && choose.count.max == Some(1)
+        && put_counters.counter_type == crate::object::CounterType::MinusOneMinusOne
+        && let ChooseSpec::Tagged(tag) = &put_counters.target
+        && *tag == choose.tag
+    {
+        return format!("you may blight {}", describe_value(&put_counters.amount));
+    }
+
+    if costs.len() == 1
         && let Some(choose_mode) = costs[0]
             .effect_ref()
             .and_then(|effect| effect.downcast_ref::<crate::effects::ChooseModeEffect>())


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cinder Strike
Initial parse error:
```
could not find verb in effect clause (clause: 'blight 1'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'blight 1'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-0b9e22e879a152ba7
