### PR TITLE
Fix Ironsmith parse failure: Indomitable Might

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -1,5 +1,6 @@
 use super::line_family_handlers::{
     run_activation_line_family, run_additional_combat_after_this_phase_line_family,
+    run_assign_damage_as_unblocked_enchanted_creature_controller_line_family,
     run_champion_line_family, run_championed_with_this_trigger_line_family,
     run_colon_nonactivation_statement_line_family, run_combined_static_line_family,
     run_escape_enters_with_counter_line_family, run_freerunning_line_family,
@@ -48,7 +49,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 28] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 29] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -114,6 +115,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 28] = [
         priority: 39,
         heads: &["you"],
         run: run_split_top_look_and_top_land_play_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "assign-damage-as-unblocked-enchanted-creature-controller",
+        priority: 39,
+        heads: &["enchanted"],
+        run: run_assign_damage_as_unblocked_enchanted_creature_controller_line_family,
     },
     LineFamilyRuleDef {
         id: "champion-line",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -260,6 +260,32 @@ pub(super) fn run_split_top_look_and_top_land_play_line_family(
     }))
 }
 
+pub(super) fn run_assign_damage_as_unblocked_enchanted_creature_controller_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let lower = raw.to_ascii_lowercase();
+    let phrase =
+        "enchanted creature's controller may have it assign its combat damage as though it weren't blocked";
+    if lower.trim_end_matches('.') != phrase {
+        return Ok(None);
+    }
+
+    let rewritten = "Enchanted creature has \"You may have this creature assign its combat damage as though it weren't blocked.\".";
+    let rewritten_line = rewrite_line_normalized(ctx.line, rewritten)?;
+    let Some(static_cst) = parse_static_line_cst(&rewritten_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower enchanted-creature assign-damage-as-unblocked line: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Static(static_cst),
+        ctx.idx + 1,
+    )))
+}
+
 pub(super) fn run_graveyard_cast_control_condition_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10408,6 +10408,34 @@ fn test_parse_assign_damage_as_unblocked_with_this_creature() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_assign_damage_as_unblocked_with_enchanted_creature_controller() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Indomitable Might Probe")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant creature\nEnchanted creature gets +3/+3.\nEnchanted creature's controller may have it assign its combat damage as though it weren't blocked.",
+        )
+        .expect("assign-as-unblocked wording with enchanted creature's controller should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("enchanted creature gets +3/+3"),
+        "expected aura buff to be preserved, got {rendered}"
+    );
+    assert!(
+        rendered.contains("assign its combat damage as though it weren't blocked"),
+        "expected enchanted creature grant to include assign-as-unblocked text, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("MayAssignDamageAsUnblocked"),
+        "expected lowered aura effect to include MayAssignDamageAsUnblocked, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_first_spell_cost_modifier_marker_errors() {
     let err = CardDefinitionBuilder::new(CardId::from_raw(1), "First Spell Cost Probe")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -15676,6 +15676,97 @@ fn test_thorn_elemental_combat_decision() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_indomitable_might_grants_power_and_assign_as_unblocked_static_ability() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::object::AttachmentTarget;
+    use crate::types::{CardType, Subtype};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let enchanted_id = create_creature(&mut game, "Grizzly Probe", alice, 2, 2);
+    let aura = CardDefinitionBuilder::new(CardId::new(), "Indomitable Might")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Flash\nEnchant creature\nEnchanted creature gets +3/+3.\nEnchanted creature's controller may have it assign its combat damage as though it weren't blocked.",
+        )
+        .expect("Indomitable Might text should parse into an Aura card definition");
+    let aura_id = game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+
+    {
+        let aura_obj = game
+            .object_mut(aura_id)
+            .expect("aura should exist on battlefield");
+        aura_obj.attached_to = Some(AttachmentTarget::Object(enchanted_id));
+    }
+    {
+        let enchanted_obj = game
+            .object_mut(enchanted_id)
+            .expect("enchanted creature should exist");
+        enchanted_obj.attachments.push(aura_id);
+    }
+    let characteristics = game
+        .calculated_characteristics(enchanted_id)
+        .expect("enchanted creature should have calculated characteristics");
+    assert_eq!(characteristics.power, Some(5));
+    assert_eq!(characteristics.toughness, Some(5));
+    assert!(characteristics.static_abilities.iter().any(|ability| {
+        ability.id() == crate::static_abilities::StaticAbilityId::MayAssignDamageAsUnblocked
+    }));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_indomitable_might_blocked_combat_defaults_to_blocker_damage_assignment() {
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::object::AttachmentTarget;
+    use crate::types::{CardType, Subtype};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let enchanted_id = create_creature(&mut game, "Enchanted Attacker", alice, 2, 2);
+    let blocker_id = create_creature(&mut game, "Blocking Bear", bob, 2, 2);
+
+    let aura = CardDefinitionBuilder::new(CardId::new(), "Indomitable Might")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Flash\nEnchant creature\nEnchanted creature gets +3/+3.\nEnchanted creature's controller may have it assign its combat damage as though it weren't blocked.",
+        )
+        .expect("Indomitable Might text should parse into an Aura card definition");
+    let aura_id = game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+    {
+        let aura_obj = game
+            .object_mut(aura_id)
+            .expect("aura should exist on battlefield");
+        aura_obj.attached_to = Some(AttachmentTarget::Object(enchanted_id));
+    }
+    {
+        let enchanted_obj = game
+            .object_mut(enchanted_id)
+            .expect("enchanted creature should exist");
+        enchanted_obj.attachments.push(aura_id);
+    }
+    game.remove_summoning_sickness(enchanted_id);
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: enchanted_id,
+        target: AttackTarget::Player(bob),
+    });
+    combat.blockers.insert(enchanted_id, vec![blocker_id]);
+
+    let events = execute_combat_damage_step(&mut game, &combat, false);
+    assert!(!events.is_empty());
+    assert_eq!(game.damage_on(blocker_id), 2);
+    assert_eq!(game.player(bob).expect("defender should exist").life, 20);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_stormbreath_dragon_has_abilities() {
     use crate::ability::AbilityKind;
     use crate::cards::definitions::stormbreath_dragon;

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1107,6 +1107,52 @@ fn compile_oracle_text_strictly_compiles_archipelagore_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_indomitable_might_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Indomitable Might")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Indomitable Might --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Indomitable Might should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Indomitable Might"), "{stdout}");
+    assert!(stdout.contains("Similarity:"), "{stdout}");
+    assert!(
+        stdout.contains(
+            "Enchanted creature's controller may have it assign its combat damage as though it weren't blocked."
+        ),
+        "expected assign-as-unblocked enchanted-creature clause in comparison output, got {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "Enchanted creature gets +3/+3 and has You may have this creature assign its combat damage as though it weren't blocked."
+        ),
+        "expected compiled output to keep assign-as-unblocked grant text, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_mindleecher_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Indomitable Might
Initial parse error:
```
parser does not yet support line family: 'Enchanted creature's controller may have it assign its combat damage as though it weren't blocked.'; oracle-only fallback also failed: parser does not yet support line family: 'Enchanted creature's controller may have it assign its combat damage as though it weren't blocked.'
```

Worker: i-02c31ef830a0b487c
