### PR TITLE
Fix Ironsmith parse failure: Hordewing Skaab

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -2498,9 +2498,12 @@ fn split_trigger_sentence_chunks_rewrite_lexed(
 
 fn starts_with_when_one_or_more_this_way_clause(tokens: &[OwnedLexToken]) -> bool {
     let words = token_word_refs(tokens);
+    let this_way_in_prefix = grammar::split_lexed_once_on_delimiter(tokens, TokenKind::Comma)
+        .map(|(before, _after)| grammar::contains_phrase(before, &["this", "way"]))
+        .unwrap_or(false);
     (words.starts_with(&["when", "one", "or", "more"])
         || words.starts_with(&["whenever", "one", "or", "more"]))
-        && grammar::contains_phrase(tokens, &["this", "way"])
+        && this_way_in_prefix
 }
 
 fn rewrite_when_one_or_more_this_way_line(line: &PreprocessedLine) -> PreprocessedLine {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/parser_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/parser_support.rs
@@ -8,7 +8,9 @@ use super::activation_and_restrictions::{
     is_activate_only_restriction_sentence_lexed, is_trigger_only_restriction_sentence_lexed,
 };
 use super::grammar::primitives as grammar;
-use super::lexer::{LexStream, OwnedLexToken, lex_line, render_token_slice, split_lexed_sentences};
+use super::lexer::{
+    LexStream, OwnedLexToken, TokenKind, lex_line, render_token_slice, split_lexed_sentences,
+};
 
 pub(crate) fn split_text_for_parse(
     raw_text: &str,
@@ -191,8 +193,11 @@ fn token_slice_contains_phrase(tokens: &[OwnedLexToken], phrase: &'static [&'sta
 }
 
 fn looks_like_when_one_or_more_this_way_followup_lexed(tokens: &[OwnedLexToken]) -> bool {
+    let this_way_in_prefix = grammar::split_lexed_once_on_delimiter(tokens, TokenKind::Comma)
+        .map(|(before, _after)| token_slice_contains_phrase(before, &["this", "way"]))
+        .unwrap_or(false);
     starts_with_lexed_parser(tokens, 0, parse_when_one_or_more_followup_head_inner)
-        && token_slice_contains_phrase(tokens, &["this", "way"])
+        && this_way_in_prefix
 }
 
 fn parse_when_it_connives_this_way_followup_intro_inner<'a>(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2866,10 +2866,12 @@ pub(crate) fn rewrite_when_one_or_more_this_way_clause_prefix(
 ) -> Vec<OwnedLexToken> {
     // Generic "When one or more ... this way, ..." follow-ups are semantically
     // "If you do, ..." against the immediately previous effect result.
-    let has_this_way = grammar::contains_phrase(tokens, &["this", "way"]);
+    let this_way_in_prefix = grammar::split_lexed_once_on_delimiter(tokens, TokenKind::Comma)
+        .map(|(before, _after)| grammar::contains_phrase(before, &["this", "way"]))
+        .unwrap_or(false);
     if (grammar::strip_lexed_prefix_phrase(tokens, &["when", "one", "or", "more"]).is_some()
         || grammar::strip_lexed_prefix_phrase(tokens, &["whenever", "one", "or", "more"]).is_some())
-        && has_this_way
+        && this_way_in_prefix
     {
         let Some((_before, after)) =
             grammar::split_lexed_once_on_delimiter(tokens, TokenKind::Comma)

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12519,6 +12519,57 @@ fn rewrite_semantic_parse_merges_multiline_spell_when_you_do_followup() -> Resul
 }
 
 #[test]
+fn rewrite_when_one_or_more_this_way_prefix_only_rewrites_when_this_way_is_in_clause_prefix() {
+    let tokens = lex_line(
+        "Whenever one or more cards are exiled this way, draw a card.",
+        0,
+    )
+    .expect("rewrite lexer should classify when-one-or-more this-way follow-up");
+    let rewritten =
+        super::effect_sentences::rewrite_when_one_or_more_this_way_clause_prefix(&tokens);
+
+    let words = token_word_refs(&rewritten);
+    assert_eq!(words[..3], ["if", "you", "do"]);
+}
+
+#[test]
+fn rewrite_when_one_or_more_this_way_prefix_skips_tail_only_this_way_references() {
+    let tokens = lex_line(
+        "Whenever one or more Zombies you control deal combat damage to one or more of your opponents, you may draw cards equal to the number of opponents dealt damage this way.",
+        0,
+    )
+    .expect("rewrite lexer should classify Hordewing Skaab trigger sentence");
+    let rewritten =
+        super::effect_sentences::rewrite_when_one_or_more_this_way_clause_prefix(&tokens);
+
+    let words = token_word_refs(&rewritten);
+    assert_eq!(words[0], "whenever");
+    assert_ne!(words[..3], ["if", "you", "do"]);
+}
+
+#[test]
+fn hordewing_skaab_parses_and_keeps_if_you_do_discard_followup() -> Result<(), CardTextError> {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Hordewing Skaab")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Horror])
+        .power_toughness(crate::card::PowerToughness::fixed(3, 3));
+    let text = "Flying\nOther Zombies you control have flying.\nWhenever one or more Zombies you control deal combat damage to one or more of your opponents, you may draw cards equal to the number of opponents dealt damage this way. If you do, discard that many cards.";
+    let (definition, _) = parse_text_with_annotations_lowered(builder, text.to_string(), false)?;
+
+    let debug = format!("{definition:?}");
+    assert!(
+        debug.contains("IfThen"),
+        "expected lowered if-you-do followup in Hordewing Skaab trigger: {debug}"
+    );
+    assert!(
+        debug.contains("DiscardCards"),
+        "expected lowered discard clause for Hordewing Skaab: {debug}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn rewrite_lowering_conditional_antecedent_prelude_carries_target_spec() -> Result<(), CardTextError>
 {
     let def = CardDefinitionBuilder::new(CardId::new(), "Conditional Fight Variant")

--- a/crates/ironsmith-runtime/src/triggers/combat/deals_combat_damage_to_player.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/deals_combat_damage_to_player.rs
@@ -84,7 +84,6 @@ impl TriggerMatcher for DealsCombatDamageToPlayerTrigger {
     }
 
     fn display(&self) -> String {
-        let player = self.player.description();
         if self.one_or_more {
             let mut subject = self.filter.description();
             if let Some(stripped) = subject.strip_prefix("a ") {
@@ -92,8 +91,14 @@ impl TriggerMatcher for DealsCombatDamageToPlayerTrigger {
             } else if let Some(stripped) = subject.strip_prefix("an ") {
                 subject = stripped.to_string();
             }
+            let player = if matches!(self.player, PlayerFilter::Opponent) {
+                "one or more of your opponents".to_string()
+            } else {
+                self.player.description()
+            };
             return format!("Whenever one or more {subject} deal combat damage to {player}");
         }
+        let player = self.player.description();
         format!(
             "Whenever {} deals combat damage to {}",
             self.filter.description(),
@@ -138,6 +143,18 @@ mod tests {
         let trigger =
             DealsCombatDamageToPlayerTrigger::new(ObjectFilter::creature(), PlayerFilter::Any);
         assert!(trigger.display().contains("deals combat damage"));
+    }
+
+    #[test]
+    fn test_one_or_more_opponent_display_uses_plural_opponents_phrase() {
+        let trigger = DealsCombatDamageToPlayerTrigger::one_or_more(
+            ObjectFilter::creature(),
+            PlayerFilter::Opponent,
+        );
+        assert_eq!(
+            trigger.display(),
+            "Whenever one or more creature deal combat damage to one or more of your opponents"
+        );
     }
 
     #[test]

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1107,6 +1107,48 @@ fn compile_oracle_text_strictly_compiles_archipelagore_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_hordewing_skaab_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Hordewing Skaab")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Hordewing Skaab --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Hordewing Skaab should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Hordewing Skaab"), "{stdout}");
+    assert!(stdout.contains("Semantic mismatch: false"), "{stdout}");
+    assert!(
+        stdout.contains("one or more of your opponents"),
+        "expected opponent plurality phrase in comparison output, got {stdout}"
+    );
+    assert!(
+        stdout.contains("If you do, discard that many cards."),
+        "expected if-you-do discard followup in comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_indomitable_might_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hordewing Skaab
Initial parse error:
```
missing prior effect for if clause; oracle-only fallback also failed: missing prior effect for if clause
```

Worker: i-097725ef8a63980cf
