### PR TITLE
Fix Ironsmith parse failure: Robe of the Archmagi

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
@@ -754,26 +754,37 @@ fn parse_equip_target_filter_qualifier(tokens: &[OwnedLexToken]) -> Option<Objec
     if words.is_empty() {
         return None;
     }
-    if words.last().copied() == Some("creature") {
-        let subtype_words = &words[..words.len().saturating_sub(1)];
-        if subtype_words.is_empty() {
-            return None;
-        }
-        if subtype_words.len() != 1 {
-            return None;
-        }
-        let subtype = parse_subtype_flexible(subtype_words[0])?;
-        let mut filter = ObjectFilter::creature().you_control();
-        push_unique(&mut filter.subtypes, subtype);
-        return Some(filter);
+    let mut subtype_words = words.as_slice();
+    if subtype_words.last().copied() == Some("creature") {
+        subtype_words = &subtype_words[..subtype_words.len().saturating_sub(1)];
     }
-
-    if words.len() != 1 {
+    if subtype_words.is_empty() {
         return None;
     }
-    let subtype = parse_subtype_flexible(words[0])?;
+
+    let mut parsed_subtypes = Vec::new();
+    let mut saw_subtype = false;
+    for word in subtype_words {
+        if matches!(*word, "or" | "and" | "and/or") {
+            if !saw_subtype {
+                return None;
+            }
+            continue;
+        }
+
+        let subtype = parse_subtype_flexible(word)?;
+        push_unique(&mut parsed_subtypes, subtype);
+        saw_subtype = true;
+    }
+
+    if parsed_subtypes.is_empty() {
+        return None;
+    }
+
     let mut filter = ObjectFilter::creature().you_control();
-    push_unique(&mut filter.subtypes, subtype);
+    for subtype in parsed_subtypes {
+        push_unique(&mut filter.subtypes, subtype);
+    }
     Some(filter)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1757,6 +1757,35 @@ fn rewrite_document_parser_supports_equip_with_subtype_qualifier() {
 }
 
 #[test]
+fn rewrite_document_parser_supports_robe_of_the_archmagi() {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Robe of the Archmagi")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment]);
+
+    let def = builder
+        .parse_text(
+            "Whenever equipped creature deals combat damage to a player, you draw that many cards.\n\
+             Equip {4}\n\
+             Equip Shaman, Warlock, or Wizard {1}",
+        )
+        .expect("expected Robe of the Archmagi to parse strictly");
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("Shaman")
+            && abilities_debug.contains("Warlock")
+            && abilities_debug.contains("Wizard"),
+        "expected subtype-disjunction equip target filter, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("DrawCardsEffect")
+            && abilities_debug.contains("EventValue(")
+            && abilities_debug.contains("Amount"),
+        "expected triggered draw-that-many effect to be preserved, got {abilities_debug}"
+    );
+}
+
+#[test]
 fn rewrite_document_parser_splits_activation_cost_on_colon_outside_quotes() {
     let builder = CardDefinitionBuilder::new(CardId::new(), "Quoted Colon Variant")
         .card_types(vec![CardType::Artifact]);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -155,6 +155,30 @@ fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_robe_of_the_archmagi_compiled_text_includes_class_equip_clause() {
+    let def = parse_oracle_card_definition("Robe of the Archmagi");
+    let lines = canonical_compiled_lines(&def);
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "Whenever equipped creature deals combat damage to a player, you draw that many cards."),
+        "expected Robe trigger text in compiled output, got {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line == "Equip {4}"),
+        "expected base equip line in compiled output, got {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "Equip Shaman or Warlock or Wizard {1}"),
+        "expected class-qualified equip line in compiled output, got {lines:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn day_of_the_moon_chapter_resolution_goads_only_chosen_name() {
     struct ChooseMemnite;
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32617,6 +32617,14 @@ fn equip_target_qualifier_text(spec: &ChooseSpec) -> Option<String> {
             if filter.subtypes.len() == 1 {
                 return Some(filter.subtypes[0].to_string());
             }
+            if filter.subtypes.len() > 1 {
+                let names = filter
+                    .subtypes
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>();
+                return Some(names.join(" or "));
+            }
             None
         }
         _ => None,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -17938,6 +17938,134 @@ fn test_auriok_steelshaper_anthem_requires_being_equipped_and_only_buffs_soldier
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_robe_of_the_archmagi_equip_branches_and_damage_trigger() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let robe_def = CardDefinitionBuilder::new(CardId::new(), "Robe of the Archmagi")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Whenever equipped creature deals combat damage to a player, you draw that many cards.\n\
+             Equip {4}\n\
+             Equip Shaman, Warlock, or Wizard {1}",
+        )
+        .expect("Robe of the Archmagi should parse");
+    let robe_id = game.create_object_from_definition(&robe_def, alice, Zone::Battlefield);
+
+    let bear_id = create_creature(&mut game, "Vanilla Bear", alice, 2, 2);
+    let wizard_id = CardBuilder::new(CardId::from_raw(88_001), "Apprentice Wizard")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let wizard_id = game.create_object_from_card(&wizard_id, alice, Zone::Battlefield);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 1);
+
+    let one_mana_actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        one_mana_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility {
+                source,
+                ability_index: idx
+            } if *source == robe_id && *idx == 2
+        )),
+        "expected subtype-qualified equip ability to be legal with one mana when a Wizard is present"
+    );
+    if let Some(wizard) = game.object_mut(wizard_id) {
+        wizard.subtypes.clear();
+    }
+    let no_wizard_actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        !no_wizard_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility {
+                source,
+                ability_index: idx
+            } if *source == robe_id && *idx == 2
+        )),
+        "expected subtype-qualified equip ability to be unavailable without a Shaman, Warlock, or Wizard"
+    );
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 3);
+
+    let four_mana_actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        four_mana_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility {
+                source,
+                ability_index: idx
+            } if *source == robe_id && *idx == 1
+        )),
+        "expected base Equip {{4}} ability to be legal with four mana"
+    );
+
+    let triggered = robe_def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Robe should have its combat-damage trigger");
+
+    for id in [88_010, 88_011, 88_012] {
+        let draw_card = CardBuilder::new(CardId::from_raw(id), "Draw Fodder")
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_card(&draw_card, alice, Zone::Library);
+    }
+    let hand_before = game.player(alice).expect("alice exists").hand.len();
+    let library_before = game.player(alice).expect("alice exists").library.len();
+
+    let damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            bear_id,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            true,
+            crate::events::cause::EventCause::combat_damage(bear_id),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let mut dm = AutoPassDecisionMaker;
+    let mut ctx = ExecutionContext::new_default(robe_id, alice)
+        .with_decision_maker(&mut dm)
+        .with_triggering_event(damage_event);
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("Robe trigger should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        hand_before + 3,
+        "Robe trigger should draw cards equal to combat damage dealt"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        library_before - 3,
+        "Robe trigger should move the same number of cards from library to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_gargoyle_sentinel_gains_flying_only_for_itself_until_end_of_turn() {
     use crate::PriorityResponse;
     use crate::cards::CardDefinitionBuilder;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Robe of the Archmagi
Initial parse error:
```
parser does not yet support line family: 'Equip Shaman, Warlock, or Wizard {1}'; oracle-only fallback also failed: parser does not yet support line family: 'Equip Shaman, Warlock, or Wizard {1}'
```

Worker: i-09445cfddd0e4a545
