### PR TITLE
Fix Ironsmith parse failure: Cream of the Crop

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -553,6 +553,81 @@ pub(crate) fn parse_put_into_hand(
     let has_hand = grammar::contains_word(tokens, "hand");
     let has_into = grammar::contains_word(tokens, "into");
 
+    // "Put one of those cards on top of your library and the rest on the bottom of your library"
+    if grammar::contains_word(tokens, "rest")
+        && grammar::contains_word(tokens, "top")
+        && grammar::contains_word(tokens, "bottom")
+        && grammar::contains_word(tokens, "library")
+        && clause_words.iter().any(|w| *w == "and" || *w == "then")
+    {
+        let mut up_to = false;
+        let (count, used) = if tokens.first().is_some_and(|t| t.is_word("up"))
+            && tokens.get(1).is_some_and(|t| t.is_word("to"))
+        {
+            up_to = true;
+            parse_number(&tokens[2..]).map(|(value, used)| (value, used + 2))
+        } else {
+            parse_number(tokens)
+        }
+        .ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "missing put count (clause: '{}')",
+                clause_words.join(" ")
+            ))
+        })?;
+
+        let mut idx = used;
+        if tokens.get(idx).is_some_and(|t| t.is_word("of")) {
+            idx += 1;
+        }
+        if tokens.get(idx).is_some_and(|t| t.is_word("them")) {
+            idx += 1;
+        } else if tokens.get(idx).is_some_and(|t| t.is_word("those")) {
+            idx += 1;
+            if tokens
+                .get(idx)
+                .is_some_and(|t| t.is_word("card") || t.is_word("cards"))
+            {
+                idx += 1;
+            }
+        } else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported library rearrange put clause (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+
+        if !tokens.get(idx).is_some_and(|t| t.is_word("on"))
+            || !tokens.get(idx + 1).is_some_and(|t| t.is_word("top"))
+        {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported library rearrange put clause (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+
+        let library_owner = if grammar::contains_word(tokens, "your") {
+            PlayerAst::You
+        } else if grammar::contains_word(tokens, "their")
+            || grammar::words_match_any_prefix(tokens, THAT_PLAYER_PREFIXES).is_some()
+        {
+            PlayerAst::That
+        } else {
+            player
+        };
+
+        let choice_count = if up_to {
+            ChoiceCount::up_to(count as usize)
+        } else {
+            ChoiceCount::exactly(count as usize)
+        };
+        return Ok(EffectAst::subject_verb_rearrange_looked_cards_in_library(
+            library_owner,
+            TagKey::from(IT_TAG),
+            choice_count,
+        ));
+    }
+
     if has_hand && has_into && (has_it || has_them) {
         // "Put N of them into your hand and the rest on the bottom of your library in any order."
         if has_them

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10367,6 +10367,24 @@ fn rewrite_sequence_registry_matches_looked_cards_reveal_top_rest_bottom_bundle(
 }
 
 #[test]
+fn rewrite_lexed_effect_sequence_parses_may_rearrange_looked_cards_bundle() {
+    let text = "Whenever a creature you control enters, you may look at the top X cards of your library, where X is that creature's power. If you do, put one of those cards on top of your library and the rest on the bottom of your library in any order.";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify Cream of the Crop text");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&lexed)
+        .expect("Cream of the Crop sequence should parse");
+    let debug = format!("{parsed:#?}").to_ascii_lowercase();
+
+    assert!(debug.contains("lookattopcards"), "{debug}");
+    assert!(debug.contains("powerof"), "{debug}");
+    assert!(debug.contains("rearrangelookedcardsinlibrary"), "{debug}");
+    assert!(
+        debug.contains("min: 1") && debug.contains("dynamic_x: false"),
+        "{debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_sequence_parses_divvy_pile_choice_bundle() {
     let text = "Exile up to five target permanent cards from your graveyard and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. (Piles can be empty.)";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify divvy pile text");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40854,6 +40854,30 @@ fn parse_oracle_consult_the_star_charts_keeps_kicker_choice_override_surface() {
 }
 
 #[test]
+fn parse_oracle_cream_of_the_crop_keeps_power_scaled_rearrange_surface() {
+    let def = parse_oracle_card_definition("Cream of the Crop");
+    let rendered = crate::compiled_text::compiled_text_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    let abilities_debug = format!("{:#?}", def.abilities).to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("whenever a creature you control enters")
+            && rendered.contains("look at the top x cards of your library")
+            && rendered.contains("where x is its power")
+            && rendered.contains("if you do")
+            && rendered.contains("put one of those cards on top of your library")
+            && rendered.contains("the rest on the bottom of your library in any order"),
+        "expected Cream of the Crop scored text to keep the full top/bottom rearrange wording, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("rearrangelookedcardsinlibrary")
+            && abilities_debug.contains("powerof"),
+        "expected Cream of the Crop definition to use looked-card rearrange with source-power count, got {abilities_debug}"
+    );
+}
+
+#[test]
 fn parse_oracle_divergent_transformations_keeps_reveal_until_creature_surface() {
     let def = parse_oracle_card_definition("Divergent Transformations");
     let spell_debug = format!("{:#?}", def.spell_effect);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26676,29 +26676,31 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(look_at_top) = effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>() {
         let owner = describe_possessive_player_filter(&look_at_top.player);
-        let (count_text, noun, _) = describe_look_count_and_noun(&look_at_top.count);
+        let (count_text, noun, where_clause) = describe_top_count_noun_and_where_clause(&look_at_top.count);
         if look_at_top.reveal {
             if look_at_top.player == PlayerFilter::You {
-                return format!("Reveal the top {count_text} {noun} of your library");
+                return format!("Reveal the top {count_text} {noun} of your library{where_clause}");
             }
             let subject = describe_player_filter(&look_at_top.player);
             let verb = player_verb(&subject, "reveal", "reveals");
-            return format!("{subject} {verb} the top {count_text} {noun} of {owner} library");
+            return format!(
+                "{subject} {verb} the top {count_text} {noun} of {owner} library{where_clause}"
+            );
         }
-        return format!("Look at the top {count_text} {noun} of {owner} library");
+        return format!("Look at the top {count_text} {noun} of {owner} library{where_clause}");
     }
     if let Some(rearrange) =
         effect.downcast_ref::<crate::effects::RearrangeLookedCardsInLibraryEffect>()
     {
         let count_text = match (rearrange.count.min, rearrange.count.max) {
             (0, Some(1)) => "up to one".to_string(),
-            (min, Some(max)) if min == max => max.to_string(),
+            (min, Some(max)) if min == max => small_number_word(max as u32).unwrap_or_else(|| max.to_string()),
             (0, Some(max)) => format!("up to {max}"),
             (min, Some(max)) => format!("between {min} and {max}"),
             (min, None) => format!("at least {min}"),
         };
         return format!(
-            "Put {count_text} of the looked-at cards on top of your library and the rest on the bottom of your library in a random order"
+            "Put {count_text} of those cards on top of your library and the rest on the bottom of your library in any order"
         );
     }
     if let Some(look_at_hand) = effect.downcast_ref::<crate::effects::LookAtHandEffect>() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26315,6 +26315,62 @@ fn test_oreskos_explorer_searches_for_players_with_more_lands_than_you() {
     assert_eq!(plains_in_hand, 2, "Oreskos Explorer should find two Plains");
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_cream_of_the_crop_etb_trigger_uses_may_and_source_power_rearrange() {
+    use crate::ability::AbilityKind;
+    use crate::card::PowerToughness;
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::ids::{CardId, PlayerId};
+    use crate::types::CardType;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let cream = CardDefinitionBuilder::new(CardId::new(), "Cream of the Crop")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text("Whenever a creature you control enters, you may look at the top X cards of your library, where X is that creature's power. If you do, put one of those cards on top of your library and the rest on the bottom of your library in any order.")
+        .expect("Cream of the Crop text should parse");
+    let grizzly = CardDefinitionBuilder::new(CardId::new(), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("")
+        .expect("vanilla creature should parse");
+
+    let cream_id = game.create_object_from_definition(&cream, alice, Zone::Battlefield);
+    let _creature_id = game.create_object_from_definition(&grizzly, alice, Zone::Battlefield);
+
+    let trigger = game
+        .object(cream_id)
+        .expect("Cream of the Crop should exist")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Cream of the Crop should have an enters trigger");
+
+    let trigger_debug = format!("{:#?}", trigger).to_ascii_lowercase();
+    assert!(
+        trigger_debug.contains("youcontrol") && trigger_debug.contains("enter"),
+        "Cream trigger should only watch your creatures entering, got {trigger_debug}"
+    );
+    assert!(
+        trigger_debug.contains("mayeffect"),
+        "Cream trigger should preserve the may branch, got {trigger_debug}"
+    );
+    assert!(
+        trigger_debug.contains("lookattopcards") && trigger_debug.contains("powerof"),
+        "Cream trigger should scale looked card count from the entering creature's power, got {trigger_debug}"
+    );
+    assert!(
+        trigger_debug.contains("rearrangelookedcardsinlibrary")
+            && trigger_debug.contains("min: 1"),
+        "Cream trigger should rearrange looked cards by choosing exactly one for top, got {trigger_debug}"
+    );
+}
+
 fn doubling_chant_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), "Doubling Chant")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cream of the Crop
Initial parse error:
```
unsupported target phrase (clause: 'cards'); oracle-only fallback also failed: unsupported target phrase (clause: 'cards')
```

Worker: i-01012cbc2aad0a8a2
