### PR TITLE
Fix Ironsmith parse failure: Return to Dust

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3350,6 +3350,16 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
     }
 
+    if filtered.as_slice()
+        == [
+            "you", "cast", "this", "spell", "during", "your", "main", "phase",
+        ]
+    {
+        return Ok(PredicateAst::ThisSpellPaidLabel(
+            "CastDuringYourMainPhase".to_string(),
+        ));
+    }
+
     let spell_cast_prefix = if slice_starts_with(&filtered, &["opponent", "has", "cast"]) {
         Some((3usize, PlayerFilter::Opponent))
     } else if slice_starts_with(&filtered, &["opponents", "have", "cast"]) {
@@ -3527,6 +3537,25 @@ mod tests {
         let parsed = parse_predicate(&predicate_tokens)?;
 
         assert_eq!(parsed, PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_you_cast_this_spell_during_your_main_phase(
+    ) -> Result<(), CardTextError> {
+        let tokens = lex_line("If you cast this spell during your main phase", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::ThisSpellPaidLabel("CastDuringYourMainPhase".to_string())
+        );
         Ok(())
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36081,6 +36081,64 @@ fn parse_oracle_undercellar_sweep_strictly_parses_and_renders_initiative_gate() 
     );
 }
 
+#[test]
+fn parse_oracle_return_to_dust_strictly_parses_and_renders_main_phase_clause() {
+    let def = parse_oracle_card_definition("Return to Dust");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        !lower.contains("unsupported predicate") && !lower.contains("unsupported effect"),
+        "expected Return to Dust to parse without unsupported placeholders, got {rendered}"
+    );
+    assert!(
+        lower.contains("you cast this spell during your main phase"),
+        "expected Return to Dust to render the main-phase cast clause, got {rendered}"
+    );
+
+    let raw = format!("{:#?}", def.spell_effect);
+    assert!(
+        raw.contains("ThisSpellPaidLabel") && raw.contains("CastDuringYourMainPhase"),
+        "expected Return to Dust to lower the branch predicate, got {raw}"
+    );
+}
+
+#[test]
+fn return_to_dust_main_phase_paid_label_condition_branches() {
+    struct NoChoices;
+    impl crate::decision::DecisionMaker for NoChoices {}
+
+    let def = parse_oracle_card_definition("Return to Dust");
+    let raw = format!("{:#?}", def.spell_effect);
+    assert!(
+        raw.contains("CastDuringYourMainPhase"),
+        "expected Return to Dust to include CastDuringYourMainPhase condition, got {raw}"
+    );
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut decision_maker = NoChoices;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_id, alice, &mut decision_maker);
+
+    let cond = crate::effect::Condition::ThisSpellPaidLabel("CastDuringYourMainPhase".to_string());
+    let without_label = crate::condition_eval::evaluate_condition_resolution(&game, &cond, &ctx)
+        .expect("condition evaluation should succeed");
+    assert!(
+        !without_label,
+        "expected Return to Dust branch condition to be false when spell was not marked as cast in your main phase"
+    );
+
+    ctx.optional_costs_paid
+        .mark_label_paid("CastDuringYourMainPhase");
+    let with_label = crate::condition_eval::evaluate_condition_resolution(&game, &cond, &ctx)
+        .expect("condition evaluation should succeed");
+    assert!(
+        with_label,
+        "expected Return to Dust branch condition to be true when spell is marked as cast in your main phase"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn undercellar_sweep_attack_trigger_creates_tokens_when_you_have_initiative() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10637,6 +10637,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             if label.eq_ignore_ascii_case("bargain") {
                 return "this spell was bargained".to_string();
             }
+            if label.eq_ignore_ascii_case("CastDuringYourMainPhase") {
+                return "you cast this spell during your main phase".to_string();
+            }
             format!("this spell's {} cost was paid", label.to_ascii_lowercase())
         }
         Condition::YouHaveFullParty => "you have a full party".to_string(),

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -611,6 +611,22 @@ pub fn apply_priority_response_with_dm(
                 mana_cost.as_ref(),
             );
 
+            let mut optional_costs_paid = game
+                .object(stack_id)
+                .map(|obj| OptionalCostsPaid::from_costs(&obj.optional_costs))
+                .unwrap_or_default();
+            if player == game.turn.active_player
+                && matches!(
+                    game.turn.phase,
+                    crate::game_state::Phase::FirstMain | crate::game_state::Phase::NextMain
+                )
+            {
+                optional_costs_paid.mark_label_paid("CastDuringYourMainPhase");
+            }
+            if let Some(obj) = game.object_mut(stack_id) {
+                obj.optional_costs_paid = optional_costs_paid.clone();
+            }
+
             if needs_x {
                 // Extract target requirements for later (use stack_id since spell is on stack)
                 let requirements = extract_target_requirements_from_program_with_modes(
@@ -620,12 +636,6 @@ pub fn apply_priority_response_with_dm(
                     Some(stack_id),
                     None,
                 );
-
-                // Initialize optional costs tracker from the spell's optional costs
-                let optional_costs_paid = game
-                    .object(stack_id)
-                    .map(|obj| OptionalCostsPaid::from_costs(&obj.optional_costs))
-                    .unwrap_or_default();
 
                 state.pending_cast = Some(PendingCast::new(
                     stack_id,
@@ -657,12 +667,6 @@ pub fn apply_priority_response_with_dm(
                     Some(stack_id),
                     None,
                 );
-
-                // Initialize optional costs tracker from the spell's optional costs
-                let optional_costs_paid = game
-                    .object(stack_id)
-                    .map(|obj| OptionalCostsPaid::from_costs(&obj.optional_costs))
-                    .unwrap_or_default();
 
                 let pending = PendingCast::new(
                     stack_id,

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1286,6 +1286,16 @@ pub(super) fn finalize_pending_spell_cast(
             .optional_costs_paid
             .mark_label_paid("CompleatedLifePaid");
     }
+    if pending.caster == game.turn.active_player
+        && matches!(
+            game.turn.phase,
+            crate::game_state::Phase::FirstMain | crate::game_state::Phase::NextMain
+        )
+    {
+        pending
+            .optional_costs_paid
+            .mark_label_paid("CastDuringYourMainPhase");
+    }
     let spell_cast_provenance =
         game.alloc_child_event_provenance(pending.provenance, crate::events::EventKind::SpellCast);
     let result = finalize_spell_cast(

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -1459,7 +1459,7 @@ fn cast_time_selected_effects_from_effect(
         caster,
         source_id,
     );
-    let selected_branch = if condition_result || conditional.if_false.is_empty() {
+    let selected_branch = if condition_result {
         &conditional.if_true
     } else {
         &conditional.if_false

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -31154,6 +31154,198 @@ fn test_compute_legal_actions_respects_valley_floodcaller_flash_grant_on_opponen
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn return_to_dust_allows_second_target_on_your_main_phase() {
+    use crate::decision::{GameProgress, LegalAction};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 4);
+
+    let return_to_dust = CardDefinitionBuilder::new(CardId::from_raw(100_910), "Return to Dust")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Colorless],
+            vec![ManaSymbol::Colorless],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
+        )
+        .expect("Return to Dust should parse");
+
+    let spell_id = game.create_object_from_definition(&return_to_dust, alice, Zone::Hand);
+    let target_a = CardBuilder::new(CardId::from_raw(100_911), "Target A")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let target_b = CardBuilder::new(CardId::from_raw(100_912), "Target B")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    game.create_object_from_card(&target_a, bob, Zone::Battlefield);
+    game.create_object_from_card(&target_b, bob, Zone::Battlefield);
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("Return to Dust cast should start");
+
+    let targets = match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(ctx)) => ctx,
+        other => panic!("unexpected cast flow state for Return to Dust: {other:?}"),
+    };
+
+    assert_eq!(targets.requirements.len(), 2, "main phase cast should expose both target branches");
+    assert_eq!(targets.requirements[0].min_targets, 1);
+    assert_eq!(targets.requirements[0].max_targets, Some(1));
+    assert_eq!(targets.requirements[1].min_targets, 0);
+    assert_eq!(targets.requirements[1].max_targets, Some(1));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn return_to_dust_does_not_allow_second_target_outside_main_phase() {
+    use crate::decision::{GameProgress, LegalAction};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(Step::DeclareAttackers);
+    game.turn.priority_player = Some(alice);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 4);
+
+    let return_to_dust = CardDefinitionBuilder::new(CardId::from_raw(100_913), "Return to Dust")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Colorless],
+            vec![ManaSymbol::Colorless],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
+        )
+        .expect("Return to Dust should parse");
+
+    let spell_id = game.create_object_from_definition(&return_to_dust, alice, Zone::Hand);
+    let target_a = CardBuilder::new(CardId::from_raw(100_914), "Target A")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&target_a, bob, Zone::Battlefield);
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("Return to Dust cast should start");
+
+    let targets = match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(ctx)) => ctx,
+        other => panic!("unexpected cast flow state for Return to Dust: {other:?}"),
+    };
+
+    assert_eq!(targets.requirements.len(), 1, "non-main-phase cast should not expose second target branch");
+    assert_eq!(targets.requirements[0].min_targets, 1);
+    assert_eq!(targets.requirements[0].max_targets, Some(1));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn return_to_dust_does_not_allow_second_target_on_opponents_turn() {
+    use crate::decision::{GameProgress, LegalAction};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 4);
+
+    let return_to_dust = CardDefinitionBuilder::new(CardId::from_raw(100_915), "Return to Dust")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Colorless],
+            vec![ManaSymbol::Colorless],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Exile target artifact or enchantment. If you cast this spell during your main phase, you may exile up to one other target artifact or enchantment.",
+        )
+        .expect("Return to Dust should parse");
+
+    let spell_id = game.create_object_from_definition(&return_to_dust, alice, Zone::Hand);
+    let target_a = CardBuilder::new(CardId::from_raw(100_916), "Target A")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&target_a, bob, Zone::Battlefield);
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("Return to Dust cast should start");
+
+    let targets = match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(ctx)) => ctx,
+        other => panic!("unexpected cast flow state for Return to Dust: {other:?}"),
+    };
+
+    assert_eq!(targets.requirements.len(), 1, "opponent-turn cast should not expose second target branch");
+    assert_eq!(targets.requirements[0].min_targets, 1);
+    assert_eq!(targets.requirements[0].max_targets, Some(1));
+}
+
 #[test]
 fn test_gift_given_event_queues_opponent_gives_gift_trigger() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Return to Dust
Initial parse error:
```
unsupported predicate (predicate: 'you cast this spell during your main phase'); oracle-only fallback also failed: unsupported predicate (predicate: 'you cast this spell during your main phase')
```

Worker: i-00ac3baada2ad70d5
