### PR TITLE
Fix Ironsmith parse failure: Nature's Embrace

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -871,6 +871,8 @@ pub(crate) fn parse_granted_keyword_static_line(
         return Ok(None);
     }
 
+    let attached_subject_filter =
+        infer_attached_subject_filter_from_condition_expr(condition.as_ref());
     let subject_words = crate::runtime_backend::token_word_refs(&subject_tokens);
     let subject = if subject_words.as_slice()
         == ["the", "first", "spell", "you", "cast", "each", "turn"]
@@ -882,7 +884,10 @@ pub(crate) fn parse_granted_keyword_static_line(
                 .first_spell_cast_each_turn(),
         )
     } else {
-        parse_anthem_subject(&subject_tokens)?
+        parse_anthem_subject_with_attached_fallback(
+            &subject_tokens,
+            attached_subject_filter.as_ref(),
+        )?
     };
 
     let grants_conspire = actions
@@ -1941,6 +1946,20 @@ fn parse_anthem_subject_with_attached_fallback(
     parse_anthem_subject(tokens)
 }
 
+fn infer_attached_subject_filter_from_condition_expr(
+    condition: Option<&crate::ConditionExpr>,
+) -> Option<ObjectFilter> {
+    match condition {
+        Some(crate::ConditionExpr::EnchantedPermanentIsCreature)
+        | Some(crate::ConditionExpr::EnchantedPermanentIsLand)
+        | Some(crate::ConditionExpr::EnchantedPermanentIsEquipment)
+        | Some(crate::ConditionExpr::EnchantedPermanentIsVehicle) => {
+            Some(ObjectFilter::tagged("enchanted"))
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_static_quantity_prefix(
     tokens: &[OwnedLexToken],
     allow_default_one: bool,
@@ -2173,6 +2192,11 @@ pub(crate) fn parse_static_condition_clause(
         || clause_words == ["enchanted", "permanent", "is", "creature"]
     {
         return Ok(crate::ConditionExpr::EnchantedPermanentIsCreature);
+    }
+    if clause_words == ["enchanted", "permanent", "is", "a", "land"]
+        || clause_words == ["enchanted", "permanent", "is", "land"]
+    {
+        return Ok(crate::ConditionExpr::EnchantedPermanentIsLand);
     }
     if clause_words == ["enchanted", "permanent", "is", "an", "equipment"]
         || clause_words == ["enchanted", "permanent", "is", "a", "equipment"]
@@ -6501,7 +6525,11 @@ pub(crate) fn parse_filter_has_granted_ability_line(
                 continue;
             }
         };
-        let subject = match parse_anthem_subject(&subject_tokens) {
+        let attached_subject_filter = infer_attached_subject_filter_from_condition_expr(condition.as_ref());
+        let subject = match parse_anthem_subject_with_attached_fallback(
+            &subject_tokens,
+            attached_subject_filter.as_ref(),
+        ) {
             Ok(subject) => subject,
             Err(err) => {
                 deferred_error.get_or_insert(err);

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -776,6 +776,7 @@ pub enum Condition {
     SourceIsEquipped,
     SourceIsEnchanted,
     EnchantedPermanentIsCreature,
+    EnchantedPermanentIsLand,
     EnchantedPermanentIsEquipment,
     EnchantedPermanentIsVehicle,
     EquippedCreatureTapped,

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -11176,6 +11176,41 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_natures_embrace_creature_or_land_static_conditions() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Nature's Embrace")
+            .parse_text(
+                "Enchant creature or land\nAs long as enchanted permanent is a creature, it gets +2/+2.\nAs long as enchanted permanent is a land, it has \"{T}: Add two mana of any one color.\"",
+            )
+            .expect("Nature's Embrace should parse");
+
+        let displays: Vec<String> = def
+            .abilities
+            .iter()
+            .filter_map(|ability| match &ability.kind {
+                AbilityKind::Static(static_ability) => Some(static_ability.display()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            displays.iter().any(|display| {
+                display.contains("enchanted permanent gets +2/+2")
+                    && display.contains("as long as enchanted permanent is a creature")
+            }),
+            "expected creature branch with +2/+2, got: {displays:?}"
+        );
+        assert!(
+            displays.iter().any(|display| {
+                display.contains("as long as enchanted permanent is a land")
+                    && (display.to_ascii_lowercase().contains("add two mana")
+                        || display.contains("{T}: Add"))
+            }),
+            "expected land branch granting mana ability, got: {displays:?}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_conditional_attached_anthem_keyword_and_activated_grant() {
         let def = CardDefinitionBuilder::new(CardId::new(), "Careful Cultivation Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -1006,6 +1006,19 @@ pub(super) fn have_verb_for_subject(subject: &str) -> &'static str {
     }
 }
 
+fn merge_line_conditions_compatible(left: &str, right: &str) -> bool {
+    match (
+        parse_conditional_subject_predicate(left),
+        parse_conditional_subject_predicate(right),
+    ) {
+        (Some(left_conditional), Some(right_conditional)) => left_conditional
+            .condition
+            .eq_ignore_ascii_case(&right_conditional.condition),
+        (Some(_), None) | (None, Some(_)) => false,
+        (None, None) => true,
+    }
+}
+
 pub(super) fn merge_subject_has_keyword_lines(lines: Vec<String>) -> Vec<String> {
     let mut merged = Vec::with_capacity(lines.len());
     let mut idx = 0usize;
@@ -1092,6 +1105,7 @@ pub(super) fn merge_subject_has_keyword_lines(lines: Vec<String>) -> Vec<String>
                 && let Some((right_subject, right_tail)) = split_have_clause(right)
                 && left_subject.eq_ignore_ascii_case(&right_subject)
                 && left_rest.contains(" and has ")
+                && merge_line_conditions_compatible(left, right)
             {
                 let right_tail = normalize_keyword_predicate_case(&right_tail);
                 let left_key = strip_parenthetical_segments(left_rest).to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10924,6 +10924,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::EnchantedPermanentIsCreature => {
             "enchanted permanent is a creature".to_string()
         }
+        Condition::EnchantedPermanentIsLand => "enchanted permanent is a land".to_string(),
         Condition::EnchantedPermanentIsEquipment => {
             "enchanted permanent is an equipment".to_string()
         }

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -935,6 +935,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::VoteOptionGetsMoreVotes(..) => {}
         Condition::VoteOptionGetsMoreVotesOrTied(..) => {}
         Condition::EnchantedPermanentIsCreature => {}
+        Condition::EnchantedPermanentIsLand => {}
         Condition::EnchantedPermanentIsEquipment => {}
         Condition::EnchantedPermanentIsVehicle => {}
         Condition::EquippedCreatureTapped => {}
@@ -1587,6 +1588,10 @@ pub fn evaluate_condition_external(
             .object(ctx.source)
             .and_then(|source_obj| source_obj.attached_to.and_then(|target| target.object_id()))
             .is_some_and(|attached| game.object_has_card_type(attached, CardType::Creature)),
+        Condition::EnchantedPermanentIsLand => game
+            .object(ctx.source)
+            .and_then(|source_obj| source_obj.attached_to.and_then(|target| target.object_id()))
+            .is_some_and(|attached| game.object_has_card_type(attached, CardType::Land)),
         Condition::EnchantedPermanentIsEquipment => game
             .object(ctx.source)
             .and_then(|source_obj| source_obj.attached_to.and_then(|target| target.object_id()))
@@ -2364,6 +2369,7 @@ fn evaluate_condition_simple(
         | Condition::SourceIsEquipped
         | Condition::SourceIsEnchanted
         | Condition::EnchantedPermanentIsCreature
+        | Condition::EnchantedPermanentIsLand
         | Condition::EnchantedPermanentIsEquipment
         | Condition::EnchantedPermanentIsVehicle
         | Condition::EquippedCreatureTapped
@@ -3362,6 +3368,12 @@ fn evaluate_condition(
             .and_then(|source_obj| source_obj.attached_to.and_then(|target| target.object_id()))
             .is_some_and(|attached| {
                 game.object_has_card_type(attached, crate::types::CardType::Creature)
+            })),
+        Condition::EnchantedPermanentIsLand => Ok(game
+            .object(ctx.source)
+            .and_then(|source_obj| source_obj.attached_to.and_then(|target| target.object_id()))
+            .is_some_and(|attached| {
+                game.object_has_card_type(attached, crate::types::CardType::Land)
             })),
         Condition::EnchantedPermanentIsEquipment => Ok(game
             .object(ctx.source)

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -849,6 +849,9 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::EnchantedPermanentIsCreature => {
             "as long as enchanted permanent is a creature".to_string()
         }
+        crate::ConditionExpr::EnchantedPermanentIsLand => {
+            "as long as enchanted permanent is a land".to_string()
+        }
         crate::ConditionExpr::EnchantedPermanentIsEquipment => {
             "as long as enchanted permanent is an equipment".to_string()
         }

--- a/crates/ironsmith-runtime/src/tests/layer_system_tests.rs
+++ b/crates/ironsmith-runtime/src/tests/layer_system_tests.rs
@@ -592,6 +592,99 @@ fn test_conditional_attached_creature_check_uses_in_progress_characteristics() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_natures_embrace_creature_branch_applies_only_creature_bonus() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let creature = CardBuilder::new(CardId::new(), "Test Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let creature_id = game.create_object_from_card(&creature, alice, Zone::Battlefield);
+
+    let aura_def = CardDefinitionBuilder::new(CardId::new(), "Nature's Embrace")
+        .parse_text(
+            "Enchant creature or land\nAs long as enchanted permanent is a creature, it gets +2/+2.\nAs long as enchanted permanent is a land, it has \"{T}: Add two mana of any one color.\"",
+        )
+        .expect("Nature's Embrace should parse");
+    let aura_id = game.create_object_from_definition(&aura_def, alice, Zone::Battlefield);
+
+    {
+        let aura = game.object_mut(aura_id).expect("aura should exist");
+        aura.attached_to = Some(crate::object::AttachmentTarget::Object(creature_id));
+    }
+    {
+        let creature = game.object_mut(creature_id).expect("creature should exist");
+        creature.attachments.push(aura_id);
+    }
+
+    let chars = game
+        .calculated_characteristics(creature_id)
+        .expect("conditional attached effect should evaluate");
+
+    assert_eq!(chars.power, Some(4));
+    assert_eq!(chars.toughness, Some(4));
+    assert!(
+        !chars.abilities.iter().any(|ability| {
+            crate::ability::ability_surface_text_for_tests(ability).is_some_and(|text| {
+                text.to_ascii_lowercase().contains("add two mana of any one color")
+            })
+        }),
+        "creature branch should not gain the land mana ability"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_natures_embrace_land_branch_grants_mana_not_creature_bonus() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let land = CardBuilder::new(CardId::new(), "Test Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let land_id = game.create_object_from_card(&land, alice, Zone::Battlefield);
+
+    let aura_def = CardDefinitionBuilder::new(CardId::new(), "Nature's Embrace")
+        .parse_text(
+            "Enchant creature or land\nAs long as enchanted permanent is a creature, it gets +2/+2.\nAs long as enchanted permanent is a land, it has \"{T}: Add two mana of any one color.\"",
+        )
+        .expect("Nature's Embrace should parse");
+    let aura_id = game.create_object_from_definition(&aura_def, alice, Zone::Battlefield);
+
+    {
+        let aura = game.object_mut(aura_id).expect("aura should exist");
+        aura.attached_to = Some(crate::object::AttachmentTarget::Object(land_id));
+    }
+    {
+        let land = game.object_mut(land_id).expect("land should exist");
+        land.attachments.push(aura_id);
+    }
+
+    let chars = game
+        .calculated_characteristics(land_id)
+        .expect("conditional attached effect should evaluate");
+
+    assert!(
+        chars.abilities.iter().any(|ability| {
+            crate::ability::ability_surface_text_for_tests(ability).is_some_and(|text| {
+                text.to_ascii_lowercase().contains("add two mana of any one color")
+            })
+        }),
+        "land branch should gain the two-mana ability"
+    );
+    assert_eq!(
+        chars.power, None,
+        "land branch should not gain creature power/toughness"
+    );
+    assert_eq!(
+        chars.toughness, None,
+        "land branch should not gain creature power/toughness"
+    );
+}
+
 /// Tests that Urza's Saga survives under Blood Moon even with max lore counters.
 ///
 /// Scenario: Urza's Saga has 3 lore counters (would normally sacrifice).


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nature's Embrace
Initial parse error:
```
unsupported static condition clause (clause: 'enchanted permanent is a land'); oracle-only fallback also failed: unsupported static condition clause (clause: 'enchanted permanent is a land')
```

Worker: i-0949c0fb89efe2d41
