### PR TITLE
Fix Ironsmith parse failure: Wild Roads

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -211,13 +211,19 @@ fn keyword_static_marker(tokens: &[OwnedLexToken]) -> StaticAbility {
 
 fn supported_keyword_marker_text(text: &str) -> bool {
     let text = text.trim_start().to_ascii_lowercase();
+    let is_power_greater_marker = |prefix: &str| {
+        text.starts_with(prefix) && text.ends_with(" greater.")
+    };
     text.starts_with("prototype ")
         || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
         || is_ticket_power_toughness_sticker_marker_line(&text)
         || text == "this creature crews vehicles using its toughness rather than its power."
-        || (text.starts_with("this creature crews vehicles as though its power were ")
-            && text.ends_with(" greater."))
+        || is_power_greater_marker("this creature crews vehicles as though its power were ")
+        || is_power_greater_marker(
+            "this creature saddles mounts and crews vehicles as though its power were ",
+        )
+        || is_power_greater_marker("this token saddles mounts and crews vehicles as though its power were ")
         || (text.starts_with(
             "you may remove a loyalty counter from a planeswalker you control rather than pay ",
         ) && text.ends_with("'s crew cost."))

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -1894,6 +1894,16 @@ pub(crate) fn parse_crew_amount(words: &[&str]) -> Option<u32> {
     u32::try_from(amount).ok()
 }
 
+pub(crate) fn parse_as_though_power_were_greater_amount(words: &[&str]) -> Option<u32> {
+    let were_idx = find_index(words, |word| *word == "were")?;
+    let amount_word = words.get(were_idx + 1)?;
+    if words.get(were_idx + 2).copied() != Some("greater") {
+        return None;
+    }
+    let amount = parse_number_word(amount_word)?;
+    u32::try_from(amount).ok()
+}
+
 pub(crate) fn parse_equip_amount(words: &[&str]) -> Option<u32> {
     let equip_idx = find_index(words, |word| *word == "equip")?;
     let amount_word = words.get(equip_idx + 1)?;
@@ -3484,8 +3494,15 @@ pub(crate) fn token_definition_for(name: &str) -> Option<CardDefinition> {
         if let Some(symbol) = parse_token_tap_add_single_mana_symbol(&words) {
             builder = builder.with_ability(token_tap_add_single_mana_ability(symbol));
         }
-        if has_words(&["crews", "vehicles", "power", "greater", "2"]) {
-            return None;
+        if !applied_quoted_keyword
+            && has_words(&["saddles", "mounts", "crews", "vehicles", "power", "greater"])
+            && let Some(amount) = parse_as_though_power_were_greater_amount(&words)
+        {
+            builder = builder.with_ability(Ability::static_ability(StaticAbility::keyword_marker(
+                format!(
+                    "This creature saddles Mounts and crews Vehicles as though its power were {amount} greater."
+                ),
+            )));
         }
         if has_word("banding") {
             builder = builder.with_ability(Ability::static_ability(StaticAbility::banding()));

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33318,6 +33318,109 @@ fn parse_rankle_master_of_pranks_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_wild_roads_strict_regression() {
+    assert_oracle_card_parses_strict("Wild Roads");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wild_roads_compiled_text_keeps_pilot_saddle_and_crew_clause() {
+    let def = parse_oracle_card_definition("Wild Roads");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("saddles mounts and crews vehicles as though its power were 2 greater"),
+        "expected Wild Roads compiled text to preserve Pilot token saddle/crew clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wild_roads_pilot_token_power_bonus_applies_to_saddle_and_crew_costs() {
+    let def = parse_oracle_card_definition("Wild Roads");
+    let pilot = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .segments
+                .iter()
+                .flat_map(|segment| segment.default_effects.iter())
+                .find_map(|effect| effect.downcast_ref::<CreateTokenEffect>())
+                .map(|create| create.token.clone()),
+            _ => None,
+        })
+        .expect("Wild Roads should have an activated ability that creates a Pilot token");
+
+    let alice = PlayerId::from_index(0);
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let pilot_id = game.create_object_from_definition(&pilot, alice, Zone::Battlefield);
+    let vehicle = CardDefinitionBuilder::new(CardId::new(), "Vehicle Probe")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Vehicle])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let vehicle_id = game.create_object_from_definition(&vehicle, alice, Zone::Battlefield);
+    let mount = CardDefinitionBuilder::new(CardId::new(), "Mount Probe")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Mount])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+
+    let crew_cost = crate::effects::CrewCostEffect { required_power: 3 };
+    crate::effects::CostExecutableEffect::can_execute_as_cost(&crew_cost, &game, vehicle_id, alice)
+        .expect("Wild Roads Pilot token should crew as though its power were 2 greater");
+
+    let mount_id = game.create_object_from_definition(&mount, alice, Zone::Battlefield);
+    let saddle_cost = crate::effects::SaddleCostEffect::new(3);
+    crate::effects::CostExecutableEffect::can_execute_as_cost(&saddle_cost, &game, mount_id, alice)
+        .expect("Wild Roads Pilot token should saddle as though its power were 2 greater");
+
+    let vanilla = CardDefinitionBuilder::new(CardId::new(), "Vanilla 1/1")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let mut baseline_crew = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    baseline_crew.create_object_from_definition(&vanilla, alice, Zone::Battlefield);
+    let baseline_vehicle =
+        baseline_crew.create_object_from_definition(&vehicle, alice, Zone::Battlefield);
+
+    assert!(
+        crate::effects::CostExecutableEffect::can_execute_as_cost(
+            &crew_cost,
+            &baseline_crew,
+            baseline_vehicle,
+            alice,
+        )
+        .is_err(),
+        "baseline 1/1 without Wild Roads Pilot marker should not satisfy crew 3"
+    );
+
+    let mut baseline_saddle = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    baseline_saddle.create_object_from_definition(&vanilla, alice, Zone::Battlefield);
+    let baseline_mount = baseline_saddle.create_object_from_definition(&mount, alice, Zone::Battlefield);
+
+    assert!(
+        crate::effects::CostExecutableEffect::can_execute_as_cost(
+            &saddle_cost,
+            &baseline_saddle,
+            baseline_mount,
+            alice,
+        )
+        .is_err(),
+        "baseline 1/1 without Wild Roads Pilot marker should not satisfy saddle 3"
+    );
+
+    assert!(
+        game.object(pilot_id).is_some(),
+        "sanity check: Wild Roads Pilot token should exist on battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn james_wandering_dad_follow_him_compiled_text_keeps_spend_this_mana_only_clause() {
     let def = parse_oracle_card_definition("James, Wandering Dad // Follow Him");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -595,7 +595,17 @@ pub(super) fn describe_token_blueprint(token: &CardDefinition) -> String {
 }
 
 fn token_extra_abilities_prefer_with_clause(abilities: &[String]) -> bool {
-    matches!(abilities, [ability] if ability == "\"This token can't block.\"")
+    match abilities {
+        [ability] => {
+            if ability == "\"This token can't block.\"" {
+                return true;
+            }
+            ability
+                .to_ascii_lowercase()
+                .starts_with("\"this token saddles mounts and crews vehicles as though its power were ")
+        }
+        _ => false,
+    }
 }
 
 fn token_has_non_toxic_poison_trigger(token: &CardDefinition) -> bool {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12555,6 +12555,8 @@ fn describe_static_ability_with_subject(
     );
     line = line.replace("This creature creature ", "This creature ");
     line = line.replace("this creature creature ", "this creature ");
+    line = line.replace("This land land ", "This land ");
+    line = line.replace("this land land ", "this land ");
     line = line.replace(
         "number of other creature artifact you control",
         "number of other creatures and/or artifacts you control",

--- a/crates/ironsmith-runtime/src/effects/permanents/crew.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/crew.rs
@@ -76,9 +76,17 @@ fn keyword_marker_texts(game: &GameState, object_id: ObjectId) -> Vec<String> {
 }
 
 fn crew_power_bonus_from_marker(marker: &str) -> Option<i32> {
-    let rest = marker.strip_prefix("this creature crews vehicles as though its power were ")?;
-    let amount = rest.strip_suffix(" greater.")?;
-    amount.parse::<i32>().ok()
+    let prefixes = [
+        "this creature crews vehicles as though its power were ",
+        "this creature saddles mounts and crews vehicles as though its power were ",
+        "this token saddles mounts and crews vehicles as though its power were ",
+    ];
+    prefixes.iter().find_map(|prefix| {
+        marker
+            .strip_prefix(prefix)
+            .and_then(|rest| rest.strip_suffix(" greater."))
+            .and_then(|amount| amount.parse::<i32>().ok())
+    })
 }
 
 fn crew_value(game: &GameState, object_id: ObjectId) -> i32 {

--- a/crates/ironsmith-runtime/src/effects/permanents/saddle.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/saddle.rs
@@ -21,7 +21,9 @@ use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::PermanentTappedEvent;
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
+use crate::static_abilities::StaticAbilityId;
 use crate::triggers::TriggerEvent;
+use crate::ability::AbilityKind;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SaddleCostEffect {
@@ -60,6 +62,47 @@ impl SaddleCostEffect {
             .and_then(|calc| calc.power)
             .or_else(|| game.object(object_id).and_then(|obj| obj.power()))
             .unwrap_or(0)
+    }
+
+    fn keyword_marker_texts(game: &GameState, object_id: ObjectId) -> Vec<String> {
+        let abilities = game.current_abilities(object_id).unwrap_or_else(|| {
+            game.object(object_id)
+                .map(|obj| obj.abilities.clone())
+                .unwrap_or_default()
+        });
+        abilities
+            .into_iter()
+            .filter_map(|ability| match ability.kind {
+                AbilityKind::Static(static_ability)
+                    if static_ability.id() == StaticAbilityId::KeywordMarker =>
+                {
+                    Some(static_ability.display().to_ascii_lowercase())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn saddle_power_bonus_from_marker(marker: &str) -> Option<i32> {
+        let prefixes = [
+            "this creature saddles mounts and crews vehicles as though its power were ",
+            "this token saddles mounts and crews vehicles as though its power were ",
+        ];
+        prefixes.iter().find_map(|prefix| {
+            marker
+                .strip_prefix(prefix)
+                .and_then(|rest| rest.strip_suffix(" greater."))
+                .and_then(|amount| amount.parse::<i32>().ok())
+        })
+    }
+
+    fn saddle_value(game: &GameState, object_id: ObjectId) -> i32 {
+        let base = Self::object_power(game, object_id);
+        let bonus: i32 = Self::keyword_marker_texts(game, object_id)
+            .iter()
+            .filter_map(|marker| Self::saddle_power_bonus_from_marker(marker))
+            .sum();
+        base + bonus
     }
 }
 
@@ -104,20 +147,20 @@ impl EffectExecutor for SaddleCostEffect {
         // If the decision maker picked a set that doesn't meet the requirement,
         // greedily add remaining candidates until it does (or we exhaust options).
         let required = self.required_power as i32;
-        let mut total_power: i32 = chosen.iter().map(|id| Self::object_power(game, *id)).sum();
+        let mut total_power: i32 = chosen.iter().map(|id| Self::saddle_value(game, *id)).sum();
         if total_power < required {
             let mut remaining: Vec<ObjectId> = candidates
                 .iter()
                 .copied()
                 .filter(|id| !chosen.contains(id))
                 .collect();
-            remaining.sort_by_key(|id| -Self::object_power(game, *id));
+            remaining.sort_by_key(|id| -Self::saddle_value(game, *id));
             for id in remaining {
                 if total_power >= required {
                     break;
                 }
                 chosen.push(id);
-                total_power += Self::object_power(game, id);
+                total_power += Self::saddle_value(game, id);
             }
         }
 
@@ -175,7 +218,7 @@ impl CostExecutableEffect for SaddleCostEffect {
         let candidates = Self::saddle_candidates(game, controller, source);
         let total: i32 = candidates
             .iter()
-            .map(|id| Self::object_power(game, *id))
+            .map(|id| Self::saddle_value(game, *id))
             .sum();
         if total >= self.required_power as i32 {
             Ok(())


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wild Roads
Initial parse error:
```
unsupported token '1/1 colorless pilot creature with "this token saddles mounts and crews vehicles as though its power were 2 greater'; oracle-only fallback also failed: unsupported token '1/1 colorless pilot creature with "this token saddles mounts and crews vehicles as though its power were 2 greater'
```

Worker: i-032b4068e5026c942
