### PR TITLE
Fix Ironsmith parse failure: Experiment Twelve

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -314,9 +314,29 @@ fn parse_put_counter_count_value(
         )));
     }
 
-    parse_value(tokens).ok_or_else(|| {
-        CardTextError::ParseError(format!("missing counter amount (clause: '{}')", clause))
-    })
+    if parse_counter_type_from_tokens(tokens).is_some()
+        && let Some(on_idx) = find_token_index(tokens, |token| token.is_word("on"))
+    {
+        let on_tail = trim_commas(&tokens[on_idx + 1..]);
+        if let Some(equal_idx) = find_token_index(&on_tail, |token| token.is_word("equal"))
+            && on_tail
+                .get(equal_idx + 1)
+                .is_some_and(|token| token.is_word("to"))
+        {
+            let value_tokens = trim_commas(&on_tail[equal_idx + 2..]);
+            if let Some((value, used)) = parse_value(&value_tokens)
+                && used == value_tokens.len()
+            {
+                return Ok((value, 0));
+            }
+            if let Some(value) = parse_named_source_power_value(&value_tokens) {
+                return Ok((value, 0));
+            }
+        }
+    }
+
+    parse_value(tokens)
+        .ok_or_else(|| CardTextError::ParseError(format!("missing counter amount (clause: '{}')", clause)))
 }
 
 fn parse_named_source_power_value(tokens: &[OwnedLexToken]) -> Option<Value> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11440,6 +11440,25 @@ fn test_parse_trigger_when_face_down_permanent_is_turned_face_up() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_experiment_twelve_strict_parse_regression() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Experiment Twelve")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "Trample\nWhenever this creature or another creature you control is turned face up, put +1/+1 counters on that creature equal to its power.\nDisguise {4}{G}",
+        )
+        .expect("Experiment Twelve should parse");
+
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains("put x +1/+1 counters on it, where x is its power"),
+        "expected dynamic power-based counter clause in compiled output, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_this_creature_enters_from_your_graveyard() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Phyrexian Dragon Engine")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -4733,6 +4733,148 @@ fn test_turn_face_up_action_puts_turned_face_up_trigger_on_stack() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_experiment_twelve_puts_counters_when_itself_is_turned_face_up() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::decision::{LegalAction, SelectFirstDecisionMaker};
+    use crate::ids::CardId;
+    use crate::mana::{ManaCost, ManaSymbol};
+    use crate::special_actions::TurnFaceUpMethod;
+    use crate::static_abilities::StaticAbility;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let experiment = CardDefinitionBuilder::new(CardId::new(), "Experiment Twelve")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)], vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Trample\nWhenever this creature or another creature you control is turned face up, put +1/+1 counters on that creature equal to its power.\nDisguise {4}{G}",
+        )
+        .expect("Experiment Twelve should parse for runtime test");
+
+    let experiment_id = game.create_object_from_definition(&experiment, alice, Zone::Battlefield);
+    game.object_mut(experiment_id)
+        .expect("Experiment Twelve permanent should exist")
+        .abilities
+        .push(Ability::static_ability(StaticAbility::morph(
+            crate::cost::TotalCost::mana(ManaCost::from_pips(vec![vec![ManaSymbol::Green]])),
+        )));
+    game.set_face_down(experiment_id);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 1);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let response = PriorityResponse::PriorityAction(LegalAction::TurnFaceUp {
+        creature_id: experiment_id,
+        method: TurnFaceUpMethod::TurnFaceUpAbility,
+    });
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &response,
+        &mut dm,
+    )
+    .expect("turning Experiment Twelve face up should succeed");
+
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("resolve Experiment Twelve trigger");
+    }
+
+    let experiment_obj = game
+        .object(experiment_id)
+        .expect("Experiment Twelve should remain on battlefield");
+    assert_eq!(experiment_obj.power(), Some(8));
+    assert_eq!(experiment_obj.toughness(), Some(8));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_experiment_twelve_puts_counters_on_another_turned_face_up_creature() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::decision::{LegalAction, SelectFirstDecisionMaker};
+    use crate::ids::CardId;
+    use crate::mana::{ManaCost, ManaSymbol};
+    use crate::special_actions::TurnFaceUpMethod;
+    use crate::static_abilities::StaticAbility;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let experiment = CardDefinitionBuilder::new(CardId::new(), "Experiment Twelve")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)], vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Trample\nWhenever this creature or another creature you control is turned face up, put +1/+1 counters on that creature equal to its power.\nDisguise {4}{G}",
+        )
+        .expect("Experiment Twelve should parse for runtime test");
+    game.create_object_from_definition(&experiment, alice, Zone::Battlefield);
+
+    let morph_probe = CardDefinitionBuilder::new(CardId::new(), "Face-Up Counter Target")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let morph_id = game.create_object_from_definition(&morph_probe, alice, Zone::Battlefield);
+    game.object_mut(morph_id)
+        .expect("morph target permanent should exist")
+        .abilities
+        .push(Ability::static_ability(StaticAbility::morph(
+            crate::cost::TotalCost::mana(ManaCost::from_pips(vec![vec![ManaSymbol::Green]])),
+        )));
+    game.set_face_down(morph_id);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 1);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let response = PriorityResponse::PriorityAction(LegalAction::TurnFaceUp {
+        creature_id: morph_id,
+        method: TurnFaceUpMethod::TurnFaceUpAbility,
+    });
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &response,
+        &mut dm,
+    )
+    .expect("turning the other creature face up should succeed");
+
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("resolve Experiment Twelve trigger");
+    }
+
+    let morph_obj = game
+        .object(morph_id)
+        .expect("morph target should remain on battlefield");
+    assert_eq!(morph_obj.power(), Some(7));
+    assert_eq!(morph_obj.toughness(), Some(7));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn ecological_appreciation_puts_two_chosen_cards_back_and_recruits_the_rest() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::ids::CardId;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Experiment Twelve
Initial parse error:
```
missing counter amount (clause: '+1/+1 counters on that creature equal to its power'); oracle-only fallback also failed: missing counter amount (clause: '+1/+1 counters on that creature equal to its power')
```

Worker: i-0deb224716757f6d4
