### PR TITLE
Fix Ironsmith parse failure: Cephalid Vandal

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::cards::builders::{
     SubjectVerbActionAst, SubjectVerbEffectAst, SubjectVerbRoleAst, SubjectVerbSubjectAst,
 };
+use crate::runtime_backend::parse_counter_type_from_tokens;
+use crate::TextSpan;
 
 fn subject_verb_player_effect(
     role: SubjectVerbRoleAst,
@@ -272,13 +274,62 @@ pub(crate) fn parse_mill(
     tokens: &[OwnedLexToken],
     subject: Option<SubjectAst>,
 ) -> Result<EffectAst, CardTextError> {
+    fn parse_trailing_for_each_count(tokens: &[OwnedLexToken]) -> Option<Value> {
+        let mut words = crate::runtime_backend::token_word_refs(tokens);
+        if words.first().copied() == Some("card") || words.first().copied() == Some("cards") {
+            words = words[1..].to_vec();
+        }
+        if !(words.starts_with(&["for", "each"]) || words.starts_with(&["each"])) {
+            return None;
+        }
+
+        let after_each = if words.starts_with(&["for", "each"]) {
+            &words[2..]
+        } else {
+            &words[1..]
+        };
+        if let Some(on_idx) = after_each
+            .iter()
+            .position(|word| *word == "on")
+            .filter(|on_idx| *on_idx > 0)
+        {
+            let counter_words = &after_each[..on_idx];
+            let reference = &after_each[on_idx + 1..];
+            if matches!(counter_words.last().copied(), Some("counter" | "counters"))
+                && matches!(reference, ["it"] | ["this"] | ["this", ..])
+            {
+                let counter_tokens = counter_words
+                    .iter()
+                    .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                    .collect::<Vec<_>>();
+                if let Some(counter_type) = parse_counter_type_from_tokens(&counter_tokens) {
+                    return Some(Value::CountersOnSource(counter_type));
+                }
+            }
+        }
+
+        let mut number_of_words = vec!["the", "number", "of"];
+        number_of_words.extend_from_slice(after_each);
+        let number_of_tokens = number_of_words
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        if let Some((value, used)) = parse_value(&number_of_tokens)
+            && used == number_of_tokens.len()
+        {
+            return Some(value);
+        }
+
+        parse_get_for_each_count_value(tokens).ok().flatten()
+    }
+
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     let starts_with_card_keyword = tokens
         .first()
         .and_then(OwnedLexToken::as_word)
         .is_some_and(|word| word == "card" || word == "cards");
 
-    let (count, used) =
+    let (mut count, used) =
         if let Some((prefix, _)) = grammar::words_match_any_prefix(tokens, THAT_MANY_PREFIXES) {
             (Value::EventValue(EventValueSpec::Amount), prefix.len())
         } else if starts_with_card_keyword {
@@ -304,12 +355,30 @@ pub(crate) fn parse_mill(
 
     let rest = &tokens[used..];
     if starts_with_card_keyword {
-        let trailing_words: Vec<&str> = rest.iter().filter_map(OwnedLexToken::as_word).collect();
+        let trailing_count_tokens = if rest
+            .first()
+            .and_then(OwnedLexToken::as_word)
+            .is_some_and(|word| word == "card" || word == "cards")
+        {
+            &rest[1..]
+        } else {
+            rest
+        };
+        let trailing_words: Vec<&str> = trailing_count_tokens
+            .iter()
+            .filter_map(OwnedLexToken::as_word)
+            .collect();
         if !trailing_words.is_empty() {
+            if matches!(count, Value::Fixed(1))
+                && let Some(for_each_count) = parse_trailing_for_each_count(trailing_count_tokens)
+            {
+                count = for_each_count;
+            } else {
             return Err(CardTextError::ParseError(format!(
                 "unsupported trailing mill clause (clause: '{}')",
                 clause_words.join(" ")
             )));
+            }
         }
     } else {
         if rest
@@ -321,16 +390,22 @@ pub(crate) fn parse_mill(
                 "missing card keyword".to_string(),
             ));
         }
-        let trailing_words: Vec<&str> = rest
+        let trailing_count_tokens = &rest[1..];
+        let trailing_words: Vec<&str> = trailing_count_tokens
             .iter()
-            .skip(1)
             .filter_map(OwnedLexToken::as_word)
             .collect();
         if !trailing_words.is_empty() {
-            return Err(CardTextError::ParseError(format!(
-                "unsupported trailing mill clause (clause: '{}')",
-                clause_words.join(" ")
-            )));
+            if matches!(count, Value::Fixed(1))
+                && let Some(for_each_count) = parse_trailing_for_each_count(trailing_count_tokens)
+            {
+                count = for_each_count;
+            } else {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported trailing mill clause (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            }
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34196,8 +34196,7 @@ fn cephalid_vandal_compiled_text_keeps_shred_counter_mill_clause() {
     assert!(
         rendered.contains("at the beginning of your upkeep")
             && rendered.contains("put a shred counter on this creature")
-            && (rendered.contains("mill a card for each shred counter on this creature")
-                || rendered.contains("mill a card for each shred counters on this creature")),
+            && rendered.contains("mill a card for each shred counter on this creature"),
         "expected Cephalid Vandal upkeep shred-counter mill clause, got {rendered}"
     );
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34183,6 +34183,123 @@ fn parse_cloud_ex_soldier_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_cephalid_vandal_strict_regression() {
+    assert_oracle_card_parses_strict("Cephalid Vandal");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cephalid_vandal_compiled_text_keeps_shred_counter_mill_clause() {
+    let def = parse_oracle_card_definition("Cephalid Vandal");
+    let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("at the beginning of your upkeep")
+            && rendered.contains("put a shred counter on this creature")
+            && (rendered.contains("mill a card for each shred counter on this creature")
+                || rendered.contains("mill a card for each shred counters on this creature")),
+        "expected Cephalid Vandal upkeep shred-counter mill clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cephalid_vandal_upkeep_trigger_adds_shred_counter_then_mills_one() {
+    let def = parse_oracle_card_definition("Cephalid Vandal");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Cephalid Vandal should have an upkeep triggered ability");
+
+    let effects = &triggered.effects.segments[0].default_effects;
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let library_card = CardDefinitionBuilder::new(CardId::new(), "Library Card")
+        .card_types(vec![CardType::Land])
+        .build();
+    for _ in 0..3 {
+        game.create_object_from_definition(&library_card, alice, Zone::Library);
+    }
+    let library_before = game.player(alice).expect("alice should exist").library.len();
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    for effect in effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Cephalid Vandal upkeep effects should resolve");
+    }
+
+    assert_eq!(
+        game.counter_count(source_id, crate::object::CounterType::Named("shred")),
+        1,
+        "Cephalid Vandal should gain one shred counter during upkeep"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice should exist").library.len(),
+        library_before - 1,
+        "Cephalid Vandal should mill one card after the first shred counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cephalid_vandal_upkeep_trigger_mill_count_scales_with_existing_shred_counters() {
+    let def = parse_oracle_card_definition("Cephalid Vandal");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Cephalid Vandal should have an upkeep triggered ability");
+
+    let effects = &triggered.effects.segments[0].default_effects;
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let library_card = CardDefinitionBuilder::new(CardId::new(), "Library Card")
+        .card_types(vec![CardType::Land])
+        .build();
+    for _ in 0..5 {
+        game.create_object_from_definition(&library_card, alice, Zone::Library);
+    }
+
+    game.add_counters_with_source(
+        source_id,
+        crate::object::CounterType::Named("shred"),
+        1,
+        None,
+        None,
+    );
+    let library_before = game.player(alice).expect("alice should exist").library.len();
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    for effect in effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Cephalid Vandal upkeep effects should resolve");
+    }
+
+    assert_eq!(
+        game.counter_count(source_id, crate::object::CounterType::Named("shred")),
+        2,
+        "Cephalid Vandal should add a second shred counter during upkeep"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice should exist").library.len(),
+        library_before - 2,
+        "Cephalid Vandal should mill two cards when it has two shred counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn cloud_ex_soldier_compiled_text_keeps_power_threshold_treasure_clause() {
     let def = parse_oracle_card_definition("Cloud, Ex-SOLDIER");
     let rendered = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17776,6 +17776,13 @@ pub(super) fn describe_draw_for_each(draw: &crate::effects::DrawCardsEffect) -> 
     }
 }
 
+fn singularize_for_each_basis(basis: &str) -> String {
+    if let Some((head, tail)) = basis.split_once(" counters on ") {
+        return format!("{head} counter on {tail}");
+    }
+    basis.to_string()
+}
+
 fn describe_tagged_creature_power_count_basis(spec: &ChooseSpec) -> Option<&'static str> {
     match spec.base() {
         ChooseSpec::Tagged(tag)
@@ -26424,7 +26431,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         }
         let count_text = describe_card_count(&mill.count);
         if let Some(rest) = count_text.strip_prefix("the number of ") {
-            let basis = rest.strip_suffix(" cards").unwrap_or(rest);
+            let basis = singularize_for_each_basis(rest.strip_suffix(" cards").unwrap_or(rest));
             return format!(
                 "{} {} a card for each {}",
                 player,

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26422,11 +26422,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 player_verb(&player, "mill", "mills")
             );
         }
+        let count_text = describe_card_count(&mill.count);
+        if let Some(rest) = count_text.strip_prefix("the number of ") {
+            let basis = rest.strip_suffix(" cards").unwrap_or(rest);
+            return format!(
+                "{} {} a card for each {}",
+                player,
+                player_verb(&player, "mill", "mills"),
+                basis
+            );
+        }
         return format!(
             "{} {} {}",
             player,
             player_verb(&player, "mill", "mills"),
-            describe_card_count(&mill.count)
+            count_text
         );
     }
     if let Some(tap) = effect.downcast_ref::<crate::effects::TapEffect>() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cephalid Vandal
Initial parse error:
```
unsupported trailing mill clause (clause: 'a card for each shred counter on this creature'); oracle-only fallback also failed: unsupported trailing mill clause (clause: 'a card for each shred counter on this creature')
```

Worker: i-0dae812586406cb44
