### PR TITLE
Fix Ironsmith parse failure: Rix Maadi Reveler

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -653,6 +653,19 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     if filtered.len() >= 2 && filtered[0] == "it" && filtered[1] == "s" {
         filtered.remove(1);
     }
+    if let Some(instead_idx) = filtered.iter().position(|word| *word == "instead")
+        && instead_idx > 0
+    {
+        let maybe_predicate = &filtered[..instead_idx];
+        let paid_tail = maybe_predicate.len() >= 3
+            && (maybe_predicate[maybe_predicate.len() - 3..] == ["cost", "was", "paid"]
+                || maybe_predicate[maybe_predicate.len() - 3..] == ["cost", "wasnt", "paid"]);
+        let unpaid_tail = maybe_predicate.len() >= 4
+            && maybe_predicate[maybe_predicate.len() - 4..] == ["cost", "was", "not", "paid"];
+        if paid_tail || unpaid_tail {
+            filtered.truncate(instead_idx);
+        }
+    }
 
     if let Some(predicate) = parse_repeated_if_or_predicate(&filtered)? {
         return Ok(predicate);
@@ -2367,7 +2380,14 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         && filtered[0] == "this"
         && matches!(
             filtered[1],
-            "spell's" | "spells" | "card's" | "creature's" | "permanent's"
+            "spell's"
+                | "spells"
+                | "card's"
+                | "cards"
+                | "creature's"
+                | "creatures"
+                | "permanent's"
+                | "permanents"
         )
         && filtered[3] == "cost"
         && filtered[4] == "was"
@@ -3300,6 +3320,28 @@ mod tests {
         assert_eq!(
             parsed,
             PredicateAst::ThisSpellPaidLabel("Surge".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_accepts_paid_label_with_trailing_instead_effect_tail(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line(
+            "If this creature's spectacle cost was paid instead discard your hand",
+            0,
+        )?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::ThisSpellPaidLabel("Spectacle".to_string())
         );
         Ok(())
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1238,6 +1238,22 @@ pub(crate) fn split_if_clause_lexed(
     tokens: &[OwnedLexToken],
     mut parse_effects: impl FnMut(&[OwnedLexToken]) -> Result<Vec<EffectAst>, CardTextError>,
 ) -> Result<IfClauseSplitSpec, CardTextError> {
+    let parse_effects_with_leading_instead = |effect_tokens: &[OwnedLexToken],
+                                              parse_effects: &mut dyn FnMut(
+        &[OwnedLexToken],
+    ) -> Result<Vec<EffectAst>, CardTextError>| {
+        let trimmed = trim_lexed_commas(effect_tokens);
+        let without_instead = if trimmed
+            .first()
+            .is_some_and(|token| token.is_word("instead"))
+        {
+            trim_lexed_commas(&trimmed[1..])
+        } else {
+            trimmed
+        };
+        parse_effects(without_instead)
+    };
+
     if let Some(effect_token_idx) =
         primitives::find_phrase_start(tokens, &["exile", "them", "then", "meld", "them", "into"])
     {
@@ -1251,7 +1267,7 @@ pub(crate) fn split_if_clause_lexed(
         if !predicate_tokens_without_commas.is_empty() {
             if let Ok(predicate) =
                 parse_predicate_with_grammar_entrypoint_lexed(&predicate_tokens_without_commas)
-                && let Ok(effects) = parse_effects(effect_tokens)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1260,7 +1276,7 @@ pub(crate) fn split_if_clause_lexed(
                 });
             }
             if let Some(predicate) = parse_if_result_predicate(&predicate_tokens_without_commas)
-                && let Ok(effects) = parse_effects(effect_tokens)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1284,7 +1300,7 @@ pub(crate) fn split_if_clause_lexed(
                 continue;
             }
             if let Ok(predicate) = parse_predicate_with_grammar_entrypoint_lexed(predicate_tokens)
-                && let Ok(effects) = parse_effects(effect_tokens)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1293,7 +1309,7 @@ pub(crate) fn split_if_clause_lexed(
                 });
             }
             if let Some(predicate) = parse_if_result_predicate(predicate_tokens)
-                && let Ok(effects) = parse_effects(effect_tokens)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1314,14 +1330,14 @@ pub(crate) fn split_if_clause_lexed(
             let effect_tokens = &tokens[first_comma_idx + 1..];
             let comma_fragment_looks_like_effect = if comma_indices.len() > 1 {
                 let fragment_tokens = &tokens[first_comma_idx + 1..comma_indices[1]];
-                parse_effects(fragment_tokens)
+                parse_effects_with_leading_instead(fragment_tokens, &mut parse_effects)
                     .map(|effects| !effects.is_empty())
                     .unwrap_or(false)
             } else {
                 true
             };
             if comma_fragment_looks_like_effect
-                && let Ok(effects) = parse_effects(effect_tokens)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1332,7 +1348,7 @@ pub(crate) fn split_if_clause_lexed(
         }
         if let Some(predicate) = parse_if_result_predicate(predicate_tokens) {
             let effect_tokens = &tokens[first_comma_idx + 1..];
-            let effects = parse_effects(effect_tokens)?;
+            let effects = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)?;
             return Ok(IfClauseSplitSpec {
                 predicate: IfClausePredicateSpec::Result(predicate),
                 effects,
@@ -1346,7 +1362,7 @@ pub(crate) fn split_if_clause_lexed(
         if effect_tokens.is_empty() {
             continue;
         }
-        if let Ok(effects) = parse_effects(effect_tokens)
+        if let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
             && !effects.is_empty()
         {
             split = Some((idx, effects));
@@ -1359,7 +1375,10 @@ pub(crate) fn split_if_clause_lexed(
     } else {
         let first_idx = comma_indices[0];
         let effect_tokens = &tokens[first_idx + 1..];
-        (first_idx, parse_effects(effect_tokens)?)
+        (
+            first_idx,
+            parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)?,
+        )
     };
     let predicate_tokens = &tokens[1..comma_idx];
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6963,6 +6963,152 @@ fn test_parse_spectacle_keyword_line_compiles_to_alternative_cast() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_rix_maadi_reveler_parses_with_spectacle_paid_predicate() {
+    let def = parse_oracle_card_definition("Rix Maadi Reveler");
+    let debug = format!("{def:#?}");
+
+    assert!(
+        !debug.to_ascii_lowercase().contains("unsupported"),
+        "expected Rix Maadi Reveler to parse without unsupported placeholders, got {debug}"
+    );
+    assert!(
+        debug.contains("condition: ThisSpellPaidLabel(") && debug.contains("\"Spectacle\""),
+        "expected spectacle-paid predicate in compiled definition, got {debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("you discard a card")
+            && rendered.contains("Draw a card")
+            && rendered.contains("If this spell's spectacle cost was paid, instead you discard your hand")
+            && rendered.contains("You draw three cards"),
+        "expected Rix Maadi Reveler compiled text to keep both ETB branches, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_rix_maadi_reveler_etb_uses_base_branch_when_spectacle_not_paid() {
+    use crate::ability::AbilityKind;
+    use crate::condition_eval::evaluate_condition_resolution;
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::tests::test_helpers::setup_two_player_game;
+    use crate::zone::Zone;
+
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let def = parse_oracle_card_definition("Rix Maadi Reveler");
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let filler = CardDefinitionBuilder::new(CardId::new(), "Filler")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+
+    for _ in 0..2 {
+        game.create_object_from_definition(&filler, alice, Zone::Hand);
+    }
+    for _ in 0..3 {
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) if triggered.trigger.display().contains("enters") => {
+                Some(triggered.clone())
+            }
+            _ => None,
+        })
+        .expect("Rix Maadi Reveler ETB trigger should exist");
+
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    let segment = &triggered.effects.segments[0];
+    let replacement = &segment.self_replacements[0];
+    assert!(
+        !evaluate_condition_resolution(&game, &replacement.condition, &ctx)
+            .expect("condition evaluation should succeed"),
+        "spectacle branch should be false when spectacle was not paid"
+    );
+    for effect in &segment.default_effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("Rix Maadi Reveler ETB should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("player exists").hand.len(),
+        2,
+        "without spectacle payment, ETB should discard 1 then draw 1"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_rix_maadi_reveler_etb_uses_spectacle_branch_when_paid() {
+    use crate::ability::AbilityKind;
+    use crate::condition_eval::evaluate_condition_resolution;
+    use crate::cost::OptionalCostsPaid;
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::tests::test_helpers::setup_two_player_game;
+    use crate::zone::Zone;
+
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let def = parse_oracle_card_definition("Rix Maadi Reveler");
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let filler = CardDefinitionBuilder::new(CardId::new(), "Filler")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+
+    for _ in 0..2 {
+        game.create_object_from_definition(&filler, alice, Zone::Hand);
+    }
+    for _ in 0..4 {
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+
+    let paid = OptionalCostsPaid {
+        costs: vec![("Spectacle".to_string(), 1)],
+    };
+    game.object_mut(source)
+        .expect("source object exists")
+        .optional_costs_paid = paid.clone();
+
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) if triggered.trigger.display().contains("enters") => {
+                Some(triggered.clone())
+            }
+            _ => None,
+        })
+        .expect("Rix Maadi Reveler ETB trigger should exist");
+
+    let mut ctx = ExecutionContext::new_default(source, alice).with_optional_costs_paid(paid);
+    let segment = &triggered.effects.segments[0];
+    let replacement = &segment.self_replacements[0];
+    assert!(
+        evaluate_condition_resolution(&game, &replacement.condition, &ctx)
+            .expect("condition evaluation should succeed"),
+        "spectacle branch should be true when spectacle was paid"
+    );
+    for effect in &replacement.replacement_effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("Rix Maadi Reveler ETB should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("player exists").hand.len(),
+        3,
+        "with spectacle payment, ETB should discard hand then draw three"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_disturb_keyword_line_compiles_to_alternative_cast() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Disturb Probe")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rix Maadi Reveler
Initial parse error:
```
unsupported predicate (predicate: 'this creatures spectacle cost was paid instead discard your hand'); oracle-only fallback also failed: unsupported predicate (predicate: 'this creatures spectacle cost was paid instead discard your hand')
```

Worker: i-0dc76d5798bb1bc2e
