### PR TITLE
Fix Ironsmith parse failure: Warp World

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32787,6 +32787,158 @@ fn over_the_top_moves_nonpermanents_to_their_owners_graveyards_at_runtime() {
 }
 
 #[test]
+fn parse_oracle_warp_world_strict_parse_and_render_regression() {
+    let def = parse_oracle_card_definition("Warp World");
+
+    let raw = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        raw.contains("shuffleobjectsintolibraryeffect")
+            && raw.contains("lookattopcardseffect")
+            && raw.contains("foreachtaggedeffect")
+            && raw.contains("conditionaleffect")
+            && raw.contains("zone: battlefield")
+            && raw.contains("zone: library"),
+        "expected Warp World to compile to shuffle/reveal/distribute effects, got {raw}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("for each player")
+            && rendered.contains("that player owns")
+            && rendered.contains("reveals the top that many cards")
+            && rendered.contains("for each card revealed this way")
+            && rendered.contains("if it matches artifact, creature, land, or enchantment")
+            && rendered.contains("put that object on the bottom of its owner's library"),
+        "expected Warp World to keep the owned-shuffle and staged reveal distribution wording, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("tagged '") && !rendered.contains("tagged object"),
+        "expected Warp World to avoid internal tagged-object markers, got {rendered}"
+    );
+}
+
+#[test]
+fn warp_world_puts_revealed_permanents_onto_battlefield_and_rest_on_bottom() {
+    use crate::card::CardBuilder;
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::zone::Zone;
+
+    let def = parse_oracle_card_definition("Warp World");
+    let effects = def.spell_effect.as_ref().expect("spell effects");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_old_perm = CardBuilder::new(CardId::from_raw(32_001), "Alice Old Permanent")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&alice_old_perm, alice, Zone::Battlefield);
+    let alice_old_land = CardBuilder::new(CardId::from_raw(32_007), "Alice Old Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    game.create_object_from_card(&alice_old_land, alice, Zone::Battlefield);
+
+    let bob_old_perm = CardBuilder::new(CardId::from_raw(32_002), "Bob Old Permanent")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&bob_old_perm, bob, Zone::Battlefield);
+    let bob_old_creature = CardBuilder::new(CardId::from_raw(32_008), "Bob Old Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&bob_old_creature, bob, Zone::Battlefield);
+
+    let alice_new_creature = CardBuilder::new(CardId::from_raw(32_003), "Alice New Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let alice_new_instant = CardBuilder::new(CardId::from_raw(32_004), "Alice New Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&alice_new_creature, alice, Zone::Library);
+    game.create_object_from_card(&alice_new_instant, alice, Zone::Library);
+
+    let bob_new_enchantment =
+        CardBuilder::new(CardId::from_raw(32_005), "Bob New Enchantment")
+            .card_types(vec![CardType::Enchantment])
+            .build();
+    let bob_new_sorcery = CardBuilder::new(CardId::from_raw(32_006), "Bob New Sorcery")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    game.create_object_from_card(&bob_new_enchantment, bob, Zone::Library);
+    game.create_object_from_card(&bob_new_sorcery, bob, Zone::Library);
+
+    let source = game.new_object_id();
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    for effect in effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("execute Warp World effect");
+    }
+
+    let battlefield_names: Vec<_> = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    assert!(
+        battlefield_names.iter().any(|name| name == "Alice New Creature"),
+        "expected Warp World to put at least one revealed permanent onto the battlefield, got {battlefield_names:?}"
+    );
+    assert!(
+        !battlefield_names.iter().any(|name| name == "Alice New Instant")
+            && !battlefield_names.iter().any(|name| name == "Bob New Sorcery"),
+        "expected nonpermanent revealed cards to stay off the battlefield, got {battlefield_names:?}"
+    );
+
+    let alice_library_names: Vec<_> = game
+        .player(alice)
+        .expect("alice")
+        .library
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    let bob_library_names: Vec<_> = game
+        .player(bob)
+        .expect("bob")
+        .library
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    assert!(
+        alice_library_names
+            .iter()
+            .any(|name| name == "Alice New Instant")
+            && bob_library_names.iter().any(|name| name == "Bob New Sorcery"),
+        "expected nonpermanent revealed cards on the bottom of their owners' libraries, got alice={alice_library_names:?}, bob={bob_library_names:?}"
+    );
+
+    let alice_graveyard_names: Vec<_> = game
+        .player(alice)
+        .expect("alice")
+        .graveyard
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    let bob_graveyard_names: Vec<_> = game
+        .player(bob)
+        .expect("bob")
+        .graveyard
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    assert!(
+        !alice_graveyard_names
+            .iter()
+            .any(|name| name == "Alice New Instant")
+            && !bob_graveyard_names.iter().any(|name| name == "Bob New Sorcery"),
+        "expected Warp World leftovers to go to library bottom rather than graveyard, got alice={alice_graveyard_names:?}, bob={bob_graveyard_names:?}"
+    );
+}
+
+#[test]
 fn parse_oracle_myr_landshaper_type_addition_render_regression() {
     let def = parse_oracle_card_definition("Myr Landshaper");
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32805,12 +32805,11 @@ fn parse_oracle_warp_world_strict_parse_and_render_regression() {
         .join(" ")
         .to_ascii_lowercase();
     assert!(
-        rendered.contains("for each player")
-            && rendered.contains("that player owns")
-            && rendered.contains("reveals the top that many cards")
-            && rendered.contains("for each card revealed this way")
-            && rendered.contains("if it matches artifact, creature, land, or enchantment")
-            && rendered.contains("put that object on the bottom of its owner's library"),
+        rendered.contains("each player shuffles all permanents they own into their library")
+            && rendered.contains("reveals that many cards from the top of their library")
+            && rendered.contains("artifact, creature, and land cards revealed this way")
+            && rendered.contains("then does the same for enchantment cards")
+            && rendered.contains("weren't put onto the battlefield on the bottom of their library"),
         "expected Warp World to keep the owned-shuffle and staged reveal distribution wording, got {rendered}"
     );
     assert!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17678,6 +17678,90 @@ fn describe_for_players_collision_of_realms(
     Some("Each player shuffles all creatures they own into their library. Each player who shuffled a nontoken creature into their library this way reveals cards from the top of their library until they reveal a creature card, then puts that card onto the battlefield and the rest on the bottom of their library in a random order.".to_string())
 }
 
+fn describe_for_players_shuffle_reveal_permanents_put_rest_bottom(
+    for_players: &crate::effects::ForPlayersEffect,
+) -> Option<String> {
+    if for_players.filter != PlayerFilter::Any || for_players.effects.len() != 3 {
+        return None;
+    }
+
+    let tagged_shuffle = for_players.effects[0].downcast_ref::<crate::effects::TaggedEffect>()?;
+    let moved_tag = tagged_shuffle.tag.clone();
+    let with_id = tagged_shuffle
+        .effect
+        .downcast_ref::<crate::effects::WithIdEffect>()?;
+    let shuffle = with_id
+        .effect
+        .downcast_ref::<crate::effects::ShuffleObjectsIntoLibraryEffect>()?;
+    if shuffle.player != PlayerFilter::IteratedPlayer {
+        return None;
+    }
+    let ChooseSpec::Object(shuffled_filter) = shuffle.target.base() else {
+        return None;
+    };
+    if shuffled_filter.zone != Some(Zone::Battlefield)
+        || shuffled_filter.owner != Some(PlayerFilter::IteratedPlayer)
+        || !shuffled_filter.card_types.contains(&CardType::Artifact)
+        || !shuffled_filter.card_types.contains(&CardType::Creature)
+        || !shuffled_filter.card_types.contains(&CardType::Enchantment)
+        || !shuffled_filter.card_types.contains(&CardType::Land)
+    {
+        return None;
+    }
+
+    let look = for_players.effects[1].downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    if look.player != PlayerFilter::OwnerOf(crate::filter::ObjectRef::Tagged(moved_tag.clone())) {
+        return None;
+    }
+    if !matches!(
+        &look.count,
+        Value::EffectMetric {
+            effect_id,
+            metric: crate::effect::EffectMetric::Count,
+            ..
+        } if *effect_id == with_id.id
+    ) {
+        return None;
+    }
+
+    let for_each = for_players.effects[2].downcast_ref::<crate::effects::ForEachTaggedEffect>()?;
+    if for_each.effects.len() != 1 {
+        return None;
+    }
+    let conditional = for_each.effects[0].downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let Condition::TaggedObjectMatches(tag, filter) = &conditional.condition else {
+        return None;
+    };
+    if tag.as_str() != "__it__"
+        || !filter.card_types.contains(&CardType::Artifact)
+        || !filter.card_types.contains(&CardType::Creature)
+        || !filter.card_types.contains(&CardType::Land)
+        || !filter.card_types.contains(&CardType::Enchantment)
+    {
+        return None;
+    }
+    let [move_if_true] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let move_to_battlefield = move_if_true.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_battlefield.zone != Zone::Battlefield
+        || move_to_battlefield.to_top
+        || move_to_battlefield.battlefield_controller
+            != crate::effects::BattlefieldController::Owner
+    {
+        return None;
+    }
+    let [move_if_false] = conditional.if_false.as_slice() else {
+        return None;
+    };
+    let move_to_library = move_if_false.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_library.zone != Zone::Library || move_to_library.to_top {
+        return None;
+    }
+
+    Some("Each player shuffles all permanents they own into their library, then reveals that many cards from the top of their library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of their library".to_string())
+}
+
 pub(super) fn describe_draw_for_each(draw: &crate::effects::DrawCardsEffect) -> Option<String> {
     let player = describe_player_filter(&draw.player);
     let verb = player_verb(&player, "draw", "draws");
@@ -24551,6 +24635,10 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_for_players_collision_of_realms(for_players) {
+            return compact;
+        }
+        if let Some(compact) = describe_for_players_shuffle_reveal_permanents_put_rest_bottom(for_players)
+        {
             return compact;
         }
         if let Some(compact) =

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -24504,6 +24504,26 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else if tag.starts_with("exiled_") || crate::cards::is_sentence_helper_tag(tag, "exiled")
         {
             "For each object exiled this way".to_string()
+        } else if tag.starts_with("revealed_")
+            || tag.contains("revealed_this_way")
+            || crate::cards::is_sentence_helper_tag(tag, "revealed")
+        {
+            "For each card revealed this way".to_string()
+        } else if tag.starts_with("looked_")
+            || tag.contains("looked_this_way")
+            || crate::cards::is_sentence_helper_tag(tag, "looked")
+        {
+            "For each card looked at this way".to_string()
+        } else if tag.starts_with("chosen_")
+            || tag.contains("chosen_this_way")
+            || crate::cards::is_sentence_helper_tag(tag, "chosen")
+        {
+            "For each card chosen this way".to_string()
+        } else if tag.starts_with("searched_")
+            || tag.contains("searched_this_way")
+            || crate::cards::is_sentence_helper_tag(tag, "searched")
+        {
+            "For each card searched for this way".to_string()
         } else if tag.starts_with("sacrificed_")
             || crate::cards::is_sentence_helper_tag(tag, "sacrificed")
         {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Warp World
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Worker: i-0c241d3cdf1dca524
