### PR TITLE
Fix Ironsmith parse failure: Clown Car

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2488,6 +2488,12 @@ pub(crate) fn parse_static_condition_clause(
                         clause_words.join(" ")
                     )));
                 }
+                crate::effect::Comparison::OneOf(_) => {
+                    return Err(CardTextError::ParseError(format!(
+                        "unsupported graveyard card-count set condition (clause: '{}')",
+                        clause_words.join(" ")
+                    )));
+                }
             };
             return Ok(crate::ConditionExpr::ValueComparison {
                 left: crate::effect::Value::CardsInGraveyard(PlayerFilter::You),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
@@ -340,10 +340,6 @@ pub(super) fn diagnose_known_unsupported_rewrite_line(
         } else {
             "unsupported lose-all-abilities static becomes clause"
         }
-    } else if ctx.contains_phrase(&["for", "each", "odd", "result"])
-        && ctx.contains_phrase(&["for", "each", "even", "result"])
-    {
-        "unsupported odd-or-even die-result clause"
     } else if ctx.contains_phrase(&[
         "for", "as", "long", "as", "that", "card", "remains", "exiled", "its", "owner", "may",
         "play", "it",

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1,5 +1,5 @@
 use crate::cards::builders::{
-    CardTextError, EffectAst, GrantedAbilityAst, IT_TAG, OwnedLexToken, PlayerAst,
+    CardTextError, EffectAst, GrantedAbilityAst, IT_TAG, IfResultPredicate, OwnedLexToken, PlayerAst,
     PreventNextTimeDamageSourceAst, PreventNextTimeDamageTargetAst, SubjectAst, TagKey, TargetAst,
     TextSpan, Verb,
 };
@@ -37,6 +37,9 @@ const ODD_EVEN_RESULT_PREFIXES: &[&[&str]] = &[
     &["for", "each", "odd", "result"],
     &["for", "each", "even", "result"],
 ];
+
+const ODD_RESULT_VALUES_D6: &[i32] = &[1, 3, 5];
+const EVEN_RESULT_VALUES_D6: &[i32] = &[2, 4, 6];
 const OPEN_ATTRACTION_PREFIXES: &[&[&str]] = &[
     &["open", "an", "attraction"],
     &["opens", "an", "attraction"],
@@ -1755,16 +1758,72 @@ pub(crate) fn parse_keyword_mechanic_clause(
     }
 
     if clause_words.first() == Some(&"roll") && word_slice_contains(&clause_words, "dice") {
+        if clause_words.last() == Some(&"dice")
+            && clause_words.len() >= 5
+            && clause_words[clause_words.len() - 3..clause_words.len() - 1] == ["six", "sided"]
+        {
+            let value_words = &clause_words[1..clause_words.len() - 3];
+            let value_tokens = value_words
+                .iter()
+                .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                .collect::<Vec<_>>();
+            let (count, used) = parse_value(&value_tokens).ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "missing roll-dice count (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+            if used != value_tokens.len() {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported roll-dice count tail (clause: '{}')",
+                    clause_words.join(" ")
+                )));
+            }
+            return Ok(Some(EffectAst::RepeatEffects {
+                count,
+                effects: vec![EffectAst::subject_verb_roll_die(PlayerAst::Implicit, 6)],
+            }));
+        }
         return Err(CardTextError::ParseError(format!(
             "unsupported roll-dice clause (clause: '{}')",
             clause_words.join(" ")
         )));
     }
-    if grammar::words_match_any_prefix(clause_tokens, ODD_EVEN_RESULT_PREFIXES).is_some() {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported odd/even-result clause (clause: '{}')",
-            clause_words.join(" ")
-        )));
+    if let Some((prefix, _)) = grammar::words_match_any_prefix(clause_tokens, ODD_EVEN_RESULT_PREFIXES) {
+        let predicate = if prefix == ODD_EVEN_RESULT_PREFIXES[0] {
+            crate::effect::Comparison::OneOf(ODD_RESULT_VALUES_D6)
+        } else {
+            crate::effect::Comparison::OneOf(EVEN_RESULT_VALUES_D6)
+        };
+        let mut tail_tokens = trim_commas(&clause_tokens[prefix.len()..]);
+        if tail_tokens
+            .first()
+            .is_some_and(|token| token.is_word("then") || token.is_word("you"))
+        {
+            while tail_tokens
+                .first()
+                .is_some_and(|token| token.is_word("then") || token.is_word("you"))
+            {
+                tail_tokens = trim_commas(&tail_tokens[1..]);
+            }
+        }
+        let Some((verb, verb_idx)) = find_verb(&tail_tokens) else {
+            return Err(CardTextError::ParseError(format!(
+                "missing action after odd/even-result clause (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        };
+        if verb_idx != 0 {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported odd/even-result action prefix (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+        let effect = parse_effect_with_verb(verb, None, &tail_tokens[1..])?;
+        return Ok(Some(EffectAst::IfResult {
+            predicate: IfResultPredicate::Value(predicate),
+            effects: vec![effect],
+        }));
     }
 
     if clause_words.first() == Some(&"dredge")

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/conditionals.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/conditionals.rs
@@ -110,6 +110,7 @@ pub(crate) fn parse_subtype_word(word: &str) -> Option<Subtype> {
         "cat" => Some(Subtype::Cat),
         "centaur" => Some(Subtype::Centaur),
         "citizen" | "citizens" => Some(Subtype::Citizen),
+        "clown" | "clowns" => Some(Subtype::Clown),
         "coward" | "cowards" => Some(Subtype::Coward),
         "changeling" => Some(Subtype::Changeling),
         "cleric" => Some(Subtype::Cleric),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -13604,3 +13604,24 @@ fn parse_trigger_clause_supports_one_or_more_energy_player_gain() {
         "expected one-or-more energy player-counters trigger, got {parsed:?}"
     );
 }
+
+#[test]
+fn clown_car_parses_roll_x_six_sided_dice_with_odd_even_result_clauses() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Clown Car")
+        .parse_text(
+            "When this Vehicle enters, roll X six-sided dice. For each odd result, create a 1/1 white Clown Robot artifact creature token. For each even result, put a +1/+1 counter on this Vehicle.\nCrew 2",
+        )
+        .expect("Clown Car text should parse");
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("RepeatEffects")
+            && debug.contains("RollDieEffect")
+            && debug.contains("OneOf([1, 3, 5])")
+            && debug.contains("OneOf([2, 4, 6])")
+            && debug.contains("CreateToken")
+            && debug.contains("PutCounter")
+            && debug.contains("Clown")
+            && debug.contains("Robot"),
+        "expected repeat roll plus odd/even result branches for Clown Car, got {debug}"
+    );
+}

--- a/crates/ironsmith-core/src/effect_model.rs
+++ b/crates/ironsmith-core/src/effect_model.rs
@@ -4,6 +4,7 @@ pub enum Comparison {
     GreaterThan(i32),
     GreaterThanOrEqual(i32),
     Equal(i32),
+    OneOf(&'static [i32]),
     LessThan(i32),
     LessThanOrEqual(i32),
     NotEqual(i32),
@@ -16,6 +17,7 @@ impl Comparison {
             Self::GreaterThan(n) => value > *n,
             Self::GreaterThanOrEqual(n) => value >= *n,
             Self::Equal(n) => value == *n,
+            Self::OneOf(values) => values.contains(&value),
             Self::LessThan(n) => value < *n,
             Self::LessThanOrEqual(n) => value <= *n,
             Self::NotEqual(n) => value != *n,
@@ -64,6 +66,7 @@ mod tests {
     fn comparison_evaluates_values() {
         assert!(Comparison::GreaterThan(2).evaluate(3));
         assert!(Comparison::BetweenInclusive(2, 4).evaluate(4));
+        assert!(Comparison::OneOf(&[1, 3, 5]).evaluate(3));
         assert!(!Comparison::LessThanOrEqual(1).evaluate(2));
     }
 

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -178,6 +178,7 @@ pub enum Subtype {
     Cat,
     Centaur,
     Citizen,
+    Clown,
     Coward,
     Changeling,
     Cleric,
@@ -457,6 +458,7 @@ impl Subtype {
             Subtype::Cat,
             Subtype::Centaur,
             Subtype::Citizen,
+            Subtype::Clown,
             Subtype::Coward,
             Subtype::Changeling,
             Subtype::Cleric,
@@ -773,6 +775,7 @@ impl Subtype {
                 | Subtype::Cat
                 | Subtype::Centaur
                 | Subtype::Citizen
+                | Subtype::Clown
                 | Subtype::Coward
                 | Subtype::Changeling
                 | Subtype::Cleric

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3646,6 +3646,45 @@ fn test_parse_aberrant_mind_sorcerer_rolls_and_branch_ranges() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_clown_car_compiled_text_keeps_odd_even_branches_and_token_identity() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Clown Car")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Vehicle])
+        .parse_text(
+            "When this Vehicle enters, roll X six-sided dice. For each odd result, create a 1/1 white Clown Robot artifact creature token. For each even result, put a +1/+1 counter on this Vehicle.\nCrew 2",
+        )
+        .expect("Clown Car text should parse");
+
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(abilities_debug.contains("RepeatEffects"), "{abilities_debug}");
+    assert!(abilities_debug.contains("RollDieEffect"), "{abilities_debug}");
+    assert!(abilities_debug.contains("OneOf([1, 3, 5])"), "{abilities_debug}");
+    assert!(abilities_debug.contains("OneOf([2, 4, 6])"), "{abilities_debug}");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("roll") && rendered.contains("d6"),
+        "expected roll clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("1, 3, 5") && rendered.contains("2, 4, 6"),
+        "expected odd/even result branch conditions in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("1/1")
+            && rendered.contains("white")
+            && rendered.contains("robot")
+            && rendered.contains("artifact creature token"),
+        "expected Clown Robot token creation payload in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("+1/+1 counter") && rendered.contains("this vehicle"),
+        "expected even-result +1/+1 counter branch in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_sevinnes_reclamation_flashback_copy_clause() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Sevinne's Reclamation")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3667,8 +3667,12 @@ fn test_parse_clown_car_compiled_text_keeps_odd_even_branches_and_token_identity
         "expected roll clause in compiled text, got {rendered}"
     );
     assert!(
-        rendered.contains("1, 3, 5") && rendered.contains("2, 4, 6"),
+        rendered.contains("if you roll 1, 3, or 5") && rendered.contains("if you roll 2, 4, or 6"),
         "expected odd/even result branch conditions in compiled text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("its count is one of"),
+        "expected die-result branch wording, not generic count wording, got {rendered}"
     );
     assert!(
         rendered.contains("1/1")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9761,6 +9761,14 @@ pub(super) fn describe_comparison(cmp: &Comparison) -> String {
         Comparison::LessThan(n) => format!("is less than {n}"),
         Comparison::LessThanOrEqual(n) => format!("is at most {n}"),
         Comparison::NotEqual(n) => format!("is not equal to {n}"),
+        Comparison::OneOf(values) => format!(
+            "is one of {}",
+            values
+                .iter()
+                .map(i32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
         Comparison::BetweenInclusive(min, max) => {
             format!("is between {min} and {max} inclusive")
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -22226,6 +22226,28 @@ fn describe_with_id_if_clause(
         } else {
             format!("If {}", describe_effect_predicate(&if_effect.predicate))
         }
+    } else if let Some(repeat) = with_id
+        .effect
+        .downcast_ref::<crate::effects::RepeatEffectsEffect>()
+    {
+        if let EffectPredicate::Value(cmp) = &if_effect.predicate {
+            if repeat.effects.len() == 1
+                && let Some(roll_die) = repeat.effects[0].downcast_ref::<crate::effects::RollDieEffect>()
+            {
+                let player = describe_player_filter(&roll_die.player);
+                let result_text = describe_roll_result_comparison(cmp)?;
+                let verb = player_verb(&player, "roll", "rolls");
+                if player == "you" {
+                    format!("If you roll {result_text}")
+                } else {
+                    format!("If {player} {verb} {result_text}")
+                }
+            } else {
+                format!("If {}", describe_effect_predicate(&if_effect.predicate))
+            }
+        } else {
+            format!("If {}", describe_effect_predicate(&if_effect.predicate))
+        }
     } else if with_id
         .effect
         .downcast_ref::<crate::effects::FlipCoinEffect>()
@@ -22353,6 +22375,16 @@ fn describe_roll_result_comparison(cmp: &Comparison) -> Option<String> {
     match cmp {
         Comparison::Equal(n) => Some(n.to_string()),
         Comparison::BetweenInclusive(min, max) => Some(format!("{min}-{max}")),
+        Comparison::OneOf(values) if !values.is_empty() => {
+            let nums = values.iter().map(i32::to_string).collect::<Vec<_>>();
+            let list = match nums.len() {
+                0 => return None,
+                1 => nums[0].clone(),
+                2 => format!("{} or {}", nums[0], nums[1]),
+                _ => format!("{}, or {}", nums[..nums.len() - 1].join(", "), nums[nums.len() - 1]),
+            };
+            Some(list)
+        }
         _ => None,
     }
 }

--- a/crates/ironsmith-runtime/src/effects/composition/if_effect.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/if_effect.rs
@@ -1,6 +1,6 @@
 //! If effect implementation.
 
-use crate::effect::{EffectOutcome, EffectPredicateRuntimeExt};
+use crate::effect::{EffectOutcome, EffectPredicate, EffectPredicateRuntimeExt, ExecutionFact};
 use crate::effects::EffectExecutor;
 use crate::effects::{ExecutionContext, ExecutionError, execute_effect};
 use crate::game_state::GameState;
@@ -55,15 +55,45 @@ impl EffectExecutor for IfEffect {
             .get_outcome(self.condition)
             .ok_or(ExecutionError::EffectNotFound(self.condition))?;
 
-        let branch = if self.predicate.evaluate_outcome(outcome) {
-            &self.then
+        let match_repetitions = if let EffectPredicate::Value(cmp) = &self.predicate {
+            let chosen_numbers = outcome
+                .execution_facts
+                .iter()
+                .filter_map(|fact| match fact {
+                    ExecutionFact::ChosenNumber(n) => Some(*n as i32),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            if chosen_numbers.is_empty() {
+                None
+            } else {
+                let matches = chosen_numbers
+                    .into_iter()
+                    .filter(|value| cmp.evaluate(*value))
+                    .count();
+                Some(matches)
+            }
         } else {
-            &self.else_
+            None
+        };
+
+        let (branch, repetitions) = if let Some(matches) = match_repetitions {
+            if matches > 0 {
+                (&self.then, matches)
+            } else {
+                (&self.else_, 1)
+            }
+        } else if self.predicate.evaluate_outcome(outcome) {
+            (&self.then, 1)
+        } else {
+            (&self.else_, 1)
         };
 
         let mut outcomes = Vec::new();
-        for eff in branch {
-            outcomes.push(execute_effect(game, eff, ctx)?);
+        for _ in 0..repetitions {
+            for eff in branch {
+                outcomes.push(execute_effect(game, eff, ctx)?);
+            }
         }
         Ok(EffectOutcome::aggregate(outcomes))
     }

--- a/crates/ironsmith-runtime/src/effects/player/roll_die.rs
+++ b/crates/ironsmith-runtime/src/effects/player/roll_die.rs
@@ -1,4 +1,4 @@
-use crate::effect::EffectOutcome;
+use crate::effect::{EffectOutcome, ExecutionFact};
 use crate::effects::{EffectExecutor, helpers::resolve_player_filter};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
@@ -29,12 +29,18 @@ impl EffectExecutor for RollDieEffect {
         }
         if let Some(forced) = game.take_forced_die_roll() {
             let clamped = forced.clamp(1, self.sides);
-            return Ok(EffectOutcome::count(clamped as i32));
+            return Ok(
+                EffectOutcome::count(clamped as i32)
+                    .with_execution_fact(ExecutionFact::ChosenNumber(clamped)),
+            );
         }
 
         let mut faces: Vec<u32> = (1..=self.sides).collect();
         game.shuffle_slice(&mut faces);
-        Ok(EffectOutcome::count(faces[0] as i32))
+        Ok(
+            EffectOutcome::count(faces[0] as i32)
+                .with_execution_fact(ExecutionFact::ChosenNumber(faces[0])),
+        )
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -15214,6 +15214,80 @@ fn ancient_bronze_dragon_trigger_allows_zero_targets() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn clown_car_etb_applies_odd_even_result_branches_per_die_for_x_rolls() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.force_next_die_roll(1);
+    game.force_next_die_roll(2);
+    game.force_next_die_roll(5);
+
+    let clown_car = CardDefinitionBuilder::new(CardId::new(), "Clown Car")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::X]]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Vehicle])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "When this Vehicle enters, roll X six-sided dice. For each odd result, create a 1/1 white Clown Robot artifact creature token. For each even result, put a +1/+1 counter on this Vehicle.\nCrew 2",
+        )
+        .expect("Clown Car should parse");
+
+    let clown_car_id = game.create_object_from_definition(&clown_car, alice, Zone::Battlefield);
+    game.object_mut(clown_car_id)
+        .expect("Clown Car permanent should exist")
+        .x_value = Some(3);
+    let mut source_snapshot =
+        crate::snapshot::ObjectSnapshot::from_object(
+            game.object(clown_car_id)
+                .expect("Clown Car permanent should exist"),
+            &game,
+        );
+    source_snapshot.x_value = Some(3);
+
+    let etb_event = TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            clown_car_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(source_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, etb_event, false);
+    assert_eq!(trigger_queue.entries.len(), 1, "Clown Car should trigger once");
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Clown Car ETB trigger should go on stack");
+    resolve_stack_entry(&mut game).expect("Clown Car ETB trigger should resolve");
+
+    let clown_tokens = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id).is_some_and(|obj| {
+                obj.name == "Clown"
+                    && game.controller_of(obj) == alice
+                    && obj.card_types.contains(&CardType::Artifact)
+                    && obj.card_types.contains(&CardType::Creature)
+            })
+        })
+        .count();
+    assert_eq!(
+        clown_tokens, 2,
+        "odd die results (1 and 5) should create one Clown token each"
+    );
+
+    assert_eq!(
+        game.counter_count(clown_car_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "even die result (2) should add one +1/+1 counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_fallen_shinobi_trigger_exiles_top_two_cards_and_grants_play_permission() {
     use crate::decision::compute_legal_actions;
 

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -738,6 +738,11 @@ fn comparison_display(cmp: &Comparison) -> String {
         Comparison::LessThanOrEqual(0) => "no".to_string(),
         Comparison::LessThanOrEqual(n) => format!("{n} or less"),
         Comparison::NotEqual(n) => format!("not {n}"),
+        Comparison::OneOf(values) => values
+            .iter()
+            .map(i32::to_string)
+            .collect::<Vec<_>>()
+            .join(" or "),
         Comparison::BetweenInclusive(min, max) => format!("{min} to {max}"),
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Clown Car
Initial parse error:
```
unsupported odd-or-even die-result clause; oracle-only fallback also failed: unsupported odd-or-even die-result clause
```

Worker: i-08cc6e1bc53b934e7
