### PR TITLE
Fix Ironsmith parse failure: Oran-Rief, the Vastwood

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/player_relations.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/player_relations.rs
@@ -556,6 +556,15 @@ pub(super) fn parse_entered_battlefield_this_turn_words(
                 primitives::word_slice_eq("turn"),
             )
                 .void(),
+            (
+                primitives::word_slice_eq("entered"),
+                primitives::word_slice_eq("under"),
+                primitives::word_slice_eq("your"),
+                primitives::word_slice_eq("control"),
+                primitives::word_slice_eq("this"),
+                primitives::word_slice_eq("turn"),
+            )
+                .void(),
         )),
     ) {
         return Some((Some(PlayerFilter::You), consumed));
@@ -590,6 +599,18 @@ pub(super) fn parse_entered_battlefield_this_turn_words(
                 primitives::word_slice_eq("turn"),
             )
                 .void(),
+            (
+                primitives::word_slice_eq("entered"),
+                primitives::word_slice_eq("under"),
+                alt((
+                    primitives::word_slice_eq("opponent"),
+                    primitives::word_slice_eq("opponents"),
+                )),
+                primitives::word_slice_eq("control"),
+                primitives::word_slice_eq("this"),
+                primitives::word_slice_eq("turn"),
+            )
+                .void(),
         )),
     ) {
         return Some((Some(PlayerFilter::Opponent), consumed));
@@ -608,6 +629,12 @@ pub(super) fn parse_entered_battlefield_this_turn_words(
             (
                 primitives::word_slice_eq("entered"),
                 primitives::word_slice_eq("battlefield"),
+                primitives::word_slice_eq("this"),
+                primitives::word_slice_eq("turn"),
+            )
+                .void(),
+            (
+                primitives::word_slice_eq("entered"),
                 primitives::word_slice_eq("this"),
                 primitives::word_slice_eq("turn"),
             )
@@ -814,6 +841,17 @@ pub(super) fn try_apply_entered_battlefield_this_turn_clause(
             SegmentPhraseVariant {
                 words: &[
                     "entered",
+                    "under",
+                    "your",
+                    "control",
+                    "this",
+                    "turn",
+                ],
+                drain_start_offset: 0,
+            },
+            SegmentPhraseVariant {
+                words: &[
+                    "entered",
                     "the",
                     "battlefield",
                     "under",
@@ -853,6 +891,28 @@ pub(super) fn try_apply_entered_battlefield_this_turn_clause(
                 words: &[
                     "entered",
                     "battlefield",
+                    "under",
+                    "opponents",
+                    "control",
+                    "this",
+                    "turn",
+                ],
+                drain_start_offset: 0,
+            },
+            SegmentPhraseVariant {
+                words: &[
+                    "entered",
+                    "under",
+                    "opponent",
+                    "control",
+                    "this",
+                    "turn",
+                ],
+                drain_start_offset: 0,
+            },
+            SegmentPhraseVariant {
+                words: &[
+                    "entered",
                     "under",
                     "opponents",
                     "control",
@@ -867,6 +927,10 @@ pub(super) fn try_apply_entered_battlefield_this_turn_clause(
             },
             SegmentPhraseVariant {
                 words: &["entered", "battlefield", "this", "turn"],
+                drain_start_offset: 0,
+            },
+            SegmentPhraseVariant {
+                words: &["entered", "this", "turn"],
                 drain_start_offset: 0,
             },
         ],

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1927,14 +1927,14 @@ impl ObjectFilter {
                         "that entered the battlefield under an opponent's control this turn"
                             .to_string()
                     }
-                    PlayerFilter::Any => "that entered the battlefield this turn".to_string(),
+                    PlayerFilter::Any => "that entered this turn".to_string(),
                     other => format!(
                         "that entered the battlefield under {} control this turn",
                         describe_possessive_player_filter(other)
                     ),
                 }
             } else {
-                "that entered the battlefield this turn".to_string()
+                "that entered this turn".to_string()
             };
             parts.push(clause);
         }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32834,6 +32834,138 @@ fn assert_oracle_card_fails_strict(name: &str) {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oran_rief_the_vastwood_strict_regression() {
+    assert_oracle_card_parses_strict("Oran-Rief, the Vastwood");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oran_rief_the_vastwood_compiled_text_keeps_entered_this_turn_green_filter() {
+    let def = parse_oracle_card_definition("Oran-Rief, the Vastwood");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("each green creature that entered this turn")
+            || rendered.contains("each green creature that entered the battlefield this turn"),
+        "expected Oran-Rief compiled text to preserve entered-this-turn green creature filter, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oran_rief_the_vastwood_activation_runtime_only_counters_green_creatures_that_entered_this_turn() {
+    let def = parse_oracle_card_definition("Oran-Rief, the Vastwood");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if !activated.effects.segments.is_empty() => {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("Oran-Rief should have a countering activated ability");
+    let [segment] = activated.effects.segments.as_slice() else {
+        panic!("expected one Oran-Rief resolution segment");
+    };
+    let [effect] = segment.default_effects.as_slice() else {
+        panic!("expected one Oran-Rief default effect");
+    };
+    let for_each = effect
+        .downcast_ref::<crate::effects::ForEachObject>()
+        .expect("Oran-Rief should iterate matching creatures");
+    let put_counters = for_each.effects[0]
+        .downcast_ref::<crate::effects::PutCountersEffect>()
+        .expect("Oran-Rief should resolve a put-counters effect");
+    assert_eq!(
+        put_counters.counter_type,
+        crate::object::CounterType::PlusOnePlusOne,
+        "expected Oran-Rief to place +1/+1 counters"
+    );
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let oran_rief_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let green_def = CardDefinitionBuilder::new(CardId::new(), "Green Test Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let white_def = CardDefinitionBuilder::new(CardId::new(), "White Test Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+
+    let old_green = game.create_object_from_definition(&green_def, alice, Zone::Battlefield);
+    game.turn_store.turn_history.clear_for_new_turn();
+    let green_entered = game.create_object_from_definition(&green_def, alice, Zone::Battlefield);
+    let opponent_green_entered =
+        game.create_object_from_definition(&green_def, bob, Zone::Battlefield);
+    let white_entered = game.create_object_from_definition(&white_def, alice, Zone::Battlefield);
+
+    for obj_id in [green_entered, opponent_green_entered, white_entered] {
+        let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+            game.object(obj_id)
+                .expect("entered test creature should exist on the battlefield"),
+            &game,
+        );
+        let entry_event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::zones::ZoneChangeEvent::with_cause(
+                obj_id,
+                Zone::Hand,
+                Zone::Battlefield,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        game.record_turn_history_event(&entry_event);
+    }
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(oran_rief_id, alice);
+    effect
+        .0
+        .execute(&mut game, &mut ctx)
+        .expect("Oran-Rief counter effect should resolve");
+
+    assert_eq!(
+        game.counter_count(green_entered, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Oran-Rief should counter your green creature that entered this turn"
+    );
+    assert_eq!(
+        game.counter_count(opponent_green_entered, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Oran-Rief should counter each green creature, including opponents'"
+    );
+    assert_eq!(
+        game.counter_count(white_entered, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Oran-Rief should not counter nongreen creatures"
+    );
+    assert_eq!(
+        game.counter_count(old_green, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Oran-Rief should not counter green creatures that did not enter this turn"
+    );
+
+    game.turn_store.turn_history.clear_for_new_turn();
+    effect
+        .0
+        .execute(&mut game, &mut ctx)
+        .expect("Oran-Rief counter effect should resolve on later turns");
+    assert_eq!(
+        game.counter_count(green_entered, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Oran-Rief should stop counting prior-turn entries after the turn changes"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_cabaretti_ascendancy_strict_regression() {
     assert_oracle_card_parses_strict("Cabaretti Ascendancy");
 }

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3737,14 +3737,14 @@ impl ObjectFilterExt for ObjectFilter {
                         "that entered the battlefield under an opponent's control this turn"
                             .to_string()
                     }
-                    PlayerFilter::Any => "that entered the battlefield this turn".to_string(),
+                    PlayerFilter::Any => "that entered this turn".to_string(),
                     other => format!(
                         "that entered the battlefield under {} control this turn",
                         describe_possessive_player_filter(other)
                     ),
                 }
             } else {
-                "that entered the battlefield this turn".to_string()
+                "that entered this turn".to_string()
             };
             parts.push(clause);
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Oran-Rief, the Vastwood
Initial parse error:
```
unsupported entered-this-turn object filter (clause: 'green creature that entered this turn'); oracle-only fallback also failed: unsupported entered-this-turn object filter (clause: 'green creature that entered this turn')
```

Worker: i-0663173d4fe9ce458
