### PR TITLE
Fix Ironsmith parse failure: Living Artifact

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2456,9 +2456,24 @@ pub(crate) fn parse_trigger_clause_lexed(
         }
     }
 
-    if (slice_ends_with(&words, &["is", "dealt", "damage"])
-        || slice_ends_with(&words, &["is", "dealt", "combat", "damage"]))
-        && words.len() >= 4
+    let dealt_auxiliary = |word: &str| {
+        matches!(
+            word,
+            "is" | "are" | "was" | "were" | "be" | "been" | "re" | "youre" | "you're"
+        )
+    };
+    let ends_with_dealt_damage = words.len() >= 3
+        && words[words.len() - 2] == "dealt"
+        && words[words.len() - 1] == "damage"
+        && dealt_auxiliary(words[words.len() - 3]);
+    let ends_with_dealt_combat_damage = words.len() >= 4
+        && words[words.len() - 3] == "dealt"
+        && words[words.len() - 2] == "combat"
+        && words[words.len() - 1] == "damage"
+        && dealt_auxiliary(words[words.len() - 4]);
+
+    if ((ends_with_dealt_damage && words.len() >= 3)
+        || (ends_with_dealt_combat_damage && words.len() >= 4))
         && !slice_starts_with(&words, &["this", "creature", "is", "dealt", "damage"])
         && !slice_starts_with(
             &words,
@@ -2467,7 +2482,7 @@ pub(crate) fn parse_trigger_clause_lexed(
         && !slice_starts_with(&words, &["this", "is", "dealt", "damage"])
         && !slice_starts_with(&words, &["this", "is", "dealt", "combat", "damage"])
     {
-        let is_word_idx = if slice_ends_with(&words, &["is", "dealt", "combat", "damage"]) {
+        let is_word_idx = if ends_with_dealt_combat_damage {
             words.len().saturating_sub(4)
         } else {
             words.len().saturating_sub(3)
@@ -2475,6 +2490,16 @@ pub(crate) fn parse_trigger_clause_lexed(
         let is_token_idx = ActivationRestrictionCompatWords::new(tokens)
             .token_index_for_word_index(is_word_idx)
             .unwrap_or(tokens.len());
+        if is_word_idx == 0
+            && words
+                .first()
+                .is_some_and(|word| *word == "youre" || *word == "you're")
+        {
+            return Ok(TriggerSpec::DealsDamageToPlayer {
+                source: ObjectFilter::default(),
+                player: PlayerFilter::You,
+            });
+        }
         let subject_tokens = &tokens[..is_token_idx];
         if let Some(player) = trigger_subject_player_selector_lexed(subject_tokens) {
             return Ok(TriggerSpec::DealsDamageToPlayer {
@@ -2483,7 +2508,7 @@ pub(crate) fn parse_trigger_clause_lexed(
             });
         }
         if let Some(filter) = parse_trigger_subject_filter_lexed(subject_tokens)? {
-            if slice_ends_with(&words, &["is", "dealt", "combat", "damage"]) {
+            if ends_with_dealt_combat_damage {
                 return Ok(TriggerSpec::IsDealtCombatDamage(filter));
             }
             return Ok(TriggerSpec::IsDealtDamage(filter));

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8915,6 +8915,24 @@ fn rewrite_lexed_trigger_clause_parses_common_native_shapes() {
 }
 
 #[test]
+fn rewrite_lexed_triggered_line_parses_player_contraction_dealt_damage_trigger() {
+    let text =
+        "Whenever you're dealt damage, put that many vitality counters on this Aura.";
+    let tokens =
+        lex_line(text, 0).expect("rewrite lexer should classify player dealt-damage trigger");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("player contraction dealt-damage triggered line should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("DealsDamageToPlayer"), "{debug}");
+    assert!(debug.contains("You"), "{debug}");
+    assert!(debug.contains("PutCounter"), "{debug}");
+    assert!(debug.contains("Vitality"), "{debug}");
+    assert!(debug.contains("EventAmount"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_triggered_line_parses_ketramose_exile_trigger() {
     let text = "Whenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.";
     let tokens =

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -12905,6 +12905,25 @@ fn parse_war_elemental_strictly_parses_etb_sacrifice_unless_opponent_damage_clau
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn living_artifact_oracle_parses_with_player_damage_trigger_and_upkeep_branch() {
+    let def = parse_oracle_card_definition("Living Artifact");
+    let joined = canonical_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        joined.contains("whenever you are dealt damage")
+            && joined.contains("vitality counters on this aura"),
+        "expected Living Artifact player-damage trigger text, got {joined}"
+    );
+    assert!(
+        joined.contains("at the beginning of your upkeep")
+            && joined.contains("you may remove a vitality counter from this aura")
+            && joined.contains("if you do, you gain 1 life"),
+        "expected Living Artifact upkeep branch text, got {joined}"
+    );
+}
+
 #[test]
 fn war_elemental_runtime_condition_matches_when_opponent_lost_life_this_turn() {
     let mut game =

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -2803,4 +2803,54 @@ mod tests {
             triggered[0].ability.choices
         );
     }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn living_artifact_player_damage_trigger_matches_only_controller_damage() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let def = CardDefinitionBuilder::new(CardId::new(), "Living Artifact Variant")
+            .card_types(vec![CardType::Enchantment])
+            .subtypes(vec![Subtype::Aura])
+            .parse_text(
+                "Whenever you're dealt damage, put that many vitality counters on this Aura.",
+            )
+            .expect("Living Artifact style trigger should parse");
+        let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+        let to_controller = check_triggers(
+            &game,
+            &TriggerEvent::new_with_provenance(
+                DamageEvent::with_cause(
+                    source,
+                    DamageTarget::Player(alice),
+                    3,
+                    false,
+                    EventCause::from_game_rule(),
+                ),
+                crate::provenance::ProvNodeId::default(),
+            ),
+        );
+        assert_eq!(to_controller.len(), 1, "expected trigger on controller damage");
+
+        let to_opponent = check_triggers(
+            &game,
+            &TriggerEvent::new_with_provenance(
+                DamageEvent::with_cause(
+                    source,
+                    DamageTarget::Player(bob),
+                    3,
+                    false,
+                    EventCause::from_game_rule(),
+                ),
+                crate::provenance::ProvNodeId::default(),
+            ),
+        );
+        assert!(
+            to_opponent.is_empty(),
+            "trigger should not fire when a different player is dealt damage"
+        );
+    }
 }

--- a/crates/ironsmith-runtime/src/triggers/combat/deals_damage.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/deals_damage.rs
@@ -94,7 +94,11 @@ impl TriggerMatcher for DealsDamageTrigger {
             }
         } else if let Some(player) = &self.damaged_player {
             if self.filter == ObjectFilter::default() {
-                return format!("Whenever {} is dealt damage", player.description());
+                let player_description = player.description();
+                if player_description == "you" {
+                    return "Whenever you are dealt damage".to_string();
+                }
+                return format!("Whenever {} is dealt damage", player_description);
             }
             format!(
                 "Whenever {} deals damage to {}",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Living Artifact
Initial parse error:
```
unsupported triggered line: 'Whenever you're dealt damage, put that many vitality counters on this Aura.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever you're dealt damage, put that many vitality counters on this Aura.'
```

Worker: i-084e90364fa60acd1
