### PR TITLE
Fix Ironsmith parse failure: Brotherhood Ambushers

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -4486,6 +4486,60 @@ pub(crate) fn parse_this_spell_cost_condition(
         }
     }
 
+    // you've dealt combat damage to a player this turn with an Assassin
+    if (slice_starts_with(&w, &["youve", "dealt", "combat", "damage", "to", "a", "player"])
+        || slice_starts_with(
+            &w,
+            &["you've", "dealt", "combat", "damage", "to", "a", "player"],
+        )
+        || slice_starts_with(
+            &w,
+            &["you", "ve", "dealt", "combat", "damage", "to", "a", "player"],
+        )
+        || slice_starts_with(
+            &w,
+            &["if", "youve", "dealt", "combat", "damage", "to", "a", "player"],
+        )
+        || slice_starts_with(
+            &w,
+            &["if", "you've", "dealt", "combat", "damage", "to", "a", "player"],
+        )
+        || slice_starts_with(
+            &w,
+            &["if", "you", "ve", "dealt", "combat", "damage", "to", "a", "player"],
+        )
+        || slice_starts_with(
+            &w,
+            &["you", "dealt", "combat", "damage", "to", "a", "player"],
+        )
+        || slice_starts_with(
+            &w,
+            &["if", "you", "dealt", "combat", "damage", "to", "a", "player"],
+        ))
+        && let Some(with_idx) = find_index(&w, |word| *word == "with")
+        && with_idx >= 2
+        && w[with_idx - 2] == "this"
+        && w[with_idx - 1] == "turn"
+    {
+        let article_idx = with_idx + 1;
+        let subtype_idx = with_idx + 2;
+        if w.get(article_idx).is_some_and(|word| *word == "a" || *word == "an")
+            && let Some(subtype_word) = w.get(subtype_idx)
+            && let Some(subtype) = if *subtype_word == "assassin" {
+                Some(Subtype::Assassin)
+            } else {
+                parse_subtype_word(subtype_word)
+                    .or_else(|| parse_subtype_flexible(subtype_word))
+                    .or_else(|| str_strip_suffix(subtype_word, "s").and_then(parse_subtype_word))
+                    .or_else(|| str_strip_suffix(subtype_word, "s").and_then(parse_subtype_flexible))
+            }
+        {
+            return Some(ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                subtype,
+            ));
+        }
+    }
+
     if let Some(condition_expr) = parse_conjoined_this_spell_cost_condition(tokens) {
         return Some(ThisSpellCostCondition::ConditionExpr {
             condition: condition_expr,
@@ -4553,7 +4607,25 @@ pub(crate) fn parse_trailing_this_spell_cost_condition(
             clause_words.join(" ")
         )));
     }
-    let Some(condition) = parse_this_spell_cost_condition(&condition_tokens) else {
+    let condition_words = crate::runtime_backend::token_word_refs(&condition_tokens);
+    let explicit_assassin_condition = (slice_starts_with(
+        &condition_words,
+        &["youve", "dealt", "combat", "damage", "to", "a", "player"],
+    ) || slice_starts_with(
+        &condition_words,
+        &["you've", "dealt", "combat", "damage", "to", "a", "player"],
+    ) || slice_starts_with(
+        &condition_words,
+        &["you", "ve", "dealt", "combat", "damage", "to", "a", "player"],
+    )) && condition_words.windows(3).any(|window| window == ["with", "an", "assassin"]);
+
+    let Some(condition) = parse_this_spell_cost_condition(&condition_tokens).or_else(|| {
+        explicit_assassin_condition.then_some(
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Assassin,
+            ),
+        )
+    }) else {
         return Err(CardTextError::ParseError(format!(
             "unsupported this-spell cost condition (clause: '{}')",
             clause_words.join(" ")

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -2,7 +2,7 @@ use super::line_family_handlers::{
     run_activation_line_family, run_champion_line_family,
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
     run_combined_static_line_family, run_escape_enters_with_counter_line_family,
-    run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
+    run_freerunning_line_family, run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
     run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
     run_partner_with_keyword_line_family, run_split_top_and_face_down_look_line_family,
     run_split_top_look_and_top_land_play_line_family, run_start_your_engines_line_family,
@@ -46,7 +46,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 24] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 25] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -136,6 +136,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 24] = [
         priority: 43,
         heads: &["surge"],
         run: run_surge_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "freerunning-line",
+        priority: 43,
+        heads: &["freerunning"],
+        run: run_freerunning_line_family,
     },
     LineFamilyRuleDef {
         id: "keyword-line",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -595,6 +595,45 @@ pub(super) fn run_surge_line_family(
     )))
 }
 
+pub(super) fn run_freerunning_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let Some(rest) = raw.strip_prefix("Freerunning ") else {
+        return Ok(None);
+    };
+    let cost_text = rest
+        .split_once('(')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(rest)
+        .trim()
+        .trim_end_matches('.')
+        .trim();
+    if cost_text.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "freerunning keyword missing cost: '{}'",
+            ctx.line.info.raw_line
+        )));
+    }
+
+    let rewritten = format!(
+        "You may pay {cost_text} rather than pay this spell's mana cost if you've dealt combat damage to a player this turn with an Assassin."
+    );
+    let alternative_line = rewrite_line_normalized(ctx.line, rewritten.as_str())?;
+    let Some(mut keyword) = parse_keyword_line_cst(&alternative_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower freerunning keyword line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    keyword.text = ctx.line.info.raw_line.clone();
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Keyword(keyword),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_keyword_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1654,6 +1654,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_document_cst_rewrites_freerunning_keyword_line_to_alternative_cost()
+    -> Result<(), CardTextError> {
+        let preprocessed = preprocess_document(
+            CardDefinitionBuilder::new(CardId::new(), "Brotherhood Ambushers")
+                .card_types(vec![CardType::Creature]),
+            "Freerunning {3}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)",
+        )?;
+        let cst = super::parse_document_cst(&preprocessed, false)?;
+
+        match cst.lines.as_slice() {
+            [super::RewriteLineCst::Keyword(keyword)] => {
+                assert_eq!(keyword.kind, KeywordLineKindCst::AlternativeCast);
+                assert_eq!(
+                    render_token_slice(&keyword.parse_tokens),
+                    "You may pay {3}{B} rather than pay this spell's mana cost if you've dealt combat damage to a player this turn with an Assassin."
+                );
+            }
+            other => panic!("expected one freerunning keyword line, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn static_line_cst_recognizes_compound_unblockable_from_tokens() -> Result<(), CardTextError> {
         let line = single_preprocessed_line("Enchanted creature gets +2/+2 and can't be blocked.");
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -5254,8 +5254,17 @@ pub(crate) fn parse_you_may_rather_than_spell_cost_line(
                 line
             ))
         })?;
-    let trailing_words = crate::runtime_backend::token_word_refs(&tokens[cost_clause_end + 1..]);
-    if !trailing_words.is_empty() {
+    let trailing_tokens = tokens.get(cost_clause_end + 1..).unwrap_or_default();
+    let trailing_words = crate::runtime_backend::token_word_refs(trailing_tokens);
+    let trailing_condition = if trailing_words.is_empty() {
+        None
+    } else if trailing_words.first().copied() == Some("if") {
+        let condition_tokens = trim_commas(trailing_tokens.get(1..).unwrap_or_default());
+        parse_this_spell_cost_condition(&condition_tokens)
+    } else {
+        None
+    };
+    if !trailing_words.is_empty() && trailing_condition.is_none() {
         return Err(CardTextError::ParseError(format!(
             "unsupported trailing clause after alternative cost (line: '{}', trailing: '{}')",
             line,
@@ -5279,7 +5288,7 @@ pub(crate) fn parse_you_may_rather_than_spell_cost_line(
     Ok(Some(AlternativeCastingMethod::Composed {
         name: "Parsed alternative cost",
         total_cost,
-        condition: None,
+        condition: trailing_condition,
     }))
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41428,3 +41428,36 @@ fn knowledge_exploitation_compiled_text_keeps_prowl_and_target_opponent_library_
         "expected Knowledge Exploitation to keep search-target clause, got {rendered}"
     );
 }
+
+#[test]
+fn parse_oracle_brotherhood_ambushers_supports_freerunning_keyword_line() {
+    let def = parse_oracle_card_definition("Brotherhood Ambushers");
+    assert!(
+        !def.alternative_casts.is_empty(),
+        "Brotherhood Ambushers should compile with a freerunning alternative cost"
+    );
+
+    let has_assassin_condition = def.alternative_casts.iter().any(|method| {
+        matches!(
+            method.cast_condition(),
+            Some(crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Assassin
+            ))
+        )
+    });
+    assert!(
+        has_assassin_condition,
+        "Brotherhood Ambushers should encode freerunning with Assassin combat-damage condition"
+    );
+}
+
+#[test]
+fn brotherhood_ambushers_compiled_text_keeps_freerunning_keyword_line() {
+    let def = parse_oracle_card_definition("Brotherhood Ambushers");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Freerunning {3}{B}"),
+        "expected Brotherhood Ambushers to render its freerunning keyword cost, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1762,6 +1762,26 @@ pub(super) fn describe_alternative_cast_line(
                 .map(|cost| format!("Prowl {}", cost.to_oracle()))
                 .unwrap_or_else(|| "Prowl".to_string())
         }
+        method
+            if method.is_composed_cost()
+                && method.name().eq_ignore_ascii_case("Parsed alternative cost")
+                && matches!(
+                    method.cast_condition(),
+                    Some(crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                        crate::types::Subtype::Assassin
+                    ))
+                ) =>
+        {
+            method
+                .mana_cost()
+                .map(|cost| {
+                    format!(
+                        "Freerunning {} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)",
+                        cost.to_oracle()
+                    )
+                })
+                .unwrap_or_else(|| "Freerunning".to_string())
+        }
         method if method.is_composed_cost() => {
             let name = method.name();
             let mana_cost = method.mana_cost();

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -2134,6 +2134,128 @@ mod tests {
     }
 
     #[test]
+    fn brotherhood_ambushers_freerunning_condition_reduces_cost_after_assassin_combat_damage() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let spell = CardBuilder::new(CardId::from_raw(9601), "Brotherhood Ambushers")
+            .card_types(vec![CardType::Creature])
+            .mana_cost(ManaCost::from_symbols(vec![
+                ManaSymbol::Generic(4),
+                ManaSymbol::Black,
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+        let freerunning_condition =
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Assassin,
+            );
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Fixed(1),
+            freerunning_condition,
+        ));
+        game.object_mut(spell_id)
+            .expect("Brotherhood Ambushers should exist")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let spell_obj = game
+            .object(spell_id)
+            .expect("Brotherhood Ambushers should exist");
+        let base_cost = spell_obj
+            .mana_cost
+            .as_ref()
+            .expect("Brotherhood Ambushers should have mana cost");
+        let before_damage = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            before_damage.to_oracle(),
+            "{4}{B}",
+            "freerunning condition should be false before Assassin combat damage"
+        );
+
+        let assassin = CardBuilder::new(CardId::from_raw(9602), "Assassin Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Assassin])
+            .power_toughness(PowerToughness::fixed(2, 1))
+            .build();
+        let assassin_id = game.create_object_from_card(&assassin, alice, Zone::Battlefield);
+        stage_combat_damage_to_player_for_test(&mut game, assassin_id, bob, 2);
+
+        let spell_obj = game
+            .object(spell_id)
+            .expect("Brotherhood Ambushers should exist");
+        let base_cost = spell_obj
+            .mana_cost
+            .as_ref()
+            .expect("Brotherhood Ambushers should have mana cost");
+        let after_damage = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            after_damage.to_oracle(),
+            "{3}{B}",
+            "freerunning condition should become true after your Assassin deals combat damage"
+        );
+    }
+
+    #[test]
+    fn brotherhood_ambushers_freerunning_condition_rejects_noncombat_or_nonassassin_damage() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let spell = CardBuilder::new(CardId::from_raw(9603), "Brotherhood Ambushers")
+            .card_types(vec![CardType::Creature])
+            .mana_cost(ManaCost::from_symbols(vec![
+                ManaSymbol::Generic(4),
+                ManaSymbol::Black,
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+        let freerunning_condition =
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeThisTurn(
+                Subtype::Assassin,
+            );
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Fixed(1),
+            freerunning_condition,
+        ));
+        game.object_mut(spell_id)
+            .expect("Brotherhood Ambushers should exist")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let warrior = CardBuilder::new(CardId::from_raw(9604), "Warrior Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Warrior])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let warrior_id = game.create_object_from_card(&warrior, alice, Zone::Battlefield);
+        stage_combat_damage_to_player_for_test(&mut game, warrior_id, bob, 2);
+
+        let assassin = CardBuilder::new(CardId::from_raw(9605), "Assassin Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Assassin])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        let assassin_id = game.create_object_from_card(&assassin, alice, Zone::Battlefield);
+        stage_noncombat_damage_to_player_for_test(&mut game, assassin_id, bob, 1);
+
+        let spell_obj = game
+            .object(spell_id)
+            .expect("Brotherhood Ambushers should exist");
+        let base_cost = spell_obj
+            .mana_cost
+            .as_ref()
+            .expect("Brotherhood Ambushers should have mana cost");
+        let effective = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            effective.to_oracle(),
+            "{4}{B}",
+            "freerunning condition should stay false when damage is noncombat or from non-Assassin creatures"
+        );
+    }
+
+    #[test]
     fn this_spell_cost_reduction_supports_devotion_where_x_is_clause() {
         let mut game = setup_game();
         let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Brotherhood Ambushers
Initial parse error:
```
parser does not yet support line family: 'Freerunning {3}{B} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)'; oracle-only fallback also failed: parser does not yet support line family: 'Freerunning {3}{B}'
```

Worker: i-0bd0e33541989a849
