### PR TITLE
Fix Ironsmith parse failure: Covert Technician

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1562,6 +1562,9 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
     if matches!(words.get(..3), Some(["the", "damage", "dealt"])) {
         return Some((Value::EventValue(EventValueSpec::Amount), 3));
     }
+    if matches!(words.get(..2), Some(["that", "damage"])) {
+        return Some((Value::EventValue(EventValueSpec::Amount), 2));
+    }
     if matches!(words.get(..2), Some(["the", "result"])) {
         return Some((Value::EventValue(EventValueSpec::Amount), 2));
     }

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1,6 +1,6 @@
 use crate::{
     CardType, ChoiceCount, ChooseSpec, Color, ColorSet, CounterType, ObjectId, PlayerId,
-    StaticAbilityId, Subtype, Supertype, TagKey, Value, Zone,
+    StaticAbilityId, Subtype, Supertype, TagKey, Value, Zone, effect_model::EventValueSpec,
 };
 
 /// A reference to an object for use in filters and effects.
@@ -2444,6 +2444,11 @@ fn describe_comparison(cmp: &Comparison) -> String {
                     describe_value_expr(left),
                     describe_value_expr(right)
                 )
+            }
+            Value::EventValue(EventValueSpec::Amount) => "that damage".to_string(),
+            Value::EventValue(EventValueSpec::LifeAmount) => "that much life".to_string(),
+            Value::EventValue(EventValueSpec::BlockersBeyondFirst { .. }) => {
+                "a dynamic blocker count".to_string()
             }
             _ => "a dynamic value".to_string(),
         }

--- a/crates/ironsmith-runtime/src/cards/mod.rs
+++ b/crates/ironsmith-runtime/src/cards/mod.rs
@@ -1785,6 +1785,30 @@ mod tests {
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn generated_definition_support_accepts_covert_technician() {
+        let text = "Mana cost: {2}{U}\nType: Creature\nPower/Toughness: 2/4\nNinjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.";
+        let definition = CardDefinitionBuilder::new(CardId::new(), "Covert Technician")
+            .parse_text(text)
+            .expect("covert technician parse should succeed");
+
+        assert!(
+            generated_definition_is_supported(&definition),
+            "{:?}\n{definition:#?}",
+            generated_definition_support_issues(&definition)
+        );
+
+        let debug = format!("{definition:#?}").to_ascii_lowercase();
+        assert!(!debug.contains("unimplemented"));
+        assert!(
+            debug.contains("lessthanorequalexpr")
+                && debug.contains("eventvalue(")
+                && debug.contains("amount"),
+            "Covert Technician should keep the dynamic 'that damage' mana value gate, got {debug}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn generated_definition_support_accepts_deepcavern_imp() {
         let text = "Mana cost: {2}{B}\nType: Creature — Imp Rebel\nPower/Toughness: 2/2\nFlying, haste\nEcho—Discard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)";
         let definition = CardDefinitionBuilder::new(CardId::new(), "Deepcavern Imp")

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -27158,6 +27158,140 @@ fn atraxa_grand_unifier_puts_one_card_per_type_into_hand_and_bottoms_the_rest() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn covert_technician_combat_damage_trigger_puts_only_artifact_with_mana_value_up_to_damage() {
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::ids::ObjectId;
+
+    struct ChooseArtifactDecisionMaker {
+        accept_may: bool,
+        chosen: Option<ObjectId>,
+    }
+
+    impl DecisionMaker for ChooseArtifactDecisionMaker {
+        fn decide_boolean(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            self.accept_may
+        }
+
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            let choice = ctx
+                .candidates
+                .iter()
+                .find(|candidate| candidate.legal)
+                .map(|candidate| candidate.id);
+            self.chosen = choice;
+            choice.into_iter().collect()
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let covert_technician = CardDefinitionBuilder::new(CardId::new(), "Covert Technician")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![crate::types::Subtype::Vedalken, crate::types::Subtype::Ninja])
+        .power_toughness(PowerToughness::fixed(2, 4))
+        .parse_text(
+            "Ninjutsu {1}{U} ({1}{U}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.",
+        )
+        .expect("Covert Technician should parse");
+
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&covert_technician)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains(
+            "you may put an artifact card with mana value that damage or less from your hand onto the battlefield"
+        ),
+        "compiled text should keep the dynamic damage mana-value gate, got {rendered}"
+    );
+
+    let technician_id = game.create_object_from_definition(&covert_technician, alice, Zone::Battlefield);
+
+    let legal_artifact = CardBuilder::new(CardId::new(), "Legal Bauble")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let legal_artifact_id = game.create_object_from_card(&legal_artifact, alice, Zone::Hand);
+
+    let expensive_artifact = CardBuilder::new(CardId::new(), "Expensive Golem")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let expensive_artifact_id = game.create_object_from_card(&expensive_artifact, alice, Zone::Hand);
+
+    let triggered = covert_technician
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Covert Technician should have a combat-damage trigger");
+
+    let mut yes_dm = ChooseArtifactDecisionMaker {
+        accept_may: true,
+        chosen: None,
+    };
+    let mut yes_ctx = ExecutionContext::new_default(technician_id, alice)
+        .with_decision_maker(&mut yes_dm)
+        .with_event_value_amount(2);
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut yes_ctx)
+            .expect("Covert Technician trigger should resolve at damage=2");
+    }
+
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .contains(&expensive_artifact_id),
+        "artifact above damage-based mana value cap must stay in hand"
+    );
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .contains(&legal_artifact_id)
+            || game.battlefield.contains(&legal_artifact_id),
+        "resolving the trigger must keep the legal artifact in a valid zone"
+    );
+
+    let mut game = setup_game();
+    let technician_id = game.create_object_from_definition(&covert_technician, alice, Zone::Battlefield);
+    let legal_artifact_id = game.create_object_from_card(&legal_artifact, alice, Zone::Hand);
+    let mut no_dm = ChooseArtifactDecisionMaker {
+        accept_may: false,
+        chosen: None,
+    };
+    let mut no_ctx = ExecutionContext::new_default(technician_id, alice)
+        .with_decision_maker(&mut no_dm)
+        .with_event_value_amount(3);
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut no_ctx)
+            .expect("declined Covert Technician trigger should still resolve cleanly");
+    }
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .contains(&legal_artifact_id),
+        "declining the optional trigger should keep the artifact in hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn quandrix_apprentice_magecraft_puts_only_a_looked_land_into_hand() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/triggers/combat/this_deals_combat_damage_to_player.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/this_deals_combat_damage_to_player.rs
@@ -24,6 +24,12 @@ impl TriggerMatcher for ThisDealsCombatDamageToPlayerTrigger {
     fn display(&self) -> String {
         "Whenever this creature deals combat damage to a player".to_string()
     }
+
+    fn event_value_amount(&self, event: &TriggerEvent, ctx: &TriggerContext) -> Option<i32> {
+        let e = event.downcast::<DamageEvent>()?;
+        (e.is_combat && matches!(e.target, DamageTarget::Player(_)) && e.source == ctx.source_id)
+            .then_some(e.amount as i32)
+    }
 }
 
 #[cfg(test)]
@@ -78,5 +84,30 @@ mod tests {
         );
 
         assert!(!trigger.matches(&event, &ctx));
+        assert_eq!(trigger.event_value_amount(&event, &ctx), None);
+    }
+
+    #[test]
+    fn test_event_value_amount_uses_combat_damage_amount() {
+        let game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source_id = ObjectId::from_raw(1);
+
+        let trigger = ThisDealsCombatDamageToPlayerTrigger;
+        let ctx = TriggerContext::for_source(source_id, alice, &game);
+
+        let event = TriggerEvent::new_with_provenance(
+            DamageEvent::with_cause(
+                source_id,
+                DamageTarget::Player(bob),
+                5,
+                true,
+                crate::events::cause::EventCause::combat_damage(source_id),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+
+        assert_eq!(trigger.event_value_amount(&event, &ctx), Some(5));
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Covert Technician
Initial parse error:
```
unsupported dynamic mana value comparison operand 'that' (clause: 'artifact card with mana value less than or equal to that damage from your hand'); oracle-only fallback also failed: unsupported dynamic mana value comparison operand 'that' (clause: 'artifact card with mana value less than or equal to that damage from your hand')
```

Worker: i-01a1449148a8e5bf0
