### PR TITLE
Fix Ironsmith parse failure: Reluctant Role Model

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1295,6 +1295,17 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         None
     };
     if let Some(prefix_len) = triggering_object_had_counter_prefix_len
+        && raw_words.get(prefix_len) == Some(&"counters")
+        && raw_words.get(prefix_len + 1) == Some(&"on")
+        && matches!(
+            raw_words.get(prefix_len + 2).copied().unwrap_or(""),
+            "it" | "them" | "this" | "that" | "itself"
+        )
+    {
+        return Ok(PredicateAst::TriggeringObjectHadAnyCounterAtLeast { count: 1 });
+    }
+
+    if let Some(prefix_len) = triggering_object_had_counter_prefix_len
         && raw_words.len() >= prefix_len + 4
         && let Some(counter_idx) = find_index(&raw_words[prefix_len..], |word| {
             *word == "counter" || *word == "counters"
@@ -3426,6 +3437,25 @@ mod tests {
         assert_eq!(
             parsed,
             PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_it_had_counters_on_it() -> Result<(), CardTextError> {
+        let tokens = lex_line("if it had counters on it", 0)?;
+
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::TriggeringObjectHadAnyCounterAtLeast { count: 1 }
         );
         Ok(())
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -542,6 +542,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
             counter_type: *counter_type,
             min_count: *count,
         },
+        PredicateAst::TriggeringObjectHadAnyCounterAtLeast { count } => {
+            Condition::TriggeringObjectHadAnyCounters { min_count: *count }
+        }
         PredicateAst::SourceHasCounterAtLeast {
             counter_type,
             count,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -510,6 +510,9 @@ pub(crate) enum PredicateAst {
         counter_type: CounterType,
         count: u32,
     },
+    TriggeringObjectHadAnyCounterAtLeast {
+        count: u32,
+    },
     SourceHasCounterAtLeast {
         counter_type: CounterType,
         count: u32,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -765,6 +765,9 @@ pub enum Condition {
         counter_type: CounterType,
         min_count: u32,
     },
+    TriggeringObjectHadAnyCounters {
+        min_count: u32,
+    },
     ControlCreaturesTotalPowerAtLeast(u32),
     CardInYourGraveyard {
         card_types: Vec<crate::CardType>,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -155,6 +155,30 @@ fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_reluctant_role_model_strict_regression() {
+    let def = parse_oracle_card_definition("Reluctant Role Model");
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("TriggeringObjectHadAnyCounters")
+            && !abilities_debug.contains("UnsupportedParserLine"),
+        "expected Reluctant Role Model to parse strict trigger predicate, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_reluctant_role_model_compiled_text_mentions_counter_transfer_condition() {
+    let def = parse_oracle_card_definition("Reluctant Role Model");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("if it had counters on it")
+            && rendered.contains("put its counters on up to one target creature"),
+        "expected Reluctant Role Model compiled text to preserve counter-transfer clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_robe_of_the_archmagi_compiled_text_includes_class_equip_clause() {
     let def = parse_oracle_card_definition("Robe of the Archmagi");
     let lines = canonical_compiled_lines(&def);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10928,6 +10928,13 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             "the triggering object had {min_count} or more {} counters",
             counter_type.description()
         ),
+        Condition::TriggeringObjectHadAnyCounters { min_count } => {
+            if *min_count == 1 {
+                "it had counters on it".to_string()
+            } else {
+                format!("the triggering object had {min_count} or more counters")
+            }
+        }
         Condition::ControlCreaturesTotalPowerAtLeast(power) => format!(
             "creatures you control have total power {power} or greater"
         ),

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -129,6 +129,7 @@ fn source_escaped(game: &GameState, source: ObjectId) -> bool {
 mod tests {
     use super::*;
     use crate::card::{CardBuilder, PowerToughness};
+    use crate::object::CounterType;
     use crate::effects::ExecutionContext;
     use crate::ids::CardId;
     use crate::mana::{ManaCost, ManaSymbol};
@@ -143,6 +144,74 @@ mod tests {
             .build();
         let owner = game.players[owner_index].id;
         game.create_object_from_card(&card, owner, Zone::Hand);
+    }
+
+    #[test]
+    fn reluctant_role_model_trigger_condition_passes_when_triggering_object_had_any_counters() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = game.players[0].id;
+        let creature = CardBuilder::new(CardId::from_raw(90_001), "Countered Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let creature_id = game.create_object_from_card(&creature, alice, Zone::Battlefield);
+        game.object_mut(creature_id)
+            .expect("creature should exist")
+            .counters
+            .insert(CounterType::Lifelink, 1);
+        let snapshot = {
+            let object = game.object(creature_id).expect("creature should exist");
+            crate::snapshot::ObjectSnapshot::from_object(object, &game)
+        };
+        let event = TriggerEvent::new_with_provenance(
+            crate::events::ZoneChangeEvent::with_cause(
+                creature_id,
+                Zone::Battlefield,
+                Zone::Graveyard,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        let condition = Condition::TriggeringObjectHadAnyCounters { min_count: 1 };
+        let ctx = ExecutionContext::new_default(game.new_object_id(), alice).with_triggering_event(event);
+
+        assert!(
+            evaluate_condition(&game, &condition, &ctx).expect("condition should evaluate"),
+            "expected Reluctant Role Model style condition to pass when the dying creature had counters"
+        );
+    }
+
+    #[test]
+    fn reluctant_role_model_trigger_condition_fails_without_counters() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = game.players[0].id;
+        let creature = CardBuilder::new(CardId::from_raw(90_002), "Vanilla Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let creature_id = game.create_object_from_card(&creature, alice, Zone::Battlefield);
+        let snapshot = {
+            let object = game.object(creature_id).expect("creature should exist");
+            crate::snapshot::ObjectSnapshot::from_object(object, &game)
+        };
+        let event = TriggerEvent::new_with_provenance(
+            crate::events::ZoneChangeEvent::with_cause(
+                creature_id,
+                Zone::Battlefield,
+                Zone::Graveyard,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        let condition = Condition::TriggeringObjectHadAnyCounters { min_count: 1 };
+        let ctx = ExecutionContext::new_default(game.new_object_id(), alice).with_triggering_event(event);
+
+        assert!(
+            !evaluate_condition(&game, &condition, &ctx).expect("condition should evaluate"),
+            "expected Reluctant Role Model style condition to fail when the dying creature had no counters"
+        );
     }
 
     #[test]
@@ -926,6 +995,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::DoThisMaxTimesEachTurn(..) => {}
         Condition::TriggeringObjectWasEnchanted => {}
         Condition::TriggeringObjectHadCounters { .. } => {}
+        Condition::TriggeringObjectHadAnyCounters { .. } => {}
         Condition::ControlCreaturesTotalPowerAtLeast(..) => {}
         Condition::CardInYourGraveyard { .. } => {}
         Condition::ActivationTiming(..) => {}
@@ -1287,6 +1357,10 @@ pub fn evaluate_condition_external(
             .is_some_and(|snapshot| {
                 snapshot.counters.get(counter_type).copied().unwrap_or(0) >= *min_count
             }),
+        Condition::TriggeringObjectHadAnyCounters { min_count } => ctx
+            .triggering_event
+            .and_then(|event| event.snapshot())
+            .is_some_and(|snapshot| snapshot.counters.values().copied().sum::<u32>() >= *min_count),
 
         Condition::ControlCreaturesTotalPowerAtLeast(required_power) => {
             let total_power = game
@@ -2359,7 +2433,9 @@ fn evaluate_condition_simple(
         Condition::FirstTimeThisTurn
         | Condition::MaxTimesEachTurn(_)
         | Condition::DoThisMaxTimesEachTurn(_) => true,
-        Condition::TriggeringObjectWasEnchanted | Condition::TriggeringObjectHadCounters { .. } => {
+        Condition::TriggeringObjectWasEnchanted
+        | Condition::TriggeringObjectHadCounters { .. }
+        | Condition::TriggeringObjectHadAnyCounters { .. } => {
             false
         }
         Condition::ControlCreaturesTotalPowerAtLeast(_)
@@ -3317,6 +3393,11 @@ fn evaluate_condition(
             .is_some_and(|snapshot| {
                 snapshot.counters.get(counter_type).copied().unwrap_or(0) >= *min_count
             })),
+        Condition::TriggeringObjectHadAnyCounters { min_count } => Ok(ctx
+            .triggering_event
+            .as_ref()
+            .and_then(|event| event.snapshot())
+            .is_some_and(|snapshot| snapshot.counters.values().copied().sum::<u32>() >= *min_count)),
         Condition::ControlCreaturesTotalPowerAtLeast(required_power) => {
             let total_power = game
                 .battlefield


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Reluctant Role Model
Initial parse error:
```
unsupported predicate (predicate: 'it had counters on it'); oracle-only fallback also failed: unsupported predicate (predicate: 'it had counters on it')
```

Worker: i-00119b7b394235635
