### PR TITLE
Fix Ironsmith parse failure: Fabrication Module

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1880,7 +1880,15 @@ pub(crate) fn parse_trigger_clause_lexed(
         let one_or_more = ActivationRestrictionCompatWords::new(descriptor_span)
             .slice_eq(0, &["one", "or", "more"]);
         let counter_descriptor_tokens = &tokens[descriptor_token_start..(descriptor_token_end + 1)];
-        let counter_type = parse_counter_type_from_tokens(counter_descriptor_tokens);
+        let mut counter_type = parse_counter_type_from_tokens(counter_descriptor_tokens);
+        if counter_type.is_none()
+            && ActivationRestrictionCompatWords::new(counter_descriptor_tokens)
+                .to_word_refs()
+                .iter()
+                .any(|word| *word == "e" || *word == "energy")
+        {
+            counter_type = Some(CounterType::Energy);
+        }
 
         let object_word_start = counter_word_idx + 2;
         let object_token_start = word_view
@@ -1916,6 +1924,51 @@ pub(crate) fn parse_trigger_clause_lexed(
             filter,
             counter_type,
             source_controller: Some(source_controller),
+            one_or_more,
+        });
+    }
+
+    if let Some(get_word_idx) = find_index(&words, |word| matches!(*word, "get" | "gets"))
+        && let Some(player) = parse_trigger_subject_player_filter(&words[..get_word_idx])
+        && words
+            .get(get_word_idx + 1..)
+            .is_some_and(|tail| tail.starts_with(&["one", "or", "more", "e"]))
+    {
+        return Ok(TriggerSpec::PlayerGetsCounters {
+            player,
+            counter_type: Some(CounterType::Energy),
+            one_or_more: true,
+        });
+    }
+
+    if let Some(get_word_idx) = find_index(&words, |word| matches!(*word, "get" | "gets"))
+        && let Some(player) = parse_trigger_subject_player_filter(&words[..get_word_idx])
+        && let Some(counter_word_idx) =
+            find_index(&words, |word| *word == "counter" || *word == "counters")
+        && counter_word_idx > get_word_idx
+    {
+        let word_view = ActivationRestrictionCompatWords::new(tokens);
+        let descriptor_word_start = get_word_idx + 1;
+        let descriptor_token_start = word_view
+            .token_index_for_word_index(descriptor_word_start)
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "missing counter descriptor in trigger clause (clause: '{}')",
+                    words.join(" ")
+                ))
+            })?;
+        let descriptor_token_end = word_view
+            .token_index_for_word_index(counter_word_idx)
+            .unwrap_or(tokens.len());
+        let descriptor_span = &tokens[descriptor_token_start..descriptor_token_end];
+        let one_or_more =
+            ActivationRestrictionCompatWords::new(descriptor_span).slice_eq(0, &["one", "or", "more"]);
+        let counter_descriptor_tokens = &tokens[descriptor_token_start..(descriptor_token_end + 1)];
+        let counter_type = parse_counter_type_from_tokens(counter_descriptor_tokens);
+
+        return Ok(TriggerSpec::PlayerGetsCounters {
+            player,
+            counter_type,
             one_or_more,
         });
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -252,6 +252,20 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             }
             Trigger::new(trigger)
         }
+        TriggerSpec::PlayerGetsCounters {
+            player,
+            counter_type,
+            one_or_more,
+        } => {
+            let mut trigger = crate::triggers::PlayerGetsCountersTrigger::new(player);
+            if let Some(counter_type) = counter_type {
+                trigger = trigger.counter_type(counter_type);
+            }
+            if one_or_more {
+                trigger = trigger.count(crate::triggers::CountMode::OneOrMore);
+            }
+            Trigger::new(trigger)
+        }
         TriggerSpec::DiesCreatureDealtDamageByThisTurn { victim, damager } => match damager {
             DamageBySpec::ThisCreature => {
                 Trigger::creature_dealt_damage_by_this_creature_this_turn_dies(victim)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -253,6 +253,11 @@ pub(crate) enum TriggerSpec {
         source_controller: Option<PlayerFilter>,
         one_or_more: bool,
     },
+    PlayerGetsCounters {
+        player: PlayerFilter,
+        counter_type: Option<CounterType>,
+        one_or_more: bool,
+    },
     DiesCreatureDealtDamageByThisTurn {
         victim: ObjectFilter,
         damager: DamageBySpec,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -13245,3 +13245,23 @@ fn maddening_hex_damage_equal_to_die_result_binds_prior_roll() {
         "that player in this non-loop trigger must not lower to an unbound iterated player, got {debug}"
     );
 }
+
+#[test]
+fn parse_trigger_clause_supports_one_or_more_energy_player_gain() {
+    let tokens = lex_line("you get one or more {E}", 0)
+        .expect("rewrite lexer should tokenize one-or-more energy trigger clause");
+    let parsed = super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
+        &tokens,
+    );
+    assert!(
+        matches!(
+            parsed,
+            Ok(crate::cards::builders::TriggerSpec::PlayerGetsCounters {
+                player: crate::target::PlayerFilter::You,
+                counter_type: Some(crate::object::CounterType::Energy),
+                one_or_more: true,
+            })
+        ),
+        "expected one-or-more energy player-counters trigger, got {parsed:?}"
+    );
+}

--- a/crates/ironsmith-compiler/src/triggers.rs
+++ b/crates/ironsmith-compiler/src/triggers.rs
@@ -1,6 +1,6 @@
 pub use ironsmith_core::trigger_model::{
     CompilerTriggerMatcher, CountMode, CounterPutOnTrigger, CounterRemovedFromTrigger,
-    DamagedBySource, Trigger, TriggerKind, ZoneChangeTrigger,
+    DamagedBySource, PlayerGetsCountersTrigger, Trigger, TriggerKind, ZoneChangeTrigger,
 };
 
 pub mod zone_changes {

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -302,6 +302,7 @@ pub enum TriggerKind {
         right: Box<Trigger>,
     },
     ZoneChange(ZoneChangeTrigger),
+    PlayerGetsCounters(PlayerGetsCountersTrigger),
     CounterPutOn(CounterPutOnTrigger),
     CounterRemovedFrom(CounterRemovedFromTrigger),
 }
@@ -1093,6 +1094,39 @@ impl CompilerTriggerMatcher for ZoneChangeTrigger {
 
 pub mod zone_changes {
     pub use super::ZoneChangeTrigger;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayerGetsCountersTrigger {
+    pub player: PlayerFilter,
+    pub counter_type: Option<CounterType>,
+    pub count: CountMode,
+}
+
+impl PlayerGetsCountersTrigger {
+    pub fn new(player: PlayerFilter) -> Self {
+        Self {
+            player,
+            counter_type: None,
+            count: CountMode::One,
+        }
+    }
+
+    pub fn counter_type(mut self, counter_type: CounterType) -> Self {
+        self.counter_type = Some(counter_type);
+        self
+    }
+
+    pub fn count(mut self, mode: CountMode) -> Self {
+        self.count = mode;
+        self
+    }
+}
+
+impl CompilerTriggerMatcher for PlayerGetsCountersTrigger {
+    fn into_trigger(self) -> Trigger {
+        Trigger::typed("player_gets_counters", TriggerKind::PlayerGetsCounters(self))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -24530,6 +24530,60 @@ fn render_rain_of_daggers_uses_destroyed_this_way_life_loss_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn fabrication_module_parses_and_renders_one_or_more_energy_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Fabrication Module")
+        .parse_text(
+            "Whenever you get one or more {E} (energy counters), put a +1/+1 counter on target creature you control.\n{4}, {T}: You get {E}.",
+        )
+        .expect("Fabrication Module should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("whenever you gets one or more {e}")
+            && rendered.contains("put a +1/+1 counter on target creature you control"),
+        "expected one-or-more energy trigger with target creature clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn fabrication_module_uses_player_gets_counters_trigger_model() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Fabrication Module")
+        .parse_text(
+            "Whenever you get one or more {E}, put a +1/+1 counter on target creature you control.",
+        )
+        .expect("Fabrication Module trigger line should parse");
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("expected triggered ability");
+
+    let debug = format!("{:?}", triggered.trigger);
+    assert!(
+        debug.contains("PlayerGetsCountersTrigger")
+            && debug.contains("OneOrMore")
+            && debug.contains("Energy"),
+        "expected one-or-more energy player-counters trigger, got {debug}"
+    );
+
+    let effects_debug = format!("{:?}", triggered.effects);
+    assert!(
+        effects_debug.contains("PutCountersEffect")
+            && effects_debug.contains("card_types: [Creature]")
+            && effects_debug.contains("controller: Some(You)"),
+        "expected targeted +1/+1 counter effect, got {effects_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_terastodon_keeps_destroy_and_graveyard_loop() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Terastodon Variant")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/triggers/counters/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/counters/mod.rs
@@ -2,8 +2,10 @@
 
 mod counter_put_on;
 mod counter_removed_from;
+mod player_gets_counters;
 mod saga_chapter;
 
 pub use counter_put_on::CounterPutOnTrigger;
 pub use counter_removed_from::CounterRemovedFromTrigger;
+pub use player_gets_counters::PlayerGetsCountersTrigger;
 pub use saga_chapter::SagaChapterTrigger;

--- a/crates/ironsmith-runtime/src/triggers/counters/player_gets_counters.rs
+++ b/crates/ironsmith-runtime/src/triggers/counters/player_gets_counters.rs
@@ -1,0 +1,152 @@
+use crate::events::EventKind;
+use crate::events::other::MarkersChangedEvent;
+use crate::filter::PlayerFilterExt;
+use crate::object::CounterType;
+use crate::target::PlayerFilter;
+use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
+use crate::triggers::{CountMode, TriggerEvent};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayerGetsCountersTrigger {
+    pub player: PlayerFilter,
+    pub counter_type: Option<CounterType>,
+    pub count_mode: CountMode,
+}
+
+impl PlayerGetsCountersTrigger {
+    pub fn new(player: PlayerFilter) -> Self {
+        Self {
+            player,
+            counter_type: None,
+            count_mode: CountMode::Each,
+        }
+    }
+
+    pub fn counter_type(mut self, counter_type: CounterType) -> Self {
+        self.counter_type = Some(counter_type);
+        self
+    }
+
+    pub fn count(mut self, count_mode: CountMode) -> Self {
+        self.count_mode = count_mode;
+        self
+    }
+}
+
+impl TriggerMatcher for PlayerGetsCountersTrigger {
+    fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
+        if event.kind() != EventKind::MarkersChanged {
+            return false;
+        }
+        let Some(e) = event.downcast::<MarkersChangedEvent>() else {
+            return false;
+        };
+        if !e.is_added() {
+            return false;
+        }
+        let Some(counter_type) = e.marker.as_counter() else {
+            return false;
+        };
+        let Some(player_id) = e.player() else {
+            return false;
+        };
+        if !self.player.matches_player(player_id, &ctx.filter_ctx) {
+            return false;
+        }
+        if let Some(required) = self.counter_type
+            && required != counter_type
+        {
+            return false;
+        }
+        true
+    }
+
+    fn trigger_count(&self, event: &TriggerEvent) -> u32 {
+        match self.count_mode {
+            CountMode::OneOrMore => 1,
+            CountMode::Each => event
+                .downcast::<MarkersChangedEvent>()
+                .map_or(1, |e| e.amount.max(1)),
+        }
+    }
+
+    fn display(&self) -> String {
+        if self.counter_type == Some(CounterType::Energy) {
+            let energy = match self.count_mode {
+                CountMode::OneOrMore => "one or more {E}",
+                CountMode::Each => "{E}",
+            };
+            return format!("Whenever {} gets {energy}", self.player.description());
+        }
+        let counter_phrase = match self.counter_type {
+            Some(counter_type) => match self.count_mode {
+                CountMode::OneOrMore => format!("one or more {} counters", counter_type.description()),
+                CountMode::Each => format!("a {} counter", counter_type.description()),
+            },
+            None => match self.count_mode {
+                CountMode::OneOrMore => "one or more counters".to_string(),
+                CountMode::Each => "a counter".to_string(),
+            },
+        };
+        format!("Whenever {} gets {counter_phrase}", self.player.description())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cards::definitions::grizzly_bears;
+    use crate::events::other::{MarkerChangeType, MarkersChangedEvent};
+    use crate::ids::PlayerId;
+    use crate::provenance::ProvNodeId;
+    use crate::triggers::matcher_trait::TriggerContext;
+    use crate::zone::Zone;
+
+    #[test]
+    fn matches_only_added_counters_for_matching_player_and_type() {
+        let game = crate::tests::test_helpers::setup_two_player_game();
+        let mut game = game;
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source_id = game.create_object_from_definition(&grizzly_bears(), alice, Zone::Battlefield);
+        let trigger = PlayerGetsCountersTrigger::new(PlayerFilter::You)
+            .counter_type(CounterType::Energy)
+            .count(CountMode::OneOrMore);
+        let ctx = TriggerContext::for_source(source_id, alice, &game);
+
+        let added_for_you = TriggerEvent::new_with_provenance(
+            MarkersChangedEvent::added(CounterType::Energy, alice, 2, None, None),
+            ProvNodeId::default(),
+        );
+        assert!(trigger.matches(&added_for_you, &ctx));
+
+        let added_for_opponent = TriggerEvent::new_with_provenance(
+            MarkersChangedEvent::added(CounterType::Energy, bob, 2, None, None),
+            ProvNodeId::default(),
+        );
+        assert!(!trigger.matches(&added_for_opponent, &ctx));
+
+        let removed_for_you = TriggerEvent::new_with_provenance(
+            MarkersChangedEvent {
+                change_type: MarkerChangeType::Removed,
+                marker: CounterType::Energy.into(),
+                location: alice.into(),
+                amount: 1,
+                source: None,
+                source_controller: None,
+            },
+            ProvNodeId::default(),
+        );
+        assert!(!trigger.matches(&removed_for_you, &ctx));
+    }
+
+    #[test]
+    fn each_mode_uses_added_amount() {
+        let trigger = PlayerGetsCountersTrigger::new(PlayerFilter::You).count(CountMode::Each);
+        let event = TriggerEvent::new_with_provenance(
+            MarkersChangedEvent::added(CounterType::Energy, PlayerId::from_index(0), 3, None, None),
+            ProvNodeId::default(),
+        );
+        assert_eq!(trigger.trigger_count(&event), 3);
+    }
+}

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -862,6 +862,11 @@ impl Trigger {
         Self::new(CounterPutOnTrigger::new(filter))
     }
 
+    /// Create a "when [player] gets counters" trigger.
+    pub fn player_gets_counters(player: PlayerFilter) -> Self {
+        Self::new(PlayerGetsCountersTrigger::new(player))
+    }
+
     /// Create a "when a counter is removed from [filter]" trigger.
     pub fn counter_removed_from(filter: ObjectFilter) -> Self {
         Self::new(CounterRemovedFromTrigger::new(filter))

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -71,6 +71,17 @@ fn convert_counter_put_on_trigger(
     crate::triggers::Trigger::new(out)
 }
 
+fn convert_player_gets_counters_trigger(
+    trigger: ironsmith_core::trigger_model::PlayerGetsCountersTrigger,
+) -> crate::triggers::Trigger {
+    let mut out = crate::triggers::PlayerGetsCountersTrigger::new(trigger.player);
+    if let Some(counter_type) = trigger.counter_type {
+        out = out.counter_type(counter_type);
+    }
+    out = out.count(convert_count_mode(trigger.count));
+    crate::triggers::Trigger::new(out)
+}
+
 fn convert_counter_removed_from_trigger(
     trigger: ironsmith_core::trigger_model::CounterRemovedFromTrigger,
 ) -> crate::triggers::Trigger {
@@ -412,6 +423,9 @@ pub(crate) fn interpret_trigger_model(
             interpret_trigger_model(*right)?,
         ),
         TriggerKind::ZoneChange(zone_change) => convert_zone_change_trigger(zone_change),
+        TriggerKind::PlayerGetsCounters(player_gets_counters) => {
+            convert_player_gets_counters_trigger(player_gets_counters)
+        }
         TriggerKind::CounterPutOn(counter_put_on) => convert_counter_put_on_trigger(counter_put_on),
         TriggerKind::CounterRemovedFrom(counter_removed_from) => {
             convert_counter_removed_from_trigger(counter_removed_from)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Fabrication Module
Initial parse error:
```
unsupported triggered line: 'Whenever you get one or more {E} (energy counters), put a +1/+1 counter on target creature you control.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever you get one or more {E}, put a +1/+1 counter on target creature you control.'
```

Worker: i-08c0e661e8d71e515
