### PR TITLE
Fix Ironsmith parse failure: Dai Li Indoctrination

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2364,6 +2364,16 @@ pub(crate) fn parse_number(tokens: &[OwnedLexToken]) -> Option<(u32, usize)> {
         return Some((value, 1));
     }
 
+    let trimmed_trailing_punctuation = word.trim_end_matches(|ch: char| !ch.is_ascii_digit());
+    if trimmed_trailing_punctuation.len() < word.len()
+        && !trimmed_trailing_punctuation.is_empty()
+        && trimmed_trailing_punctuation.chars().all(|ch| ch.is_ascii_digit())
+    {
+        if let Ok(value) = trimmed_trailing_punctuation.parse::<u32>() {
+            return Some((value, 1));
+        }
+    }
+
     let mut words = Vec::new();
     for token in tokens {
         let Some(word) = token.as_word() else {
@@ -2451,6 +2461,14 @@ mod tests {
             matches!(target, TargetAst::AnyOtherTarget(_)),
             "expected AnyOtherTarget, got {target:?}"
         );
+    }
+
+    #[test]
+    fn parse_number_accepts_numeric_word_with_trailing_period() {
+        let tokens = lex_line("2.", 0).unwrap();
+        let (value, used) = parse_number(&tokens).expect("number with trailing period should parse");
+        assert_eq!(value, 2);
+        assert_eq!(used, 1);
     }
 
     #[test]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/search_library.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/search_library.rs
@@ -1293,8 +1293,11 @@ pub(crate) fn parse_earthbend_sentence(
         return Ok(None);
     }
 
-    let count_tokens = &tokens[1..];
-    let (count, _) = parse_number(count_tokens).ok_or_else(|| {
+    let parsed_count = words
+        .get(1)
+        .and_then(|word| word.parse::<u32>().ok())
+        .or_else(|| ironsmith_core::parse_cardinal_words(&words[1..]).map(|(value, _)| value));
+    let count = parsed_count.ok_or_else(|| {
         CardTextError::ParseError(format!(
             "missing earthbend count (clause: '{}')",
             words.join(" ")

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -25914,6 +25914,46 @@ fn parse_earthbend_then_earthbend_chain_keeps_both_and_life_gain() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn strict_parse_dai_li_indoctrination_regression() {
+    assert_oracle_card_parses_strict("Dai Li Indoctrination");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dai_li_indoctrination_compiled_text_keeps_earthbend_mode() {
+    let def = parse_oracle_card_definition("Dai Li Indoctrination");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("choose one"),
+        "expected modal text in compiled output, got {rendered}"
+    );
+    assert!(
+        rendered.contains("earthbend 2"),
+        "expected earthbend mode to keep count, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dai_li_indoctrination_compiled_text_keeps_discard_mode_targets() {
+    let def = parse_oracle_card_definition("Dai Li Indoctrination");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("target opponent reveals their hand"),
+        "expected reveal-hand mode text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("nonland permanent card") && rendered.contains("discards"),
+        "expected nonland-permanent discard clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_search_basic_triple_and_gain_life_keeps_all_components() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Brokers Hideout Variant")
         .parse_text(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dai Li Indoctrination
Initial parse error:
```
missing earthbend count (clause: 'earthbend 2'); oracle-only fallback also failed: missing earthbend count (clause: 'earthbend 2')
```

Worker: i-036573f436c25a6a1
