### PR TITLE
Fix Ironsmith parse failure: Kydele, Chosen of Kruphix

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -5564,6 +5564,25 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Value>, CardTextError> {
     let words_all = crate::runtime_backend::token_word_refs(tokens);
+    let has_cards_drawn_this_turn_anywhere = (slice_contains(&words_all, &"card")
+        || slice_contains(&words_all, &"cards"))
+        && slice_contains(&words_all, &"drawn")
+        && slice_contains(&words_all, &"this")
+        && slice_contains(&words_all, &"turn");
+    if has_cards_drawn_this_turn_anywhere
+        && (slice_contains(&words_all, &"you")
+            || slice_contains(&words_all, &"your")
+            || slice_contains(&words_all, &"youve")
+            || slice_contains(&words_all, &"you've"))
+    {
+        return Ok(Some(Value::MaxCardsDrawnThisTurn(PlayerFilter::You)));
+    }
+    if has_cards_drawn_this_turn_anywhere
+        && (slice_contains(&words_all, &"opponent") || slice_contains(&words_all, &"opponents"))
+    {
+        return Ok(Some(Value::MaxCardsDrawnThisTurn(PlayerFilter::Opponent)));
+    }
+
     let Some(each_idx) = find_index(&words_all, |word| *word == "each") else {
         return Ok(None);
     };
@@ -5687,6 +5706,74 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
         if simple {
             return Ok(Some(Value::SpellsCastThisTurn(player)));
         }
+    }
+
+    if slice_starts_with(
+        &filter_words,
+        &["card", "youve", "drawn", "this", "turn"],
+    )
+        || slice_starts_with(
+            &filter_words,
+            &["cards", "youve", "drawn", "this", "turn"],
+        )
+        || slice_starts_with(
+            &filter_words,
+            &["card", "you", "have", "drawn", "this", "turn"],
+        )
+        || slice_starts_with(
+            &filter_words,
+            &["cards", "you", "have", "drawn", "this", "turn"],
+        )
+        || slice_starts_with(
+            &filter_words,
+            &["card", "you", "ve", "drawn", "this", "turn"],
+        )
+        || slice_starts_with(
+            &filter_words,
+            &["cards", "you", "ve", "drawn", "this", "turn"],
+        )
+    {
+        return Ok(Some(Value::MaxCardsDrawnThisTurn(PlayerFilter::You)));
+    }
+
+    let has_cards_drawn_this_turn = (slice_contains(&filter_words, &"card")
+        || slice_contains(&filter_words, &"cards"))
+        && slice_contains(&filter_words, &"drawn")
+        && slice_contains(&filter_words, &"this")
+        && slice_contains(&filter_words, &"turn");
+    if has_cards_drawn_this_turn
+        && (slice_contains(&filter_words, &"you")
+            || slice_contains(&filter_words, &"your")
+            || slice_contains(&filter_words, &"youve")
+            || slice_contains(&filter_words, &"you've"))
+    {
+        return Ok(Some(Value::MaxCardsDrawnThisTurn(PlayerFilter::You)));
+    }
+
+    if slice_starts_with(
+        &filter_words,
+        &["card", "an", "opponent", "has", "drawn", "this", "turn"],
+    )
+        || slice_starts_with(
+            &filter_words,
+            &["cards", "an", "opponent", "has", "drawn", "this", "turn"],
+        )
+        || slice_starts_with(
+            &filter_words,
+            &["card", "opponents", "have", "drawn", "this", "turn"],
+        )
+        || slice_starts_with(
+            &filter_words,
+            &["cards", "opponents", "have", "drawn", "this", "turn"],
+        )
+    {
+        return Ok(Some(Value::MaxCardsDrawnThisTurn(PlayerFilter::Opponent)));
+    }
+    if has_cards_drawn_this_turn
+        && (slice_contains(&filter_words, &"opponent")
+            || slice_contains(&filter_words, &"opponents"))
+    {
+        return Ok(Some(Value::MaxCardsDrawnThisTurn(PlayerFilter::Opponent)));
     }
 
     if contains_any_keyword_static_phrase(&filter_words, &[&["card", "type"], &["card", "types"]])

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11244,6 +11244,22 @@ fn rewrite_lexed_effect_sentence_supports_gain_then_get_for_each_cards_drawn() {
 }
 
 #[test]
+fn rewrite_lexed_effect_sentence_supports_kydele_mana_scaling_clause() {
+    let text = "Add {C} for each card you've drawn this turn.";
+    let lexed =
+        lex_line(text, 0).expect("rewrite lexer should classify Kydele mana-scaling sentence");
+
+    let parsed = parse_effect_sentence_lexed(&lexed)
+        .expect("rewrite effect sentence parser should support cards-drawn mana scaling");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("AddMana") && debug.contains("MaxCardsDrawnThisTurn"),
+        "expected add-mana effect scaled by cards drawn this turn, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_sentence_supports_compound_damage_to_you_and_your_objects() {
     let text = "This deals 2 damage to you and each creature you control.";
     let lexed = lex_line(text, 0)

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7846,7 +7846,7 @@ pub(crate) fn describe_value(value: &Value) -> String {
             format!("the total amount of noncombat damage {source} dealt this turn")
         }
         Value::MaxCardsDrawnThisTurn(filter) => match filter {
-            PlayerFilter::You => "the greatest number of cards you've drawn this turn".to_string(),
+            PlayerFilter::You => "the number of cards you've drawn this turn".to_string(),
             PlayerFilter::Opponent => {
                 "the greatest number of cards an opponent has drawn this turn".to_string()
             }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26326,6 +26326,22 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_add_mana_destination_suffix(&add_scaled.player)
             );
         }
+        if let Value::MaxCardsDrawnThisTurn(player) = &add_scaled.amount {
+            let drawn_text = match player {
+                PlayerFilter::You => "for each card you've drawn this turn".to_string(),
+                PlayerFilter::Opponent => {
+                    "for each card the opponent who drew the most cards has drawn this turn"
+                        .to_string()
+                }
+                _ => format!("equal to {}", describe_value(&add_scaled.amount)),
+            };
+            return format!(
+                "Add {} {}{}",
+                mana_text,
+                drawn_text,
+                describe_add_mana_destination_suffix(&add_scaled.player)
+            );
+        }
         if let Value::PowerOf(spec) = &add_scaled.amount {
             return format!(
                 "Add an amount of {} equal to the power of {}{}",

--- a/crates/ironsmith-runtime/src/tests/integration_tests.rs
+++ b/crates/ironsmith-runtime/src/tests/integration_tests.rs
@@ -1826,6 +1826,93 @@ mod tests {
         );
     }
 
+    #[test]
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn test_kydele_chosen_of_kruphix_mana_scales_with_cards_drawn_this_turn() {
+        use crate::effect::Effect;
+        use crate::effects::{ExecutionContext, execute_effect};
+
+        let kydele = crate::CardDefinitionBuilder::new(
+            crate::ids::CardId::new(),
+            "Kydele, Chosen of Kruphix",
+        )
+        .card_types(vec![crate::types::CardType::Creature])
+        .subtypes(vec![crate::types::Subtype::Elf, crate::types::Subtype::Wizard])
+        .power_toughness(crate::card::PowerToughness::fixed(2, 3))
+        .parse_text("{T}: Add {C} for each card you've drawn this turn.")
+        .expect("Kydele mana ability should parse");
+
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let kydele_id = game.create_object_from_definition(&kydele, alice, Zone::Battlefield);
+        let mut dm = ChooseLastReplacementDecisionMaker;
+
+        let filler = crate::CardDefinitionBuilder::new(crate::ids::CardId::new(), "Filler")
+            .card_types(vec![crate::types::CardType::Land])
+            .build();
+        for _ in 0..3 {
+            game.create_object_from_definition(&filler, alice, Zone::Library);
+        }
+
+        let mut draw_ctx = ExecutionContext::new(kydele_id, alice, &mut dm);
+        execute_effect(&mut game, &Effect::draw(3), &mut draw_ctx)
+            .expect("draw effect should resolve");
+
+        let mut mana_ctx = ExecutionContext::new(kydele_id, alice, &mut dm);
+        execute_effect(
+            &mut game,
+            &Effect::add_colorless_mana(crate::effect::Value::MaxCardsDrawnThisTurn(
+                crate::target::PlayerFilter::You,
+            )),
+            &mut mana_ctx,
+        )
+        .expect("Kydele mana effect should resolve");
+
+        assert_eq!(
+            game.player(alice).expect("Alice should exist").mana_pool.colorless,
+            3,
+            "Kydele should add one colorless for each card drawn this turn"
+        );
+    }
+
+    #[test]
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn test_kydele_chosen_of_kruphix_adds_no_mana_when_no_cards_drawn_this_turn() {
+        use crate::effect::Effect;
+        use crate::effects::{ExecutionContext, execute_effect};
+
+        let kydele = crate::CardDefinitionBuilder::new(
+            crate::ids::CardId::new(),
+            "Kydele, Chosen of Kruphix",
+        )
+        .card_types(vec![crate::types::CardType::Creature])
+        .subtypes(vec![crate::types::Subtype::Elf, crate::types::Subtype::Wizard])
+        .power_toughness(crate::card::PowerToughness::fixed(2, 3))
+        .parse_text("{T}: Add {C} for each card you've drawn this turn.")
+        .expect("Kydele mana ability should parse");
+
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let kydele_id = game.create_object_from_definition(&kydele, alice, Zone::Battlefield);
+        let mut dm = ChooseLastReplacementDecisionMaker;
+
+        let mut mana_ctx = ExecutionContext::new(kydele_id, alice, &mut dm);
+        execute_effect(
+            &mut game,
+            &Effect::add_colorless_mana(crate::effect::Value::MaxCardsDrawnThisTurn(
+                crate::target::PlayerFilter::You,
+            )),
+            &mut mana_ctx,
+        )
+        .expect("Kydele mana effect should resolve");
+
+        assert_eq!(
+            game.player(alice).expect("Alice should exist").mana_pool.colorless,
+            0,
+            "Kydele should add no colorless when no cards were drawn this turn"
+        );
+    }
+
     // Card-specific replay tests have been moved to their respective card definition files.
     // See each card's tests module (e.g., src/cards/definitions/ancient_tomb.rs) for the tests.
     //

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1149,6 +1149,44 @@ fn compile_oracle_text_strictly_compiles_mindleecher_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_kydele_chosen_of_kruphix_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Kydele, Chosen of Kruphix")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Kydele, Chosen of Kruphix --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Kydele, Chosen of Kruphix should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Kydele, Chosen of Kruphix"), "{stdout}");
+    assert!(stdout.contains("Similarity:"), "{stdout}");
+    assert!(
+        stdout.contains("Add {C} for each card you've drawn this turn."),
+        "expected Kydele mana-scaling clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_sakashimas_will_with_choose_both_instead_clause() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kydele, Chosen of Kruphix
Initial parse error:
```
unsupported dynamic mana amount (clause: 'c for each card youve drawn this turn'); oracle-only fallback also failed: unsupported dynamic mana amount (clause: 'c for each card youve drawn this turn')
```

Worker: i-0589a1fd87e562efd
