### PR TITLE
Fix Ironsmith parse failure: Demonic Torment

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
@@ -1344,6 +1344,33 @@ pub(crate) fn parse_attached_prevent_all_damage_dealt_by_attached_line(
     }))
 }
 
+pub(crate) fn parse_attached_prevent_all_combat_damage_dealt_by_attached_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbilityAst>, CardTextError> {
+    let line_words = token_words(tokens);
+    if line_words.len() < 7 {
+        return Ok(None);
+    }
+
+    // "Prevent all combat damage that would be dealt by enchanted creature."
+    if !word_slice_starts_with(&line_words, &["prevent", "all", "combat", "damage"]) {
+        return Ok(None);
+    }
+    if !word_slice_ends_with(&line_words, &["by", "enchanted", "creature"]) {
+        return Ok(None);
+    }
+
+    let display =
+        "prevent all combat damage that would be dealt by enchanted creature".to_string();
+    Ok(Some(StaticAbilityAst::AttachedStaticAbilityGrant {
+        ability: Box::new(StaticAbilityAst::Static(StaticAbility::new(
+            crate::static_abilities::PREVENT_ALL_COMBAT_DAMAGE_DEALT_BY_THIS_PERMANENT,
+        ))),
+        display,
+        condition: None,
+    }))
+}
+
 pub(crate) fn parse_attached_has_keywords_and_triggered_ability_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -730,6 +730,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_passthrough_rule!(
             parse_attached_prevent_all_damage_dealt_by_attached_line
         ),
+        single_static_ability_ast_passthrough_rule!(
+            parse_attached_prevent_all_combat_damage_dealt_by_attached_line
+        ),
         multi_static_ability_ast_passthrough_rule!(parse_attached_gets_and_cant_block_line),
         StaticAbilityLineRuleDef {
             id: stringify!(parse_attached_has_keywords_and_triggered_ability_line),

--- a/crates/ironsmith-compiler/src/static_abilities.rs
+++ b/crates/ironsmith-compiler/src/static_abilities.rs
@@ -11,6 +11,8 @@ pub use ironsmith_core::{
 
 pub const PREVENT_ALL_DAMAGE_DEALT_BY_THIS_PERMANENT: StaticAbilityId =
     StaticAbilityId::PreventAllDamageDealtByThisPermanent;
+pub const PREVENT_ALL_COMBAT_DAMAGE_DEALT_BY_THIS_PERMANENT: StaticAbilityId =
+    StaticAbilityId::PreventAllCombatDamageDealtByThisPermanent;
 
 pub type ThisSpellCastCondition = ironsmith_core::ThisSpellCostCondition;
 pub type ThisSpellCostCondition = ironsmith_core::ThisSpellCostCondition;

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -164,6 +164,7 @@ pub enum StaticAbilityId {
     SetChosenColor,
     RedirectDamageToSource,
     PreventAllDamageDealtByThisPermanent,
+    PreventAllCombatDamageDealtByThisPermanent,
     PreventAllDamageDealtToCreatures,
     PreventAllDamageToSelf,
     PreventAllCombatDamageToSelf,
@@ -404,6 +405,7 @@ impl StaticAbilityId {
             | SetChosenColor
             | RedirectDamageToSource
             | PreventAllDamageDealtByThisPermanent
+            | PreventAllCombatDamageDealtByThisPermanent
             | PreventAllDamageDealtToCreatures
             | PreventAllDamageToSelf
             | PreventAllCombatDamageToSelf

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33896,6 +33896,38 @@ fn parse_wild_roads_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_demonic_torment_strict_regression() {
+    assert_oracle_card_parses_strict("Demonic Torment");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demonic_torment_compiled_text_keeps_combat_prevention_clause() {
+    let def = parse_oracle_card_definition("Demonic Torment");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("prevent all combat damage that would be dealt by enchanted creature"),
+        "expected Demonic Torment compiled text to keep combat-only prevention clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demonic_torment_grants_combat_only_damage_prevention_to_enchanted_creature() {
+    let def = parse_oracle_card_definition("Demonic Torment");
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("PreventAllCombatDamageDealtByThisPermanent"),
+        "expected Demonic Torment to grant combat-only prevention, got {debug}"
+    );
+    assert!(
+        !debug.contains("PreventAllDamageDealtByThisPermanent"),
+        "expected Demonic Torment to avoid all-damage prevention, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn wild_roads_compiled_text_keeps_pilot_saddle_and_crew_clause() {
     let def = parse_oracle_card_definition("Wild Roads");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/events/damage/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/damage/matchers.rs
@@ -391,6 +391,48 @@ impl ReplacementMatcher for DamageFromSelfMatcher {
     }
 }
 
+/// Matches preventable combat damage events dealt by the source of the replacement effect.
+#[derive(Debug, Clone)]
+pub struct DamageFromSelfCombatMatcher;
+
+impl DamageFromSelfCombatMatcher {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DamageFromSelfCombatMatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplacementMatcher for DamageFromSelfCombatMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        if event.event_kind() != EventKind::Damage {
+            return false;
+        }
+
+        let Some(damage) = downcast_event::<DamageEvent>(event) else {
+            return false;
+        };
+
+        if damage.is_unpreventable || !damage.is_combat {
+            return false;
+        }
+
+        ctx.source == Some(damage.source)
+    }
+
+    fn priority(&self) -> ReplacementPriority {
+        ReplacementPriority::Other
+    }
+
+    fn display(&self) -> String {
+        "When combat damage would be dealt by this permanent".to_string()
+    }
+}
+
 /// Constraint for matching damage sources.
 #[derive(Debug, Clone)]
 pub enum DamageSourceConstraint {
@@ -921,6 +963,28 @@ mod tests {
         // Unpreventable damage should not match (prevention can't apply).
         let unpreventable = unpreventable_damage(src, DamageTarget::Player(alice), 3, false);
         assert!(!matcher.matches_event(&unpreventable, &ctx));
+    }
+
+    #[test]
+    fn test_damage_from_self_combat_matcher() {
+        let game = setup_game();
+        let alice = crate::ids::PlayerId::from_index(0);
+        let src = ObjectId::from_raw(42);
+
+        let ctx = EventContext::for_replacement_effect(alice, src, &game);
+        let matcher = DamageFromSelfCombatMatcher::new();
+
+        let combat_from_src = damage(src, DamageTarget::Player(alice), 3, true);
+        assert!(matcher.matches_event(&combat_from_src, &ctx));
+
+        let noncombat_from_src = damage(src, DamageTarget::Player(alice), 3, false);
+        assert!(!matcher.matches_event(&noncombat_from_src, &ctx));
+
+        let other_source = damage(ObjectId::from_raw(7), DamageTarget::Player(alice), 3, true);
+        assert!(!matcher.matches_event(&other_source, &ctx));
+
+        let unpreventable_from_src = unpreventable_damage(src, DamageTarget::Player(alice), 3, true);
+        assert!(!matcher.matches_event(&unpreventable_from_src, &ctx));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -124,6 +124,12 @@ impl StaticAbility {
             Some(StaticAbilityId::PreventAllDamageDealtToCreatures) => {
                 Self::prevent_all_damage_dealt_to_creatures()
             }
+            Some(StaticAbilityId::PreventAllDamageDealtByThisPermanent) => {
+                Self::prevent_all_damage_dealt_by_this_permanent()
+            }
+            Some(StaticAbilityId::PreventAllCombatDamageDealtByThisPermanent) => {
+                Self::prevent_all_combat_damage_dealt_by_this_permanent()
+            }
             Some(StaticAbilityId::PreventAllDamageToSelf) => Self::prevent_all_damage_to_self(),
             Some(StaticAbilityId::PreventAllCombatDamageToSelf) => {
                 Self::prevent_all_combat_damage_to_self()

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -21,7 +21,8 @@ use crate::events::cause::CauseType;
 use crate::events::context::EventContext;
 use crate::events::damage::DamageEvent;
 use crate::events::damage::matchers::{
-    DamageFromSelfMatcher, DamageFromSourceToObjectMatcher, DamageToObjectMatcher,
+    DamageFromSelfCombatMatcher, DamageFromSelfMatcher, DamageFromSourceToObjectMatcher,
+    DamageToObjectMatcher,
     DamageToOtherCreatureYouControlMatcher, DamageToPlayerOrObjectMatcher,
     DamageToSelfCombatMatcher, DamageToSelfConstraintMatcher, DamageToSelfFromSourceFilterMatcher,
 };
@@ -1692,6 +1693,33 @@ impl StaticAbilityKind for PreventAllDamageDealtByThisPermanent {
             source,
             controller,
             DamageFromSelfMatcher::new(),
+            ReplacementAction::Prevent,
+        ))
+    }
+}
+
+/// "Prevent all combat damage that would be dealt by this permanent."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PreventAllCombatDamageDealtByThisPermanent;
+
+impl StaticAbilityKind for PreventAllCombatDamageDealtByThisPermanent {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::PreventAllCombatDamageDealtByThisPermanent
+    }
+
+    fn display(&self) -> String {
+        "Prevent all combat damage that would be dealt by this permanent.".to_string()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            DamageFromSelfCombatMatcher::new(),
             ReplacementAction::Prevent,
         ))
     }
@@ -5669,6 +5697,52 @@ mod tests {
             crate::events::cause::EventCause::effect(),
         );
         assert!(!matcher.matches_event(&unpreventable, &ctx));
+    }
+
+    #[test]
+    fn test_prevent_all_combat_damage_dealt_by_this_permanent_generates_replacement() {
+        let game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let src = ObjectId::from_raw(42);
+        let alice = PlayerId::from_index(0);
+
+        let ability = PreventAllCombatDamageDealtByThisPermanent;
+        let replacement = ability
+            .generate_replacement_effect(src, alice)
+            .expect("should generate replacement effect");
+        assert_eq!(replacement.replacement, ReplacementAction::Prevent);
+
+        let matcher = replacement
+            .matcher
+            .as_ref()
+            .expect("replacement must have a matcher");
+        let ctx = EventContext::for_replacement_effect(alice, src, &game);
+
+        let combat = DamageEvent::with_cause(
+            src,
+            DamageTarget::Player(alice),
+            3,
+            true,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(matcher.matches_event(&combat, &ctx));
+
+        let noncombat = DamageEvent::with_cause(
+            src,
+            DamageTarget::Player(alice),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(!matcher.matches_event(&noncombat, &ctx));
+
+        let from_other = DamageEvent::with_cause(
+            ObjectId::from_raw(7),
+            DamageTarget::Player(alice),
+            3,
+            true,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(!matcher.matches_event(&from_other, &ctx));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2236,6 +2236,14 @@ impl StaticAbility {
         Self::new(PreventAllDamageDealtToCreatures)
     }
 
+    pub fn prevent_all_damage_dealt_by_this_permanent() -> Self {
+        Self::new(PreventAllDamageDealtByThisPermanent)
+    }
+
+    pub fn prevent_all_combat_damage_dealt_by_this_permanent() -> Self {
+        Self::new(PreventAllCombatDamageDealtByThisPermanent)
+    }
+
     pub fn prevent_all_combat_damage_to_self() -> Self {
         Self::new(PreventAllCombatDamageToSelf)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Demonic Torment
Initial parse error:
```
parser does not yet support line family: 'Prevent all combat damage that would be dealt by enchanted creature.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all combat damage that would be dealt by enchanted creature.'
```

Worker: i-0adaecb6552532342
