### PR TITLE
Fix Ironsmith parse failure: Marang River Prowler

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -2,7 +2,8 @@ use super::line_family_handlers::{
     run_activation_line_family, run_champion_line_family,
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
     run_combined_static_line_family, run_escape_enters_with_counter_line_family,
-    run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
+    run_graveyard_cast_control_condition_line_family, run_keyword_line_family,
+    run_labeled_line_family, run_learn_line_family,
     run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
     run_partner_with_keyword_line_family, run_split_top_and_face_down_look_line_family,
     run_split_top_look_and_top_land_play_line_family, run_start_your_engines_line_family,
@@ -46,7 +47,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 24] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 25] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -166,6 +167,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 24] = [
         priority: 75,
         heads: &["creatures"],
         run: run_non_turn_conditional_untap_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "graveyard-cast-control-condition",
+        priority: 76,
+        heads: &["you"],
+        run: run_graveyard_cast_control_condition_line_family,
     },
     LineFamilyRuleDef {
         id: "statement-probe",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -2,6 +2,7 @@ use super::line_dispatch::{LineDispatchContext, LineDispatchResult};
 use super::*;
 
 const MAX_SPEED_CONDITION_LABEL: &str = "__max_speed_condition";
+const CONTROL_COLOR_PAIR_PERMANENT_CONDITION_PREFIX: &str = "__control_color_pair_permanent_";
 const STATION_THRESHOLD_CONDITION_PREFIX: &str = "__station_threshold_";
 
 pub(super) fn run_trailing_keyword_activation_line_family(
@@ -257,6 +258,57 @@ pub(super) fn run_split_top_look_and_top_land_play_line_family(
         ],
         next_idx: ctx.idx + 1,
     }))
+}
+
+pub(super) fn run_graveyard_cast_control_condition_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let raw_no_period = raw.trim_end_matches('.');
+    let lower = raw_no_period.to_ascii_lowercase();
+    let prefix = "you may cast this card from your graveyard as long as you control a ";
+    if !lower.starts_with(prefix) || !lower.ends_with(" permanent") {
+        return Ok(None);
+    }
+
+    let Some(condition_text) = raw_no_period.get(prefix.len()..) else {
+        return Ok(None);
+    };
+    let condition_text = condition_text.trim();
+    let Some(color_pair_text) = condition_text.strip_suffix(" permanent") else {
+        return Ok(None);
+    };
+    let color_pair_text = color_pair_text.trim();
+    let Some((left, right)) = color_pair_text.split_once(" or ") else {
+        return Ok(None);
+    };
+
+    let left = left.trim();
+    let right = right.trim();
+    if left.is_empty() || right.is_empty() {
+        return Ok(None);
+    }
+
+    let permission_line = rewrite_line_normalized(
+        ctx.line,
+        "You may cast this card from your graveyard.",
+    )?;
+    let Some(mut static_cst) = parse_static_line_cst(&permission_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower graveyard-cast control condition line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    static_cst.chosen_option_label = Some(format!(
+        "{CONTROL_COLOR_PAIR_PERMANENT_CONDITION_PREFIX}{}_{}",
+        left.to_ascii_lowercase(),
+        right.to_ascii_lowercase()
+    ));
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Static(static_cst),
+        ctx.idx + 1,
+    )))
 }
 
 pub(super) fn run_champion_line_family(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_sentence_grouping.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_sentence_grouping.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const MAX_SPEED_CONDITION_LABEL: &str = "__max_speed_condition";
+const CONTROL_COLOR_PAIR_PERMANENT_CONDITION_PREFIX: &str = "__control_color_pair_permanent_";
 const STATION_THRESHOLD_CONDITION_PREFIX: &str = "__station_threshold_";
 
 pub(crate) fn condition_for_chosen_option_label(label: &str) -> crate::ConditionExpr {
@@ -21,7 +22,46 @@ pub(crate) fn condition_for_chosen_option_label(label: &str) -> crate::Condition
             right: crate::effect::Value::Fixed(threshold),
         };
     }
+    if let Some(color_pair) = label.strip_prefix(CONTROL_COLOR_PAIR_PERMANENT_CONDITION_PREFIX) {
+        let Some((left_name, right_name)) = color_pair.split_once('_') else {
+            return crate::ConditionExpr::SourceChosenOption(label.to_string());
+        };
+        let Some(left) = color_from_label(left_name) else {
+            return crate::ConditionExpr::SourceChosenOption(label.to_string());
+        };
+        let Some(right) = color_from_label(right_name) else {
+            return crate::ConditionExpr::SourceChosenOption(label.to_string());
+        };
+        let left_filter = ObjectFilter::permanent()
+            .you_control()
+            .with_colors(ColorSet::from_color(left));
+        let right_filter = ObjectFilter::permanent()
+            .you_control()
+            .with_colors(ColorSet::from_color(right));
+        let left_condition = crate::ConditionExpr::CountComparison {
+            count: crate::static_abilities::AnthemCountExpression::MatchingFilter(left_filter),
+            comparison: crate::effect::Comparison::GreaterThanOrEqual(1),
+            display: Some(format!("you control a {left_name} permanent")),
+        };
+        let right_condition = crate::ConditionExpr::CountComparison {
+            count: crate::static_abilities::AnthemCountExpression::MatchingFilter(right_filter),
+            comparison: crate::effect::Comparison::GreaterThanOrEqual(1),
+            display: Some(format!("you control a {right_name} permanent")),
+        };
+        return crate::ConditionExpr::Or(Box::new(left_condition), Box::new(right_condition));
+    }
     crate::ConditionExpr::SourceChosenOption(label.to_string())
+}
+
+fn color_from_label(label: &str) -> Option<crate::Color> {
+    match label {
+        "white" => Some(crate::Color::White),
+        "blue" => Some(crate::Color::Blue),
+        "black" => Some(crate::Color::Black),
+        "red" => Some(crate::Color::Red),
+        "green" => Some(crate::Color::Green),
+        _ => None,
+    }
 }
 
 pub(crate) fn strip_non_keyword_label_prefix_for_lowering_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
@@ -8,6 +8,11 @@ pub(super) fn infer_static_ability_functional_zones(normalized_line: &str) -> Op
     {
         return Some(vec![Zone::Library]);
     }
+    if str_contains(normalized.as_str(), "cast this card from your graveyard")
+        || str_contains(normalized.as_str(), "play this card from your graveyard")
+    {
+        return Some(vec![Zone::Graveyard]);
+    }
 
     let mut zones = Vec::new();
     for (needles, zone) in [

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -350,7 +350,7 @@ fn emet_selch_keeps_graveyard_cost_and_life_loss_may_cast_trigger() {
         "expected one-shot graveyard-to-exile replacement for cast spell, got {debug}"
     );
 
-    let rendered = canonical_compiled_lines(&def).join("\n");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
     assert!(
         rendered.contains("Spells you cast from your graveyard cost {2} less to cast")
             && rendered.contains(triggered),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -350,7 +350,7 @@ fn emet_selch_keeps_graveyard_cost_and_life_loss_may_cast_trigger() {
         "expected one-shot graveyard-to-exile replacement for cast spell, got {debug}"
     );
 
-    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let rendered = canonical_compiled_lines(&def).join("\n");
     assert!(
         rendered.contains("Spells you cast from your graveyard cost {2} less to cast")
             && rendered.contains(triggered),
@@ -1401,6 +1401,27 @@ fn test_parse_start_your_engines_and_max_speed_graveyard_cast_permission() {
             && rendered.contains("You may cast this card from your graveyard")
             && rendered.contains("as long as you have max speed"),
         "expected speed keyword plus max-speed graveyard cast permission, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_parse_marang_river_prowler_graveyard_cast_condition() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Marang River Prowler")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Fish])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text(
+            "Skulk (This creature can't be blocked by creatures with greater power.)\nYou may cast this card from your graveyard as long as you control a black or green permanent.",
+        )
+        .expect("Marang River Prowler should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Skulk")
+            && rendered.contains("You may cast this card from your graveyard")
+            && rendered.contains("as long as you control a black permanent or you control a green permanent"),
+        "expected graveyard-cast condition for Marang River Prowler, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -8103,6 +8103,10 @@ fn awaken_cast_action_is_available_even_when_normal_cast_is_legal() {
     game.turn.phase = Phase::FirstMain;
     game.turn.step = None;
     game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .unwrap()
+        .mana_pool
+        .add(ManaSymbol::Blue, 3);
 
     for _ in 0..6 {
         game.create_object_from_definition(&basic_swamp(), alice, Zone::Battlefield);
@@ -12343,6 +12347,10 @@ fn test_corpse_cobble_sums_the_power_of_sacrificed_creatures() {
     game.turn.phase = Phase::FirstMain;
     game.turn.step = None;
     game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .unwrap()
+        .mana_pool
+        .add(ManaSymbol::Blue, 3);
 
     let corpse_cobble = CardDefinitionBuilder::new(CardId::from_raw(10001), "Corpse Cobble")
         .mana_cost(ManaCost::from_pips(vec![
@@ -17233,6 +17241,85 @@ fn test_legend_rule_with_different_controllers() {
 // ============================================================================
 // Flashback Tests
 // ============================================================================
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_marang_river_prowler_not_castable_from_graveyard_without_black_or_green_permanent() {
+    use crate::decision::compute_legal_actions;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let prowler = CardDefinitionBuilder::new(CardId::from_raw(72_610), "Marang River Prowler")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Fish])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text(
+            "Skulk (This creature can't be blocked by creatures with greater power.)\nYou may cast this card from your graveyard as long as you control a black or green permanent.",
+        )
+        .expect("Marang River Prowler should parse");
+    let prowler_id = game.create_object_from_definition(&prowler, alice, Zone::Graveyard);
+
+    let actions = compute_legal_actions(&game, alice);
+    let graveyard_cast = actions.iter().find(|action| {
+        matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                ..
+            } if *spell_id == prowler_id
+        )
+    });
+    assert!(
+        graveyard_cast.is_none(),
+        "Marang River Prowler should not be castable from graveyard without a black or green permanent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_marang_river_prowler_castable_from_graveyard_with_black_permanent() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let prowler = CardDefinitionBuilder::new(CardId::from_raw(72_611), "Marang River Prowler")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Fish])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text(
+            "Skulk (This creature can't be blocked by creatures with greater power.)\nYou may cast this card from your graveyard as long as you control a black or green permanent.",
+        )
+        .expect("Marang River Prowler should parse");
+    let prowler_id = game.create_object_from_definition(&prowler, alice, Zone::Graveyard);
+
+    let black_permanent = CardBuilder::new(CardId::from_raw(72_612), "Black Permanent Probe")
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Black]))
+        .color_indicator(crate::color::ColorSet::BLACK)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&black_permanent, alice, Zone::Battlefield);
+
+    let can_play_from_graveyard = game.effect_store.grant_registry.card_can_play_from_zone(
+        &game,
+        prowler_id,
+        Zone::Graveyard,
+        alice,
+    );
+    assert!(
+        can_play_from_graveyard,
+        "Marang River Prowler should grant play-from-graveyard when you control a black permanent"
+    );
+}
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -17323,6 +17323,46 @@ fn test_marang_river_prowler_castable_from_graveyard_with_black_permanent() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_marang_river_prowler_castable_from_graveyard_with_green_permanent() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let prowler = CardDefinitionBuilder::new(CardId::from_raw(72_613), "Marang River Prowler")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Fish])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text(
+            "Skulk (This creature can't be blocked by creatures with greater power.)\nYou may cast this card from your graveyard as long as you control a black or green permanent.",
+        )
+        .expect("Marang River Prowler should parse");
+    let prowler_id = game.create_object_from_definition(&prowler, alice, Zone::Graveyard);
+
+    let green_permanent = CardBuilder::new(CardId::from_raw(72_614), "Green Permanent Probe")
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Green]))
+        .color_indicator(crate::color::ColorSet::GREEN)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&green_permanent, alice, Zone::Battlefield);
+
+    let can_play_from_graveyard = game.effect_store.grant_registry.card_can_play_from_zone(
+        &game,
+        prowler_id,
+        Zone::Graveyard,
+        alice,
+    );
+    assert!(
+        can_play_from_graveyard,
+        "Marang River Prowler should grant play-from-graveyard when you control a green permanent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_flashback_appears_in_legal_actions_from_graveyard() {
     use crate::cards::definitions::think_twice;
     use crate::decision::compute_legal_actions;

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -8103,10 +8103,6 @@ fn awaken_cast_action_is_available_even_when_normal_cast_is_legal() {
     game.turn.phase = Phase::FirstMain;
     game.turn.step = None;
     game.turn.priority_player = Some(alice);
-    game.player_mut(alice)
-        .unwrap()
-        .mana_pool
-        .add(ManaSymbol::Blue, 3);
 
     for _ in 0..6 {
         game.create_object_from_definition(&basic_swamp(), alice, Zone::Battlefield);
@@ -12347,10 +12343,6 @@ fn test_corpse_cobble_sums_the_power_of_sacrificed_creatures() {
     game.turn.phase = Phase::FirstMain;
     game.turn.step = None;
     game.turn.priority_player = Some(alice);
-    game.player_mut(alice)
-        .unwrap()
-        .mana_pool
-        .add(ManaSymbol::Blue, 3);
 
     let corpse_cobble = CardDefinitionBuilder::new(CardId::from_raw(10001), "Corpse Cobble")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -977,6 +977,11 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
                 describe_anthem_count_expression(count)
             )
         }
+        crate::ConditionExpr::Or(left, right) => {
+            let left_text = describe_static_condition(left).replacen("as long as ", "", 1);
+            let right_text = describe_static_condition(right).replacen("as long as ", "", 1);
+            format!("as long as {left_text} or {right_text}")
+        }
         crate::ConditionExpr::ValueComparison {
             left: Value::Speed(crate::target::PlayerFilter::You),
             operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Marang River Prowler
Initial parse error:
```
parser does not yet support line family: 'You may cast this card from your graveyard as long as you control a black or green permanent.'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast this card from your graveyard as long as you control a black or green permanent.'
```

Worker: i-07f740ba145ebcf03
