### PR TITLE
Fix Ironsmith parse failure: Undercover Operative

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3074,6 +3074,7 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
                     added_abilities: Vec::new(),
                     set_base_power_toughness: None,
                     set_base_power_toughness_from_self: false,
+                    enters_with_counters_if_source_controlled: Vec::new(),
                 },
                 clause_words.join(" "),
             )));
@@ -3160,6 +3161,7 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
     let mut added_abilities = Vec::new();
     let mut set_base_power_toughness = None;
     let mut set_base_power_toughness_from_self = false;
+    let mut enters_with_counters_if_source_controlled = Vec::new();
     if let Some(except_idx) = except_idx {
         let tail = &clause_words[except_idx + 1..];
         if tail.is_empty() {
@@ -3186,6 +3188,30 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
             // the copied object's functional abilities for current engine use.
         } else if slice_starts_with(tail, &["it", "has"]) {
             added_abilities = parse_added_copy_abilities(tokens, &clause_words, except_idx + 2)?;
+        } else if tail.get(0..4) == Some(&["it", "enters", "with", "a"])
+            || tail.get(0..4) == Some(&["it", "enters", "with", "an"])
+        {
+            let Some(counter_word) = tail.get(4).copied() else {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported enters-as-copy exception clause (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            };
+            let Some(counter_type) = parse_counter_type_word(counter_word) else {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported enters-as-copy exception clause (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            };
+            if tail.get(5..13)
+                != Some(&["counter", "on", "it", "if", "you", "control", "that", "creature"])
+            {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported enters-as-copy exception clause (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            }
+            enters_with_counters_if_source_controlled.push((counter_type, 1));
         } else {
             let type_idx = if tail.first().copied() == Some("its")
                 && matches!(tail.get(1).copied(), Some("a" | "an"))
@@ -3310,6 +3336,7 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
             added_abilities,
             set_base_power_toughness,
             set_base_power_toughness_from_self,
+            enters_with_counters_if_source_controlled,
         },
         clause_words.join(" "),
     )))

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -357,6 +357,7 @@ fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "age" => Some(CounterType::Age),
         "blood" => Some(CounterType::Blood),
         "ice" => Some(CounterType::Ice),
+        "shield" => Some(CounterType::Shield),
         "finality" => Some(CounterType::Finality),
         "time" => Some(CounterType::Time),
         "brain" => Some(CounterType::Brain),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1227,6 +1227,7 @@ pub(crate) fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "age" => Some(CounterType::Age),
         "blood" => Some(CounterType::Blood),
         "ice" => Some(CounterType::Ice),
+        "shield" => Some(CounterType::Shield),
         "finality" => Some(CounterType::Finality),
         "time" => Some(CounterType::Time),
         "brain" => Some(CounterType::Brain),

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1111,6 +1111,8 @@ where
                         set_base_power_toughness: spec.set_base_power_toughness,
                         set_base_power_toughness_from_self: spec
                             .set_base_power_toughness_from_self,
+                        enters_with_counters_if_source_controlled: spec
+                            .enters_with_counters_if_source_controlled,
                     },
                     display,
                 }
@@ -3999,6 +4001,7 @@ pub struct EnterAsCopyAsEntersSpec<T, E, C, Cond> {
     pub added_abilities: Vec<AbilityModel<T, E, C, Cond>>,
     pub set_base_power_toughness: Option<(i32, i32)>,
     pub set_base_power_toughness_from_self: bool,
+    pub enters_with_counters_if_source_controlled: Vec<(CounterType, u32)>,
 }
 
 impl<T, E, C, Cond> crate::GrantStaticAbility for StaticAbility<T, E, C, Cond>

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -16285,6 +16285,37 @@ fn parse_omni_changeling_copy_exception_stays_localized() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_undercover_operative_strict_copy_exception_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Undercover Operative")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Shapeshifter, Subtype::Rogue])
+        .power_toughness(crate::card::PowerToughness::fixed(0, 0))
+        .parse_text(
+            "Flash\nYou may have this creature enter as a copy of any creature on the battlefield except it enters with a shield counter on it if you control that creature.",
+        )
+        .expect("Undercover Operative rules text should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "except it enters with a shield counter on it if you control that creature"
+        ),
+        "expected Undercover Operative copy exception clause in render output, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("enters_with_counters_if_source_controlled"),
+        "expected Undercover Operative copy exception lowering to record conditional counters, got {debug}"
+    );
+    assert!(
+        !debug.to_ascii_lowercase().contains("unsupported"),
+        "expected Undercover Operative parse to avoid unsupported placeholders, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_reveal_card_this_way_trigger_clause() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Primitive Etchings Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -165,6 +165,7 @@ pub(super) fn apply_trait_replacement(
             added_subtypes,
             added_abilities,
             set_base_power_toughness,
+            enters_with_counters,
         } => {
             let modified = apply_trait_enter_as_copy(
                 &event,
@@ -175,6 +176,7 @@ pub(super) fn apply_trait_replacement(
                 added_subtypes,
                 added_abilities,
                 *set_base_power_toughness,
+                enters_with_counters,
             );
             match modified {
                 Some(e) => TraitApplyResult::Modified(e),
@@ -734,6 +736,7 @@ fn apply_trait_enter_as_copy(
     added_subtypes: &[crate::types::Subtype],
     added_abilities: &[crate::ability::Ability],
     set_base_power_toughness: Option<(i32, i32)>,
+    enters_with_counters: &[(crate::object::CounterType, u32)],
 ) -> Option<Event> {
     use crate::events::{EnterBattlefieldEvent, ZoneChangeEvent, downcast_event};
 
@@ -746,6 +749,9 @@ fn apply_trait_enter_as_copy(
             .with_added_abilities(added_abilities);
         if let Some((power, toughness)) = set_base_power_toughness {
             etb = etb.with_base_power_toughness(power, toughness);
+        }
+        for (counter_type, count) in enters_with_counters {
+            etb = etb.with_counters(*counter_type, *count);
         }
         if enters_tapped {
             etb = etb.with_tapped();

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -134,6 +134,15 @@ fn push_enter_as_copy_effects_for_spec(
                     added_subtypes: spec.added_subtypes.clone(),
                     added_abilities: spec.added_abilities.clone(),
                     set_base_power_toughness,
+                    enters_with_counters: if game
+                        .object(candidate)
+                        .map(|obj| game.controller_of(obj) == controller)
+                        .unwrap_or(false)
+                    {
+                        spec.enters_with_counters_if_source_controlled.clone()
+                    } else {
+                        Vec::new()
+                    },
                 },
             )
             .with_priority_override(crate::events::ReplacementPriority::CopyEffect),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11317,6 +11317,7 @@ fn test_enter_as_copy_applies_copied_enters_with_echo_counter() {
                     added_abilities: Vec::new(),
                     set_base_power_toughness: None,
                     set_base_power_toughness_from_self: false,
+                    enters_with_counters_if_source_controlled: Vec::new(),
                 },
                 "You may have this creature enter as a copy of any creature on the battlefield."
                     .to_string(),
@@ -11375,6 +11376,7 @@ fn test_enter_as_copy_can_set_base_power_toughness_from_entering_object() {
                     added_abilities: Vec::new(),
                     set_base_power_toughness: None,
                     set_base_power_toughness_from_self: true,
+                    enters_with_counters_if_source_controlled: Vec::new(),
                 },
                 "You may have this creature enter as a copy of any creature on the battlefield, except its power and toughness are equal to this creature's power and toughness."
                     .to_string(),
@@ -11426,6 +11428,7 @@ fn test_enter_as_copy_can_set_base_power_toughness_from_entering_stack_object() 
                     added_abilities: Vec::new(),
                     set_base_power_toughness: None,
                     set_base_power_toughness_from_self: true,
+                    enters_with_counters_if_source_controlled: Vec::new(),
                 },
                 "You may have this creature enter as a copy of any creature on the battlefield, except its power and toughness are equal to this creature's power and toughness."
                     .to_string(),
@@ -11471,6 +11474,7 @@ fn test_static_source_can_make_matching_creatures_enter_as_copy_of_itself() {
                     added_abilities: Vec::new(),
                     set_base_power_toughness: None,
                     set_base_power_toughness_from_self: false,
+                    enters_with_counters_if_source_controlled: Vec::new(),
                 },
                 "Creatures you control enter as a copy of this creature.".to_string(),
             ),
@@ -11494,6 +11498,156 @@ fn test_static_source_can_make_matching_creatures_enter_as_copy_of_itself() {
     assert_eq!(copied.name, "Essence Source");
     assert_eq!(copied.base_power, Some(crate::card::PtValue::Fixed(6)));
     assert_eq!(copied.base_toughness, Some(crate::card::PtValue::Fixed(6)));
+}
+
+#[test]
+fn undercover_operative_copy_choice_applies_shield_when_source_controlled() {
+    use crate::decision::DecisionMaker;
+
+    struct ChooseCopyDecisionMaker;
+    impl DecisionMaker for ChooseCopyDecisionMaker {
+        fn decide_options(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            if ctx.options.len() > 1 { vec![1] } else { vec![0] }
+        }
+    }
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let source = CardDefinitionBuilder::new(CardId::new(), "Friendly Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    game.create_object_from_definition(&source, alice, Zone::Battlefield);
+
+    let operative = CardDefinitionBuilder::new(CardId::new(), "Undercover Operative")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Shapeshifter, Subtype::Rogue])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(
+            "Flash\nYou may have this creature enter as a copy of any creature on the battlefield except it enters with a shield counter on it if you control that creature.",
+        )
+        .expect("Undercover Operative text should parse");
+    let operative_id = game.create_object_from_definition(&operative, alice, Zone::Hand);
+
+    let mut dm = ChooseCopyDecisionMaker;
+    let result = game
+        .move_object_with_etb_processing_with_dm(operative_id, Zone::Battlefield, &mut dm)
+        .expect("operative should enter the battlefield");
+    let entered = game
+        .object(result.new_id)
+        .expect("entered operative should exist");
+
+    assert_eq!(entered.name, "Friendly Source");
+    assert_eq!(
+        entered
+            .counters
+            .get(&CounterType::Shield)
+            .copied()
+            .unwrap_or(0),
+        1,
+        "operative should enter with a shield counter when copying a creature you control"
+    );
+}
+
+#[test]
+fn undercover_operative_copy_choice_skips_shield_when_source_not_controlled() {
+    use crate::decision::DecisionMaker;
+
+    struct ChooseCopyDecisionMaker;
+    impl DecisionMaker for ChooseCopyDecisionMaker {
+        fn decide_options(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            if ctx.options.len() > 1 { vec![1] } else { vec![0] }
+        }
+    }
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let source = CardDefinitionBuilder::new(CardId::new(), "Opponent Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    game.create_object_from_definition(&source, bob, Zone::Battlefield);
+
+    let operative = CardDefinitionBuilder::new(CardId::new(), "Undercover Operative")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Shapeshifter, Subtype::Rogue])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(
+            "Flash\nYou may have this creature enter as a copy of any creature on the battlefield except it enters with a shield counter on it if you control that creature.",
+        )
+        .expect("Undercover Operative text should parse");
+    let operative_id = game.create_object_from_definition(&operative, alice, Zone::Hand);
+
+    let mut dm = ChooseCopyDecisionMaker;
+    let result = game
+        .move_object_with_etb_processing_with_dm(operative_id, Zone::Battlefield, &mut dm)
+        .expect("operative should enter the battlefield");
+    let entered = game
+        .object(result.new_id)
+        .expect("entered operative should exist");
+
+    assert_eq!(entered.name, "Opponent Source");
+    assert_eq!(
+        entered
+            .counters
+            .get(&CounterType::Shield)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "operative should not gain shield when copying a creature you do not control"
+    );
+}
+
+#[test]
+fn undercover_operative_may_decline_copy_choice() {
+    use crate::decision::AutoPassDecisionMaker;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let source = CardDefinitionBuilder::new(CardId::new(), "Friendly Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    game.create_object_from_definition(&source, alice, Zone::Battlefield);
+
+    let operative = CardDefinitionBuilder::new(CardId::new(), "Undercover Operative")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Shapeshifter, Subtype::Rogue])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(
+            "Flash\nYou may have this creature enter as a copy of any creature on the battlefield except it enters with a shield counter on it if you control that creature.",
+        )
+        .expect("Undercover Operative text should parse");
+    let operative_id = game.create_object_from_definition(&operative, alice, Zone::Hand);
+
+    let mut dm = AutoPassDecisionMaker;
+    let result = game
+        .move_object_with_etb_processing_with_dm(operative_id, Zone::Battlefield, &mut dm)
+        .expect("operative should enter the battlefield");
+    let entered = game
+        .object(result.new_id)
+        .expect("entered operative should exist");
+
+    assert_eq!(entered.name, "Undercover Operative");
+    assert_eq!(
+        entered
+            .counters
+            .get(&CounterType::Shield)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "operative should not get shield when declining to copy"
+    );
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -156,6 +156,7 @@ pub enum ReplacementAction {
         added_subtypes: Vec<Subtype>,
         added_abilities: Vec<Ability>,
         set_base_power_toughness: Option<(i32, i32)>,
+        enters_with_counters: Vec<(CounterType, u32)>,
     },
 
     /// Enter with permanent characteristic changes.

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -953,6 +953,7 @@ pub struct EnterAsCopyAsEntersSpec {
     pub added_abilities: Vec<crate::ability::Ability>,
     pub set_base_power_toughness: Option<(i32, i32)>,
     pub set_base_power_toughness_from_self: bool,
+    pub enters_with_counters_if_source_controlled: Vec<(crate::object::CounterType, u32)>,
 }
 
 /// Spec for static abilities that duplicate matching triggered abilities.

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -444,6 +444,9 @@ impl StaticAbilityModelInterpreter {
                         .collect(),
                     set_base_power_toughness: spec.set_base_power_toughness,
                     set_base_power_toughness_from_self: spec.set_base_power_toughness_from_self,
+                    enters_with_counters_if_source_controlled: spec
+                        .enters_with_counters_if_source_controlled
+                        .clone(),
                 })
             }
             ironsmith_core::StaticAbilityPayload::Conditional { ability, .. } => {
@@ -1166,6 +1169,9 @@ impl StaticAbilityModelInterpreter {
                         set_base_power_toughness: spec.set_base_power_toughness,
                         set_base_power_toughness_from_self: spec
                             .set_base_power_toughness_from_self,
+                        enters_with_counters_if_source_controlled: spec
+                            .enters_with_counters_if_source_controlled
+                            .clone(),
                     },
                     display.clone(),
                 )


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Undercover Operative
Initial parse error:
```
unsupported enters-as-copy exception clause (clause: 'you may have this creature enter as a copy of any creature on the battlefield except it enters with a shield counter on it if you control that creature'); oracle-only fallback also failed: unsupported enters-as-copy exception clause (clause: 'you may have this creature enter as a copy of any creature on the battlefield except it enters with a shield counter on it if you control that creature')
```

Worker: i-08a4c47d1f8acbd5e
