### PR TITLE
Fix Ironsmith parse failure: Wave of Rats

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3296,6 +3296,23 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         }
     }
 
+    if filtered.as_slice() == ["it", "dealt", "combat", "damage", "to", "player", "this", "turn"]
+        || filtered.as_slice()
+            == [
+                "it",
+                "dealt",
+                "combat",
+                "damage",
+                "to",
+                "a",
+                "player",
+                "this",
+                "turn",
+            ]
+    {
+        return Ok(PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
+    }
+
     let spell_cast_prefix = if slice_starts_with(&filtered, &["opponent", "has", "cast"]) {
         Some((3usize, PlayerFilter::Opponent))
     } else if slice_starts_with(&filtered, &["opponents", "have", "cast"]) {
@@ -3457,6 +3474,22 @@ mod tests {
                 filter: ObjectFilter::default().in_zone(Zone::Hand),
             }))
         );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_it_dealt_combat_damage_to_player_this_turn(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line("if it dealt combat damage to a player this turn", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(parsed, PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -559,6 +559,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
             display: Some(display.clone()),
         },
         PredicateAst::SourcePowerAtLeast(count) => Condition::SourcePowerAtLeast(*count),
+        PredicateAst::SourceDealtCombatDamageToPlayerThisTurn => {
+            Condition::SourceDealtCombatDamageToPlayerThisTurn
+        }
         PredicateAst::SourceAttackedThisTurn => Condition::SourceAttackedThisTurn,
         PredicateAst::SourceCameUnderYourControlThisTurn => {
             Condition::SourceCameUnderYourControlThisTurn

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -520,6 +520,7 @@ pub(crate) enum PredicateAst {
         display: String,
     },
     SourcePowerAtLeast(u32),
+    SourceDealtCombatDamageToPlayerThisTurn,
     SourceAttackedThisTurn,
     SourceCameUnderYourControlThisTurn,
     SourceAttackedOrBlockedThisTurn,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -729,6 +729,7 @@ pub enum Condition {
         count: u32,
     },
     SourcePowerAtLeast(u32),
+    SourceDealtCombatDamageToPlayerThisTurn,
     ManaSpentToCastThisSpellAtLeast {
         amount: u32,
         symbol: Option<ManaSymbol>,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33872,6 +33872,48 @@ fn parse_xanthic_statue_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_wave_of_rats_strict_regression() {
+    assert_oracle_card_parses_strict("Wave of Rats");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wave_of_rats_compiled_text_keeps_combat_damage_condition_clause() {
+    let def = parse_oracle_card_definition("Wave of Rats");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("when this creature dies")
+            && rendered.contains("if it dealt combat damage to a player this turn")
+            && rendered.contains("return it to the battlefield under its owner's control"),
+        "expected Wave of Rats dies condition and return clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wave_of_rats_dies_trigger_uses_source_combat_damage_condition() {
+    let def = parse_oracle_card_definition("Wave of Rats");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Wave of Rats should have a dies triggered ability");
+
+    let trigger_debug = format!("{:?}", triggered).to_ascii_lowercase();
+    assert!(
+        trigger_debug.contains("sourcedealtcombatdamagetoplayerthisturn")
+            && trigger_debug.contains("movetozoneeffect")
+            && trigger_debug.contains("battlefield"),
+        "expected Wave of Rats dies trigger to gate return on source combat damage, got {trigger_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn xanthic_statue_compiled_text_keeps_until_end_of_turn_becomes_clause() {
     let def = parse_oracle_card_definition("Xanthic Statue");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11210,6 +11210,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             counter.description()
         ),
         Condition::SourceAttackedThisTurn => "this creature attacked this turn".to_string(),
+        Condition::SourceDealtCombatDamageToPlayerThisTurn => {
+            "it dealt combat damage to a player this turn".to_string()
+        }
         Condition::SourceCameUnderYourControlThisTurn => {
             "this creature came under your control this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -24920,9 +24920,8 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 }
             }
             Zone::Battlefield => {
-                let target = if matches!(&move_to_zone.target, ChooseSpec::Tagged(tag) if tag.as_str() == "triggering")
-                {
-                    "that card".to_string()
+                let target = if matches!(&move_to_zone.target, ChooseSpec::Tagged(tag) if tag.as_str() == "triggering") {
+                    "it".to_string()
                 } else {
                     target
                 };
@@ -24942,7 +24941,8 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     crate::effects::BattlefieldController::You => " under your control",
                 };
                 if let crate::target::ChooseSpec::Tagged(tag) = &move_to_zone.target
-                    && (tag.as_str().starts_with("exiled_")
+                    && (tag.as_str() == "triggering"
+                        || tag.as_str().starts_with("exiled_")
                         || crate::cards::is_sentence_helper_tag(tag.as_str(), "exiled"))
                 {
                     format!("Return {target} to the battlefield{tapped_suffix}{controller_suffix}")

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -130,6 +130,8 @@ mod tests {
     use super::*;
     use crate::card::{CardBuilder, PowerToughness};
     use crate::effects::ExecutionContext;
+    use crate::events::cause::EventCause;
+    use crate::events::{DamageEvent, DamageTarget, RawEvent};
     use crate::ids::CardId;
     use crate::mana::{ManaCost, ManaSymbol};
     use crate::types::CardType;
@@ -371,6 +373,57 @@ mod tests {
         assert!(
             evaluate_condition_external(&game, &condition, &ctx),
             "trigger-time target condition should compare the LKI creature to the source's power"
+        );
+    }
+
+    #[test]
+    fn wave_of_rats_condition_true_when_source_dealt_combat_damage_to_player_this_turn() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = game.players[0].id;
+        let bob = game.players[1].id;
+        let rat = CardBuilder::new(CardId::from_raw(13), "Wave of Rats")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 2))
+            .build();
+        let rat_id = game.create_object_from_card(&rat, alice, Zone::Battlefield);
+        let source_snapshot = {
+            let object = game.object(rat_id).expect("Wave of Rats exists");
+            crate::snapshot::ObjectSnapshot::from_object(object, &game)
+        };
+        let damage = RawEvent::new(
+            DamageEvent::with_cause(rat_id, DamageTarget::Player(bob), 4, true, EventCause::effect()),
+            crate::provenance::ProvNodeId::default(),
+        );
+        game.turn_store
+            .turn_history
+            .record_event(&damage, None, Some(source_snapshot));
+
+        let ctx = ExecutionContext::new_default(rat_id, alice);
+        assert!(
+            evaluate_condition(
+                &game,
+                &Condition::SourceDealtCombatDamageToPlayerThisTurn,
+                &ctx
+            )
+            .expect("source combat-damage condition should evaluate"),
+            "expected Wave of Rats condition to pass after combat damage to a player"
+        );
+    }
+
+    #[test]
+    fn wave_of_rats_condition_false_without_combat_damage_to_player_this_turn() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = game.players[0].id;
+        let source = game.new_object_id();
+        let ctx = ExecutionContext::new_default(source, alice);
+        assert!(
+            !evaluate_condition(
+                &game,
+                &Condition::SourceDealtCombatDamageToPlayerThisTurn,
+                &ctx
+            )
+            .expect("source combat-damage condition should evaluate"),
+            "expected Wave of Rats condition to fail without combat damage"
         );
     }
 }
@@ -792,6 +845,9 @@ fn evaluate_condition_shared_core(
                 .or_else(|| game.object(ctx.source).and_then(|obj| obj.power()))
                 .is_some_and(|power| power >= *min_power as i32),
         ),
+        Condition::SourceDealtCombatDamageToPlayerThisTurn => {
+            Some(game.source_dealt_combat_damage_to_player_this_turn(ctx.source))
+        }
         Condition::SourceMatches(filter) => {
             let filter_ctx = game.filter_context_for(ctx.controller, Some(ctx.source));
             Some(
@@ -905,6 +961,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::SourceHasNoCounter(..) => {}
         Condition::SourceHasCounterAtLeast { .. } => {}
         Condition::SourcePowerAtLeast(..) => {}
+        Condition::SourceDealtCombatDamageToPlayerThisTurn => {}
         Condition::SourceAttackedOrBlockedThisTurn => {}
         Condition::SourceIsInZone(..) => {}
         Condition::ManaSpentToCastThisSpellAtLeast { .. } => {}
@@ -1640,6 +1697,9 @@ pub fn evaluate_condition_external(
         }),
 
         Condition::SourceAttackedThisTurn => game.creature_attacked_this_turn(ctx.source),
+        Condition::SourceDealtCombatDamageToPlayerThisTurn => {
+            game.source_dealt_combat_damage_to_player_this_turn(ctx.source)
+        }
         Condition::SourceCameUnderYourControlThisTurn => {
             game.object(ctx.source).is_some_and(|obj| {
                 game.turn_store
@@ -2379,6 +2439,7 @@ fn evaluate_condition_simple(
         | Condition::CountComparison { .. }
         | Condition::OwnsCardExiledWithCounter(_)
         | Condition::SourceAttackedThisTurn
+        | Condition::SourceDealtCombatDamageToPlayerThisTurn
         | Condition::SourceCameUnderYourControlThisTurn
         | Condition::SourceAttackedOrBlockedThisTurn
         | Condition::SourceIsUntapped
@@ -3440,6 +3501,9 @@ fn evaluate_condition(
             })
         })),
         Condition::SourceAttackedThisTurn => Ok(game.creature_attacked_this_turn(ctx.source)),
+        Condition::SourceDealtCombatDamageToPlayerThisTurn => {
+            Ok(game.source_dealt_combat_damage_to_player_this_turn(ctx.source))
+        }
         Condition::SourceCameUnderYourControlThisTurn => {
             Ok(game.object(ctx.source).is_some_and(|obj| {
                 game.turn_store

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -7833,6 +7833,13 @@ impl GameState {
             .creature_was_damaged_this_turn(creature)
     }
 
+    pub fn source_dealt_combat_damage_to_player_this_turn(&self, source: ObjectId) -> bool {
+        let stable_id = self.object(source).map(|obj| obj.stable_id);
+        self.turn_store
+            .turn_history
+            .source_dealt_combat_damage_to_player_this_turn(source, stable_id)
+    }
+
     /// Clear damage from an object.
     pub fn clear_damage(&mut self, id: ObjectId) {
         self.damage_marked.remove(&id);

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -463,6 +463,28 @@ impl TurnHistory {
         self.total_creature_damage_to_player(player) > 0
     }
 
+    pub fn source_dealt_combat_damage_to_player_this_turn(
+        &self,
+        source: ObjectId,
+        source_stable_id: Option<StableId>,
+    ) -> bool {
+        self.projected_records().any(|record| {
+            record.event.downcast::<DamageEvent>().is_some_and(|event| {
+                event.is_combat
+                    && event.amount > 0
+                    && matches!(event.target, crate::events::DamageTarget::Player(_))
+                    && (event.source == source
+                        || source_stable_id.is_some_and(|stable_id| {
+                            record
+                                .source_snapshot
+                                .as_ref()
+                                .or(record.object_snapshot.as_ref())
+                                .is_some_and(|snapshot| snapshot.stable_id == stable_id)
+                        }))
+            })
+        })
+    }
+
     pub fn player_dealt_combat_damage_to_player_with_subtype_this_turn(
         &self,
         dealer: PlayerId,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wave of Rats
Initial parse error:
```
unsupported predicate (predicate: 'it dealt combat damage to player this turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'it dealt combat damage to player this turn')
```

Worker: i-01fc7b121840d85e5
