### PR TITLE
Fix Ironsmith parse failure: Glamdring

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -3596,7 +3596,71 @@ pub(crate) fn parse_anthem_and_keyword_line(
         return Ok(None);
     };
 
-    if have_idx <= get_idx {
+    if have_idx < get_idx {
+        let have_token_idx = tokens.iter().enumerate().find_map(|(idx, token)| {
+            (idx < get_idx && (token.is_word("have") || token.is_word("has"))).then_some(idx)
+        });
+        let Some(have_token_idx) = have_token_idx else {
+            return Ok(None);
+        };
+
+        let subject_tokens = trim_edge_punctuation(&tokens[..have_token_idx]);
+        if subject_tokens.is_empty() {
+            return Ok(None);
+        }
+        let subject = parse_anthem_subject(&subject_tokens)?;
+
+        let keyword_tokens = trim_edge_punctuation(&tokens[have_token_idx + 1..get_idx]);
+        if keyword_tokens.is_empty() {
+            return Ok(None);
+        }
+        let keyword_tokens = if keyword_tokens
+            .first()
+            .is_some_and(|token| token.is_word("and"))
+        {
+            trim_edge_punctuation(&keyword_tokens[1..])
+        } else {
+            keyword_tokens
+        };
+        let keyword_tokens = if keyword_tokens
+            .last()
+            .is_some_and(|token| token.is_word("and"))
+        {
+            trim_edge_punctuation(&keyword_tokens[..keyword_tokens.len().saturating_sub(1)])
+        } else {
+            keyword_tokens
+        };
+        if keyword_tokens.is_empty() {
+            return Ok(None);
+        }
+
+        let Some(actions) = parse_ability_line(&keyword_tokens) else {
+            return Ok(None);
+        };
+        reject_unimplemented_keyword_actions(&actions, &clause_words.join(" "))?;
+
+        let mut anthem_tokens = subject_tokens.clone();
+        anthem_tokens.extend_from_slice(&tokens[get_idx..]);
+        let Some(anthem) = parse_anthem_line(&anthem_tokens)? else {
+            return Ok(None);
+        };
+        let mut result = vec![StaticAbilityAst::from(anthem)];
+        let grant_clause = ParsedAnthemClause {
+            subject,
+            power: AnthemValue::Fixed(0),
+            toughness: AnthemValue::Fixed(0),
+            condition: None,
+        };
+        for action in actions
+            .into_iter()
+            .filter(|action| action.lowers_to_static_ability())
+        {
+            result.push(grant_keyword_action_for_anthem_subject(&grant_clause, action));
+        }
+        return Ok(Some(result));
+    }
+
+    if have_idx == get_idx {
         return Ok(None);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1301,55 +1301,43 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         return Ok(None);
     }
 
-    let expected_tail_with_split_possessive = [
-        "from",
-        "your",
-        "graveyard",
-        "with",
-        "mana",
-        "value",
-        "less",
-        "than",
-        "or",
-        "equal",
-        "to",
-        "that",
-        "spell",
-        "s",
-        "mana",
-        "value",
-        "without",
-        "paying",
-        "its",
-        "mana",
-        "cost",
-    ];
-    let expected_tail_with_word_possessive = [
-        "from",
-        "your",
-        "graveyard",
-        "with",
-        "mana",
-        "value",
-        "less",
-        "than",
-        "or",
-        "equal",
-        "to",
-        "that",
-        "spells",
-        "mana",
-        "value",
-        "without",
-        "paying",
-        "its",
-        "mana",
-        "cost",
-    ];
     let normalized_tail = &normalized_words[from_idx..];
-    if normalized_tail != expected_tail_with_split_possessive
-        && normalized_tail != expected_tail_with_word_possessive
+    if normalized_tail.len() < 12
+        || normalized_tail[0] != "from"
+        || normalized_tail[1] != "your"
+        || !matches!(normalized_tail[2].as_str(), "graveyard" | "hand")
+        || normalized_tail[3] != "with"
+        || normalized_tail[4] != "mana"
+        || normalized_tail[5] != "value"
     {
+        return Ok(None);
+    }
+
+    let Some(without_idx) = normalized_tail
+        .iter()
+        .position(|word| word.as_str() == "without")
+    else {
+        return Ok(None);
+    };
+    if without_idx <= 6 {
+        return Ok(None);
+    }
+    if normalized_tail[without_idx..]
+        != ["without", "paying", "its", "mana", "cost"]
+    {
+        return Ok(None);
+    }
+
+    let comparison_tokens_start = from_idx + 6;
+    let comparison_tokens_end = from_idx + without_idx;
+    let comparison_tokens = &rest_tokens[comparison_tokens_start..comparison_tokens_end];
+    let Some((operator, rhs_tokens)) = parse_value_comparison_tokens(comparison_tokens) else {
+        return Ok(None);
+    };
+    let Some((rhs_value, used)) = parse_value_from_lexed(rhs_tokens) else {
+        return Ok(None);
+    };
+    if used != rhs_tokens.len() {
         return Ok(None);
     }
 
@@ -1363,18 +1351,53 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         return Ok(None);
     };
     filter.owner = Some(crate::target::PlayerFilter::You);
-    filter
-        .tagged_constraints
-        .push(crate::filter::TaggedObjectConstraint {
-            tag: TagKey::from(IT_TAG),
-            relation: crate::filter::TaggedOpbjectRelation::ManaValueLteTagged,
-        });
+    filter.mana_value = Some(match operator {
+        ValueComparisonOperator::Equal => crate::filter::Comparison::EqualExpr(Box::new(rhs_value)),
+        ValueComparisonOperator::NotEqual => {
+            crate::filter::Comparison::NotEqualExpr(Box::new(rhs_value))
+        }
+        ValueComparisonOperator::LessThan => {
+            crate::filter::Comparison::LessThanExpr(Box::new(rhs_value))
+        }
+        ValueComparisonOperator::LessThanOrEqual => {
+            crate::filter::Comparison::LessThanOrEqualExpr(Box::new(rhs_value))
+        }
+        ValueComparisonOperator::GreaterThan => {
+            crate::filter::Comparison::GreaterThanExpr(Box::new(rhs_value))
+        }
+        ValueComparisonOperator::GreaterThanOrEqual => {
+            crate::filter::Comparison::GreaterThanOrEqualExpr(Box::new(rhs_value))
+        }
+    });
+
+    let graveyard_uses_tagged_spell_mana_value = matches!(normalized_tail[2].as_str(), "graveyard")
+        && (normalized_tail
+            .windows(5)
+            .any(|window| window == ["that", "spell", "s", "mana", "value"])
+            || normalized_tail
+                .windows(4)
+                .any(|window| window == ["that", "spells", "mana", "value"]));
+    if graveyard_uses_tagged_spell_mana_value {
+        filter.mana_value = None;
+        filter
+            .tagged_constraints
+            .push(crate::filter::TaggedObjectConstraint {
+                tag: TagKey::from(IT_TAG),
+                relation: crate::filter::TaggedOpbjectRelation::ManaValueLteTagged,
+            });
+    }
+
+    let zone = if normalized_tail[2] == "hand" {
+        Zone::Hand
+    } else {
+        Zone::Graveyard
+    };
 
     Ok(Some(
         EffectAst::may_cast_matching_spell_without_paying_mana_cost(
             lead.player,
             filter,
-            Zone::Graveyard,
+            zone,
         ),
     ))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4604,6 +4604,24 @@ fn rewrite_lexed_parse_glamdring_trigger_clause_with_damage_value_gate() {
 }
 
 #[test]
+fn rewrite_lexed_parse_glamdring_static_clause_keeps_first_strike_and_anthem() {
+    let tokens = lex_line(
+        "Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your graveyard",
+        0,
+    )
+    .expect("rewrite lexer should classify Glamdring static clause");
+
+    let parsed = super::keyword_static::parse_static_ability_ast_line_lexed(&tokens)
+        .expect("Glamdring static clause should parse as static ability");
+
+    let debug = format!("{parsed:#?}").to_ascii_lowercase();
+    assert!(
+        debug.contains("firststrike") && debug.contains("anthem"),
+        "expected static clause to keep both first strike and anthem, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_play() {
     let tokens = lex_line("Until the end of your next turn, you may play that card", 0)
         .expect("rewrite lexer should classify until-next-turn permission clause");

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4567,6 +4567,43 @@ fn rewrite_lexed_parse_counterpoint_followup_clause_with_tagged_mana_value_gate(
 }
 
 #[test]
+fn rewrite_lexed_parse_glamdring_trigger_clause_with_damage_value_gate() {
+    let tokens = lex_line(
+        "Cast an instant or sorcery spell from your hand with mana value less than or equal to that damage without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify Glamdring cast clause");
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("Glamdring cast clause should parse as a supported effect");
+
+    let (player, filter, zone) = match effects.as_slice() {
+        [
+            crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+                player,
+                filter,
+                zone,
+            },
+        ] => (player, filter, zone),
+        _ => panic!("expected one-shot hand free-cast effect, got {effects:#?}"),
+    };
+
+    assert!(matches!(
+        player,
+        crate::cards::builders::PlayerAst::Implicit | crate::cards::builders::PlayerAst::You
+    ));
+    assert_eq!(*zone, crate::zone::Zone::Hand);
+    assert!(filter.card_types.contains(&crate::types::CardType::Instant));
+    assert!(filter.card_types.contains(&crate::types::CardType::Sorcery));
+    assert_eq!(
+        filter.mana_value,
+        Some(crate::filter::Comparison::LessThanOrEqualExpr(Box::new(
+            crate::effect::Value::EventValue(crate::effect::EventValueSpec::Amount)
+        )))
+    );
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_cover_until_next_turn_tagged_play() {
     let tokens = lex_line("Until the end of your next turn, you may play that card", 0)
         .expect("rewrite lexer should classify until-next-turn permission clause");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36264,13 +36264,17 @@ fn parse_oracle_glamdring_keeps_damage_scaled_free_cast_clause() {
         "expected Glamdring to compile without unsupported effects, got {rendered}"
     );
     assert!(
-        rendered.contains("cast a spell matching instant or sorcery")
+        rendered.contains("cast an instant or sorcery spell")
             && rendered.contains("from your hand")
             && rendered.contains("without paying its mana cost"),
         "expected Glamdring to keep its hand free-cast clause, got {rendered}"
     );
     assert!(
-        rendered.contains("mana value that damage or less"),
+        rendered.contains("first strike"),
+        "expected Glamdring to keep granted first strike, got {rendered}"
+    );
+    assert!(
+        rendered.contains("mana value less than or equal to that amount"),
         "expected Glamdring to keep the dynamic damage-based mana value limit, got {rendered}"
     );
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36253,6 +36253,29 @@ fn parse_oracle_treasure_keeper_keeps_mana_value_or_less_filter() {
 }
 
 #[test]
+fn parse_oracle_glamdring_keeps_damage_scaled_free_cast_clause() {
+    let def = parse_oracle_card_definition("Glamdring");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        !rendered.contains("unsupported effect"),
+        "expected Glamdring to compile without unsupported effects, got {rendered}"
+    );
+    assert!(
+        rendered.contains("cast a spell matching instant or sorcery")
+            && rendered.contains("from your hand")
+            && rendered.contains("without paying its mana cost"),
+        "expected Glamdring to keep its hand free-cast clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("mana value that damage or less"),
+        "expected Glamdring to keep the dynamic damage-based mana value limit, got {rendered}"
+    );
+}
+
+#[test]
 fn parse_oracle_transmogrify_shuffle_rest_into_library() {
     let def = parse_oracle_card_definition("Transmogrify");
     let rendered = unprocessed_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/cards/mod.rs
+++ b/crates/ironsmith-runtime/src/cards/mod.rs
@@ -1809,6 +1809,30 @@ mod tests {
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn generated_definition_support_accepts_glamdring() {
+        let text = "Mana cost: {2}\nType: Legendary Artifact\nEquipped creature has first strike and gets +1/+0 for each instant and sorcery card in your graveyard.\nWhenever equipped creature deals combat damage to a player, you may cast an instant or sorcery spell from your hand with mana value less than or equal to that damage without paying its mana cost.\nEquip {3}";
+        let definition = CardDefinitionBuilder::new(CardId::new(), "Glamdring")
+            .parse_text(text)
+            .expect("glamdring parse should succeed");
+
+        assert!(
+            generated_definition_is_supported(&definition),
+            "{:?}\n{definition:#?}",
+            generated_definition_support_issues(&definition)
+        );
+
+        let debug = format!("{definition:#?}").to_ascii_lowercase();
+        assert!(!debug.contains("unimplemented"));
+        assert!(
+            debug.contains("maycastmatchingspellwithoutpayingmanacost")
+                && debug.contains("eventvalue")
+                && debug.contains("amount"),
+            "Glamdring should keep the dynamic 'that damage' mana value gate, got {debug}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn generated_definition_support_accepts_deepcavern_imp() {
         let text = "Mana cost: {2}{B}\nType: Creature — Imp Rebel\nPower/Toughness: 2/2\nFlying, haste\nEcho—Discard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)";
         let definition = CardDefinitionBuilder::new(CardId::new(), "Deepcavern Imp")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29710,16 +29710,28 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 .any(|constraint| {
                     constraint.relation == crate::filter::TaggedOpbjectRelation::ManaValueLteTagged
                 });
-        let mut spell_text = describe_cast_limit_spell_filter(&may_cast_matching.filter);
-        if has_tagged_mana_value_cap && !may_cast_matching.filter.card_types.is_empty() {
+        let mut spell_text = if !may_cast_matching.filter.card_types.is_empty() {
             let card_type_words: Vec<String> = may_cast_matching
                 .filter
                 .card_types
                 .iter()
                 .map(|card_type| card_type.to_string().to_ascii_lowercase())
                 .collect();
-            spell_text = format!("a {} spell", join_with_or(&card_type_words));
-        }
+            let joined = join_with_or(&card_type_words);
+            let article = if joined.starts_with('i')
+                || joined.starts_with('a')
+                || joined.starts_with('e')
+                || joined.starts_with('o')
+                || joined.starts_with('u')
+            {
+                "an"
+            } else {
+                "a"
+            };
+            format!("{article} {joined} spell")
+        } else {
+            describe_cast_limit_spell_filter(&may_cast_matching.filter)
+        };
         if spell_text == "spell" {
             spell_text = "a spell".to_string();
         } else if !spell_text.starts_with("a ")
@@ -29749,6 +29761,15 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         };
         let mana_value_limit_text = if has_tagged_mana_value_cap {
             " with mana value less than or equal to that spell's mana value"
+        } else if matches!(
+            may_cast_matching.filter.mana_value,
+            Some(crate::filter::Comparison::LessThanOrEqualExpr(ref value))
+                if matches!(
+                    value.as_ref(),
+                    crate::effect::Value::EventValue(crate::effect::EventValueSpec::Amount)
+                )
+        ) {
+            " with mana value less than or equal to that amount"
         } else {
             ""
         };

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -104,6 +104,66 @@ fn sublime_archangel_grants_real_exalted_triggers_to_other_creatures() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn glamdring_equipped_creature_gets_first_strike_and_graveyard_scaled_power() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let glamdring = CardDefinitionBuilder::new(CardId::from_raw(72_101), "Glamdring")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your graveyard.\nWhenever equipped creature deals combat damage to a player, you may cast an instant or sorcery spell from your hand with mana value less than or equal to that damage without paying its mana cost.\nEquip {3}",
+        )
+        .expect("Glamdring should parse");
+    let glamdring_id = game.create_object_from_definition(&glamdring, alice, Zone::Battlefield);
+
+    let attacker_id = create_creature(&mut game, "Bearer", alice, 2, 2);
+    game.remove_summoning_sickness(attacker_id);
+
+    let instant = CardBuilder::new(CardId::from_raw(72_102), "Shock")
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&instant, alice, Zone::Graveyard);
+    let sorcery = CardBuilder::new(CardId::from_raw(72_103), "Ponder")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    game.create_object_from_card(&sorcery, alice, Zone::Graveyard);
+
+    if let Some(equipment) = game.object_mut(glamdring_id) {
+        equipment.attached_to = Some(crate::object::AttachmentTarget::Object(attacker_id));
+    }
+    if let Some(attacker) = game.object_mut(attacker_id) {
+        attacker.attachments.push(glamdring_id);
+    }
+
+    assert_eq!(game.calculated_power(attacker_id), Some(4));
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker_id,
+        target: AttackTarget::Player(bob),
+    });
+    combat.blockers.insert(attacker_id, Vec::new());
+
+    let first_strike_events = execute_combat_damage_step(&mut game, &combat, true);
+    assert_eq!(first_strike_events.len(), 1, "equipped Bearer should hit in first-strike step");
+    assert_eq!(game.player(bob).unwrap().life, 16, "Bearer should deal 4 first-strike damage");
+
+    let regular_events = execute_combat_damage_step(&mut game, &combat, false);
+    assert_eq!(regular_events.len(), 0, "first strike should suppress regular damage step hit");
+
+    if let Some(equipment) = game.object_mut(glamdring_id) {
+        equipment.attached_to = None;
+    }
+    if let Some(attacker) = game.object_mut(attacker_id) {
+        attacker.attachments.clear();
+    }
+
+    assert_eq!(game.calculated_power(attacker_id), Some(2));
+}
+
 #[test]
 fn proposed_granted_emerge_cast_keeps_sacrifice_cost_on_stack_spell() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Glamdring
Initial parse error:
```
could not find verb in effect clause (clause: 'cast an instant or sorcery spell from your hand with mana value less than or equal to that damage without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast an instant or sorcery spell from your hand with mana value less than or equal to that damage without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Worker: i-03ceeed420ec700d8
