### PR TITLE
Fix Ironsmith parse failure: Elsewhere Flask

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -1125,17 +1125,35 @@ pub(crate) fn parse_choose_creature_type_then_become_type(
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
     let first_tokens = trim_commas(first);
     let first_words = crate::runtime_backend::token_word_refs(&first_tokens);
-    let Some((consumed, excluded_subtypes)) =
+    enum ChoiceKind {
+        CreatureType { excluded_subtypes: Vec<Subtype> },
+        BasicLandType,
+    }
+
+    let choice_kind = if let Some((consumed, excluded_subtypes)) =
         parse_choose_creature_type_phrase_words(&first_words)?
-    else {
+    {
+        if consumed != first_words.len() {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported creature-type choice clause (clause: '{}')",
+                first_words.join(" ")
+            )));
+        }
+        Some(ChoiceKind::CreatureType { excluded_subtypes })
+    } else if let Some(consumed) = parse_choose_basic_land_type_phrase_words(&first_words) {
+        if consumed != first_words.len() {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported basic-land-type choice clause (clause: '{}')",
+                first_words.join(" ")
+            )));
+        }
+        Some(ChoiceKind::BasicLandType)
+    } else {
+        None
+    };
+    let Some(choice_kind) = choice_kind else {
         return Ok(None);
     };
-    if consumed != first_words.len() {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported creature-type choice clause (clause: '{}')",
-            first_words.join(" ")
-        )));
-    }
 
     let second_words = crate::runtime_backend::token_word_refs(second);
     let Some(become_idx) = find_index(second, |token| {
@@ -1189,9 +1207,16 @@ pub(crate) fn parse_choose_creature_type_then_become_type(
         parse_target_phrase(&subject_tokens)?
     };
 
-    Ok(Some(vec![
-        EffectAst::subject_verb_become_creature_type_choice(target, duration, excluded_subtypes),
-    ]))
+    let effect = match choice_kind {
+        ChoiceKind::CreatureType { excluded_subtypes } => {
+            EffectAst::subject_verb_become_creature_type_choice(target, duration, excluded_subtypes)
+        }
+        ChoiceKind::BasicLandType => {
+            EffectAst::subject_verb_become_basic_land_type_choice(target, duration)
+        }
+    };
+
+    Ok(Some(vec![effect]))
 }
 
 pub(crate) fn parse_sentence_target_player_chooses_then_puts_on_top_of_library(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -29219,6 +29219,34 @@ fn parse_choose_creature_type_then_each_creature_becomes_that_type() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_elsewhere_flask_strictly_compiles_choose_basic_land_type_then_that_type_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(610_618), "Elsewhere Flask")
+        .card_types(vec![CardType::Artifact])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .parse_text(
+            "When this artifact enters, draw a card.\nSacrifice this artifact: Choose a basic land type. Each land you control becomes that type until end of turn.",
+        )
+        .expect("Elsewhere Flask should parse strictly");
+
+    let abilities_debug = format!("{:#?}", def.abilities).to_ascii_lowercase();
+    assert!(
+        abilities_debug.contains("becomebasiclandtypechoiceeffect"),
+        "expected Elsewhere Flask to lower to become-basic-land-type-choice effect, got {abilities_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("sacrifice this artifact")
+            && rendered.contains("choose a basic land type")
+            && rendered.contains("each land you control becomes that type until end of turn"),
+        "expected compiled text to cover Elsewhere Flask's land-type-changing clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_standalone_choose_creature_type_effect() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Creature Type Choice Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28015,8 +28015,8 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             ChooseSpec::Object(filter) => describe_choose_spec(&ChooseSpec::All(filter.clone())),
             other => describe_choose_spec(other),
         };
+        let plural_subject = target.starts_with("all ") || target.starts_with("those ");
         if let Some(subtype) = become_basic.fixed_subtype {
-            let plural_subject = target.starts_with("all ") || target.starts_with("those ");
             let subtype_text = if plural_subject {
                 pluralize_noun_phrase(&subtype.to_string())
             } else {
@@ -28035,15 +28035,23 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_until(&become_basic.duration),
             );
         }
+        let subject_text = describe_each_object_subject(&become_basic.target)
+            .unwrap_or_else(|| describe_choose_spec(&become_basic.target));
+        let subject_text = subject_text.replacen("Each a ", "Each ", 1);
+        let verb = if subject_text.starts_with("Each ") {
+            "becomes"
+        } else if plural_subject {
+            "become"
+        } else {
+            "becomes"
+        };
         if become_basic.duration == Until::EndOfTurn {
             return format!(
-                "{} becomes the basic land type of your choice until end of turn",
-                target
+                "Choose a basic land type. {subject_text} {verb} that type until end of turn"
             );
         }
         return format!(
-            "{} becomes the basic land type of your choice {}",
-            target,
+            "Choose a basic land type. {subject_text} {verb} that type {}",
             describe_until(&become_basic.duration)
         );
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26005,6 +26005,115 @@ fn test_the_stasis_coffin_activation_grants_protection_and_exiles_itself() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_elsewhere_flask_activation_changes_land_type_until_cleanup() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::decision::compute_legal_actions;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let elsewhere_flask = CardDefinitionBuilder::new(CardId::new(), "Elsewhere Flask")
+        .card_types(vec![CardType::Artifact])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .parse_text(
+            "When this artifact enters, draw a card.\nSacrifice this artifact: Choose a basic land type. Each land you control becomes that type until end of turn.",
+        )
+        .expect("Elsewhere Flask should parse");
+    let flask_id = game.create_object_from_definition(&elsewhere_flask, alice, Zone::Battlefield);
+
+    let forest_id = game.create_object_from_definition(&crate::cards::definitions::basic_forest(), alice, Zone::Battlefield);
+    let island_id = game.create_object_from_definition(&crate::cards::definitions::basic_island(), alice, Zone::Battlefield);
+
+    let ability_index = game
+        .object(flask_id)
+        .expect("Elsewhere Flask should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Elsewhere Flask should have an activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == flask_id && *idx == ability_index
+            )
+        })
+        .expect("Elsewhere Flask activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("activating Elsewhere Flask should succeed");
+
+    let progress = match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectOptions(cost_ctx),
+        ) => apply_priority_response_with_dm(
+            &mut game,
+            &mut trigger_queue,
+            &mut state,
+            &PriorityResponse::NextCostChoice(cost_ctx.options[0].index),
+            &mut dm,
+        )
+        .expect("choosing Elsewhere Flask cost option should continue activation"),
+        other => other,
+    };
+    assert!(
+        matches!(
+            progress,
+            crate::decision::GameProgress::Continue
+                | crate::decision::GameProgress::NeedsDecisionCtx(
+                    crate::decisions::context::DecisionContext::Priority(_)
+                )
+        ),
+        "Elsewhere Flask activation should proceed after any cost choices, got {progress:?}"
+    );
+
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Elsewhere Flask ability should resolve");
+
+    assert!(
+        !game.battlefield.contains(&flask_id),
+        "Elsewhere Flask should be sacrificed to pay the activation cost"
+    );
+
+    let forest_subtypes = game.calculated_subtypes(forest_id);
+    assert!(
+        !forest_subtypes.contains(&Subtype::Forest),
+        "Elsewhere Flask should change at least one controlled land's basic subtype until end of turn; got {forest_subtypes:?}"
+    );
+
+    execute_cleanup_step(&mut game);
+
+    let forest_after_cleanup = game.calculated_subtypes(forest_id);
+    let island_after_cleanup = game.calculated_subtypes(island_id);
+    assert!(
+        forest_after_cleanup.contains(&Subtype::Forest),
+        "Forest should regain its original subtype after until-end-of-turn expires"
+    );
+    assert!(
+        island_after_cleanup.contains(&Subtype::Island),
+        "Island should regain its original subtype after until-end-of-turn expires"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_cephalid_inkshrouder_grants_shroud_and_unblockable_after_discard() {
     use crate::PriorityResponse;
     use crate::cards::builders::CardDefinitionBuilder;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Elsewhere Flask
Initial parse error:
```
unsupported become clause (clause: 'that type until end of turn'); oracle-only fallback also failed: unsupported become clause (clause: 'that type until end of turn')
```

Worker: i-03fbd1d0c0d90fc06
