### PR TITLE
Fix Ironsmith parse failure: Leonardo, the Balance

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -7,11 +7,11 @@ use super::line_family_handlers::{
     run_graveyard_cast_control_condition_line_family, run_keyword_line_family,
     run_labeled_line_family, run_learn_line_family,
     run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
-    run_partner_with_keyword_line_family, run_split_top_and_face_down_look_line_family,
-    run_split_top_look_and_top_land_play_line_family, run_start_your_engines_line_family,
-    run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
-    run_station_line_family, run_station_threshold_line_family, run_surge_line_family,
-    run_trailing_keyword_activation_line_family, run_triggered_line_family,
+    run_partner_variant_keyword_line_family, run_partner_with_keyword_line_family,
+    run_split_top_and_face_down_look_line_family, run_split_top_look_and_top_land_play_line_family,
+    run_start_your_engines_line_family, run_statement_line_family, run_statement_probe_line_family,
+    run_static_line_family, run_station_line_family, run_station_threshold_line_family,
+    run_surge_line_family, run_trailing_keyword_activation_line_family, run_triggered_line_family,
     run_unsupported_line_family, run_ward_or_echo_static_prefix_line_family,
 };
 use super::*;
@@ -49,7 +49,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 27] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 28] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -87,8 +87,14 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 27] = [
         run: run_partner_with_keyword_line_family,
     },
     LineFamilyRuleDef {
-        id: "start-your-engines-line",
+        id: "partner-variant-keyword-line",
         priority: 36,
+        heads: &["partner"],
+        run: run_partner_variant_keyword_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "start-your-engines-line",
+        priority: 37,
         heads: &["start"],
         run: run_start_your_engines_line_family,
     },

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -595,6 +595,42 @@ pub(super) fn run_partner_with_keyword_line_family(
     )))
 }
 
+pub(super) fn run_partner_variant_keyword_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let lower = raw.to_ascii_lowercase();
+    if !lower.starts_with("partner") {
+        return Ok(None);
+    }
+
+    let Some(rest) = raw.get("Partner".len()..) else {
+        return Ok(None);
+    };
+    let rest = rest.trim_start();
+    if !(rest.starts_with('\u{2014}') || rest.starts_with("-") || rest.starts_with('\u{2013}')) {
+        return Ok(None);
+    }
+
+    let partner_line = rewrite_line_normalized(ctx.line, "Partner")?;
+    if let Some(keyword_line) = parse_keyword_line_cst(&partner_line)? {
+        return Ok(Some(LineDispatchResult::single(
+            RewriteLineCst::Keyword(keyword_line),
+            ctx.idx + 1,
+        )));
+    }
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Static(StaticLineCst {
+            info: partner_line.info.clone(),
+            text: partner_line.info.normalized.normalized.clone(),
+            parse_tokens: partner_line.tokens.clone(),
+            chosen_option_label: None,
+        }),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_escape_enters_with_counter_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -613,7 +613,14 @@ pub(super) fn run_partner_variant_keyword_line_family(
     }
 
     let partner_line = rewrite_line_normalized(ctx.line, "Partner")?;
-    if let Some(keyword_line) = parse_keyword_line_cst(&partner_line)? {
+    if let Some(mut keyword_line) = parse_keyword_line_cst(&partner_line)? {
+        let visible_label = raw
+            .split_once('(')
+            .map(|(head, _)| head)
+            .unwrap_or(raw)
+            .trim()
+            .to_string();
+        keyword_line.text = visible_label;
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Keyword(keyword_line),
             ctx.idx + 1,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1216,6 +1216,23 @@ fn lower_rewrite_static_to_chunk_impl(
 ) -> Result<LineAst, CardTextError> {
     let chosen_option_label =
         effective_chosen_option_label(&line.info.raw_line, line.chosen_option_label.as_deref());
+    let raw = line.info.raw_line.trim();
+    let raw_lower = raw.to_ascii_lowercase();
+    if raw_lower.starts_with("partner") {
+        let rest = raw.get("Partner".len()..).unwrap_or("").trim_start();
+        if rest.starts_with('\u{2014}') || rest.starts_with('-') || rest.starts_with('\u{2013}') {
+            let visible_label = raw
+                .split_once('(')
+                .map(|(head, _)| head)
+                .unwrap_or(raw)
+                .trim()
+                .to_string();
+            return wrap_chosen_option_static_chunk(
+                LineAst::StaticAbility(StaticAbility::partner().with_text(visible_label).into()),
+                chosen_option_label,
+            );
+        }
+    }
     if matches!(
         line.text.as_str(),
         "for each {B} in a cost, you may pay 2 life rather than pay that mana."

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1388,6 +1388,42 @@ fn test_parse_partner_with_attack_value_renders_oracle_surface() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_leonardo_the_balance_strictly_parses_character_select_partner_line() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Leonardo, the Balance")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Mutant, Subtype::Ninja, Subtype::Turtle])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Whenever a token you control enters, you may put a +1/+1 counter on each creature you control. Do this only once each turn.\n{W}{U}{B}{R}{G}: Creatures you control gain menace, trample, and lifelink until end of turn.\nPartner—Character select (You can have two commanders if both have this ability.)",
+        )
+        .expect("Leonardo, the Balance should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Partner") && rendered.contains("Do this only once each turn"),
+        "expected Leonardo output to include partner and once-per-turn limiter, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_parse_partner_variant_does_not_override_partner_with() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Partner Variant Guard")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Partner with Proud Mentor (When this creature enters, target player may put Proud Mentor into their hand from their library, then shuffle.)",
+        )
+        .expect("partner-with should still parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Partner with Proud Mentor"),
+        "expected partner-with line to remain intact, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_start_your_engines_and_max_speed_graveyard_cast_permission() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Speed Parse Test")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1398,10 +1398,21 @@ fn test_parse_leonardo_the_balance_strictly_parses_character_select_partner_line
         )
         .expect("Leonardo, the Balance should parse");
 
-    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let rendered_lines = unprocessed_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+    let debug = format!("{:#?}", def);
     assert!(
-        rendered.contains("Partner") && rendered.contains("Do this only once each turn"),
-        "expected Leonardo output to include partner and once-per-turn limiter, got {rendered}"
+        rendered_lines
+            .iter()
+            .any(|line| line.starts_with("Partner—Character select"))
+            && rendered.contains("Do this only once each turn")
+            && rendered.contains("Creatures you control gain menace")
+            && rendered.contains("gain trample")
+            && rendered.contains("gain lifelink until end of turn")
+            && debug.contains("id: Some(\n                            Partner,")
+            && debug.contains("DoThisMaxTimesEachTurn")
+            && !debug.contains("id: Some(\n                            PartnerWith,"),
+        "expected Leonardo output to preserve the partner variant label and keep once-per-turn and grant semantics, got rendered={rendered}; debug={debug}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -30983,6 +30983,9 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
     if text == "partner" {
         return Some("Partner".to_string());
     }
+    if text.starts_with("partner-") || text.starts_with("partner\u{2014}") {
+        return Some(raw_text.to_string());
+    }
     if text.starts_with("partner with ") {
         return Some(raw_text.to_string());
     }

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -59,7 +59,13 @@ impl StaticAbility {
             Some(StaticAbilityId::DayNightStartsDayAsEnters) => {
                 Self::day_night_starts_day_as_enters()
             }
-            Some(StaticAbilityId::Partner) => Self::partner(),
+            Some(StaticAbilityId::Partner) => {
+                if label.trim().eq_ignore_ascii_case("partner") {
+                    Self::partner()
+                } else {
+                    Self::partner_variant(label)
+                }
+            }
             Some(StaticAbilityId::PartnerWith) => Self::partner_with(label),
             Some(StaticAbilityId::StartYourEngines) => Self::start_your_engines(),
             Some(StaticAbilityId::DoctorsCompanion) => Self::doctors_companion(),

--- a/crates/ironsmith-runtime/src/static_abilities/keywords.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/keywords.rs
@@ -114,6 +114,33 @@ define_keyword!(Flanking, Flanking, "Flanking");
 define_keyword!(Partner, Partner, "Partner");
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartnerVariant {
+    display: String,
+}
+
+impl PartnerVariant {
+    pub fn new(display: impl AsRef<str>) -> Self {
+        Self {
+            display: display.as_ref().trim().to_string(),
+        }
+    }
+}
+
+impl StaticAbilityKind for PartnerVariant {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::Partner
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn is_keyword(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartnerWith {
     display: String,
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -1606,6 +1606,10 @@ impl StaticAbility {
         Self::new(Partner)
     }
 
+    pub fn partner_variant(display: impl AsRef<str>) -> Self {
+        Self::new(PartnerVariant::new(display))
+    }
+
     pub fn partner_with(partner_name: impl AsRef<str>) -> Self {
         Self::new(PartnerWith::new(partner_name))
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Leonardo, the Balance
Initial parse error:
```
parser does not yet support line family: 'Partner—Character select (You can have two commanders if both have this ability.)'; oracle-only fallback also failed: parser does not yet support line family: 'Partner—Character select'
```

Worker: i-0297cdfef70baa284
