### PR TITLE
Fix Ironsmith parse failure: Knowledge Exploitation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -362,6 +362,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
             winnow::combinator::alt((
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),
                 grammar::kw("warp").value(KeywordDispatchHint::Warp),
+                grammar::kw("prowl").value(KeywordDispatchHint::AlternativeOrExertFamily),
                 grammar::kw("escalate").value(KeywordDispatchHint::Escalate),
                 grammar::kw("evoke").value(KeywordDispatchHint::Evoke),
                 grammar::kw("epic").value(KeywordDispatchHint::Epic),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -38,6 +38,7 @@ use super::util::{
     parse_harmonize_line_lexed, parse_if_conditional_alternative_cost_line_lexed,
     parse_jump_start_line_lexed, parse_kicker_line_lexed, parse_madness_line_lexed,
     parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_offspring_line_lexed,
+    parse_prowl_line_lexed,
     parse_reinforce_line_lexed, parse_replicate_line_lexed, parse_retrace_line_lexed,
     parse_self_free_cast_alternative_cost_line_lexed, parse_squad_line_lexed,
     parse_transmute_line_lexed, parse_warp_line_lexed,
@@ -282,6 +283,9 @@ pub(super) fn lower_alternative_cast(
     if let Some(method) =
         parse_if_conditional_alternative_cost_line_lexed(tokens, line.text.as_str())?
     {
+        return Ok(LineAst::AlternativeCastingMethod(method.into()));
+    }
+    if let Some(method) = parse_prowl_line_lexed(tokens)? {
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     Err(CardTextError::ParseError(format!(
@@ -957,6 +961,7 @@ fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTex
         || parse_flash_with_additional_cost_line_lexed(tokens).is_some()
         || parse_jump_start_line_lexed(tokens)?.is_some()
         || parse_if_conditional_alternative_cost_line_lexed(tokens, rendered.as_str())?.is_some()
+        || parse_prowl_line_lexed(tokens)?.is_some()
         || parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)?.is_some())
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4323,6 +4323,24 @@ pub(crate) fn parse_evoke_line_lexed(
     }))
 }
 
+pub(crate) fn parse_prowl_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    let Some(cost_tokens) = keyword_cost_tail_tokens(tokens, "prowl") else {
+        return Ok(None);
+    };
+    let total_cost = parse_activation_cost(&cost_tokens)?;
+    Ok(Some(AlternativeCastingMethod::Composed {
+        name: "Prowl",
+        total_cost,
+        condition: Some(
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Rogue,
+            ),
+        ),
+    }))
+}
+
 pub(crate) fn parse_eternalize_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<ManaCost>, CardTextError> {

--- a/crates/ironsmith-core/src/spell_cost_condition_model.rs
+++ b/crates/ironsmith-core/src/spell_cost_condition_model.rs
@@ -1,4 +1,4 @@
-use crate::{CardType, Condition, ObjectFilter, PlayerFilter};
+use crate::{CardType, Condition, ObjectFilter, PlayerFilter, Subtype};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ThisSpellCostCondition {
@@ -49,4 +49,5 @@ pub enum ThisSpellCostCondition {
     NotStartingPlayer,
     CreatureCardPutIntoYourGraveyardThisTurn,
     CreatureIsAttackingYou,
+    YouDealtCombatDamageToPlayerWithSubtypeThisTurn(Subtype),
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40928,3 +40928,40 @@ fn parse_oracle_trove_tracker_regression_compiles_with_encore_keyword_line() {
         "expected Trove Tracker death trigger to compile, got {rendered}"
     );
 }
+
+#[test]
+fn parse_oracle_knowledge_exploitation_supports_prowl_keyword_line() {
+    let def = parse_oracle_card_definition("Knowledge Exploitation");
+    assert!(
+        !def.alternative_casts.is_empty(),
+        "Knowledge Exploitation should compile with a prowl alternative cost"
+    );
+
+    let has_prowl = def.alternative_casts.iter().any(|method| {
+        matches!(
+            method.cast_condition(),
+            Some(crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Rogue
+            ))
+        )
+    });
+    assert!(
+        has_prowl,
+        "Knowledge Exploitation should encode Prowl with Rogue-combat-damage condition"
+    );
+}
+
+#[test]
+fn knowledge_exploitation_compiled_text_keeps_prowl_and_target_opponent_library_clause() {
+    let def = parse_oracle_card_definition("Knowledge Exploitation");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Prowl {3}{U}"),
+        "expected Knowledge Exploitation to render the prowl keyword cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains("search target opponent's library for an instant or sorcery"),
+        "expected Knowledge Exploitation to keep search-target clause, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1756,6 +1756,12 @@ pub(super) fn describe_alternative_cast_line(
                 })
                 .unwrap_or_else(|| "Surge".to_string())
         }
+        method if method.is_composed_cost() && method.name().eq_ignore_ascii_case("Prowl") => {
+            method
+                .mana_cost()
+                .map(|cost| format!("Prowl {}", cost.to_oracle()))
+                .unwrap_or_else(|| "Prowl".to_string())
+        }
         method if method.is_composed_cost() => {
             let name = method.name();
             let mana_cost = method.mana_cost();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27129,9 +27129,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else {
             "cast"
         };
+        let tag = cast_tagged.tag.as_str();
+        let helper_tag = tag.starts_with("targeted_")
+            || tag.starts_with("__source_")
+            || tag == "__it__"
+            || matches!(tag, "exiled" | "revealed" | "looked" | "chosen" | "searched")
+            || crate::cards::is_sentence_helper_tag(tag, "exiled")
+            || crate::cards::is_sentence_helper_tag(tag, "revealed")
+            || crate::cards::is_sentence_helper_tag(tag, "looked")
+            || crate::cards::is_sentence_helper_tag(tag, "chosen")
+            || crate::cards::is_sentence_helper_tag(tag, "searched");
         let spec = crate::target::ChooseSpec::Tagged(cast_tagged.tag.clone());
         let target = if cast_tagged.as_copy {
-            let tag = cast_tagged.tag.as_str();
             let tag_is_numbered = tag.rsplit_once('_').is_some_and(|(_, suffix)| {
                 !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
             });
@@ -27140,6 +27149,8 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             } else {
                 format!("a copy of {}", describe_choose_spec(&spec))
             }
+        } else if helper_tag {
+            "that card".to_string()
         } else {
             describe_choose_spec(&spec)
         };

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -464,6 +464,25 @@ mod tests {
         game.stage_turn_history_event(&event);
     }
 
+    fn stage_combat_damage_to_player_for_test(
+        game: &mut GameState,
+        source: ObjectId,
+        player: PlayerId,
+        amount: u32,
+    ) {
+        let event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::DamageEvent::with_cause(
+                source,
+                crate::events::DamageTarget::Player(player),
+                amount,
+                true,
+                crate::events::cause::EventCause::effect(),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        game.stage_turn_history_event(&event);
+    }
+
     fn stage_artifact_sacrifice_for_test(game: &mut GameState, player: PlayerId) {
         let artifact = CardBuilder::new(CardId::new(), "Sacrificed Artifact")
             .card_types(vec![CardType::Artifact])
@@ -1946,6 +1965,129 @@ mod tests {
         let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
         let effective = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
         assert_eq!(effective.to_oracle(), "{5}{B}");
+    }
+
+    #[test]
+    fn knowledge_exploitation_prowl_alternative_cost_requires_rogue_combat_damage() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let spell = CardBuilder::new(CardId::from_raw(9501), "Knowledge Exploitation")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_symbols(vec![
+                ManaSymbol::Generic(5),
+                ManaSymbol::Blue,
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+        let prowl_condition =
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Rogue,
+            );
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Fixed(2),
+            prowl_condition,
+        ));
+        game.object_mut(spell_id)
+            .expect("knowledge exploitation should exist")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let spell_obj = game
+            .object(spell_id)
+            .expect("knowledge exploitation should exist");
+        let base_cost = spell_obj
+            .mana_cost
+            .as_ref()
+            .expect("knowledge exploitation should have mana cost");
+        let effective = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            effective.to_oracle(),
+            "{5}{U}",
+            "prowl condition should be false before Rogue combat damage"
+        );
+
+
+        let rogue = CardBuilder::new(CardId::from_raw(9502), "Rogue Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Rogue])
+            .power_toughness(PowerToughness::fixed(2, 1))
+            .build();
+        let rogue_id = game.create_object_from_card(&rogue, alice, Zone::Battlefield);
+        stage_combat_damage_to_player_for_test(&mut game, rogue_id, bob, 2);
+
+        let spell_obj = game
+            .object(spell_id)
+            .expect("knowledge exploitation should exist");
+        let base_cost = spell_obj
+            .mana_cost
+            .as_ref()
+            .expect("knowledge exploitation should have mana cost");
+        let effective = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            effective.to_oracle(),
+            "{3}{U}",
+            "prowl condition should become true after your Rogue deals combat damage to a player"
+        );
+    }
+
+    #[test]
+    fn knowledge_exploitation_prowl_alternative_cost_rejects_noncombat_or_nonrogue_damage() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let spell = CardBuilder::new(CardId::from_raw(9503), "Knowledge Exploitation")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_symbols(vec![
+                ManaSymbol::Generic(5),
+                ManaSymbol::Blue,
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+        let prowl_condition =
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Rogue,
+            );
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Fixed(2),
+            prowl_condition,
+        ));
+        game.object_mut(spell_id)
+            .expect("knowledge exploitation should exist")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let wizard = CardBuilder::new(CardId::from_raw(9504), "Wizard Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Wizard])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let wizard_id = game.create_object_from_card(&wizard, alice, Zone::Battlefield);
+        stage_combat_damage_to_player_for_test(&mut game, wizard_id, bob, 2);
+
+        let rogue = CardBuilder::new(CardId::from_raw(9505), "Rogue Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Rogue])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        let rogue_id = game.create_object_from_card(&rogue, alice, Zone::Battlefield);
+        stage_noncombat_damage_to_player_for_test(&mut game, rogue_id, bob, 1);
+
+        let spell_obj = game
+            .object(spell_id)
+            .expect("knowledge exploitation should exist");
+        let base_cost = spell_obj
+            .mana_cost
+            .as_ref()
+            .expect("knowledge exploitation should have mana cost");
+        let effective = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            effective.to_oracle(),
+            "{5}{U}",
+            "prowl condition should stay false when damage is noncombat or from non-Rogue creatures"
+        );
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -1223,6 +1223,12 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
         ThisSpellCostCondition::CreatureIsAttackingYou => {
             Some("a creature is attacking you".to_string())
         }
+        ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(subtype) => {
+            Some(format!(
+                "you dealt combat damage to a player this turn with a {}",
+                subtype.to_string().to_ascii_lowercase()
+            ))
+        }
     }
 }
 
@@ -1611,6 +1617,10 @@ pub fn this_spell_cost_condition_is_active_for_cast_with_optional_costs_paid(
                 })
             })
         }
+        ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(subtype) => game
+            .turn_store
+            .turn_history
+            .player_dealt_combat_damage_to_player_with_subtype_this_turn(controller, *subtype),
     }
 }
 

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -17,7 +17,7 @@ use crate::provenance::{ProvNodeId, ProvenanceGraph};
 use crate::snapshot::ObjectSnapshot;
 use crate::triggers::TriggerEvent;
 use crate::triggers::TriggerIdentity;
-use crate::types::CardType;
+use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
 
 /// One ingested trigger/event observation for the current turn.
@@ -461,6 +461,34 @@ impl TurnHistory {
 
     pub fn player_was_dealt_damage_by_creature_this_turn(&self, player: PlayerId) -> bool {
         self.total_creature_damage_to_player(player) > 0
+    }
+
+    pub fn player_dealt_combat_damage_to_player_with_subtype_this_turn(
+        &self,
+        dealer: PlayerId,
+        subtype: Subtype,
+    ) -> bool {
+        self.projected_records().any(|record| {
+            let Some(event) = record.event.downcast::<DamageEvent>() else {
+                return false;
+            };
+            if !event.is_combat || event.amount == 0 {
+                return false;
+            }
+            if !matches!(event.target, crate::events::DamageTarget::Player(_)) {
+                return false;
+            }
+
+            record
+                .source_snapshot
+                .as_ref()
+                .or(record.object_snapshot.as_ref())
+                .is_some_and(|snapshot| {
+                snapshot.controller == dealer
+                    && snapshot.card_types.contains(&CardType::Creature)
+                    && snapshot.subtypes.contains(&subtype)
+                })
+        })
     }
 
     pub fn creature_was_damaged_by_source_this_turn(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Knowledge Exploitation
Initial parse error:
```
parser does not yet support line family: 'Prowl {3}{U} (You may cast this for its prowl cost if you dealt combat damage to a player this turn with a Rogue.)'; oracle-only fallback also failed: parser does not yet support line family: 'Prowl {3}{U}'
```

Worker: i-0db84437e9b70bb60
