### PR TITLE
Fix Ironsmith parse failure: Mindleecher

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -354,6 +354,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
             winnow::combinator::alt((
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),
                 grammar::kw("warp").value(KeywordDispatchHint::Warp),
+                grammar::kw("mutate").value(KeywordDispatchHint::AlternativeOrExertFamily),
                 grammar::kw("escalate").value(KeywordDispatchHint::Escalate),
                 grammar::kw("evoke").value(KeywordDispatchHint::Evoke),
                 grammar::kw("epic").value(KeywordDispatchHint::Epic),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -37,7 +37,8 @@ use super::util::{
     parse_flash_with_additional_cost_line_lexed, parse_flashback_line_lexed,
     parse_harmonize_line_lexed, parse_if_conditional_alternative_cost_line_lexed,
     parse_jump_start_line_lexed, parse_kicker_line_lexed, parse_madness_line_lexed,
-    parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_offspring_line_lexed,
+    parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_mutate_line_lexed,
+    parse_offspring_line_lexed,
     parse_reinforce_line_lexed, parse_replicate_line_lexed, parse_retrace_line_lexed,
     parse_self_free_cast_alternative_cost_line_lexed, parse_squad_line_lexed,
     parse_transmute_line_lexed, parse_warp_line_lexed,
@@ -265,6 +266,9 @@ pub(super) fn lower_alternative_cast(
     if let Some(method) =
         parse_if_conditional_alternative_cost_line_lexed(tokens, line.text.as_str())?
     {
+        return Ok(LineAst::AlternativeCastingMethod(method.into()));
+    }
+    if let Some(method) = parse_mutate_line_lexed(tokens)? {
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     Err(CardTextError::ParseError(format!(
@@ -911,6 +915,7 @@ fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTex
             || parse_jump_start_line_lexed(tokens)?.is_some()
             || parse_if_conditional_alternative_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()
+            || parse_mutate_line_lexed(tokens)?.is_some()
             || parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)?.is_some(),
     )
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4722,6 +4722,23 @@ pub(crate) fn parse_bestow_line_lexed(
     parse_bestow_line(tokens)
 }
 
+pub(crate) fn parse_mutate_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    if !tokens.first().is_some_and(|token| token.is_word("mutate")) {
+        return Ok(None);
+    }
+
+    let (mana_cost, _) = leading_mana_cost_from_tokens(tokens.get(1..).unwrap_or_default())
+        .ok_or_else(|| CardTextError::ParseError("mutate keyword missing mana cost".to_string()))?;
+
+    Ok(Some(AlternativeCastingMethod::alternative_cost(
+        "Mutate",
+        Some(mana_cost),
+        Vec::new(),
+    )))
+}
+
 pub(crate) fn parse_blitz_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -414,6 +414,18 @@ pub(crate) fn parse_exile_top_library_clause(
 
     let owner_tokens = trim_commas(&after_cards[1..]);
     let owner_words = crate::runtime_backend::token_word_refs(&owner_tokens);
+    if slice_starts_with(&owner_words, &["each", "opponent", "library"])
+        || slice_starts_with(&owner_words, &["each", "opponents", "library"])
+    {
+        return Some(EffectAst::ForEachOpponent {
+            effects: vec![EffectAst::subject_verb_exile_top_of_library(
+                PlayerAst::That,
+                count,
+                vec![helper_tag_for_tokens(&tokens, "exiled")],
+                Vec::new(),
+            )],
+        });
+    }
     let default_player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
     let (player, used_words) = parse_library_owner_prefix(&owner_words, default_player)?;
     if used_words < owner_words.len() {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -326,6 +326,29 @@ pub(crate) fn parse_look(
         .map(String::as_str)
         .collect::<Vec<_>>();
 
+    if clause_words.as_slice()
+        == [
+            "and",
+            "play",
+            "those",
+            "cards",
+            "for",
+            "as",
+            "long",
+            "as",
+            "they",
+            "remain",
+            "exiled",
+        ]
+    {
+        return Ok(EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+            TagKey::from(IT_TAG),
+            PlayerAst::You,
+            true,
+            false,
+        ));
+    }
+
     let mut hand_tokens = clause_tokens.clone();
     while hand_tokens
         .first()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -13191,6 +13191,63 @@ fn test_zagoth_mamba_mutates_trigger_condition() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_mindleecher_mutates_trigger_condition() {
+    use crate::ability::AbilityKind;
+    use crate::cards::CardDefinitionBuilder;
+    use crate::events::other::{BecameMonstrousEvent, MutatedEvent};
+    use crate::triggers::check_triggers;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let mindleecher_def = CardDefinitionBuilder::new(CardId::from_raw(2), "Mindleecher")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Mutate {4}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)\nWhenever this creature mutates, exile the top card of each opponent's library face down. You may look at and play those cards for as long as they remain exiled.",
+        )
+        .expect("Mindleecher should parse");
+    let mindleecher_id = game.create_object_from_definition(&mindleecher_def, alice, Zone::Battlefield);
+
+    let mindleecher = game
+        .object(mindleecher_id)
+        .expect("mindleecher permanent exists");
+    let has_mutates_trigger = mindleecher.abilities.iter().any(|ability| {
+        if let AbilityKind::Triggered(triggered) = &ability.kind {
+            triggered.trigger.display().contains("mutates")
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_mutates_trigger,
+        "Mindleecher should have a mutates triggered ability"
+    );
+
+    let mutate_event = TriggerEvent::new_with_provenance(
+        MutatedEvent::new(mindleecher_id, alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mutate_triggers = check_triggers(&game, &mutate_event);
+    assert_eq!(
+        mutate_triggers.len(),
+        1,
+        "MutatedEvent should trigger Mindleecher's ability"
+    );
+
+    let monstrous_event = TriggerEvent::new_with_provenance(
+        BecameMonstrousEvent::new(mindleecher_id, alice, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let monstrous_triggers = check_triggers(&game, &monstrous_event);
+    assert_eq!(
+        monstrous_triggers.len(),
+        0,
+        "BecameMonstrousEvent should not trigger Mindleecher's mutates ability"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_anger_grants_haste_from_graveyard_when_you_control_mountain() {
     use crate::card::PowerToughness;
     use crate::cards::CardDefinitionBuilder;

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1024,6 +1024,42 @@ fn compile_oracle_text_strictly_compiles_zagoth_mamba_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_mindleecher_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(cards_path.exists(), "expected workspace cards.json at {cards_path:?}");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Mindleecher")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Mindleecher --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Mindleecher should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Mindleecher"), "{stdout}");
+    assert!(stdout.contains("Similarity:"), "{stdout}");
+    assert!(stdout.contains("Mutate {4}{B}"), "{stdout}");
+    assert!(
+        stdout.contains("Whenever this creature mutates, exile the top card of each opponent's library face down."),
+        "expected mutate trigger exile clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_sakashimas_will_with_choose_both_instead_clause() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mindleecher
Initial parse error:
```
parser does not yet support line family: 'Mutate {4}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)'; oracle-only fallback also failed: parser does not yet support line family: 'Mutate {4}{B}'
```

Worker: i-0bd6b45aac2b0c433
