### PR TITLE
Fix Ironsmith parse failure: Shadow of Mortality

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -288,6 +288,9 @@ pub(super) fn lower_alternative_cast(
     if let Some(method) = parse_prowl_line_lexed(tokens)? {
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
+    if let Some(ability) = parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)? {
+        return Ok(LineAst::StaticAbility(ability.into()));
+    }
     Err(CardTextError::ParseError(format!(
         "rewrite keyword lowering could not parse alternative cost line '{}'",
         line.info.raw_line

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -21728,6 +21728,51 @@ fn parse_spells_cost_modifier_supports_extended_where_x_clauses() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn shadow_of_mortality_strict_parser_regression() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(90_321), "Shadow of Mortality")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.\nTrample",
+        )
+        .expect("Shadow of Mortality should parse through conditional this-spell reduction");
+
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+            _ => None,
+        })
+        .expect("expected this-spell cost reduction for Shadow of Mortality");
+
+    assert!(matches!(
+        reduction.condition,
+        crate::static_abilities::ThisSpellCostCondition::LifeTotalLessThanStarting
+    ));
+    assert!(matches!(reduction.reduction, crate::effect::Value::X));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn shadow_of_mortality_compiled_text_keeps_life_difference_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(90_322), "Shadow of Mortality")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.\nTrample",
+        )
+        .expect("Shadow of Mortality should parse for compiled text regression");
+
+    let compiled = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    assert!(
+        compiled.contains("This spell costs {X} less to cast")
+            && compiled.contains("where X is the difference")
+            && compiled.contains("if your life total is less than your starting life total"),
+        "expected conditional X reduction clause with explicit difference wording in compiled text, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_this_spell_cost_reduction_counts_creature_types_with_cap() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Valiant Changeling Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -1968,6 +1968,49 @@ mod tests {
     }
 
     #[test]
+    fn shadow_of_mortality_cost_reduction_applies_only_below_starting_life() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+
+        let spell_card = CardBuilder::new(CardId::from_raw(9_146), "Shadow of Mortality")
+            .card_types(vec![CardType::Creature])
+            .mana_cost(ManaCost::from_pips(vec![
+                vec![ManaSymbol::Generic(13)],
+                vec![ManaSymbol::Black],
+                vec![ManaSymbol::Black],
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell_card, alice, Zone::Hand);
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::X,
+            crate::static_abilities::ThisSpellCostCondition::LifeTotalLessThanStarting,
+        ));
+        game.object_mut(spell_id)
+            .expect("spell exists")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let spell_obj = game.object(spell_id).expect("spell exists");
+        let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
+        let at_starting_life = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            at_starting_life.to_oracle(),
+            "{13}{B}{B}",
+            "cost reduction must not apply at starting life total"
+        );
+
+        game.player_mut(alice).expect("player exists").life = 12;
+        let spell_obj = game.object(spell_id).expect("spell exists");
+        let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
+        let reduced = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            reduced.to_oracle(),
+            "{5}{B}{B}",
+            "cost reduction must equal life lost from starting life total"
+        );
+    }
+
+    #[test]
     fn knowledge_exploitation_prowl_alternative_cost_requires_rogue_combat_damage() {
         let mut game = setup_game();
         let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -1651,6 +1651,13 @@ impl StaticAbilityKind for ThisSpellCostReduction {
         if let Some(tail) = tail {
             line.push(' ');
             line.push_str(&tail);
+        } else if matches!(self.reduction, Value::X)
+            && matches!(
+                self.condition,
+                ThisSpellCostCondition::LifeTotalLessThanStarting
+            )
+        {
+            line.push_str(", where X is the difference");
         }
         if is_domain_cost_reduction(&self.reduction, &self.condition) {
             line = format!("Domain — {line}");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Shadow of Mortality
Initial parse error:
```
rewrite keyword lowering could not parse alternative cost line 'If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.'; oracle-only fallback also failed: rewrite keyword lowering could not parse alternative cost line 'If your life total is less than your starting life total, this spell costs {X} less to cast, where X is the difference.'
```

Worker: i-0866a2f95e347ab3f
