### PR TITLE
Fix Ironsmith parse failure: Word of Blasting

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
@@ -718,6 +718,18 @@ pub(crate) fn parse_add_mana_equal_amount_value_lexed(tokens: &[OwnedLexToken]) 
     };
 
     let parse_mana_value_segment = |segment: &[&str]| -> Option<Value> {
+        let is_tagged_that_object_mana_value = || {
+            if segment.len() < 4
+                || segment[0] != "that"
+                || segment[segment.len() - 2] != "mana"
+                || segment[segment.len() - 1] != "value"
+            {
+                return false;
+            }
+
+            !segment[1..segment.len() - 2].is_empty()
+        };
+
         if slice_starts_with(&segment, &["that", "spell", "mana", "value"])
             || slice_starts_with(&segment, &["that", "spell's", "mana", "value"])
             || slice_starts_with(&segment, &["that", "spells", "mana", "value"])
@@ -808,6 +820,7 @@ pub(crate) fn parse_add_mana_equal_amount_value_lexed(tokens: &[OwnedLexToken]) 
             || slice_starts_with(&segment, &["sacrificed", "artifacts", "mana", "value"])
             || slice_starts_with(&segment, &["sacrificed", "permanents", "mana", "value"])
             || slice_starts_with(&segment, &["its", "mana", "value"])
+            || is_tagged_that_object_mana_value()
         {
             return Some(Value::ManaValueOf(Box::new(ChooseSpec::Tagged(
                 TagKey::from(IT_TAG),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -3199,11 +3199,14 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
                 | "card"
                 | "cards"
         ) || parse_card_type(normalized).is_some()
+            || parse_subtype_word(normalized).is_some()
             || str_strip_suffix(normalized, "s")
-                .is_some_and(|singular| parse_card_type(singular).is_some())
+                .is_some_and(|singular| {
+                    parse_card_type(singular).is_some() || parse_subtype_word(singular).is_some()
+                })
     });
     if remaining_words.len() >= 3
-        && remaining_words[0] == "that"
+        && matches!(remaining_words[0], "that" | "the")
         && second_word_is_object_head
         && matches!(
             remaining_words[2],
@@ -3271,8 +3274,11 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
                 | "card"
                 | "cards"
         ) || parse_card_type(object_head).is_some()
+            || parse_subtype_word(object_head).is_some()
             || str_strip_suffix(object_head, "s")
-                .is_some_and(|singular| parse_card_type(singular).is_some()))
+                .is_some_and(|singular| {
+                    parse_card_type(singular).is_some() || parse_subtype_word(singular).is_some()
+                }))
         {
             let player = if str_starts_with(remaining_words[1], "owner") {
                 PlayerFilter::OwnerOf(crate::filter::ObjectRef::tagged(IT_TAG))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -347,7 +347,6 @@ pub(crate) fn parse_deal_damage_equal_to_clause(
             || parse_target_phrase(&tokens[idx + 1..]).is_ok();
         if looks_like_target {
             target_to_idx = Some(idx);
-            break;
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8291,6 +8291,39 @@ fn test_parse_ignite_memories_keeps_random_hand_reveal_and_damage_link() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_word_of_blasting_uses_destroyed_wall_mana_value_for_damage() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Word of Blasting")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Destroy target Wall. It can't be regenerated. Word of Blasting deals damage equal to that Wall's mana value to the Wall's controller.",
+        )
+        .expect("Word of Blasting should parse");
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("DestroyNoRegenerationEffect")
+            && debug.contains("DealDamageEffect")
+            && debug.contains("ManaValueOf"),
+        "expected destroy/no-regeneration plus mana-value damage linkage, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("destroy target wall")
+            && rendered.contains("it can't be regenerated")
+            && rendered.contains("deals damage equal to its mana value to that object's controller"),
+        "expected Word of Blasting compiled text to preserve wall mana-value damage clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_scent_of_cinder_uses_source_damage_surface() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Scent of Cinder")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -15611,6 +15611,136 @@ fn test_bosh_iron_golem_uses_sacrificed_artifact_mana_value_for_damage() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_word_of_blasting_destroys_wall_and_deals_mana_value_damage_to_controller() {
+    use crate::decision::LegalAction;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let word_def = CardDefinitionBuilder::new(CardId::new(), "Word of Blasting")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Destroy target Wall. It can't be regenerated. Word of Blasting deals damage equal to that Wall's mana value to the Wall's controller.",
+        )
+        .expect("Word of Blasting should parse");
+    let spell_id = game.create_object_from_definition(&word_def, alice, Zone::Hand);
+
+    game.player_mut(alice)
+        .expect("alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+
+    let wall = CardBuilder::new(CardId::new(), "Runed Wall")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Wall])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .power_toughness(PowerToughness::fixed(0, 4))
+        .build();
+    let wall_id = game.create_object_from_card(&wall, bob, Zone::Battlefield);
+
+    let cast_action = LegalAction::CastSpell {
+        spell_id,
+        from_zone: Zone::Hand,
+        casting_method: CastingMethod::Normal,
+    };
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+
+    let cast_response = PriorityResponse::PriorityAction(cast_action);
+    let progress = apply_priority_response(&mut game, &mut trigger_queue, &mut state, &cast_response)
+        .expect("Word of Blasting cast should start");
+    assert!(
+        matches!(
+            progress,
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Targets(_)
+            )
+        ),
+        "Word of Blasting cast should request a wall target"
+    );
+
+    let choose_target = PriorityResponse::Targets(vec![Target::Object(wall_id)]);
+    apply_priority_response(&mut game, &mut trigger_queue, &mut state, &choose_target)
+        .expect("should accept wall target");
+    assert_eq!(game.stack.len(), 1, "Word of Blasting should be on stack");
+
+    resolve_stack_entry(&mut game).expect("Word of Blasting should resolve");
+
+    assert!(
+        !game.battlefield.contains(&wall_id),
+        "Word of Blasting should destroy the targeted Wall"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob should exist").life,
+        16,
+        "Word of Blasting should deal damage equal to the destroyed Wall's mana value"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_word_of_blasting_has_no_cast_action_without_a_wall_target() {
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let word_def = CardDefinitionBuilder::new(CardId::new(), "Word of Blasting")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Destroy target Wall. It can't be regenerated. Word of Blasting deals damage equal to that Wall's mana value to the Wall's controller.",
+        )
+        .expect("Word of Blasting should parse");
+    let spell_id = game.create_object_from_definition(&word_def, alice, Zone::Hand);
+
+    game.player_mut(alice)
+        .expect("alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+
+    let non_wall = CardBuilder::new(CardId::new(), "Vanilla Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&non_wall, bob, Zone::Battlefield);
+
+    let actions = compute_legal_actions(&game, alice);
+    let can_cast_word = actions.iter().any(|action| {
+        matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: candidate,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::Normal,
+            } if *candidate == spell_id
+        )
+    });
+    assert!(
+        !can_cast_word,
+        "Word of Blasting should not be castable when no Wall is a legal target"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_brutal_suppression_adds_a_land_sacrifice_activation_cost() {
     use crate::PriorityResponse;
     use crate::cost::TotalCost;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Word of Blasting
Initial parse error:
```
missing damage amount (clause: 'damage equal to that wall's mana value to the wall's controller'); oracle-only fallback also failed: missing damage amount (clause: 'damage equal to that wall's mana value to the wall's controller')
```

Worker: i-066c0f5c406a18a9b
