### PR TITLE
Fix Ironsmith parse failure: Phyrexian Colossus

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
@@ -509,6 +509,34 @@ pub(crate) fn parse_cant_clause(
         } else {
             5
         };
+        if let Some(amount_word) = normalized.get(idx).copied()
+            && normalized.get(idx + 1) == Some(&"or")
+            && normalized.get(idx + 2) == Some(&"more")
+            && normalized
+                .get(idx + 3)
+                .is_some_and(|word| *word == "creature" || *word == "creatures")
+            && idx + 4 == normalized.len()
+        {
+            let amount_tokens = vec![OwnedLexToken::word(
+                amount_word.to_string(),
+                TextSpan::synthetic(),
+            )];
+            let (min_blockers, used) = parse_number(&amount_tokens).ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "invalid blocker threshold in cant-be-blocked-except clause (clause: '{}')",
+                    normalized.join(" ")
+                ))
+            })?;
+            if used != 1 {
+                return Err(CardTextError::ParseError(format!(
+                    "invalid blocker threshold in cant-be-blocked-except clause (clause: '{}')",
+                    normalized.join(" ")
+                )));
+            }
+            return Ok(Some(StaticAbility::cant_be_blocked_except_by_n_or_more(
+                min_blockers as usize,
+            )));
+        }
         if let Some(color_word) = normalized.get(idx)
             && normalized
                 .get(idx + 1)

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -71,6 +71,7 @@ pub enum StaticAbilityId {
     CantBeBlockedByPowerOrGreater,
     CantBeBlockedByLowerPowerThanSource,
     CantBeBlockedByMoreThan,
+    CantBeBlockedExceptByNOrMore,
     CanAttackAsThoughNoDefender,
     MustAttack,
     ExertAttack,
@@ -310,6 +311,7 @@ impl StaticAbilityId {
             | CantBeBlockedByPowerOrGreater
             | CantBeBlockedByLowerPowerThanSource
             | CantBeBlockedByMoreThan
+            | CantBeBlockedExceptByNOrMore
             | CanAttackAsThoughNoDefender
             | MustAttack
             | ExertAttack
@@ -552,6 +554,7 @@ impl StaticAbilityId {
                 | CantBeBlockedByPowerOrGreater
                 | CantBeBlockedByLowerPowerThanSource
                 | CantBeBlockedByMoreThan
+                | CantBeBlockedExceptByNOrMore
                 | Landwalk
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardType
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardTypes
@@ -591,6 +594,7 @@ impl StaticAbilityId {
                 | CantBeBlockedByPowerOrGreater
                 | CantBeBlockedByLowerPowerThanSource
                 | CantBeBlockedByMoreThan
+                | CantBeBlockedExceptByNOrMore
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardType
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardTypes
                 | CanAttackAsThoughNoDefender

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -191,6 +191,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     Megamorph(TotalCost<C>),
     CanBlockAdditionalCreatureEachCombat(usize),
     CantBeBlockedByMoreThan(usize),
+    CantBeBlockedExceptByNOrMore(usize),
     CantBeBlockedByPowerOrLess(i32),
     CantBeBlockedByPowerOrGreater(i32),
     CantBeBlockedAsLongAsDefendingPlayerControlsCardTypes(Vec<CardType>),
@@ -837,6 +838,9 @@ where
             }
             StaticAbilityPayload::CantBeBlockedByMoreThan(count) => {
                 StaticAbilityPayload::CantBeBlockedByMoreThan(count)
+            }
+            StaticAbilityPayload::CantBeBlockedExceptByNOrMore(count) => {
+                StaticAbilityPayload::CantBeBlockedExceptByNOrMore(count)
             }
             StaticAbilityPayload::CantBeBlockedByPowerOrLess(power) => {
                 StaticAbilityPayload::CantBeBlockedByPowerOrLess(power)
@@ -2076,6 +2080,14 @@ impl<
             id: Some(StaticAbilityId::CantBeBlockedByMoreThan),
             label: format!("can't be blocked by more than {count} creature"),
             payload: StaticAbilityPayload::CantBeBlockedByMoreThan(count),
+        }
+    }
+
+    pub fn cant_be_blocked_except_by_n_or_more(count: usize) -> Self {
+        Self {
+            id: Some(StaticAbilityId::CantBeBlockedExceptByNOrMore),
+            label: format!("can't be blocked except by {count} or more creatures"),
+            payload: StaticAbilityPayload::CantBeBlockedExceptByNOrMore(count),
         }
     }
     pub fn enters_tapped_ability() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -30407,6 +30407,25 @@ fn parse_this_creature_cant_be_blocked_except_by_black_creatures() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_phyrexian_colossus_strict_and_render_three_or_more_blockers_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Phyrexian Colossus")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .power_toughness(PowerToughness::fixed(8, 8))
+        .parse_text(
+            "Trample\nPhyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
+        )
+        .expect("Phyrexian Colossus should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("can't be blocked except by 3 or more creatures")
+            || rendered.contains("can't be blocked except by three or more creatures"),
+        "expected rendered min-blockers clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_this_creature_cant_be_blocked_by_walls() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Bog Rats Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7998,6 +7998,105 @@ fn test_apply_blocker_declarations_enforces_maximum_blockers() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn phyrexian_colossus_requires_three_or_more_blockers() {
+    let mut game = setup_game();
+    let mut tq = TriggerQueue::new();
+    let mut combat = CombatState::default();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let colossus_def = CardDefinitionBuilder::new(CardId::new(), "Phyrexian Colossus")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .power_toughness(PowerToughness::fixed(8, 8))
+        .parse_text(
+            "Trample\nPhyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
+        )
+        .expect("Phyrexian Colossus should parse for combat test");
+    let attacker = game.create_object_from_definition(&colossus_def, alice, Zone::Battlefield);
+    let blocker1 = create_creature(&mut game, "Blocker 1", bob, 1, 1);
+    let blocker2 = create_creature(&mut game, "Blocker 2", bob, 1, 1);
+    let blocker3 = create_creature(&mut game, "Blocker 3", bob, 1, 1);
+
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: AttackTarget::Player(bob),
+    });
+
+    let two_blockers = vec![
+        BlockerDeclaration {
+            blocker: blocker1,
+            blocking: attacker,
+        },
+        BlockerDeclaration {
+            blocker: blocker2,
+            blocking: attacker,
+        },
+    ];
+
+    let err = apply_blocker_declarations(&mut game, &mut combat, &mut tq, &two_blockers, bob)
+        .expect_err("two blockers should be illegal against Phyrexian Colossus");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("requires 3 blockers") || msg.contains("needs at least 3 blockers"),
+        "expected minimum-blockers rejection, got {msg}"
+    );
+
+    let three_blockers = vec![
+        BlockerDeclaration {
+            blocker: blocker1,
+            blocking: attacker,
+        },
+        BlockerDeclaration {
+            blocker: blocker2,
+            blocking: attacker,
+        },
+        BlockerDeclaration {
+            blocker: blocker3,
+            blocking: attacker,
+        },
+    ];
+
+    apply_blocker_declarations(&mut game, &mut combat, &mut tq, &three_blockers, bob)
+        .expect("three blockers should be legal against Phyrexian Colossus");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn phyrexian_colossus_untap_activation_requires_eight_life() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let colossus_def = CardDefinitionBuilder::new(CardId::new(), "Phyrexian Colossus")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .power_toughness(PowerToughness::fixed(8, 8))
+        .parse_text(
+            "Trample\nPhyrexian Colossus doesn't untap during your untap step.\nPay 8 life: Untap Phyrexian Colossus.\nPhyrexian Colossus can't be blocked except by three or more creatures.",
+        )
+        .expect("Phyrexian Colossus should parse for activation test");
+    let colossus_id = game.create_object_from_definition(&colossus_def, alice, Zone::Battlefield);
+
+    game.player_mut(alice).expect("alice exists").life = 20;
+    let can_activate_with_twenty = compute_legal_actions(&game, alice)
+        .into_iter()
+        .any(|action| matches!(action, LegalAction::ActivateAbility { source, .. } if source == colossus_id));
+    assert!(
+        can_activate_with_twenty,
+        "Phyrexian Colossus untap ability should be legal at 20 life"
+    );
+
+    game.player_mut(alice).expect("alice exists").life = 7;
+    let can_activate_with_seven = compute_legal_actions(&game, alice)
+        .into_iter()
+        .any(|action| matches!(action, LegalAction::ActivateAbility { source, .. } if source == colossus_id));
+    assert!(
+        !can_activate_with_seven,
+        "Phyrexian Colossus untap ability should be illegal below 8 life"
+    );
+}
+
 #[test]
 fn test_marhault_elsdragon_rampage_buffs_for_blockers_beyond_first() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -397,11 +397,20 @@ fn protection_prevents_blocking_with_view(
 ///
 /// Most creatures require 1 blocker. Creatures with menace require 2.
 pub fn minimum_blockers(attacker: &Object) -> usize {
-    if attacker.has_static_ability_id(StaticAbilityId::Menace) {
-        2
-    } else {
-        1
-    }
+    attacker
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            crate::ability::AbilityKind::Static(static_ability) => static_ability.minimum_blockers(),
+            _ => None,
+        })
+        .max()
+        .or_else(|| {
+            attacker
+                .has_static_ability_id(StaticAbilityId::Menace)
+                .then_some(2)
+        })
+        .unwrap_or(1)
 }
 
 /// Returns the minimum number of blockers required to block an attacker,
@@ -412,11 +421,20 @@ pub fn minimum_blockers_with_game(attacker: &Object, game: &crate::game_state::G
 }
 
 pub(crate) fn minimum_blockers_with_view(attacker: &Object, view: &DerivedGameView<'_>) -> usize {
-    if view.object_has_static_ability_id(attacker.id, StaticAbilityId::Menace) {
-        2
-    } else {
-        1
-    }
+    let abilities = view
+        .calculated_characteristics(attacker.id)
+        .map(|c| c.static_abilities)
+        .unwrap_or_else(|| get_static_abilities(attacker));
+
+    abilities
+        .iter()
+        .filter_map(|ability| ability.minimum_blockers())
+        .max()
+        .or_else(|| {
+            view.object_has_static_ability_id(attacker.id, StaticAbilityId::Menace)
+                .then_some(2)
+        })
+        .unwrap_or(1)
 }
 
 /// Returns the maximum number of blockers allowed for an attacker, if restricted.

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -652,6 +652,39 @@ impl StaticAbilityKind for CantBeBlockedByMoreThan {
     }
 }
 
+/// Can't be blocked except by N or more creatures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CantBeBlockedExceptByNOrMore {
+    pub min_blockers: usize,
+}
+
+impl CantBeBlockedExceptByNOrMore {
+    pub const fn new(min_blockers: usize) -> Self {
+        Self { min_blockers }
+    }
+}
+
+impl StaticAbilityKind for CantBeBlockedExceptByNOrMore {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::CantBeBlockedExceptByNOrMore
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "Can't be blocked except by {} or more creatures",
+            self.min_blockers
+        )
+    }
+
+    fn grants_evasion(&self) -> bool {
+        true
+    }
+
+    fn minimum_blockers(&self) -> Option<usize> {
+        Some(self.min_blockers)
+    }
+}
+
 // Can attack as though it didn't have defender.
 define_combat_ability!(
     CanAttackAsThoughNoDefender,

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -510,6 +510,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Returns the minimum number of blockers required to block this creature.
+    fn minimum_blockers(&self) -> Option<usize> {
+        None
+    }
+
     /// Returns how many additional attackers this creature can block.
     ///
     /// Used for abilities like "This creature can block an additional creature each combat."
@@ -1242,6 +1247,10 @@ impl StaticAbility {
         self.0.maximum_blockers()
     }
 
+    pub fn minimum_blockers(&self) -> Option<usize> {
+        self.0.minimum_blockers()
+    }
+
     pub fn additional_blockable_attackers(&self) -> Option<usize> {
         self.0.additional_blockable_attackers()
     }
@@ -1828,6 +1837,10 @@ impl StaticAbility {
 
     pub fn cant_be_blocked_by_more_than(max_blockers: usize) -> Self {
         Self::new(CantBeBlockedByMoreThan::new(max_blockers))
+    }
+
+    pub fn cant_be_blocked_except_by_n_or_more(min_blockers: usize) -> Self {
+        Self::new(CantBeBlockedExceptByNOrMore::new(min_blockers))
     }
 
     pub fn can_attack_as_though_no_defender() -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -929,6 +929,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::CantBeBlockedByMoreThan(count) => {
                 StaticAbility::cant_be_blocked_by_more_than(*count)
             }
+            ironsmith_core::StaticAbilityPayload::CantBeBlockedExceptByNOrMore(count) => {
+                StaticAbility::cant_be_blocked_except_by_n_or_more(*count)
+            }
             ironsmith_core::StaticAbilityPayload::CantBeBlockedByPowerOrLess(power) => {
                 StaticAbility::cant_be_blocked_by_power_or_less(*power)
             }
@@ -1674,6 +1677,23 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
 
     fn has_menace(&self) -> bool {
         self.id() == StaticAbilityId::Menace
+    }
+
+    fn minimum_blockers(&self) -> Option<usize> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::CantBeBlockedExceptByNOrMore(count) => {
+                Some(*count)
+            }
+            _ if self.id() == StaticAbilityId::Menace => Some(2),
+            _ => None,
+        }
+    }
+
+    fn maximum_blockers(&self) -> Option<usize> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::CantBeBlockedByMoreThan(count) => Some(*count),
+            _ => None,
+        }
     }
 
     fn has_flying(&self) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Phyrexian Colossus
Initial parse error:
```
unsupported negated restriction tail (clause: 'this creature can't be blocked except by three or more creatures'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'this creature can't be blocked except by three or more creatures')
```

Worker: i-06b6b3fb3af369ac4
