### PR TITLE
Fix Ironsmith parse failure: Tainted Strike

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -189,6 +189,12 @@ pub(crate) fn parse_top_level_subject_verb_recognition(
             effects,
         )));
     }
+    if let Some(effects) = parse_target_gets_then_gains_subject_verb(tokens)? {
+        return Ok(Some((
+            "subject-verb verb=Get subject=target recognizer=shared-subject-get-gain",
+            effects,
+        )));
+    }
 
     let program = if let Some(effect) = parse_generic_meld_subject_verb(tokens)? {
         Some(GenericTopLevelProgram::Meld { effect })
@@ -332,6 +338,31 @@ fn parse_target_gains_then_gets_subject_verb(
         .windows(2)
         .any(|window| matches!(window, ["and", "get"] | ["and", "gets"]));
     if !has_get_tail {
+        return Ok(None);
+    }
+    if words
+        .windows(3)
+        .any(|window| matches!(window, ["where", "x", "is"]))
+    {
+        return Ok(None);
+    }
+    super::gain_ability::parse_gain_ability_sentence(tokens)
+}
+
+fn parse_target_gets_then_gains_subject_verb(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(get_idx) = words
+        .iter()
+        .position(|word| matches!(*word, "get" | "gets"))
+    else {
+        return Ok(None);
+    };
+    let has_gain_tail = words[get_idx + 1..]
+        .windows(2)
+        .any(|window| matches!(window, ["and", "gain"] | ["and", "gains"]));
+    if !has_gain_tail {
         return Ok(None);
     }
     if words

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
@@ -499,9 +499,9 @@ pub(crate) fn parse_get_modifier_values_with_tail(
             tail_words.get(1).copied(),
             Some("gain" | "gains" | "has" | "have")
         )
-        && tail_words
-            .iter()
-            .any(|word| matches!(*word, "trample" | "haste" | "first" | "strike"))
+        && tail_words.iter().any(|word| {
+            matches!(*word, "trample" | "haste" | "first" | "strike" | "infect")
+        })
         && contains_until_end_of_turn(&tail_words)
     {
         return Ok((out_power, out_toughness, duration, condition));
@@ -510,9 +510,9 @@ pub(crate) fn parse_get_modifier_values_with_tail(
         && tail_words
             .iter()
             .any(|word| matches!(*word, "gain" | "gains" | "has" | "have"))
-        && tail_words
-            .iter()
-            .any(|word| matches!(*word, "trample" | "haste" | "first" | "strike"))
+        && tail_words.iter().any(|word| {
+            matches!(*word, "trample" | "haste" | "first" | "strike" | "infect")
+        })
         && contains_until_end_of_turn(&tail_words)
     {
         return Ok((out_power, out_toughness, duration, condition));

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37848,6 +37848,106 @@ fn parse_oracle_garruk_unleashed_compacts_pump_and_trample() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_tainted_strike_compiles_strictly() {
+    let def = parse_oracle_card_definition("Tainted Strike");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Target creature gets +1/+0 and gains infect until end of turn"),
+        "expected Tainted Strike to keep shared pump/infect clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tainted_strike_runtime_grants_infect_and_pump_until_end_of_turn() {
+    let def = parse_oracle_card_definition("Tainted Strike");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Tainted Strike should produce spell effects")
+        .clone();
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(93_001), "Test Attacker")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::target_creature(),
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &spell,
+        None,
+        &[],
+    )
+    .expect("Tainted Strike should resolve");
+
+    assert_eq!(game.current_power(target), Some(3));
+    assert!(game.object_has_static_ability_id(target, StaticAbilityId::Infect));
+
+    let keywords = crate::rules::damage::SourceDamageKeywords {
+        has_infect: true,
+        ..crate::rules::damage::SourceDamageKeywords::default()
+    };
+    let player_damage = crate::rules::damage::apply_processed_damage_assignment(
+        &mut game,
+        target,
+        crate::events::DamageTarget::Player(bob),
+        3,
+        keywords,
+        crate::events::cause::EventCause::from_effect(target, alice),
+    );
+    assert!(player_damage.applied, "damage assignment to player should apply");
+    assert_eq!(game.players[1].life, 20, "infect damage to player should not reduce life");
+    assert_eq!(game.players[1].poison_counters, 3, "infect damage should add poison counters");
+
+    let blocker = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(93_002), "Test Blocker")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let creature_damage = crate::rules::damage::apply_processed_damage_assignment(
+        &mut game,
+        target,
+        crate::events::DamageTarget::Object(blocker),
+        3,
+        keywords,
+        crate::events::cause::EventCause::from_effect(target, alice),
+    );
+    assert!(creature_damage.applied, "damage assignment to creature should apply");
+    assert_eq!(
+        game.object(blocker).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::MinusOneMinusOne)
+            .copied()),
+        Some(3),
+        "infect damage to creature should use -1/-1 counters"
+    );
+
+}
+
 #[test]
 fn parse_oracle_maskwood_nexus_uses_generic_subtype_family_effects() {
     let def = parse_oracle_card_definition("Maskwood Nexus");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37883,6 +37883,30 @@ fn tainted_strike_runtime_grants_infect_and_pump_until_end_of_turn() {
         Zone::Battlefield,
     );
 
+    assert_eq!(game.current_power(target), Some(2));
+    assert!(
+        !game.object_has_static_ability_id(target, StaticAbilityId::Infect),
+        "target should not start with infect"
+    );
+
+    let normal_damage = crate::rules::damage::apply_processed_damage_assignment(
+        &mut game,
+        target,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        crate::rules::damage::SourceDamageKeywords::default(),
+        crate::events::cause::EventCause::from_effect(target, alice),
+    );
+    assert!(
+        normal_damage.applied,
+        "baseline damage assignment to player should apply"
+    );
+    assert_eq!(game.players[1].life, 18, "non-infect damage should reduce life");
+    assert_eq!(
+        game.players[1].poison_counters, 0,
+        "non-infect damage should not add poison counters"
+    );
+
     let mut dm = crate::decision::AutoPassDecisionMaker;
     let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
         .with_targets(vec![crate::effects::ResolvedTarget::Object(target)])
@@ -37917,7 +37941,7 @@ fn tainted_strike_runtime_grants_infect_and_pump_until_end_of_turn() {
         crate::events::cause::EventCause::from_effect(target, alice),
     );
     assert!(player_damage.applied, "damage assignment to player should apply");
-    assert_eq!(game.players[1].life, 20, "infect damage to player should not reduce life");
+    assert_eq!(game.players[1].life, 18, "infect damage to player should not reduce life");
     assert_eq!(game.players[1].poison_counters, 3, "infect damage should add poison counters");
 
     let blocker = game.create_object_from_definition(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tainted Strike
Initial parse error:
```
unsupported trailing gets clause (clause: '+1/+0 and gains infect until end of turn'); oracle-only fallback also failed: unsupported trailing gets clause (clause: '+1/+0 and gains infect until end of turn')
```

Worker: i-0835abefbb49b8c84
