### PR TITLE
Fix Ironsmith parse failure: Ruthless Cullblade

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2087,6 +2087,10 @@ pub(crate) fn parse_static_condition_clause(
         return Ok(condition);
     }
 
+    if let Some(condition) = parse_life_total_static_condition(&tokens) {
+        return Ok(condition);
+    }
+
     if clause_words.len() >= 6
         && clause_words[0] == "you"
         && clause_words[1] == "have"
@@ -2795,6 +2799,40 @@ fn parse_cards_in_hand_static_condition(tokens: &[OwnedLexToken]) -> Option<crat
             count: count as i32,
         });
     }
+    None
+}
+
+fn parse_life_total_static_condition(tokens: &[OwnedLexToken]) -> Option<crate::ConditionExpr> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    let (player, count_start_idx) = match clause_words.as_slice() {
+        ["you", "have", ..] => (PlayerFilter::You, 2usize),
+        ["that", "player", "has", ..] => (PlayerFilter::Target(Box::new(PlayerFilter::Any)), 3),
+        ["an", "opponent", "has", ..] => (PlayerFilter::Opponent, 3usize),
+        ["opponent", "has", ..] => (PlayerFilter::Opponent, 2usize),
+        ["a", "player", "has", ..] => (PlayerFilter::Any, 3usize),
+        ["player", "has", ..] => (PlayerFilter::Any, 2usize),
+        _ => return None,
+    };
+
+    let count_tokens = tokens.get(count_start_idx..)?;
+    let (count, used) = parse_number(count_tokens)?;
+    let tail_tokens = count_tokens.get(used..)?;
+    let tail_words = crate::runtime_backend::token_word_refs(tail_tokens);
+    if tail_words.as_slice() == ["or", "less", "life"] {
+        return Some(crate::ConditionExpr::ValueComparison {
+            left: crate::effect::Value::LifeTotal(player),
+            operator: crate::effect::ValueComparisonOperator::LessThanOrEqual,
+            right: crate::effect::Value::Fixed(count as i32),
+        });
+    }
+    if tail_words.as_slice() == ["or", "more", "life"] {
+        return Some(crate::ConditionExpr::ValueComparison {
+            left: crate::effect::Value::LifeTotal(player),
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: crate::effect::Value::Fixed(count as i32),
+        });
+    }
+
     None
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -13044,6 +13044,41 @@ fn heaven_sent_strict_compile_succeeds() {
 }
 
 #[test]
+fn ruthless_cullblade_strict_compile_succeeds() {
+    let oracle_text = "As long as an opponent has 10 or less life, Ruthless Cullblade gets +2/+1.";
+
+    let def = CardDefinitionBuilder::new(CardId::new(), "Ruthless Cullblade")
+        .parse_text(oracle_text)
+        .expect("Ruthless Cullblade text should parse");
+
+    assert_eq!(def.name(), "Ruthless Cullblade");
+    let debug = format!("{:?}", def.abilities);
+    assert!(debug.contains("ValueComparison"), "{debug}");
+    assert!(debug.contains("LifeTotal(Opponent)"), "{debug}");
+    assert!(debug.contains("LessThanOrEqual"), "{debug}");
+    assert!(debug.contains("Fixed(10)"), "{debug}");
+}
+
+#[test]
+fn ruthless_cullblade_compiled_condition_uses_opponent_life_threshold() {
+    let oracle_text = "As long as an opponent has 10 or less life, Ruthless Cullblade gets +2/+1.";
+
+    let def = CardDefinitionBuilder::new(CardId::new(), "Ruthless Cullblade")
+        .parse_text(oracle_text)
+        .expect("Ruthless Cullblade text should parse");
+
+    let rendered = format!("{def:#?}");
+    assert!(
+        rendered.contains("LifeTotal(")
+            && rendered.contains("Opponent")
+            && rendered.contains("LessThanOrEqual")
+            && rendered.contains("Fixed(")
+            && rendered.contains("10"),
+        "expected compiled condition to retain opponent life-threshold clause, got: {rendered}"
+    );
+}
+
+#[test]
 fn rewrite_grammar_battlefield_count_predicate_parses_other_creatures() {
     let tokens = lex_line(
         "there are two or more other creatures on the battlefield",

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1015,6 +1015,30 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             operator,
             right,
         } => {
+            if let (
+                crate::effect::Value::LifeTotal(player),
+                crate::effect::ValueComparisonOperator::LessThanOrEqual,
+                crate::effect::Value::Fixed(threshold),
+            ) = (left, operator, right)
+            {
+                return format!(
+                    "as long as {} has {} or less life",
+                    describe_static_player(player),
+                    threshold
+                );
+            }
+            if let (
+                crate::effect::Value::LifeTotal(player),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                crate::effect::Value::Fixed(threshold),
+            ) = (left, operator, right)
+            {
+                return format!(
+                    "as long as {} has {} or more life",
+                    describe_static_player(player),
+                    threshold
+                );
+            }
             let operator_text = match operator {
                 crate::effect::ValueComparisonOperator::GreaterThan => "is greater than",
                 crate::effect::ValueComparisonOperator::GreaterThanOrEqual => {
@@ -4119,6 +4143,18 @@ mod tests {
                 right: Value::Fixed(7),
             }),
             "as long as your devotion to black and red is less than seven"
+        );
+    }
+
+    #[test]
+    fn describe_static_condition_displays_opponent_life_threshold() {
+        assert_eq!(
+            describe_static_condition(&crate::ConditionExpr::ValueComparison {
+                left: Value::LifeTotal(PlayerFilter::Opponent),
+                operator: crate::effect::ValueComparisonOperator::LessThanOrEqual,
+                right: Value::Fixed(10),
+            }),
+            "as long as an opponent has 10 or less life"
         );
     }
 

--- a/crates/ironsmith-runtime/src/tests/integration_tests.rs
+++ b/crates/ironsmith-runtime/src/tests/integration_tests.rs
@@ -1764,6 +1764,68 @@ mod tests {
         assert_eq!(game.commander_cast_count(commander_identity), 1);
     }
 
+    #[test]
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn test_ruthless_cullblade_gets_bonus_when_opponent_is_at_ten_or_less_life() {
+        let def = crate::CardDefinitionBuilder::new(crate::ids::CardId::new(), "Ruthless Cullblade")
+            .card_types(vec![crate::types::CardType::Creature])
+            .subtypes(vec![crate::types::Subtype::Vampire, crate::types::Subtype::Warrior])
+            .power_toughness(crate::card::PowerToughness::fixed(2, 1))
+            .parse_text(
+                "As long as an opponent has 10 or less life, this creature gets +2/+1.",
+            )
+            .expect("Ruthless Cullblade text should parse");
+
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 10);
+        let cullblade_id = game.create_object_from_definition(
+            &def,
+            PlayerId::from_index(0),
+            crate::zone::Zone::Battlefield,
+        );
+
+        assert_eq!(
+            game.calculated_power(cullblade_id),
+            Some(4),
+            "Ruthless Cullblade should be 4 power when an opponent has 10 or less life"
+        );
+        assert_eq!(
+            game.calculated_toughness(cullblade_id),
+            Some(2),
+            "Ruthless Cullblade should be 2 toughness when an opponent has 10 or less life"
+        );
+    }
+
+    #[test]
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn test_ruthless_cullblade_no_bonus_when_opponent_is_above_ten_life() {
+        let def = crate::CardDefinitionBuilder::new(crate::ids::CardId::new(), "Ruthless Cullblade")
+            .card_types(vec![crate::types::CardType::Creature])
+            .subtypes(vec![crate::types::Subtype::Vampire, crate::types::Subtype::Warrior])
+            .power_toughness(crate::card::PowerToughness::fixed(2, 1))
+            .parse_text(
+                "As long as an opponent has 10 or less life, this creature gets +2/+1.",
+            )
+            .expect("Ruthless Cullblade text should parse");
+
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 11);
+        let cullblade_id = game.create_object_from_definition(
+            &def,
+            PlayerId::from_index(0),
+            crate::zone::Zone::Battlefield,
+        );
+
+        assert_eq!(
+            game.calculated_power(cullblade_id),
+            Some(2),
+            "Ruthless Cullblade should stay 2 power when no opponent has 10 or less life"
+        );
+        assert_eq!(
+            game.calculated_toughness(cullblade_id),
+            Some(1),
+            "Ruthless Cullblade should stay 1 toughness when no opponent has 10 or less life"
+        );
+    }
+
     // Card-specific replay tests have been moved to their respective card definition files.
     // See each card's tests module (e.g., src/cards/definitions/ancient_tomb.rs) for the tests.
     //


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ruthless Cullblade
Initial parse error:
```
unsupported static condition clause (clause: 'an opponent has 10 or less life'); oracle-only fallback also failed: unsupported static condition clause (clause: 'an opponent has 10 or less life')
```

Worker: i-05d5716be02e2763c
