### PR TITLE
Fix Ironsmith parse failure: Quagmire

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -272,6 +272,40 @@ pub(crate) fn parse_subject_has_keywords_and_cant_be_blocked_line(
     Ok(Some(granted))
 }
 
+pub(crate) fn parse_landwalk_as_though_block_override_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbilityAst>, CardTextError> {
+    let normalized = normalize_cant_words(tokens);
+    let normalized_refs = normalized.iter().map(String::as_str).collect::<Vec<_>>();
+    let Some(can_idx) = anthem_find_word_sequence_index(&normalized_refs, &["can", "be", "blocked"])
+    else {
+        return Ok(None);
+    };
+    if can_idx == 0 {
+        return Ok(None);
+    }
+    let tail = &normalized_refs[can_idx + 3..];
+    if tail.len() != 6
+        || !matches!(tail[0..5], ["as", "though", "they", "didnt", "have"] | ["as", "though", "they", "didn't", "have"])
+        || !tail[5].ends_with("walk")
+    {
+        return Ok(None);
+    }
+
+    let Some(subject_end) = token_index_for_word_index(tokens, can_idx) else {
+        return Ok(None);
+    };
+    let subject_tokens = trim_commas(&tokens[..subject_end]);
+    let AnthemSubjectAst::Filter(filter) = parse_anthem_subject(&subject_tokens)? else {
+        return Ok(None);
+    };
+
+    let removed = StaticAbility::keyword_marker(tail[5]);
+    Ok(Some(StaticAbilityAst::Static(StaticAbility::remove_ability(
+        filter, removed,
+    ))))
+}
+
 pub(crate) fn parse_subject_cant_be_blocked_as_long_as_condition_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbilityAst>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -358,6 +358,10 @@ fn static_ability_rule_head_hints(rule_id: &'static str) -> Vec<StaticAbilityLin
             StaticAbilityLineHeadHint::Single("this"),
             StaticAbilityLineHeadHint::Pair("this", "creature"),
         ],
+        "parse_landwalk_as_though_block_override_line" => vec![
+            StaticAbilityLineHeadHint::Single("creatures"),
+            StaticAbilityLineHeadHint::Pair("creatures", "with"),
+        ],
         "parse_multi_subject_anthem_line" => vec![
             StaticAbilityLineHeadHint::Single("this"),
             StaticAbilityLineHeadHint::Pair("this", "creature"),
@@ -677,6 +681,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         multi_static_ability_ast_rule!(parse_lands_are_pt_creatures_still_lands_line),
         single_static_ability_ast_rule!(parse_remove_snow_line),
         multi_static_ability_ast_rule!(parse_attached_is_legendary_gets_and_has_keywords_line),
+        single_static_ability_ast_rule!(parse_landwalk_as_though_block_override_line),
         StaticAbilityLineRuleDef {
             id: stringify!(parse_granted_keyword_static_line),
             rule: StaticAbilityLineRuleAst::Multi(parse_granted_keyword_static_line),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11407,17 +11407,17 @@ fn parse_anger_graveyard_condition_with_land_control() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn test_parse_landwalk_as_though_clause_is_not_partially_parsed() {
-    let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Landwalk Override Variant")
+fn test_parse_quagmire_landwalk_as_though_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Quagmire")
         .card_types(vec![CardType::Enchantment])
         .parse_text(
-            "Creatures with islandwalk can be blocked as though they didn't have islandwalk.",
+            "Creatures with swampwalk can be blocked as though they didn't have swampwalk.",
         )
-        .expect_err("landwalk as-though clause should not partially parse");
-    let message = format!("{err:?}");
+        .expect("quagmire landwalk as-though clause should parse");
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
     assert!(
-        message.contains("could not find verb in effect clause") || message.contains("unsupported"),
-        "expected actionable parse failure, got {message}"
+        rendered.contains("as though they didn't have swampwalk"),
+        "expected rendered as-though swampwalk override clause, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -1526,4 +1526,66 @@ mod tests {
             &game,
         ));
     }
+
+    #[test]
+    fn test_quagmire_allows_blocking_swampwalk_creatures() {
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let mut attacker = make_creature("Bog Raider", 2, 2);
+        attacker.owner = alice;
+        add_ability(&mut attacker, StaticAbility::landwalk(crate::types::Subtype::Swamp));
+
+        let mut blocker = make_creature("Blocker", 2, 2);
+        blocker.owner = bob;
+
+        let mut swamp = make_creature("Swamp", 0, 1);
+        swamp.owner = bob;
+        swamp.card_types = vec![CardType::Land];
+        swamp.subtypes = vec![crate::types::Subtype::Swamp];
+
+        let mut quagmire = make_creature("Quagmire", 0, 0);
+        quagmire.owner = alice;
+        quagmire.card_types = vec![CardType::Enchantment];
+        quagmire.abilities.push(Ability::static_ability(StaticAbility::remove_ability(
+            crate::filter::ObjectFilter::creature().with_ability_marker("swampwalk"),
+            StaticAbility::landwalk(crate::types::Subtype::Swamp),
+        )));
+
+        let mut game = test_game_state();
+        game.add_object(attacker.clone());
+        game.add_object(blocker.clone());
+        game.add_object(swamp);
+        assert!(!can_block(&attacker, &blocker, &game));
+
+        game.add_object(quagmire);
+        assert!(can_block(&attacker, &blocker, &game));
+    }
+
+    #[test]
+    fn test_quagmire_does_not_affect_non_swampwalk_attackers() {
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let mut attacker = make_creature("Vanilla Attacker", 2, 2);
+        attacker.owner = alice;
+
+        let mut blocker = make_creature("Blocker", 2, 2);
+        blocker.owner = bob;
+
+        let mut quagmire = make_creature("Quagmire", 0, 0);
+        quagmire.owner = alice;
+        quagmire.card_types = vec![CardType::Enchantment];
+        quagmire.abilities.push(Ability::static_ability(StaticAbility::remove_ability(
+            crate::filter::ObjectFilter::creature().with_ability_marker("swampwalk"),
+            StaticAbility::landwalk(crate::types::Subtype::Swamp),
+        )));
+
+        let mut game = test_game_state();
+        game.add_object(attacker.clone());
+        game.add_object(blocker.clone());
+        game.add_object(quagmire);
+
+        assert!(can_block(&attacker, &blocker, &game));
+    }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -2205,6 +2205,24 @@ impl StaticAbilityKind for RemoveAbilityForFilter {
     }
 
     fn display(&self) -> String {
+        if self
+            .ability
+            .landwalk_kind()
+            .is_some()
+            && self.filter.card_types.len() == 1
+            && self.filter.card_types[0] == crate::types::CardType::Creature
+            && self
+                .filter
+                .ability_markers
+                .iter()
+                .any(|marker| marker.eq_ignore_ascii_case(&self.ability.display()))
+        {
+            return format!(
+                "{} can be blocked as though they didn't have {}",
+                pluralized_subject_text(&self.filter),
+                self.ability.display().to_ascii_lowercase()
+            );
+        }
         let subject = pluralized_subject_text(&self.filter);
         let singular_subject = subject.starts_with("enchanted ")
             || subject.starts_with("equipped ")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Quagmire
Initial parse error:
```
compiled text dropped required semantic marker: as-though
```

Worker: i-07605b668bfcbddb4
