### PR TITLE
Fix Ironsmith parse failure: Doom Weaver

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -11498,6 +11498,32 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_doom_weaver_soulbond_shared_dies_draw_clause() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Doom Weaver")
+            .parse_text(
+                "Reach\nSoulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as Doom Weaver is paired with another creature, each of those creatures has \"When this creature dies, draw cards equal to its power.\"",
+            )
+            .expect("Doom Weaver should parse");
+
+        let rendered = unprocessed_compiled_lines(&def).join(" ");
+        let rendered_lower = rendered.to_ascii_lowercase();
+        assert!(
+            rendered_lower.contains("as long as this creature is paired with another creature"),
+            "expected soulbond shared condition in compiled text, got: {rendered}"
+        );
+        assert!(
+            rendered_lower.contains("each of those creatures has"),
+            "expected soulbond shared recipient wording in compiled text, got: {rendered}"
+        );
+        assert!(
+            rendered_lower.contains("when this creature dies")
+                && rendered_lower.contains("draw cards equal to its power"),
+            "expected granted dies trigger draw clause in compiled text, got: {rendered}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_soulbond_shared_copy_clause_can_lose_soulbond() {
         let err = CardDefinitionBuilder::new(CardId::new(), "Mirage Phalanx Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -26199,6 +26199,11 @@ fn render_source_surface_for_hard_triggered_and_static_clauses() {
             "soulbond",
         ),
         (
+            "Doom Weaver",
+            "Reach\nSoulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as Doom Weaver is paired with another creature, each of those creatures has \"When this creature dies, draw cards equal to its power.\"",
+            "when this creature dies",
+        ),
+        (
             "Hearth Elemental Variant",
             "This spell costs {X} less to cast, where X is the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
             "costs {x} less to cast, where x is",

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -938,6 +938,9 @@ pub(super) fn normalize_trigger_colon_clause(line: &str) -> Option<String> {
     };
 
     let (head, tail) = body.split_once(": ")?;
+    if head.contains('"') {
+        return None;
+    }
     let normalized_head = if let Some(rest) = head.strip_prefix("You ") {
         format!("you {rest}")
     } else {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33051,9 +33051,12 @@ pub(super) fn describe_ability(
             if static_ability.id() == crate::static_abilities::StaticAbilityId::SoulbondSharedBonus
                 && let Some(granted) = static_ability.granted_inline_ability()
             {
+                let granted_surface = normalize_granted_triggered_ability_surface(
+                    describe_inline_ability(granted),
+                );
                 return vec![format!(
-                    "Static ability {index}: As long as this creature is paired with another creature, both creatures have \"{}\"",
-                    describe_inline_ability(granted)
+                    "Static ability {index}: As long as this creature is paired with another creature, each of those creatures has \"{}\"",
+                    granted_surface
                 )];
             }
             if let Some(levels) = static_ability.level_abilities()
@@ -33448,6 +33451,38 @@ pub(super) fn describe_ability(
             vec![line]
         }
     }
+}
+
+fn normalize_granted_triggered_ability_surface(surface: String) -> String {
+    let Some((head, tail)) = surface.split_once(": ") else {
+        return surface;
+    };
+    let lower_head = head.to_ascii_lowercase();
+    if !(lower_head.starts_with("when ")
+        || lower_head.starts_with("whenever ")
+        || lower_head.starts_with("at the beginning "))
+    {
+        return surface;
+    }
+
+    let tail = tail
+        .strip_prefix("You ")
+        .or_else(|| tail.strip_prefix("you "))
+        .unwrap_or(tail)
+        .trim_start();
+    if tail.is_empty() {
+        return surface;
+    }
+
+    let mut normalized_tail = lowercase_first(tail);
+    if !normalized_tail.ends_with('.')
+        && !normalized_tail.ends_with('!')
+        && !normalized_tail.ends_with('?')
+    {
+        normalized_tail.push('.');
+    }
+
+    format!("{head}, {normalized_tail}")
 }
 
 fn normalize_zone_bound_self_exile_cost(

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -4795,6 +4795,104 @@ fn joint_assault_pumps_target_and_its_soulbond_partner() {
 }
 
 #[test]
+fn doom_weaver_grants_dies_trigger_to_soulbond_partner() {
+    let doom_weaver = CardDefinitionBuilder::new(CardId::new(), "Doom Weaver")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spider, Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(1, 8))
+        .parse_text(
+            "Reach\nSoulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as Doom Weaver is paired with another creature, each of those creatures has \"When this creature dies, draw cards equal to its power.\"",
+        )
+        .expect("Doom Weaver should parse");
+
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let doom_weaver_id = game.create_object_from_definition(&doom_weaver, alice, Zone::Battlefield);
+    for idx in 0..4 {
+        let library_card = CardBuilder::new(CardId::new(), format!("Draw Fodder {idx}"))
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        game.create_object_from_card(&library_card, alice, Zone::Library);
+    }
+    let partner = CardBuilder::new(CardId::new(), "Soulbond Partner")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let partner_id = game.create_object_from_card(&partner, alice, Zone::Battlefield);
+    game.set_soulbond_pair(doom_weaver_id, partner_id);
+
+    let hand_before = game.player(alice).expect("alice exists").hand.len();
+    let moved = game.move_object_by_effect(partner_id, Zone::Graveyard);
+    assert!(moved.is_some(), "partner should move to the graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "partner death should trigger Doom Weaver grant"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Doom Weaver trigger should be put on stack");
+
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("granted dies trigger should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        hand_before + 3,
+        "partner should draw cards equal to its power when it dies while paired"
+    );
+}
+
+#[test]
+fn doom_weaver_dies_trigger_not_granted_when_unpaired() {
+    let doom_weaver = CardDefinitionBuilder::new(CardId::new(), "Doom Weaver")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spider, Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(1, 8))
+        .parse_text(
+            "Reach\nSoulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as Doom Weaver is paired with another creature, each of those creatures has \"When this creature dies, draw cards equal to its power.\"",
+        )
+        .expect("Doom Weaver should parse");
+
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let _doom_weaver_id = game.create_object_from_definition(&doom_weaver, alice, Zone::Battlefield);
+    for idx in 0..4 {
+        let library_card = CardBuilder::new(CardId::new(), format!("No Draw Fodder {idx}"))
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        game.create_object_from_card(&library_card, alice, Zone::Library);
+    }
+    let partner = CardBuilder::new(CardId::new(), "Unpaired Partner")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let partner_id = game.create_object_from_card(&partner, alice, Zone::Battlefield);
+
+    let hand_before = game.player(alice).expect("alice exists").hand.len();
+    let moved = game.move_object_by_effect(partner_id, Zone::Graveyard);
+    assert!(moved.is_some(), "partner should move to the graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "unpaired partner death should not trigger draw"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        hand_before,
+        "unpaired death should not draw cards"
+    );
+}
+
+#[test]
 fn test_extract_target_specs_necromentia_uses_one_target_opponent_requirement() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Necromentia")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/semantic_compare.rs
+++ b/crates/ironsmith-runtime/src/semantic_compare.rs
@@ -1365,6 +1365,7 @@ fn split_common_clause_conjunctions(text: &str) -> String {
             "Target opponent's nonland permanent",
             "Target nonland permanent an opponent controls",
         );
+    normalized = normalize_named_soulbond_pairing_surface(&normalized);
     for (from, to) in [
         (
             " from your hand if you dont this land enters tapped",
@@ -2836,6 +2837,40 @@ fn normalize_target_count_wording(text: &str) -> String {
     for token in number_tokens {
         normalized = normalized.replace(&format!("target {token} "), &format!("{token} "));
         normalized = normalized.replace(&format!("Target {token} "), &format!("{token} "));
+    }
+    normalized
+}
+
+fn normalize_named_soulbond_pairing_surface(text: &str) -> String {
+    let marker = " is paired with another creature, each of those creatures has ";
+    let mut normalized = String::with_capacity(text.len());
+    for segment in text.split_inclusive('\n') {
+        let (line, line_ending) = if let Some(stripped) = segment.strip_suffix('\n') {
+            (stripped, "\n")
+        } else {
+            (segment, "")
+        };
+
+        if let Some(rest) = line.strip_prefix("As long as ")
+            && let Some(marker_idx) = rest.find(marker)
+        {
+            normalized.push_str("As long as this creature");
+            normalized.push_str(&rest[marker_idx..]);
+            normalized.push_str(line_ending);
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("as long as ")
+            && let Some(marker_idx) = rest.find(marker)
+        {
+            normalized.push_str("as long as this creature");
+            normalized.push_str(&rest[marker_idx..]);
+            normalized.push_str(line_ending);
+            continue;
+        }
+
+        normalized.push_str(line);
+        normalized.push_str(line_ending);
     }
     normalized
 }
@@ -6288,6 +6323,24 @@ As long as this creature is paired with another creature, each of those creature
         assert!(
             !mismatch,
             "expected no mismatch for soulbond keyword scaffolding"
+        );
+    }
+
+    #[test]
+    fn compare_semantics_normalizes_named_soulbond_pairing_surface() {
+        let oracle = "As long as Doom Weaver is paired with another creature, each of those creatures has \"When this creature dies, draw cards equal to its power.\"";
+        let compiled = vec![String::from(
+            "Static ability 3: As long as this creature is paired with another creature, each of those creatures has \"When this creature dies, draw cards equal to its power.\"",
+        )];
+        let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+            compare_semantics_scored(oracle, &compiled, strict_embedding());
+        assert!(
+            similarity >= 0.99,
+            "expected named soulbond pairing wording normalization to stay above strict threshold, got {similarity}"
+        );
+        assert!(
+            !mismatch,
+            "expected no mismatch for named soulbond pairing wording"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Doom Weaver
Initial parse error:
```
compiled text contains malformed output: malformed-whenever-as-long-as
```

Worker: i-05596d921ff32c7af
