### PR TITLE
Fix Ironsmith parse failure: Magma Mine

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1235,6 +1235,7 @@ pub(crate) fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "lore" => Some(CounterType::Lore),
         "luck" => Some(CounterType::Luck),
         "oil" => Some(CounterType::Oil),
+        "pressure" => Some(CounterType::Named(intern_counter_name("pressure"))),
         _ => None,
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -358,7 +358,14 @@ pub(crate) fn parse_deal_damage_equal_to_clause(
         )));
     };
 
-    let amount_tokens = &tokens[..target_to_idx];
+    let amount_tokens = if tokens
+        .first()
+        .is_some_and(|token| token.is_word("damage"))
+    {
+        &tokens[1..target_to_idx]
+    } else {
+        &tokens[..target_to_idx]
+    };
     let amount = parse_add_mana_equal_amount_value(amount_tokens)
         .or(parse_equal_to_aggregate_filter_value(amount_tokens))
         .or(parse_devotion_value_from_add_clause(amount_tokens)?)

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11093,6 +11093,26 @@ fn rewrite_lexed_effect_sentence_supports_equal_to_damage_to_controller_phrase_t
 }
 
 #[test]
+fn rewrite_lexed_effect_sentence_supports_equal_to_damage_to_any_target_with_source_counters() {
+    let text = "It deals damage equal to the number of pressure counters on it to any target.";
+    let lexed = lex_line(text, 0)
+        .expect("rewrite lexer should classify equal-to source-counter damage sentence");
+
+    let parsed = parse_effect_sentence_lexed(&lexed)
+        .expect("rewrite effect sentence parser should accept equal-to any-target damage");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("CountersOnSource(Named(\"pressure\"))"),
+        "{debug}"
+    );
+    assert!(
+        debug.contains("target: AnyTarget") || debug.contains("target: Any"),
+        "expected any-target damage lowering, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_sentence_supports_target_gain_then_get_where_x() {
     let text = "Target creature gains trample and gets +X/+0 until end of turn, where X is the number of creatures you control.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify gain-then-get sentence");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36421,6 +36421,27 @@ fn parse_oracle_opaline_bracers_charge_counter_scaling_regression() {
 }
 
 #[test]
+fn parse_oracle_magma_mine_pressure_counter_damage_regression() {
+    let def = parse_oracle_card_definition("Magma Mine");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("deals damage")
+            && rendered.contains("to any target")
+            && rendered.contains("equal to the number of pressure counters on this artifact"),
+        "expected pressure-counter damage wording, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("CountersOnSource(Named(\"pressure\"))"),
+        "expected activated ability to count pressure counters on source, got {debug}"
+    );
+}
+
+#[test]
 fn parse_oracle_commanders_insignia_commander_cast_count_regression() {
     let def = parse_oracle_card_definition("Commander's Insignia");
     let rendered = unprocessed_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12161,6 +12161,7 @@ fn describe_damage_amount_clause(amount: &Value) -> (String, Option<String>) {
 fn count_damage_prefers_equal_to(amount: &Value) -> bool {
     match amount.unhinted() {
         Value::Count(_) | Value::CountScaled(_, _) => true,
+        Value::CountersOnSource(_) | Value::CountersOn(_, _) => true,
         Value::Scaled(inner, _) => count_damage_prefers_equal_to(inner),
         _ => false,
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -6625,6 +6625,197 @@ fn stack_spell_with_granted_static_ability_still_executes_spell_effect() {
 }
 
 #[test]
+fn magma_mine_activated_ability_sacrifices_source_and_deals_counter_scaled_damage_to_player() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mine_def = CardDefinitionBuilder::new(CardId::from_raw(994_000), "Magma Mine")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{4}: Put a pressure counter on this artifact.\n{T}, Sacrifice this artifact: It deals damage equal to the number of pressure counters on it to any target.",
+        )
+        .expect("Magma Mine text should parse");
+    let mine_id = game.create_object_from_definition(&mine_def, alice, Zone::Battlefield);
+    game.add_counters(
+        mine_id,
+        crate::object::CounterType::Named("pressure"),
+        3,
+    )
+        .expect("pressure counters should be addable to Magma Mine");
+
+    {
+        let player = game.player_mut(alice).expect("Alice should exist");
+        player.mana_pool.add(ManaSymbol::Red, 4);
+    }
+
+    let ability_index = game
+        .object(mine_id)
+        .expect("Magma Mine should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                let debug = format!("{:?}", activated.effects).to_ascii_lowercase();
+                debug.contains("dealdamageeffect")
+            } else {
+                false
+            }
+        })
+        .expect("Magma Mine should have a damage activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == mine_id && *idx == ability_index
+            )
+        })
+        .expect("Magma Mine activation should be legal with mana available");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Magma Mine activation should start");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Magma Mine activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("choosing player target should complete activation");
+
+    assert!(
+        game.object(mine_id).is_none(),
+        "Magma Mine should be sacrificed as part of activation cost"
+    );
+
+    resolve_stack_entry(&mut game).expect("Magma Mine ability should resolve");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        17,
+        "Magma Mine should deal damage equal to pressure counters on source"
+    );
+}
+
+#[test]
+fn magma_mine_activated_ability_uses_current_pressure_counter_count_when_zero() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mine_def = CardDefinitionBuilder::new(CardId::from_raw(994_010), "Magma Mine")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{4}: Put a pressure counter on this artifact.\n{T}, Sacrifice this artifact: It deals damage equal to the number of pressure counters on it to any target.",
+        )
+        .expect("Magma Mine text should parse");
+    let mine_id = game.create_object_from_definition(&mine_def, alice, Zone::Battlefield);
+
+    let target_creature = CardBuilder::new(CardId::from_raw(994_001), "Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_card(&target_creature, bob, Zone::Battlefield);
+
+    {
+        let player = game.player_mut(alice).expect("Alice should exist");
+        player.mana_pool.add(ManaSymbol::Red, 4);
+    }
+
+    let ability_index = game
+        .object(mine_id)
+        .expect("Magma Mine should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                let debug = format!("{:?}", activated.effects).to_ascii_lowercase();
+                debug.contains("dealdamageeffect")
+            } else {
+                false
+            }
+        })
+        .expect("Magma Mine should have a damage activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == mine_id && *idx == ability_index
+            )
+        })
+        .expect("Magma Mine activation should be legal with mana available");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Magma Mine activation should start");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Magma Mine activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("choosing creature target should complete activation");
+
+    resolve_stack_entry(&mut game).expect("Magma Mine ability should resolve");
+
+    assert_eq!(
+        game.damage_on(target_id),
+        0,
+        "without pressure counters, Magma Mine should deal zero damage"
+    );
+}
+
+#[test]
 fn protected_stack_spell_still_resolves_after_failed_counterspell() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Magma Mine
Initial parse error:
```
missing damage amount (clause: 'damage equal to the number of pressure counters on it to any target'); oracle-only fallback also failed: missing damage amount (clause: 'damage equal to the number of pressure counters on it to any target')
```

Worker: i-05bd3ed66bf6ac122
