### PR TITLE
Fix Ironsmith parse failure: They Came from the Pipes

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1848,9 +1848,43 @@ pub(crate) fn parse_keyword_mechanic_clause(
         )));
     }
 
-    if clause_words == ["manifest", "dread"] {
-        return Ok(Some(EffectAst::subject_verb_manifest_dread(
-            PlayerAst::Implicit,
+    if clause_words.starts_with(&["manifest", "dread"]) {
+        let manifest_dread = EffectAst::subject_verb_manifest_dread(PlayerAst::Implicit);
+        let trailing_words = &clause_words[2..];
+        if trailing_words.is_empty() {
+            return Ok(Some(manifest_dread));
+        }
+
+        if trailing_words == ["twice"] {
+            return Ok(Some(EffectAst::RepeatEffects {
+                count: Value::Fixed(2),
+                effects: vec![manifest_dread],
+            }));
+        }
+
+        if matches!(trailing_words.last(), Some(&"time") | Some(&"times")) {
+            let value_tokens = &clause_tokens[2..clause_tokens.len() - 1];
+            let (count, used) = parse_value(value_tokens).ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "missing manifest dread count (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+            if used != value_tokens.len() {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported manifest dread count tail (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            }
+            return Ok(Some(EffectAst::RepeatEffects {
+                count,
+                effects: vec![manifest_dread],
+            }));
+        }
+
+        return Err(CardTextError::ParseError(format!(
+            "unsupported trailing manifest dread clause (clause: '{}')",
+            clause_words.join(" ")
         )));
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7473,6 +7473,105 @@ fn test_parse_manifest_dread_trigger_without_fallback_marker() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn they_came_from_the_pipes_strict_parse_includes_manifest_dread_twice_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "They Came from the Pipes")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "When this enchantment enters, manifest dread twice. (To manifest dread, look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever a face-down creature you control enters, draw a card.",
+        )
+        .expect("They Came from the Pipes should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("manifest dread")
+            && (rendered.contains("twice") || rendered.contains("2 times")),
+        "expected compiled text to preserve the manifest-dread-twice clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("whenever a face-down creature you control enters, draw a card"),
+        "expected face-down ETB draw trigger in compiled text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported parser line fallback"),
+        "They Came from the Pipes should not rely on unsupported parser fallback: {rendered}"
+    );
+
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("RepeatEffects") && abilities_debug.contains("Fixed(2)"),
+        "expected manifest dread twice to lower to a repeat effect with count 2, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn they_came_from_the_pipes_face_down_trigger_respects_controller() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "They Came from the Pipes")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "When this enchantment enters, manifest dread twice. (To manifest dread, look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nWhenever a face-down creature you control enters, draw a card.",
+        )
+        .expect("They Came from the Pipes should parse strictly");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let vanilla_creature = CardDefinitionBuilder::new(CardId::from_raw(2), "Vanilla Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice_face_down = game.create_object_from_definition(&vanilla_creature, alice, Zone::Battlefield);
+    game.set_face_down(alice_face_down);
+    let alice_etb = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            alice_face_down,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let alice_trigger_count = crate::triggers::check_triggers(&game, &alice_etb)
+        .iter()
+        .filter(|entry| entry.source == source_id)
+        .count();
+    assert_eq!(
+        alice_trigger_count, 1,
+        "expected They Came from the Pipes to trigger for your own face-down creature ETB"
+    );
+
+    let bob_face_down = game.create_object_from_definition(&vanilla_creature, bob, Zone::Battlefield);
+    game.set_face_down(bob_face_down);
+    let bob_etb = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            bob_face_down,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let bob_trigger_count = crate::triggers::check_triggers(&game, &bob_etb)
+        .iter()
+        .filter(|entry| entry.source == source_id)
+        .count();
+    assert_eq!(
+        bob_trigger_count, 0,
+        "expected They Came from the Pipes not to trigger for opponent face-down creature ETB"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_manifest_top_card_of_your_library_without_fallback_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Manifest Probe")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: They Came from the Pipes
Initial parse error:
```
could not find verb in effect clause (clause: 'manifest dread twice'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'manifest dread twice'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Worker: i-0a48af7ae9ccc9cb8
