### PR TITLE
Fix Ironsmith parse failure: Brambleback Brute

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -1312,14 +1312,19 @@ fn parse_remove_counter_segment_tokens(
         });
     }
 
-    let counter_type = counter_type.ok_or_else(|| {
-        CardTextError::ParseError(format!(
-            "rewrite remove-counter parser missing counter type in '{raw}'"
-        ))
-    })?;
-    Ok(ActivationCostSegmentCst::RemoveCounters {
-        counter_type,
+    if let Some(counter_type) = counter_type {
+        return Ok(ActivationCostSegmentCst::RemoveCounters {
+            counter_type,
+            count,
+        });
+    }
+
+    Ok(ActivationCostSegmentCst::RemoveCountersAmong {
+        counter_type: None,
         count,
+        filter_text: target_filter_text,
+        display_x: false,
+        dynamic: false,
     })
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11691,6 +11691,9 @@ fn rewrite_activation_cost_parses_energy_and_counter_variants() {
         .expect("parser should parse add-counter cost");
     let counter_remove = parse_activation_cost_rewrite("Remove a +1/+1 counter from this creature")
         .expect("parser should parse remove-counter cost");
+    let counter_remove_unspecified =
+        parse_activation_cost_rewrite("Remove a counter from this creature")
+            .expect("parser should parse unspecified remove-counter cost");
     let exile_hand = parse_activation_cost_rewrite("Exile a blue card from your hand")
         .expect("parser should parse exile-from-hand cost");
     let reveal_source = parse_activation_cost_rewrite("Reveal this card from your hand")
@@ -11719,6 +11722,16 @@ fn rewrite_activation_cost_parses_energy_and_counter_variants() {
             counter_type: CounterType::PlusOnePlusOne,
             count: 1
         }]
+    ));
+    assert!(matches!(
+        counter_remove_unspecified.segments.as_slice(),
+        [super::ActivationCostSegmentCst::RemoveCountersAmong {
+            counter_type: None,
+            count: 1,
+            filter_text,
+            display_x: false,
+            dynamic: false,
+        }] if filter_text == "this creature"
     ));
     assert!(matches!(
         exile_hand.segments.as_slice(),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33318,6 +33318,12 @@ fn parse_rankle_master_of_pranks_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_brambleback_brute_strict_regression() {
+    assert_oracle_card_parses_strict("Brambleback Brute");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn james_wandering_dad_follow_him_compiled_text_keeps_spend_this_mana_only_clause() {
     let def = parse_oracle_card_definition("James, Wandering Dad // Follow Him");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
@@ -33349,6 +33355,151 @@ fn rankle_master_of_pranks_compiled_text_keeps_choose_any_number_modal_header() 
     assert!(
         rendered.contains("choose any number"),
         "expected Rankle, Master of Pranks compiled text to preserve choose-any-number modal header, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn brambleback_brute_compiled_text_keeps_unspecified_remove_counter_activation_cost() {
+    let def = parse_oracle_card_definition("Brambleback Brute");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("remove a counter from this creature"),
+        "expected Brambleback Brute compiled text to keep unspecified remove-counter cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains("target creature can't block this turn"),
+        "expected Brambleback Brute compiled text to keep can't-block effect, got {rendered}"
+    );
+    assert!(
+        rendered.contains("activate only as a sorcery"),
+        "expected Brambleback Brute compiled text to keep sorcery-speed activation rider, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn brambleback_brute_activation_cost_and_effect_runtime_regression() {
+    let def = parse_oracle_card_definition("Brambleback Brute");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Brambleback Brute should have one activated ability");
+
+    assert_eq!(
+        activated.timing,
+        crate::ability::ActivationTiming::SorcerySpeed,
+        "Brambleback Brute activation must stay sorcery speed"
+    );
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+    let brute_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target_id = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Blocking Target")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    assert!(
+        game.add_counters(brute_id, crate::object::CounterType::MinusOneMinusOne, 2)
+            .is_some(),
+        "Brambleback Brute should be on battlefield"
+    );
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 4);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        brute_id,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("first Brambleback Brute activation cost should be payable");
+
+    let counters_after_first = game
+        .object(brute_id)
+        .expect("Brambleback Brute should still be on battlefield")
+        .counters
+        .get(&crate::object::CounterType::MinusOneMinusOne)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        counters_after_first, 1,
+        "first activation should remove exactly one counter from Brambleback Brute"
+    );
+
+    let mut resolve_ctx = crate::effects::ExecutionContext::new(brute_id, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target_id)]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut resolve_ctx,
+        alice,
+        brute_id,
+        &activated.effects,
+        None,
+        &[],
+    )
+    .expect("Brambleback Brute ability effect should resolve");
+    assert!(
+        !game.can_block(target_id),
+        "target creature should be unable to block this turn after Brambleback Brute resolves"
+    );
+
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        brute_id,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("second Brambleback Brute activation cost should be payable");
+
+    let counters_after_second = game
+        .object(brute_id)
+        .expect("Brambleback Brute should still be on battlefield")
+        .counters
+        .get(&crate::object::CounterType::MinusOneMinusOne)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        counters_after_second, 0,
+        "second activation should remove the last counter from Brambleback Brute"
+    );
+
+    let pay_third = crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        brute_id,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    );
+    assert!(
+        pay_third.is_err(),
+        "activation should fail once Brambleback Brute has no counters left"
     );
 }
 

--- a/crates/ironsmith-runtime/src/effects/counters/remove_any_counters_among.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/remove_any_counters_among.rs
@@ -367,6 +367,16 @@ fn counter_article(counter_name: &str) -> &'static str {
 }
 
 fn remove_counters_target_phrase(filter: &ObjectFilter, plural: bool) -> String {
+    if filter.source {
+        if plural {
+            return "this source".to_string();
+        }
+        if filter.card_types.len() == 1 {
+            return format!("this {}", filter.card_types[0].name().to_ascii_lowercase());
+        }
+        return "this source".to_string();
+    }
+
     if is_simple_permanent_you_control_filter(filter) {
         return if plural {
             "permanents you control".to_string()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Brambleback Brute
Initial parse error:
```
unsupported activation cost segment (clause: 'remove a counter from this creature'): rewrite remove-counter parser missing counter type in 'remove a counter from this creature'; oracle-only fallback also failed: unsupported activation cost segment (clause: 'remove a counter from this creature'): rewrite remove-counter parser missing counter type in 'remove a counter from this creature'
```

Worker: i-0fb30a77aadbb69c9
