### PR TITLE
Fix Ironsmith parse failure: Invasion of Alara // Awaken the Maelstrom

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -111,10 +111,14 @@ fn parse_tagged_cast_or_play_target_inner<'a>(
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
             }),
-            grammar::phrase(&["one", "of", "those", "cards"]).value(TaggedPermissionTarget {
-                tag: TagKey::from(IT_TAG),
-                as_copy: false,
-            }),
+            alt((
+                grammar::phrase(&["one", "of", "those", "cards"]),
+                grammar::phrase(&["one", "of", "those", "two", "cards"]),
+            ))
+            .value(TaggedPermissionTarget {
+                    tag: TagKey::from(IT_TAG),
+                    as_copy: false,
+                }),
             grammar::phrase(&["one", "of", "those", "card"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10611,6 +10611,23 @@ fn rewrite_lexed_effect_sequence_keeps_consult_cast_bottom_family_parseable() {
 }
 
 #[test]
+fn rewrite_lexed_effect_sequence_parses_invasion_of_alara_cast_one_of_those_two_cards_clause() {
+    let text = "Exile cards from the top of your library until you exile two nonland cards with mana value 4 or less. You may cast one of those two cards without paying its mana cost. Put one of them into your hand. Then put the other cards exiled this way on the bottom of your library in a random order.";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify Invasion of Alara ETB text");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&lexed)
+        .expect("Invasion of Alara ETB sequence should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("action: Exile"), "{debug}");
+    assert!(debug.contains("CastTagged"), "{debug}");
+    assert!(debug.contains("without_paying_mana_cost: true"), "{debug}");
+    assert!(debug.contains("action: PutIntoHand"), "{debug}");
+    assert!(debug.contains("relation: IsTaggedObject"), "{debug}");
+    assert!(debug.contains("zone: Library"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_effect_sequence_keeps_reveal_consult_cast_bottom_family_parseable() {
     let text = "Reveal cards from the top of your library until you reveal a nonland card. You may cast that card without paying its mana cost. Then put all revealed cards not cast this way on the bottom of your library in a random order.";
     let lexed =

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1110,6 +1110,46 @@ fn compile_oracle_text_strictly_compiles_mindleecher_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_invasion_of_alara_with_cast_one_of_two_clause() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Invasion of Alara // Awaken the Maelstrom")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Invasion of Alara // Awaken the Maelstrom --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Invasion of Alara // Awaken the Maelstrom should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(
+        stdout.contains("Name: Invasion of Alara"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("without paying its mana cost"),
+        "expected free-cast clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_sakashimas_will_with_choose_both_instead_clause() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Invasion of Alara // Awaken the Maelstrom
Initial parse error:
```
could not find verb in effect clause (clause: 'cast one of those two cards without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast one of those two cards without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect)
```

Worker: i-09750f32c00cf8c95
