### PR TITLE
Fix Ironsmith parse failure: Ardenvale Paladin

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -184,12 +184,12 @@ fn lower_rewrite_statement_to_chunks_impl(
         for group_tokens in parse_groups {
             if let Some(chunk) = parse_day_night_starts_day_static_chunk(group_tokens) {
                 chunks.push(chunk);
-            } else if statement_group_should_parse_as_effects_first(group_tokens) {
-                let effects = parse_effect_sentences_lexed(group_tokens)?;
-                chunks.push(LineAst::Statement { effects });
             } else if let Some(chunk) = parse_self_enters_with_x_counters_static_chunk(group_tokens)
             {
                 chunks.push(chunk);
+            } else if statement_group_should_parse_as_effects_first(group_tokens) {
+                let effects = parse_effect_sentences_lexed(group_tokens)?;
+                chunks.push(LineAst::Statement { effects });
             } else if let Some(chunk) = parse_day_night_starts_day_static_chunk(group_tokens) {
                 chunks.push(chunk);
             } else if let Some(abilities) = parse_static_ability_ast_line_lexed(group_tokens)? {
@@ -241,13 +241,13 @@ fn lower_rewrite_statement_to_chunks_impl(
             for group_tokens in grouped_tokens {
                 if let Some(chunk) = parse_day_night_starts_day_static_chunk(&group_tokens) {
                     chunks.push(chunk);
-                } else if statement_group_should_parse_as_effects_first(&group_tokens) {
-                    let effects = parse_effect_sentences_lexed(&group_tokens)?;
-                    chunks.push(LineAst::Statement { effects });
                 } else if let Some(chunk) =
                     parse_self_enters_with_x_counters_static_chunk(&group_tokens)
                 {
                     chunks.push(chunk);
+                } else if statement_group_should_parse_as_effects_first(&group_tokens) {
+                    let effects = parse_effect_sentences_lexed(&group_tokens)?;
+                    chunks.push(LineAst::Statement { effects });
                 } else if let Some(chunk) = parse_day_night_starts_day_static_chunk(&group_tokens) {
                     chunks.push(chunk);
                 } else if let Some(abilities) = parse_static_ability_ast_line_lexed(&group_tokens)?
@@ -409,6 +409,68 @@ fn parse_self_enters_with_x_counters_static_chunk(tokens: &[OwnedLexToken]) -> O
         .trim()
         .trim_end_matches('.')
         .to_string();
+    let enters_with_single_counter = normalized == "this creature enters with a +1/+1 counter on it"
+        || normalized == "this permanent enters with a +1/+1 counter on it"
+        || normalized == "it enters with a +1/+1 counter on it";
+    if enters_with_single_counter {
+        return Some(LineAst::StaticAbilities(vec![
+            crate::cards::builders::StaticAbilityAst::Static(StaticAbility::enters_with_counters_value(
+                crate::object::CounterType::PlusOnePlusOne,
+                crate::effect::Value::Fixed(1),
+            )),
+        ]));
+    }
+
+    if let Some((predicate, effect)) = normalized.split_once(',') {
+        let effect = effect.trim();
+        let is_single_counter_effect = effect == "this creature enters with a +1/+1 counter on it"
+            || effect == "this permanent enters with a +1/+1 counter on it"
+            || effect == "it enters with a +1/+1 counter on it";
+        if is_single_counter_effect {
+            let predicate_text = predicate.trim();
+            let predicate_body = predicate_text
+                .strip_prefix("if ")
+                .or_else(|| predicate_text.rsplit_once(" if ").map(|(_, tail)| tail))?;
+            let predicate_words = predicate_body
+                .split_whitespace()
+                .collect::<Vec<_>>();
+            if predicate_words.len() == 11
+                && predicate_words[0] == "at"
+                && predicate_words[1] == "least"
+                && predicate_words[4] == "mana"
+                && matches!(predicate_words[5], "was" | "were")
+                && predicate_words[6] == "spent"
+                && predicate_words[7] == "to"
+                && predicate_words[8] == "cast"
+                && predicate_words[9] == "this"
+                && predicate_words[10] == "spell"
+            {
+                let amount_tokens = [OwnedLexToken::word(
+                    predicate_words[2].to_string(),
+                    TextSpan::synthetic(),
+                )];
+                let (amount, _) =
+                    crate::runtime_backend::front_end::shared::util::parse_number(&amount_tokens)?;
+                let symbol = crate::runtime_backend::front_end::shared::util::parse_mana_symbol_word_flexible(
+                    predicate_words[3],
+                )?;
+                return Some(LineAst::StaticAbilities(vec![
+                    crate::cards::builders::StaticAbilityAst::Static(
+                        StaticAbility::enters_with_counters_if_condition(
+                            crate::object::CounterType::PlusOnePlusOne,
+                            crate::effect::Value::Fixed(1),
+                            crate::ConditionExpr::ManaSpentToCastThisSpellAtLeast {
+                                amount,
+                                symbol: Some(symbol),
+                            },
+                            predicate_body.to_string(),
+                        ),
+                    ),
+                ]));
+            }
+        }
+    }
+
     let is_self_x_counter_etb = normalized
         .starts_with("this creature enters with x +1/+1 counters on it")
         || normalized.starts_with("this permanent enters with x +1/+1 counters on it")
@@ -417,10 +479,8 @@ fn parse_self_enters_with_x_counters_static_chunk(tokens: &[OwnedLexToken]) -> O
         return None;
     }
 
-    let count =
-        crate::runtime_backend::front_end::shared::util::revealed_cards_total_mana_value_x_value(
-            &normalized,
-        )
+    let count = crate::runtime_backend::front_end::shared::util::
+        revealed_cards_total_mana_value_x_value(&normalized)
         .unwrap_or(crate::effect::Value::X);
 
     Some(LineAst::StaticAbilities(vec![

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -61,6 +61,7 @@ use crate::cards::builders::{
     ReturnControllerAst, SubjectAst, SubjectVerbActionAst, SubjectVerbRoleAst, TargetAst,
 };
 use crate::effect::{ChoiceCount, Until, Value};
+use crate::object::CounterType;
 use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
@@ -865,6 +866,41 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
             zones: vec![Zone::Exile],
             search_mode: None,
         });
+    }
+
+    if matches!(
+        clause_words.as_slice(),
+        [
+            "this",
+            "creature",
+            "enters",
+            "with",
+            "a",
+            "+1/+1",
+            "counter",
+            "on",
+            "it"
+        ]
+            | [
+                "this",
+                "permanent",
+                "enters",
+                "with",
+                "a",
+                "+1/+1",
+                "counter",
+                "on",
+                "it"
+            ]
+            | ["it", "enters", "with", "a", "+1/+1", "counter", "on", "it"]
+    ) {
+        return Ok(EffectAst::subject_verb_put_counters(
+            CounterType::PlusOnePlusOne,
+            Value::Fixed(1),
+            TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(tokens)),
+            None,
+            false,
+        ));
     }
 
     let (verb, verb_idx) = find_verb(tokens).ok_or_else(|| {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10804,6 +10804,45 @@ fn rewrite_lowered_supports_adamant_spent_to_cast_statement_line() -> Result<(),
 }
 
 #[test]
+fn rewrite_lowered_supports_ardenvale_paladin_adamant_enters_with_counter()
+-> Result<(), CardTextError> {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Ardenvale Paladin")
+        .card_types(vec![CardType::Creature]);
+    let (definition, _) = parse_text_with_annotations_lowered(
+        builder,
+        "Adamant - If at least three white mana was spent to cast this spell, this creature enters with a +1/+1 counter on it."
+            .to_string(),
+        false,
+    )?;
+
+    let debug = format!("{definition:#?}");
+    assert!(debug.contains("EnterWithCountersIfCondition"), "{debug}");
+    assert!(debug.contains("ManaSpentToCastThisSpellAtLeast"), "{debug}");
+    assert!(debug.contains("White"), "{debug}");
+    assert!(debug.contains("PlusOnePlusOne"), "{debug}");
+    Ok(())
+}
+
+#[test]
+fn rewrite_lowered_ardenvale_paladin_adamant_counter_condition_keeps_threshold_and_color()
+-> Result<(), CardTextError> {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Ardenvale Paladin")
+        .card_types(vec![CardType::Creature]);
+    let (definition, _) = parse_text_with_annotations_lowered(
+        builder,
+        "If at least three white mana was spent to cast this spell, this creature enters with a +1/+1 counter on it."
+            .to_string(),
+        false,
+    )?;
+
+    let debug = format!("{definition:#?}");
+    assert!(debug.contains("amount: 3"), "{debug}");
+    assert!(debug.contains("symbol: Some("), "{debug}");
+    assert!(debug.contains("White"), "{debug}");
+    Ok(())
+}
+
+#[test]
 fn rewrite_lexed_effect_sentence_supports_spent_to_cast_followup_on_that_permanent() {
     let text = "Tap target artifact or creature an opponent controls. If {S} was spent to cast this spell, that permanent doesn't untap during its controller's next untap step.";
     let lexed = lex_line(text, 0)

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -254,6 +254,7 @@ fn finalize_ast_surface_line(line: String) -> String {
         return format!("This creature enters with a +1/+1 counter on it for each {each}");
     }
     line = normalize_conditional_additional_x_counters(&line);
+    line = normalize_adamant_enters_with_counter_clause(&line);
     if line
         .to_ascii_lowercase()
         .contains("a land is put into a graveyard from the battlefield")
@@ -296,6 +297,25 @@ fn normalize_conditional_additional_x_counters(line: &str) -> String {
     format!(
         "This creature enters with X +1/+1 counters on it. If {condition}, it enters with an additional X +1/+1 counters on it"
     )
+}
+
+fn normalize_adamant_enters_with_counter_clause(line: &str) -> String {
+    let Some((enter_clause, condition_clause)) = line.split_once(" if ") else {
+        return line.to_string();
+    };
+    if !enter_clause.starts_with("This creature enters with ") || !enter_clause.ends_with(" on it") {
+        return line.to_string();
+    }
+    let condition = condition_clause.trim().trim_end_matches('.');
+    if !condition.contains(" mana was spent to cast this spell") {
+        return line.to_string();
+    }
+    let mut enter_text = enter_clause.to_string();
+    if let Some(first) = enter_text.chars().next() {
+        let lower = first.to_ascii_lowercase();
+        enter_text.replace_range(0..first.len_utf8(), &lower.to_string());
+    }
+    format!("Adamant — If {condition}, {enter_text}")
 }
 
 fn normalize_conditional_followup_case(line: &str) -> String {
@@ -681,6 +701,17 @@ mod tests {
                 "This creature enters with X +1/+1 counters on it. If X is 5 or more, it enters with an additional X +1/+1 counters on it."
                     .to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn conditional_enters_with_counter_uses_adamant_prefix_surface() {
+        assert_eq!(
+            finalize_ast_surface_line(
+                "This creature enters with a +1/+1 counter on it if at least three white mana was spent to cast this spell."
+                    .to_string()
+            ),
+            "Adamant — If at least three white mana was spent to cast this spell, this creature enters with a +1/+1 counter on it."
         );
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -5331,6 +5331,90 @@ mod tests {
     }
 
     #[test]
+    fn ardenvale_paladin_enters_with_counter_when_three_white_was_spent() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let card = CardBuilder::new(CardId::from_raw(70151), "Ardenvale Paladin")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::new(PtValue::Fixed(2), PtValue::Fixed(5)))
+            .build();
+
+        let source = game.create_object_from_card(&card, alice, Zone::Stack);
+        {
+            let source_obj = game.object_mut(source).expect("source should exist");
+            source_obj.abilities.push(Ability::static_ability(StaticAbility::new(
+                EntersWithCountersIfCondition::new(
+                    CounterType::PlusOnePlusOne,
+                    Value::Fixed(1),
+                    Condition::ManaSpentToCastThisSpellAtLeast {
+                        amount: 3,
+                        symbol: Some(crate::mana::ManaSymbol::White),
+                    },
+                    "If at least three white mana was spent to cast this spell, this creature enters with a +1/+1 counter on it".to_string(),
+                ),
+            )));
+            let mut spent = crate::player::ManaPool::new();
+            spent.add(crate::mana::ManaSymbol::White, 3);
+            spent.add(crate::mana::ManaSymbol::Colorless, 1);
+            source_obj.mana_spent_to_cast = spent;
+        }
+
+        let mut decision_maker = crate::decision::SelectFirstDecisionMaker;
+        let result = game
+            .move_object_with_etb_processing_with_dm(source, Zone::Battlefield, &mut decision_maker)
+            .expect("Ardenvale Paladin should enter the battlefield");
+        let permanent = game
+            .object(result.new_id)
+            .expect("Ardenvale Paladin should exist on battlefield");
+        assert_eq!(
+            permanent.counters.get(&CounterType::PlusOnePlusOne).copied(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn ardenvale_paladin_does_not_get_counter_without_three_white_spent() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let card = CardBuilder::new(CardId::from_raw(70151), "Ardenvale Paladin")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::new(PtValue::Fixed(2), PtValue::Fixed(5)))
+            .build();
+
+        let source = game.create_object_from_card(&card, alice, Zone::Stack);
+        {
+            let source_obj = game.object_mut(source).expect("source should exist");
+            source_obj.abilities.push(Ability::static_ability(StaticAbility::new(
+                EntersWithCountersIfCondition::new(
+                    CounterType::PlusOnePlusOne,
+                    Value::Fixed(1),
+                    Condition::ManaSpentToCastThisSpellAtLeast {
+                        amount: 3,
+                        symbol: Some(crate::mana::ManaSymbol::White),
+                    },
+                    "If at least three white mana was spent to cast this spell, this creature enters with a +1/+1 counter on it".to_string(),
+                ),
+            )));
+            let mut spent = crate::player::ManaPool::new();
+            spent.add(crate::mana::ManaSymbol::White, 2);
+            spent.add(crate::mana::ManaSymbol::Colorless, 2);
+            source_obj.mana_spent_to_cast = spent;
+        }
+
+        let mut decision_maker = crate::decision::SelectFirstDecisionMaker;
+        let result = game
+            .move_object_with_etb_processing_with_dm(source, Zone::Battlefield, &mut decision_maker)
+            .expect("Ardenvale Paladin should enter the battlefield");
+        let permanent = game
+            .object(result.new_id)
+            .expect("Ardenvale Paladin should exist on battlefield");
+        assert_eq!(
+            permanent.counters.get(&CounterType::PlusOnePlusOne).copied(),
+            None
+        );
+    }
+
+    #[test]
     fn enters_with_counters_if_kicked_uses_discarded_cost_card_mana_value() {
         let mut game = GameState::new(vec!["Alice".to_string()], 20);
         let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ardenvale Paladin
Initial parse error:
```
could not find verb in effect clause (clause: 'this creature enters with a +1/+1 counter on it'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'this creature enters with a +1/+1 counter on it'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-076f211230f314e78
