### PR TITLE
Fix Ironsmith parse failure: Undercellar Sweep

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3190,6 +3190,38 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         });
     }
 
+    if filtered.as_slice() == [
+        "you",
+        "or",
+        "player",
+        "youre",
+        "attacking",
+        "has",
+        "initiative",
+    ]
+        || filtered.as_slice()
+            == [
+                "you",
+                "or",
+                "a",
+                "player",
+                "youre",
+                "attacking",
+                "has",
+                "the",
+                "initiative",
+            ]
+    {
+        return Ok(PredicateAst::Or(
+            Box::new(PredicateAst::PlayerHasInitiative {
+                player: PlayerAst::You,
+            }),
+            Box::new(PredicateAst::PlayerHasInitiative {
+                player: PlayerAst::Defending,
+            }),
+        ));
+    }
+
     if filtered.as_slice() == ["youve", "completed", "a", "dungeon"]
         || filtered.as_slice() == ["you", "have", "completed", "a", "dungeon"]
     {
@@ -3376,6 +3408,32 @@ mod tests {
             PredicateAst::PlayerWouldBeginExtraTurn {
                 player: PlayerAst::Opponent,
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_you_or_player_youre_attacking_has_initiative(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line("If you or a player you're attacking has the initiative", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::Or(
+                Box::new(PredicateAst::PlayerHasInitiative {
+                    player: PlayerAst::You,
+                }),
+                Box::new(PredicateAst::PlayerHasInitiative {
+                    player: PlayerAst::Defending,
+                }),
+            )
         );
         Ok(())
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35400,6 +35400,163 @@ fn dungeon_regression_cards_render_key_mechanics() {
 }
 
 #[test]
+fn parse_oracle_undercellar_sweep_strictly_parses_and_renders_initiative_gate() {
+    let def = parse_oracle_card_definition("Undercellar Sweep");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        !lower.contains("unsupported predicate") && !lower.contains("unsupported effect"),
+        "expected Undercellar Sweep to parse without unsupported placeholders, got {rendered}"
+    );
+    assert!(
+        lower.contains("you take the initiative"),
+        "expected Undercellar Sweep to keep ETB initiative text, got {rendered}"
+    );
+    assert!(
+        lower.contains("you or")
+            && lower.contains("attacking")
+            && lower.contains("initiative")
+            && lower.contains("create two 1/1 white soldier creature token")
+            && lower.contains("tapped and attacking"),
+        "expected Undercellar Sweep attack trigger and initiative gate to render, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn undercellar_sweep_attack_trigger_creates_tokens_when_you_have_initiative() {
+    let def = parse_oracle_card_definition("Undercellar Sweep");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.set_initiative(Some(alice));
+
+    let attacker = CardDefinitionBuilder::new(CardId::new(), "Attack Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let attacker_id = game.create_object_from_definition(&attacker, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker_id);
+
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[crate::decision::AttackerDeclaration {
+            creature: attacker_id,
+            target: crate::combat_state::AttackTarget::Player(bob),
+        }],
+    )
+    .expect("attack declaration should succeed");
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("attack trigger should go on stack");
+    crate::game_loop::resolve_stack_entry(&mut game).expect("attack trigger should resolve");
+
+    let soldier_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id).map(|obj| (*id, obj)))
+        .filter(|(_, obj)| {
+            game.controller_of(obj) == alice
+                && obj.kind == crate::object::ObjectKind::Token
+                && obj.name == "Soldier"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        soldier_tokens.len(),
+        2,
+        "expected initiative-on-you branch to create two Soldier tokens"
+    );
+    assert!(
+        soldier_tokens
+            .iter()
+            .all(|(id, _)| game.is_tapped(*id)),
+        "expected created Soldier tokens to enter tapped"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn undercellar_sweep_attack_trigger_branches_on_initiative_holder() {
+    let def = parse_oracle_card_definition("Undercellar Sweep");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let attacker = CardDefinitionBuilder::new(CardId::new(), "Attack Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let attacker_id = game.create_object_from_definition(&attacker, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker_id);
+
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut run_attack = |initiative: Option<PlayerId>| {
+        game.set_initiative(initiative);
+        game.untap(attacker_id);
+        let before = game
+            .battlefield
+            .iter()
+            .filter_map(|id| game.object(*id))
+            .filter(|obj| {
+                obj.kind == crate::object::ObjectKind::Token && game.controller_of(obj) == alice
+            })
+            .count();
+        let mut combat = crate::combat_state::CombatState::default();
+        let mut trigger_queue = crate::triggers::TriggerQueue::new();
+        crate::game_loop::apply_attacker_declarations(
+            &mut game,
+            &mut combat,
+            &mut trigger_queue,
+            &[crate::decision::AttackerDeclaration {
+                creature: attacker_id,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            }],
+        )
+        .expect("attack declaration should succeed");
+        crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+            .expect("attack trigger should go on stack");
+        if !game.stack.is_empty() {
+            crate::game_loop::resolve_stack_entry(&mut game)
+                .expect("attack trigger should resolve");
+        }
+        game.battlefield
+            .iter()
+            .filter_map(|id| game.object(*id))
+            .filter(|obj| {
+                obj.kind == crate::object::ObjectKind::Token && game.controller_of(obj) == alice
+            })
+            .count()
+            - before
+    };
+
+    assert_eq!(
+        run_attack(Some(bob)),
+        2,
+        "expected defending-player initiative branch to create two tokens"
+    );
+    assert_eq!(
+        run_attack(None),
+        0,
+        "expected no-initiative branch to create no tokens"
+    );
+}
+
+#[test]
 fn parse_oracle_the_most_dangerous_gamer_regression() {
     let def = parse_oracle_card_definition("The Most Dangerous Gamer");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11256,9 +11256,37 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             format!("{} and {}", describe_condition(left), describe_condition(right))
         }
         Condition::Or(left, right) => {
+            if let Some(initiative_gate) = describe_you_or_attacked_player_initiative_condition(left, right)
+            {
+                return initiative_gate;
+            }
             format!("{} or {}", describe_condition(left), describe_condition(right))
         }
     }
+}
+
+fn describe_you_or_attacked_player_initiative_condition(
+    left: &Condition,
+    right: &Condition,
+) -> Option<String> {
+    fn is_player_initiative(condition: &Condition, player: PlayerFilter) -> bool {
+        matches!(
+            condition,
+            Condition::PlayerHasInitiative {
+                player: condition_player
+            } if *condition_player == player
+        )
+    }
+
+    let matches_pair = (is_player_initiative(left, PlayerFilter::You)
+        && is_player_initiative(right, PlayerFilter::Defending))
+        || (is_player_initiative(left, PlayerFilter::Defending)
+            && is_player_initiative(right, PlayerFilter::You));
+    if !matches_pair {
+        return None;
+    }
+
+    Some("you or a player you're attacking has the initiative".to_string())
 }
 
 fn describe_you_control_two_card_types_condition(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Undercellar Sweep
Initial parse error:
```
unsupported predicate (predicate: 'you or player youre attacking has initiative'); oracle-only fallback also failed: unsupported predicate (predicate: 'you or player youre attacking has initiative')
```

Worker: i-004486e11887df830
