### PR TITLE
Fix Ironsmith parse failure: Frontier Warmonger

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3064,25 +3064,38 @@ pub(crate) fn parse_trigger_clause_lexed(
         }
     }
 
-    let words = if let Some(attacks_word_idx) =
+    let (words, attacked_player_filter, attacked_target_must_be_player) = if let Some(attacks_word_idx) =
         find_index(&words, |word| matches!(*word, "attack" | "attacks"))
     {
         let tail = &words[attacks_word_idx + 1..];
-        if matches!(
+        if matches!(tail, ["a", "player"]) {
+            (
+                &words[..=attacks_word_idx],
+                Some(PlayerFilter::Any),
+                true,
+            )
+        } else if matches!(tail, ["the", "defending", "player"] | ["defending", "player"]) {
+            (
+                &words[..=attacks_word_idx],
+                Some(PlayerFilter::Any),
+                true,
+            )
+        } else if matches!(
             tail,
-            ["a", "player"]
-                | ["a", "planeswalker"]
-                | ["a", "battle"]
-                | ["one", "of", "your", "opponents", "or", "a", "planeswalker", "they", "control"]
-                | ["the", "defending", "player"]
-                | ["defending", "player"]
+            ["one", "of", "your", "opponents", "or", "a", "planeswalker", "they", "control"]
         ) {
-            &words[..=attacks_word_idx]
+            (
+                &words[..=attacks_word_idx],
+                Some(PlayerFilter::Opponent),
+                false,
+            )
+        } else if matches!(tail, ["a", "planeswalker"] | ["a", "battle"]) {
+            (&words[..=attacks_word_idx], None, false)
         } else {
-            &words
+            (&words[..], None, false)
         }
     } else {
-        &words
+        (&words[..], None, false)
     };
 
     let last = words
@@ -3103,7 +3116,14 @@ pub(crate) fn parse_trigger_clause_lexed(
                 || player_subject;
             Ok(
                 match parse_attack_trigger_subject_filter_lexed(subject_tokens)? {
-                    Some(filter) => {
+                    Some(mut filter) => {
+                        if let Some(player_filter) = attacked_player_filter.clone() {
+                            filter.attacking_player_or_planeswalker_controlled_by =
+                                Some(player_filter.clone());
+                            if attacked_target_must_be_player {
+                                filter.targets_only_player = Some(player_filter);
+                            }
+                        }
                         if one_or_more {
                             TriggerSpec::AttacksOneOrMore(filter)
                         } else {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3073,6 +3073,7 @@ pub(crate) fn parse_trigger_clause_lexed(
             ["a", "player"]
                 | ["a", "planeswalker"]
                 | ["a", "battle"]
+                | ["one", "of", "your", "opponents", "or", "a", "planeswalker", "they", "control"]
                 | ["the", "defending", "player"]
                 | ["defending", "player"]
         ) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20915,6 +20915,32 @@ fn parse_wyrms_crossing_patrol_myriad_renders_you_as_token_creator() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_frontier_warmonger_trigger_and_menace_grant() {
+    let oracle = "Whenever one or more creatures attack one of your opponents or a planeswalker they control, those creatures gain menace until end of turn.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "Frontier Warmonger")
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Frontier Warmonger should parse strictly");
+
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("AttacksOneOrMore")
+            && abilities_debug.contains("gain menace until end of turn"),
+        "expected attack trigger with menace grant, got {abilities_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("one or more creatures attack")
+            && rendered.contains("those creatures gain menace until end of turn"),
+        "expected compiled text to preserve Frontier Warmonger clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_named_vehicle_token_with_flying_and_crew() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Lita Token Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20924,8 +20924,9 @@ fn parse_frontier_warmonger_trigger_and_menace_grant() {
 
     let abilities_debug = format!("{:?}", def.abilities);
     assert!(
-        abilities_debug.contains("AttacksOneOrMore")
-            && abilities_debug.contains("gain menace until end of turn"),
+        abilities_debug.contains("one_or_more: true")
+            && abilities_debug.contains("attacking_player_or_planeswalker_controlled_by: Some(Opponent)")
+            && abilities_debug.contains("Some(Menace)"),
         "expected attack trigger with menace grant, got {abilities_debug}"
     );
 
@@ -20933,8 +20934,9 @@ fn parse_frontier_warmonger_trigger_and_menace_grant() {
         .join(" ")
         .to_ascii_lowercase();
     assert!(
-        rendered.contains("one or more creatures attack")
-            && rendered.contains("those creatures gain menace until end of turn"),
+        rendered.contains("one or more creature attacking")
+            && rendered.contains("attacking an opponent or a planeswalker controlled by an opponent")
+            && rendered.contains("gains menace until end of turn"),
         "expected compiled text to preserve Frontier Warmonger clause, got {rendered}"
     );
 }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26,6 +26,13 @@ fn setup_game() -> GameState {
     crate::tests::test_helpers::setup_two_player_game()
 }
 
+fn setup_three_player_game() -> GameState {
+    GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    )
+}
+
 #[test]
 fn regeneration_count_tracks_used_shields_until_cleanup() {
     let mut game = setup_game();
@@ -167,9 +174,10 @@ fn glamdring_equipped_creature_gets_first_strike_and_graveyard_scaled_power() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup() {
-    let mut game = setup_game();
+    let mut game = setup_three_player_game();
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
 
     let warmonger = CardDefinitionBuilder::new(CardId::from_raw(72_140), "Frontier Warmonger")
         .card_types(vec![CardType::Creature])
@@ -178,34 +186,58 @@ fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup()
         .expect("Frontier Warmonger should parse");
     game.create_object_from_definition(&warmonger, alice, Zone::Battlefield);
 
-    let attacker_id = create_creature(&mut game, "Attacker", alice, 2, 2);
-    game.remove_summoning_sickness(attacker_id);
+    let legal_attacker_id = create_creature(&mut game, "Legal Attacker", alice, 2, 2);
+    game.remove_summoning_sickness(legal_attacker_id);
+    let illegal_attacker_id = create_creature(&mut game, "Illegal Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(illegal_attacker_id);
     let home_creature_id = create_creature(&mut game, "Home Creature", alice, 2, 2);
 
     assert!(
-        !game.object_has_ability(attacker_id, &StaticAbility::menace()),
+        !game.object_has_ability(legal_attacker_id, &StaticAbility::menace()),
         "attacker should not start with menace"
     );
 
-    game.turn.active_player = alice;
+    game.turn.active_player = bob;
     game.turn.phase = Phase::Combat;
     game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
 
     let mut combat = CombatState::default();
     let mut trigger_queue = TriggerQueue::new();
     let declarations = vec![AttackerDeclaration {
-        creature: attacker_id,
-        target: AttackTarget::Player(bob),
+        creature: illegal_attacker_id,
+        target: AttackTarget::Player(alice),
     }];
 
     apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
         .expect("attacker declaration should be legal");
-    put_triggers_on_stack(&mut game, &mut trigger_queue);
-    resolve_top_of_stack(&mut game);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("trigger should go on stack");
+    assert!(
+        game.stack.is_empty(),
+        "attacking you should not create a Frontier Warmonger trigger"
+    );
 
     assert!(
-        game.object_has_ability(attacker_id, &StaticAbility::menace()),
-        "attacking creature should gain menace"
+        !game.object_has_ability(illegal_attacker_id, &StaticAbility::menace()),
+        "attacker that attacked you should not gain menace"
+    );
+
+    game.turn.active_player = alice;
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    let declarations = vec![AttackerDeclaration {
+        creature: legal_attacker_id,
+        target: AttackTarget::Player(charlie),
+    }];
+    apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("attacker declaration should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("trigger should go on stack");
+    resolve_stack_entry(&mut game).expect("trigger should resolve");
+
+    assert!(
+        game.object_has_ability(legal_attacker_id, &StaticAbility::menace()),
+        "attacking one of your opponents should grant menace"
     );
     assert!(
         !game.object_has_ability(home_creature_id, &StaticAbility::menace()),
@@ -214,7 +246,7 @@ fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup()
 
     execute_cleanup_step(&mut game);
     assert!(
-        !game.object_has_ability(attacker_id, &StaticAbility::menace()),
+        !game.object_has_ability(legal_attacker_id, &StaticAbility::menace()),
         "temporary menace should end at cleanup"
     );
 }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -166,6 +166,61 @@ fn glamdring_equipped_creature_gets_first_strike_and_graveyard_scaled_power() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let warmonger = CardDefinitionBuilder::new(CardId::from_raw(72_140), "Frontier Warmonger")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text("Whenever one or more creatures attack one of your opponents or a planeswalker they control, those creatures gain menace until end of turn.")
+        .expect("Frontier Warmonger should parse");
+    game.create_object_from_definition(&warmonger, alice, Zone::Battlefield);
+
+    let attacker_id = create_creature(&mut game, "Attacker", alice, 2, 2);
+    game.remove_summoning_sickness(attacker_id);
+    let home_creature_id = create_creature(&mut game, "Home Creature", alice, 2, 2);
+
+    assert!(
+        !game.object_has_ability(attacker_id, &StaticAbility::menace()),
+        "attacker should not start with menace"
+    );
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    let declarations = vec![AttackerDeclaration {
+        creature: attacker_id,
+        target: AttackTarget::Player(bob),
+    }];
+
+    apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("attacker declaration should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue);
+    resolve_top_of_stack(&mut game);
+
+    assert!(
+        game.object_has_ability(attacker_id, &StaticAbility::menace()),
+        "attacking creature should gain menace"
+    );
+    assert!(
+        !game.object_has_ability(home_creature_id, &StaticAbility::menace()),
+        "nonattacking creature should not gain menace"
+    );
+
+    execute_cleanup_step(&mut game);
+    assert!(
+        !game.object_has_ability(attacker_id, &StaticAbility::menace()),
+        "temporary menace should end at cleanup"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn sharpened_pitchfork_boosts_only_humans_but_always_grants_first_strike() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Frontier Warmonger
Initial parse error:
```
triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(ApplyContinuousEffect { target: Filter(ObjectFilter { zone: Some(Battlefield), controller: Some(IteratedPlayer), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Planeswalker, Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }), target_spec: None, modification: Some(AddAbility(StaticAbility { id: Some(Menace), label: "menace", payload: None })), additional_modifications: [], runtime_modifications: [], until: EndOfTurn, condition: None, source_type: None, lock_filter_at_resolution: true, resolve_set_pt_values_at_resolution: false, require_creature_target: false }); oracle-only fallback also failed: triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(ApplyContinuousEffect { target: Filter(ObjectFilter { zone: Some(Battlefield), controller: Some(IteratedPlayer), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Planeswalker, Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }), target_spec: None, modification: Some(AddAbility(StaticAbility { id: Some(Menace), label: "menace", payload: None })), additional_modifications: [], runtime_modifications: [], until: EndOfTurn, condition: None, source_type: None, lock_filter_at_resolution: true, resolve_set_pt_values_at_resolution: false, require_creature_target: false })
```

Worker: i-0ffbfa8f8d704d266
