### PR TITLE
Fix Ironsmith parse failure: Watcher in the Web

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -901,6 +901,32 @@ fn parse_static_ability_ast_line_early_lexed(
     }
 
     let words = parser_text_word_refs(tokens);
+    if words.starts_with(&["this", "creature", "can", "block"]) {
+        let mut idx = 4usize;
+        if words.get(idx).copied() == Some("an") {
+            idx += 1;
+        }
+
+        if words.get(idx).copied() == Some("additional") {
+            idx += 1;
+            let mut additional = 1usize;
+            if let Some((count, used)) = parse_number(&tokens[idx..]) {
+                additional = count as usize;
+                idx += used;
+            }
+
+            if matches!(words.get(idx).copied(), Some("creature") | Some("creatures"))
+                && (words.get(idx + 1..).unwrap_or_default().is_empty()
+                    || words.get(idx + 1..) == Some(&["each", "combat"][..])
+                    || words.get(idx + 1..) == Some(&["this", "turn"][..]))
+            {
+                return Ok(Some(vec![
+                    StaticAbility::can_block_additional_creature_each_combat(additional).into(),
+                ]));
+            }
+        }
+    }
+
     let normalized_line = render_token_slice(tokens)
         .to_ascii_lowercase()
         .replace('\u{2019}', "'")
@@ -1618,33 +1644,44 @@ pub(crate) fn parse_can_block_additional_creature_each_combat_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
     let normalized = crate::runtime_backend::token_word_refs(tokens);
-    if matches!(
-        normalized.as_slice(),
-        [
-            "this",
-            "creature",
-            "can",
-            "block",
-            "an",
-            "additional",
-            "creature",
-            "each",
-            "combat"
-        ] | [
-            "this",
-            "creature",
-            "can",
-            "block",
-            "an",
-            "additional",
-            "creature"
-        ]
-    ) {
-        return Ok(Some(
-            StaticAbility::can_block_additional_creature_each_combat(1),
-        ));
+    if !slice_starts_with(&normalized, &["this", "creature", "can", "block"])
+        || !matches!(
+            normalized.last().copied(),
+            Some("combat") | Some("turn") | Some("creature") | Some("creatures")
+        )
+    {
+        return Ok(None);
     }
-    Ok(None)
+
+    let mut idx = 4usize;
+    if normalized.get(idx).copied() == Some("an") {
+        idx += 1;
+    }
+
+    if normalized.get(idx).copied() != Some("additional") {
+        return Ok(None);
+    }
+    idx += 1;
+
+    let mut additional = 1usize;
+    if let Some((count, used)) = parse_number(&tokens[idx..]) {
+        additional = count as usize;
+        idx += used;
+    }
+
+    if !matches!(normalized.get(idx).copied(), Some("creature") | Some("creatures")) {
+        return Ok(None);
+    }
+    idx += 1;
+
+    let tail = &normalized[idx..];
+    if !tail.is_empty() && tail != ["each", "combat"] && tail != ["this", "turn"] {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        StaticAbility::can_block_additional_creature_each_combat(additional),
+    ))
 }
 
 pub(crate) fn parse_skulk_rules_text_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -242,6 +242,7 @@ pub(super) fn parse_static_line_cst(
             | "while voting, you get an additional vote."
     ) || is_first_equip_cost_alternative_line(normalized)
         || is_additional_land_play_static_line(normalized)
+        || is_can_block_additional_creatures_static_line(normalized)
     {
         return Ok(Some(make_static(None)));
     }
@@ -331,6 +332,14 @@ fn is_additional_land_play_static_line(normalized: &str) -> bool {
             "turns"
         ])
     )
+}
+
+fn is_can_block_additional_creatures_static_line(normalized: &str) -> bool {
+    let normalized = normalized.trim_end_matches('.').to_ascii_lowercase();
+    if !normalized.starts_with("this creature can block an additional ") {
+        return false;
+    }
+    normalized.ends_with(" each combat") || normalized.ends_with(" this turn")
 }
 
 fn parse_split_static_item_count(tokens: &[OwnedLexToken]) -> Result<Option<usize>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -827,6 +827,7 @@ pub(super) fn run_statement_probe_line_family(
             ctx.preprocessed,
             &ctx.line.tokens,
         ))
+        && !is_can_block_additional_creatures_static_line(&ctx.line.tokens)
         && let Some(statement_line) = parse_statement_line_cst(ctx.line)?
     {
         return Ok(Some(LineDispatchResult::single(
@@ -835,6 +836,21 @@ pub(super) fn run_statement_probe_line_family(
         )));
     }
     Ok(None)
+}
+
+fn is_can_block_additional_creatures_static_line(tokens: &[OwnedLexToken]) -> bool {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !words.starts_with(&["this", "creature", "can", "block"]) {
+        return false;
+    }
+
+    let has_additional = words.iter().any(|word| *word == "additional");
+    let has_creature_noun = words.iter().any(|word| *word == "creature" || *word == "creatures");
+    if !has_additional || !has_creature_noun {
+        return false;
+    }
+
+    words.ends_with(&["each", "combat"]) || words.ends_with(&["this", "turn"])
 }
 
 pub(super) fn run_static_line_family(

--- a/crates/ironsmith-runtime/src/cards/mod.rs
+++ b/crates/ironsmith-runtime/src/cards/mod.rs
@@ -1381,6 +1381,28 @@ mod tests {
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_watcher_in_the_web_oracle_text_and_render_additional_blockers() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Watcher in the Web")
+            .card_types(vec![CardType::Creature])
+            .parse_text(
+                "Flash\nReach\nThis creature can block an additional seven creatures each combat.",
+            )
+            .expect("Watcher in the Web oracle text should parse strictly");
+
+        let compiled = crate::compiled_text::canonical_compiled_lines(&def)
+            .join(" ")
+            .to_ascii_lowercase();
+        assert!(
+            compiled.contains("block")
+                && compiled.contains("additional")
+                && compiled.contains("7")
+                && compiled.contains("combat"),
+            "expected compiled text to preserve seven-additional-blockers clause, got {compiled}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_enchanted_creature_cant_attack_or_block_static() {
         use crate::static_abilities::StaticAbilityId;
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7952,6 +7952,81 @@ fn test_apply_blocker_declarations_allows_blocking_multiple_attackers_with_abili
 }
 
 #[test]
+fn watcher_in_the_web_can_block_eight_attackers() {
+    let mut game = setup_game();
+    let mut tq = TriggerQueue::new();
+    let mut combat = CombatState::default();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let watcher = create_creature(&mut game, "Watcher in the Web", bob, 2, 5);
+
+    game.object_mut(watcher)
+        .expect("watcher exists")
+        .abilities
+        .push(Ability {
+            kind: AbilityKind::Static(StaticAbility::can_block_additional_creature_each_combat(7)),
+            functional_zones: vec![Zone::Battlefield],
+        });
+
+    let mut declarations = Vec::new();
+    for idx in 0..8 {
+        let attacker = create_creature(&mut game, &format!("Attacker {idx}"), alice, 2, 2);
+        combat.attackers.push(crate::combat_state::AttackerInfo {
+            creature: attacker,
+            target: AttackTarget::Player(bob),
+        });
+        declarations.push(BlockerDeclaration {
+            blocker: watcher,
+            blocking: attacker,
+        });
+    }
+
+    apply_blocker_declarations(&mut game, &mut combat, &mut tq, &declarations, bob)
+        .expect("Watcher in the Web should block up to eight attackers");
+}
+
+#[test]
+fn watcher_in_the_web_cannot_block_nine_attackers() {
+    let mut game = setup_game();
+    let mut tq = TriggerQueue::new();
+    let mut combat = CombatState::default();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let watcher = create_creature(&mut game, "Watcher in the Web", bob, 2, 5);
+
+    game.object_mut(watcher)
+        .expect("watcher exists")
+        .abilities
+        .push(Ability {
+            kind: AbilityKind::Static(StaticAbility::can_block_additional_creature_each_combat(7)),
+            functional_zones: vec![Zone::Battlefield],
+        });
+
+    let mut declarations = Vec::new();
+    for idx in 0..9 {
+        let attacker = create_creature(&mut game, &format!("Attacker {idx}"), alice, 2, 2);
+        combat.attackers.push(crate::combat_state::AttackerInfo {
+            creature: attacker,
+            target: AttackTarget::Player(bob),
+        });
+        declarations.push(BlockerDeclaration {
+            blocker: watcher,
+            blocking: attacker,
+        });
+    }
+
+    let err = apply_blocker_declarations(&mut game, &mut combat, &mut tq, &declarations, bob)
+        .expect_err("Watcher in the Web should not block nine attackers");
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("InvalidBlockers"),
+        "expected invalid blockers error, got {message}"
+    );
+}
+
+#[test]
 fn test_apply_blocker_declarations_enforces_maximum_blockers() {
     let mut game = setup_game();
     let mut tq = TriggerQueue::new();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Watcher in the Web
Initial parse error:
```
parser does not yet support line family: 'This creature can block an additional seven creatures each combat.'; oracle-only fallback also failed: parser does not yet support line family: 'This creature can block an additional seven creatures each combat.'
```

Worker: i-0d84e3412ce841521
