### PR TITLE
Fix Ironsmith parse failure: Molten Hydra

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1572,6 +1572,18 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
     if words.first().copied() == Some("result") {
         return Some((Value::EventValue(EventValueSpec::Amount), 1));
     }
+    if matches!(words.get(..3), Some(["the", "number", "of"]))
+        && words.len() >= 6
+        && matches!(words.get(words.len() - 3..), Some(["removed", "this", "way"]))
+    {
+        return Some((Value::EventValue(EventValueSpec::Amount), words.len()));
+    }
+    if matches!(words.get(..2), Some(["number", "of"]))
+        && words.len() >= 5
+        && matches!(words.get(words.len() - 3..), Some(["removed", "this", "way"]))
+    {
+        return Some((Value::EventValue(EventValueSpec::Amount), words.len()));
+    }
 
     if words[0] == "x" {
         return Some((Value::X, 1));

--- a/crates/ironsmith-runtime/src/cards/mod.rs
+++ b/crates/ironsmith-runtime/src/cards/mod.rs
@@ -1403,6 +1403,27 @@ mod tests {
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_molten_hydra_oracle_text_and_render_removed_counter_damage_clause() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Molten Hydra")
+            .card_types(vec![CardType::Creature])
+            .parse_text(
+                "{1}{R}{R}: Put a +1/+1 counter on this creature.\n{T}, Remove all +1/+1 counters from this creature: It deals damage to any target equal to the number of +1/+1 counters removed this way.",
+            )
+            .expect("Molten Hydra oracle text should parse strictly");
+
+        let compiled = crate::compiled_text::canonical_compiled_lines(&def)
+            .join(" ")
+            .to_ascii_lowercase();
+        assert!(
+            compiled.contains("deals damage")
+                && compiled.contains("equal to")
+                && compiled.contains("removed this way"),
+            "expected compiled text to preserve removed-counter damage scaling clause, got {compiled}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_enchanted_creature_cant_attack_or_block_static() {
         use crate::static_abilities::StaticAbilityId;
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12290,6 +12290,14 @@ pub(super) fn describe_inline_ability(ability: &Ability) -> String {
 fn rewrite_cost_bound_x_phrases(mut effects: String, costs: &[crate::costs::Cost]) -> String {
     if let Some(x_phrase) = removed_counters_this_way_x_phrase(costs) {
         effects = effects.replace("where X is X", &format!("where X is {x_phrase}"));
+        effects = effects.replace(
+            "deals X damage to",
+            &format!("deals damage equal to {x_phrase} to"),
+        );
+        effects = effects.replace(
+            "Deal X damage to",
+            &format!("Deal damage equal to {x_phrase} to"),
+        );
     }
     effects
 }

--- a/crates/ironsmith-runtime/src/costs/cost_effect.rs
+++ b/crates/ironsmith-runtime/src/costs/cost_effect.rs
@@ -266,7 +266,6 @@ impl CostPayer for CostEffect {
         let removed_marker_total = outcome.total_marker_changes(|event| event.is_removed());
 
         if ctx.x_value.is_none()
-            && removed_marker_total > 0
             && (self
                 .effect
                 .downcast_ref::<crate::effects::RemoveCountersEffect>()
@@ -605,6 +604,32 @@ mod tests {
         assert_eq!(result, CostPaymentResult::Paid);
         assert_eq!(ctx.x_value, Some(2));
         assert_eq!(game.counter_count(source, CounterType::Charge), 1);
+    }
+
+    #[test]
+    fn remove_all_counters_cost_sets_x_to_zero_when_none_are_removed() {
+        let mut game = create_test_game();
+        let alice = PlayerId::from_index(0);
+
+        let card = CardBuilder::new(CardId::from_raw(11), "Empty Battery")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let source = game.create_object_from_card(&card, alice, Zone::Battlefield);
+
+        let cost = CostEffect::new(RemoveCountersEffect::new(
+            CounterType::Charge,
+            u32::MAX,
+            crate::target::ChooseSpec::Source,
+        ));
+        let mut dm = SelectFirstDecisionMaker;
+        let mut ctx = CostContext::new(source, alice, &mut dm);
+
+        let result = cost
+            .pay(&mut game, &mut ctx)
+            .expect("remove-all counters cost should be payable with zero counters");
+
+        assert_eq!(result, CostPaymentResult::Paid);
+        assert_eq!(ctx.x_value, Some(0));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7317,6 +7317,89 @@ fn molten_hydra_activated_damage_can_target_creatures() {
 }
 
 #[test]
+fn molten_hydra_activated_damage_is_zero_when_no_counters_are_removed() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let hydra_def = CardDefinitionBuilder::new(CardId::from_raw(994_103), "Molten Hydra")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{1}{R}{R}: Put a +1/+1 counter on this creature.\n{T}, Remove all +1/+1 counters from this creature: It deals damage to any target equal to the number of +1/+1 counters removed this way.",
+        )
+        .expect("Molten Hydra oracle text should parse");
+    let hydra_id = game.create_object_from_definition(&hydra_def, alice, Zone::Battlefield);
+
+    let ability_index = game
+        .object(hydra_id)
+        .expect("Molten Hydra should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                let debug = format!("{:?}", activated.effects).to_ascii_lowercase();
+                debug.contains("dealdamageeffect")
+            } else {
+                false
+            }
+        })
+        .expect("Molten Hydra should have a damage activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == hydra_id && *idx == ability_index
+            )
+        })
+        .expect("Molten Hydra activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Molten Hydra activation should start");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Molten Hydra activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("choosing target player should complete Molten Hydra activation");
+
+    resolve_stack_entry(&mut game).expect("Molten Hydra ability should resolve");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        20,
+        "Molten Hydra should deal zero damage when zero counters are removed"
+    );
+}
+
+#[test]
 fn protected_stack_spell_still_resolves_after_failed_counterspell() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7135,6 +7135,188 @@ fn magma_mine_activated_ability_uses_current_pressure_counter_count_when_zero() 
 }
 
 #[test]
+fn molten_hydra_activated_damage_uses_number_of_removed_plus1_counters() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let hydra_def = CardDefinitionBuilder::new(CardId::from_raw(994_100), "Molten Hydra")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{1}{R}{R}: Put a +1/+1 counter on this creature.\n{T}, Remove all +1/+1 counters from this creature: It deals damage to any target equal to the number of +1/+1 counters removed this way.",
+        )
+        .expect("Molten Hydra oracle text should parse");
+    let hydra_id = game.create_object_from_definition(&hydra_def, alice, Zone::Battlefield);
+    game.add_counters(hydra_id, crate::object::CounterType::PlusOnePlusOne, 3)
+        .expect("+1/+1 counters should be addable to Molten Hydra");
+
+    let ability_index = game
+        .object(hydra_id)
+        .expect("Molten Hydra should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                let debug = format!("{:?}", activated.effects).to_ascii_lowercase();
+                debug.contains("dealdamageeffect")
+            } else {
+                false
+            }
+        })
+        .expect("Molten Hydra should have a damage activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == hydra_id && *idx == ability_index
+            )
+        })
+        .expect("Molten Hydra activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Molten Hydra activation should start");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Molten Hydra activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("choosing target player should complete Molten Hydra activation");
+
+    assert_eq!(
+        game.counter_count(hydra_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Molten Hydra activation cost should remove all +1/+1 counters"
+    );
+
+    resolve_stack_entry(&mut game).expect("Molten Hydra ability should resolve");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        17,
+        "Molten Hydra should deal damage equal to removed +1/+1 counters"
+    );
+}
+
+#[test]
+fn molten_hydra_activated_damage_can_target_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let hydra_def = CardDefinitionBuilder::new(CardId::from_raw(994_101), "Molten Hydra")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{1}{R}{R}: Put a +1/+1 counter on this creature.\n{T}, Remove all +1/+1 counters from this creature: It deals damage to any target equal to the number of +1/+1 counters removed this way.",
+        )
+        .expect("Molten Hydra oracle text should parse");
+    let hydra_id = game.create_object_from_definition(&hydra_def, alice, Zone::Battlefield);
+
+    let target_creature = CardBuilder::new(CardId::from_raw(994_102), "Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_card(&target_creature, bob, Zone::Battlefield);
+    game.add_counters(hydra_id, crate::object::CounterType::PlusOnePlusOne, 1)
+        .expect("+1/+1 counters should be addable to Molten Hydra");
+
+    let ability_index = game
+        .object(hydra_id)
+        .expect("Molten Hydra should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                let debug = format!("{:?}", activated.effects).to_ascii_lowercase();
+                debug.contains("dealdamageeffect")
+            } else {
+                false
+            }
+        })
+        .expect("Molten Hydra should have a damage activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == hydra_id && *idx == ability_index
+            )
+        })
+        .expect("Molten Hydra activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Molten Hydra activation should start");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Molten Hydra activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("choosing target creature should complete Molten Hydra activation");
+
+    resolve_stack_entry(&mut game).expect("Molten Hydra ability should resolve");
+
+    assert_eq!(
+        game.damage_on(target_id),
+        1,
+        "Molten Hydra should deal removed-counter damage to target creatures"
+    );
+}
+
+#[test]
 fn protected_stack_spell_still_resolves_after_failed_counterspell() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Molten Hydra
Initial parse error:
```
missing damage amount (clause: 'damage to any target equal to the number of +1/+1 counters removed this way'); oracle-only fallback also failed: missing damage amount (clause: 'damage to any target equal to the number of +1/+1 counters removed this way')
```

Worker: i-0dbc79032b6899259
