### PR TITLE
Fix Ironsmith parse failure: Dread Summons

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/search_library.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/search_library.rs
@@ -1279,9 +1279,24 @@ pub(crate) fn parse_for_each_put_into_graveyard_this_way_sentence(
         )));
     }
 
+    let creature_only = grammar::words_match_prefix(tokens, &["for", "each", "creature", "card"])
+        .is_some()
+        || grammar::words_match_prefix(tokens, &["for", "each", "creature"]).is_some();
+    let loop_effects = if creature_only {
+        vec![EffectAst::Conditional {
+            predicate: crate::cards::builders::PredicateAst::ItMatches(
+                ObjectFilter::default().with_type(CardType::Creature),
+            ),
+            if_true: effects,
+            if_false: vec![],
+        }]
+    } else {
+        effects
+    };
+
     Ok(Some(vec![EffectAst::ForEachTagged {
         tag: IT_TAG.into(),
-        effects,
+        effects: loop_effects,
     }]))
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33318,6 +33318,38 @@ fn parse_rankle_master_of_pranks_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_dread_summons_strict_regression() {
+    assert_oracle_card_parses_strict("Dread Summons");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dread_summons_compiled_text_keeps_milled_this_way_token_clause() {
+    let def = parse_oracle_card_definition("Dread Summons");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("each player mills x cards"),
+        "expected Dread Summons to keep the mill-X clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("for each creature card milled this way")
+            && rendered.contains("2/2 black zombie creature token")
+            && rendered.contains("tapped"),
+        "expected Dread Summons to render its milled-this-way token clause, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("if it's a creature"),
+        "expected Dread Summons to render creature-card identity directly, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("tagged object") && !rendered.contains("tagged '"),
+        "expected Dread Summons compiled text to avoid internal tag markers, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn james_wandering_dad_follow_him_compiled_text_keeps_spend_this_mana_only_clause() {
     let def = parse_oracle_card_definition("James, Wandering Dad // Follow Him");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -24340,6 +24340,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         let tag = for_each_tagged.tag.as_str();
+        let mut described_effects = for_each_tagged.effects.as_slice();
         let subject = if tag.starts_with("destroyed_")
             || crate::cards::is_sentence_helper_tag(tag, "destroyed")
         {
@@ -24351,6 +24352,42 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             || crate::cards::is_sentence_helper_tag(tag, "sacrificed")
         {
             "For each object sacrificed this way".to_string()
+        } else if tag.starts_with("milled_")
+            || crate::cards::is_sentence_helper_tag(tag, "milled")
+        {
+            if for_each_tagged.effects.len() == 1 {
+                if let Some(conditional) =
+                    for_each_tagged.effects[0].downcast_ref::<crate::effects::ConditionalEffect>()
+                {
+                    if conditional.if_false.is_empty() {
+                        if let crate::effect::Condition::TaggedObjectMatches(condition_tag, filter) =
+                            &conditional.condition
+                        {
+                            if condition_tag.as_str() == "__it__" {
+                                described_effects = conditional.if_true.as_slice();
+                                let filter_description = filter.description();
+                                let filter_text = strip_indefinite_article(&filter_description);
+                                let card_text = if filter_text.ends_with("card") {
+                                    filter_text.to_string()
+                                } else {
+                                    format!("{filter_text} card")
+                                };
+                                format!("For each {card_text} milled this way")
+                            } else {
+                                "For each object milled this way".to_string()
+                            }
+                        } else {
+                            "For each object milled this way".to_string()
+                        }
+                    } else {
+                        "For each object milled this way".to_string()
+                    }
+                } else {
+                    "For each object milled this way".to_string()
+                }
+            } else {
+                "For each object milled this way".to_string()
+            }
         } else if tag.is_empty() {
             "For each tagged object".to_string()
         } else {
@@ -24358,7 +24395,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         };
         return format!(
             "{subject}, {}",
-            describe_effect_list(&for_each_tagged.effects)
+            describe_effect_list(described_effects)
         );
     }
     if let Some(for_players) = effect.downcast_ref::<crate::effects::ForPlayersEffect>() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2089,6 +2089,177 @@ fn mind_funeral_mills_until_four_lands_and_moves_every_revealed_card_to_graveyar
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn dread_summons_mills_each_player_and_creates_tapped_zombies_for_milled_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let dread_summons = CardDefinitionBuilder::new(CardId::from_raw(99_260), "Dread Summons")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text("Each player mills X cards. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token. (To mill a card, a player puts the top card of their library into their graveyard.)")
+        .expect("Dread Summons should parse for runtime regression");
+
+    let spell_id = game.create_object_from_definition(&dread_summons, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_x(2));
+
+    let make_library_card = |id: u32, name: &str, card_types: Vec<CardType>| {
+        CardBuilder::new(CardId::from_raw(id), name)
+            .card_types(card_types)
+            .build()
+    };
+
+    game.create_object_from_card(
+        &make_library_card(99_261, "Alice Bottom Relic", vec![CardType::Artifact]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &make_library_card(99_262, "Alice Second Top Charm", vec![CardType::Instant]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &make_library_card(99_263, "Alice Top Ghoul", vec![CardType::Creature]),
+        alice,
+        Zone::Library,
+    );
+
+    game.create_object_from_card(
+        &make_library_card(99_264, "Bob Bottom Relic", vec![CardType::Artifact]),
+        bob,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &make_library_card(99_265, "Bob Second Top Marsh", vec![CardType::Land]),
+        bob,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &make_library_card(99_266, "Bob Top Zombie", vec![CardType::Creature]),
+        bob,
+        Zone::Library,
+    );
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let zombie_tokens_before = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .filter(|obj| game.controller_of(obj) == alice && obj.name == "Zombie")
+        .count();
+
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Dread Summons should resolve");
+
+    let alice_graveyard_names = game
+        .player(alice)
+        .expect("alice exists")
+        .graveyard
+        .iter()
+        .filter_map(|id| game.object(*id).map(|obj| obj.name.clone()))
+        .collect::<Vec<_>>();
+    assert!(
+        alice_graveyard_names.contains(&"Alice Top Ghoul".to_string())
+            && alice_graveyard_names.contains(&"Alice Second Top Charm".to_string()),
+        "Dread Summons should mill Alice's top two library cards, got {:?}",
+        alice_graveyard_names
+    );
+
+    let bob_graveyard_names = game
+        .player(bob)
+        .expect("bob exists")
+        .graveyard
+        .iter()
+        .filter_map(|id| game.object(*id).map(|obj| obj.name.clone()))
+        .collect::<Vec<_>>();
+    assert!(
+        bob_graveyard_names.contains(&"Bob Top Zombie".to_string())
+            && bob_graveyard_names.contains(&"Bob Second Top Marsh".to_string()),
+        "Dread Summons should mill Bob's top two library cards, got {:?}",
+        bob_graveyard_names
+    );
+
+    let zombie_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id).map(|obj| (*id, obj)))
+        .filter(|(id, obj)| {
+            game.controller_of(obj) == alice
+                && obj.name == "Zombie"
+                && obj.kind == ObjectKind::Token
+                && game.is_tapped(*id)
+        })
+        .count();
+    assert_eq!(
+        zombie_tokens,
+        zombie_tokens_before + 2,
+        "Dread Summons should create one tapped Zombie per milled creature card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dread_summons_does_not_create_tokens_when_no_creatures_are_milled() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let dread_summons = CardDefinitionBuilder::new(CardId::from_raw(99_267), "Dread Summons")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text("Each player mills X cards. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token. (To mill a card, a player puts the top card of their library into their graveyard.)")
+        .expect("Dread Summons should parse for no-creature branch regression");
+
+    let spell_id = game.create_object_from_definition(&dread_summons, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_x(1));
+
+    game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(99_268), "Alice Top Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(99_269), "Bob Top Ritual")
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let zombie_tokens_before = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .filter(|obj| game.controller_of(obj) == alice && obj.name == "Zombie")
+        .count();
+
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Dread Summons should resolve");
+
+    let zombie_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .filter(|obj| game.controller_of(obj) == alice && obj.name == "Zombie")
+        .count();
+    assert_eq!(
+        zombie_tokens, zombie_tokens_before,
+        "Dread Summons should not create Zombies when no creature cards are milled"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn wild_dogs_upkeep_trigger_hands_control_to_the_life_leader() {
     let mut game = setup_game();
     let mut trigger_queue = TriggerQueue::new();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dread Summons
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Worker: i-0bf3f56daf02493fb
