### PR TITLE
Fix Ironsmith parse failure: Sleep with the Fishes

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
@@ -1524,6 +1524,7 @@ pub(crate) fn parse_cant_clause(
         | ["this", "cant", "be", "blocked", "this", "turn"]
         | ["cant", "be", "blocked", "this", "turn"] => return Ok(None),
         ["this", "creature", "cant", "be", "blocked"] => StaticAbility::unblockable(),
+        ["this", "token", "cant", "be", "blocked"] => StaticAbility::unblockable(),
         ["this", "cant", "be", "blocked"] => StaticAbility::unblockable(),
         ["cant", "be", "blocked"] => StaticAbility::unblockable(),
         _ => {
@@ -1572,6 +1573,26 @@ mod tests {
                 || display
                     .contains("cant attack or block unless there are seven or more cards in exile"),
             "expected original conditional attack/block restriction text, got {display}"
+        );
+    }
+
+    #[test]
+    fn parse_this_token_cant_be_blocked_clause() {
+        let tokens = tokenize_line("This token can't be blocked.", 0);
+
+        let abilities = parse_cant_clauses(&tokens)
+            .expect("this-token-cant-be-blocked clause should parse")
+            .expect("expected unblockable static ability");
+
+        assert_eq!(abilities.len(), 1);
+        let display = abilities[0].display().to_ascii_lowercase();
+        let debug = format!("{:?}", abilities[0]).to_ascii_lowercase();
+        assert!(
+            display.contains("can't be blocked")
+                || display.contains("cant be blocked")
+                || display.contains("unblockable")
+                || debug.contains("unblockable"),
+            "expected unblockable static ability, display={display}, debug={debug}"
         );
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -3725,6 +3725,8 @@ pub(crate) fn token_definition_for(name: &str) -> Option<CardDefinition> {
                 crate::effect::Restriction::attack_or_block(ObjectFilter::source()),
                 "this token can't attack or block".to_string(),
             )));
+        } else if has_words(&["cant", "be", "blocked"]) {
+            builder = builder.with_ability(Ability::static_ability(StaticAbility::unblockable()));
         } else if has_words(&["cant", "block"]) {
             builder = builder.with_ability(Ability::static_ability(StaticAbility::cant_block()));
         }
@@ -4313,6 +4315,20 @@ mod parse_compile_tests {
         assert!(
             !debug.contains("label: \"Cumulative upkeep {G}\""),
             "quoted cumulative upkeep should not remain a keyword marker, got {debug}"
+        );
+    }
+
+    #[test]
+    fn token_definition_lowers_quoted_unblockable_keyword() {
+        let source_text = "1/1 blue Fish creature token with \"This token can't be blocked.\"";
+
+        let def = token_definition_for(source_text)
+            .expect("quoted unblockable token text should build token");
+        let debug = format!("{def:#?}");
+
+        assert!(
+            debug.contains("Unblockable"),
+            "expected quoted unblockable token text to lower into a static ability, got {debug}"
         );
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1075,6 +1075,12 @@ pub(crate) fn parse_create(
     }
     let name = raw_name_override.unwrap_or_else(|| normalize_token_name(&name_words));
 
+    let grants_unblockable = word_slice_contains_sequence(
+        &tail_words,
+        &["this", "token", "cant", "be", "blocked"],
+    ) || word_slice_contains_sequence(&tail_words, &["this", "creature", "cant", "be", "blocked"])
+        || word_slice_contains_sequence(&tail_words, &["cant", "be", "blocked"]);
+
     if let Some((start, end)) = rules_text_range {
         if start < end && end <= modifier_tail_words.len() {
             modifier_tail_words = modifier_tail_words[..start]
@@ -1120,6 +1126,9 @@ pub(crate) fn parse_create(
     let mut granted_abilities = Vec::new();
     if word_slice_contains(&modifier_tail_words, "decayed") {
         granted_abilities.push(GrantedAbilityAst::KeywordAction(KeywordAction::Decayed));
+    }
+    if grants_unblockable {
+        granted_abilities.push(GrantedAbilityAst::KeywordAction(KeywordAction::Unblockable));
     }
     let references_iterated_object = attached_to_target
         .as_ref()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20863,6 +20863,30 @@ fn parse_mercenary_token_with_tap_pump_ability() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_sleep_with_the_fishes_keeps_unblockable_token_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Sleep with the Fishes")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant creature\nWhen this Aura enters, tap enchanted creature and you create a 1/1 blue Fish creature token with \"This token can't be blocked.\"\nEnchanted creature doesn't untap during its controller's untap step.",
+        )
+        .expect("Sleep with the Fishes should parse");
+
+    let compiled = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        compiled.contains("can't be blocked") || compiled.contains("cant be blocked"),
+        "expected compiled text to keep unblockable token clause, got {compiled}"
+    );
+    assert!(
+        compiled.contains("doesn't untap during its controller's untap step")
+            || compiled.contains("doesnt untap during its controller's untap step")
+            || compiled.contains("doesnt untap during its controllers untap step"),
+        "expected compiled text to keep enchanted-creature untap restriction, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_token_becomes_tapped_damage_trigger() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Tapped Trigger Token Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -747,6 +747,8 @@ pub(super) fn normalize_token_granted_static_ability_text(text: &str) -> String 
         normalized = "This token gets +1/+1.".to_string();
     } else if normalized == "Can't block." {
         normalized = "This token can't block.".to_string();
+    } else if normalized == "Can't be blocked." {
+        normalized = "This token can't be blocked.".to_string();
     }
     if is_keyword_style_line(&normalized) {
         normalized

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -27757,6 +27757,55 @@ fn test_cephalid_inkshrouder_grants_shroud_and_unblockable_after_discard() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn sleep_with_the_fishes_creates_unblockable_fish_token() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::effects::CreateTokenEffect;
+    use crate::ids::CardId;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let sleep = CardDefinitionBuilder::new(CardId::new(), "Sleep with the Fishes")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![crate::types::Subtype::Aura])
+        .parse_text(
+            "Enchant creature\nWhen this Aura enters, tap enchanted creature and you create a 1/1 blue Fish creature token with \"This token can't be blocked.\"\nEnchanted creature doesn't untap during its controller's untap step.",
+        )
+        .expect("Sleep with the Fishes should parse");
+
+    let create_effect = sleep
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered
+                .effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<CreateTokenEffect>()),
+            _ => None,
+        })
+        .expect("Sleep with the Fishes trigger should create a token");
+
+    let fish_id = game.create_object_from_definition(&create_effect.token, alice, Zone::Battlefield);
+    let blocker_id = create_creature(&mut game, "Would-be Blocker", bob, 2, 2);
+    game.refresh_continuous_state();
+
+    assert!(
+        !game.can_be_blocked(fish_id),
+        "Fish token from Sleep with the Fishes should be unblockable"
+    );
+    assert!(
+        !crate::rules::combat::can_block(
+            game.object(fish_id).expect("fish token should exist"),
+            game.object(blocker_id).expect("blocker should exist"),
+            &game,
+        ),
+        "opponent creature should not be able to block Sleep with the Fishes Fish token"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn absolute_virtue_blocks_opponent_controlled_sources_from_targeting_you() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::ids::CardId;

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -608,7 +608,7 @@ fn authoritative_semantic_marker_parse_error(snapshot: &CompilationSnapshot) -> 
         ),
         (
             ["can't be blocked"].as_slice(),
-            ["can't be blocked"].as_slice(),
+            ["can't be blocked", "unblockable"].as_slice(),
             "cant-be-blocked",
         ),
         (
@@ -3287,6 +3287,11 @@ CardDefinition {
         snapshot.compiled_text = Some(
             "Choose target creature you control. That creature deals damage equal to its power to target creature an opponent controls.".to_string(),
         );
+        assert!(authoritative_semantic_marker_parse_error(&snapshot).is_none());
+
+        snapshot.normalized_oracle_text =
+            "This token can't be blocked until end of turn.".to_string();
+        snapshot.compiled_text = Some("This token is unblockable until end of turn.".to_string());
         assert!(authoritative_semantic_marker_parse_error(&snapshot).is_none());
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sleep with the Fishes
Initial parse error:
```
compiled text dropped required semantic marker: cant-be-blocked
```

Worker: i-0b399af5d7ead2656
