### PR TITLE
Fix Ironsmith parse failure: Rankle, Master of Pranks

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
@@ -552,6 +552,10 @@ pub(crate) fn parse_type_line_rewrite(raw: &str) -> Result<TypeLineCst, CardText
 pub(crate) fn parse_modal_choose_range(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<(Option<Value>, Option<Value>)>, CardTextError> {
+    if primitives::parse_prefix(tokens, primitives::phrase(&["any", "number"])).is_some() {
+        return Ok(Some((Some(Value::Fixed(0)), None)));
+    }
+
     if let Some((range, _)) = parse_count_range_prefix(tokens) {
         return Ok(Some(range));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11552,6 +11552,24 @@ fn rewrite_modal_header_parse_all_reports_cut_for_partial_choose_range() {
 }
 
 #[test]
+fn rewrite_modal_header_parse_all_accepts_choose_any_number_clause() {
+    use super::grammar::primitives::parse_all;
+
+    let tokens = lex_line("Choose any number", 0)
+        .expect("rewrite lexer should classify choose-any-number modal header");
+    let parsed = parse_all(
+        &tokens,
+        super::grammar::structure::parse_modal_header_choose_spec,
+        "modal-header",
+    )
+    .expect("choose-any-number modal header should parse");
+
+    let choose_spec = parsed.expect("choose-any-number header should produce a choose spec");
+    assert_eq!(choose_spec.min, crate::effect::Value::Fixed(0));
+    assert_eq!(choose_spec.max, None);
+}
+
+#[test]
 fn rewrite_type_line_error_mentions_type_line_subtypes_after_dash() {
     let error = parse_error_message(parse_type_line_rewrite("Legendary Creature — !"));
     assert!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32999,6 +32999,12 @@ fn parse_raphael_tag_team_tough_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_rankle_master_of_pranks_strict_regression() {
+    assert_oracle_card_parses_strict("Rankle, Master of Pranks");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn james_wandering_dad_follow_him_compiled_text_keeps_spend_this_mana_only_clause() {
     let def = parse_oracle_card_definition("James, Wandering Dad // Follow Him");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
@@ -33019,6 +33025,39 @@ fn raphael_tag_team_tough_compiled_text_keeps_additional_combat_phase_clause() {
         rendered.contains("there is an additional combat phase"),
         "expected Raphael, Tag Team Tough compiled text to preserve additional combat clause, got {rendered}"
     );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rankle_master_of_pranks_compiled_text_keeps_choose_any_number_modal_header() {
+    let def = parse_oracle_card_definition("Rankle, Master of Pranks");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("choose any number"),
+        "expected Rankle, Master of Pranks compiled text to preserve choose-any-number modal header, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rankle_master_of_pranks_models_zero_to_all_modal_selection_bounds() {
+    let def = parse_oracle_card_definition("Rankle, Master of Pranks");
+    let modal = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered
+                .effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>()),
+            _ => None,
+        })
+        .expect("Rankle, Master of Pranks should include a triggered modal choice effect");
+
+    assert_eq!(modal.min_choose_count, Value::Fixed(0));
+    assert_eq!(modal.modes.len(), 3);
+    assert_eq!(modal.choose_count, Value::Fixed(3));
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7007,7 +7007,11 @@ pub(super) fn normalize_search_you_own_clause(text: &str) -> Option<String> {
     Some(format!("Search your library for {selection}{tail}"))
 }
 
-pub(super) fn describe_mode_choice_header(max: &Value, min: Option<&Value>) -> String {
+pub(super) fn describe_mode_choice_header(
+    max: &Value,
+    min: Option<&Value>,
+    mode_count: Option<usize>,
+) -> String {
     match (min, max) {
         (Some(Value::Fixed(min_value)), Value::Fixed(max_value)) => {
             match (*min_value, *max_value) {
@@ -7016,6 +7020,9 @@ pub(super) fn describe_mode_choice_header(max: &Value, min: Option<&Value>) -> S
                 (1, 2) => "Choose one or both —".to_string(),
                 (1, n) if n > 2 => "Choose one or more —".to_string(),
                 (0, n) => {
+                    if mode_count == Some(n as usize) && n > 1 {
+                        return "Choose any number —".to_string();
+                    }
                     if let Some(word) = number_word(n) {
                         format!("Choose up to {word} —")
                     } else {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27330,6 +27330,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         let mut header = describe_mode_choice_header(
             &choose_mode.choose_count,
             Some(&choose_mode.min_choose_count),
+            Some(choose_mode.modes.len()),
         );
         if choose_mode.disallow_previously_chosen_modes {
             header = if choose_mode.disallow_previously_chosen_modes_this_turn {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rankle, Master of Pranks
Initial parse error:
```
rewrite modal-header parse failed on line 5 at 56..59 near "any": invalid modal header choose clause expected modal choice range, modal header line; oracle-only fallback also failed: rewrite modal-header parse failed on line 2 at 54..57 near "any": invalid modal header choose clause expected modal choice range, modal header line
```

Worker: i-0af87b6d317687567
