### PR TITLE
Fix Ironsmith parse failure: Exuberant Fuseling

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2874,6 +2874,24 @@ pub(crate) fn parse_anthem_for_each_expression(
         });
     }
 
+    let rest_words = crate::runtime_backend::token_word_refs(rest);
+    if let Some(counter_word_idx) =
+        anthem_find_word_index(&rest_words, |word| matches!(word, "counter" | "counters"))
+        && counter_word_idx > 0
+        && let Some(counter_type) = parse_counter_type_word(rest_words[counter_word_idx - 1])
+    {
+        let tail_words = &rest_words[counter_word_idx + 1..];
+        let on_source_tail = anthem_word_slice_starts_with(tail_words, &["on", "it"])
+            || anthem_word_slice_starts_with(tail_words, &["on", "this"])
+            || anthem_word_slice_starts_with(tail_words, &["on", "him"])
+            || anthem_word_slice_starts_with(tail_words, &["on", "her"])
+            || anthem_word_slice_starts_with(tail_words, &["on", "this", "creature"])
+            || anthem_word_slice_starts_with(tail_words, &["on", "this", "permanent"]);
+        if on_source_tail {
+            return Ok(AnthemCountExpression::CountersOnSource(counter_type));
+        }
+    }
+
     let filter = parse_object_filter(rest, false).map_err(|_| {
         CardTextError::ParseError(format!(
             "unsupported 'for each' filter in anthem clause (clause: '{}')",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34017,6 +34017,12 @@ fn exuberant_fuseling_compiled_text_keeps_oil_counter_scaling_clause() {
         rendered.contains("this creature gets +1/+0 for each oil counter on it"),
         "expected Exuberant Fuseling to keep its oil-counter scaling clause, got {rendered}"
     );
+    assert!(
+        rendered.contains(
+            "when this creature enters and whenever another creature or artifact you control is put into a graveyard from the battlefield"
+        ),
+        "expected Exuberant Fuseling trigger wording to preserve enters-and-whenever structure, got {rendered}"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
@@ -34112,6 +34118,29 @@ fn exuberant_fuseling_trigger_adds_oil_counter_for_etb_and_other_controlled_deat
     assert_eq!(
         opposing_triggers, 0,
         "expected opponent permanent dying to not trigger Exuberant Fuseling"
+    );
+
+    let fuseling_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(fuseling_id).expect("fuseling should exist"),
+        &game,
+    );
+    let fuseling_dies_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            fuseling_id,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(fuseling_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let self_dies_triggers = crate::triggers::check_triggers(&game, &fuseling_dies_event)
+        .into_iter()
+        .filter(|entry| entry.source == fuseling_id)
+        .count();
+    assert_eq!(
+        self_dies_triggers, 0,
+        "expected Exuberant Fuseling to not trigger from its own death under the 'another' clause"
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33963,6 +33963,7 @@ strict_parse_card_test!(strict_parse_cavern_of_souls, "Cavern of Souls");
 strict_parse_card_expected_fail_test!(strict_parse_clown_car, "Clown Car");
 strict_parse_card_test!(strict_parse_encroaching_mycosynth, "Encroaching Mycosynth");
 strict_parse_card_test!(strict_parse_escaped_null, "Escaped Null");
+strict_parse_card_test!(strict_parse_exuberant_fuseling, "Exuberant Fuseling");
 strict_parse_card_test!(strict_parse_fatal_push, "Fatal Push");
 strict_parse_card_test!(strict_parse_feudkillers_verdict, "Feudkiller's Verdict");
 strict_parse_card_test!(strict_parse_gemstone_caverns, "Gemstone Caverns");
@@ -34005,6 +34006,112 @@ fn escaped_null_compiled_text_keeps_blocks_or_becomes_blocked_trigger() {
         rendered.contains("whenever this creature blocks or this creature becomes blocked")
             && rendered.contains("gets +5/+0 until end of turn"),
         "expected Escaped Null to keep its combat trigger and pump clause, got {rendered}"
+    );
+}
+
+#[test]
+fn exuberant_fuseling_compiled_text_keeps_oil_counter_scaling_clause() {
+    let def = parse_oracle_card_definition("Exuberant Fuseling");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("this creature gets +1/+0 for each oil counter on it"),
+        "expected Exuberant Fuseling to keep its oil-counter scaling clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn exuberant_fuseling_trigger_adds_oil_counter_for_etb_and_other_controlled_death_only() {
+    let def = parse_oracle_card_definition("Exuberant Fuseling");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let fuseling_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let etb_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            fuseling_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut etb_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(&game, &etb_event)
+        .into_iter()
+        .filter(|entry| entry.source == fuseling_id)
+    {
+        etb_queue.add(entry);
+    }
+    assert_eq!(
+        etb_queue.entries.len(),
+        1,
+        "expected Exuberant Fuseling ETB branch to trigger once"
+    );
+
+    let allied_artifact = CardDefinitionBuilder::new(CardId::new(), "Allied Artifact")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let allied_artifact_id =
+        game.create_object_from_definition(&allied_artifact, alice, Zone::Battlefield);
+    let allied_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(allied_artifact_id)
+            .expect("allied artifact should exist"),
+        &game,
+    );
+    let allied_dies_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            allied_artifact_id,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(allied_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut allied_dies_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(&game, &allied_dies_event)
+        .into_iter()
+        .filter(|entry| entry.source == fuseling_id)
+    {
+        allied_dies_queue.add(entry);
+    }
+    assert_eq!(
+        allied_dies_queue.entries.len(),
+        1,
+        "expected another controlled artifact dying to trigger Exuberant Fuseling"
+    );
+
+    let opposing_artifact = CardDefinitionBuilder::new(CardId::new(), "Opposing Artifact")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let opposing_artifact_id =
+        game.create_object_from_definition(&opposing_artifact, bob, Zone::Battlefield);
+    let opposing_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(opposing_artifact_id)
+            .expect("opposing artifact should exist"),
+        &game,
+    );
+    let opposing_dies_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            opposing_artifact_id,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(opposing_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let opposing_triggers = crate::triggers::check_triggers(&game, &opposing_dies_event)
+        .into_iter()
+        .filter(|entry| entry.source == fuseling_id)
+        .count();
+    assert_eq!(
+        opposing_triggers, 0,
+        "expected opponent permanent dying to not trigger Exuberant Fuseling"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -4649,6 +4649,14 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     {
         return format!("Whenever this or another {rest}");
     }
+    if let Some(rest) = normalized.strip_prefix("When this creature enters or a ")
+        && let Some((subject, effect_clause)) =
+            rest.split_once(" you control other than this is put into a graveyard from the battlefield,")
+    {
+        return format!(
+            "When this creature enters and whenever another {subject} you control is put into a graveyard from the battlefield,{effect_clause}"
+        );
+    }
     if let Some((left, right)) = normalized.split_once(" or Whenever another ") {
         if left.starts_with("Whenever ") {
             return format!("{left} or another {right}");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26825,6 +26825,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     describe_count_filter_value_subject(power_filter)
                 ))
             }
+            (Value::CountersOnSource(power_counter), Value::CountersOnSource(toughness_counter))
+                if power_counter == toughness_counter =>
+            {
+                Some(format!("{} counter on it", power_counter.description()))
+            }
             _ => None,
         };
         if let Some(for_each_text) = for_each_text {
@@ -26846,6 +26851,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if !matches!(modify_pt.power, Value::Fixed(_))
             && matches!(modify_pt.toughness, Value::Fixed(0))
         {
+            if let Value::CountersOnSource(counter_type) = &modify_pt.power {
+                return format!(
+                    "{} gets +1/+0 for each {} counter on it {}",
+                    describe_choose_spec(&modify_pt.target),
+                    counter_type.description(),
+                    describe_until(&modify_pt.duration)
+                );
+            }
             return format!(
                 "{} gets +X/+0 {}, where X is {}",
                 describe_choose_spec(&modify_pt.target),

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -670,6 +670,9 @@ fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Op
         AnthemCountExpression::AffectedAttackedThisTurn => {
             Some("time it has attacked this turn".to_string())
         }
+        AnthemCountExpression::CountersOnSource(counter_type) => {
+            Some(format!("{} counter on it", counter_type.description()))
+        }
         AnthemCountExpression::BasicLandTypesAmong(_) => {
             Some("basic land type among lands you control".to_string())
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Exuberant Fuseling
Initial parse error:
```
unsupported 'for each' filter in anthem clause (clause: 'for each oil counter on it'); oracle-only fallback also failed: unsupported 'for each' filter in anthem clause (clause: 'for each oil counter on it')
```

Worker: i-07d4def51862c83d2
