### PR TITLE
Fix Ironsmith parse failure: Trove Tracker

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -386,6 +386,9 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
     if str_strip_suffix(first, "cycling").is_some() {
         return Some(KeywordDispatchHint::Cycling);
     }
+    if first == "encore" {
+        return Some(KeywordDispatchHint::AlternativeOrExertFamily);
+    }
     if matches!(first, "jumpstart" | "jump-start")
         || (first == "jump" && word_view.get(1) == Some("start"))
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -212,6 +212,23 @@ pub(super) fn lower_alternative_cast(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
 ) -> Result<LineAst, CardTextError> {
+    if tokens.first().is_some_and(|token| token.is_word("encore")) {
+        let (cost, _) = leading_mana_cost_from_tokens(tokens.get(1..).unwrap_or_default())
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "encore keyword missing mana cost '{}'",
+                    line.info.raw_line
+                ))
+            })?;
+        return Ok(LineAst::StaticAbility(
+            crate::static_abilities::StaticAbility::keyword_marker(format!(
+                "Encore {}",
+                cost.to_oracle()
+            ))
+            .into(),
+        ));
+    }
+
     if line.text.trim_start().starts_with("Surge ") {
         let raw_tokens = lex_line(line.text.as_str(), line.info.line_index)?;
         let cost_tokens = raw_tokens.get(1..).unwrap_or_default();
@@ -932,6 +949,8 @@ fn parse_additional_cost_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardText
 fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTextError> {
     let rendered = render_token_slice(tokens).trim().to_ascii_lowercase();
     Ok(
+        tokens.first().is_some_and(|token| token.is_word("encore"))
+            ||
         parse_self_free_cast_alternative_cost_line_lexed(tokens).is_some()
             || parse_you_may_rather_than_spell_cost_line_lexed(tokens, rendered.as_str())?
                 .is_some()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40197,3 +40197,18 @@ fn eruth_tormented_prophet_compiled_text_keeps_replacement_and_play_clause() {
         "expected play-permission clause in compiled text, got {rendered}"
     );
 }
+
+#[test]
+fn parse_oracle_trove_tracker_regression_compiles_with_encore_keyword_line() {
+    let def = parse_oracle_card_definition("Trove Tracker");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Encore {5}{U}{U}"),
+        "expected Trove Tracker to preserve encore keyword cost line, got {rendered}"
+    );
+    assert!(
+        rendered.contains("When this creature dies, draw a card."),
+        "expected Trove Tracker death trigger to compile, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -8249,13 +8249,13 @@ fn record_battlefield_entry_this_turn(game: &mut GameState, object_id: ObjectId)
     use crate::snapshot::ObjectSnapshot;
     use crate::triggers::TriggerEvent;
 
-    let snapshot = ObjectSnapshot::from_object(
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
         game.object(object_id)
             .expect("battlefield entry event object should exist"),
         game,
     );
     let event = TriggerEvent::new_with_provenance(
-        ZoneChangeEvent::with_cause(
+        crate::events::ZoneChangeEvent::with_cause(
             object_id,
             Zone::Hand,
             Zone::Battlefield,
@@ -28600,5 +28600,91 @@ fn test_gift_given_event_queues_opponent_gives_gift_trigger() {
         game.player(alice).expect("alice exists").hand.len(),
         1,
         "the queued gift trigger should resolve using the normal stack path"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trove_tracker_dies_trigger_draws_a_card() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let tracker = CardDefinitionBuilder::new(CardId::from_raw(93_001), "Trove Tracker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("When this creature dies, draw a card.\nEncore {5}{U}{U}")
+        .expect("Trove Tracker text should parse");
+    let tracker_id = game.create_object_from_definition(&tracker, alice, Zone::Battlefield);
+    let library_card = CardBuilder::new(CardId::from_raw(93_003), "Draw Probe")
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&library_card, alice, Zone::Library);
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(tracker_id).expect("Trove Tracker permanent should exist"),
+        &game,
+    );
+    let dies_event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            tracker_id,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::from_sba(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, dies_event, false);
+
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Trove Tracker should trigger when it dies"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("trigger should be put on stack");
+    resolve_stack_entry(&mut game).expect("draw trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        1,
+        "Trove Tracker death trigger should draw exactly one card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trove_tracker_only_triggers_on_battlefield_to_graveyard_moves() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let tracker = CardDefinitionBuilder::new(CardId::from_raw(93_002), "Trove Tracker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("When this creature dies, draw a card.\nEncore {5}{U}{U}")
+        .expect("Trove Tracker text should parse");
+    let tracker_id = game.create_object_from_definition(&tracker, alice, Zone::Hand);
+
+    let snapshot = ObjectSnapshot::from_object(
+        game.object(tracker_id).expect("Trove Tracker card should exist"),
+        &game,
+    );
+    let non_dies_event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            tracker_id,
+            Zone::Hand,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, non_dies_event, false);
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "moving Trove Tracker from hand to graveyard should not count as dying"
     );
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Trove Tracker
Initial parse error:
```
parser does not yet support line family: 'Encore {5}{U}{U} ({5}{U}{U}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)'; oracle-only fallback also failed: parser does not yet support line family: 'Encore {5}{U}{U}'
```

Worker: i-0cf00b0aeeb76ccac
