### PR TITLE
Fix Ironsmith parse failure: Riveteers Charm

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/token_primitives.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/token_primitives.rs
@@ -630,6 +630,8 @@ fn parse_turn_duration_phrase_inner<'a>(input: &mut LexedInput<'a>) -> WResult<T
         "until" => alt((
             grammar::phrase(&["until", "your", "next", "turn"])
                 .value(TurnDurationPhrase::UntilYourNextTurn),
+            grammar::phrase(&["until", "your", "next", "end", "step"])
+                .value(TurnDurationPhrase::UntilYourNextTurnEnd),
             grammar::phrase(&["until", "the", "end", "of", "your", "next", "turn"])
                 .value(TurnDurationPhrase::UntilYourNextTurnEnd),
             grammar::phrase(&["until", "end", "of", "your", "next", "turn"])
@@ -648,6 +650,9 @@ fn parse_turn_duration_phrase_inner<'a>(input: &mut LexedInput<'a>) -> WResult<T
 fn turn_duration_from_suffix_phrase(phrase: &[&str]) -> Option<TurnDurationPhrase> {
     match phrase {
         ["until", "your", "next", "turn"] => Some(TurnDurationPhrase::UntilYourNextTurn),
+        ["until", "your", "next", "end", "step"] => {
+            Some(TurnDurationPhrase::UntilYourNextTurnEnd)
+        }
         ["until", "the", "end", "of", "your", "next", "turn"]
         | ["until", "end", "of", "your", "next", "turn"] => {
             Some(TurnDurationPhrase::UntilYourNextTurnEnd)
@@ -671,6 +676,7 @@ pub(crate) fn parse_turn_duration_suffix<'a>(
 ) -> Option<(&'a [OwnedLexToken], TurnDurationPhrase)> {
     let phrases = [
         &["until", "your", "next", "turn"][..],
+        &["until", "your", "next", "end", "step"][..],
         &["until", "the", "end", "of", "your", "next", "turn"][..],
         &["until", "end", "of", "your", "next", "turn"][..],
         &["until", "the", "end", "of", "turn"][..],
@@ -728,6 +734,7 @@ pub(crate) fn parse_simple_restriction_duration_suffix<'a>(
 ) -> Option<(&'a [OwnedLexToken], Until)> {
     let phrases = [
         &["until", "your", "next", "turn"][..],
+        &["until", "your", "next", "end", "step"][..],
         &["until", "your", "next", "upkeep"][..],
         &["until", "the", "end", "of", "your", "next", "turn"][..],
         &["until", "end", "of", "your", "next", "turn"][..],

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
@@ -519,11 +519,18 @@ pub(crate) fn parse_consult_mana_value_condition_tokens(
 pub(crate) fn parse_consult_cast_clause(tokens: &[OwnedLexToken]) -> Option<ConsultCastClause> {
     let mut second_tokens = trim_commas(tokens);
     let mut timing = ConsultCastTiming::Immediate;
-    if let Some((super::super::token_primitives::TurnDurationPhrase::UntilEndOfTurn, remainder)) =
-        parse_turn_duration_prefix(&second_tokens)
-    {
-        second_tokens = trim_commas(remainder);
-        timing = ConsultCastTiming::UntilEndOfTurn;
+    if let Some((duration, remainder)) = parse_turn_duration_prefix(&second_tokens) {
+        match duration {
+            super::super::token_primitives::TurnDurationPhrase::UntilEndOfTurn => {
+                second_tokens = trim_commas(remainder);
+                timing = ConsultCastTiming::UntilEndOfTurn;
+            }
+            super::super::token_primitives::TurnDurationPhrase::UntilYourNextTurnEnd => {
+                second_tokens = trim_commas(remainder);
+                timing = ConsultCastTiming::UntilYourNextTurnEnd;
+            }
+            _ => {}
+        }
     }
 
     let may_idx = find_index(&second_tokens, |token: &OwnedLexToken| token.is_word("may"))?;
@@ -891,14 +898,29 @@ pub(crate) fn consult_cast_effects(
         ConsultCastCost::Normal | ConsultCastCost::WithoutPayingManaCost => {
             let without_paying_mana_cost =
                 matches!(clause.cost, ConsultCastCost::WithoutPayingManaCost);
-            if clause.allow_land || matches!(clause.timing, ConsultCastTiming::UntilEndOfTurn) {
-                vec![EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
-                    match_tag.clone(),
-                    clause.caster,
-                    clause.allow_land,
-                    without_paying_mana_cost,
-                    false,
-                )]
+            if clause.allow_land
+                || matches!(
+                    clause.timing,
+                    ConsultCastTiming::UntilEndOfTurn | ConsultCastTiming::UntilYourNextTurnEnd
+                )
+            {
+                let grant = if matches!(clause.timing, ConsultCastTiming::UntilYourNextTurnEnd) {
+                    EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
+                        match_tag.clone(),
+                        clause.caster,
+                        clause.allow_land,
+                        false,
+                    )
+                } else {
+                    EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
+                        match_tag.clone(),
+                        clause.caster,
+                        clause.allow_land,
+                        without_paying_mana_cost,
+                        false,
+                    )
+                };
+                vec![grant]
             } else {
                 vec![EffectAst::May {
                     effects: vec![EffectAst::subject_verb_cast_tagged(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -359,6 +359,7 @@ pub(super) struct ConsultCastClause {
 pub(super) enum ConsultCastTiming {
     Immediate,
     UntilEndOfTurn,
+    UntilYourNextTurnEnd,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -61,6 +61,20 @@ fn parse_unless_mana_spent_to_cast_predicate(tokens: &[OwnedLexToken]) -> Option
     })
 }
 
+fn split_greatest_mana_value_among_clause(
+    tokens: &[OwnedLexToken],
+) -> Option<(&[OwnedLexToken], &[OwnedLexToken])> {
+    let marker = ["with", "the", "greatest", "mana", "value", "among"];
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let marker_start = words
+        .windows(marker.len())
+        .position(|window| window == marker)?;
+    let marker_end = marker_start + marker.len();
+    let before_idx = token_index_for_word_index(tokens, marker_start)?;
+    let after_idx = token_index_for_word_index(tokens, marker_end)?;
+    Some((&tokens[..before_idx], &tokens[after_idx..]))
+}
+
 pub(crate) fn parse_sacrifice(
     tokens: &[OwnedLexToken],
     subject: Option<SubjectAst>,
@@ -116,15 +130,6 @@ pub(crate) fn parse_sacrifice(
                 clause_words.join(" ")
             )));
         }
-    }
-    let has_greatest_mana_value = grammar::contains_word(tokens, "greatest")
-        && grammar::contains_word(tokens, "mana")
-        && grammar::contains_word(tokens, "value");
-    if has_greatest_mana_value {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported greatest-mana-value sacrifice clause (clause: '{}')",
-            normalized_words.join(" ")
-        )));
     }
     let has_for_each_graveyard_history = grammar::contains_word(tokens, "for")
         && grammar::contains_word(tokens, "each")
@@ -185,15 +190,40 @@ pub(crate) fn parse_sacrifice(
 
     // Split off a trailing "for each ..." suffix before parsing the filter.
     let remaining_tokens = &tokens[idx..];
-    let for_each_idx = grammar::find_prefix(remaining_tokens, || grammar::phrase(&["for", "each"]))
-        .map(|(idx, _, _)| idx);
+    let mut greatest_mana_value_reference_filter = None;
+    let object_clause_tokens = if let Some((base_object_tokens, among_tokens)) =
+        split_greatest_mana_value_among_clause(remaining_tokens)
+    {
+        if among_tokens.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing object set after greatest mana value among (clause: '{}')",
+                normalized_words.join(" ")
+            )));
+        }
+        let among_filter = parse_object_filter_lexed(among_tokens, false)?;
+        greatest_mana_value_reference_filter = Some(among_filter);
+        base_object_tokens
+    } else {
+        remaining_tokens
+    };
+
+    if object_clause_tokens.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing sacrifice object in clause (clause: '{}')",
+            normalized_words.join(" ")
+        )));
+    }
+    let for_each_idx = grammar::find_prefix(object_clause_tokens, || {
+        grammar::phrase(&["for", "each"])
+    })
+    .map(|(idx, _, _)| idx);
 
     let (object_tokens, for_each_filter) = if let Some(fe_idx) = for_each_idx {
-        let fe_count_tokens = &remaining_tokens[fe_idx..];
+        let fe_count_tokens = &object_clause_tokens[fe_idx..];
         let fe_value = parse_get_for_each_count_value(fe_count_tokens)?;
-        (&remaining_tokens[..fe_idx], fe_value)
+        (&object_clause_tokens[..fe_idx], fe_value)
     } else {
-        (remaining_tokens, None)
+        (object_clause_tokens, None)
     };
 
     let filter_words = ZoneHandlerNormalizedWords::new(object_tokens);
@@ -236,6 +266,12 @@ pub(crate) fn parse_sacrifice(
     };
     if other {
         filter.other = true;
+    }
+    if let Some(among_filter) = greatest_mana_value_reference_filter {
+        filter.mana_value = Some(crate::filter::Comparison::EqualExpr(Box::new(
+            Value::GreatestManaValue(
+            among_filter,
+        ))));
     }
     if filter.source && count != 1 {
         return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39174,6 +39174,36 @@ fn parse_oracle_clarion_ultimatum_for_each_chosen_permanent_regression() {
     );
 }
 
+#[test]
+fn parse_oracle_riveteers_charm_strict_regression() {
+    let def = parse_oracle_card_definition("Riveteers Charm");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("greatest mana value among creatures and planeswalkers they control"),
+        "expected greatest-mana-value sacrifice clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("until your next end step, you may play those cards"),
+        "expected next-end-step play duration in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("exile target player's graveyard"),
+        "expected graveyard-exile mode in compiled text, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("SacrificePlayerEffect") && debug.contains("GreatestManaValue"),
+        "expected sacrifice effect constrained by greatest mana value, got {debug}"
+    );
+    assert!(
+        debug.contains("UntilYourNextTurnEnd"),
+        "expected timing branch for 'until your next end step', got {debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn planar_genesis_fallback_with_extra_tail_still_fails_loudly() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -15203,6 +15203,263 @@ fn test_fallen_shinobi_trigger_exiles_top_two_cards_and_grants_play_permission()
     }
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn riveteers_charm_mode_one_limits_sacrifice_to_greatest_mana_value_ties() {
+    struct ChooseSacrificeFromGreatestTie {
+        desired: ObjectId,
+        seen_candidates: Vec<ObjectId>,
+    }
+
+    impl DecisionMaker for ChooseSacrificeFromGreatestTie {
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            self.seen_candidates = ctx.candidates.iter().map(|candidate| candidate.id).collect();
+            vec![self.desired]
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let riveteers_charm = CardDefinitionBuilder::new(CardId::new(), "Riveteers Charm")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Choose one —\n\
+• Target opponent sacrifices a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.\n\
+• Exile the top three cards of your library. Until your next end step, you may play those cards.\n\
+• Exile target player's graveyard.",
+        )
+        .expect("Riveteers Charm should parse");
+
+    let low_creature = CardBuilder::new(CardId::new(), "Low Creature")
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let tie_creature = CardBuilder::new(CardId::new(), "Tie Creature")
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let tie_planeswalker = CardBuilder::new(CardId::new(), "Tie Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .build();
+
+    let low_id = game.create_object_from_card(&low_creature, bob, Zone::Battlefield);
+    let tie_creature_id = game.create_object_from_card(&tie_creature, bob, Zone::Battlefield);
+    let tie_planeswalker_id = game.create_object_from_card(&tie_planeswalker, bob, Zone::Battlefield);
+
+    let spell_id = game.create_object_from_definition(&riveteers_charm, alice, Zone::Hand);
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut trigger_queue = TriggerQueue::new();
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("casting Riveteers Charm should reach mode selection");
+
+    match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Modes(_)) => {}
+        other => panic!("expected mode selection for Riveteers Charm, got {other:?}"),
+    }
+
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Modes(vec![0]),
+    )
+    .expect("choosing Riveteers Charm sacrifice mode should request targets");
+
+    match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(_)) => {}
+        other => panic!("expected opponent target selection for Riveteers Charm, got {other:?}"),
+    }
+
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+    )
+    .expect("choosing target opponent should finish casting Riveteers Charm");
+
+    let mut dm = ChooseSacrificeFromGreatestTie {
+        desired: tie_planeswalker_id,
+        seen_candidates: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Riveteers Charm sacrifice mode should resolve cleanly");
+
+    let tie_survivors = [tie_creature_id, tie_planeswalker_id]
+        .iter()
+        .filter(|id| game.battlefield.contains(id))
+        .count();
+
+    assert!(
+        game.battlefield.contains(&low_id),
+        "lower-mana-value permanents should not be sacrificed"
+    );
+    assert!(
+        tie_survivors == 1,
+        "exactly one greatest-mana-value permanent should be sacrificed from the tie; candidates seen: {:?}",
+        dm.seen_candidates
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn riveteers_charm_mode_two_play_permission_lasts_through_next_end_step_window() {
+    use crate::decision::compute_legal_actions;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let riveteers_charm = CardDefinitionBuilder::new(CardId::new(), "Riveteers Charm")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Choose one —\n\
+• Target opponent sacrifices a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control.\n\
+• Exile the top three cards of your library. Until your next end step, you may play those cards.\n\
+• Exile target player's graveyard.",
+        )
+        .expect("Riveteers Charm should parse");
+
+    let top_land = CardBuilder::new(CardId::new(), "Charm Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let top_spell = CardBuilder::new(CardId::new(), "Charm Spell")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .build();
+    let third_card = CardBuilder::new(CardId::new(), "Charm Third")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .build();
+
+    let _top_land_id = game.create_object_from_card(&top_land, alice, Zone::Library);
+    let _top_spell_id = game.create_object_from_card(&top_spell, alice, Zone::Library);
+    let _third_card_id = game.create_object_from_card(&third_card, alice, Zone::Library);
+
+    let spell_id = game.create_object_from_definition(&riveteers_charm, alice, Zone::Hand);
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut trigger_queue = TriggerQueue::new();
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("casting Riveteers Charm should reach mode selection");
+
+    match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Modes(_)) => {}
+        other => panic!("expected mode selection for Riveteers Charm, got {other:?}"),
+    }
+
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Modes(vec![1]),
+    )
+    .expect("choosing Riveteers Charm exile mode should finish casting");
+
+    resolve_stack_entry_with(&mut game, &mut AutoPassDecisionMaker)
+        .expect("Riveteers Charm exile mode should resolve cleanly");
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let exiled_ids = game.exile.clone();
+    let exiled_names: Vec<_> = exiled_ids
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| (id, obj.name.clone())))
+        .collect();
+    let exiled_land_id = exiled_names
+        .iter()
+        .find_map(|(id, name)| (*name == "Charm Land").then_some(*id))
+        .expect("Riveteers Charm should exile the top land card");
+    let exiled_spell_id = exiled_names
+        .iter()
+        .find_map(|(id, name)| (*name == "Charm Spell").then_some(*id))
+        .expect("Riveteers Charm should exile the top spell card");
+
+    assert_eq!(game.exile.len(), 3, "Riveteers Charm should exile three cards");
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(&game, exiled_land_id, Zone::Exile, alice),
+        "Riveteers Charm should let you play exiled lands during the window"
+    );
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(&game, exiled_spell_id, Zone::Exile, alice),
+        "Riveteers Charm should let you cast exiled spells during the window"
+    );
+
+    let actions_now = compute_legal_actions(&game, alice);
+    assert!(
+        actions_now.iter().any(|action| matches!(
+            action,
+            LegalAction::PlayLand { land_id } if *land_id == exiled_land_id
+        )),
+        "Riveteers Charm should expose a land play action from exile"
+    );
+    assert!(
+        actions_now.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, from_zone: Zone::Exile, .. } if *spell_id == exiled_spell_id
+        )),
+        "Riveteers Charm should expose a cast action from exile"
+    );
+
+    game.turn.turn_number = game.turn.turn_number.saturating_add(1);
+    game.turn.active_player = PlayerId::from_index(1);
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(&game, exiled_spell_id, Zone::Exile, alice),
+        "Riveteers Charm play window should still exist before your next end step"
+    );
+
+    game.turn.turn_number = game.turn.turn_number.saturating_add(2);
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            exiled_spell_id,
+            Zone::Exile,
+            alice
+        ),
+        "Riveteers Charm play window should expire after your next end step"
+    );
+}
+
 // === Full Game Flow Integration Test ===
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Riveteers Charm
Initial parse error:
```
unsupported greatest-mana-value sacrifice clause (clause: 'a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control'); oracle-only fallback also failed: unsupported greatest-mana-value sacrifice clause (clause: 'a creature or planeswalker they control with the greatest mana value among creatures and planeswalkers they control')
```

Worker: i-0424fd7c416763857
