### PR TITLE
Fix Ironsmith parse failure: Vault 101: Birthday Party

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3078,6 +3078,20 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         });
     }
 
+    if filtered.len() >= 7
+        && filtered[1] == "is"
+        && filtered[2] == "put"
+        && slice_ends_with(&filtered, &["onto", "battlefield", "this", "way"])
+    {
+        let filter_words = &filtered[..filtered.len() - 6];
+        let filter_tokens = filter_words
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        let filter = parse_object_filter(&filter_tokens, false)?;
+        return Ok(PredicateAst::TaggedMatches(TagKey::from(IT_TAG), filter));
+    }
+
     let didnt_put_into_hand = matches!(
         filtered.as_slice(),
         ["you", "dont", "put", "the", "card", "into", "your", "hand"]
@@ -3364,6 +3378,48 @@ mod tests {
                 tag: TagKey::from(IT_TAG),
                 filter: ObjectFilter::default().in_zone(Zone::Hand),
             }))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_if_equipment_is_put_onto_the_battlefield_this_way(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line("If an Equipment is put onto the battlefield this way", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+        let equipment_filter_tokens = lex_line("an Equipment", 0)?;
+        let equipment_filter = parse_object_filter(&equipment_filter_tokens, false)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::TaggedMatches(TagKey::from(IT_TAG), equipment_filter)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_if_aura_is_put_onto_the_battlefield_this_way(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line("If an Aura is put onto the battlefield this way", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+        let aura_filter_tokens = lex_line("an Aura", 0)?;
+        let aura_filter = parse_object_filter(&aura_filter_tokens, false)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::TaggedMatches(TagKey::from(IT_TAG), aura_filter)
         );
         Ok(())
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7496,6 +7496,60 @@ fn test_parse_manifest_top_card_of_your_library_without_fallback_marker() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_vault_101_birthday_party_parses_strictly() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Vault 101: Birthday Party")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI - Create a 1/1 white Human Soldier creature token and a Food token. (A Food token is an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nII, III - You may put an Aura or Equipment card from your hand or graveyard onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control.",
+        )
+        .expect("Vault 101: Birthday Party should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        !rendered.contains("unsupported predicate") && !rendered.contains("unsupported effect"),
+        "Vault 101: Birthday Party should parse without unsupported markers, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_vault_101_birthday_party_renders_equipment_only_attach_branch() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Vault 101: Birthday Party")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "II, III - You may put an Aura or Equipment card from your hand or graveyard onto the battlefield. If an Equipment is put onto the battlefield this way, you may attach it to a creature you control.",
+        )
+        .expect("Vault 101: Birthday Party chapter II/III line should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("if an equipment is put onto the battlefield this way")
+            || rendered.contains("if that permanent is an equipment")
+            || rendered.contains("if it is an equipment")
+            || rendered.contains("if it matches equipment"),
+        "expected conditional Equipment-only attach branch, got {rendered}"
+    );
+    assert!(
+        rendered.contains("attach") && rendered.contains("creature you control"),
+        "expected optional attach branch targeting your creature, got {rendered}"
+    );
+
+    let effect_debug = format!("{:?}", def.abilities);
+    assert!(
+        effect_debug.contains("ConditionalEffect")
+            && effect_debug.contains("TaggedObjectMatches")
+            && effect_debug.contains("Equipment")
+            && effect_debug.contains("AttachObjectsEffect"),
+        "expected parsed chapter line to gate attach behavior to moved Equipment objects, got {effect_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_manifest_top_card_of_that_players_library_without_fallback_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Manifest Theft Probe")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vault 101: Birthday Party
Initial parse error:
```
unsupported predicate (predicate: 'equipment is put onto battlefield this way'); oracle-only fallback also failed: unsupported predicate (predicate: 'equipment is put onto battlefield this way')
```

Worker: i-03e98361cd2229fc6
