### PR TITLE
Fix Ironsmith parse failure: James, Wandering Dad // Follow Him

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -599,7 +599,21 @@ pub(crate) fn parse_mana_usage_restriction_sentence_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<ManaUsageRestriction> {
     parse_legacy_mana_usage_restriction_sentence_lexed(tokens)
+        .or_else(|| parse_activate_ability_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_filter_mana_usage_restriction_sentence_lexed(tokens))
+}
+
+fn parse_activate_ability_mana_usage_restriction_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ManaUsageRestriction> {
+    let words = TokenWordView::new(tokens).to_word_refs();
+    if words == ["spend", "this", "mana", "only", "to", "activate", "abilities"]
+        || words == ["spend", "this", "mana", "only", "to", "activate", "an", "ability"]
+    {
+        Some(ManaUsageRestriction::ActivateAbility)
+    } else {
+        None
+    }
 }
 
 fn parse_legacy_mana_usage_restriction_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2509,6 +2509,17 @@ fn rewrite_spell_mana_restriction_wraps_preceding_mana_effect() {
 }
 
 #[test]
+fn rewrite_activate_ability_mana_restriction_parses() {
+    let tokens = lex_line("Spend this mana only to activate abilities.", 0)
+        .expect("rewrite lexer should classify mana restriction");
+
+    assert!(matches!(
+        parse_mana_usage_restriction_sentence_lexed(&tokens),
+        Some(crate::ability::ManaUsageRestriction::ActivateAbility)
+    ));
+}
+
+#[test]
 fn learn_keyword_line_lowers_to_real_effect() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Learn Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -38,6 +38,7 @@ pub enum ManaUsageRestriction {
         enters_with_counters: Vec<(crate::CounterType, u32)>,
         granted_abilities: Vec<StaticAbilityId>,
     },
+    ActivateAbility,
 }
 
 impl Eq for ManaUsageRestriction {}

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32921,6 +32921,45 @@ fn parse_oran_rief_the_vastwood_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_james_wandering_dad_follow_him_strict_regression() {
+    assert_oracle_card_parses_strict("James, Wandering Dad // Follow Him");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn james_wandering_dad_follow_him_compiled_text_keeps_spend_this_mana_only_clause() {
+    let def = parse_oracle_card_definition("James, Wandering Dad // Follow Him");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("spend this mana only to activate abilities"),
+        "expected James, Wandering Dad // Follow Him compiled text to preserve spend restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn james_wandering_dad_follow_him_models_activate_only_mana_usage_restriction() {
+    let def = parse_oracle_card_definition("James, Wandering Dad // Follow Him");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.mana_output.is_some() => Some(activated),
+            _ => None,
+        })
+        .expect("James, Wandering Dad should have a mana ability");
+
+    assert!(
+        activated
+            .mana_usage_restrictions
+            .contains(&crate::ability::ManaUsageRestriction::ActivateAbility),
+        "expected James, Wandering Dad mana ability to keep activate-abilities usage restriction"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn oran_rief_the_vastwood_compiled_text_keeps_entered_this_turn_green_filter() {
     let def = parse_oracle_card_definition("Oran-Rief, the Vastwood");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -30150,6 +30150,9 @@ fn describe_mana_usage_restriction(
             line.push_str(&bonuses.join(" and "));
             Some(line)
         }
+        crate::ability::ManaUsageRestriction::ActivateAbility => {
+            Some("Spend this mana only to activate abilities".to_string())
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -724,6 +724,7 @@ fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRe
             restrict_to_matching_spell,
             ..
         } => *restrict_to_matching_spell,
+        crate::ability::ManaUsageRestriction::ActivateAbility => true,
     }
 }
 
@@ -771,6 +772,7 @@ fn restriction_bonus_applies_to_payment_source(
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, payment_source)
         }
+        crate::ability::ManaUsageRestriction::ActivateAbility => false,
     }
 }
 
@@ -835,6 +837,7 @@ pub(super) fn payment_source_matches_restriction(
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, Some(source_obj.id))
         }
+        crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
     }
 }
 
@@ -973,6 +976,7 @@ pub(super) fn apply_spent_mana_bonuses(
                 enters_with_counters,
                 granted_abilities,
             ),
+            crate::ability::ManaUsageRestriction::ActivateAbility => continue,
         };
 
         if grant_uncounterable || !enters_with_counters.is_empty() {
@@ -4734,6 +4738,66 @@ mod priority_mana_tests {
                         if static_ability.id() == StaticAbilityId::CantBeCountered
                 )),
             "spending restricted Cavern-style mana should make the matching spell uncounterable"
+        );
+    }
+
+    #[test]
+    fn james_wandering_dad_follow_him_restricted_mana_only_pays_for_activated_abilities() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+
+        let james = CardDefinitionBuilder::new(CardId::new(), "James, Wandering Dad // Follow Him")
+            .card_types(vec![CardType::Creature])
+            .parse_text("{T}: Add {C}{C}. Spend this mana only to activate abilities.")
+            .expect("James mana ability text should parse");
+
+        let restriction = james
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Activated(activated) if !activated.mana_usage_restrictions.is_empty() => {
+                    activated.mana_usage_restrictions.first().cloned()
+                }
+                _ => None,
+            })
+            .expect("James mana ability should include a usage restriction");
+
+        let source_id = game.new_object_id();
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Colorless,
+                source: source_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction],
+            });
+
+        let mana_rock = CardDefinitionBuilder::new(CardId::new(), "Ability Target")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let mana_rock_id = game.create_object_from_definition(&mana_rock, alice, Zone::Battlefield);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Colorless, Some(mana_rock_id)).is_some(),
+            "James restricted mana should be spendable to activate abilities"
+        );
+
+        let mut game = setup_game();
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Colorless,
+                source: source_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![crate::ability::ManaUsageRestriction::ActivateAbility],
+            });
+
+        let spell = CardDefinitionBuilder::new(CardId::new(), "Spell Target")
+            .card_types(vec![CardType::Instant])
+            .build();
+        let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Colorless, Some(spell_id)).is_none(),
+            "James restricted mana should not be spendable to cast spells"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: James, Wandering Dad // Follow Him
Initial parse error:
```
compiled text dropped required semantic marker: spend-this-mana-only
```

Worker: i-0fcf66b9072822e51
