### PR TITLE
Fix Ironsmith parse failure: Roshan, Hidden Magister

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -668,7 +668,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_foretelling_cards_cost_modifier_line),
         single_static_ability_ast_rule!(parse_players_skip_upkeep_line),
         single_static_ability_ast_rule!(parse_legend_rule_doesnt_apply_line),
-        single_static_ability_ast_rule!(
+        multi_static_ability_ast_rule!(
             parse_subject_are_card_types_in_addition_to_their_other_types_line
         ),
         single_static_ability_ast_rule!(parse_all_permanents_colorless_line),
@@ -5919,7 +5919,7 @@ pub(crate) fn parse_all_permanents_colorless_line(
 
 pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line(
     tokens: &[OwnedLexToken],
-) -> Result<Option<StaticAbility>, CardTextError> {
+) -> Result<Option<Vec<StaticAbility>>, CardTextError> {
     let words = crate::runtime_backend::token_word_refs(tokens);
     if words.len() < 8 {
         return Ok(None);
@@ -5950,24 +5950,28 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
     }
 
     let mut card_types = Vec::new();
+    let mut subtypes = Vec::new();
     for descriptor in &tail[..addition_idx] {
         if is_article(descriptor) || matches!(*descriptor, "and" | "or" | "and/or") {
             continue;
         }
-        if parse_subtype_word(descriptor)
-            .or_else(|| str_strip_suffix(descriptor, "s").and_then(parse_subtype_word))
-            .is_some_and(is_land_subtype)
-        {
+        if let Some(card_type) = parse_card_type(descriptor) {
+            if !slice_contains(&card_types, &card_type) {
+                card_types.push(card_type);
+            }
             continue;
         }
-        let Some(card_type) = parse_card_type(descriptor) else {
+
+        let Some(subtype) = parse_subtype_word(descriptor)
+            .or_else(|| str_strip_suffix(descriptor, "s").and_then(parse_subtype_word))
+        else {
             return Ok(None);
         };
-        if !slice_contains(&card_types, &card_type) {
-            card_types.push(card_type);
+        if !slice_contains(&subtypes, &subtype) {
+            subtypes.push(subtype);
         }
     }
-    if card_types.is_empty() {
+    if card_types.is_empty() && subtypes.is_empty() {
         return Ok(None);
     }
 
@@ -5977,7 +5981,14 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
     }
     let filter = parse_object_filter(subject_tokens, false)?;
 
-    Ok(Some(StaticAbility::add_card_types(filter, card_types)))
+    let mut abilities = Vec::new();
+    if !card_types.is_empty() {
+        abilities.push(StaticAbility::add_card_types(filter.clone(), card_types));
+    }
+    if !subtypes.is_empty() {
+        abilities.push(StaticAbility::add_subtypes(filter, subtypes));
+    }
+    Ok(Some(abilities))
 }
 
 pub(crate) fn parse_all_cards_spells_permanents_colorless_line(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31750,6 +31750,47 @@ fn parse_oracle_encroaching_mycosynth_type_addition_regression() {
 }
 
 #[test]
+fn parse_oracle_roshan_hidden_magister_regression() {
+    let def = parse_oracle_card_definition("Roshan, Hidden Magister");
+
+    let raw = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        raw.matches("addsubtypes").count() >= 3 && raw.contains("assassin"),
+        "expected Roshan to add Assassin subtype on battlefield, stack, and off-battlefield zones, got {raw}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains(
+            "other creatures you control are assassins in addition to their other types"
+        ),
+        "expected Roshan battlefield clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains("creature spells you control are assassins in addition to their other types")
+            || rendered.contains("the same is true for creature spells you control"),
+        "expected Roshan stack clause to render, got {rendered}"
+    );
+    assert!(
+        (rendered.contains("creature cards in your hand")
+            && rendered.contains("creature cards in your library")
+            && rendered.contains("creature cards in your graveyard")
+            && rendered.contains("creature cards in your exile")
+            && rendered.contains("creature cards in your command zone")
+            && rendered.contains("are assassins in addition to their other types"))
+            || (rendered.contains("creature cards you own that aren't on the battlefield")
+                && rendered.contains("are assassins in addition to their other types")),
+        "expected Roshan off-battlefield clause to render, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported effect"),
+        "expected Roshan to avoid unsupported markers, got {rendered}"
+    );
+}
+
+#[test]
 fn parse_oracle_leyline_of_the_guildpact_static_characteristics_regression() {
     let def = parse_oracle_card_definition("Leyline of the Guildpact");
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -4733,6 +4733,181 @@ fn test_turn_face_up_action_puts_turned_face_up_trigger_on_stack() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn roshan_hidden_magister_applies_assassin_subtype_across_zones_for_you_only() {
+    use crate::cards::builders::CardDefinitionBuilder;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let roshan = CardDefinitionBuilder::new(CardId::new(), "Roshan, Hidden Magister")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
+        )
+        .expect("Roshan text should parse");
+    let _roshan_id = game.create_object_from_definition(&roshan, alice, Zone::Battlefield);
+
+    let draw_probe = CardBuilder::new(CardId::new(), "Roshan Draw Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let _ = game.create_object_from_card(&draw_probe, alice, Zone::Library);
+
+    let ally_creature = CardBuilder::new(CardId::new(), "Roshan Ally")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let ally_id = game.create_object_from_card(&ally_creature, alice, Zone::Battlefield);
+
+    let opponent_creature = CardBuilder::new(CardId::new(), "Roshan Opponent")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let opponent_id = game.create_object_from_card(&opponent_creature, bob, Zone::Battlefield);
+
+    let ally_gy_card = CardBuilder::new(CardId::new(), "Roshan GY")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let ally_gy_id = game.create_object_from_card(&ally_gy_card, alice, Zone::Graveyard);
+
+    assert!(
+        game.calculated_subtypes(ally_id).contains(&Subtype::Assassin),
+        "other creature you control should gain Assassin"
+    );
+    assert!(
+        game.calculated_subtypes(ally_gy_id).contains(&Subtype::Assassin),
+        "creature card you own off battlefield should gain Assassin"
+    );
+    assert!(
+        !game.calculated_subtypes(opponent_id).contains(&Subtype::Assassin),
+        "opponent creatures should not gain Assassin"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn roshan_hidden_magister_face_up_trigger_only_for_your_permanents() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::decision::{LegalAction, SelectFirstDecisionMaker};
+    use crate::special_actions::TurnFaceUpMethod;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let roshan = CardDefinitionBuilder::new(CardId::new(), "Roshan, Hidden Magister")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.\nFace-down creatures you control have menace.\nWhenever a permanent you control is turned face up, you draw a card and you lose 1 life.",
+        )
+        .expect("Roshan text should parse");
+    let _roshan_id = game.create_object_from_definition(&roshan, alice, Zone::Battlefield);
+
+    let draw_probe = CardBuilder::new(CardId::new(), "Roshan Draw Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let _ = game.create_object_from_card(&draw_probe, alice, Zone::Library);
+
+    let morph = CardBuilder::new(CardId::new(), "Roshan Morph")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let alice_morph_id = game.create_object_from_card(&morph, alice, Zone::Battlefield);
+    let bob_morph_id = game.create_object_from_card(&morph, bob, Zone::Battlefield);
+    for id in [alice_morph_id, bob_morph_id] {
+        if let Some(obj) = game.object_mut(id) {
+            obj.abilities.push(Ability::static_ability(StaticAbility::morph(
+                crate::cost::TotalCost::mana(ManaCost::from_pips(vec![vec![ManaSymbol::Green]])),
+            )));
+        }
+        game.set_face_down(id);
+    }
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 1);
+    game.player_mut(bob)
+        .expect("bob exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 1);
+
+    let alice_hand_before = game.player(alice).expect("alice exists").hand.len();
+    let alice_life_before = game.player(alice).expect("alice exists").life;
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let turn_up_alice = PriorityResponse::PriorityAction(LegalAction::TurnFaceUp {
+        creature_id: alice_morph_id,
+        method: TurnFaceUpMethod::TurnFaceUpAbility,
+    });
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &turn_up_alice,
+        &mut dm,
+    )
+    .expect("turning your face-down permanent up should succeed");
+    resolve_stack_entry(&mut game).expect("Roshan trigger should resolve after your permanent turns up");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        alice_hand_before + 1,
+        "Roshan should draw one card when your permanent turns face up"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        alice_life_before - 1,
+        "Roshan should make you lose 1 life when your permanent turns face up"
+    );
+
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+    let turn_up_bob = PriorityResponse::PriorityAction(LegalAction::TurnFaceUp {
+        creature_id: bob_morph_id,
+        method: TurnFaceUpMethod::TurnFaceUpAbility,
+    });
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &turn_up_bob,
+        &mut dm,
+    )
+    .expect("opponent should be able to turn their permanent face up");
+
+    assert!(
+        game.stack_is_empty(),
+        "Roshan should not trigger when an opponent-controlled permanent is turned face up"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn ecological_appreciation_puts_two_chosen_cards_back_and_recruits_the_rest() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::ids::CardId;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Roshan, Hidden Magister
Initial parse error:
```
parser does not yet support line family: 'Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.'; oracle-only fallback also failed: parser does not yet support line family: 'Other creatures you control are Assassins in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.'
```

Worker: i-0e121c9ba9aace563
