### PR TITLE
Fix Ironsmith parse failure: Illuna, Apex of Wishes

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/looked_cards_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/looked_cards_family.rs
@@ -18,6 +18,7 @@ use crate::cards::builders::{
 use crate::effect::Value;
 use crate::runtime_backend::grammar::primitives::TokenWordView;
 use crate::target::TaggedOpbjectRelation;
+use crate::types::CardType;
 use crate::zone::Zone;
 use ironsmith_core::{EffectMetric, EffectMetricSource, ValueSurfaceHint};
 
@@ -543,6 +544,20 @@ pub(crate) fn parse_looked_card_reveal_filter(tokens: &[OwnedLexToken]) -> Optio
         ["permanent", "card"] | ["permanent", "cards"]
     ) {
         let mut filter = ObjectFilter::permanent_card();
+        if same_name_suffix_len.is_some() {
+            filter = filter.match_tagged(
+                TagKey::from(CHOSEN_NAME_TAG),
+                TaggedOpbjectRelation::SameNameAsTagged,
+            );
+        }
+        return Some(filter);
+    }
+    if matches!(
+        non_article_words.as_slice(),
+        ["nonland", "permanent", "card"] | ["nonland", "permanent", "cards"]
+    ) {
+        let mut filter = ObjectFilter::permanent_card();
+        filter.excluded_card_types.push(CardType::Land);
         if same_name_suffix_len.is_some() {
             filter = filter.match_tagged(
                 TagKey::from(CHOSEN_NAME_TAG),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -1887,6 +1887,80 @@ pub(crate) fn parse_consult_match_into_hand_exile_others(
     Ok(Some(effects))
 }
 
+pub(crate) fn parse_consult_match_into_battlefield_or_hand(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let first = sentences[sentence_idx].lowered();
+    let second = sentences[sentence_idx + 1].lowered();
+    let Some(parts) = parse_consult_traversal_sentence(first)? else {
+        return Ok(None);
+    };
+    if !matches!(
+        parts.effects.last(),
+        Some(EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::ConsultTopOfLibrary {
+                mode: crate::cards::builders::LibraryConsultModeAst::Exile,
+                ..
+            },
+            ..
+        }))
+    ) {
+        return Ok(None);
+    }
+
+    let second_tokens = trim_commas(second);
+    let moves_to_battlefield_or_hand = crate::runtime_backend::grammar::primitives::words_match_prefix(
+        &second_tokens,
+        &[
+            "put",
+            "that",
+            "card",
+            "onto",
+            "the",
+            "battlefield",
+            "or",
+            "into",
+            "your",
+            "hand",
+        ],
+    )
+    .is_some()
+        || crate::runtime_backend::grammar::primitives::words_match_prefix(
+            &second_tokens,
+            &["put", "it", "onto", "the", "battlefield", "or", "into", "your", "hand"],
+        )
+        .is_some();
+    if !moves_to_battlefield_or_hand {
+        return Ok(None);
+    }
+
+    let mut effects = parts.effects;
+    effects.push(EffectAst::May {
+        effects: vec![EffectAst::subject_verb_move_to_zone(
+            TargetAst::Tagged(parts.match_tag.clone(), None),
+            Zone::Battlefield,
+            false,
+            ReturnControllerAst::Preserve,
+            false,
+            None,
+        )],
+    });
+    effects.push(EffectAst::IfResult {
+        predicate: IfResultPredicate::WasDeclined,
+        effects: vec![EffectAst::subject_verb_move_to_zone(
+            TargetAst::Tagged(parts.match_tag, None),
+            Zone::Hand,
+            false,
+            ReturnControllerAst::Preserve,
+            false,
+            None,
+        )],
+    });
+
+    Ok(Some(effects))
+}
+
 /// Parses the two-sentence pattern:
 ///   S1: "Reveal cards from the top of your library until you reveal a <filter> card."
 ///   S2: "Put that card into your hand and all other cards revealed this way into your graveyard."

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -588,9 +588,17 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         parser: generic_subject_verb_sequences::pairs::parse_consult_match_move_and_bottom_remainder,
     },
     SequenceRuleDef {
+        name: "consult-match-onto-battlefield-or-into-hand",
+        feature_tag: Some("consult-battlefield-or-hand"),
+        priority: 229,
+        consumed_sentences: 2,
+        predicate: first_word_target_exile_look_or_reveal,
+        parser: generic_subject_verb_sequences::pairs::parse_consult_match_into_battlefield_or_hand,
+    },
+    SequenceRuleDef {
         name: "consult-match-move-graveyard-remainder",
         feature_tag: Some("consult-graveyard-remainder"),
-        priority: 229,
+        priority: 228,
         consumed_sentences: 2,
         predicate: first_word_target_exile_look_or_reveal,
         parser: generic_subject_verb_sequences::pairs::parse_consult_match_move_all_to_graveyard,
@@ -598,7 +606,7 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
     SequenceRuleDef {
         name: "consult-match-into-hand-exile-others",
         feature_tag: Some("consult-hand-exile-others"),
-        priority: 228,
+        priority: 227,
         consumed_sentences: 2,
         predicate: first_word_target_exile_look_or_reveal,
         parser: generic_subject_verb_sequences::pairs::parse_consult_match_into_hand_exile_others,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -30190,6 +30190,41 @@ fn parse_oracle_solstice_revelations_uses_dynamic_consult_gate_with_hand_fallbac
     );
 }
 
+#[test]
+fn parse_oracle_illuna_apex_of_wishes_strictly_parses_mutate_trigger() {
+    let def = parse_oracle_card_definition("Illuna, Apex of Wishes");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Mutate {3}{R/G}{U}{U}")
+            && rendered.contains("When this creature mutates"),
+        "expected Illuna mutate keyword and mutate trigger in compiled text, got {rendered}"
+    );
+}
+
+#[test]
+fn parse_oracle_illuna_apex_of_wishes_compiles_battlefield_or_hand_clause() {
+    let def = parse_oracle_card_definition("Illuna, Apex of Wishes");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("you may put it onto the battlefield")
+            && rendered_lower.contains("return it to its owner's hand")
+            && !rendered_lower.contains("exile the top card of your library"),
+        "expected consult branch over nonland permanent and no top-card fallback text, got {rendered}"
+    );
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("ConsultTopOfLibrary")
+            && abilities_debug.contains("mode: Exile")
+            && abilities_debug.contains("MayEffect")
+            && abilities_debug.contains("WasDeclined")
+            && abilities_debug.contains("zone: Battlefield")
+            && abilities_debug.contains("zone: Hand"),
+        "expected consult + battlefield-or-hand fallback lowering, got {abilities_debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_synthesis_pod_accepts_that_exiled_card_cast_clause() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -13249,6 +13249,61 @@ fn test_archipelagore_mutate_keyword_and_trigger_condition() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_illuna_apex_of_wishes_mutate_trigger_condition() {
+    use crate::ability::AbilityKind;
+    use crate::cards::CardDefinitionBuilder;
+    use crate::events::other::{BecameMonstrousEvent, MutatedEvent};
+    use crate::triggers::check_triggers;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let illuna_def = CardDefinitionBuilder::new(CardId::from_raw(1), "Illuna, Apex of Wishes")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Mutate {3}{R/G}{U}{U}\nFlying, trample\nWhenever this creature mutates, exile cards from the top of your library until you exile a nonland permanent card. Put that card onto the battlefield or into your hand.",
+        )
+        .expect("Illuna should parse");
+    let illuna_id = game.create_object_from_definition(&illuna_def, alice, Zone::Battlefield);
+
+    let illuna = game.object(illuna_id).expect("Illuna permanent exists");
+    let has_mutates_trigger = illuna.abilities.iter().any(|ability| {
+        if let AbilityKind::Triggered(triggered) = &ability.kind {
+            triggered.trigger.display().contains("mutates")
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_mutates_trigger,
+        "Illuna should have a mutates triggered ability"
+    );
+
+    let mutate_event = TriggerEvent::new_with_provenance(
+        MutatedEvent::new(illuna_id, alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mutate_triggers = check_triggers(&game, &mutate_event);
+    assert_eq!(
+        mutate_triggers.len(),
+        1,
+        "MutatedEvent should trigger Illuna's ability"
+    );
+
+    let monstrous_event = TriggerEvent::new_with_provenance(
+        BecameMonstrousEvent::new(illuna_id, alice, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let monstrous_triggers = check_triggers(&game, &monstrous_event);
+    assert_eq!(
+        monstrous_triggers.len(),
+        0,
+        "BecameMonstrousEvent should not trigger Illuna's mutates ability"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_anger_grants_haste_from_graveyard_when_you_control_mountain() {
     use crate::card::PowerToughness;
     use crate::cards::CardDefinitionBuilder;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Illuna, Apex of Wishes
Initial parse error:
```
parser does not yet support line family: 'Mutate {3}{R/G}{U}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)'; oracle-only fallback also failed: parser does not yet support line family: 'Mutate {3}{R/G}{U}{U}'
```

Worker: i-0ee262e7f1938707a
