### PR TITLE
Fix Ironsmith parse failure: Foul-Tongue Invocation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -600,6 +600,39 @@ fn parse_happily_style_conjoined_predicate(words: &[&str]) -> Option<PredicateAs
     ))
 }
 
+fn parse_revealed_or_controlled_subtype_predicate(words: &[&str]) -> Option<PredicateAst> {
+    let suffix_len = usize::from(slice_ends_with(
+        words,
+        &["as", "you", "cast", "this", "spell"],
+    )) * 5;
+    let core_words = if suffix_len > 0 {
+        &words[..words.len().saturating_sub(suffix_len)]
+    } else {
+        words
+    };
+
+    if core_words.len() != 7
+        || core_words[0] != "you"
+        || core_words[1] != "revealed"
+        || parse_subtype_word(core_words[2]).is_none()
+        || core_words[3] != "card"
+        || core_words[4] != "or"
+        || !(core_words[5] == "control" || core_words[5] == "controlled")
+        || parse_subtype_word(core_words[6]).is_none()
+        || core_words[2] != core_words[6]
+    {
+        return None;
+    }
+
+    Some(PredicateAst::Or(
+        Box::new(PredicateAst::ThisSpellPaidLabel("Behold".to_string())),
+        Box::new(PredicateAst::PlayerControls {
+            player: PlayerAst::You,
+            filter: ObjectFilter::default().with_subtype(parse_subtype_word(core_words[2])?),
+        }),
+    ))
+}
+
 pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, CardTextError> {
     let raw_words_view = GrammarFilterNormalizedWords::new(tokens);
     let raw_words = raw_words_view.to_word_refs();
@@ -685,6 +718,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_happily_style_conjoined_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_revealed_or_controlled_subtype_predicate(&filtered) {
         return Ok(predicate);
     }
 
@@ -3280,6 +3317,35 @@ mod tests {
         let parsed = parse_predicate(&predicate_tokens)?;
 
         assert_eq!(parsed, PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_behold_or_controlled_subtype_as_cast(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line(
+            "If you revealed a Dragon card or controlled a Dragon as you cast this spell",
+            0,
+        )?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::Or(
+                Box::new(PredicateAst::ThisSpellPaidLabel("Behold".to_string())),
+                Box::new(PredicateAst::PlayerControls {
+                    player: PlayerAst::You,
+                    filter: ObjectFilter::default()
+                        .with_subtype(parse_subtype_word("dragon").expect("dragon subtype")),
+                }),
+            )
+        );
         Ok(())
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -14264,6 +14264,97 @@ fn parse_instead_if_control_keeps_prior_damage_target() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn foul_tongue_invocation_strict_parse_regression() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Foul-Tongue Invocation")
+        .parse_text(
+            "As an additional cost to cast this spell, you may reveal a Dragon card from your hand.\n\
+Target player sacrifices a creature of their choice. If you revealed a Dragon card or controlled a Dragon as you cast this spell, you gain 4 life.",
+        )
+        .expect("Foul-Tongue Invocation should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("target player sacrifices a creature")
+            && rendered.contains("if this spell's behold cost was paid or you control a dragon")
+            && rendered.contains("you gain 4 life"),
+        "expected Foul-Tongue Invocation to render behold-or-control condition, got {rendered}"
+    );
+}
+
+#[test]
+fn foul_tongue_invocation_condition_fails_without_behold_or_dragon_control() {
+    let def = parse_oracle_card_definition("Foul-Tongue Invocation");
+    let condition = def
+        .spell_effect
+        .as_ref()
+        .and_then(|effects| {
+            effects.iter().find_map(|effect| {
+                effect
+                    .downcast_ref::<crate::effects::ConditionalEffect>()
+                    .map(|conditional| conditional.condition.clone())
+            })
+        })
+        .expect("Foul-Tongue Invocation should lower a conditional life-gain clause");
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(
+        &def,
+        crate::PlayerId::from_index(0),
+        crate::zone::Zone::Stack,
+    );
+    let condition_matches = crate::condition_eval::evaluate_condition_cast_time(
+        &game,
+        &condition,
+        crate::PlayerId::from_index(0),
+        source,
+    );
+
+    assert!(
+        !condition_matches,
+        "Foul-Tongue Invocation life-gain condition should fail without a behold payment or controlled Dragon"
+    );
+}
+
+#[test]
+fn foul_tongue_invocation_condition_matches_when_behold_label_was_paid() {
+    let def = parse_oracle_card_definition("Foul-Tongue Invocation");
+    let condition = def
+        .spell_effect
+        .as_ref()
+        .and_then(|effects| {
+            effects.iter().find_map(|effect| {
+                effect
+                    .downcast_ref::<crate::effects::ConditionalEffect>()
+                    .map(|conditional| conditional.condition.clone())
+            })
+        })
+        .expect("Foul-Tongue Invocation should lower a conditional life-gain clause");
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(
+        &def,
+        crate::PlayerId::from_index(0),
+        crate::zone::Zone::Stack,
+    );
+    game.object_mut(source)
+        .expect("source spell object should exist")
+        .optional_costs_paid
+        .mark_label_paid("Behold");
+    let condition_matches = crate::condition_eval::evaluate_condition_cast_time(
+        &game,
+        &condition,
+        crate::PlayerId::from_index(0),
+        source,
+    );
+
+    assert!(
+        condition_matches,
+        "Foul-Tongue Invocation life-gain condition should pass when its Behold label is marked paid"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_instead_if_control_omitted_target_reuses_prior_damage_target() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Invasive Maneuvers Variant")
         .parse_text(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Foul-Tongue Invocation
Initial parse error:
```
unsupported predicate (predicate: 'you revealed dragon card or controlled dragon as you cast this spell'); oracle-only fallback also failed: unsupported predicate (predicate: 'you revealed dragon card or controlled dragon as you cast this spell')
```

Worker: i-0f8bd2f4ebea88ca1
