### PR TITLE
Fix Ironsmith parse failure: Olivia's Midnight Ambush

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3310,6 +3310,13 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         }
     }
 
+    if filtered.as_slice() == ["its", "night"]
+        || filtered.as_slice() == ["it", "is", "night"]
+        || filtered.as_slice() == ["it", "night"]
+    {
+        return Ok(PredicateAst::ItIsNight);
+    }
+
     if filtered.as_slice() == ["it", "dealt", "combat", "damage", "to", "player", "this", "turn"]
         || filtered.as_slice()
             == [
@@ -3466,6 +3473,21 @@ mod tests {
                 }),
             )
         );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_its_night() -> Result<(), CardTextError> {
+        let tokens = lex_line("If it's night", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(parsed, PredicateAst::ItIsNight);
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -170,6 +170,7 @@ pub(crate) fn compile_condition_from_predicate_ast(
 ) -> Result<Condition, CardTextError> {
     let refs = current_reference_env(ctx);
     Ok(match predicate {
+        PredicateAst::ItIsNight => Condition::ItIsNight,
         PredicateAst::ItIsLandCard => {
             let mut filter = ObjectFilter {
                 zone: None,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -350,6 +350,7 @@ pub(crate) enum TriggerSpec {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PredicateAst {
+    ItIsNight,
     ItIsLandCard,
     ItIsSoulbondPaired,
     SourceChosenOption(String),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2606,7 +2606,8 @@ pub(crate) fn replace_it_damage_target(effect: &mut EffectAst, target: &TargetAs
 
 pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
     fn should_replace_self_replacement_target(effect_target: &TargetAst) -> bool {
-        target_references_it(effect_target) || matches!(effect_target, TargetAst::Tagged(_, _))
+        target_references_it(effect_target)
+            || matches!(effect_target, TargetAst::Tagged(_, _) | TargetAst::Source(_))
     }
 
     match effect {
@@ -2719,6 +2720,34 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
                 target: effect_target,
             }
             | SubjectVerbActionAst::Connive {
+                target: effect_target,
+                ..
+            } => {
+                if should_replace_self_replacement_target(effect_target) {
+                    *effect_target = target.clone();
+                }
+            }
+            SubjectVerbActionAst::Pump {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::SetBasePowerToughness {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::BecomeBasePtCreature {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::SetBasePower {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::PumpForEach {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::PumpByLastEffect {
                 target: effect_target,
                 ..
             } => {

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -722,6 +722,7 @@ pub enum Condition {
     YouControlMoreCreaturesThanTargetSpellController,
     TargetHasGreatestPowerAmongCreatures,
     TargetManaValueLteColorsSpentToCastThisSpell,
+    ItIsNight,
     SourceIsTapped,
     SourceIsSaddled,
     SourceDevouredCreaturesOrMore(u32),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35596,6 +35596,86 @@ fn strict_parse_nighthawk_scavenger_regression() {
 }
 
 #[test]
+fn strict_parse_olivias_midnight_ambush_regression() {
+    assert_oracle_card_parses_strict("Olivia's Midnight Ambush");
+}
+
+#[test]
+fn olivias_midnight_ambush_compiled_text_preserves_night_branch() {
+    let def = parse_oracle_card_definition("Olivia's Midnight Ambush");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("target creature gets -2/-2 until end of turn")
+            && rendered.contains("if it's night, that creature gets -13/-13 until end of turn instead"),
+        "expected Olivia's Midnight Ambush to preserve both base and night conditional branches, got {rendered}"
+    );
+}
+
+#[test]
+fn olivias_midnight_ambush_runtime_applies_correct_day_night_branch() {
+    use crate::effects::ResolvedTarget;
+
+    let def = parse_oracle_card_definition("Olivia's Midnight Ambush");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Olivia's Midnight Ambush should produce spell effects")
+        .clone();
+
+    let resolve_with_night = |is_night: bool| {
+        let mut game =
+            crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        game.is_night = is_night;
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+        let target = game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(91_301), "Ambush Target")
+                .card_types(vec![CardType::Creature])
+                .power_toughness(PowerToughness::fixed(20, 20))
+                .build(),
+            bob,
+            Zone::Battlefield,
+        );
+
+        let mut dm = crate::decision::AutoPassDecisionMaker;
+        let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+            .with_targets(vec![ResolvedTarget::Object(target)]);
+        crate::game_loop::execute_resolution_program(
+            &mut game,
+            &mut ctx,
+            alice,
+            spell_source,
+            &spell,
+            None,
+            &[],
+        )
+        .expect("Olivia's Midnight Ambush should resolve");
+
+        let power = game.current_power(target).unwrap_or(0);
+        let toughness = game.current_toughness(target).unwrap_or(0);
+        (power, toughness)
+    };
+
+    let (day_power, day_toughness) = resolve_with_night(false);
+    assert_eq!(
+        (day_power, day_toughness),
+        (18, 18),
+        "day branch should apply the default -2/-2 effect"
+    );
+
+    let (night_power, night_toughness) = resolve_with_night(true);
+    assert_eq!(
+        (night_power, night_toughness),
+        (7, 7),
+        "night branch should replace the default effect with -13/-13"
+    );
+}
+
+#[test]
 fn nighthawk_scavenger_compiled_text_preserves_card_types_among_clause() {
     let def = parse_oracle_card_definition("Nighthawk Scavenger");
     let rendered = unprocessed_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -386,7 +386,7 @@ pub(super) fn describe_mana_ability_resolution_program(
     let replacement_text = describe_effect_list(&branch.replacement_effects);
     let condition_text = super::normalize_common::describe_condition(&branch.condition);
     Some(format!(
-        "{default_text}. If {condition_text}, instead {}",
+        "{default_text}. If {condition_text}, {} instead",
         super::normalize_common::lowercase_first(&replacement_text)
     ))
 }
@@ -472,9 +472,19 @@ fn describe_single_self_replacement_segment(
         return Some(damage_text);
     }
     Some(format!(
-        "{default_text}. If {condition_text}, instead {}",
-        super::normalize_common::lowercase_first(&replacement_text)
+        "{default_text}. If {condition_text}, {} instead",
+        rewrite_self_replacement_referent_phrase(&default_text, &replacement_text)
     ))
+}
+
+fn rewrite_self_replacement_referent_phrase(default_text: &str, replacement_text: &str) -> String {
+    let mut replacement = super::normalize_common::lowercase_first(replacement_text);
+    if default_text.to_ascii_lowercase().contains("target creature")
+        && replacement.starts_with("target creature ")
+    {
+        replacement = replacement.replacen("target creature", "that creature", 1);
+    }
+    replacement
 }
 
 fn describe_rendered_optional_zone_rewrite_self_replacement(

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10511,6 +10511,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             )
         }
         Condition::NoSpellsWereCastLastTurn => "no spells were cast last turn".to_string(),
+        Condition::ItIsNight => "it's night".to_string(),
         Condition::SpellsWereCastLastTurnOrMore(count) => {
             let count_text = small_number_word(*count)
                 .unwrap_or_else(|| count.to_string());

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -783,6 +783,7 @@ fn evaluate_condition_shared_core(
         Condition::NoSpellsWereCastLastTurn => {
             Some(game.turn_store.spells_cast_last_turn_total == 0)
         }
+        Condition::ItIsNight => Some(game.is_night),
         Condition::SpellsWereCastLastTurnOrMore(count) => {
             Some(game.turn_store.spells_cast_last_turn_total >= *count)
         }
@@ -938,6 +939,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::ThisSpellEscaped => {}
         Condition::ThisSpellWasCastFromZone(..) => {}
         Condition::NoSpellsWereCastLastTurn => {}
+        Condition::ItIsNight => {}
         Condition::SpellsWereCastLastTurnOrMore(..) => {}
         Condition::YouHaveFullParty => {}
         Condition::TargetIsTapped => {}
@@ -1121,6 +1123,7 @@ pub fn evaluate_condition_external(
 
     match condition {
         Condition::XValueAtLeast(_) => false, // X not available in static context
+        Condition::ItIsNight => game.is_night,
         Condition::ThisSpellEscaped => source_escaped(game, ctx.source),
         Condition::ThisSpellWasKicked => game
             .object(ctx.source)
@@ -1995,6 +1998,7 @@ fn evaluate_condition_simple(
     }
 
     match condition {
+        Condition::ItIsNight => game.is_night,
         Condition::ThisSpellWasKicked => game
             .object(source)
             .is_some_and(|obj| obj.optional_costs_paid.was_kicked()),
@@ -2725,6 +2729,7 @@ fn evaluate_condition(
     }
 
     match condition {
+        Condition::ItIsNight => Ok(game.is_night),
         Condition::YouControl(filter) => {
             let filter_ctx = ctx.filter_context(game);
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Olivia's Midnight Ambush
Initial parse error:
```
unsupported predicate (predicate: 'it night'); oracle-only fallback also failed: unsupported predicate (predicate: 'it night')
```

Worker: i-01b06d0e9e80b3ff1
