### PR TITLE
Fix Ironsmith parse failure: The Mana Rig

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5291,11 +5291,12 @@ fn compile_subject_verb_effect(
 fn compile_put_some_into_hand_rest_to_zone(
     role: SubjectRole,
     player: PlayerAst,
-    count: u32,
+    count: ChoiceCount,
     rest_zone: Zone,
     ctx: &mut EffectLoweringContext,
 ) -> Result<(Vec<Effect>, Vec<ChooseSpec>), CardTextError> {
     use crate::effect::Condition;
+    use crate::effects::consult_helpers::LibraryBottomOrder;
     use crate::target::{ObjectFilter, TaggedObjectConstraint, TaggedOpbjectRelation};
 
     let looked_tag = ctx.last_object_tag.clone().ok_or_else(|| {
@@ -5303,6 +5304,7 @@ fn compile_put_some_into_hand_rest_to_zone(
     })?;
     let subject = resolve_subject_verb_subject(role, player, ctx, true, true, false)?;
     let chooser = subject.as_chooser();
+    let player_filter = subject.clone_player_filter();
     let choices = subject.into_choices();
 
     let mut choose_filter = ObjectFilter::tagged(looked_tag.clone());
@@ -5312,7 +5314,7 @@ fn compile_put_some_into_hand_rest_to_zone(
     let choose = Effect::new(
         crate::effects::ChooseObjectsEffect::new(
             choose_filter,
-            ChoiceCount::exactly(count as usize),
+            count,
             chooser,
             chosen_tag_key.clone(),
         )
@@ -5334,15 +5336,24 @@ fn compile_put_some_into_hand_rest_to_zone(
             tag: TagKey::from("__it__"),
             relation: TaggedOpbjectRelation::SameStableId,
         });
-    let in_chosen = Condition::TaggedObjectMatches(chosen_tag_key, membership_filter);
-    let move_rest = Effect::for_each_tagged(
-        looked_tag,
-        vec![Effect::conditional(
-            in_chosen,
-            Vec::new(),
-            vec![Effect::move_to_zone(ChooseSpec::Iterated, rest_zone, false)],
-        )],
-    );
+    let in_chosen = Condition::TaggedObjectMatches(chosen_tag_key.clone(), membership_filter);
+    let move_rest = if rest_zone == Zone::Library {
+        Effect::put_tagged_remainder_on_library_bottom(
+            TagKey::from(looked_tag.as_str()),
+            Some(chosen_tag_key),
+            LibraryBottomOrder::Random,
+            player_filter,
+        )
+    } else {
+        Effect::for_each_tagged(
+            looked_tag,
+            vec![Effect::conditional(
+                in_chosen,
+                Vec::new(),
+                vec![Effect::move_to_zone(ChooseSpec::Iterated, rest_zone, false)],
+            )],
+        )
+    };
 
     Ok((vec![choose, move_chosen, move_rest], choices))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -897,10 +897,10 @@ pub(crate) enum SubjectVerbActionAst {
         zone: Zone,
     },
     PutSomeIntoHandRestIntoGraveyard {
-        count: u32,
+        count: ChoiceCount,
     },
     PutSomeIntoHandRestOnBottomOfLibrary {
-        count: u32,
+        count: ChoiceCount,
     },
     AdditionalLandPlays {
         count: Value,
@@ -3252,6 +3252,16 @@ impl EffectAst {
         player: PlayerAst,
         count: u32,
     ) -> Self {
+        Self::subject_verb_put_some_into_hand_rest_into_graveyard_with_count(
+            player,
+            ChoiceCount::exactly(count as usize),
+        )
+    }
+
+    pub(crate) fn subject_verb_put_some_into_hand_rest_into_graveyard_with_count(
+        player: PlayerAst,
+        count: ChoiceCount,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Chooser,
             player,
@@ -3274,6 +3284,16 @@ impl EffectAst {
     pub(crate) fn subject_verb_put_some_into_hand_rest_on_bottom_of_library(
         player: PlayerAst,
         count: u32,
+    ) -> Self {
+        Self::subject_verb_put_some_into_hand_rest_on_bottom_of_library_with_count(
+            player,
+            ChoiceCount::exactly(count as usize),
+        )
+    }
+
+    pub(crate) fn subject_verb_put_some_into_hand_rest_on_bottom_of_library_with_count(
+        player: PlayerAst,
+        count: ChoiceCount,
     ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Chooser,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -767,9 +767,12 @@ mod tests {
                 }),
                 EffectAst::SubjectVerb(SubjectVerbEffectAst {
                     subject,
-                    action: SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { count: 1 },
+                    action: SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { count },
                 }),
-            ] => assert_eq!(subject.player, PlayerAst::You),
+            ] => {
+                assert_eq!(subject.player, PlayerAst::You);
+                assert_eq!(*count, crate::effect::ChoiceCount::exactly(1));
+            }
             other => panic!("expected looked-cards split effects, got {other:?}"),
         }
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -534,7 +534,16 @@ pub(crate) fn parse_put_into_hand(
             && grammar::contains_word(tokens, "library")
             && clause_words.iter().any(|w| *w == "and" || *w == "then")
         {
-            let (count, used) = parse_number(tokens).ok_or_else(|| {
+            let mut up_to = false;
+            let (count, used) = if tokens.first().is_some_and(|t| t.is_word("up"))
+                && tokens.get(1).is_some_and(|t| t.is_word("to"))
+            {
+                up_to = true;
+                parse_number(&tokens[2..]).map(|(value, used)| (value, used + 2))
+            } else {
+                parse_number(tokens)
+            }
+            .ok_or_else(|| {
                 CardTextError::ParseError(format!(
                     "missing put count (clause: '{}')",
                     clause_words.join(" ")
@@ -561,12 +570,12 @@ pub(crate) fn parse_put_into_hand(
                 player
             };
 
-            return Ok(
-                EffectAst::subject_verb_put_some_into_hand_rest_on_bottom_of_library(
-                    dest_player,
-                    count as u32,
-                ),
-            );
+            let choice_count = if up_to {
+                ChoiceCount::up_to(count as usize)
+            } else {
+                ChoiceCount::exactly(count as usize)
+            };
+            return Ok(EffectAst::subject_verb_put_some_into_hand_rest_on_bottom_of_library_with_count(dest_player, choice_count));
         }
 
         // "Put N of them into your hand and the rest into your graveyard."
@@ -575,7 +584,16 @@ pub(crate) fn parse_put_into_hand(
             && grammar::contains_word(tokens, "graveyard")
             && clause_words.iter().any(|w| *w == "and" || *w == "then")
         {
-            let (count, used) = parse_number(tokens).ok_or_else(|| {
+            let mut up_to = false;
+            let (count, used) = if tokens.first().is_some_and(|t| t.is_word("up"))
+                && tokens.get(1).is_some_and(|t| t.is_word("to"))
+            {
+                up_to = true;
+                parse_number(&tokens[2..]).map(|(value, used)| (value, used + 2))
+            } else {
+                parse_number(tokens)
+            }
+            .ok_or_else(|| {
                 CardTextError::ParseError(format!(
                     "missing put count (clause: '{}')",
                     clause_words.join(" ")
@@ -604,10 +622,12 @@ pub(crate) fn parse_put_into_hand(
                 player
             };
 
-            return Ok(EffectAst::subject_verb_put_some_into_hand_rest_into_graveyard(
-                dest_player,
-                count as u32,
-            ));
+            let choice_count = if up_to {
+                ChoiceCount::up_to(count as usize)
+            } else {
+                ChoiceCount::exactly(count as usize)
+            };
+            return Ok(EffectAst::subject_verb_put_some_into_hand_rest_into_graveyard_with_count(dest_player, choice_count));
         }
 
         let effect = EffectAst::subject_verb_put_into_hand(player, ObjectRefAst::Tagged(TagKey::from(IT_TAG)));

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10494,6 +10494,21 @@ fn rewrite_lexed_effect_sequence_parses_consult_hand_bottom_family() {
 }
 
 #[test]
+fn rewrite_lexed_effect_sequence_parses_up_to_counted_looked_cards_into_hand_rest_bottom() {
+    let text = "Look at the top X cards of your library. Put up to two of them into your hand and the rest on the bottom of your library in a random order.";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify The Mana Rig activated text");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&lexed).expect("sequence");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("LookAtTopCards"), "{debug}");
+    assert!(
+        debug.contains("PutSomeIntoHandRestOnBottomOfLibrary") && debug.contains("up_to"),
+        "expected up-to counted looked-card move with remainder to bottom, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_sequence_parses_optional_consult_battlefield_graveyard_family() {
     let text = "You may reveal cards from the top of your library until you reveal a land card. If you do, put that card onto the battlefield and put all other cards revealed this way into your graveyard.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify optional consult text");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -19875,6 +19875,48 @@ fn render_powerstone_token_name() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_the_mana_rig_oracle_text_strictly() {
+    let oracle = "Whenever you cast a multicolored spell, create a tapped Powerstone token.\n{X}{X}{X}, {T}: Look at the top X cards of your library. Put up to two of them into your hand and the rest on the bottom of your library in a random order.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "The Mana Rig")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(oracle)
+        .expect("The Mana Rig should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Put up to two of them into your hand and the rest on the bottom of your library in a random order"),
+        "expected looked-card split clause in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_the_mana_rig_tracks_trigger_and_xxx_tap_activation_shape() {
+    let oracle = "Whenever you cast a multicolored spell, create a tapped Powerstone token.\n{X}{X}{X}, {T}: Look at the top X cards of your library. Put up to two of them into your hand and the rest on the bottom of your library in a random order.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "The Mana Rig")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(oracle)
+        .expect("The Mana Rig should parse strictly");
+
+    let abilities_debug = format!("{:#?}", def.abilities).to_ascii_lowercase();
+    assert!(
+        abilities_debug.contains("multicolored") && abilities_debug.contains("powerstone"),
+        "expected multicolored-cast trigger creating Powerstone token, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("manapaymentcost")
+            && abilities_debug.contains("pips")
+            && abilities_debug.contains("tapeffect")
+            && abilities_debug.contains("choicecount")
+            && abilities_debug.contains("min: 0")
+            && abilities_debug.contains("max: some(")
+            && abilities_debug.contains("2"),
+        "expected XXX+tap activated ability with up-to-two looked-card choice, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_token_with_banding_keyword_modifier() {
     let result = CardDefinitionBuilder::new(CardId::new(), "Errand of Duty Variant")
         .parse_text("Create a 1/1 white Knight creature token with banding.");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -8985,10 +8985,12 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                 return None;
             }
             let mut idx = 2usize;
+            let mut reveals_selection = false;
             if effects
                 .get(idx)
                 .is_some_and(|effect| for_each_reveals_iterated_tag(effect, &choose.tag))
             {
+                reveals_selection = true;
                 idx += 1;
             }
             if !effects
@@ -9020,6 +9022,14 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                     && constraint.tag == look.tag)
             });
             let mut filter_text = filter.description();
+            let unfiltered_looked_cards = filter_text == "permanent";
+            if unfiltered_looked_cards {
+                filter_text = if choose.count.max == Some(1) {
+                    "card".to_string()
+                } else {
+                    "cards".to_string()
+                };
+            }
             if !filter_text.contains("card") {
                 filter_text.push_str(if choose.count.max == Some(1) {
                     " card"
@@ -9027,7 +9037,17 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                     " cards"
                 });
             }
-            let selection = if choose.count.max == Some(1) {
+            let selection = if unfiltered_looked_cards {
+                match (choose.count.min, choose.count.max) {
+                    (0, Some(1)) => "up to one of them".to_string(),
+                    (1, Some(1)) => "one of them".to_string(),
+                    (0, Some(max)) => {
+                        let max_text = number_word(max as i32).unwrap_or_else(|| max.to_string());
+                        format!("up to {max_text} of them")
+                    }
+                    _ => format!("{} of them", describe_choice_count(&choose.count)),
+                }
+            } else if choose.count.max == Some(1) {
                 with_indefinite_article(&filter_text)
             } else {
                 let count_text = match (choose.count.min, choose.count.max) {
@@ -9040,10 +9060,24 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                 format!("{count_text} {filter_text}")
             };
             Some((
-                format!(
-                    "{}. You may reveal {selection} from among them and put them into your hand. Put the rest on the bottom of your library{order_text}",
-                    describe_effect(effects[0])
-                ),
+                if reveals_selection {
+                    format!(
+                        "{}. You may reveal {selection} from among them and put them into your hand. Put the rest on the bottom of your library{order_text}",
+                        describe_effect(effects[0])
+                    )
+                } else {
+                    if unfiltered_looked_cards {
+                        format!(
+                            "{}. Put {selection} into your hand and the rest on the bottom of your library{order_text}",
+                            describe_effect(effects[0])
+                        )
+                    } else {
+                        format!(
+                            "{}. Put {selection} from among them into your hand. Put the rest on the bottom of your library{order_text}",
+                            describe_effect(effects[0])
+                        )
+                    }
+                },
                 idx + 1,
             ))
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The Mana Rig
Initial parse error:
```
missing put count (clause: 'up to two of them into your hand and the rest on the bottom of your library in a random order'); oracle-only fallback also failed: missing put count (clause: 'up to two of them into your hand and the rest on the bottom of your library in a random order')
```

Worker: i-08689a342706d8daa
