### PR TITLE
Fix Ironsmith parse failure: Sharpened Pitchfork

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2256,6 +2256,46 @@ pub(crate) fn parse_static_condition_clause(
     if clause_words == ["equipped", "creature", "is", "attacking"] {
         return Ok(crate::ConditionExpr::EquippedCreatureAttacking);
     }
+    if clause_words.len() >= 4
+        && clause_words[0] == "equipped"
+        && clause_words[1] == "creature"
+        && clause_words[2] == "is"
+    {
+        let mut descriptor_words = &clause_words[3..];
+        if descriptor_words.first().is_some_and(|word| is_article(word)) {
+            descriptor_words = &descriptor_words[1..];
+        }
+
+        if descriptor_words.len() == 1 {
+            let descriptor = descriptor_words[0];
+            let mut filter = ObjectFilter::creature()
+                .match_tagged(crate::TagKey::from("equipped"), crate::target::TaggedOpbjectRelation::IsTaggedObject);
+            if let Some(color) = parse_color(descriptor) {
+                filter.colors = Some(color);
+                return Ok(crate::ConditionExpr::CountComparison {
+                    count: AnthemCountExpression::MatchingFilter(filter),
+                    comparison: crate::effect::Comparison::GreaterThanOrEqual(1),
+                    display: Some(clause_words.join(" ")),
+                });
+            }
+            if let Some(subtype) = parse_subtype_flexible(descriptor) {
+                filter = filter.with_subtype(subtype);
+                return Ok(crate::ConditionExpr::CountComparison {
+                    count: AnthemCountExpression::MatchingFilter(filter),
+                    comparison: crate::effect::Comparison::GreaterThanOrEqual(1),
+                    display: Some(clause_words.join(" ")),
+                });
+            }
+            if let Some(card_type) = parse_card_type(descriptor) {
+                filter.card_types.push(card_type);
+                return Ok(crate::ConditionExpr::CountComparison {
+                    count: AnthemCountExpression::MatchingFilter(filter),
+                    comparison: crate::effect::Comparison::GreaterThanOrEqual(1),
+                    display: Some(clause_words.join(" ")),
+                });
+            }
+        }
+    }
     if clause_words == ["it", "is", "attacking"]
         || clause_words == ["its", "attacking"]
         || clause_words == ["this", "creature", "is", "attacking"]

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -12733,6 +12733,42 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn sharpened_pitchfork_parses_with_human_equipped_condition() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Sharpened Pitchfork")
+            .parse_text(
+                "Equipped creature has first strike.\nAs long as equipped creature is a Human, it gets +1/+1.\nEquip {1}",
+            )
+            .expect("Sharpened Pitchfork should parse");
+
+        let displays = def
+            .abilities
+            .iter()
+            .filter_map(|ability| match &ability.kind {
+                AbilityKind::Static(static_ability) => Some(static_ability.display()),
+                AbilityKind::Activated(_) => crate::ability::ability_surface_text_for_tests(ability),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            displays
+                .iter()
+                .any(|display| display.to_ascii_lowercase().contains("equipped creature has first strike")),
+            "missing first-strike static grant in displays: {displays:?}"
+        );
+        assert!(
+            displays
+                .iter()
+                .any(|display| display.contains("as long as equipped creature is a human")),
+            "missing human equipped-creature condition in displays: {displays:?}"
+        );
+        assert!(
+            displays.iter().any(|display| display == "Equip {1}"),
+            "missing equip activation in displays: {displays:?}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_static_condition_its_attacking() {
         let def = CardDefinitionBuilder::new(CardId::new(), "Kitesail Corsair Variant")
             .parse_text("This creature has flying as long as it's attacking.")

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -710,6 +710,15 @@ pub(super) fn merge_adjacent_subject_predicate_lines(lines: Vec<String>) -> Vec<
             }
             let left_raw = left_rest.trim_end_matches('.').trim();
             let right_raw = right_rest.trim_end_matches('.').trim();
+            let has_conditional_tail = |text: &str| {
+                let lower = text.to_ascii_lowercase();
+                lower.contains(" as long as ") || lower.contains(" for as long as ")
+            };
+            if has_conditional_tail(left_raw) || has_conditional_tail(right_raw) {
+                merged.push(lines[idx].clone());
+                idx += 1;
+                continue;
+            }
             let is_trait = |verb: &str| matches!(verb, "has" | "have" | "gains" | "gain");
             if is_trait(left_verb) && is_trait(right_verb) {
                 let left_lower = left_raw.to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -788,6 +788,23 @@ mod tests {
     }
 
     #[test]
+    fn equipped_keyword_and_conditional_pt_bonus_keep_separate_lines() {
+        let lines = merge_ast_surface_lines(vec![
+            "Equipped creature has first strike.".to_string(),
+            "Equipped creature gets +1/+1 as long as equipped creature is a human.".to_string(),
+        ]);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Equipped creature has first strike.".to_string(),
+                "Equipped creature gets +1/+1 as long as equipped creature is a human."
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn each_creature_turn_pump_and_keyword_merge_to_plural_subject() {
         let lines = merge_ast_surface_lines(vec![
             "Each creature you control gets +1/+0 as long as it's your turn.".to_string(),

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9233,6 +9233,34 @@ fn describe_attached_object_color_condition(tag: &TagKey, filter: &ObjectFilter)
     Some(format!("{subject} is {color_text}"))
 }
 
+fn describe_attached_object_type_condition(tag: &TagKey, filter: &ObjectFilter) -> Option<String> {
+    let subject = match tag.as_str() {
+        "enchanted" => "enchanted creature",
+        "equipped" => "equipped creature",
+        _ => return None,
+    };
+
+    if filter.subtypes.len() == 1 {
+        let subtype = format!("{:?}", filter.subtypes[0]).to_ascii_lowercase();
+        let mut bare = filter.clone();
+        bare.subtypes.clear();
+        if bare == ObjectFilter::default() {
+            return Some(format!("{subject} is {}", with_indefinite_article(&subtype)));
+        }
+    }
+
+    if filter.card_types.len() == 1 {
+        let card_type = filter.card_types[0].to_string().to_ascii_lowercase();
+        let mut bare = filter.clone();
+        bare.card_types.clear();
+        if bare == ObjectFilter::default() {
+            return Some(format!("{subject} is {}", with_indefinite_article(&card_type)));
+        }
+    }
+
+    None
+}
+
 pub(super) fn describe_until(until: &Until) -> String {
     match until {
         Until::Forever => "forever".to_string(),
@@ -10677,6 +10705,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             if let Some(condition) = describe_attached_object_color_condition(tag, filter) {
                 return condition;
             }
+            if let Some(condition) = describe_attached_object_type_condition(tag, filter) {
+                return condition;
+            }
             if tag.as_str().starts_with("countered_")
                 && strip_leading_article(&desc)
                     .eq_ignore_ascii_case("permanent")
@@ -11530,6 +11561,16 @@ mod tests {
         );
 
         assert_eq!(describe_condition(&condition), "equipped creature is green");
+    }
+
+    #[test]
+    fn describe_condition_uses_attached_object_for_equipped_subtype_checks() {
+        let condition = Condition::TaggedObjectMatches(
+            TagKey::from("equipped"),
+            ObjectFilter::default().with_subtype(crate::types::Subtype::Human),
+        );
+
+        assert_eq!(describe_condition(&condition), "equipped creature is a human");
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -164,6 +164,80 @@ fn glamdring_equipped_creature_gets_first_strike_and_graveyard_scaled_power() {
     assert_eq!(game.calculated_power(attacker_id), Some(2));
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sharpened_pitchfork_boosts_only_humans_but_always_grants_first_strike() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let pitchfork = CardDefinitionBuilder::new(CardId::from_raw(72_111), "Sharpened Pitchfork")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Equipped creature has first strike.\nAs long as equipped creature is a Human, it gets +1/+1.\nEquip {1}",
+        )
+        .expect("Sharpened Pitchfork should parse");
+    let pitchfork_id = game.create_object_from_definition(&pitchfork, alice, Zone::Battlefield);
+
+    let human_id = CardBuilder::new(CardId::from_raw(72_112), "Human Bearer")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let human_id = game.create_object_from_card(&human_id, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(human_id);
+
+    let non_human_id = CardBuilder::new(CardId::from_raw(72_113), "Elf Bearer")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let non_human_id = game.create_object_from_card(&non_human_id, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(non_human_id);
+
+    if let Some(equipment) = game.object_mut(pitchfork_id) {
+        equipment.attached_to = Some(crate::object::AttachmentTarget::Object(human_id));
+    }
+    if let Some(human) = game.object_mut(human_id) {
+        human.attachments.push(pitchfork_id);
+    }
+
+    assert_eq!(game.calculated_power(human_id), Some(3));
+    assert_eq!(game.calculated_toughness(human_id), Some(3));
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: human_id,
+        target: AttackTarget::Player(bob),
+    });
+    combat.blockers.insert(human_id, Vec::new());
+
+    let first_strike_events = execute_combat_damage_step(&mut game, &combat, true);
+    assert_eq!(
+        first_strike_events.len(),
+        1,
+        "equipped Human should deal first-strike combat damage"
+    );
+    assert_eq!(game.player(bob).unwrap().life, 17);
+
+    let regular_events = execute_combat_damage_step(&mut game, &combat, false);
+    assert_eq!(regular_events.len(), 0, "first strike should suppress regular damage");
+
+    if let Some(human) = game.object_mut(human_id) {
+        human.attachments.clear();
+    }
+    if let Some(equipment) = game.object_mut(pitchfork_id) {
+        equipment.attached_to = Some(crate::object::AttachmentTarget::Object(non_human_id));
+    }
+    if let Some(non_human) = game.object_mut(non_human_id) {
+        non_human.attachments.push(pitchfork_id);
+    }
+
+    assert_eq!(game.calculated_power(non_human_id), Some(2));
+    assert_eq!(game.calculated_toughness(non_human_id), Some(2));
+}
+
 #[test]
 fn proposed_granted_emerge_cast_keeps_sacrifice_cost_on_stack_spell() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -870,6 +870,14 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::EquippedCreatureAttacking => {
             "as long as equipped creature is attacking".to_string()
         }
+        crate::ConditionExpr::TaggedObjectMatches(tag, filter)
+            if tag.as_str() == "equipped"
+                && filter.subtypes.len() == 1
+                && filter == &ObjectFilter::default().with_subtype(filter.subtypes[0]) =>
+        {
+            let subtype = format!("{:?}", filter.subtypes[0]).to_ascii_lowercase();
+            format!("as long as equipped creature is a {subtype}")
+        }
         crate::ConditionExpr::SourceChosenOption(option) => {
             format!("as long as the chosen option is {}", option)
         }
@@ -4181,6 +4189,17 @@ mod tests {
                 right: Value::Fixed(10),
             }),
             "as long as an opponent has 10 or less life"
+        );
+    }
+
+    #[test]
+    fn describe_static_condition_displays_equipped_subtype_match() {
+        assert_eq!(
+            describe_static_condition(&crate::ConditionExpr::TaggedObjectMatches(
+                crate::TagKey::from("equipped"),
+                ObjectFilter::default().with_subtype(Subtype::Human),
+            )),
+            "as long as equipped creature is a human"
         );
     }
 

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1157,6 +1157,45 @@ fn compile_oracle_text_strictly_compiles_sakashimas_will_with_choose_both_instea
 }
 
 #[test]
+fn compile_oracle_text_sharpened_pitchfork_keeps_conditional_bonus_separate() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Sharpened Pitchfork")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Sharpened Pitchfork --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Sharpened Pitchfork should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Sharpened Pitchfork"), "{stdout}");
+    assert!(
+        stdout.contains(
+            "Equipped creature has first strike.\nEquipped creature gets +1/+1 as long as equipped creature is a human.\nEquip {1}"
+        ),
+        "expected compiled text to preserve a separate Human-condition bonus line, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_outputs_original_oracle_text() {
     let dir = tempdir().expect("tempdir");
     let cards_path = dir.path().join("cards.json");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sharpened Pitchfork
Initial parse error:
```
unsupported static condition clause (clause: 'equipped creature is a human'); oracle-only fallback also failed: unsupported static condition clause (clause: 'equipped creature is a human')
```

Worker: i-0fa24164e977c6ba6
