### PR TITLE
Fix Ironsmith parse failure: Rageform

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
@@ -232,10 +232,17 @@ pub(crate) fn parse_become_clause(
         return Ok(EffectAst::subject_verb_make_colorless(target, duration));
     }
 
-    if word_slice_starts_with(
+    let aura_with_enchant_creature_words = if word_slice_starts_with(
         become_words,
         &["aura", "enchantment", "with", "enchant", "creature"],
     ) {
+        Some(&become_words[5..])
+    } else if word_slice_starts_with(become_words, &["aura", "with", "enchant", "creature"]) {
+        Some(&become_words[4..])
+    } else {
+        None
+    };
+    if let Some(aura_tail_words) = aura_with_enchant_creature_words {
         if matches!(
             target_subject_words.as_slice(),
             ["it"] | ["this"] | ["this", "creature"]
@@ -243,7 +250,7 @@ pub(crate) fn parse_become_clause(
         {
             target = TargetAst::Source(span_from_tokens(subject_tokens));
         }
-        let attachment_filter = if word_slice_starts_with(&become_words[5..], &["you", "control"]) {
+        let attachment_filter = if word_slice_starts_with(aura_tail_words, &["you", "control"]) {
             ObjectFilter::creature().you_control()
         } else {
             ObjectFilter::creature()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7413,6 +7413,43 @@ fn test_parse_adapt_activation_with_reminder_text_without_fallback_marker() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_rageform_parses_and_renders_aura_become_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Rageform")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "When this enchantment enters, it becomes an Aura with enchant creature. Manifest the top card of your library and attach this enchantment to it. (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)\nEnchanted creature has double strike. (It deals both first-strike and regular combat damage.)",
+        )
+        .expect("Rageform should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("becomes an aura in addition to its other types")
+            && rendered.contains("has enchant restriction"),
+        "expected aura become + enchant restriction clauses in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("manifest the top card of your library"),
+        "expected manifest clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("attach this enchantment to it"),
+        "expected attach clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("enchanted creature has double strike"),
+        "expected enchanted-creature static line, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported parser line fallback"),
+        "Rageform should not rely on parser fallback markers: {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_manifest_dread_trigger_without_fallback_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Manifest Dread Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/tests/layer_system_tests.rs
+++ b/crates/ironsmith-runtime/src/tests/layer_system_tests.rs
@@ -685,6 +685,93 @@ fn test_natures_embrace_land_branch_grants_mana_not_creature_bonus() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_rageform_grants_double_strike_only_to_attached_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let attached_creature = CardBuilder::new(CardId::new(), "Attached Test Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let attached_creature_id =
+        game.create_object_from_card(&attached_creature, alice, Zone::Battlefield);
+
+    let unattached_creature = CardBuilder::new(CardId::new(), "Unattached Test Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let unattached_creature_id =
+        game.create_object_from_card(&unattached_creature, alice, Zone::Battlefield);
+
+    let rageform_def = CardDefinitionBuilder::new(CardId::new(), "Rageform")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "When this enchantment enters, it becomes an Aura with enchant creature. Manifest the top card of your library and attach this enchantment to it.\nEnchanted creature has double strike.",
+        )
+        .expect("Rageform should parse for runtime behavior test");
+    let rageform_id = game.create_object_from_definition(&rageform_def, alice, Zone::Battlefield);
+
+    {
+        let rageform = game.object_mut(rageform_id).expect("Rageform should exist");
+        rageform.attached_to = Some(crate::object::AttachmentTarget::Object(attached_creature_id));
+    }
+    {
+        let creature = game
+            .object_mut(attached_creature_id)
+            .expect("attached creature should exist");
+        creature.attachments.push(rageform_id);
+    }
+
+    assert!(
+        game.object_has_ability(attached_creature_id, &StaticAbility::double_strike()),
+        "Rageform should grant double strike to the enchanted creature"
+    );
+    assert!(
+        !game.object_has_ability(unattached_creature_id, &StaticAbility::double_strike()),
+        "Rageform should not grant double strike to creatures it does not enchant"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_rageform_can_enchant_opponents_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let bob_creature = CardBuilder::new(CardId::new(), "Opponent Test Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bob_creature_id = game.create_object_from_card(&bob_creature, bob, Zone::Battlefield);
+
+    let rageform_def = CardDefinitionBuilder::new(CardId::new(), "Rageform")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "When this enchantment enters, it becomes an Aura with enchant creature. Manifest the top card of your library and attach this enchantment to it.\nEnchanted creature has double strike.",
+        )
+        .expect("Rageform should parse for opponent-attachment test");
+    let rageform_id = game.create_object_from_definition(&rageform_def, alice, Zone::Battlefield);
+
+    {
+        let rageform = game.object_mut(rageform_id).expect("Rageform should exist");
+        rageform.attached_to = Some(crate::object::AttachmentTarget::Object(bob_creature_id));
+    }
+    {
+        let creature = game
+            .object_mut(bob_creature_id)
+            .expect("opponent creature should exist");
+        creature.attachments.push(rageform_id);
+    }
+
+    assert!(
+        game.object_has_ability(bob_creature_id, &StaticAbility::double_strike()),
+        "enchant creature should allow Rageform to grant double strike to an opponent's creature"
+    );
+}
+
 /// Tests that Urza's Saga survives under Blood Moon even with max lore counters.
 ///
 /// Scenario: Urza's Saga has 3 lore counters (would normally sacrifice).


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rageform
Initial parse error:
```
unsupported become clause (clause: 'an aura with enchant creature'); oracle-only fallback also failed: unsupported become clause (clause: 'an aura with enchant creature')
```

Worker: i-024efbe7e26658948
