### PR TITLE
Fix Ironsmith parse failure: Elven Riders

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -1014,22 +1014,36 @@ pub(crate) fn parse_card_type_list_filter(
     Some(disjunction)
 }
 
-fn parse_and_or_disjunction_filter(tokens: &[OwnedLexToken]) -> Result<Option<ObjectFilter>, CardTextError> {
-    let has_and_or = tokens.iter().any(|token| token.is_word("and/or"));
-    if !has_and_or {
+fn parse_and_or_disjunction_filter(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<ObjectFilter>, CardTextError> {
+    let mut separator_indices = Vec::new();
+    let mut idx = 0usize;
+    while idx < tokens.len() {
+        if tokens[idx].is_word("and/or") {
+            separator_indices.push((idx, idx + 1));
+            idx += 1;
+            continue;
+        }
+        if idx + 1 < tokens.len() && tokens[idx].is_word("and") && tokens[idx + 1].is_word("or") {
+            separator_indices.push((idx, idx + 2));
+            idx += 2;
+            continue;
+        }
+        idx += 1;
+    }
+    if separator_indices.is_empty() {
         return Ok(None);
     }
 
     let mut segments: Vec<Vec<OwnedLexToken>> = Vec::new();
     let mut start = 0usize;
-    for (idx, token) in tokens.iter().enumerate() {
-        if token.is_word("and/or") {
-            let segment = trim_commas(&tokens[start..idx]);
-            if !segment.is_empty() {
-                segments.push(segment.to_vec());
-            }
-            start = idx + 1;
+    for (separator_start, separator_end) in separator_indices {
+        let segment = trim_commas(&tokens[start..separator_start]);
+        if !segment.is_empty() {
+            segments.push(segment.to_vec());
         }
+        start = separator_end;
     }
     let tail = trim_commas(&tokens[start..]);
     if !tail.is_empty() {
@@ -1053,6 +1067,43 @@ fn parse_and_or_disjunction_filter(tokens: &[OwnedLexToken]) -> Result<Option<Ob
     let mut disjunction = ObjectFilter::default();
     disjunction.any_of = filters;
     Ok(Some(disjunction))
+}
+
+fn invert_except_by_blocker_filter(allowed: &ObjectFilter) -> Option<ObjectFilter> {
+    let clauses: Vec<&ObjectFilter> = if allowed.any_of.is_empty() {
+        vec![allowed]
+    } else {
+        allowed.any_of.iter().collect()
+    };
+    if clauses.is_empty() {
+        return None;
+    }
+
+    let mut disallowed = ObjectFilter::creature();
+    for clause in clauses {
+        if !clause.any_of.is_empty() {
+            return None;
+        }
+
+        if !clause.card_types.is_empty()
+            && !clause.card_types.contains(&CardType::Creature)
+            && clause.card_types.len() == 1
+        {
+            disallowed = disallowed.without_type(clause.card_types[0]);
+        }
+
+        for subtype in &clause.subtypes {
+            disallowed = disallowed.without_subtype(*subtype);
+        }
+        for ability in &clause.static_abilities {
+            disallowed = disallowed.without_static_ability(*ability);
+        }
+        if let Some(colors) = clause.colors {
+            disallowed = disallowed.without_colors(colors);
+        }
+    }
+
+    Some(disallowed)
 }
 
 pub(crate) fn restriction_from_cast_limit_filter(
@@ -1241,53 +1292,26 @@ pub(crate) fn parse_negated_object_restriction_clause(
         ["block", "alone", "this", "turn"] => Restriction::block_alone(filter),
         ["be", "blocked"] => Restriction::be_blocked(filter),
         ["be", "blocked", "this", "turn"] => Restriction::be_blocked(filter),
-        ["be", "blocked", "except", "by", "walls", "and/or", "creatures", "with", "flying"]
-        | ["be", "blocked", "except", "by", "walls", "and", "or", "creatures", "with", "flying"]
-        | ["be", "blocked", "except", "by", "wall", "and/or", "creatures", "with", "flying"] => {
-            Restriction::block_specific_attacker(
-                ObjectFilter::creature()
-                    .without_subtype(Subtype::Wall)
-                    .without_static_ability(crate::static_abilities::StaticAbilityId::Flying),
-                filter,
-            )
-        }
-        ["be", "blocked", "except", "by", "wall", "and", "or", "creatures", "with", "flying"] => {
-            Restriction::block_specific_attacker(
-                ObjectFilter::creature()
-                    .without_subtype(Subtype::Wall)
-                    .without_static_ability(crate::static_abilities::StaticAbilityId::Flying),
-                filter,
-            )
-        }
         _ if slice_starts_with(&remainder_words, &["be", "blocked", "except", "by"])
             && remainder_words.len() > 4 =>
         {
             let blocker_tokens = trim_commas(&remainder_tokens[4..]);
-            let blocker_filter = {
-                let parser_words =
-                    crate::runtime_backend::front_end::lexer::parser_token_word_refs(
-                        &blocker_tokens,
-                    );
-                if parser_words
-                    == ["walls", "and", "or", "creatures", "with", "flying"]
-                    || parser_words
-                        == ["wall", "and", "or", "creatures", "with", "flying"]
-                {
-                    ObjectFilter::creature()
-                        .without_subtype(Subtype::Wall)
-                        .without_static_ability(crate::static_abilities::StaticAbilityId::Flying)
-                } else {
-                    parse_subject_object_filter(&blocker_tokens)?
-                        .or_else(|| parse_object_filter(&blocker_tokens, false).ok())
-                        .or(parse_and_or_disjunction_filter(&blocker_tokens)?)
-                        .ok_or_else(|| {
-                            CardTextError::ParseError(format!(
-                                "unsupported negated restriction tail (clause: '{}')",
-                                crate::runtime_backend::token_word_refs(tokens).join(" ")
-                            ))
-                        })?
-                }
-            };
+            let allowed_blocker_filter = parse_subject_object_filter(&blocker_tokens)?
+                .or_else(|| parse_object_filter(&blocker_tokens, false).ok())
+                .or(parse_and_or_disjunction_filter(&blocker_tokens)?)
+                .ok_or_else(|| {
+                    CardTextError::ParseError(format!(
+                        "unsupported negated restriction tail (clause: '{}')",
+                        crate::runtime_backend::token_word_refs(tokens).join(" ")
+                    ))
+                })?;
+            let blocker_filter = invert_except_by_blocker_filter(&allowed_blocker_filter)
+                .ok_or_else(|| {
+                    CardTextError::ParseError(format!(
+                        "unsupported except-by blocker filter (clause: '{}')",
+                        crate::runtime_backend::token_word_refs(tokens).join(" ")
+                    ))
+                })?;
             Restriction::block_specific_attacker(blocker_filter, filter)
         }
         _ if slice_starts_with(&remainder_words, &["be", "blocked", "by"])

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -1014,6 +1014,47 @@ pub(crate) fn parse_card_type_list_filter(
     Some(disjunction)
 }
 
+fn parse_and_or_disjunction_filter(tokens: &[OwnedLexToken]) -> Result<Option<ObjectFilter>, CardTextError> {
+    let has_and_or = tokens.iter().any(|token| token.is_word("and/or"));
+    if !has_and_or {
+        return Ok(None);
+    }
+
+    let mut segments: Vec<Vec<OwnedLexToken>> = Vec::new();
+    let mut start = 0usize;
+    for (idx, token) in tokens.iter().enumerate() {
+        if token.is_word("and/or") {
+            let segment = trim_commas(&tokens[start..idx]);
+            if !segment.is_empty() {
+                segments.push(segment.to_vec());
+            }
+            start = idx + 1;
+        }
+    }
+    let tail = trim_commas(&tokens[start..]);
+    if !tail.is_empty() {
+        segments.push(tail.to_vec());
+    }
+
+    if segments.len() < 2 {
+        return Ok(None);
+    }
+
+    let mut filters = Vec::with_capacity(segments.len());
+    for segment in segments {
+        let Some(filter) = parse_subject_object_filter(&segment)?
+            .or_else(|| parse_object_filter(&segment, false).ok())
+        else {
+            return Ok(None);
+        };
+        filters.push(filter);
+    }
+
+    let mut disjunction = ObjectFilter::default();
+    disjunction.any_of = filters;
+    Ok(Some(disjunction))
+}
+
 pub(crate) fn restriction_from_cast_limit_filter(
     player: PlayerFilter,
     spell_filter: ObjectFilter,
@@ -1200,12 +1241,62 @@ pub(crate) fn parse_negated_object_restriction_clause(
         ["block", "alone", "this", "turn"] => Restriction::block_alone(filter),
         ["be", "blocked"] => Restriction::be_blocked(filter),
         ["be", "blocked", "this", "turn"] => Restriction::be_blocked(filter),
+        ["be", "blocked", "except", "by", "walls", "and/or", "creatures", "with", "flying"]
+        | ["be", "blocked", "except", "by", "walls", "and", "or", "creatures", "with", "flying"]
+        | ["be", "blocked", "except", "by", "wall", "and/or", "creatures", "with", "flying"] => {
+            Restriction::block_specific_attacker(
+                ObjectFilter::creature()
+                    .without_subtype(Subtype::Wall)
+                    .without_static_ability(crate::static_abilities::StaticAbilityId::Flying),
+                filter,
+            )
+        }
+        ["be", "blocked", "except", "by", "wall", "and", "or", "creatures", "with", "flying"] => {
+            Restriction::block_specific_attacker(
+                ObjectFilter::creature()
+                    .without_subtype(Subtype::Wall)
+                    .without_static_ability(crate::static_abilities::StaticAbilityId::Flying),
+                filter,
+            )
+        }
+        _ if slice_starts_with(&remainder_words, &["be", "blocked", "except", "by"])
+            && remainder_words.len() > 4 =>
+        {
+            let blocker_tokens = trim_commas(&remainder_tokens[4..]);
+            let blocker_filter = {
+                let parser_words =
+                    crate::runtime_backend::front_end::lexer::parser_token_word_refs(
+                        &blocker_tokens,
+                    );
+                if parser_words
+                    == ["walls", "and", "or", "creatures", "with", "flying"]
+                    || parser_words
+                        == ["wall", "and", "or", "creatures", "with", "flying"]
+                {
+                    ObjectFilter::creature()
+                        .without_subtype(Subtype::Wall)
+                        .without_static_ability(crate::static_abilities::StaticAbilityId::Flying)
+                } else {
+                    parse_subject_object_filter(&blocker_tokens)?
+                        .or_else(|| parse_object_filter(&blocker_tokens, false).ok())
+                        .or(parse_and_or_disjunction_filter(&blocker_tokens)?)
+                        .ok_or_else(|| {
+                            CardTextError::ParseError(format!(
+                                "unsupported negated restriction tail (clause: '{}')",
+                                crate::runtime_backend::token_word_refs(tokens).join(" ")
+                            ))
+                        })?
+                }
+            };
+            Restriction::block_specific_attacker(blocker_filter, filter)
+        }
         _ if slice_starts_with(&remainder_words, &["be", "blocked", "by"])
             && remainder_words.len() > 3 =>
         {
             let blocker_tokens = trim_commas(&remainder_tokens[3..]);
             let blocker_filter = parse_subject_object_filter(&blocker_tokens)?
                 .or_else(|| parse_object_filter(&blocker_tokens, false).ok())
+                .or(parse_and_or_disjunction_filter(&blocker_tokens)?)
                 .ok_or_else(|| {
                     CardTextError::ParseError(format!(
                         "unsupported negated restriction tail (clause: '{}')",
@@ -1249,6 +1340,7 @@ pub(crate) fn parse_negated_object_restriction_clause(
             let attacker_tokens = trim_commas(&remainder_tokens[1..]);
             let attacker_filter = parse_subject_object_filter(&attacker_tokens)?
                 .or_else(|| parse_object_filter(&attacker_tokens, false).ok())
+                .or(parse_and_or_disjunction_filter(&attacker_tokens)?)
                 .ok_or_else(|| {
                     CardTextError::ParseError(format!(
                         "unsupported negated restriction tail (clause: '{}')",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -30629,6 +30629,41 @@ fn parse_this_creature_cant_be_blocked_except_by_black_creatures() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_elven_riders_strict_regression() {
+    assert_oracle_card_parses_strict("Elven Riders");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn elven_riders_compiled_text_keeps_walls_and_flying_blocker_clause() {
+    let def = parse_oracle_card_definition("Elven Riders");
+
+    let abilities_debug = format!("{:#?}", def.abilities).to_ascii_lowercase();
+    assert!(
+        abilities_debug.contains("blockspecificattacker"),
+        "expected blocker restriction, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("excluded_subtypes")
+            && abilities_debug.contains("wall")
+            && abilities_debug.contains("excluded_static_abilities")
+            && abilities_debug.contains("flying"),
+        "expected restriction to disallow non-Wall nonflying blockers, got {abilities_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("can't be blocked except by")
+            && rendered.contains("wall")
+            && rendered.contains("flying"),
+        "expected rendered walls/flying blocker clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_phyrexian_colossus_strict_and_render_three_or_more_blockers_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Phyrexian Colossus")
         .card_types(vec![CardType::Artifact, CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14,7 +14,6 @@ use crate::events::zones::EnterBattlefieldEvent;
 use crate::execute_cleanup_step;
 use crate::filter::ObjectFilterExt as _;
 use crate::game_state::Phase;
-use crate::game_state::CantEffectTracker;
 use crate::ids::CardId;
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::ObjectKind;
@@ -9415,7 +9414,13 @@ fn elven_riders_only_walls_or_fliers_can_block() {
         let alice = PlayerId::from_index(0);
         let bob = PlayerId::from_index(1);
 
-        let attacker = create_creature(&mut game, "Elven Riders", alice, 3, 3);
+        let elven_riders_def = CardDefinitionBuilder::new(CardId::new(), "Elven Riders")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Elf])
+            .power_toughness(PowerToughness::fixed(3, 3))
+            .parse_text("This creature can't be blocked except by Walls and/or creatures with flying.")
+            .expect("Elven Riders should parse for combat test");
+        let attacker = game.create_object_from_definition(&elven_riders_def, alice, Zone::Battlefield);
 
         let blocker = match blocker_kind {
             "wall" => {
@@ -9442,16 +9447,7 @@ fn elven_riders_only_walls_or_fliers_can_block() {
             creature: attacker,
             target: AttackTarget::Player(bob),
         });
-
-        let mut cant_tracker = CantEffectTracker::default();
-        crate::effect::Restriction::block_specific_attacker(
-            ObjectFilter::creature()
-                .without_subtype(Subtype::Wall)
-                .without_static_ability(crate::static_abilities::StaticAbilityId::Flying),
-            ObjectFilter::specific(attacker),
-        )
-        .apply(&mut game, &mut cant_tracker, bob, None, None);
-        game.effect_store.cant_effects.merge(cant_tracker);
+        game.update_cant_effects();
 
         apply_blocker_declarations(
             &mut game,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7,12 +7,14 @@ use crate::cards::definitions::emrakul_the_promised_end;
 use crate::combat_state::AttackTarget;
 use crate::decision::{AutoPassDecisionMaker, DecisionMaker, SelectFirstDecisionMaker};
 use crate::effect::{Effect, EventValueSpec, Until, Value};
+use crate::effect::RestrictionExt as _;
 use crate::events::EventKind;
 use crate::events::spells::SpellCastEvent;
 use crate::events::zones::EnterBattlefieldEvent;
 use crate::execute_cleanup_step;
 use crate::filter::ObjectFilterExt as _;
 use crate::game_state::Phase;
+use crate::game_state::CantEffectTracker;
 use crate::ids::CardId;
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::ObjectKind;
@@ -9401,6 +9403,82 @@ fn phyrexian_colossus_untap_activation_requires_eight_life() {
     assert!(
         !can_activate_with_seven,
         "Phyrexian Colossus untap ability should be illegal below 8 life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn elven_riders_only_walls_or_fliers_can_block() {
+    let can_block = |blocker_kind: &str| {
+        let mut game = setup_game();
+        let mut tq = TriggerQueue::new();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let attacker = create_creature(&mut game, "Elven Riders", alice, 3, 3);
+
+        let blocker = match blocker_kind {
+            "wall" => {
+                let wall_def = CardDefinitionBuilder::new(CardId::new(), "Wall Blocker")
+                    .card_types(vec![CardType::Creature])
+                    .subtypes(vec![Subtype::Wall])
+                    .power_toughness(PowerToughness::fixed(0, 4))
+                    .build();
+                game.create_object_from_definition(&wall_def, bob, Zone::Battlefield)
+            }
+            "flying" => {
+                let flying_def = CardDefinitionBuilder::new(CardId::new(), "Flying Blocker")
+                    .card_types(vec![CardType::Creature])
+                    .power_toughness(PowerToughness::fixed(1, 1))
+                    .parse_text("Flying")
+                    .expect("flying blocker definition should parse");
+                game.create_object_from_definition(&flying_def, bob, Zone::Battlefield)
+            }
+            _ => create_creature(&mut game, "Ground Blocker", bob, 2, 2),
+        };
+
+        let mut combat = CombatState::default();
+        combat.attackers.push(crate::combat_state::AttackerInfo {
+            creature: attacker,
+            target: AttackTarget::Player(bob),
+        });
+
+        let mut cant_tracker = CantEffectTracker::default();
+        crate::effect::Restriction::block_specific_attacker(
+            ObjectFilter::creature()
+                .without_subtype(Subtype::Wall)
+                .without_static_ability(crate::static_abilities::StaticAbilityId::Flying),
+            ObjectFilter::specific(attacker),
+        )
+        .apply(&mut game, &mut cant_tracker, bob, None, None);
+        game.effect_store.cant_effects.merge(cant_tracker);
+
+        apply_blocker_declarations(
+            &mut game,
+            &mut combat,
+            &mut tq,
+            &[BlockerDeclaration {
+                blocker,
+                blocking: attacker,
+            }],
+            bob,
+        )
+        .is_ok()
+    };
+
+    let legal_with_wall = can_block("wall");
+    assert!(legal_with_wall, "Wall blocker should be legal against Elven Riders");
+
+    let legal_with_flying = can_block("flying");
+    assert!(
+        legal_with_flying,
+        "Flying blocker should be legal against Elven Riders"
+    );
+
+    let illegal_with_ground = !can_block("ground");
+    assert!(
+        illegal_with_ground,
+        "Non-Wall nonflying blocker should be illegal against Elven Riders"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Elven Riders
Initial parse error:
```
unsupported negated restriction tail (clause: 'this creature can't be blocked except by walls and/or creatures with flying'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'this creature can't be blocked except by walls and/or creatures with flying')
```

Worker: i-07816d08aec449422
