### PR TITLE
Fix Ironsmith parse failure: Animate Land

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -381,6 +381,24 @@ pub(crate) fn find_verb_lexed(tokens: &[OwnedLexToken]) -> Option<(Verb, usize)>
             continue;
         };
         let lower = word.to_ascii_lowercase();
+        if matches!(lower.as_str(), "end" | "ends")
+            && tokens
+                .get(idx.saturating_sub(1))
+                .and_then(OwnedLexToken::as_word)
+                .is_some_and(|prev| prev.eq_ignore_ascii_case("until"))
+            && tokens
+                .get(idx + 1)
+                .and_then(OwnedLexToken::as_word)
+                .is_some_and(|next| next.eq_ignore_ascii_case("of"))
+            && tokens
+                .get(idx + 2)
+                .and_then(OwnedLexToken::as_word)
+                .is_some_and(|next| {
+                    next.eq_ignore_ascii_case("turn") || next.eq_ignore_ascii_case("combat")
+                })
+        {
+            continue;
+        }
         if matches!(lower.as_str(), "counter" | "counters")
             && tokens
                 .get(idx + 1)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34824,6 +34824,88 @@ strict_parse_card_test!(strict_parse_talon_gates_of_madara, "Talon Gates of Mada
 strict_parse_card_expected_fail_test!(strict_parse_the_soul_stone, "The Soul Stone");
 strict_parse_card_test!(strict_parse_unmarked_grave, "Unmarked Grave");
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn strict_parse_animate_land() {
+    assert_oracle_card_parses_strict("Animate Land");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn animate_land_compiled_text_keeps_animation_clause() {
+    let def = parse_oracle_card_definition("Animate Land");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("target land becomes a 3/3 creature")
+            && rendered.contains("until end of turn")
+            && rendered.contains("still a land"),
+        "expected Animate Land compiled text to preserve animation, duration, and still-a-land clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn animate_land_runtime_animates_target_land_until_end_of_turn() {
+    let def = parse_oracle_card_definition("Animate Land");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Animate Land should produce spell effects")
+        .clone();
+    let apply = spell
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .find_map(|effect| {
+            effect
+                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+                .or_else(|| {
+                    effect
+                        .downcast_ref::<crate::effects::TaggedEffect>()
+                        .and_then(|tagged| {
+                            tagged
+                                .effect
+                                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+                        })
+                })
+        })
+        .expect("Animate Land should lower to an ApplyContinuousEffect");
+
+    let target_spec = apply
+        .target_spec
+        .as_ref()
+        .expect("Animate Land should carry an explicit target spec");
+    let ChooseSpec::Target(inner) = target_spec else {
+        panic!("expected Animate Land target to be target-only, got {target_spec:?}");
+    };
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        panic!("expected Animate Land target to be an object filter, got {inner:?}");
+    };
+    assert!(
+        filter.card_types == vec![CardType::Land] && !filter.card_types.contains(&CardType::Creature),
+        "expected Animate Land to target lands only, got {filter:?}"
+    );
+
+    assert_eq!(apply.until, crate::effect::Until::EndOfTurn);
+    assert!(
+        matches!(apply.modification, Some(crate::continuous::Modification::AddCardTypes(ref added)) if added == &vec![CardType::Creature]),
+        "expected Animate Land to add creature card type, got {apply:?}"
+    );
+    assert!(
+        apply.additional_modifications.iter().any(|modification| {
+            matches!(
+                modification,
+                crate::continuous::Modification::SetPowerToughness {
+                    power: Value::Fixed(3),
+                    toughness: Value::Fixed(3),
+                    ..
+                }
+            )
+        }),
+        "expected Animate Land to set base power/toughness to 3/3, got {apply:?}"
+    );
+}
+
 #[test]
 fn escaped_null_compiled_text_keeps_blocks_or_becomes_blocked_trigger() {
     let def = parse_oracle_card_definition("Escaped Null");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8655,14 +8655,25 @@ pub(super) fn describe_apply_continuous_animation_effect(
         }
     }
     let tail = describe_apply_continuous_tail(effect);
-    if let Some(tail) = &tail {
-        text.push(' ');
-        text.push_str(tail);
-    }
-    if preserves_land_types && !render_as_addition_to_other_types {
-        if !plural_target && target_text == "target land" && tail.is_none() {
+    let inline_still_land =
+        preserves_land_types && !render_as_addition_to_other_types && !plural_target && target_text == "target land";
+    match &tail {
+        Some(tail) if inline_still_land => {
             text.push_str(" that's still a land");
-        } else if plural_target {
+            text.push(' ');
+            text.push_str(tail);
+        }
+        Some(tail) => {
+            text.push(' ');
+            text.push_str(tail);
+        }
+        None if inline_still_land => {
+            text.push_str(" that's still a land");
+        }
+        None => {}
+    }
+    if preserves_land_types && !render_as_addition_to_other_types && !inline_still_land {
+        if plural_target {
             text.push_str(". They're still lands");
         } else {
             text.push_str(". It's still a land");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Animate Land
Initial parse error:
```
unsupported end clause (clause: 'of turn target land becomes a 3/3 creature that's still a land'); oracle-only fallback also failed: unsupported end clause (clause: 'of turn target land becomes a 3/3 creature that's still a land')
```

Worker: i-0e8d8f472869b8fa1
