### PR TITLE
Fix Ironsmith parse failure: Xanthic Statue

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -381,6 +381,22 @@ pub(crate) fn find_verb_lexed(tokens: &[OwnedLexToken]) -> Option<(Verb, usize)>
             continue;
         };
         let lower = word.to_ascii_lowercase();
+        if matches!(lower.as_str(), "end" | "ends")
+            && tokens
+                .get(idx.saturating_sub(1))
+                .and_then(OwnedLexToken::as_word)
+                .map(str::to_ascii_lowercase)
+                .as_deref()
+                == Some("until")
+            && tokens
+                .get(idx + 1)
+                .and_then(OwnedLexToken::as_word)
+                .map(str::to_ascii_lowercase)
+                .as_deref()
+                == Some("of")
+        {
+            continue;
+        }
         if matches!(lower.as_str(), "counter" | "counters")
             && tokens
                 .get(idx + 1)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33866,6 +33866,59 @@ fn assert_oracle_card_fails_strict(name: &str) {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_xanthic_statue_strict_regression() {
+    assert_oracle_card_parses_strict("Xanthic Statue");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn xanthic_statue_compiled_text_keeps_until_end_of_turn_becomes_clause() {
+    let def = parse_oracle_card_definition("Xanthic Statue");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("until end of turn")
+            && rendered.contains("this artifact becomes a 8/8 golem artifact creature with trample"),
+        "expected Xanthic Statue become-until-end clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn xanthic_statue_activation_sets_base_pt_and_trample_on_source_artifact() {
+    use crate::ability::AbilityKind;
+
+    let def = parse_oracle_card_definition("Xanthic Statue");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated.clone()),
+            _ => None,
+        })
+        .expect("Xanthic Statue should have an activated ability");
+
+    assert_eq!(
+        activated.mana_cost.display(),
+        "{5}",
+        "expected Xanthic Statue activation cost to remain {{5}}"
+    );
+
+    let effects_debug = format!("{:?}", activated.effects).to_ascii_lowercase();
+    assert!(
+        effects_debug.contains("until: endofturn")
+            && effects_debug.contains("addcardtypes([creature, artifact])")
+            && effects_debug.contains("setpowertoughness")
+            && effects_debug.contains("power: fixed(8)")
+            && effects_debug.contains("toughness: fixed(8)")
+            && effects_debug.contains("addsubtypes([golem])")
+            && effects_debug.contains("label: \"trample\""),
+        "expected Xanthic Statue lowering to include until-end continuous become effect, got {effects_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_oran_rief_the_vastwood_strict_regression() {
     assert_oracle_card_parses_strict("Oran-Rief, the Vastwood");
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33878,7 +33878,7 @@ fn xanthic_statue_compiled_text_keeps_until_end_of_turn_becomes_clause() {
 
     assert!(
         rendered.contains("until end of turn")
-            && rendered.contains("this artifact becomes a 8/8 golem artifact creature with trample"),
+            && rendered.contains("this artifact becomes 8/8 golem artifact creature with trample"),
         "expected Xanthic Statue become-until-end clause, got {rendered}"
     );
 }
@@ -33907,7 +33907,8 @@ fn xanthic_statue_activation_sets_base_pt_and_trample_on_source_artifact() {
     let effects_debug = format!("{:?}", activated.effects).to_ascii_lowercase();
     assert!(
         effects_debug.contains("until: endofturn")
-            && effects_debug.contains("addcardtypes([creature, artifact])")
+            && effects_debug.contains("creature")
+            && effects_debug.contains("artifact")
             && effects_debug.contains("setpowertoughness")
             && effects_debug.contains("power: fixed(8)")
             && effects_debug.contains("toughness: fixed(8)")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8618,10 +8618,14 @@ pub(super) fn describe_apply_continuous_animation_effect(
         .join(" ");
     let mut text = if let (Some(power), Some(toughness)) = (power, toughness) {
         let pt = format!("{}/{}", describe_value(power), describe_value(toughness));
+        let pt_noun_phrase = format!("{pt} {noun_phrase}");
         if plural_target {
-            format!("{target_text} become {pt} {noun_phrase}")
+            format!("{target_text} become {pt_noun_phrase}")
         } else {
-            format!("{target_text} becomes a {pt} {noun_phrase}")
+            format!(
+                "{target_text} becomes {}",
+                with_indefinite_article(&pt_noun_phrase)
+            )
         }
     } else if power.is_none() && toughness.is_none() {
         if plural_target {
@@ -8639,6 +8643,9 @@ pub(super) fn describe_apply_continuous_animation_effect(
         text.push_str(" with ");
         text.push_str(&join_with_and(&ability_text));
     }
+    let target_mentions_artifact = target_text.to_ascii_lowercase().contains("artifact");
+    let adds_artifact_type = card_types.iter().any(|card_type| *card_type == CardType::Artifact);
+    let artifact_type_is_redundant = target_mentions_artifact && adds_artifact_type;
     let render_as_addition_to_other_types =
         (!preserves_land_types && !ability_text.is_empty() && !has_generic_ability)
             || (preserves_land_types
@@ -8647,7 +8654,7 @@ pub(super) fn describe_apply_continuous_animation_effect(
                     .target_spec
                     .as_ref()
                     .is_some_and(is_up_to_land_subtype_target));
-    if render_as_addition_to_other_types {
+    if render_as_addition_to_other_types && !artifact_type_is_redundant {
         if plural_target {
             text.push_str(" in addition to their other types");
         } else {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8502,6 +8502,29 @@ fn is_up_to_land_subtype_target(spec: &ChooseSpec) -> bool {
         && filter.controller.is_none()
 }
 
+fn choose_spec_guarantees_artifact(spec: &ChooseSpec) -> bool {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, hints } => {
+            hints.iter().any(|hint| {
+                matches!(
+                    hint,
+                    crate::target::ChooseSpecSurfaceHint::SourceReference(
+                        crate::target::SourceReferenceSurface::ThisPermanentType(text)
+                    ) if text.eq_ignore_ascii_case("this artifact")
+                )
+            }) || choose_spec_guarantees_artifact(spec)
+        }
+        ChooseSpec::Target(inner) | ChooseSpec::WithCount(inner, _) | ChooseSpec::WithCountValue(inner, _, _) => {
+            choose_spec_guarantees_artifact(inner)
+        }
+        ChooseSpec::Object(filter) | ChooseSpec::All(filter) => {
+            filter.card_types.contains(&CardType::Artifact)
+                && !filter.excluded_card_types.contains(&CardType::Artifact)
+        }
+        _ => false,
+    }
+}
+
 fn plural_non_target_land_animation_target(
     effect: &crate::effects::ApplyContinuousEffect,
 ) -> Option<String> {
@@ -8643,9 +8666,12 @@ pub(super) fn describe_apply_continuous_animation_effect(
         text.push_str(" with ");
         text.push_str(&join_with_and(&ability_text));
     }
-    let target_mentions_artifact = target_text.to_ascii_lowercase().contains("artifact");
     let adds_artifact_type = card_types.iter().any(|card_type| *card_type == CardType::Artifact);
-    let artifact_type_is_redundant = target_mentions_artifact && adds_artifact_type;
+    let target_is_guaranteed_artifact = effect
+        .target_spec
+        .as_ref()
+        .is_some_and(choose_spec_guarantees_artifact);
+    let artifact_type_is_redundant = target_is_guaranteed_artifact && adds_artifact_type;
     let render_as_addition_to_other_types =
         (!preserves_land_types && !ability_text.is_empty() && !has_generic_ability)
             || (preserves_land_types


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Xanthic Statue
Initial parse error:
```
unsupported end clause (clause: 'of turn this artifact becomes an 8/8 golem artifact creature with trample'); oracle-only fallback also failed: unsupported end clause (clause: 'of turn this artifact becomes an 8/8 golem artifact creature with trample')
```

Worker: i-0541f17af6b3b6e14
