### PR TITLE
Fix Ironsmith parse failure: Davros, Dalek Creator

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
@@ -416,6 +416,15 @@ pub(crate) fn parse_draw_trailing_clause(
     draw_effect: EffectAst,
 ) -> Result<Option<EffectAst>, CardTextError> {
     let tail_words = crate::runtime_backend::token_word_refs(tokens);
+
+    if let Some(discard_effect) = parse_draw_or_that_player_discards_clause(tokens) {
+        return Ok(Some(EffectAst::UnlessAction {
+            effects: vec![draw_effect],
+            alternative: vec![discard_effect],
+            player: PlayerAst::That,
+        }));
+    }
+
     if tail_words.as_slice() == ["instead"] {
         return Ok(Some(draw_effect));
     }
@@ -443,6 +452,28 @@ pub(crate) fn parse_draw_trailing_clause(
     }
 
     Ok(None)
+}
+
+fn parse_draw_or_that_player_discards_clause(tokens: &[OwnedLexToken]) -> Option<EffectAst> {
+    let trimmed = trim_commas(tokens);
+    let words = crate::runtime_backend::token_word_refs(&trimmed);
+    if !words.starts_with(&["or", "that", "player", "discards"]) {
+        return None;
+    }
+
+    let discard_tail = words.get(4..)?;
+    if !matches!(discard_tail, ["a", "card"] | ["one", "card"]) {
+        return None;
+    }
+
+    Some(EffectAst::subject_verb_discard(
+        PlayerAst::That,
+        Value::Fixed(1),
+        false,
+        false,
+        None,
+        None,
+    ))
 }
 
 pub(crate) fn parse_draw_delayed_timing_words(words: &[&str]) -> Option<DelayedReturnTimingAst> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34110,6 +34110,48 @@ fn parse_wave_of_rats_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_davros_dalek_creator_strict_regression() {
+    assert_oracle_card_parses_strict("Davros, Dalek Creator");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn davros_dalek_creator_compiled_text_keeps_villainous_choice_clause() {
+    let def = parse_oracle_card_definition("Davros, Dalek Creator");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("each opponent draws a card unless each opponent discards a card"),
+        "expected Davros villainous choice clause in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn davros_dalek_creator_trigger_models_choice_branch_per_opponent() {
+    let def = parse_oracle_card_definition("Davros, Dalek Creator");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Davros should have a triggered ability");
+
+    let trigger_debug = format!("{:?}", triggered).to_ascii_lowercase();
+    assert!(
+        trigger_debug.contains("forplayerseffect")
+            && trigger_debug.contains("unlessactioneffect")
+            && trigger_debug.contains("drawcardseffect")
+            && trigger_debug.contains("discardeffect")
+            && trigger_debug.contains("iteratedplayer"),
+        "expected Davros trigger to model per-opponent choice between discard and draw, got {trigger_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn wave_of_rats_compiled_text_keeps_combat_damage_condition_clause() {
     let def = parse_oracle_card_definition("Wave of Rats");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Davros, Dalek Creator
Initial parse error:
```
unsupported trailing draw clause (clause: 'a card or that player discards a card'); oracle-only fallback also failed: unsupported trailing draw clause (clause: 'a card or that player discards a card')
```

Worker: i-0d4d2a69a6354f4d4
