### PR TITLE
Fix Ironsmith parse failure: Nighthawk Scavenger

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3799,6 +3799,27 @@ pub(crate) fn parse_characteristic_defining_pt_term(tokens: &[OwnedLexToken]) ->
         }
     }
 
+    if slice_starts_with(&start_words, &["card", "type", "among"])
+        || slice_starts_with(&start_words, &["card", "types", "among"])
+    {
+        let mut scope_word_idx = 3usize;
+        if matches!(start_words.get(scope_word_idx).copied(), Some("the")) {
+            scope_word_idx += 1;
+        }
+        let scope_token_idx = token_index_for_word_index(start, scope_word_idx)?;
+        let scope_tokens = trim_commas(&start[scope_token_idx..]);
+        if let Ok(filter) = parse_object_filter(&scope_tokens, false)
+            && filter.zone == Some(Zone::Graveyard)
+        {
+            let player = match filter.owner.clone() {
+                Some(player) => player,
+                None if !filter.single_graveyard => PlayerFilter::Any,
+                None => PlayerFilter::You,
+            };
+            return Some(Value::CardTypesInGraveyard(player));
+        }
+    }
+
     let filter = parse_object_filter(start, false).ok()?;
     Some(Value::Count(filter))
 }
@@ -5601,7 +5622,7 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
         }
     }
 
-    if contains_keyword_static_phrase(&filter_words, &["card", "type"])
+    if contains_any_keyword_static_phrase(&filter_words, &[&["card", "type"], &["card", "types"]])
         && slice_contains(&filter_words, &"graveyard")
     {
         let player = if contains_keyword_static_phrase(&filter_words, &["your", "graveyard"]) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35103,6 +35103,89 @@ fn strict_parse_shared_parser_regression_cards() {
     }
 }
 
+#[test]
+fn strict_parse_nighthawk_scavenger_regression() {
+    assert_oracle_card_parses_strict("Nighthawk Scavenger");
+}
+
+#[test]
+fn nighthawk_scavenger_compiled_text_preserves_card_types_among_clause() {
+    let def = parse_oracle_card_definition("Nighthawk Scavenger");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        (rendered.contains("power is 1 plus") || rendered.contains("power is equal to 1 plus"))
+            && (rendered
+                .contains("1 plus the number of card types among cards in your opponents' graveyard")
+            || rendered
+                .contains("1 plus the number of card types among cards in your opponents' graveyards")
+            || rendered.contains("1 plus the number of distinct card types in your opponents' graveyard")
+            || rendered
+                .contains("1 plus the number of distinct card types in your opponents' graveyards")),
+        "expected Nighthawk Scavenger to keep a card-types-in-opponents-graveyards scaling clause, got {rendered}"
+    );
+}
+
+#[test]
+fn nighthawk_scavenger_characteristic_runtime_scaling_regression() {
+    let def = parse_oracle_card_definition("Nighthawk Scavenger");
+    let static_ability = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::CharacteristicDefiningPT =>
+            {
+                Some(static_ability)
+            }
+            _ => None,
+        })
+        .expect("Nighthawk Scavenger should have a characteristic-defining power ability");
+
+    let game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let effects = static_ability.generate_effects(
+        crate::ids::ObjectId::from_raw(1),
+        crate::ids::PlayerId::from_index(0),
+        &game,
+    );
+    let crate::continuous::Modification::SetPowerToughness {
+        power,
+        toughness,
+        sublayer: _,
+    } = &effects[0].modification
+    else {
+        panic!("expected Nighthawk Scavenger to use a SetPowerToughness CDA");
+    };
+
+    let is_expected_power = match power {
+        crate::effect::Value::Add(left, right) => {
+            matches!(
+                (&**left, &**right),
+                (
+                    crate::effect::Value::Fixed(1),
+                    crate::effect::Value::CardTypesInGraveyard(PlayerFilter::Opponent)
+                ) | (
+                    crate::effect::Value::CardTypesInGraveyard(PlayerFilter::Opponent),
+                    crate::effect::Value::Fixed(1)
+                )
+            )
+        }
+        _ => false,
+    };
+    assert!(
+        is_expected_power,
+        "expected Nighthawk Scavenger power to be 1 plus card types in opponents' graveyards, got {:?}",
+        power
+    );
+    assert!(
+        matches!(toughness, crate::effect::Value::SourceToughness),
+        "expected Nighthawk Scavenger toughness CDA axis to keep source toughness, got {:?}",
+        toughness
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_gwen_stacy_ghost_spider_compiled_text_regression() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -269,6 +269,23 @@ pub(super) fn describe_possessive_choose_spec(spec: &ChooseSpec) -> String {
     }
 }
 
+fn describe_card_type_graveyard_scope(player: &PlayerFilter) -> String {
+    match player {
+        PlayerFilter::You => "your graveyard".to_string(),
+        PlayerFilter::Opponent | PlayerFilter::NotYou => {
+            "your opponents' graveyards".to_string()
+        }
+        PlayerFilter::Any => "all graveyards".to_string(),
+        PlayerFilter::Target(inner) if matches!(inner.as_ref(), PlayerFilter::Opponent) => {
+            "target opponent's graveyard".to_string()
+        }
+        PlayerFilter::Target(inner) if matches!(inner.as_ref(), PlayerFilter::You) => {
+            "your graveyard".to_string()
+        }
+        _ => format!("{} graveyard", describe_possessive_player_filter(player)),
+    }
+}
+
 pub(super) fn join_with_and(parts: &[String]) -> String {
     match parts.len() {
         0 => String::new(),
@@ -7782,8 +7799,8 @@ pub(crate) fn describe_value(value: &Value) -> String {
             "the damage dealt this turn by the chosen spell".to_string()
         }
         Value::CardTypesInGraveyard(filter) => format!(
-            "the number of card types among cards in {} graveyard",
-            describe_possessive_player_filter(filter)
+            "the number of card types among cards in {}",
+            describe_card_type_graveyard_scope(filter)
         ),
         Value::Devotion { player, color } => format!(
             "{} devotion to {}",
@@ -10131,12 +10148,12 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             )
         }
         Condition::PlayerHasCardTypesInGraveyardOrMore { player, count } => {
-            let subject = describe_player_filter(player);
             let count_text = small_number_word(*count)
                 .unwrap_or_else(|| count.to_string());
             format!(
-                "there are {} or more card types among cards in {} graveyard",
-                count_text, subject
+                "there are {} or more card types among cards in {}",
+                count_text,
+                describe_card_type_graveyard_scope(player)
             )
         }
         Condition::PlayerControlsMost { player, filter } => {

--- a/crates/ironsmith-runtime/src/static_abilities/characteristics.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/characteristics.rs
@@ -45,7 +45,10 @@ impl StaticAbilityKind for CharacteristicDefiningPT {
                 describe_value(&self.power)
             )
         } else if matches!(self.toughness, Value::SourceToughness) {
-            format!("This creature's power is {}", describe_value(&self.power))
+            format!(
+                "This creature's power is equal to {}",
+                describe_value(&self.power)
+            )
         } else {
             format!(
                 "This creature's power is {}, and its toughness is {}",
@@ -137,7 +140,7 @@ mod tests {
         let ability = CharacteristicDefiningPT::new(Value::Count(filter), Value::SourceToughness);
         assert_eq!(
             ability.display(),
-            "This creature's power is the number of land cards in your graveyard"
+            "This creature's power is equal to the number of land cards in your graveyard"
         );
     }
 

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -691,13 +691,19 @@ fn authoritative_semantic_marker_parse_error(snapshot: &CompilationSnapshot) -> 
 
     let guarded_markers = [
         (
-            ["shares a card type", "share a card type"],
-            ["shares a card type", "share a card type"],
+            ["shares a card type", "share a card type"].as_slice(),
+            ["shares a card type", "share a card type"].as_slice(),
             "shares-a-card-type",
         ),
         (
-            ["card type among", "card types among"],
-            ["card type among", "card types among"],
+            ["card type among", "card types among"].as_slice(),
+            [
+                "card type among",
+                "card types among",
+                "number of distinct card types in",
+                "number of card types in",
+            ]
+            .as_slice(),
             "card-types-among",
         ),
     ];
@@ -3015,6 +3021,19 @@ CardDefinition {
             authoritative_semantic_marker_parse_error(&snapshot).as_deref(),
             Some("compiled text contains internal marker: object-predicate-debug")
         );
+    }
+
+    #[test]
+    fn authoritative_marker_guard_accepts_equivalent_card_types_in_wording() {
+        let mut snapshot = compile_snapshot_from_payload(&lightning_bolt_payload());
+        snapshot.normalized_oracle_text =
+            "This creature's power is equal to the number of card types among cards in all graveyards".to_string();
+        snapshot.compiled_text = Some(
+            "This creature's power is equal to the number of distinct card types in all graveyards"
+                .to_string(),
+        );
+
+        assert_eq!(authoritative_semantic_marker_parse_error(&snapshot), None);
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nighthawk Scavenger
Initial parse error:
```
compiled text dropped required semantic marker: card-types-among
```

Worker: i-072daeb48f9d6d2f8
