### PR TITLE
Fix Ironsmith parse failure: Inviolability

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
@@ -1371,6 +1371,34 @@ pub(crate) fn parse_attached_prevent_all_combat_damage_dealt_by_attached_line(
     }))
 }
 
+pub(crate) fn parse_attached_prevent_all_damage_dealt_to_attached_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbilityAst>, CardTextError> {
+    let line_words = token_words(tokens);
+    if line_words.len() < 6 {
+        return Ok(None);
+    }
+
+    // "Prevent all damage that would be dealt to enchanted creature."
+    if !word_slice_starts_with(&line_words, &[
+        "prevent", "all", "damage", "that", "would", "be", "dealt", "to",
+    ]) {
+        return Ok(None);
+    }
+    if !word_slice_ends_with(&line_words, &["to", "enchanted", "creature"]) {
+        return Ok(None);
+    }
+
+    let display = "prevent all damage that would be dealt to enchanted creature".to_string();
+    Ok(Some(StaticAbilityAst::AttachedStaticAbilityGrant {
+        ability: Box::new(StaticAbilityAst::Static(StaticAbility::new(
+            crate::static_abilities::StaticAbilityId::PreventAllDamageToSelf,
+        ))),
+        display,
+        condition: None,
+    }))
+}
+
 pub(crate) fn parse_attached_has_keywords_and_triggered_ability_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -734,6 +734,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_passthrough_rule!(
             parse_attached_prevent_all_combat_damage_dealt_by_attached_line
         ),
+        single_static_ability_ast_passthrough_rule!(
+            parse_attached_prevent_all_damage_dealt_to_attached_line
+        ),
         multi_static_ability_ast_passthrough_rule!(parse_attached_gets_and_cant_block_line),
         StaticAbilityLineRuleDef {
             id: stringify!(parse_attached_has_keywords_and_triggered_ability_line),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8228,6 +8228,30 @@ fn parse_prevent_all_damage_by_opponents_creatures_effect_clause() {
 }
 
 #[test]
+fn rewrite_grammar_attached_prevent_all_damage_to_enchanted_creature_line() {
+    let tokens = lex_line(
+        "Prevent all damage that would be dealt to enchanted creature.",
+        0,
+    )
+    .expect("rewrite lexer should classify attached prevention static line");
+
+    let parsed = super::keyword_static::parse_attached_prevent_all_damage_dealt_to_attached_line(
+        &tokens,
+    )
+    .expect("attached prevention line should parse");
+
+    assert!(matches!(
+        parsed,
+        Some(crate::cards::builders::StaticAbilityAst::AttachedStaticAbilityGrant { ability, .. })
+            if matches!(
+                ability.as_ref(),
+                crate::cards::builders::StaticAbilityAst::Static(ability)
+                    if ability.id() == crate::static_abilities::StaticAbilityId::PreventAllDamageToSelf
+            )
+    ));
+}
+
+#[test]
 fn rewrite_grammar_skulk_rules_text_probe_matches_static_line() {
     let tokens = lex_line(
         "Creatures with power less than this creature's power can't block this creature.",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35646,6 +35646,7 @@ strict_parse_card_test!(strict_parse_orcish_bowmasters, "Orcish Bowmasters");
 strict_parse_card_test!(strict_parse_pawn_of_ulamog, "Pawn of Ulamog");
 strict_parse_card_test!(strict_parse_profane_memento, "Profane Memento");
 strict_parse_card_test!(strict_parse_genesis_chamber, "Genesis Chamber");
+strict_parse_card_test!(strict_parse_inviolability, "Inviolability");
 strict_parse_card_test!(strict_parse_sacrifice, "Sacrifice");
 strict_parse_card_test!(
     strict_parse_sephiroth_fabled_soldier,
@@ -35674,6 +35675,97 @@ fn animate_land_compiled_text_keeps_animation_clause() {
             && rendered.contains("until end of turn")
             && rendered.contains("still a land"),
         "expected Animate Land compiled text to preserve animation, duration, and still-a-land clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn inviolability_compiled_text_keeps_damage_prevention_clause() {
+    let def = parse_oracle_card_definition("Inviolability");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("prevent all damage that would be dealt to enchanted creature"),
+        "expected Inviolability compiled text to preserve enchanted-creature prevention semantics, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn inviolability_runtime_prevents_damage_to_enchanted_creature_only() {
+    let aura_def = parse_oracle_card_definition("Inviolability");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let protected_creature = CardBuilder::new(CardId::from_raw(98_001), "Protected Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let protected_id =
+        game.create_object_from_card(&protected_creature, alice, crate::zone::Zone::Battlefield);
+
+    let other_creature = CardBuilder::new(CardId::from_raw(98_002), "Other Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let other_id = game.create_object_from_card(&other_creature, alice, crate::zone::Zone::Battlefield);
+
+    let source_creature = CardBuilder::new(CardId::from_raw(98_003), "Damage Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let source_id = game.create_object_from_card(&source_creature, bob, crate::zone::Zone::Battlefield);
+
+    let aura_id = game.create_object_from_definition(&aura_def, alice, crate::zone::Zone::Battlefield);
+    game.object_mut(aura_id)
+        .expect("Inviolability object should exist")
+        .attached_to = Some(crate::object::AttachmentTarget::Object(protected_id));
+    game.object_mut(protected_id)
+        .expect("protected creature should exist")
+        .attachments
+        .push(aura_id);
+    assert_eq!(
+        game.object(aura_id).and_then(|obj| obj.attached_to),
+        Some(crate::object::AttachmentTarget::Object(protected_id)),
+        "Inviolability should attach to the selected creature"
+    );
+
+    let (damage_to_protected, protected_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            source_id,
+            crate::events::DamageTarget::Object(protected_id),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        damage_to_protected, 0,
+        "Inviolability should prevent all damage to enchanted creature"
+    );
+    assert!(
+        protected_prevented || damage_to_protected == 0,
+        "damage to enchanted creature should be prevented"
+    );
+
+    let (damage_to_other, other_prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        source_id,
+        crate::events::DamageTarget::Object(other_id),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        damage_to_other, 3,
+        "Inviolability should not prevent damage to unenchanted creatures"
+    );
+    assert!(
+        !other_prevented,
+        "damage to unenchanted creature should remain unprevented"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Inviolability
Initial parse error:
```
parser does not yet support line family: 'Prevent all damage that would be dealt to enchanted creature.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all damage that would be dealt to enchanted creature.'
```

Worker: i-041e208d6022451dc
