### PR TITLE
Fix Ironsmith parse failure: Stonebinder's Familiar

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1237,6 +1237,14 @@ pub(crate) fn parse_trigger_clause_lexed(
 
     for (tail, from_zones) in [
         (
+            ["is", "put", "into", "exile"].as_slice(),
+            Vec::new(),
+        ),
+        (
+            ["are", "put", "into", "exile"].as_slice(),
+            Vec::new(),
+        ),
+        (
             [
                 "is",
                 "put",
@@ -1367,12 +1375,17 @@ pub(crate) fn parse_trigger_clause_lexed(
             let subject_words = subject_view.to_word_refs();
             let one_or_more = subject_words.starts_with(&["one", "or", "more"]);
             let subject_tokens = strip_leading_one_or_more_lexed(subject_tokens);
-            let mut filter = parse_object_filter_lexed(subject_tokens, false).map_err(|_| {
-                CardTextError::ParseError(format!(
-                    "unsupported filter in put-into-exile-from-zones trigger clause (clause: '{}')",
-                    words.join(" ")
-                ))
-            })?;
+            let stripped_subject_words = ActivationRestrictionCompatWords::new(subject_tokens).to_word_refs();
+            let mut filter = if matches!(stripped_subject_words.as_slice(), ["card"] | ["cards"]) {
+                ObjectFilter::default()
+            } else {
+                parse_object_filter_lexed(subject_tokens, false).map_err(|_| {
+                    CardTextError::ParseError(format!(
+                        "unsupported filter in put-into-exile-from-zones trigger clause (clause: '{}')",
+                        words.join(" ")
+                    ))
+                })?
+            };
             filter.zone = None;
             filter.controller = None;
             filter.owner = None;
@@ -1380,7 +1393,10 @@ pub(crate) fn parse_trigger_clause_lexed(
                 .iter()
                 .any(|word| matches!(*word, "card" | "cards"))
             {
-                filter.nontoken = true;
+                filter.card_types.clear();
+                if !from_zones.is_empty() {
+                    filter.nontoken = true;
+                }
             }
             return Ok(TriggerSpec::PutIntoExileFromZones {
                 filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1394,9 +1394,7 @@ pub(crate) fn parse_trigger_clause_lexed(
                 .any(|word| matches!(*word, "card" | "cards"))
             {
                 filter.card_types.clear();
-                if !from_zones.is_empty() {
-                    filter.nontoken = true;
-                }
+                filter.nontoken = true;
             }
             return Ok(TriggerSpec::PutIntoExileFromZones {
                 filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -223,9 +223,11 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             during_turn,
         } => {
             let mut trigger = crate::triggers::zone_changes::ZoneChangeTrigger::new()
-                .from_any_of(from)
                 .to(crate::zone::Zone::Exile)
                 .filter(filter);
+            if !from.is_empty() {
+                trigger = trigger.from_any_of(from);
+            }
             if one_or_more {
                 trigger = trigger.count(crate::triggers::CountMode::OneOrMore);
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8947,6 +8947,7 @@ fn rewrite_lexed_triggered_line_parses_stonebinders_familiar_trigger() {
     assert!(debug.contains("one_or_more: true"), "{debug}");
     assert!(debug.contains("during_turn: Some"), "{debug}");
     assert!(debug.contains("You"), "{debug}");
+    assert!(debug.contains("nontoken: true"), "{debug}");
     assert!(debug.contains("PutCounters"), "{debug}");
     assert!(debug.contains("PlusOnePlusOne"), "{debug}");
     assert!(debug.contains("max_triggers_per_turn: Some"), "{debug}");

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8934,6 +8934,25 @@ fn rewrite_lexed_triggered_line_parses_ketramose_exile_trigger() {
 }
 
 #[test]
+fn rewrite_lexed_triggered_line_parses_stonebinders_familiar_trigger() {
+    let text = "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.";
+    let tokens = lex_line(text, 0)
+        .expect("rewrite lexer should classify Stonebinder's Familiar triggered line");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("Stonebinder's Familiar triggered line should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("PutIntoExileFromZones"), "{debug}");
+    assert!(debug.contains("one_or_more: true"), "{debug}");
+    assert!(debug.contains("during_turn: Some"), "{debug}");
+    assert!(debug.contains("You"), "{debug}");
+    assert!(debug.contains("PutCounters"), "{debug}");
+    assert!(debug.contains("PlusOnePlusOne"), "{debug}");
+    assert!(debug.contains("max_triggers_per_turn: Some"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_triggered_line_handles_punctuation_before_enter_verb() {
     let text = "Whenever one or more noncreature, nonland permanents you control enter, put a +1/+1 counter on target creature you control.";
     let tokens = lex_line(text, 0)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -983,7 +983,7 @@ fn guild_artisan_grants_treasure_trigger_when_commander_attacks_tied_life_leader
 
 #[test]
 fn attack_trigger_with_countered_attacker_taps_defending_creature() {
-    use crate::object::CounterType;
+    use crate::object::{CounterType, ObjectKind};
 
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);
@@ -2885,12 +2885,43 @@ fn stonebinders_familiar_triggers_once_each_turn_and_only_during_your_turn() {
     let familiar_id =
         game.create_object_from_definition(&familiar, alice, crate::zone::Zone::Battlefield);
 
+    let exiled_token_card = CardBuilder::new(CardId::from_raw(81_714), "Exiled Token")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let exiled_token_id = game.create_object_from_card(&exiled_token_card, alice, Zone::Battlefield);
+    if let Some(token) = game.object_mut(exiled_token_id) {
+        token.kind = ObjectKind::Token;
+    }
+
     let exiled_card = CardBuilder::new(CardId::from_raw(81_711), "Exiled Card")
         .card_types(vec![CardType::Creature])
         .build();
     let exiled_id = game.create_object_from_card(&exiled_card, alice, Zone::Graveyard);
 
     game.turn.active_player = alice;
+    let token_exile = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            exiled_token_id,
+            Zone::Battlefield,
+            Zone::Exile,
+            crate::events::cause::EventCause::from_effect(familiar_id, alice),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, token_exile, false);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("token exile event should be processed cleanly");
+    assert!(
+        game.stack.is_empty(),
+        "Stonebinder's Familiar should not trigger when a token is exiled"
+    );
+    assert_eq!(
+        game.counter_count(familiar_id, CounterType::PlusOnePlusOne),
+        0,
+        "token exile should not add a +1/+1 counter"
+    );
+
     let first_exile = TriggerEvent::new_with_provenance(
         ZoneChangeEvent::with_cause(
             exiled_id,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2861,6 +2861,113 @@ fn vengeful_warchief_triggers_only_on_the_first_life_loss_each_turn() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn stonebinders_familiar_triggers_once_each_turn_and_only_during_your_turn() {
+    use crate::events::zones::ZoneChangeEvent;
+    use crate::object::CounterType;
+    use crate::triggers::TriggerEvent;
+
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let familiar = CardDefinitionBuilder::new(CardId::from_raw(81_710), "Stonebinder's Familiar")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![crate::types::Subtype::Spirit, crate::types::Subtype::Dog])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.",
+        )
+        .expect("Stonebinder's Familiar should parse");
+    let familiar_id =
+        game.create_object_from_definition(&familiar, alice, crate::zone::Zone::Battlefield);
+
+    let exiled_card = CardBuilder::new(CardId::from_raw(81_711), "Exiled Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let exiled_id = game.create_object_from_card(&exiled_card, alice, Zone::Graveyard);
+
+    game.turn.active_player = alice;
+    let first_exile = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            exiled_id,
+            Zone::Graveyard,
+            Zone::Exile,
+            crate::events::cause::EventCause::from_effect(familiar_id, alice),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, first_exile, false);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Stonebinder's Familiar should trigger when cards are exiled during your turn");
+    assert_eq!(game.stack.len(), 1, "first exile event should trigger once");
+    resolve_stack_entry(&mut game).expect("Stonebinder's Familiar trigger should resolve");
+    assert_eq!(
+        game.counter_count(familiar_id, CounterType::PlusOnePlusOne),
+        1,
+        "first trigger should add one +1/+1 counter"
+    );
+
+    let second_exiled_card = CardBuilder::new(CardId::from_raw(81_712), "Second Exiled Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let second_exiled_id = game.create_object_from_card(&second_exiled_card, alice, Zone::Hand);
+    let second_exile_same_turn = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            second_exiled_id,
+            Zone::Hand,
+            Zone::Exile,
+            crate::events::cause::EventCause::from_effect(familiar_id, alice),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, second_exile_same_turn, false);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("second same-turn exile should be processed cleanly");
+    assert!(
+        game.stack.is_empty(),
+        "Stonebinder's Familiar should not trigger a second time in the same turn"
+    );
+    assert_eq!(
+        game.counter_count(familiar_id, CounterType::PlusOnePlusOne),
+        1,
+        "second same-turn exile should not add another counter"
+    );
+
+    game.turn.active_player = bob;
+    let opponent_exiled_card = CardBuilder::new(CardId::from_raw(81_713), "Opponent Exiled Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let opponent_exiled_id = game.create_object_from_card(&opponent_exiled_card, bob, Zone::Graveyard);
+    let exile_on_opponents_turn = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            opponent_exiled_id,
+            Zone::Graveyard,
+            Zone::Exile,
+            crate::events::cause::EventCause::from_effect(familiar_id, bob),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, exile_on_opponents_turn, false);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("opponent-turn exile event should be processed cleanly");
+    assert!(
+        game.stack.is_empty(),
+        "Stonebinder's Familiar should not trigger during an opponent's turn"
+    );
+    assert_eq!(
+        game.counter_count(familiar_id, CounterType::PlusOnePlusOne),
+        1,
+        "opponent-turn exile should not add a counter"
+    );
+}
+
 #[test]
 fn test_triggered_mana_ability_resolves_immediately_without_stack() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
@@ -348,15 +348,21 @@ impl ZoneChangeTrigger {
         }
 
         fn is_nontoken_card_subject_from_card_zones(trigger: &ZoneChangeTrigger) -> bool {
-            trigger.to == ZonePattern::Specific(Zone::Exile)
-                && matches!(
-                    &trigger.from,
-                    ZonePattern::OneOf(zones)
-                        if zones.contains(&Zone::Graveyard)
-                            && zones.contains(&Zone::Battlefield)
-                            && zones.len() == 2
-                )
-                && trigger.object_filter == ObjectFilter::default().nontoken()
+            if trigger.to != ZonePattern::Specific(Zone::Exile) {
+                return false;
+            }
+            if matches!(&trigger.from, ZonePattern::OneOf(zones) if zones.is_empty())
+                && trigger.object_filter == ObjectFilter::default()
+            {
+                return true;
+            }
+            matches!(
+                &trigger.from,
+                ZonePattern::OneOf(zones)
+                    if zones.contains(&Zone::Graveyard)
+                        && zones.contains(&Zone::Battlefield)
+                        && zones.len() == 2
+            ) && trigger.object_filter == ObjectFilter::default().nontoken()
         }
 
         if self.this_object {
@@ -480,7 +486,7 @@ impl ZoneChangeTrigger {
                 if let Some(source_phrase) = source_zone_phrase(self) {
                     parts.push(format!("{verb} put into exile {source_phrase}"));
                 } else {
-                    parts.push(format!("{verb} exiled"));
+                    parts.push(format!("{verb} put into exile"));
                 }
             }
             _ => {

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
@@ -348,16 +348,17 @@ impl ZoneChangeTrigger {
         }
 
         fn is_nontoken_card_subject_from_card_zones(trigger: &ZoneChangeTrigger) -> bool {
+            let card_subject_anywhere_filter =
+                trigger.object_filter == ObjectFilter::default()
+                    || trigger.object_filter == ObjectFilter::default().nontoken();
             if trigger.to != ZonePattern::Specific(Zone::Exile) {
                 return false;
             }
-            if matches!(&trigger.from, ZonePattern::Any)
-                && trigger.object_filter == ObjectFilter::default()
-            {
+            if matches!(&trigger.from, ZonePattern::Any) && card_subject_anywhere_filter {
                 return true;
             }
             if matches!(&trigger.from, ZonePattern::OneOf(zones) if zones.is_empty())
-                && trigger.object_filter == ObjectFilter::default()
+                && card_subject_anywhere_filter
             {
                 return true;
             }
@@ -1103,6 +1104,16 @@ mod tests {
             .during_turn(PlayerFilter::You);
         assert_eq!(
             anywhere_to_exile.display(),
+            "Whenever one or more cards are put into exile during your turn"
+        );
+
+        let nontoken_anywhere_to_exile = ZoneChangeTrigger::new()
+            .to(Zone::Exile)
+            .filter(ObjectFilter::default().nontoken())
+            .count(CountMode::OneOrMore)
+            .during_turn(PlayerFilter::You);
+        assert_eq!(
+            nontoken_anywhere_to_exile.display(),
             "Whenever one or more cards are put into exile during your turn"
         );
     }

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
@@ -351,6 +351,11 @@ impl ZoneChangeTrigger {
             if trigger.to != ZonePattern::Specific(Zone::Exile) {
                 return false;
             }
+            if matches!(&trigger.from, ZonePattern::Any)
+                && trigger.object_filter == ObjectFilter::default()
+            {
+                return true;
+            }
             if matches!(&trigger.from, ZonePattern::OneOf(zones) if zones.is_empty())
                 && trigger.object_filter == ObjectFilter::default()
             {
@@ -1090,6 +1095,15 @@ mod tests {
         assert_eq!(
             graveyard_or_battlefield_to_exile.display(),
             "Whenever one or more cards are put into exile from graveyards and/or the battlefield during your turn"
+        );
+
+        let anywhere_to_exile = ZoneChangeTrigger::new()
+            .to(Zone::Exile)
+            .count(CountMode::OneOrMore)
+            .during_turn(PlayerFilter::You);
+        assert_eq!(
+            anywhere_to_exile.display(),
+            "Whenever one or more cards are put into exile during your turn"
         );
     }
 

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -3004,6 +3004,10 @@ CardDefinition {
             "compiled text should keep the counter-adding trigger effect, got: {compiled}"
         );
         assert!(
+            compiled.contains("Whenever one or more cards are put into exile during your turn"),
+            "compiled text should keep the exile trigger card subject, got: {compiled}"
+        );
+        assert!(
             compiled.contains("This ability triggers only once each turn"),
             "compiled text should preserve the once-each-turn limit, got: {compiled}"
         );

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -2810,6 +2810,23 @@ CardDefinition {
         }
     }
 
+    fn stonebinders_familiar_payload() -> CardPayload {
+        CardPayload {
+            name: "Stonebinder's Familiar".to_string(),
+            parse_name: None,
+            oracle_text: "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.".to_string(),
+            raw_oracle_text: "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.".to_string(),
+            metadata_lines: vec![
+                "Mana cost: {W}".to_string(),
+                "Type: Creature - Spirit Dog".to_string(),
+                "Power/Toughness: 1/1".to_string(),
+            ],
+            parse_input: "Mana cost: {W}\nType: Creature - Spirit Dog\nPower/Toughness: 1/1\nWhenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.".to_string(),
+            other_face_name: None,
+            linked_face_layout: None,
+        }
+    }
+
     fn semantic_mismatch_payload() -> CardPayload {
         CardPayload {
             name: "Mismatch Fixture".to_string(),
@@ -2970,6 +2987,25 @@ CardDefinition {
         assert!(
             snapshot.compiled_text.is_some(),
             "semantic mismatch snapshots should keep their compiled text"
+        );
+    }
+
+    #[test]
+    fn snapshot_strictly_compiles_stonebinders_familiar() {
+        let snapshot = compile_snapshot_from_payload(&stonebinders_familiar_payload());
+
+        assert_eq!(snapshot.parse_status, ParseStatus::StrictCompiled);
+        let compiled = snapshot
+            .compiled_text
+            .as_deref()
+            .expect("Stonebinder's Familiar should produce compiled text");
+        assert!(
+            compiled.contains("put") && compiled.contains("+1/+1") && compiled.contains("counter"),
+            "compiled text should keep the counter-adding trigger effect, got: {compiled}"
+        );
+        assert!(
+            compiled.contains("This ability triggers only once each turn"),
+            "compiled text should preserve the once-each-turn limit, got: {compiled}"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Stonebinder's Familiar
Initial parse error:
```
unsupported triggered line: 'Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.'
```

Worker: i-001e872cfd4749709
