### PR TITLE
Fix Ironsmith parse failure: Tekuthal, Inquiry Dominus

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -8036,6 +8036,43 @@ pub(crate) fn parse_keyword_action_replacement_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
     let line_words = parser_token_word_refs(tokens);
+    let proliferate_display = render_token_slice(tokens);
+    if line_words == [
+        "if",
+        "you",
+        "would",
+        "proliferate",
+        "proliferate",
+        "twice",
+        "instead",
+    ] {
+        return Ok(Some(StaticAbility::keyword_action_replacement(
+            crate::events::KeywordActionKind::Proliferate,
+            ObjectFilter::default().controlled_by(PlayerFilter::You),
+            vec![Effect::proliferate(2)],
+            proliferate_display,
+        )));
+    }
+    if line_words == [
+        "if",
+        "an",
+        "opponent",
+        "would",
+        "proliferate",
+        "that",
+        "player",
+        "proliferates",
+        "twice",
+        "instead",
+    ] {
+        return Ok(Some(StaticAbility::keyword_action_replacement(
+            crate::events::KeywordActionKind::Proliferate,
+            ObjectFilter::default().controlled_by(PlayerFilter::Opponent),
+            vec![Effect::proliferate(2)],
+            proliferate_display,
+        )));
+    }
+
     let prefix = [
         "if", "a", "creature", "you", "control", "would", "explore", "instead",
     ];

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1868,6 +1868,20 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if matches!(
         filtered.as_slice(),
+        ["you", "would", "proliferate"]
+            | ["an", "opponent", "would", "proliferate"]
+            | ["opponent", "would", "proliferate"]
+    ) {
+        let player = if filtered[0] == "you" {
+            PlayerAst::You
+        } else {
+            PlayerAst::Opponent
+        };
+        return Ok(PredicateAst::PlayerWouldProliferate { player });
+    }
+
+    if matches!(
+        filtered.as_slice(),
         ["opponent", "would", "begin", "extra", "turn"]
             | ["an", "opponent", "would", "begin", "an", "extra", "turn"]
             | ["opponents", "would", "begin", "extra", "turn"]
@@ -3535,6 +3549,25 @@ mod tests {
 
         let parsed = parse_predicate(&predicate_tokens)?;
         assert_eq!(parsed, PredicateAst::PlayerWouldDrawCard { player: PlayerAst::You });
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_you_would_proliferate() -> Result<(), CardTextError> {
+        let tokens = lex_line("If you would proliferate", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+        assert_eq!(
+            parsed,
+            PredicateAst::PlayerWouldProliferate {
+                player: PlayerAst::You
+            }
+        );
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -1725,7 +1725,15 @@ fn split_activation_cost_segments_tokens(tokens: &[OwnedLexToken]) -> Vec<Vec<Ow
 
         let split_here = if tokens[idx].is_comma() {
             let remainder = &tokens[idx + 1..];
-            !inside_named_card || starts_new_activation_cost_segment_tokens(remainder)
+            let remainder = if remainder
+                .first()
+                .is_some_and(|token| token.is_word("and"))
+            {
+                &remainder[1..]
+            } else {
+                remainder
+            };
+            !inside_named_card && starts_new_activation_cost_segment_tokens(remainder)
         } else if tokens[idx].is_word("and") && idx > start {
             let remainder = &tokens[idx + 1..];
             !inside_named_card && starts_new_activation_cost_segment_tokens(remainder)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -496,6 +496,14 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 _ => "player_would_draw_card",
             })
         }
+        PredicateAst::PlayerWouldProliferate { player } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::Custom(match player {
+                PlayerFilter::You => "you_would_proliferate",
+                PlayerFilter::Opponent => "opponent_would_proliferate",
+                _ => "player_would_proliferate",
+            })
+        }
         PredicateAst::PlayerWouldBeginExtraTurn { player } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::Custom(match player {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -497,6 +497,9 @@ pub(crate) enum PredicateAst {
     PlayerWouldDrawCard {
         player: PlayerAst,
     },
+    PlayerWouldProliferate {
+        player: PlayerAst,
+    },
     PlayerWouldBeginExtraTurn {
         player: PlayerAst,
     },

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -179,7 +179,10 @@ fn parse_proliferate(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextErro
     let trailing_words = crate::runtime_backend::token_word_refs(&trailing);
     let trailing_ok = trailing_words.is_empty()
         || trailing_words.as_slice() == ["time"]
-        || trailing_words.as_slice() == ["times"];
+        || trailing_words.as_slice() == ["times"]
+        || trailing_words.as_slice() == ["instead"]
+        || trailing_words.as_slice() == ["time", "instead"]
+        || trailing_words.as_slice() == ["times", "instead"];
     if !trailing_ok {
         return Err(CardTextError::ParseError(format!(
             "unsupported trailing proliferate clause (clause: '{}')",

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12157,6 +12157,32 @@ fn rewrite_activation_cost_token_entrypoint_parses_counter_variants() {
 }
 
 #[test]
+fn rewrite_activation_cost_parser_keeps_among_list_with_commas_in_one_segment() {
+    let tokens = lex_line(
+        "Remove three counters from among other artifacts, creatures, and planeswalkers you control",
+        0,
+    )
+    .expect("lexer should classify Tekuthal remove-counter activation cost");
+    let cst = parse_activation_cost_tokens_rewrite(&tokens)
+        .expect("activation-cost parser should keep among-list as one segment");
+    let [super::ActivationCostSegmentCst::RemoveCountersAmong {
+        counter_type: None,
+        count: 3,
+        filter_text,
+        display_x: false,
+        dynamic: false,
+    }] = cst.segments.as_slice()
+    else {
+        panic!("unexpected segments: {:?}", cst.segments);
+    };
+    assert!(
+        filter_text == "other artifacts, creatures, and planeswalkers you control"
+            || filter_text == "other artifacts creatures and planeswalkers you control",
+        "unexpected filter text: {filter_text}"
+    );
+}
+
+#[test]
 fn rewrite_activation_cost_shared_parser_supports_behold_costs() {
     let cst = parse_activation_cost_rewrite("Behold an Elemental")
         .expect("shared activation-cost parser should support behold costs");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -206,7 +206,7 @@ fn day_of_the_moon_chapter_resolution_goads_only_chosen_name() {
     let bob = PlayerId::from_index(1);
     let mut game =
         crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
-    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let _source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
     let memnite = CardDefinitionBuilder::new(CardId::from_raw(91_001), "Memnite")
         .card_types(vec![CardType::Artifact, CardType::Creature])
         .power_toughness(PowerToughness::fixed(1, 1))
@@ -33365,6 +33365,89 @@ fn proud_pack_rhino_proliferate_mode_increases_selected_counters() {
     assert_eq!(
         game.players[1].poison_counters, 2,
         "selected player should get another poison counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_tekuthal_inquiry_dominus_compiles_strictly() {
+    let def = parse_oracle_card_definition("Tekuthal, Inquiry Dominus");
+    let rendered = canonical_compiled_lines(&def).join("\n").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("if you would proliferate, proliferate twice instead"),
+        "expected Tekuthal replacement clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("remove 3 counters from among other artifacts, creatures, and planeswalkers you control"),
+        "expected Tekuthal activated cost in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tekuthal_activation_cost_targets_other_countered_permanents_only() {
+    use crate::ability::AbilityKind;
+    let def = parse_oracle_card_definition("Tekuthal, Inquiry Dominus");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(98_001), "Other Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Tekuthal should have an activated ability");
+    let cost_text = activated.mana_cost.display().to_ascii_lowercase();
+    assert!(
+        cost_text.contains("remove 3 counters from among other artifacts, creatures, and planeswalkers you control"),
+        "Tekuthal activation cost should preserve among-other list, got {cost_text}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tekuthal_activated_effect_puts_indestructible_counter_on_source() {
+    use crate::ability::AbilityKind;
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let def = parse_oracle_card_definition("Tekuthal, Inquiry Dominus");
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Tekuthal should have an activated ability");
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Tekuthal activated effect should resolve");
+    }
+
+    assert_eq!(
+        game.object(source).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::Indestructible)
+            .copied()),
+        Some(1),
+        "Tekuthal activated effect should put an indestructible counter on Tekuthal"
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -206,7 +206,7 @@ fn day_of_the_moon_chapter_resolution_goads_only_chosen_name() {
     let bob = PlayerId::from_index(1);
     let mut game =
         crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
-    let _source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
     let memnite = CardDefinitionBuilder::new(CardId::from_raw(91_001), "Memnite")
         .card_types(vec![CardType::Artifact, CardType::Creature])
         .power_toughness(PowerToughness::fixed(1, 1))
@@ -33392,7 +33392,7 @@ fn tekuthal_activation_cost_targets_other_countered_permanents_only() {
     let mut game =
         crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
     let alice = PlayerId::from_index(0);
-    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let _source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
     game.create_object_from_definition(
         &CardDefinitionBuilder::new(CardId::from_raw(98_001), "Other Artifact")
             .card_types(vec![CardType::Artifact])
@@ -33448,6 +33448,71 @@ fn tekuthal_activated_effect_puts_indestructible_counter_on_source() {
             .copied()),
         Some(1),
         "Tekuthal activated effect should put an indestructible counter on Tekuthal"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tekuthal_replacement_makes_single_proliferate_happen_twice() {
+    struct SelectSameTargetsTwice {
+        permanent: ObjectId,
+        player: PlayerId,
+    }
+
+    impl crate::decision::DecisionMaker for SelectSameTargetsTwice {
+        fn decide_proliferate(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::ProliferateContext,
+        ) -> crate::decisions::specs::ProliferateResponse {
+            crate::decisions::specs::ProliferateResponse {
+                permanents: vec![self.permanent],
+                players: vec![self.player],
+            }
+        }
+    }
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let tekuthal = parse_oracle_card_definition("Tekuthal, Inquiry Dominus");
+    let proliferate_source = game.create_object_from_definition(&tekuthal, alice, Zone::Battlefield);
+    let countered_creature = CardDefinitionBuilder::new(CardId::from_raw(98_101), "Countered Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let countered_id = game.create_object_from_definition(&countered_creature, alice, Zone::Battlefield);
+    assert!(
+        game.add_counters(countered_id, crate::object::CounterType::PlusOnePlusOne, 1)
+            .is_some(),
+        "countered creature should be on the battlefield"
+    );
+    game.players[1].poison_counters = 1;
+
+    let mut dm = SelectSameTargetsTwice {
+        permanent: countered_id,
+        player: bob,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(proliferate_source, alice, &mut dm);
+    crate::effects::execute_effect(
+        &mut game,
+        &crate::effect::Effect::proliferate(1),
+        &mut ctx,
+    )
+    .expect("proliferate should resolve");
+
+    assert_eq!(
+        game.object(countered_id).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()),
+        Some(3),
+        "Tekuthal replacement should apply proliferate twice"
+    );
+    assert_eq!(
+        game.players[1].poison_counters, 3,
+        "Tekuthal replacement should apply proliferate to players twice"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11230,6 +11230,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::XValueAtLeast(min) => format!("X is {min} or more"),
         Condition::Custom(id) => match *id {
+            "you_would_proliferate" => "you would proliferate".to_string(),
+            "opponent_would_proliferate" => "an opponent would proliferate".to_string(),
+            "player_would_proliferate" => "a player would proliferate".to_string(),
             "opponent_would_begin_extra_turn" => {
                 "an opponent would begin an extra turn".to_string()
             }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -23946,6 +23946,21 @@ pub(super) fn describe_conditional_replacement_instead(
     let true_branch = describe_effect_clause_list(&conditional.if_true)
         .unwrap_or_else(|| describe_effect_list(&conditional.if_true));
     let true_branch = true_branch.trim().trim_end_matches('.');
+    let condition_lower = condition.to_ascii_lowercase();
+    if (condition_lower == "you would proliferate"
+        || condition_lower == "an opponent would proliferate"
+        || condition_lower == "a player would proliferate")
+        && true_branch.to_ascii_lowercase().starts_with("proliferate")
+        && !true_branch.to_ascii_lowercase().contains(" instead")
+    {
+        let branch = if let Some(rest) = true_branch.strip_prefix("Proliferate") {
+            format!("proliferate{rest}")
+        } else {
+            true_branch.to_string()
+        };
+        return Some(format!("If {condition}, {branch} instead"));
+    }
+
     if true_branch.is_empty()
         || !true_branch.to_ascii_lowercase().starts_with("exile ")
         || true_branch.to_ascii_lowercase().contains(" instead")

--- a/crates/ironsmith-runtime/src/effects/counters/proliferate.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/proliferate.rs
@@ -6,11 +6,79 @@ use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_value;
 use crate::effects::{ExecutionContext, ExecutionError};
-use crate::events::{KeywordActionEvent, KeywordActionKind};
+use crate::events::processing::{TraitEventResult, process_trait_event_with_dm_and_applied_effects};
+use crate::events::{Event, KeywordActionEvent, KeywordActionKind};
 use crate::game_state::GameState;
 use crate::object::CounterType;
+use crate::snapshot::ObjectSnapshot;
 use crate::triggers::TriggerEvent;
 pub use ironsmith_core::ProliferateEffect;
+
+fn execute_keyword_action_replacement_effects(
+    game: &mut GameState,
+    ctx: &mut ExecutionContext,
+    effects: Vec<crate::effect::Effect>,
+    effect_id: crate::replacement::ReplacementEffectId,
+    action_snapshot: Option<ObjectSnapshot>,
+) -> Result<EffectOutcome, ExecutionError> {
+    let replacement_effect = game
+        .effect_store
+        .replacement_effects
+        .get_effect(effect_id)
+        .cloned();
+    let replacement_key = replacement_effect.as_ref().map(|effect| effect.application_key());
+    let was_suppressed = !ctx
+        .replacement
+        .suppressed_replacement_effects
+        .insert(effect_id);
+    let key_was_suppressed = if let Some(key) = replacement_key.as_ref() {
+        !ctx.replacement
+            .suppressed_replacement_effect_keys
+            .insert(key.clone())
+    } else {
+        true
+    };
+
+    let original_it = ctx.clear_object_tag("__it__");
+    let original_plain_it = ctx.clear_object_tag("it");
+    if let Some(snapshot) = action_snapshot {
+        ctx.set_tagged_objects("__it__", vec![snapshot.clone()]);
+        ctx.set_tagged_objects("it", vec![snapshot]);
+    }
+
+    let result = (|| -> Result<EffectOutcome, ExecutionError> {
+        let mut outcomes = Vec::new();
+        for effect in effects {
+            outcomes.push(crate::effects::execute_effect(game, &effect, ctx)?);
+        }
+        Ok(EffectOutcome::aggregate_summing_counts(outcomes))
+    })();
+
+    if !was_suppressed {
+        ctx.replacement
+            .suppressed_replacement_effects
+            .remove(&effect_id);
+    }
+    if !key_was_suppressed && let Some(key) = replacement_key {
+        ctx.replacement
+            .suppressed_replacement_effect_keys
+            .remove(&key);
+    }
+    match original_it {
+        Some(snapshots) => ctx.set_tagged_objects("__it__", snapshots),
+        None => {
+            ctx.clear_object_tag("__it__");
+        }
+    }
+    match original_plain_it {
+        Some(snapshots) => ctx.set_tagged_objects("it", snapshots),
+        None => {
+            ctx.clear_object_tag("it");
+        }
+    }
+
+    result
+}
 
 /// Effect that proliferates (adds counters to permanents/players with counters).
 ///
@@ -38,6 +106,39 @@ impl EffectExecutor for ProliferateEffect {
         let mut action_events = Vec::with_capacity(count);
 
         for _ in 0..count {
+            let would_event = Event::new_with_provenance(
+                KeywordActionEvent::new(KeywordActionKind::Proliferate, ctx.controller, ctx.source, 1),
+                ctx.provenance,
+            );
+            let applied_effects = ctx.replacement.suppressed_replacement_effects.clone();
+            let applied_effect_keys = ctx.replacement.suppressed_replacement_effect_keys.clone();
+            if applied_effects.is_empty() && applied_effect_keys.is_empty() {
+                game.update_replacement_effects();
+            }
+            match process_trait_event_with_dm_and_applied_effects(
+                game,
+                would_event,
+                ctx.decision_maker,
+                &applied_effects,
+                &applied_effect_keys,
+            ) {
+                TraitEventResult::Replaced { effects, effect_id } => {
+                    let snapshot = game
+                        .object(ctx.source)
+                        .map(|object| ObjectSnapshot::from_object(object, game));
+                    let replacement_outcome = execute_keyword_action_replacement_effects(
+                        game, ctx, effects, effect_id, snapshot,
+                    )?;
+                    outcome = outcome.with_events(replacement_outcome.events);
+                    continue;
+                }
+                TraitEventResult::Prevented => continue,
+                TraitEventResult::NeedsChoice { .. } | TraitEventResult::NeedsInteraction { .. } => {
+                    return Ok(outcome);
+                }
+                TraitEventResult::Proceed(_) | TraitEventResult::Modified(_) => {}
+            }
+
             let mut proliferated_count = 0;
             let mut proliferated_permanents = Vec::new();
 

--- a/crates/ironsmith-runtime/src/effects/counters/remove_any_counters_among.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/remove_any_counters_among.rs
@@ -367,6 +367,20 @@ fn counter_article(counter_name: &str) -> &'static str {
 }
 
 fn remove_counters_target_phrase(filter: &ObjectFilter, plural: bool) -> String {
+    fn join_type_names(names: &[String]) -> String {
+        match names.len() {
+            0 => String::new(),
+            1 => names[0].clone(),
+            2 => format!("{} and {}", names[0], names[1]),
+            _ => {
+                let mut out = names[..names.len() - 1].join(", ");
+                out.push_str(", and ");
+                out.push_str(&names[names.len() - 1]);
+                out
+            }
+        }
+    }
+
     if filter.source {
         if plural {
             return "this source".to_string();
@@ -399,8 +413,9 @@ fn remove_counters_target_phrase(filter: &ObjectFilter, plural: bool) -> String 
         } else {
             card_type.name()
         };
+        let other_prefix = if filter.other && plural { "other " } else { "" };
         return if plural {
-            format!("{noun} you control")
+            format!("{other_prefix}{noun} you control")
         } else {
             format!("a {noun} you control")
         };
@@ -413,14 +428,24 @@ fn remove_counters_target_phrase(filter: &ObjectFilter, plural: bool) -> String 
             "a permanent".to_string()
         }
     } else {
-        let joined = filter
+        let type_names = filter
             .card_types
             .iter()
-            .map(|card_type| card_type.name().to_ascii_lowercase())
-            .collect::<Vec<_>>()
-            .join(" or ");
+            .map(|card_type| {
+                if plural {
+                    card_type.plural_name().to_ascii_lowercase()
+                } else {
+                    card_type.name().to_ascii_lowercase()
+                }
+            })
+            .collect::<Vec<_>>();
+        let joined = join_type_names(&type_names);
         if plural {
-            format!("{joined}s")
+            if filter.other {
+                format!("other {joined}")
+            } else {
+                joined
+            }
         } else {
             format!("a {joined}")
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tekuthal, Inquiry Dominus
Initial parse error:
```
unsupported trailing proliferate clause (clause: 'twice instead'); oracle-only fallback also failed: unsupported trailing proliferate clause (clause: 'twice instead')
```

Worker: i-034e5d4cd88af8852
