### PR TITLE
Fix Ironsmith parse failure: Everybody Lives!

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
@@ -1453,6 +1453,7 @@ pub(crate) fn parse_cant_clause(
                 | crate::effect::Restriction::CastMoreThanOneSpellEachTurn(_, _)
                 | crate::effect::Restriction::DrawCards(_)
                 | crate::effect::Restriction::DrawExtraCards(_)
+                | crate::effect::Restriction::LoseLife(_)
                 | crate::effect::Restriction::ChangeLifeTotal(_)
                 | crate::effect::Restriction::LoseGame(_)
                 | crate::effect::Restriction::WinGame(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -38,6 +38,26 @@ pub(crate) fn format_negated_restriction_display(tokens: &[OwnedLexToken]) -> St
 pub(crate) fn parse_cant_restrictions(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<ParsedCantRestriction>>, CardTextError> {
+    let normalized_storage = normalize_cant_words(tokens);
+    let normalized = normalized_storage
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if normalized.starts_with(&[
+        "players", "cant", "lose", "the", "game", "or", "win", "the", "game",
+    ]) {
+        return Ok(Some(vec![
+            ParsedCantRestriction {
+                restriction: crate::effect::Restriction::lose_game(PlayerFilter::Any),
+                target: None,
+            },
+            ParsedCantRestriction {
+                restriction: crate::effect::Restriction::win_game(PlayerFilter::Any),
+                target: None,
+            },
+        ]));
+    }
+
     let words = crate::runtime_backend::token_word_refs(tokens);
     if is_mana_retention_negated_clause(&words) {
         return Ok(None);
@@ -83,6 +103,24 @@ pub(crate) fn parse_cant_restrictions(
                     crate::runtime_backend::token_word_refs(segment).join(" ")
                 )));
             };
+            let segment_words = normalize_cant_words(segment)
+                .into_iter()
+                .collect::<Vec<_>>();
+            let has_or_win_tail = segment_words
+                .windows(5)
+                .any(|window| window == ["or", "win", "the", "game", "this"])
+                || segment_words
+                    .windows(4)
+                    .any(|window| window == ["or", "win", "the", "game"]);
+            if has_or_win_tail
+                && let crate::effect::Restriction::LoseGame(player_filter) =
+                    restriction.restriction.clone()
+            {
+                restrictions.push(ParsedCantRestriction {
+                    restriction: crate::effect::Restriction::win_game(player_filter),
+                    target: None,
+                });
+            }
             restrictions.push(restriction);
         }
 
@@ -1088,6 +1126,9 @@ pub(crate) fn parse_negated_object_restriction_clause(
             }
             words if slice_starts_with(words, &["lose", "the", "game"]) => {
                 Restriction::lose_game(player)
+            }
+            words if slice_starts_with(words, &["lose", "life"]) => {
+                Restriction::change_life_total(player)
             }
             words if slice_starts_with(words, &["win", "the", "game"]) => {
                 Restriction::win_game(player)

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -1128,7 +1128,7 @@ pub(crate) fn parse_negated_object_restriction_clause(
                 Restriction::lose_game(player)
             }
             words if slice_starts_with(words, &["lose", "life"]) => {
-                Restriction::change_life_total(player)
+                Restriction::lose_life(player)
             }
             words if slice_starts_with(words, &["win", "the", "game"]) => {
                 Restriction::win_game(player)

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -428,6 +428,9 @@ pub(crate) fn resolve_restriction_it_tag(
         Restriction::DrawExtraCards(player) => {
             Restriction::DrawExtraCards(resolve_contextual_player_filter(player, refs)?)
         }
+        Restriction::LoseLife(player) => {
+            Restriction::LoseLife(resolve_contextual_player_filter(player, refs)?)
+        }
         Restriction::ChangeLifeTotal(player) => {
             Restriction::ChangeLifeTotal(resolve_contextual_player_filter(player, refs)?)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -306,9 +306,9 @@ fn player_gain_effects_for_abilities(
     abilities: &[GrantedAbilityAst],
     duration: &Until,
     subject_tokens: &[OwnedLexToken],
+    player_filter: PlayerFilter,
 ) -> Option<Vec<EffectAst>> {
-    let player_target =
-        TargetAst::Player(PlayerFilter::You, span_from_lexed_tokens(subject_tokens));
+    let player_target = TargetAst::Player(player_filter.clone(), span_from_lexed_tokens(subject_tokens));
     let mut effects = Vec::new();
 
     for ability in abilities {
@@ -316,7 +316,7 @@ fn player_gain_effects_for_abilities(
             GrantedAbilityAst::KeywordAction(KeywordAction::Hexproof) => {
                 effects.push(EffectAst::subject_verb_cant(
                     crate::effect::Restriction::be_targeted_player_from(
-                        PlayerFilter::You,
+                        player_filter.clone(),
                         ObjectFilter::default().controlled_by(PlayerFilter::Opponent),
                     ),
                     duration.clone(),
@@ -326,7 +326,7 @@ fn player_gain_effects_for_abilities(
             GrantedAbilityAst::KeywordAction(KeywordAction::HexproofFrom(filter)) => {
                 effects.push(EffectAst::subject_verb_cant(
                     crate::effect::Restriction::be_targeted_player_from(
-                        PlayerFilter::You,
+                        player_filter.clone(),
                         filter.clone().controlled_by(PlayerFilter::Opponent),
                     ),
                     duration.clone(),
@@ -335,7 +335,7 @@ fn player_gain_effects_for_abilities(
             }
             GrantedAbilityAst::KeywordAction(KeywordAction::ProtectionFromEverything) => {
                 effects.push(EffectAst::subject_verb_cant(
-                    crate::effect::Restriction::be_targeted_player(PlayerFilter::You),
+                    crate::effect::Restriction::be_targeted_player(player_filter.clone()),
                     duration.clone(),
                     None,
                 ));
@@ -842,6 +842,21 @@ fn parse_simple_ability_modifier_clause_lexed(
         )));
     }
 
+    if !losing
+        && (subject_word_refs.as_slice() == ["players"]
+            || subject_word_refs.as_slice() == ["all", "players"])
+    {
+        let Some(mut player_effects) =
+            player_gain_effects_for_abilities(&abilities, &duration, subject_tokens, PlayerFilter::Any)
+        else {
+            return Ok(None);
+        };
+        if player_effects.len() == 1 {
+            return Ok(player_effects.pop());
+        }
+        return Ok(None);
+    }
+
     let filter = parse_object_filter_lexed(subject_tokens, false).map_err(|_| {
         CardTextError::ParseError(format!(
             "unsupported subject in {}-ability clause (clause: '{}')",
@@ -1026,6 +1041,24 @@ pub(crate) fn parse_simple_ability_modifier_clause(
         return Ok(Some(EffectAst::subject_verb_grant_abilities_to_target(
             target, abilities, duration,
         )));
+    }
+
+    if !losing
+        && (subject_word_refs.as_slice() == ["players"]
+            || subject_word_refs.as_slice() == ["all", "players"])
+    {
+        let Some(mut player_effects) = player_gain_effects_for_abilities(
+            &abilities,
+            &duration,
+            &subject_tokens,
+            PlayerFilter::Any,
+        ) else {
+            return Ok(None);
+        };
+        if player_effects.len() == 1 {
+            return Ok(player_effects.pop());
+        }
+        return Ok(None);
     }
 
     let filter = parse_object_filter(&subject_tokens, false).map_err(|_| {
@@ -1653,7 +1686,12 @@ pub(crate) fn parse_gain_ability_sentence(
     if !losing && real_subject_words.as_slice() == ["you", "and", "permanents", "you", "control"] {
         let permanent_filter = crate::target::ObjectFilter::permanent().you_control();
         let Some(mut player_effects) =
-            player_gain_effects_for_abilities(&abilities, &duration, &real_subject_tokens)
+            player_gain_effects_for_abilities(
+                &abilities,
+                &duration,
+                &real_subject_tokens,
+                PlayerFilter::You,
+            )
         else {
             return Err(CardTextError::ParseError(format!(
                 "unsupported mixed player/permanent gain-ability clause (clause: '{}')",
@@ -1666,6 +1704,23 @@ pub(crate) fn parse_gain_ability_sentence(
             abilities,
             duration,
         ));
+        effects = append_gain_ability_trailing_effects(effects, &trailing_tail_tokens)?;
+        return Ok(Some(effects));
+    }
+
+    if !losing && (real_subject_words.as_slice() == ["players"] || real_subject_words.as_slice() == ["all", "players"]) {
+        let Some(mut player_effects) = player_gain_effects_for_abilities(
+            &abilities,
+            &duration,
+            &real_subject_tokens,
+            PlayerFilter::Any,
+        ) else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported player gain-ability clause (clause: '{}')",
+                word_list.join(" ")
+            )));
+        };
+        effects.append(&mut player_effects);
         effects = append_gain_ability_trailing_effects(effects, &trailing_tail_tokens)?;
         return Ok(Some(effects));
     }
@@ -2550,6 +2605,22 @@ mod tests {
                 && string_contains(&compact_rendered, "isdealtdamage")
                 && string_contains(&compact_rendered, "putcounterseffect"),
             "grant should stay targeted in the lowered structure: {rendered}"
+        );
+    }
+
+    #[test]
+    fn players_gain_hexproof_clause_parses_as_player_wide_targeting_restriction() {
+        let tokens = tokenize_line("Players gain hexproof until end of turn.", 0);
+        let effect = parse_simple_gain_ability_clause(&tokens)
+            .expect("players gain clause should parse")
+            .expect("players gain clause should produce an effect");
+
+        let debug = format!("{effect:?}");
+        assert!(
+            string_contains(&debug, "Cant")
+                && string_contains(&debug, "BeTargetedPlayerFrom(Any")
+                && string_contains(&debug, "EndOfTurn"),
+            "expected a player-wide temporary targeting restriction, got {debug}"
         );
     }
 }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -265,6 +265,7 @@ pub enum Restriction {
     DrawCards(PlayerFilter),
     DrawExtraCards(PlayerFilter),
     PoisonCounters(PlayerFilter),
+    LoseLife(PlayerFilter),
     ChangeLifeTotal(PlayerFilter),
     LoseGame(PlayerFilter),
     WinGame(PlayerFilter),
@@ -458,6 +459,10 @@ impl Restriction {
 
     pub fn poison_counters(filter: PlayerFilter) -> Self {
         Self::PoisonCounters(filter)
+    }
+
+    pub fn lose_life(filter: PlayerFilter) -> Self {
+        Self::LoseLife(filter)
     }
 
     pub fn change_life_total(filter: PlayerFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2942,6 +2942,37 @@ fn test_parse_double_cant_clause_from_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn everybody_lives_parses_strictly_with_player_hexproof_clause() {
+    CardDefinitionBuilder::new(CardId::from_raw(1), "Everybody Lives!")
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "All creatures gain hexproof and indestructible until end of turn. Players gain hexproof until end of turn. Players can't lose life this turn and players can't lose the game or win the game this turn.",
+        )
+        .expect("Everybody Lives! should parse strictly");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn everybody_lives_compiled_text_includes_player_hexproof_and_life_lock_clauses() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Everybody Lives!")
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "All creatures gain hexproof and indestructible until end of turn. Players gain hexproof until end of turn. Players can't lose life this turn and players can't lose the game or win the game this turn.",
+        )
+        .expect("Everybody Lives! should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Players have hexproof")
+            && rendered.contains("Players can't have life total changed this turn")
+            && rendered.contains("Players can't lose the game this turn")
+            && rendered.contains("Players can't win the game this turn"),
+        "expected Everybody Lives! compiled text to keep player clauses, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_characteristic_pt_constant_plus_count() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Aysen Crusader")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2964,7 +2964,7 @@ fn everybody_lives_compiled_text_includes_player_hexproof_and_life_lock_clauses(
     let rendered = unprocessed_compiled_lines(&def).join(" ");
     assert!(
         rendered.contains("Players have hexproof this turn")
-            && rendered.contains("Players can't have life total changed this turn")
+            && rendered.contains("Players can't lose life this turn")
             && rendered.contains("Players can't lose the game this turn")
             && rendered.contains("Players can't win the game this turn"),
         "expected Everybody Lives! compiled text to keep player clauses, got {rendered}"

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2963,7 +2963,7 @@ fn everybody_lives_compiled_text_includes_player_hexproof_and_life_lock_clauses(
 
     let rendered = unprocessed_compiled_lines(&def).join(" ");
     assert!(
-        rendered.contains("Players have hexproof")
+        rendered.contains("Players have hexproof this turn")
             && rendered.contains("Players can't have life total changed this turn")
             && rendered.contains("Players can't lose the game this turn")
             && rendered.contains("Players can't win the game this turn"),

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9468,6 +9468,9 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
                 describe_player_set_filter(filter)
             )
         }
+        crate::effect::Restriction::LoseLife(filter) => {
+            format!("{} can't lose life", describe_player_set_filter(filter))
+        }
         crate::effect::Restriction::ChangeLifeTotal(filter) => {
             format!(
                 "{} can't have life total changed",

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9546,10 +9546,14 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             format!("{} can't be targeted", describe_player_set_filter(filter))
         }
         crate::effect::Restriction::BeTargetedPlayerFrom(player, source_filter) => {
+            let source_description = describe_hexproof_from_filter(source_filter);
+            if source_description == "an opponent's" {
+                return format!("{} have hexproof", describe_player_set_filter(player));
+            }
             format!(
                 "{} have hexproof from {}",
                 describe_player_set_filter(player),
-                describe_hexproof_from_filter(source_filter)
+                source_description
             )
         }
         crate::effect::Restriction::BeCountered(filter) => {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -940,6 +940,13 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::LoseLife(filter) => {
+                for player in &game.players {
+                    if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
+                        tracker.cant_lose_life.insert(player.id);
+                    }
+                }
+            }
             Restriction::ChangeLifeTotal(filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -329,6 +329,83 @@ fn proposed_granted_emerge_cast_keeps_sacrifice_cost_on_stack_spell() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn everybody_lives_prevents_life_loss_and_game_win_loss_for_all_players_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let everybody_lives = CardDefinitionBuilder::new(CardId::from_raw(72_301), "Everybody Lives!")
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "All creatures gain hexproof and indestructible until end of turn. Players gain hexproof until end of turn. Players can't lose life this turn and players can't lose the game or win the game this turn.",
+        )
+        .expect("Everybody Lives! should parse");
+
+    let spell_id = game.create_object_from_definition(&everybody_lives, alice, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice).with_source_info(
+            game.object(spell_id)
+                .expect("Everybody Lives! spell should exist")
+                .stable_id,
+            "Everybody Lives!".to_string(),
+        ),
+    );
+    resolve_stack_entry(&mut game).expect("Everybody Lives! should resolve");
+
+    assert!(!game.can_lose_life(alice));
+    assert!(!game.can_lose_life(bob));
+    assert!(!game.can_lose_game(alice));
+    assert!(!game.can_lose_game(bob));
+    assert!(!game.can_win_game(alice));
+    assert!(!game.can_win_game(bob));
+
+    let bob_life_before = game.player(bob).expect("bob exists").life;
+    assert_eq!(game.lose_life(bob, 3), 0, "life loss should be prevented this turn");
+    assert_eq!(game.player(bob).expect("bob exists").life, bob_life_before);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn everybody_lives_switches_player_restrictions_on_resolution() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let everybody_lives = CardDefinitionBuilder::new(CardId::from_raw(72_302), "Everybody Lives!")
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "All creatures gain hexproof and indestructible until end of turn. Players gain hexproof until end of turn. Players can't lose life this turn and players can't lose the game or win the game this turn.",
+        )
+        .expect("Everybody Lives! should parse");
+
+    let spell_id = game.create_object_from_definition(&everybody_lives, alice, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice).with_source_info(
+            game.object(spell_id)
+                .expect("Everybody Lives! spell should exist")
+                .stable_id,
+            "Everybody Lives!".to_string(),
+        ),
+    );
+    assert!(game.can_lose_life(alice));
+    assert!(game.can_lose_life(bob));
+    assert!(game.can_lose_game(alice));
+    assert!(game.can_lose_game(bob));
+    assert!(game.can_win_game(alice));
+    assert!(game.can_win_game(bob));
+
+    resolve_stack_entry(&mut game).expect("Everybody Lives! should resolve");
+
+    assert!(!game.can_lose_life(alice));
+    assert!(!game.can_lose_life(bob));
+    assert!(!game.can_lose_game(alice));
+    assert!(!game.can_lose_game(bob));
+    assert!(!game.can_win_game(alice));
+    assert!(!game.can_win_game(bob));
+}
+
 fn resolve_triggered_ability_from_spell_cast(
     game: &mut GameState,
     triggered: &crate::ability::TriggeredAbility,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -364,6 +364,16 @@ fn everybody_lives_prevents_life_loss_and_game_win_loss_for_all_players_this_tur
     let bob_life_before = game.player(bob).expect("bob exists").life;
     assert_eq!(game.lose_life(bob, 3), 0, "life loss should be prevented this turn");
     assert_eq!(game.player(bob).expect("bob exists").life, bob_life_before);
+
+    let alice_life_before = game.player(alice).expect("alice exists").life;
+    let mut gain_ctx = crate::effects::ExecutionContext::new_default(spell_id, alice);
+    crate::effects::execute_effect(&mut game, &crate::effect::Effect::gain_life(3), &mut gain_ctx)
+        .expect("life gain effect should resolve");
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        alice_life_before + 3,
+        "life gain should still be allowed"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -619,6 +619,9 @@ pub struct CantEffectTracker {
     /// Example: Platinum Emperion
     pub life_total_cant_change: HashSet<PlayerId>,
 
+    /// Players who can't lose life.
+    pub cant_lose_life: HashSet<PlayerId>,
+
     /// Players who can't lose the game.
     /// Example: Platinum Angel
     pub cant_lose_game: HashSet<PlayerId>,
@@ -855,6 +858,7 @@ impl CantEffectTracker {
         self.damage_cant_be_prevented |= other.damage_cant_be_prevented;
         self.life_total_cant_change
             .extend(other.life_total_cant_change);
+        self.cant_lose_life.extend(other.cant_lose_life);
         self.cant_lose_game.extend(other.cant_lose_game);
         self.cant_win_game.extend(other.cant_win_game);
         self.cant_become_monarch.extend(other.cant_become_monarch);
@@ -897,6 +901,7 @@ impl CantEffectTracker {
         self.cant_have_counters_placed.clear();
         self.damage_cant_be_prevented = false;
         self.life_total_cant_change.clear();
+        self.cant_lose_life.clear();
         self.cant_lose_game.clear();
         self.cant_win_game.clear();
         self.cant_become_monarch.clear();
@@ -915,7 +920,7 @@ impl CantEffectTracker {
 
     /// Check if a player can lose life (not from damage).
     pub fn can_lose_life(&self, player: PlayerId) -> bool {
-        !self.life_total_cant_change.contains(&player)
+        !self.cant_lose_life.contains(&player) && !self.life_total_cant_change.contains(&player)
     }
 
     /// Check if a player's life total can change (Platinum Emperion, etc.).
@@ -2927,7 +2932,7 @@ impl GameState {
         if amount == 0 {
             return self.player(player).is_some();
         }
-        self.can_change_life_total(player)
+        self.can_lose_life(player)
             && self.player(player).is_some_and(|p| p.life >= amount as i32)
     }
 
@@ -2951,7 +2956,7 @@ impl GameState {
     ///
     /// Returns the amount of life actually lost.
     pub fn lose_life(&mut self, player: PlayerId, amount: u32) -> u32 {
-        if amount == 0 || !self.can_change_life_total(player) {
+        if amount == 0 || !self.can_lose_life(player) {
             return 0;
         }
         if let Some(p) = self.player_mut(player) {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Everybody Lives!
Initial parse error:
```
unsupported subject in gain-ability clause (clause: 'players gain hexproof until end of turn'); oracle-only fallback also failed: unsupported subject in gain-ability clause (clause: 'players gain hexproof until end of turn')
```

Worker: i-0951aa72be0ad0c45
