### PR TITLE
Fix Ironsmith parse failure: Eruth, Tormented Prophet

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -599,6 +599,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_reduced_maximum_hand_size_line),
         single_static_ability_ast_rule!(parse_effect_discard_to_library_replacement_line),
         single_static_ability_ast_rule!(parse_draw_replace_exile_top_face_down_line),
+        single_static_ability_ast_rule!(parse_draw_replacement_exile_top_and_play_line),
         single_static_ability_ast_rule!(parse_draw_replacement_double_line),
         single_static_ability_ast_rule!(parse_keyword_action_replacement_line),
         single_static_ability_ast_rule!(parse_exile_to_exile_instead_of_graveyard_line),
@@ -7855,6 +7856,42 @@ pub(crate) fn parse_draw_replace_exile_top_face_down_line(
     }
 
     Ok(None)
+}
+
+pub(crate) fn parse_draw_replacement_exile_top_and_play_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = parser_token_word_refs(tokens);
+    if words.len() < 20 {
+        return Ok(None);
+    }
+
+    if !slice_starts_with(&words, &["if", "you", "would", "draw", "a", "card", "exile", "the", "top"])
+    {
+        return Ok(None);
+    }
+
+    let Some(count_word) = words.get(9).copied() else {
+        return Ok(None);
+    };
+    let Some(count) = parse_named_number(count_word) else {
+        return Ok(None);
+    };
+
+    if !matches!(words.get(10).copied(), Some("card" | "cards")) {
+        return Ok(None);
+    }
+
+    let tail = [
+        "of", "your", "library", "instead", "you", "may", "play", "those", "cards", "this", "turn",
+    ];
+    if words.get(11..22) != Some(&tail[..]) || words.len() != 22 {
+        return Ok(None);
+    }
+
+    Ok(Some(StaticAbility::draw_replacement_exile_top_and_play(
+        count,
+    )))
 }
 
 pub(crate) fn parse_draw_replacement_double_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1798,6 +1798,23 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if matches!(
         filtered.as_slice(),
+        ["you", "would", "draw", "a", "card"]
+            | ["you", "would", "draw", "card"]
+            | ["an", "opponent", "would", "draw", "a", "card"]
+            | ["an", "opponent", "would", "draw", "card"]
+            | ["opponent", "would", "draw", "a", "card"]
+            | ["opponent", "would", "draw", "card"]
+    ) {
+        let player = if filtered[0] == "you" {
+            PlayerAst::You
+        } else {
+            PlayerAst::Opponent
+        };
+        return Ok(PredicateAst::PlayerWouldDrawCard { player });
+    }
+
+    if matches!(
+        filtered.as_slice(),
         ["opponent", "would", "begin", "extra", "turn"]
             | ["an", "opponent", "would", "begin", "an", "extra", "turn"]
             | ["opponents", "would", "begin", "extra", "turn"]
@@ -3240,6 +3257,21 @@ mod tests {
                 player: PlayerAst::Opponent,
             }
         );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_you_would_draw_card() -> Result<(), CardTextError> {
+        let tokens = lex_line("If you would draw a card", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(parsed, PredicateAst::PlayerWouldDrawCard { player: PlayerAst::You });
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -488,6 +488,14 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::YouHaveNoCardsInHand => {
             Condition::Not(Box::new(Condition::CardsInHandOrMore(1)))
         }
+        PredicateAst::PlayerWouldDrawCard { player } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::Custom(match player {
+                PlayerFilter::You => "you_would_draw_card",
+                PlayerFilter::Opponent => "opponent_would_draw_card",
+                _ => "player_would_draw_card",
+            })
+        }
         PredicateAst::PlayerWouldBeginExtraTurn { player } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::Custom(match player {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -488,6 +488,9 @@ pub(crate) enum PredicateAst {
     },
     OpponentLostLifeThisTurn,
     YouHaveNoCardsInHand,
+    PlayerWouldDrawCard {
+        player: PlayerAst,
+    },
     PlayerWouldBeginExtraTurn {
         player: PlayerAst,
     },

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -208,6 +208,7 @@ pub enum StaticAbilityId {
     CastThisCardFromLibraryWhileSearching,
     EffectDiscardToLibraryReplacement,
     DrawReplacementExileTopFaceDown,
+    DrawReplacementExileTopAndPlay,
     DrawReplacementDouble,
     KeywordActionReplacement,
     ExileToCounteredExileInsteadOfGraveyard,
@@ -445,6 +446,7 @@ impl StaticAbilityId {
             | CastThisCardFromLibraryWhileSearching
             | EffectDiscardToLibraryReplacement
             | DrawReplacementExileTopFaceDown
+            | DrawReplacementExileTopAndPlay
             | DrawReplacementDouble
             | KeywordActionReplacement
             | ExileToCounteredExileInsteadOfGraveyard

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3185,6 +3185,14 @@ impl<
         }
     }
 
+    pub fn draw_replacement_exile_top_and_play(count: u32) -> Self {
+        Self {
+            id: Some(StaticAbilityId::DrawReplacementExileTopAndPlay),
+            label: format!("draw replacement exile top {count} and play"),
+            payload: StaticAbilityPayload::None,
+        }
+    }
+
     pub fn keyword_action_replacement(
         action: KeywordActionKind,
         source_filter: ObjectFilter,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39715,3 +39715,60 @@ fn rayami_first_of_the_fallen_parses_and_renders_blood_counter_replacement() {
         "expected would-die replacement text, got {rendered}"
     );
 }
+
+#[test]
+fn eruth_tormented_prophet_parses_strictly_as_draw_replacement() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Eruth, Tormented Prophet")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(2, 4))
+        .parse_text(
+            "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
+        )
+        .expect("Eruth, Tormented Prophet oracle text should parse");
+    let static_ids = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        static_ids.contains(&StaticAbilityId::DrawReplacementExileTopAndPlay),
+        "expected Eruth replacement static ability, got {static_ids:?}"
+    );
+}
+
+#[test]
+fn eruth_tormented_prophet_compiled_text_keeps_replacement_and_play_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Eruth, Tormented Prophet")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(2, 4))
+        .parse_text(
+            "If you would draw a card, exile the top two cards of your library instead. You may play those cards this turn.",
+        )
+        .expect("Eruth, Tormented Prophet oracle text should parse");
+    let rendered = unprocessed_compiled_lines(&def).join("\n").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("if you would draw a card, exile the top 2 cards of your library instead"),
+        "expected replacement clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("you may play those cards this turn"),
+        "expected play-permission clause in compiled text, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -179,6 +179,9 @@ impl StaticAbility {
             Some(StaticAbilityId::DrawReplacementExileTopFaceDown) => {
                 Self::draw_replacement_exile_top_face_down()
             }
+            Some(StaticAbilityId::DrawReplacementExileTopAndPlay) => {
+                Self::draw_replacement_exile_top_and_play(2)
+            }
             Some(StaticAbilityId::DrawReplacementDouble) => Self::draw_replacement_double(),
             Some(StaticAbilityId::ExileWouldDieInstead) => {
                 Self::exile_would_die_instead(crate::target::ObjectFilter::creature())

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3766,6 +3766,70 @@ impl StaticAbilityKind for DrawReplacementDouble {
     }
 }
 
+/// "If you would draw a card, exile the top N cards of your library instead. You may play those
+/// cards this turn."
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrawReplacementExileTopAndPlay {
+    pub count: u32,
+}
+
+impl DrawReplacementExileTopAndPlay {
+    pub fn new(count: u32) -> Self {
+        Self { count }
+    }
+}
+
+impl StaticAbilityKind for DrawReplacementExileTopAndPlay {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::DrawReplacementExileTopAndPlay
+    }
+
+    fn display(&self) -> String {
+        let cards = if self.count == 1 { "card" } else { "cards" };
+        format!(
+            "If you would draw a card, exile the top {} {} of your library instead. You may play those cards this turn.",
+            self.count, cards
+        )
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        const TOP_CARDS_TAG: &str = "draw_replacement_top_cards";
+
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            WouldDrawCardMatcher::you(),
+            ReplacementAction::Instead(vec![
+                Effect::new(
+                    crate::effects::ChooseObjectsEffect::new(
+                        ObjectFilter::default()
+                            .in_zone(Zone::Library)
+                            .owned_by(PlayerFilter::You),
+                        self.count as usize,
+                        PlayerFilter::You,
+                        TOP_CARDS_TAG,
+                    )
+                    .top_only(),
+                ),
+                Effect::new(crate::effects::ExileEffect::with_spec(ChooseSpec::tagged(
+                    TOP_CARDS_TAG,
+                ))),
+                Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+                    TOP_CARDS_TAG,
+                    PlayerFilter::You,
+                    crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn,
+                    true,
+                    false,
+                )),
+            ]),
+        ))
+    }
+}
+
 /// "If [object] would [keyword action], instead [effects]."
 #[derive(Debug, Clone, PartialEq)]
 pub struct KeywordActionReplacement {
@@ -4822,6 +4886,33 @@ mod tests {
             format!("{:?}", effects[0]).contains("DrawCardsEffect"),
             "expected nested draw effect, got {:?}",
             effects[0]
+        );
+    }
+
+    #[test]
+    fn test_draw_replacement_exile_top_and_play_sequence() {
+        let ability = DrawReplacementExileTopAndPlay::new(2);
+        assert_eq!(ability.id(), StaticAbilityId::DrawReplacementExileTopAndPlay);
+
+        let replacement = ability
+            .generate_replacement_effect(ObjectId::from_raw(1), PlayerId::from_index(0))
+            .expect("draw replacement should create replacement effect");
+        let ReplacementAction::Instead(effects) = replacement.replacement else {
+            panic!("expected draw replacement to use an Instead action");
+        };
+
+        assert_eq!(effects.len(), 3, "expected choose+exile+grant sequence");
+        assert!(
+            ability.display().contains("top 2 cards"),
+            "expected display text to keep top-two count"
+        );
+        assert!(
+            format!("{:?}", effects[0]).contains("draw_replacement_top_cards"),
+            "expected choose effect to tag exiled cards for follow-up play permission"
+        );
+        assert!(
+            format!("{:?}", effects[2]).contains("GrantPlayTaggedEffect"),
+            "expected final effect to grant play permission"
         );
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2663,6 +2663,10 @@ impl StaticAbility {
         Self::new(DrawReplacementDouble)
     }
 
+    pub fn draw_replacement_exile_top_and_play(count: u32) -> Self {
+        Self::new(DrawReplacementExileTopAndPlay::new(count))
+    }
+
     pub fn keyword_action_replacement(
         action: crate::events::KeywordActionKind,
         source_filter: crate::target::ObjectFilter,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Eruth, Tormented Prophet
Initial parse error:
```
unsupported predicate (predicate: 'you would draw card'); oracle-only fallback also failed: unsupported predicate (predicate: 'you would draw card')
```

Worker: i-0a31bfa398896f1fa
