### PR TITLE
Fix Ironsmith parse failure: Archipelagore

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -52,6 +52,7 @@ pub(super) enum KeywordDispatchHint {
     Madness,
     Escape,
     MorphFamily,
+    Mutate,
     Squad,
     Transmute,
     CastThisSpellOnly,
@@ -142,6 +143,12 @@ mod activated_keywords {
             hints: &[KeywordDispatchHint::MorphFamily],
             matches: registry::matches_morph,
             lower: registry::lower_morph,
+        },
+        KeywordLineRule {
+            cst_kind: super::super::cst::KeywordLineKindCst::Mutate,
+            hints: &[KeywordDispatchHint::Mutate],
+            matches: registry::matches_mutate,
+            lower: registry::lower_mutate,
         },
         KeywordLineRule {
             cst_kind: super::super::cst::KeywordLineKindCst::Transmute,
@@ -343,6 +350,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
                     grammar::kw("morph").value(KeywordDispatchHint::MorphFamily),
                     grammar::kw("megamorph").value(KeywordDispatchHint::MorphFamily),
                     grammar::kw("disguise").value(KeywordDispatchHint::MorphFamily),
+                    grammar::kw("mutate").value(KeywordDispatchHint::Mutate),
                 )),
                 grammar::kw("squad").value(KeywordDispatchHint::Squad),
                 grammar::kw("transmute").value(KeywordDispatchHint::Transmute),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -429,6 +429,24 @@ pub(super) fn lower_morph(
     )?))
 }
 
+pub(super) fn lower_mutate(
+    line: &RewriteKeywordLine,
+    tokens: &[OwnedLexToken],
+) -> Result<LineAst, CardTextError> {
+    let cost_tokens = tokens.get(1..).unwrap_or_default();
+    let (cost, _) = leading_mana_cost_from_tokens(cost_tokens).ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "rewrite keyword lowering could not parse mutate line '{}'",
+            line.info.raw_line
+        ))
+    })?;
+
+    Ok(LineAst::StaticAbility(
+        crate::static_abilities::StaticAbility::keyword_marker(format!("Mutate {}", cost.to_oracle()))
+            .into(),
+    ))
+}
+
 pub(super) fn lower_multikicker(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
@@ -816,6 +834,16 @@ pub(super) fn matches_morph(
     tokens: &[OwnedLexToken],
 ) -> Result<bool, CardTextError> {
     Ok(parse_morph_keyword_line_lexed(tokens)?.is_some())
+}
+
+pub(super) fn matches_mutate(
+    _line: &PreprocessedLine,
+    tokens: &[OwnedLexToken],
+) -> Result<bool, CardTextError> {
+    if !tokens.first().is_some_and(|token| token.is_word("mutate")) {
+        return Ok(false);
+    }
+    Ok(leading_mana_cost_from_tokens(tokens.get(1..).unwrap_or_default()).is_some())
 }
 
 pub(super) fn matches_squad(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -54,6 +54,7 @@ pub(crate) enum KeywordLineKindCst {
     Kicker,
     Madness,
     Morph,
+    Mutate,
     Multikicker,
     Replicate,
     Offspring,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -13191,6 +13191,64 @@ fn test_zagoth_mamba_mutates_trigger_condition() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_archipelagore_mutate_keyword_and_trigger_condition() {
+    use crate::ability::AbilityKind;
+    use crate::cards::CardDefinitionBuilder;
+    use crate::events::other::{BecameMonstrousEvent, MutatedEvent};
+    use crate::triggers::check_triggers;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let archipelagore_def = CardDefinitionBuilder::new(CardId::from_raw(1), "Archipelagore")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Mutate {5}{U}\nWhenever this creature mutates, tap up to X target creatures your opponents control, where X is the number of times this creature has mutated. Those creatures don't untap during their controller's next untap step.",
+        )
+        .expect("Archipelagore should parse");
+    let archipelagore_id =
+        game.create_object_from_definition(&archipelagore_def, alice, Zone::Battlefield);
+
+    let archipelagore = game
+        .object(archipelagore_id)
+        .expect("Archipelagore permanent exists");
+    let has_mutates_trigger = archipelagore.abilities.iter().any(|ability| {
+        if let AbilityKind::Triggered(triggered) = &ability.kind {
+            triggered.trigger.display().contains("mutates")
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_mutates_trigger,
+        "Archipelagore should have a mutates triggered ability"
+    );
+
+    let mutate_event = TriggerEvent::new_with_provenance(
+        MutatedEvent::new(archipelagore_id, alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mutate_triggers = check_triggers(&game, &mutate_event);
+    assert_eq!(
+        mutate_triggers.len(),
+        1,
+        "MutatedEvent should trigger Archipelagore's ability"
+    );
+
+    let monstrous_event = TriggerEvent::new_with_provenance(
+        BecameMonstrousEvent::new(archipelagore_id, alice, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let monstrous_triggers = check_triggers(&game, &monstrous_event);
+    assert_eq!(
+        monstrous_triggers.len(),
+        0,
+        "BecameMonstrousEvent should not trigger Archipelagore's mutates ability"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_anger_grants_haste_from_graveyard_when_you_control_mountain() {
     use crate::card::PowerToughness;
     use crate::cards::CardDefinitionBuilder;

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1024,6 +1024,41 @@ fn compile_oracle_text_strictly_compiles_zagoth_mamba_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_archipelagore_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(cards_path.exists(), "expected workspace cards.json at {cards_path:?}");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Archipelagore")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Archipelagore --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Archipelagore should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Archipelagore"), "{stdout}");
+    assert!(stdout.contains("Mutate {5}{U}"), "{stdout}");
+    assert!(
+        stdout.contains("tap up to X target creatures"),
+        "expected mutate trigger tap clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_sakashimas_will_with_choose_both_instead_clause() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Archipelagore
Initial parse error:
```
parser does not yet support line family: 'Mutate {5}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)'; oracle-only fallback also failed: parser does not yet support line family: 'Mutate {5}{U}'
```

Worker: i-03941c9547439640b
