### PR TITLE
Fix Ironsmith parse failure: Tezzeret, Cruel Machinist

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -1447,7 +1447,10 @@ pub(crate) fn parse_effect_clause_lexed(
 
 fn rewrite_theyre_characteristic_clause(tokens: &[OwnedLexToken]) -> Option<Vec<OwnedLexToken>> {
     let words = crate::runtime_backend::token_word_refs(tokens);
-    let starts_with_theyre = matches!(words.as_slice(), ["theyre", ..] | ["they", "re", ..]);
+    let starts_with_theyre = matches!(words.as_slice(), ["theyre", ..] | ["they", "re", ..])
+        || tokens
+            .first()
+            .is_some_and(|token| token.is_word("they're"));
     if !starts_with_theyre {
         return None;
     }
@@ -1457,7 +1460,10 @@ fn rewrite_theyre_characteristic_clause(tokens: &[OwnedLexToken]) -> Option<Vec<
     }
 
     let mut rewritten = tokens.to_vec();
-    if rewritten.first().is_some_and(|token| token.is_word("theyre")) {
+    if rewritten
+        .first()
+        .is_some_and(|token| token.is_word("theyre") || token.is_word("they're"))
+    {
         rewritten[0] = OwnedLexToken::synthetic_word("they");
         rewritten.insert(1, OwnedLexToken::synthetic_word("become"));
         return Some(rewritten);
@@ -1477,6 +1483,17 @@ mod tests {
 
     fn lex_tail(text: &str) -> Vec<OwnedLexToken> {
         lex_line(text, 0).expect("lex test tail")
+    }
+
+    #[test]
+    fn rewrite_theyre_characteristic_clause_handles_apostrophe_form() {
+        let tokens = lex_tail("they're 5/5 artifact creatures");
+        let rewritten = rewrite_theyre_characteristic_clause(&tokens)
+            .expect("apostrophe contraction should rewrite into a become clause");
+        assert_eq!(
+            crate::runtime_backend::token_word_refs(&rewritten),
+            vec!["they", "become", "5/5", "artifact", "creatures"]
+        );
     }
 
     #[test]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -358,6 +358,8 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
 
     let stripped_instead = super::strip_leading_instead_prefix(tokens);
     let tokens = stripped_instead.as_deref().unwrap_or(tokens);
+    let rewritten_theyre = rewrite_theyre_characteristic_clause(tokens);
+    let tokens = rewritten_theyre.as_deref().unwrap_or(tokens);
 
     if let Some(spec) = parse_may_cast_it_sentence(tokens) {
         return Ok(build_may_cast_tagged_effect(&spec));
@@ -1441,6 +1443,31 @@ pub(crate) fn parse_effect_clause_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<EffectAst, CardTextError> {
     parse_effect_clause(tokens)
+}
+
+fn rewrite_theyre_characteristic_clause(tokens: &[OwnedLexToken]) -> Option<Vec<OwnedLexToken>> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let starts_with_theyre = matches!(words.as_slice(), ["theyre", ..] | ["they", "re", ..]);
+    if !starts_with_theyre {
+        return None;
+    }
+    let mentions_creature = words.iter().any(|word| *word == "creature" || *word == "creatures");
+    if !mentions_creature {
+        return None;
+    }
+
+    let mut rewritten = tokens.to_vec();
+    if rewritten.first().is_some_and(|token| token.is_word("theyre")) {
+        rewritten[0] = OwnedLexToken::synthetic_word("they");
+        rewritten.insert(1, OwnedLexToken::synthetic_word("become"));
+        return Some(rewritten);
+    }
+    if rewritten.len() >= 2 && rewritten[0].is_word("they") && rewritten[1].is_word("re") {
+        rewritten.remove(1);
+        rewritten.insert(1, OwnedLexToken::synthetic_word("become"));
+        return Some(rewritten);
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -436,6 +436,74 @@ fn pre_rule_still_lands_followup(
     Ok(None)
 }
 
+fn pre_rule_theyre_become_characteristics_followup(
+    state: &mut SentenceDispatchState<'_>,
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+    sentence_tokens: &[OwnedLexToken],
+) -> Result<Option<PreParseFollowupResult>, CardTextError> {
+    let sentence_words = crate::runtime_backend::token_word_refs(sentence_tokens);
+    let starts_with_theyre = matches!(
+        sentence_words.as_slice(),
+        ["theyre", ..] | ["they", "re", ..]
+    );
+    if !starts_with_theyre {
+        return Ok(None);
+    }
+
+    let previous_moves_to_battlefield_effect = state.effects.iter().rev().any(|effect| {
+        matches!(
+            effect,
+            EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                action: SubjectVerbActionAst::MoveToZone {
+                    zone: Zone::Battlefield,
+                    ..
+                },
+                ..
+            })
+        )
+    });
+    let previous_sentence_moves_to_battlefield = sentence_idx
+        .checked_sub(1)
+        .and_then(|idx| sentences.get(idx))
+        .is_some_and(|previous_sentence| {
+            let previous_words = crate::runtime_backend::token_word_refs(previous_sentence.lowered());
+            previous_words.iter().any(|word| *word == "onto")
+                && previous_words.iter().any(|word| *word == "battlefield")
+        });
+    if !previous_moves_to_battlefield_effect && !previous_sentence_moves_to_battlefield {
+        return Ok(None);
+    }
+
+    let is_characteristic_sentence = sentence_words
+        .iter()
+        .any(|word| *word == "creature" || *word == "creatures");
+    if !is_characteristic_sentence {
+        return Ok(None);
+    }
+
+    let mut rewritten = sentence_tokens.to_vec();
+    if rewritten.first().is_some_and(|token| token.is_word("theyre")) {
+        rewritten[0] = OwnedLexToken::synthetic_word("they");
+        rewritten.insert(1, OwnedLexToken::synthetic_word("become"));
+    } else if rewritten.len() >= 2
+        && rewritten[0].is_word("they")
+        && rewritten[1].is_word("re")
+    {
+        rewritten.remove(1);
+        rewritten.insert(1, OwnedLexToken::synthetic_word("become"));
+    } else {
+        return Ok(None);
+    }
+
+    Ok(Some(PreParseFollowupResult::Plan(SentenceParsePlan {
+        tokens: rewritten,
+        wrap_if_result: None,
+        direct_effects: None,
+        consumed_sentences: 1,
+    })))
+}
+
 pub(super) fn is_still_lands_followup_sentence(sentence_tokens: &[OwnedLexToken]) -> bool {
     let sentence_words = TokenWordView::new(sentence_tokens).to_word_refs();
     matches!(
@@ -972,6 +1040,12 @@ const PRE_PARSE_SUBJECT_VERB_FOLLOWUP_RULES: &[SubjectVerbFollowupRuleDef] = &[
         priority: 20,
         heads: &["theyre", "they", "its", "it"],
         run: pre_rule_still_lands_followup,
+    },
+    SubjectVerbFollowupRuleDef {
+        id: "theyre-become-characteristics",
+        priority: 21,
+        heads: &["theyre", "they"],
+        run: pre_rule_theyre_become_characteristics_followup,
     },
     SubjectVerbFollowupRuleDef {
         id: "cant-be-regenerated",

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -446,7 +446,9 @@ fn pre_rule_theyre_become_characteristics_followup(
     let starts_with_theyre = matches!(
         sentence_words.as_slice(),
         ["theyre", ..] | ["they", "re", ..]
-    );
+    ) || sentence_tokens
+        .first()
+        .is_some_and(|token| token.is_word("they're"));
     if !starts_with_theyre {
         return Ok(None);
     }
@@ -483,7 +485,10 @@ fn pre_rule_theyre_become_characteristics_followup(
     }
 
     let mut rewritten = sentence_tokens.to_vec();
-    if rewritten.first().is_some_and(|token| token.is_word("theyre")) {
+    if rewritten
+        .first()
+        .is_some_and(|token| token.is_word("theyre") || token.is_word("they're"))
+    {
         rewritten[0] = OwnedLexToken::synthetic_word("they");
         rewritten.insert(1, OwnedLexToken::synthetic_word("become"));
     } else if rewritten.len() >= 2

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -1156,6 +1156,18 @@ pub(crate) fn parse_put_into_hand(
         destination_tail.retain(|token| !token.is_word("and"));
         destination_tail.retain(|token| !token.is_word("tapped"));
         destination_tail.retain(|token| !token.is_word("attacking"));
+        if destination_tail.len() >= 2
+            && destination_tail[0].is_word("face")
+            && destination_tail[1].is_word("down")
+        {
+            destination_tail.drain(0..2);
+        }
+        if destination_tail
+            .first()
+            .is_some_and(|token| token.is_word("face-down"))
+        {
+            destination_tail.remove(0);
+        }
         if battlefield_attacking {
             return Err(CardTextError::ParseError(format!(
                 "unsupported put destination after 'onto' (clause: '{}')",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42570,6 +42570,61 @@ fn sorin_markov_compiles_control_player_and_life_total_effects() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tezzeret_cruel_machinist_strict_parse_and_text_flow_regression() {
+    let def = parse_oracle_card_definition("Tezzeret, Cruel Machinist");
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("put any number of cards from your hand onto the battlefield face down"),
+        "expected Tezzeret ultimate to keep face-down battlefield destination, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("they're 5/5 artifact creatures")
+            || rendered_lower.contains("they are 5/5 artifact creatures"),
+        "expected Tezzeret ultimate followup characteristics sentence, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tezzeret_cruel_machinist_ultimate_compiles_face_down_move_and_5_5_artifact_animation() {
+    let def = parse_oracle_card_definition("Tezzeret, Cruel Machinist");
+
+    let ultimate = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            crate::ability::AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .find(|activated| {
+            let debug = format!("{:?}", activated.effects);
+            debug.contains("zone: Battlefield") && debug.contains("face_down: Some(true)")
+        })
+        .expect("Tezzeret should compile an ultimate that moves cards to battlefield face down");
+
+    let effects_debug = format!("{:?}", ultimate.effects);
+    let compact = effects_debug.to_ascii_lowercase().replace(' ', "");
+
+    assert!(
+        compact.contains("movetozoneeffect")
+            && compact.contains("zone:battlefield")
+            && compact.contains("face_down:some(true)"),
+        "expected Tezzeret ultimate to move cards from hand to battlefield face down, got {effects_debug}"
+    );
+    assert!(
+        compact.contains("addcardtypes")
+            && compact.contains("artifact")
+            && compact.contains("creature")
+            && compact.contains("setbasepowertoughness")
+            && compact.contains("fixed(5)"),
+        "expected Tezzeret ultimate followup to animate moved cards as 5/5 artifact creatures, got {effects_debug}"
+    );
+}
+
 #[test]
 fn eruth_tormented_prophet_parses_strictly_as_draw_replacement() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Eruth, Tormented Prophet")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tezzeret, Cruel Machinist
Initial parse error:
```
unsupported put destination after 'onto' (clause: 'any number of cards from your hand onto the battlefield face down'); oracle-only fallback also failed: unsupported put destination after 'onto' (clause: 'any number of cards from your hand onto the battlefield face down')
```

Worker: i-0d67f465673d4dd21
