### PR TITLE
Fix Ironsmith parse failure: Healing Grace

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1129,6 +1129,17 @@ impl Effect {
         ))
     }
 
+    pub fn prevent_damage_with_source_choice(
+        amount: Value,
+        target: crate::target::ChooseSpec,
+        until: Until,
+    ) -> Self {
+        Self::new(
+            crate::effects::PreventDamageEffect::new(amount, target, until)
+                .with_source_of_your_choice(),
+        )
+    }
+
     pub fn prevent_all_combat_damage(until: Until) -> Self {
         Self::new(crate::effects::PreventAllCombatDamageEffect::new(
             crate::effects::CombatDamagePreventionTarget::All,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1446,6 +1446,7 @@ fn compile_subject_verb_effect(
             amount,
             target,
             duration,
+            source_of_your_choice,
         } => {
             let amount = resolve_value_it_tag(amount, &current_reference_env(ctx))?;
             if let TargetAst::Object(filter, explicit_target_span, _) = target
@@ -1463,7 +1464,15 @@ fn compile_subject_verb_effect(
                 Ok((vec![effect], Vec::new()))
             } else {
                 compile_effect_for_target(target, ctx, |spec| {
-                    Effect::prevent_damage(amount.clone(), spec, duration.clone())
+                    if *source_of_your_choice {
+                        Effect::prevent_damage_with_source_choice(
+                            amount.clone(),
+                            spec,
+                            duration.clone(),
+                        )
+                    } else {
+                        Effect::prevent_damage(amount.clone(), spec, duration.clone())
+                    }
                 })
             }
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -951,6 +951,7 @@ pub(crate) enum SubjectVerbActionAst {
         amount: Value,
         target: TargetAst,
         duration: Until,
+        source_of_your_choice: bool,
     },
     PreventAllDamageToTarget {
         target: TargetAst,
@@ -2045,6 +2046,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 amount,
                 target,
                 duration,
+                ..
             } => f
                 .debug_struct("PreventDamage")
                 .field("amount", amount)
@@ -3393,6 +3395,15 @@ impl EffectAst {
         target: TargetAst,
         duration: Until,
     ) -> Self {
+        Self::subject_verb_prevent_damage_with_source_choice(amount, target, duration, false)
+    }
+
+    pub(crate) fn subject_verb_prevent_damage_with_source_choice(
+        amount: Value,
+        target: TargetAst,
+        duration: Until,
+        source_of_your_choice: bool,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
@@ -3400,6 +3411,7 @@ impl EffectAst {
                 amount,
                 target,
                 duration,
+                source_of_your_choice,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -139,12 +139,18 @@ pub(crate) fn parse_prevent_next_damage_clause(
             ))
         })?;
     let this_turn_idx = idx + this_turn_rel;
-    if this_turn_idx + 2 != clause_words.len() {
+    let source_of_your_choice = if this_turn_idx + 2 == clause_words.len() {
+        false
+    } else if clause_words[this_turn_idx + 2..]
+        == ["by", "a", "source", "of", "your", "choice"]
+    {
+        true
+    } else {
         return Err(CardTextError::ParseError(format!(
             "unsupported trailing prevent-next damage clause (clause: '{}')",
             clause_words.join(" ")
         )));
-    }
+    };
 
     let target_words = &clause_words[idx..this_turn_idx];
     if target_words.is_empty() {
@@ -159,10 +165,11 @@ pub(crate) fn parse_prevent_next_damage_clause(
         .collect::<Vec<_>>();
     let target = parse_target_phrase(&target_tokens)?;
 
-    Ok(Some(EffectAst::subject_verb_prevent_damage(
+    Ok(Some(EffectAst::subject_verb_prevent_damage_with_source_choice(
         amount,
         target,
         Until::EndOfTurn,
+        source_of_your_choice,
     )))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
@@ -408,6 +408,7 @@ pub(crate) fn parse_damage_prevention_counter_sequence(
                     amount,
                     target,
                     duration,
+                    ..
                 },
             ..
         }) => (Some(amount.clone()), target.clone(), duration.clone()),

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3300,6 +3300,7 @@ pub struct PreventDamageEffect<E> {
     pub target: ChooseSpec,
     pub until: Until,
     pub follow_up_effects: Vec<E>,
+    pub source_of_your_choice: bool,
 }
 
 impl<E> PreventDamageEffect<E> {
@@ -3309,11 +3310,17 @@ impl<E> PreventDamageEffect<E> {
             target,
             until,
             follow_up_effects: Vec::new(),
+            source_of_your_choice: false,
         }
     }
 
     pub fn with_follow_up_effects(mut self, effects: Vec<E>) -> Self {
         self.follow_up_effects = effects;
+        self
+    }
+
+    pub fn with_source_of_your_choice(mut self) -> Self {
+        self.source_of_your_choice = true;
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13034,6 +13034,36 @@ fn parse_oracle_healing_grace_strict_and_keeps_source_choice_clause() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
+    struct ChooseNamedSourceDecisionMaker {
+        source_name: &'static str,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseNamedSourceDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            if let Some(chosen) = ctx.candidates.iter().find_map(|candidate| {
+                if !candidate.legal {
+                    return None;
+                }
+                let matches_name = game
+                    .object(candidate.id)
+                    .is_some_and(|object| object.name == self.source_name);
+                if matches_name {
+                    Some(candidate.id)
+                } else {
+                    None
+                }
+            }) {
+                vec![chosen]
+            } else {
+                crate::decision::AutoPassDecisionMaker.decide_objects(game, ctx)
+            }
+        }
+    }
+
     let def = parse_oracle_card_definition("Healing Grace");
     let spell = def
         .spell_effect
@@ -13044,7 +13074,7 @@ fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
     let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
-    let damage_source = game.create_object_from_definition(
+    let chosen_source = game.create_object_from_definition(
         &CardDefinitionBuilder::new(CardId::from_raw(91_100), "Damage Source")
             .card_types(vec![CardType::Creature])
             .power_toughness(PowerToughness::fixed(2, 2))
@@ -13052,8 +13082,18 @@ fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
         bob,
         Zone::Battlefield,
     );
+    let other_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_102), "Other Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
 
-    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut dm = ChooseNamedSourceDecisionMaker {
+        source_name: "Damage Source",
+    };
     let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
         .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
         .with_target_assignments(vec![crate::game_state::TargetAssignment {
@@ -13076,7 +13116,7 @@ fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
 
     let (first_damage, first_prevented) = crate::events::processing::process_damage_with_event(
         &mut game,
-        damage_source,
+        chosen_source,
         crate::events::DamageTarget::Player(bob),
         2,
         false,
@@ -13090,7 +13130,7 @@ fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
 
     let (second_damage, second_prevented) = crate::events::processing::process_damage_with_event(
         &mut game,
-        damage_source,
+        chosen_source,
         crate::events::DamageTarget::Player(bob),
         2,
         false,
@@ -13100,6 +13140,24 @@ fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
     assert!(
         second_prevented || second_damage < 2,
         "second damage application should still be partially prevented"
+    );
+
+    let (other_source_damage, other_source_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            other_source,
+            crate::events::DamageTarget::Player(bob),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        other_source_damage, 2,
+        "non-chosen source damage should not be prevented"
+    );
+    assert!(
+        !other_source_prevented,
+        "non-chosen source damage should remain fully unprevented"
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13020,6 +13020,152 @@ fn parse_prevent_next_damage_rejects_trailing_tail_strictly() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_healing_grace_strict_and_keeps_source_choice_clause() {
+    let def = parse_oracle_card_definition("Healing Grace");
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Prevent the next 3 damage")
+            && rendered.contains("by a source of your choice")
+            && rendered.contains("You gain 3 life"),
+        "expected Healing Grace prevention + source choice + life gain in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
+    let def = parse_oracle_card_definition("Healing Grace");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Healing Grace should produce spell effects")
+        .clone();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_100), "Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::AnyTarget,
+            range: 0..1,
+        }]);
+
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &spell,
+        None,
+        &[],
+    )
+        .expect("Healing Grace should resolve");
+
+    assert_eq!(game.players[0].life, 23, "Healing Grace should gain 3 life for the caster");
+
+    let (first_damage, first_prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(first_damage, 0, "first 2 damage should be prevented");
+    assert!(
+        first_prevented || first_damage == 0,
+        "first damage application should reflect prevention"
+    );
+
+    let (second_damage, second_prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(second_damage, 1, "shield should have exactly 1 prevention remaining");
+    assert!(
+        second_prevented || second_damage < 2,
+        "second damage application should still be partially prevented"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn healing_grace_runtime_only_protects_chosen_target() {
+    let def = parse_oracle_card_definition("Healing Grace");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Healing Grace should produce spell effects")
+        .clone();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_101), "Damage Source Two")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::AnyTarget,
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &spell,
+        None,
+        &[],
+    )
+    .expect("Healing Grace should resolve");
+
+    let (damage_to_alice, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(alice),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(damage_to_alice, 2, "non-targeted player should not be protected");
+
+    let (damage_to_bob, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(damage_to_bob, 0, "chosen target should receive prevented damage");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_target_opponent_chooses_creature_then_other_cant_block() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Eunuchs Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28730,23 +28730,30 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else {
             describe_until(&prevent_damage.duration)
         };
+        let source_text = if prevent_damage.source_of_your_choice {
+            " by a source of your choice"
+        } else {
+            ""
+        };
         if let Some(put) = prevention_put_counters_follow_up(&prevent_damage.follow_up_effects) {
             return format!(
-                "Prevent the next {} {} that would be dealt to {} {}. For each 1 damage prevented this way, put a {} counter on {}",
+                "Prevent the next {} {} that would be dealt to {} {}{}. For each 1 damage prevented this way, put a {} counter on {}",
                 describe_value(&prevent_damage.amount),
                 damage_text,
                 describe_choose_spec(&prevent_damage.target),
                 timing,
+                source_text,
                 describe_counter_type(put.counter_type),
                 describe_prevention_follow_up_target(&prevent_damage.target)
             );
         }
         return format!(
-            "Prevent the next {} {} that would be dealt to {} {}",
+            "Prevent the next {} {} that would be dealt to {} {}{}",
             describe_value(&prevent_damage.amount),
             damage_text,
             describe_choose_spec(&prevent_damage.target),
-            timing
+            timing,
+            source_text
         );
     }
     if let Some(prevent_all_target) =

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -577,16 +577,18 @@ where
     if let Some(payload) =
         M::downcast_ref::<ironsmith_core::PreventDamageEffect<M::Effect>>(&effect)
     {
+        let mut prevent = crate::effects::PreventDamageEffect::new(
+            payload.amount.clone(),
+            payload.target.clone(),
+            payload.until.clone(),
+        )
+        .with_follow_up_effects(convert_effects(
+            payload.follow_up_effects.iter().cloned(),
+            hooks,
+        )?);
+        prevent.source_of_your_choice = payload.source_of_your_choice;
         return Ok(Effect::new(
-            crate::effects::PreventDamageEffect::new(
-                payload.amount.clone(),
-                payload.target.clone(),
-                payload.until.clone(),
-            )
-            .with_follow_up_effects(convert_effects(
-                payload.follow_up_effects.iter().cloned(),
-                hooks,
-            )?),
+            prevent,
         ));
     }
     if let Some(converted) = clone_direct_effect::<M, crate::effects::LoseTheGameEffect>(&effect) {

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
@@ -41,6 +41,8 @@ pub struct PreventDamageEffect {
     pub damage_filter: DamageFilter,
     /// Effects to run using the amount this shield actually prevented.
     pub follow_up_effects: Vec<Effect>,
+    /// Whether the source is chosen as the effect resolves.
+    pub source_of_your_choice: bool,
 }
 
 impl PreventDamageEffect {
@@ -52,6 +54,7 @@ impl PreventDamageEffect {
             duration,
             damage_filter: DamageFilter::all(),
             follow_up_effects: Vec::new(),
+            source_of_your_choice: false,
         }
     }
 
@@ -70,6 +73,7 @@ impl PreventDamageEffect {
         self.damage_filter = filter;
         self
     }
+
 
     /// Execute these effects using the amount this shield prevented.
     pub fn with_follow_up_effects(mut self, effects: Vec<Effect>) -> Self {

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
@@ -95,6 +95,46 @@ impl EffectExecutor for PreventDamageEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let amount = resolve_value(game, &self.amount, ctx)?.max(0) as u32;
+        let mut damage_filter = self.damage_filter.clone();
+
+        if self.source_of_your_choice {
+            let mut candidates = Vec::new();
+            candidates.extend(game.stack.iter().map(|entry| entry.object_id));
+            candidates.extend(game.battlefield.iter().copied());
+            candidates.sort_by_key(|id| id.0);
+            candidates.dedup();
+
+            if candidates.is_empty() {
+                return Ok(EffectOutcome::resolved());
+            }
+
+            let selectable = candidates
+                .iter()
+                .copied()
+                .map(|id| {
+                    let name = game
+                        .object(id)
+                        .map(|object| object.name.clone())
+                        .unwrap_or_else(|| format!("object {}", id.0));
+                    crate::decisions::context::SelectableObject::new(id, name)
+                })
+                .collect::<Vec<_>>();
+            let select_ctx = crate::decisions::context::SelectObjectsContext::new(
+                ctx.controller,
+                Some(ctx.source),
+                "Choose a source",
+                selectable,
+                1,
+                Some(1),
+            );
+            let chosen_source = ctx
+                .decision_maker
+                .decide_objects(game, &select_ctx)
+                .into_iter()
+                .next()
+                .unwrap_or(candidates[0]);
+            damage_filter.from_specific_source = Some(chosen_source);
+        }
 
         let protected = resolve_prevention_target_from_spec(game, &self.target, ctx)?;
         register_prevention_shield(
@@ -103,7 +143,7 @@ impl EffectExecutor for PreventDamageEffect {
             protected,
             Some(amount),
             self.duration.clone(),
-            self.damage_filter.clone(),
+            damage_filter,
             self.follow_up_effects.clone(),
         );
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Healing Grace
Initial parse error:
```
parser does not yet support line family: 'Prevent the next 3 damage that would be dealt to any target this turn by a source of your choice. You gain 3 life.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent the next 3 damage that would be dealt to any target this turn by a source of your choice. You gain 3 life.'
```

Worker: i-02d5f9aafa82b7348
