### PR TITLE
Fix Ironsmith parse failure: Oracle's Attendants

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1566,7 +1566,11 @@ fn compile_subject_verb_effect(
                 ))
             })
         }
-        SubjectVerbActionAst::RedirectNextTimeDamageToSource { source, target } => {
+        SubjectVerbActionAst::RedirectNextTimeDamageToSource {
+            source,
+            target,
+            all_this_turn,
+        } => {
             let source_spec = match source {
                 PreventNextTimeDamageSourceAst::Choice => {
                     crate::effects::RedirectNextTimeDamageSource::Choice
@@ -1579,10 +1583,16 @@ fn compile_subject_verb_effect(
                 }
             };
             compile_effect_for_target(target, ctx, |spec| {
-                Effect::new(crate::effects::RedirectNextTimeDamageToSourceEffect::new(
+                let effect = crate::effects::RedirectNextTimeDamageToSourceEffect::new(
                     source_spec.clone(),
                     spec,
-                ))
+                );
+                let effect = if *all_this_turn {
+                    effect.all_this_turn()
+                } else {
+                    effect
+                };
+                Effect::new(effect)
             })
         }
         SubjectVerbActionAst::PutOrRemoveCounters {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1311,6 +1311,7 @@ pub(crate) enum SubjectVerbActionAst {
     RedirectNextTimeDamageToSource {
         source: PreventNextTimeDamageSourceAst,
         target: TargetAst,
+        all_this_turn: bool,
     },
     Meld {
         result_name: String,
@@ -2626,10 +2627,15 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("amount", amount)
                 .field("target", target)
                 .finish(),
-            Self::RedirectNextTimeDamageToSource { source, target } => f
+            Self::RedirectNextTimeDamageToSource {
+                source,
+                target,
+                all_this_turn,
+            } => f
                 .debug_struct("RedirectNextTimeDamageToSource")
                 .field("source", source)
                 .field("target", target)
+                .field("all_this_turn", all_this_turn)
                 .finish(),
             Self::Meld {
                 result_name,
@@ -4306,7 +4312,26 @@ impl EffectAst {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::RedirectNextTimeDamageToSource { source, target },
+            SubjectVerbActionAst::RedirectNextTimeDamageToSource {
+                source,
+                target,
+                all_this_turn: false,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_redirect_all_damage_this_turn_to_source(
+        source: PreventNextTimeDamageSourceAst,
+        target: TargetAst,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::RedirectNextTimeDamageToSource {
+                source,
+                target,
+                all_this_turn: true,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1253,6 +1253,77 @@ pub(crate) fn parse_redirect_next_damage_sentence(
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
     let clause_word_view = ClausePatternCompatWords::new(tokens);
     let clause_words = clause_word_view.to_word_refs();
+    if word_slice_starts_with(&clause_words, &["all", "damage", "that", "would", "be", "dealt", "to"]) {
+        let idx = 7usize;
+        let this_turn_rel = find_word_sequence_index(&clause_words[idx..], &["this", "turn"])
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unsupported redirected-all-damage duration (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+        let this_turn_idx = idx + this_turn_rel;
+        let target_words = &clause_words[idx..this_turn_idx];
+        if target_words.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing redirected-all-damage target (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+
+        let by_idx = this_turn_idx + 2;
+        if clause_words.get(by_idx) != Some(&"by") {
+            return Ok(None);
+        }
+        let is_dealt_rel = find_word_sequence_index(&clause_words[by_idx + 1..], &["is", "dealt", "to"])
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unsupported redirected-all-damage destination (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+        let is_dealt_idx = by_idx + 1 + is_dealt_rel;
+
+        let source_words = &clause_words[by_idx + 1..is_dealt_idx];
+        if source_words.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing redirected-all-damage source (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+
+        let source = if word_slice_contains_sequence(source_words, &["of", "your", "choice"]) {
+            PreventNextTimeDamageSourceAst::Choice
+        } else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported redirected-all-damage source scope (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        };
+
+        let redirect_words = &clause_words[is_dealt_idx + 3..];
+        let redirects_to_source = matches!(
+            redirect_words,
+            ["this", "creature", "instead"] | ["this", "permanent", "instead"] | ["this", "instead"] | ["it", "instead"]
+        );
+        if !redirects_to_source {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported redirected-all-damage protected destination (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+
+        let target_tokens = target_words
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        let target = parse_target_phrase(&target_tokens)?;
+
+        return Ok(Some(vec![
+            EffectAst::subject_verb_redirect_all_damage_this_turn_to_source(source, target),
+        ]));
+    }
+
     if word_slice_starts_with(&clause_words, &["the", "next", "time"]) {
         let Some(would_idx) = find_word_index(&clause_words, |word| word == "would") else {
             return Ok(None);

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_special_recognizers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_special_recognizers.rs
@@ -523,7 +523,7 @@ pub(super) const SUBJECT_VERB_PRE_DIAGNOSTIC_RULES_LEXED: [LexRuleDef<Vec<Effect
     LexRuleDef {
         id: "redirect-next-damage",
         priority: 100,
-        heads: &["the"],
+        heads: &["the", "all"],
         shape_mask: 0,
         run: parse_redirect_next_damage_sentence_rule_lexed,
     },

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3388,6 +3388,7 @@ impl RedirectNextDamageToTargetEffect {
 pub struct RedirectNextTimeDamageToSourceEffect {
     pub source: RedirectNextTimeDamageSource,
     pub target: Option<ChooseSpec>,
+    pub all_this_turn: bool,
 }
 
 impl RedirectNextTimeDamageToSourceEffect {
@@ -3395,7 +3396,13 @@ impl RedirectNextTimeDamageToSourceEffect {
         Self {
             source,
             target: Some(target),
+            all_this_turn: false,
         }
+    }
+
+    pub fn all_this_turn(mut self) -> Self {
+        self.all_this_turn = true;
+        self
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -22952,6 +22952,25 @@ fn parse_next_time_source_damage_redirect_to_this_creature() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn oracles_attendants_parses_and_renders_all_damage_source_redirect_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Oracle's Attendants")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "{T}: All damage that would be dealt to target creature this turn by a source of your choice is dealt to this creature instead.",
+        )
+        .expect("Oracle's Attendants should parse");
+
+    let joined = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains("all damage that would be dealt to target creature this turn by a source of your choice is dealt to this creature instead"),
+        "expected all-damage source redirect text in compiled output, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_spells_cost_modifier_subtype_does_not_force_creature_word() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Dinosaur Cost Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28954,6 +28954,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 }
             }
         };
+        if redirect_next_time.all_this_turn {
+            return format!(
+                "All damage that would be dealt to {} this turn by {source_text} is dealt to this creature instead",
+                describe_choose_spec(&redirect_next_time.target)
+            );
+        }
         return format!(
             "The next time {source_text} would deal damage to {} this turn, that damage is dealt to this creature instead",
             describe_choose_spec(&redirect_next_time.target)

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -988,9 +988,13 @@ where
                 "redirect next time damage to source without a protected target".to_string(),
             ));
         };
-        return Ok(Effect::new(
-            crate::effects::RedirectNextTimeDamageToSourceEffect::new(source, target),
-        ));
+        let effect = crate::effects::RedirectNextTimeDamageToSourceEffect::new(source, target);
+        let effect = if payload.all_this_turn {
+            effect.all_this_turn()
+        } else {
+            effect
+        };
+        return Ok(Effect::new(effect));
     }
     if let Some(payload) =
         M::downcast_ref::<ironsmith_core::ExecuteWithSourceEffect<M::Effect>>(&effect)

--- a/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
@@ -142,7 +142,7 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
             ctx.controller,
             DamageSourceToSpecificObjectMatcher::new(source_constraint, protected_target),
             ReplacementAction::Redirect {
-                target: RedirectTarget::ToSource,
+                target: RedirectTarget::ToObject(ctx.source),
                 which: RedirectWhich::First,
             },
         );
@@ -171,11 +171,52 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
 mod tests {
     use super::*;
     use crate::card::CardBuilder;
+    use crate::events::DamageTarget;
+    use crate::events::cause::EventCause;
     use crate::effects::ExecutionContext;
     use crate::ids::CardId;
+    use crate::ids::PlayerId;
     use crate::effects::ResolvedTarget;
     use crate::types::CardType;
     use crate::zone::Zone;
+
+    struct ChooseNamedSourceDecisionMaker {
+        source_name: &'static str,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseNamedSourceDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<crate::ids::ObjectId> {
+            if let Some(chosen) = ctx.candidates.iter().find_map(|candidate| {
+                if !candidate.legal {
+                    return None;
+                }
+                let matches = game
+                    .object(candidate.id)
+                    .is_some_and(|object| object.name == self.source_name);
+                if matches { Some(candidate.id) } else { None }
+            }) {
+                vec![chosen]
+            } else {
+                crate::decision::AutoPassDecisionMaker.decide_objects(game, ctx)
+            }
+        }
+    }
+
+    fn create_creature(
+        game: &mut crate::game_state::GameState,
+        name: &str,
+        controller: PlayerId,
+        card_id: u32,
+    ) -> crate::ids::ObjectId {
+        let card = CardBuilder::new(CardId::from_raw(card_id), name)
+            .card_types(vec![CardType::Creature])
+            .build();
+        game.create_object_from_card(&card, controller, Zone::Battlefield)
+    }
 
     #[test]
     fn oracles_attendants_style_redirect_registers_until_end_of_turn_effect() {
@@ -254,5 +295,147 @@ mod tests {
             0,
             "next-time redirect should not register until end of turn"
         );
+    }
+
+    #[test]
+    fn oracles_attendants_redirects_chosen_source_damage_for_rest_of_turn() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+
+        let chosen_source = create_creature(&mut game, "Chosen Source", alice, 80_100);
+        let attendants = create_creature(&mut game, "Oracle's Attendants", alice, 80_101);
+        let protected = create_creature(&mut game, "Protected Creature", alice, 80_102);
+
+        let mut decision_maker = ChooseNamedSourceDecisionMaker {
+            source_name: "Chosen Source",
+        };
+        let mut ctx = ExecutionContext::new(attendants, alice, &mut decision_maker)
+            .with_targets(vec![ResolvedTarget::Object(protected)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::target_creature(),
+        )
+        .all_this_turn()
+        .execute(&mut game, &mut ctx)
+        .expect("oracle attendants replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            chosen_source,
+            DamageTarget::Object(protected),
+            3,
+            false,
+            EventCause::effect(),
+        );
+        let protected_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(protected))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let redirected_to_attendants: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(attendants))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(protected_damage, 0, "chosen-source damage should not stay on protected creature");
+        assert!(
+            !processed.replacement_prevented,
+            "redirect should not count as prevention"
+        );
+        assert_eq!(redirected_to_attendants, 3, "chosen-source damage should be redirected to this creature");
+    }
+
+    #[test]
+    fn oracles_attendants_does_not_redirect_other_sources() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+
+        let _chosen_source = create_creature(&mut game, "Chosen Source", alice, 80_110);
+        let attendants = create_creature(&mut game, "Oracle's Attendants", alice, 80_111);
+        let protected = create_creature(&mut game, "Protected Creature", alice, 80_112);
+        let other_source = create_creature(&mut game, "Other Source", alice, 80_113);
+
+        let mut decision_maker = ChooseNamedSourceDecisionMaker {
+            source_name: "Chosen Source",
+        };
+        let mut ctx = ExecutionContext::new(attendants, alice, &mut decision_maker)
+            .with_targets(vec![ResolvedTarget::Object(protected)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::target_creature(),
+        )
+        .all_this_turn()
+        .execute(&mut game, &mut ctx)
+        .expect("oracle attendants replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            other_source,
+            DamageTarget::Object(protected),
+            2,
+            false,
+            EventCause::effect(),
+        );
+        let protected_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(protected))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let redirected_to_attendants: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(attendants))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(protected_damage, 2, "non-chosen source should still damage the protected creature");
+        assert!(
+            !processed.replacement_prevented,
+            "unredirected damage should not be prevented"
+        );
+        assert_eq!(redirected_to_attendants, 0, "non-chosen source should not be redirected to this creature");
+    }
+
+    #[test]
+    fn oracles_attendants_redirect_expires_at_end_of_turn() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+
+        let chosen_source = create_creature(&mut game, "Chosen Source", alice, 80_120);
+        let attendants = create_creature(&mut game, "Oracle's Attendants", alice, 80_121);
+        let protected = create_creature(&mut game, "Protected Creature", alice, 80_122);
+
+        let mut decision_maker = ChooseNamedSourceDecisionMaker {
+            source_name: "Chosen Source",
+        };
+        let mut ctx = ExecutionContext::new(attendants, alice, &mut decision_maker)
+            .with_targets(vec![ResolvedTarget::Object(protected)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::target_creature(),
+        )
+        .all_this_turn()
+        .execute(&mut game, &mut ctx)
+        .expect("oracle attendants replacement should register");
+
+        game.effect_store
+            .replacement_effects
+            .clear_until_end_of_turn_effects();
+
+        let (protected_damage, replacement_prevented) = crate::events::processing::process_damage_with_event(
+            &mut game,
+            chosen_source,
+            DamageTarget::Object(protected),
+            4,
+            false,
+            EventCause::effect(),
+        );
+
+        assert_eq!(protected_damage, 4, "chosen-source damage should stop redirecting after end of turn");
+        assert!(!replacement_prevented, "expired redirect should not prevent damage");
     }
 }

--- a/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
@@ -64,11 +64,21 @@ pub enum RedirectNextTimeDamageSource {
 pub struct RedirectNextTimeDamageToSourceEffect {
     pub source: RedirectNextTimeDamageSource,
     pub target: ChooseSpec,
+    pub all_this_turn: bool,
 }
 
 impl RedirectNextTimeDamageToSourceEffect {
     pub fn new(source: RedirectNextTimeDamageSource, target: ChooseSpec) -> Self {
-        Self { source, target }
+        Self {
+            source,
+            target,
+            all_this_turn: false,
+        }
+    }
+
+    pub fn all_this_turn(mut self) -> Self {
+        self.all_this_turn = true;
+        self
     }
 }
 
@@ -136,9 +146,15 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
                 which: RedirectWhich::First,
             },
         );
-        game.effect_store
-            .replacement_effects
-            .add_one_shot_effect(replacement);
+        if self.all_this_turn {
+            game.effect_store
+                .replacement_effects
+                .add_until_end_of_turn_effect(replacement);
+        } else {
+            game.effect_store
+                .replacement_effects
+                .add_one_shot_effect(replacement);
+        }
         Ok(EffectOutcome::resolved())
     }
 
@@ -148,5 +164,95 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
 
     fn target_description(&self) -> &'static str {
         "target creature to protect and redirect from"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card::CardBuilder;
+    use crate::effects::ExecutionContext;
+    use crate::ids::CardId;
+    use crate::effects::ResolvedTarget;
+    use crate::types::CardType;
+    use crate::zone::Zone;
+
+    #[test]
+    fn oracles_attendants_style_redirect_registers_until_end_of_turn_effect() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = crate::ids::PlayerId::from_index(0);
+
+        let attendants = CardBuilder::new(CardId::from_raw(80_001), "Oracle's Attendants")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source = game.create_object_from_card(&attendants, alice, Zone::Battlefield);
+
+        let bear = CardBuilder::new(CardId::from_raw(80_002), "Runeclaw Bear")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let target = game.create_object_from_card(&bear, alice, Zone::Battlefield);
+
+        let mut ctx = ExecutionContext::new_default(source, alice)
+            .with_targets(vec![ResolvedTarget::Object(target)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::target_creature(),
+        )
+            .all_this_turn()
+            .execute(&mut game, &mut ctx)
+            .expect("Oracle's Attendants style replacement should register");
+
+        assert_eq!(
+            game.effect_store.replacement_effects.one_shot_effects_snapshot().len(),
+            0,
+            "all-damage redirect should not register as one-shot"
+        );
+        assert_eq!(
+            game.effect_store
+                .replacement_effects
+                .until_end_of_turn_effects_snapshot()
+                .len(),
+            1,
+            "all-damage redirect should register until end of turn"
+        );
+    }
+
+    #[test]
+    fn next_time_redirect_stays_one_shot() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = crate::ids::PlayerId::from_index(0);
+
+        let shaman = CardBuilder::new(CardId::from_raw(80_011), "Shaman en-Kor")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source = game.create_object_from_card(&shaman, alice, Zone::Battlefield);
+
+        let target_creature = CardBuilder::new(CardId::from_raw(80_012), "Target Creature")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let target = game.create_object_from_card(&target_creature, alice, Zone::Battlefield);
+
+        let mut ctx = ExecutionContext::new_default(source, alice)
+            .with_targets(vec![ResolvedTarget::Object(target)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::target_creature(),
+        )
+            .execute(&mut game, &mut ctx)
+            .expect("next-time replacement should register");
+
+        assert_eq!(
+            game.effect_store.replacement_effects.one_shot_effects_snapshot().len(),
+            1,
+            "next-time redirect should remain one-shot"
+        );
+        assert_eq!(
+            game.effect_store
+                .replacement_effects
+                .until_end_of_turn_effects_snapshot()
+                .len(),
+            0,
+            "next-time redirect should not register until end of turn"
+        );
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Oracle's Attendants
Initial parse error:
```
could not find verb in effect clause (clause: 'all damage that would be dealt to target creature this turn by a source of your choice is dealt to this creature instead'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'all damage that would be dealt to target creature this turn by a source of your choice is dealt to this creature instead'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Worker: i-02cee9d77305d8e6c
