### PR TITLE
Fix Ironsmith parse failure: Megatron, Tyrant // Megatron, Destructive Force

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -212,6 +212,7 @@ fn keyword_static_marker(tokens: &[OwnedLexToken]) -> StaticAbility {
 fn supported_keyword_marker_text(text: &str) -> bool {
     let text = text.trim_start().to_ascii_lowercase();
     text.starts_with("prototype ")
+        || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
         || is_ticket_power_toughness_sticker_marker_line(&text)
         || text == "this creature crews vehicles using its toughness rather than its power."

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -197,6 +197,7 @@ fn supported_keyword_marker_text(text: &str) -> bool {
     let text = text.trim_start().to_ascii_lowercase();
     text == "compleated"
         || text.starts_with("prototype ")
+        || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
         || is_ticket_power_toughness_sticker_marker_line(&text)
         || text.starts_with("dredge ")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -931,6 +931,7 @@ fn supported_keyword_marker_text(text: &str) -> bool {
     let text = text.trim_start().to_ascii_lowercase();
     text == "compleated"
         || text.starts_with("prototype ")
+        || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
         || is_ticket_power_toughness_sticker_marker_line(&text)
         || text.starts_with("dredge ")

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -755,4 +755,29 @@ mod tests {
         assert_eq!(object.abilities.len(), 1);
         assert!(object.abilities[0].is_mana_ability());
     }
+
+    #[test]
+    fn megatron_tyrant_strict_compiles_without_keyword_fallback() {
+        let definition = compile_to_runtime_definition(
+            "Megatron, Tyrant // Megatron, Destructive Force",
+            "Mana cost: {3}{R}{W}{B}\nType: Legendary Artifact Creature — Robot\nPower/Toughness: 7/5\nMore Than Meets the Eye {1}{R}{W}{B} (You may cast this card converted for {1}{R}{W}{B}.)\nYour opponents can't cast spells during combat.\nAt the beginning of each of your postcombat main phases, you may convert Megatron. If you do, add {C} for each 1 life your opponents have lost this turn.",
+            false,
+        )
+        .expect("Megatron should strict-compile without unsupported keyword fallbacks");
+
+        let debug = format!("{definition:#?}");
+        assert!(
+            !debug.contains("KeywordFallbackText") && !debug.contains("RuleFallbackText"),
+            "Megatron should not lower to fallback static abilities:\n{debug}"
+        );
+        assert!(
+            debug.to_ascii_lowercase()
+                .contains("more than meets the eye {1}{r}{w}{b}")
+                && debug.contains("OpponentsCantCastSpells")
+                && debug.contains("ConvertEffect")
+                && debug.contains("AddScaledManaEffect")
+                && debug.contains("LifeLostThisTurn"),
+            "Megatron should preserve keyword marker and main ability semantics:\n{debug}"
+        );
+    }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37102,7 +37102,7 @@ fn parse_megatron_life_lost_turn_mana_clause() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Megatron Variant")
         .card_types(vec![CardType::Creature])
         .parse_text(
-            "Your opponents can't cast spells during combat.\nAt the beginning of each of your postcombat main phases, you may convert Megatron. If you do, add {C} for each 1 life your opponents have lost this turn.",
+            "More Than Meets the Eye {1}{R}{W}{B} (You may cast this card converted for {1}{R}{W}{B}.)\nYour opponents can't cast spells during combat.\nAt the beginning of each of your postcombat main phases, you may convert Megatron. If you do, add {C} for each 1 life your opponents have lost this turn.",
         )
         .expect("life-lost mana clause should parse");
 
@@ -37110,7 +37110,8 @@ fn parse_megatron_life_lost_turn_mana_clause() {
         .join(" ")
         .to_ascii_lowercase();
     assert!(
-        rendered.contains("during combat")
+        rendered.contains("more than meets the eye {1}{r}{w}{b}")
+            && rendered.contains("during combat")
             && rendered.contains("convert")
             && !rendered.contains("transform")
             && rendered.contains("add {c} for each 1 life your opponents have lost this turn")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Megatron, Tyrant // Megatron, Destructive Force
Initial parse error:
```
card ability compiled to unsupported static ability fallback KeywordFallbackText: more than meets the eye {1}{r}{w}{b}; oracle-only fallback also failed: card ability compiled to unsupported static ability fallback KeywordFallbackText: more than meets the eye {1}{r}{w}{b}
```

Worker: i-098862a0351d5807d
