### PR TITLE
Fix Ironsmith parse failure: Jetfire, Ingenious Scientist // Jetfire, Air Guardian

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -522,6 +522,10 @@ const ACTIVATE_ONLY_RESTRICTION_PREFIXES: &[&[&str]] =
 const SPEND_MANA_RESTRICTION_PREFIXES: &[&[&str]] = &[
     &["spend", "this", "mana", "only"],
     &["spend", "that", "mana", "only"],
+    &["this", "mana", "cant", "be", "spent", "to", "cast"],
+    &["this", "mana", "can't", "be", "spent", "to", "cast"],
+    &["that", "mana", "cant", "be", "spent", "to", "cast"],
+    &["that", "mana", "can't", "be", "spent", "to", "cast"],
 ];
 const SPEND_MANA_CAST_PREFIXES: &[&[&str]] = &[
     &["spend", "this", "mana", "only", "to", "cast"],
@@ -600,7 +604,43 @@ pub(crate) fn parse_mana_usage_restriction_sentence_lexed(
 ) -> Option<ManaUsageRestriction> {
     parse_legacy_mana_usage_restriction_sentence_lexed(tokens)
         .or_else(|| parse_activate_ability_mana_usage_restriction_sentence_lexed(tokens))
+        .or_else(|| parse_cant_be_spent_to_cast_sentence_lexed(tokens))
         .or_else(|| parse_filter_mana_usage_restriction_sentence_lexed(tokens))
+}
+
+fn parse_cant_be_spent_to_cast_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ManaUsageRestriction> {
+    let words = TokenWordView::new(tokens).to_word_refs();
+    let start_idx = if words.starts_with(&["this", "mana", "cant", "be", "spent", "to", "cast"])
+        || words.starts_with(&["this", "mana", "can't", "be", "spent", "to", "cast"])
+        || words.starts_with(&["that", "mana", "cant", "be", "spent", "to", "cast"])
+        || words.starts_with(&["that", "mana", "can't", "be", "spent", "to", "cast"])
+    {
+        7
+    } else {
+        return None;
+    };
+
+    let spec_words = &words[start_idx..];
+    if spec_words.is_empty() {
+        return None;
+    }
+
+    let filter = match spec_words {
+        ["nonartifact", "spell"] | ["nonartifact", "spells"] => {
+            ObjectFilter::default().with_type(crate::types::CardType::Artifact)
+        }
+        _ => return None,
+    };
+
+    Some(ManaUsageRestriction::CastSpellMatching {
+        filter,
+        restrict_to_matching_spell: true,
+        grant_uncounterable: false,
+        enters_with_counters: vec![],
+        granted_abilities: vec![],
+    })
 }
 
 fn parse_activate_ability_mana_usage_restriction_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -148,7 +148,13 @@ fn bind_event_amounts_to_cost_x_in_effect(effect: &mut EffectAst) {
             SubjectVerbActionAst::DealDamage { amount, .. }
             | SubjectVerbActionAst::DealDamageEach { amount, .. }
             | SubjectVerbActionAst::Mill { count: amount }
-            | SubjectVerbActionAst::Draw { count: amount } => {
+            | SubjectVerbActionAst::Draw { count: amount }
+            | SubjectVerbActionAst::AddManaScaled { amount, .. }
+            | SubjectVerbActionAst::AddManaAnyColor { amount, .. }
+            | SubjectVerbActionAst::AddManaAnyOneColor { amount }
+            | SubjectVerbActionAst::AddManaChosenColor { amount, .. }
+            | SubjectVerbActionAst::AddManaFromLandCouldProduce { amount, .. }
+            | SubjectVerbActionAst::AddManaCommanderIdentity { amount } => {
                 bind_event_amount_to_cost_x(amount);
             }
             _ => {}

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2549,6 +2549,49 @@ fn rewrite_activate_ability_mana_restriction_parses() {
 }
 
 #[test]
+fn rewrite_cant_be_spent_mana_restriction_parses_as_positive_filter() {
+    let tokens = lex_line("This mana can't be spent to cast nonartifact spells.", 0)
+        .expect("rewrite lexer should classify negative mana restriction");
+
+    match parse_mana_usage_restriction_sentence_lexed(&tokens) {
+        Some(crate::ability::ManaUsageRestriction::CastSpellMatching {
+            filter,
+            restrict_to_matching_spell,
+            grant_uncounterable,
+            enters_with_counters,
+            granted_abilities,
+        }) => {
+            assert_eq!(filter.card_types, vec![CardType::Artifact]);
+            assert!(restrict_to_matching_spell);
+            assert!(!grant_uncounterable);
+            assert!(enters_with_counters.is_empty());
+            assert!(granted_abilities.is_empty());
+        }
+        other => panic!("expected cast-spell-matching restriction, got {other:?}"),
+    }
+}
+
+#[test]
+fn rewrite_counter_removal_cost_binds_that_much_for_mana_addition() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Jetfire-style ability")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .parse_text(
+            "Remove one or more +1/+1 counters from among artifacts you control: Target player adds that much {C}. This mana can't be spent to cast nonartifact spells.",
+        )
+        .expect("counter-removal mana ability should parse");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("AddManaScaled") || debug.contains("AddManaAnyColor"),
+        "expected parsed mana ability to retain scaled mana amount, got {debug}"
+    );
+    assert!(
+        debug.contains("mana_usage_restrictions") && debug.contains("Artifact"),
+        "expected parsed mana ability to carry artifact-only usage restriction, got {debug}"
+    );
+}
+
+#[test]
 fn learn_keyword_line_lowers_to_real_effect() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Learn Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35179,6 +35179,74 @@ fn james_wandering_dad_follow_him_models_activate_only_mana_usage_restriction() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn jetfire_ingenious_scientist_card_parses_strictly() {
+    let def = parse_oracle_card_definition("Jetfire, Ingenious Scientist // Jetfire, Air Guardian");
+    assert!(
+        !def.abilities.is_empty(),
+        "Jetfire should compile to a card definition with abilities"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn jetfire_ingenious_scientist_compiled_text_keeps_nonartifact_mana_spend_restriction() {
+    let def = parse_oracle_card_definition("Jetfire, Ingenious Scientist // Jetfire, Air Guardian");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("add an amount of {c} equal to x"),
+        "expected Jetfire compiled text to preserve scaled mana output from removed counters, got {rendered}"
+    );
+    assert!(
+        rendered.contains("spend this mana only to cast artifact spells")
+            || rendered.contains("spend this mana only to cast an artifact spell"),
+        "expected Jetfire compiled text to preserve nonartifact spend restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn jetfire_ingenious_scientist_mana_ability_restricts_nonartifact_spells() {
+    let def = parse_oracle_card_definition("Jetfire, Ingenious Scientist // Jetfire, Air Guardian");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.mana_output.is_some() && !activated.mana_usage_restrictions.is_empty() =>
+            {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("Jetfire should have a restricted mana ability");
+
+    let has_artifact_only_restriction = activated.mana_usage_restrictions.iter().any(|restriction| {
+        matches!(
+            restriction,
+            crate::ability::ManaUsageRestriction::CastSpellMatching {
+                filter,
+                restrict_to_matching_spell: true,
+                ..
+            } if filter.card_types == vec![CardType::Artifact]
+        )
+    });
+    assert!(
+        has_artifact_only_restriction,
+        "expected Jetfire mana ability to allow only artifact spell casting"
+    );
+
+    assert_eq!(
+        activated.mana_usage_restrictions.len(),
+        1,
+        "Jetfire mana ability should carry a single cast restriction"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn oran_rief_the_vastwood_compiled_text_keeps_entered_this_turn_green_filter() {
     let def = parse_oracle_card_definition("Oran-Rief, the Vastwood");
     let rendered = canonical_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12465,6 +12465,12 @@ pub(super) fn describe_inline_ability_with_self_subject(
                 }
                 line.push_str(&join_activation_restriction_clauses(&restriction_clauses));
             }
+            for clause in describe_mana_usage_restriction_clauses_for_activated(activated) {
+                if !line.is_empty() {
+                    line.push_str(". ");
+                }
+                line.push_str(&clause);
+            }
             if line.is_empty() {
                 "an activated ability".to_string()
             } else {
@@ -33791,6 +33797,10 @@ pub(super) fn describe_ability(
             if !restriction_clauses.is_empty() {
                 line.push_str(". ");
                 line.push_str(&join_activation_restriction_clauses(&restriction_clauses));
+            }
+            for clause in describe_mana_usage_restriction_clauses_for_activated(activated) {
+                line.push_str(". ");
+                line.push_str(&clause);
             }
             if is_grandeur_activation_cost(activated) {
                 line = format!("Grandeur — {line}");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jetfire, Ingenious Scientist // Jetfire, Air Guardian
Initial parse error:
```
could not find verb in effect clause (clause: 'this mana cant be spent to cast nonartifact spells'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'this mana cant be spent to cast nonartifact spells'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Worker: i-0aacadc7f51e47693
