### PR TITLE
Fix Ironsmith parse failure: Meathook Massacre II

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -474,7 +474,10 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         | TriggerSpec::EntersBattlefieldOneOrMore { .. }
         | TriggerSpec::EntersBattlefieldFromZone { .. }
         | TriggerSpec::EntersBattlefieldTapped { .. }
-        | TriggerSpec::EntersBattlefieldUntapped { .. } => Some(PlayerFilter::ControllerOf(
+        | TriggerSpec::EntersBattlefieldUntapped { .. }
+        | TriggerSpec::Dies(_)
+        | TriggerSpec::DiesOneOrMore(_)
+        | TriggerSpec::DiesDuringTurn { .. } => Some(PlayerFilter::ControllerOf(
             ObjectRef::tagged(TagKey::from("triggering")),
         )),
         TriggerSpec::SpellCast { caster, .. } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
@@ -143,6 +143,7 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
     }
 
     let mut to_idx = None;
+    let mut implicit_battlefield_destination = false;
     let mut idx = tokens.len();
     while idx > 0 {
         idx -= 1;
@@ -158,6 +159,15 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
         {
             to_idx = Some(idx);
             break;
+        }
+    }
+    if to_idx.is_none()
+        && let Some(under_idx) = find_index(tokens, |token| token.is_word("under"))
+    {
+        let tail_tokens = &tokens[under_idx + 1..];
+        if grammar::contains_word(tail_tokens, "control") {
+            to_idx = Some(under_idx);
+            implicit_battlefield_destination = true;
         }
     }
     let to_idx = to_idx.ok_or_else(|| {
@@ -243,7 +253,12 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
     }
     let is_hand =
         slice_contains(&destination_words, &"hand") || slice_contains(&destination_words, &"hands");
-    let is_battlefield = slice_contains(&destination_words, &"battlefield");
+    let is_battlefield = slice_contains(&destination_words, &"battlefield")
+        || (implicit_battlefield_destination
+            && destination_words.iter().any(|word| {
+                matches!(*word, "owner" | "owners" | "owner's" | "owners'" | "your")
+            })
+            && slice_contains(&destination_words, &"control"));
     let is_graveyard = slice_contains(&destination_words, &"graveyard")
         || slice_contains(&destination_words, &"graveyards");
     let tapped = slice_contains(&destination_words, &"tapped");

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -447,14 +447,23 @@ pub(crate) fn parse_return_with_counters_on_it_sentence(
         return Ok(None);
     }
 
-    let Some(to_idx) = rfind_index(tokens, |token| token.is_word("to")) else {
+    let mut implicit_under_destination = false;
+    let split_idx = if let Some(to_idx) = rfind_index(tokens, |token| token.is_word("to")) {
+        to_idx
+    } else if let Some(under_idx) = find_index(tokens, |token| token.is_word("under")) {
+        if under_idx <= 1 {
+            return Ok(None);
+        }
+        implicit_under_destination = true;
+        under_idx
+    } else {
         return Ok(None);
     };
-    if to_idx <= 1 {
+    if split_idx <= 1 {
         return Ok(None);
     }
 
-    let target_tokens = trim_commas(&tokens[1..to_idx]);
+    let target_tokens = trim_commas(&tokens[1..split_idx]);
     if target_tokens.is_empty() {
         return Err(CardTextError::ParseError(format!(
             "missing return target before destination (clause: '{}')",
@@ -462,11 +471,16 @@ pub(crate) fn parse_return_with_counters_on_it_sentence(
         )));
     }
 
-    let destination_tokens = trim_commas(&tokens[to_idx + 1..]);
+    let destination_start = if implicit_under_destination {
+        split_idx
+    } else {
+        split_idx + 1
+    };
+    let destination_tokens = trim_commas(&tokens[destination_start..]);
     if destination_tokens.is_empty() {
         return Ok(None);
     }
-    if !grammar::contains_word(&destination_tokens, "battlefield") {
+    if !implicit_under_destination && !grammar::contains_word(&destination_tokens, "battlefield") {
         return Ok(None);
     }
 
@@ -480,16 +494,28 @@ pub(crate) fn parse_return_with_counters_on_it_sentence(
     let base_destination_word_storage =
         crate::runtime_backend::token_word_refs(&destination_tokens[..with_idx]);
     let base_destination_words = normalize_destination_words(&base_destination_word_storage);
-    let Some(battlefield_idx) = find_index(&base_destination_words, |word| *word == "battlefield")
-    else {
-        return Ok(None);
+    let battlefield_idx = if implicit_under_destination {
+        0usize
+    } else {
+        let Some(idx) = find_index(&base_destination_words, |word| *word == "battlefield") else {
+            return Ok(None);
+        };
+        idx
     };
     let tapped = slice_contains(&base_destination_words, &"tapped");
-    let destination_tail: Vec<&str> = base_destination_words[battlefield_idx + 1..]
-        .iter()
-        .copied()
-        .filter(|word| *word != "tapped")
-        .collect();
+    let destination_tail: Vec<&str> = if implicit_under_destination {
+        base_destination_words
+            .iter()
+            .copied()
+            .filter(|word| *word != "tapped")
+            .collect()
+    } else {
+        base_destination_words[battlefield_idx + 1..]
+            .iter()
+            .copied()
+            .filter(|word| *word != "tapped")
+            .collect()
+    };
     let battlefield_controller = if destination_tail.is_empty()
         || destination_tail == ["under", "its", "control"]
         || destination_tail == ["under", "their", "control"]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40925,6 +40925,115 @@ fn score_surface_normalizes_granted_death_return_trigger() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_meathook_massacre_ii_oracle_text_strictly() {
+    let def = parse_oracle_card_definition("Meathook Massacre II");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lc = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lc.contains("whenever a creature you control dies")
+            && rendered_lc.contains("you may pay 3 life")
+            && rendered_lc.contains("if you do, return it from graveyard to the battlefield"),
+        "expected self-dies return branch to resolve as a return-to-battlefield effect, got {rendered}"
+    );
+    assert!(
+        rendered_lc.contains("whenever an opponent's creature dies")
+            && rendered_lc.contains("that object's controller may lose 3 life")
+            && rendered_lc.contains("if that object's controller doesn't, return it from graveyard to the battlefield"),
+        "expected opponent-dies branch with pay-or-return clause to compile, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn meathook_massacre_ii_triggers_when_your_creature_dies() {
+    let meathook = parse_oracle_card_definition("Meathook Massacre II");
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Meathook Self Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let meathook_id = game.create_object_from_definition(&meathook, alice, Zone::Battlefield);
+    let dying = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(dying).expect("dying creature should exist"),
+        &game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            dying,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    let meathook_triggers: Vec<_> = triggered
+        .iter()
+        .filter(|entry| entry.source == meathook_id)
+        .collect();
+    assert_eq!(
+        meathook_triggers.len(),
+        1,
+        "Meathook Massacre II should trigger once when your creature dies"
+    );
+    assert_eq!(game.life_total(alice), 20);
+    assert_eq!(game.life_total(bob), 20);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn meathook_massacre_ii_triggers_when_opponent_creature_dies() {
+    let meathook = parse_oracle_card_definition("Meathook Massacre II");
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Meathook Opponent Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let meathook_id = game.create_object_from_definition(&meathook, alice, Zone::Battlefield);
+    let bob = PlayerId::from_index(1);
+    let dying = game.create_object_from_definition(&creature, bob, Zone::Battlefield);
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(dying).expect("dying creature should exist"),
+        &game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            dying,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    let meathook_triggers: Vec<_> = triggered
+        .iter()
+        .filter(|entry| entry.source == meathook_id)
+        .collect();
+    assert_eq!(
+        meathook_triggers.len(),
+        1,
+        "Meathook Massacre II should trigger once when an opponent's creature dies"
+    );
+    assert_eq!(game.life_total(alice), 20);
+    assert_eq!(game.life_total(bob), 20);
+}
+
 #[test]
 fn score_surface_normalizes_attached_count_anthem() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Attached Count Anthem Variant")

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40935,14 +40935,29 @@ fn parse_meathook_massacre_ii_oracle_text_strictly() {
     assert!(
         rendered_lc.contains("whenever a creature you control dies")
             && rendered_lc.contains("you may pay 3 life")
-            && rendered_lc.contains("if you do, return it from graveyard to the battlefield"),
+            && rendered_lc.contains("if you do, put that card onto the battlefield under your control")
+            && rendered_lc.contains("put a finality counter on it"),
         "expected self-dies return branch to resolve as a return-to-battlefield effect, got {rendered}"
     );
     assert!(
         rendered_lc.contains("whenever an opponent's creature dies")
             && rendered_lc.contains("that object's controller may lose 3 life")
-            && rendered_lc.contains("if that object's controller doesn't, return it from graveyard to the battlefield"),
+            && rendered_lc.contains("if that object's controller doesn't, put that card onto the battlefield under your control")
+            && rendered_lc.contains("put a finality counter on it"),
         "expected opponent-dies branch with pay-or-return clause to compile, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_meathook_massacre_ii_compiled_definition_tracks_finality_counter_returns() {
+    let def = parse_oracle_card_definition("Meathook Massacre II");
+    let debug = format!("{def:#?}").to_ascii_lowercase();
+
+    assert!(
+        debug.matches("counter_type: finality").count() >= 2
+            && debug.matches("battlefield_controller: you").count() >= 2,
+        "expected both death triggers to return the creature with a finality counter, got {debug}"
     );
 }
 
@@ -41032,6 +41047,46 @@ fn meathook_massacre_ii_triggers_when_opponent_creature_dies() {
     );
     assert_eq!(game.life_total(alice), 20);
     assert_eq!(game.life_total(bob), 20);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn meathook_massacre_ii_does_not_trigger_for_noncreature_death() {
+    let meathook = parse_oracle_card_definition("Meathook Massacre II");
+    let noncreature = CardDefinitionBuilder::new(CardId::new(), "Meathook Noncreature")
+        .card_types(vec![CardType::Artifact])
+        .build();
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let meathook_id = game.create_object_from_definition(&meathook, alice, Zone::Battlefield);
+    let dying = game.create_object_from_definition(&noncreature, alice, Zone::Battlefield);
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(dying).expect("dying object should exist"),
+        &game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            dying,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    let meathook_triggers: Vec<_> = triggered
+        .iter()
+        .filter(|entry| entry.source == meathook_id)
+        .collect();
+    assert_eq!(
+        meathook_triggers.len(),
+        0,
+        "Meathook Massacre II should not trigger when a noncreature dies"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Meathook Massacre II
Initial parse error:
```
missing return destination (clause: 'that card under your control with a finality counter on it'); oracle-only fallback also failed: missing return destination (clause: 'that card under your control with a finality counter on it')
```

Worker: i-0073c5e6d7590ca5d
