### PR TITLE
Fix Ironsmith parse failure: Loot, the Key to Everything

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -1882,6 +1882,22 @@ pub(crate) fn parse_where_x_is_number_of_filter_value(tokens: &[OwnedLexToken]) 
             multiplier,
         ));
     }
+    if etb_word_slice_starts_with(&filter_words, &["card", "type", "among"])
+        || etb_word_slice_starts_with(&filter_words, &["card", "types", "among"])
+    {
+        let mut scope_tokens = &filter_tokens[3..];
+        if scope_tokens
+            .first()
+            .is_some_and(|token| token.is_word("the"))
+        {
+            scope_tokens = &scope_tokens[1..];
+        }
+        let scope_filter = parse_object_filter_lexed(scope_tokens, false).ok()?;
+        return Some(scale_where_x_number_value(
+            Value::CardTypesAmong(scope_filter),
+            multiplier,
+        ));
+    }
     if matches!(
         filter_words.as_slice(),
         ["creature", "that", "died", "this", "turn"]

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -5691,6 +5691,24 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
             return Ok(Some(Value::CreatureTypesAmong(filter)));
         }
     }
+    if slice_starts_with(&filter_words, &["card", "type", "among"])
+        || slice_starts_with(&filter_words, &["card", "types", "among"])
+    {
+        let Some(after_among_token_idx) = token_index_for_word_index(filter_tokens, 3) else {
+            return Ok(None);
+        };
+        let mut end_token_idx = filter_tokens.len();
+        if let Some(period_idx) = filter_tokens[after_among_token_idx..]
+            .iter()
+            .position(|token| token.is_period())
+        {
+            end_token_idx = after_among_token_idx + period_idx;
+        }
+        let card_scope_tokens = trim_commas(&filter_tokens[after_among_token_idx..end_token_idx]);
+        if let Ok(filter) = parse_object_filter(&card_scope_tokens, false) {
+            return Ok(Some(Value::CardTypesAmong(filter)));
+        }
+    }
 
     let has_card_type_among = contains_any_keyword_static_phrase(
         &filter_words,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42760,3 +42760,51 @@ fn loot_the_key_to_everything_runtime_count_zero_without_other_nonlands() {
         .expect("Loot upkeep X value should resolve");
     assert_eq!(resolved, 0, "no other nonland permanents should produce X=0");
 }
+
+#[test]
+fn loot_the_key_to_everything_runtime_count_ignores_lands_and_opponents_permanents() {
+    let def = parse_oracle_card_definition("Loot, the Key to Everything");
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = crate::ids::PlayerId::from_index(0);
+    let bob = crate::ids::PlayerId::from_index(1);
+    let source_id = game.create_object_from_definition(&def, alice, crate::zone::Zone::Battlefield);
+
+    let forest = parse_oracle_card_definition("Forest");
+    let shivan_dragon = parse_oracle_card_definition("Shivan Dragon");
+    game.create_object_from_definition(&forest, alice, crate::zone::Zone::Battlefield);
+    game.create_object_from_definition(&shivan_dragon, bob, crate::zone::Zone::Battlefield);
+
+    let count_value = crate::effect::Value::CardTypesAmong(crate::target::ObjectFilter {
+        zone: Some(crate::zone::Zone::Battlefield),
+        controller: Some(crate::target::PlayerFilter::You),
+        excluded_card_types: vec![crate::types::CardType::Land],
+        other: true,
+        ..Default::default()
+    });
+    let ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    let resolved = crate::effects::helpers::resolve_value(&game, &count_value, &ctx)
+        .expect("Loot upkeep X value should resolve");
+    assert_eq!(
+        resolved, 0,
+        "lands and opponents' permanents should not contribute to Loot's X"
+    );
+}
+
+#[test]
+fn loot_the_key_to_everything_runtime_grants_play_permission_until_end_of_turn() {
+    let def = parse_oracle_card_definition("Loot, the Key to Everything");
+    let debug = format!("{:?}", def.abilities);
+
+    assert!(
+        debug.contains("GrantPlayTaggedEffect"),
+        "expected Loot upkeep trigger to grant play permission to exiled cards, got {debug}"
+    );
+    assert!(
+        debug.contains("duration: UntilEndOfTurn"),
+        "expected Loot play permission duration to end at end of turn, got {debug}"
+    );
+    assert!(
+        debug.contains("allow_land: true"),
+        "expected Loot play permission to allow lands as well as spells, got {debug}"
+    );
+}

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42677,3 +42677,86 @@ fn knowledge_exploitation_compiled_text_keeps_prowl_and_target_opponent_library_
         "expected Knowledge Exploitation to keep search-target clause, got {rendered}"
     );
 }
+
+#[test]
+fn parse_oracle_loot_the_key_to_everything_strict_regression() {
+    let def = parse_oracle_card_definition("Loot, the Key to Everything");
+    let debug = format!("{:?}", def.abilities);
+
+    assert!(
+        debug.contains("CardTypesAmong"),
+        "expected Loot trigger to bind X to CardTypesAmong, got {debug}"
+    );
+    assert!(
+        debug.contains("controller: Some(You)")
+            && debug.contains("excluded_card_types: [Land]")
+            && debug.contains("other: true"),
+        "expected Loot trigger to scope to other nonland permanents you control, got {debug}"
+    );
+}
+
+#[test]
+fn loot_the_key_to_everything_compiled_text_keeps_card_types_among_marker() {
+    let def = parse_oracle_card_definition("Loot, the Key to Everything");
+    let rendered = unprocessed_compiled_lines(&def).join("\n").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("where x is the number of card types among other nonland permanents you control"),
+        "expected Loot compiled text to preserve card-types-among clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("you may play those cards this turn"),
+        "expected Loot compiled text to preserve temporary play permission, got {rendered}"
+    );
+}
+
+#[test]
+fn loot_the_key_to_everything_runtime_count_uses_distinct_card_types_among_other_nonlands() {
+    let def = parse_oracle_card_definition("Loot, the Key to Everything");
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("CardTypesAmong"),
+        "expected Loot upkeep X value to use CardTypesAmong, got {debug}"
+    );
+
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = crate::ids::PlayerId::from_index(0);
+    let source_id = game.create_object_from_definition(&def, alice, crate::zone::Zone::Battlefield);
+
+    let sol_ring = parse_oracle_card_definition("Sol Ring");
+    let llanowar_elves = parse_oracle_card_definition("Llanowar Elves");
+    game.create_object_from_definition(&sol_ring, alice, crate::zone::Zone::Battlefield);
+    game.create_object_from_definition(&llanowar_elves, alice, crate::zone::Zone::Battlefield);
+
+    let count_value = crate::effect::Value::CardTypesAmong(crate::target::ObjectFilter {
+        zone: Some(crate::zone::Zone::Battlefield),
+        controller: Some(crate::target::PlayerFilter::You),
+        excluded_card_types: vec![crate::types::CardType::Land],
+        other: true,
+        ..Default::default()
+    });
+    let ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    let resolved = crate::effects::helpers::resolve_value(&game, &count_value, &ctx)
+        .expect("Loot upkeep X value should resolve");
+    assert_eq!(resolved, 2, "artifact + creature should produce two card types");
+}
+
+#[test]
+fn loot_the_key_to_everything_runtime_count_zero_without_other_nonlands() {
+    let def = parse_oracle_card_definition("Loot, the Key to Everything");
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = crate::ids::PlayerId::from_index(0);
+    let source_id = game.create_object_from_definition(&def, alice, crate::zone::Zone::Battlefield);
+
+    let count_value = crate::effect::Value::CardTypesAmong(crate::target::ObjectFilter {
+        zone: Some(crate::zone::Zone::Battlefield),
+        controller: Some(crate::target::PlayerFilter::You),
+        excluded_card_types: vec![crate::types::CardType::Land],
+        other: true,
+        ..Default::default()
+    });
+    let ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    let resolved = crate::effects::helpers::resolve_value(&game, &count_value, &ctx)
+        .expect("Loot upkeep X value should resolve");
+    assert_eq!(resolved, 0, "no other nonland permanents should produce X=0");
+}

--- a/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
@@ -109,6 +109,8 @@ fn normalize_debug_safe_spelling_surface(line: &str) -> String {
         .replace("that much +1/+1 counter", "that many +1/+1 counters")
         .replace("one or more another ", "one or more other ")
         .replace("One or more another ", "One or more other ")
+        .replace("number of card types among another ", "number of card types among other ")
+        .replace("Number of card types among another ", "Number of card types among other ")
         .replace("This creature ability costs ", "This ability costs ")
         .replace("Return all other permanent card in exile", "return all other permanent cards exiled with this artifact")
         .replace("Return all other permanent cards exiled with this artifact", "return all other permanent cards exiled with this artifact")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -10806,6 +10806,17 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 3;
             continue;
         }
+        if idx + 1 < filtered.len()
+            && let Some(exile_top) =
+                filtered[idx].downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()
+            && let Some(grant_play) =
+                filtered[idx + 1].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(compact) = describe_exile_top_then_play(exile_top, grant_play)
+        {
+            parts.push(compact);
+            idx += 2;
+            continue;
+        }
         if idx + 2 < filtered.len()
             && let Some(look_at_top) =
                 filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
@@ -18811,6 +18822,46 @@ fn describe_exile_top_then_play_without_paying_mana(
     };
     Some(format!(
         "That player exiles the top {count_text} {noun} of their library. Until end of turn, you may play {cards_text} without paying {mana_cost_text}"
+    ))
+}
+
+fn describe_exile_top_then_play(
+    exile_top: &crate::effects::ExileTopOfLibraryEffect,
+    grant_play: &crate::effects::GrantPlayTaggedEffect,
+) -> Option<String> {
+    let Some(first_tag) = exile_top.moved_tags.first() else {
+        return None;
+    };
+    if grant_play.tag != *first_tag
+        || grant_play.duration != crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+        || grant_play.player != exile_top.player
+    {
+        return None;
+    }
+
+    let singular_count = matches!(exile_top.count, Value::Fixed(1));
+    let exile_clause = match &exile_top.count {
+        Value::Fixed(n) if *n >= 0 => {
+            let count_u32 = *n as u32;
+            let count_text = small_number_word(count_u32).unwrap_or_else(|| n.to_string());
+            let noun = if *n == 1 { "card" } else { "cards" };
+            let owner = describe_possessive_player_filter(&exile_top.player);
+            format!("Exile the top {count_text} {noun} of {owner} library")
+        }
+        _ => {
+            let owner = describe_possessive_player_filter(&exile_top.player);
+            let value_text = describe_value(&exile_top.count);
+            if value_text == "X" {
+                format!("Exile the top X cards of {owner} library")
+            } else {
+                format!("Exile the top X cards of {owner} library, where X is {value_text}")
+            }
+        }
+    };
+    let cards_text = if singular_count { "that card" } else { "those cards" };
+    let verb = if grant_play.allow_land { "play" } else { "cast" };
+    Some(format!(
+        "{exile_clause}. You may {verb} {cards_text} this turn"
     ))
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Loot, the Key to Everything
Initial parse error:
```
compiled text dropped required semantic marker: card-types-among
```

Worker: i-0a4be3aff0c431536
