### PR TITLE
Fix Ironsmith parse failure: Overpowering Attack

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -260,6 +260,25 @@ pub(super) fn lower_alternative_cast(
         ));
     }
 
+    if line.text.trim_start().starts_with("Freerunning ") {
+        let raw_tokens = lex_line(line.text.as_str(), line.info.line_index)?;
+        let cost_tokens = raw_tokens.get(1..).unwrap_or_default();
+        let (cost, _) = leading_mana_cost_from_tokens(cost_tokens).ok_or_else(|| {
+            CardTextError::ParseError(format!("freerunning keyword missing cost '{}'", line.text))
+        })?;
+        return Ok(LineAst::AlternativeCastingMethod(
+            crate::alternative_cast::AlternativeCastingMethod::alternative_cost_with_condition(
+                "Freerunning",
+                Some(cost),
+                Vec::new(),
+                crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(
+                    crate::types::Subtype::Assassin,
+                ),
+            )
+            .into(),
+        ));
+    }
+
     let line_text = line.text.to_ascii_lowercase();
     if line_text.contains("from your graveyard") && line_text.contains("using its blitz ability") {
         return Ok(LineAst::Abilities(vec![

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -4558,6 +4558,28 @@ pub(crate) fn parse_this_spell_cost_condition(
         }
     }
 
+    if slice_starts_with(
+        &w,
+        &[
+            "you",
+            "dealt",
+            "combat",
+            "damage",
+            "to",
+            "a",
+            "player",
+            "this",
+            "turn",
+            "with",
+            "an",
+            "assassin",
+            "or",
+            "commander",
+        ],
+    ) {
+        return Some(ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(Subtype::Assassin));
+    }
+
     if let Some(condition_expr) = parse_conjoined_this_spell_cost_condition(tokens) {
         return Some(ThisSpellCostCondition::ConditionExpr {
             condition: condition_expr,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -1,7 +1,9 @@
 use super::line_family_handlers::{
+    run_additional_combat_after_this_phase_line_family,
     run_activation_line_family, run_champion_line_family,
     run_championed_with_this_trigger_line_family, run_colon_nonactivation_statement_line_family,
     run_combined_static_line_family, run_escape_enters_with_counter_line_family,
+    run_freerunning_line_family,
     run_graveyard_cast_control_condition_line_family, run_keyword_line_family,
     run_labeled_line_family, run_learn_line_family,
     run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
@@ -47,7 +49,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 25] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 27] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -139,6 +141,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 25] = [
         run: run_surge_line_family,
     },
     LineFamilyRuleDef {
+        id: "freerunning-line",
+        priority: 43,
+        heads: &["freerunning"],
+        run: run_freerunning_line_family,
+    },
+    LineFamilyRuleDef {
         id: "keyword-line",
         priority: 40,
         heads: &[],
@@ -173,6 +181,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 25] = [
         priority: 76,
         heads: &["you"],
         run: run_graveyard_cast_control_condition_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "additional-combat-after-this-phase",
+        priority: 77,
+        heads: &[],
+        run: run_additional_combat_after_this_phase_line_family,
     },
     LineFamilyRuleDef {
         id: "statement-probe",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -647,12 +647,87 @@ pub(super) fn run_surge_line_family(
     )))
 }
 
+pub(super) fn run_freerunning_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let Some(rest) = raw.strip_prefix("Freerunning ") else {
+        return Ok(None);
+    };
+    let cost_text = rest
+        .split_once('(')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(rest)
+        .trim()
+        .trim_end_matches('.')
+        .trim();
+    if cost_text.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "freerunning keyword missing cost: '{}'",
+            ctx.line.info.raw_line
+        )));
+    }
+
+    let rewritten = format!(
+        "If you dealt combat damage to a player this turn with an Assassin or commander, you may pay {cost_text} rather than pay this spell's mana cost."
+    );
+    let alternative_line = rewrite_line_normalized(ctx.line, rewritten.as_str())?;
+    let Some(mut keyword) = parse_keyword_line_cst(&alternative_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower freerunning keyword line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    keyword.text = ctx.line.info.raw_line.clone();
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Keyword(keyword),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_keyword_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     Ok(parse_keyword_line_cst(ctx.line)?.map(|keyword_line| {
         LineDispatchResult::single(RewriteLineCst::Keyword(keyword_line), ctx.idx + 1)
     }))
+}
+
+pub(super) fn run_additional_combat_after_this_phase_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let needle =
+        "there is an additional combat phase after this phase, followed by an additional main phase";
+    let raw = ctx.line.info.raw_line.trim();
+    if !raw.to_ascii_lowercase().contains(needle) {
+        return Ok(None);
+    }
+
+    let rewritten = raw
+        .replace(
+            "If it's your main phase, there is an additional combat phase after this phase, followed by an additional main phase",
+            "After this main phase, there is an additional combat phase followed by an additional main phase",
+        )
+        .replace(
+            "if it's your main phase, there is an additional combat phase after this phase, followed by an additional main phase",
+            "after this main phase, there is an additional combat phase followed by an additional main phase",
+        )
+        .replace(
+            "there is an additional combat phase after this phase, followed by an additional main phase",
+            "after this main phase, there is an additional combat phase followed by an additional main phase",
+        );
+    let rewritten_line = rewrite_line_normalized(ctx.line, rewritten.as_str())?;
+    let Some(statement_line) = parse_statement_line_cst(&rewritten_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower additional-combat-after-this-phase line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Statement(statement_line),
+        ctx.idx + 1,
+    )))
 }
 
 pub(super) fn run_ward_or_echo_static_prefix_line_family(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1654,6 +1654,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_document_cst_rewrites_freerunning_keyword_line_to_alternative_cost()
+    -> Result<(), CardTextError> {
+        let preprocessed = preprocess_document(
+            CardDefinitionBuilder::new(CardId::new(), "Freerunning Parse Test")
+                .card_types(vec![CardType::Sorcery]),
+            "Freerunning {2}{R} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nUntap all creatures you control that attacked this turn.",
+        )?;
+        let cst = super::parse_document_cst(&preprocessed, false)?;
+
+        match cst.lines.as_slice() {
+            [
+                super::RewriteLineCst::Keyword(keyword),
+                super::RewriteLineCst::Statement(_),
+            ] => {
+                assert_eq!(keyword.kind, KeywordLineKindCst::AlternativeCast);
+                assert_eq!(
+                    render_token_slice(&keyword.parse_tokens),
+                    "If you dealt combat damage to a player this turn with an Assassin or commander, you may pay {2}{R} rather than pay this spell's mana cost."
+                );
+            }
+            other => panic!("expected freerunning keyword plus statement line, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn static_line_cst_recognizes_compound_unblockable_from_tokens() -> Result<(), CardTextError> {
         let line = single_preprocessed_line("Enchanted creature gets +2/+2 and can't be blocked.");
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -5530,6 +5530,29 @@ pub(crate) fn parse_if_conditional_alternative_cost_line(
     } else {
         let condition_words_view = UtilWordView::new(&condition_tokens);
         let condition_words = condition_words_view.to_word_refs();
+        if words_have_prefix(
+            condition_words.as_slice(),
+            &[
+                "you",
+                "dealt",
+                "combat",
+                "damage",
+                "to",
+                "a",
+                "player",
+                "this",
+                "turn",
+                "with",
+                "an",
+                "assassin",
+                "or",
+                "commander",
+            ],
+        ) {
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(
+                crate::types::Subtype::Assassin,
+            )
+        } else
         if (words_have_prefix(
             condition_words.as_slice(),
             &["youve", "been", "dealt", "damage", "by"],

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/delayed_step_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/delayed_step_family.rs
@@ -728,21 +728,6 @@ pub(crate) fn parse_sentence_fallback_mechanic_marker(
         || grammar::words_match_prefix(
             tokens,
             &[
-                "there",
-                "is",
-                "an",
-                "additional",
-                "combat",
-                "phase",
-                "after",
-                "this",
-                "phase",
-            ],
-        )
-        .is_some()
-        || grammar::words_match_prefix(
-            tokens,
-            &[
                 "that",
                 "creature",
                 "attacks",

--- a/crates/ironsmith-core/src/spell_cost_condition_model.rs
+++ b/crates/ironsmith-core/src/spell_cost_condition_model.rs
@@ -50,4 +50,5 @@ pub enum ThisSpellCostCondition {
     CreatureCardPutIntoYourGraveyardThisTurn,
     CreatureIsAttackingYou,
     YouDealtCombatDamageToPlayerWithSubtypeThisTurn(Subtype),
+    YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(Subtype),
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42915,6 +42915,48 @@ fn loot_the_key_to_everything_runtime_count_uses_distinct_card_types_among_other
 }
 
 #[test]
+fn parse_oracle_overpowering_attack_supports_freerunning_keyword_line() {
+    let def = parse_oracle_card_definition("Overpowering Attack");
+    assert!(
+        !def.alternative_casts.is_empty(),
+        "Overpowering Attack should compile with a freerunning alternative cost"
+    );
+
+    let has_freerunning = def.alternative_casts.iter().any(|method| {
+        method.name().eq_ignore_ascii_case("Freerunning")
+            && matches!(
+                method.cast_condition(),
+                Some(
+                    crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(
+                        Subtype::Assassin
+                    )
+                )
+            )
+    });
+    assert!(
+        has_freerunning,
+        "Overpowering Attack should encode Freerunning with Assassin-or-commander combat damage condition"
+    );
+}
+
+#[test]
+fn overpowering_attack_compiled_text_keeps_freerunning_and_extra_combat_clause() {
+    let def = parse_oracle_card_definition("Overpowering Attack");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Freerunning {2}{R}"),
+        "expected Overpowering Attack to render the freerunning keyword cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "After this main phase, there is an additional combat phase followed by an additional main phase"
+        ),
+        "expected Overpowering Attack to keep additional combat/main phase clause, got {rendered}"
+    );
+}
+
+#[test]
 fn loot_the_key_to_everything_runtime_count_zero_without_other_nonlands() {
     let def = parse_oracle_card_definition("Loot, the Key to Everything");
     let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1756,6 +1756,17 @@ pub(super) fn describe_alternative_cast_line(
                 })
                 .unwrap_or_else(|| "Surge".to_string())
         }
+        method if method.is_composed_cost() && method.name().eq_ignore_ascii_case("Freerunning") => {
+            method
+                .mana_cost()
+                .map(|cost| {
+                    format!(
+                        "Freerunning {} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)",
+                        cost.to_oracle()
+                    )
+                })
+                .unwrap_or_else(|| "Freerunning".to_string())
+        }
         method if method.is_composed_cost() && method.name().eq_ignore_ascii_case("Prowl") => {
             method
                 .mana_cost()

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -2134,6 +2134,121 @@ mod tests {
     }
 
     #[test]
+    fn overpowering_attack_freerunning_condition_accepts_assassin_or_commander_combat_damage() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let spell = CardBuilder::new(CardId::from_raw(9510), "Overpowering Attack")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_symbols(vec![
+                ManaSymbol::Generic(3),
+                ManaSymbol::Red,
+                ManaSymbol::Red,
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+        let freerunning_condition = crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(Subtype::Assassin);
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Fixed(2),
+            freerunning_condition,
+        ));
+        game.object_mut(spell_id)
+            .expect("Overpowering Attack should exist")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let spell_obj = game.object(spell_id).expect("Overpowering Attack should exist");
+        let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
+        let initial_cost = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            initial_cost.to_oracle(),
+            "{3}{R}{R}",
+            "freerunning condition should be false before combat damage"
+        );
+
+        let wizard = CardBuilder::new(CardId::from_raw(9511), "Wizard Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Wizard])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let wizard_id = game.create_object_from_card(&wizard, alice, Zone::Battlefield);
+        stage_combat_damage_to_player_for_test(&mut game, wizard_id, bob, 2);
+
+        let spell_obj = game.object(spell_id).expect("Overpowering Attack should exist");
+        let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
+        let wizard_only_cost = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            wizard_only_cost.to_oracle(),
+            "{3}{R}{R}",
+            "freerunning should remain unavailable after non-Assassin non-commander combat damage"
+        );
+
+        let assassin = CardBuilder::new(CardId::from_raw(9512), "Assassin Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Assassin])
+            .power_toughness(PowerToughness::fixed(2, 1))
+            .build();
+        let assassin_id = game.create_object_from_card(&assassin, alice, Zone::Battlefield);
+        stage_combat_damage_to_player_for_test(&mut game, assassin_id, bob, 2);
+
+        let spell_obj = game.object(spell_id).expect("Overpowering Attack should exist");
+        let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
+        let assassin_cost = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            assassin_cost.to_oracle(),
+            "{1}{R}{R}",
+            "freerunning should apply after Assassin combat damage"
+        );
+    }
+
+    #[test]
+    fn overpowering_attack_freerunning_condition_accepts_commander_combat_damage() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let spell = CardBuilder::new(CardId::from_raw(9513), "Overpowering Attack")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_symbols(vec![
+                ManaSymbol::Generic(3),
+                ManaSymbol::Red,
+                ManaSymbol::Red,
+            ]))
+            .build();
+        let spell_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+        let ability = StaticAbility::new(crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Fixed(2),
+            crate::static_abilities::ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(Subtype::Assassin),
+        ));
+        game.object_mut(spell_id)
+            .expect("Overpowering Attack should exist")
+            .abilities
+            .push(Ability::static_ability(ability));
+
+        let soldier = CardBuilder::new(CardId::from_raw(9514), "Commander Test Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Soldier])
+            .power_toughness(PowerToughness::fixed(3, 3))
+            .build();
+        let commander_id = game.create_object_from_card(&soldier, alice, Zone::Battlefield);
+        game.set_commander(commander_id);
+        game.player_mut(alice)
+            .expect("player exists")
+            .set_commanders(vec![commander_id]);
+        stage_combat_damage_to_player_for_test(&mut game, commander_id, bob, 3);
+
+        let spell_obj = game.object(spell_id).expect("Overpowering Attack should exist");
+        let base_cost = spell_obj.mana_cost.as_ref().expect("spell has mana cost");
+        let commander_cost = calculate_effective_mana_cost(&game, alice, spell_obj, base_cost);
+        assert_eq!(
+            commander_cost.to_oracle(),
+            "{1}{R}{R}",
+            "freerunning should apply after commander combat damage"
+        );
+    }
+
+    #[test]
     fn this_spell_cost_reduction_supports_devotion_where_x_is_clause() {
         let mut game = setup_game();
         let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -1229,6 +1229,12 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
                 subtype.to_string().to_ascii_lowercase()
             ))
         }
+        ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(
+            subtype,
+        ) => Some(format!(
+            "you dealt combat damage to a player this turn with a {} or commander",
+            subtype.to_string().to_ascii_lowercase()
+        )),
     }
 }
 
@@ -1621,6 +1627,15 @@ pub fn this_spell_cost_condition_is_active_for_cast_with_optional_costs_paid(
             .turn_store
             .turn_history
             .player_dealt_combat_damage_to_player_with_subtype_this_turn(controller, *subtype),
+        ThisSpellCostCondition::YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(
+            subtype,
+        ) => game
+            .turn_store
+            .turn_history
+            .player_dealt_combat_damage_to_player_with_subtype_or_commander_this_turn(
+                controller,
+                *subtype,
+            ),
     }
 }
 

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -491,6 +491,34 @@ impl TurnHistory {
         })
     }
 
+    pub fn player_dealt_combat_damage_to_player_with_subtype_or_commander_this_turn(
+        &self,
+        dealer: PlayerId,
+        subtype: Subtype,
+    ) -> bool {
+        self.projected_records().any(|record| {
+            let Some(event) = record.event.downcast::<DamageEvent>() else {
+                return false;
+            };
+            if !event.is_combat || event.amount == 0 {
+                return false;
+            }
+            if !matches!(event.target, crate::events::DamageTarget::Player(_)) {
+                return false;
+            }
+
+            record
+                .source_snapshot
+                .as_ref()
+                .or(record.object_snapshot.as_ref())
+                .is_some_and(|snapshot| {
+                    snapshot.controller == dealer
+                        && snapshot.card_types.contains(&CardType::Creature)
+                        && (snapshot.subtypes.contains(&subtype) || snapshot.is_commander)
+                })
+        })
+    }
+
     pub fn creature_was_damaged_by_source_this_turn(
         &self,
         creature: ObjectId,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Overpowering Attack
Initial parse error:
```
parser does not yet support line family: 'Freerunning {2}{R} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)'; oracle-only fallback also failed: parser does not yet support line family: 'Freerunning {2}{R}'
```

Worker: i-05b75878df05d1861
