### PR TITLE
Fix Ironsmith parse failure: Sporeweb Weaver

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -246,6 +246,48 @@ fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>
     }
 }
 
+fn color_only_hexproof_filter_words(words: &[&str]) -> Option<ObjectFilter> {
+    let mut filters = Vec::new();
+    for word in words {
+        if matches!(*word, "and" | "from") {
+            continue;
+        }
+        let color = crate::color::Color::from_name(word)?;
+        let mut filter = ObjectFilter::default();
+        filter.colors = Some(crate::color::ColorSet::from_color(color));
+        filters.push(filter);
+    }
+
+    match filters.len() {
+        0 => None,
+        1 => filters.pop(),
+        _ => {
+            let mut filter = ObjectFilter::default();
+            filter.any_of = filters;
+            Some(filter)
+        }
+    }
+}
+
+fn parse_hexproof_from_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
+    let words_view = TokenWordView::new(tokens);
+    let words = words_view.word_refs();
+    let first_word_idx = if words.first().copied() == Some("and") {
+        1
+    } else {
+        0
+    };
+    if words.len().saturating_sub(first_word_idx) < 3
+        || words.get(first_word_idx).copied() != Some("hexproof")
+        || words.get(first_word_idx + 1).copied() != Some("from")
+    {
+        return None;
+    }
+
+    color_only_hexproof_filter_words(&words[first_word_idx + 2..])
+        .map(|filter| vec![KeywordAction::HexproofFrom(filter)])
+}
+
 pub(crate) fn rewrite_parse_ability_line(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
     if let Some(actions) = parse_flashback_keyword_line(tokens) {
         return Some(actions);
@@ -261,6 +303,11 @@ pub(crate) fn rewrite_parse_ability_line(tokens: &[OwnedLexToken]) -> Option<Vec
 
         if let Some(protection_actions) = parse_protection_chain(segment) {
             actions.extend(protection_actions);
+            continue;
+        }
+
+        if let Some(hexproof_actions) = parse_hexproof_from_chain(segment) {
+            actions.extend(hexproof_actions);
             continue;
         }
 
@@ -550,6 +597,10 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
         }
     }
 
+    fn parse_hexproof_from_chain_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
+        parse_hexproof_from_chain(tokens)
+    }
+
     fn split_on_lexed_comma_or_semicolon(tokens: &[OwnedLexToken]) -> Vec<&[OwnedLexToken]> {
         let mut segments = Vec::new();
         let mut start = 0usize;
@@ -601,6 +652,11 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
         }
         if let Some(protection_actions) = parse_protection_chain_lexed(segment) {
             actions.extend(protection_actions);
+            continue;
+        }
+
+        if let Some(hexproof_actions) = parse_hexproof_from_chain_lexed(segment) {
+            actions.extend(hexproof_actions);
             continue;
         }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7296,6 +7296,22 @@ fn rewrite_lexed_keyword_line_routes_separator_lists_through_grammar_primitives(
 }
 
 #[test]
+fn rewrite_lexed_keyword_line_parses_hexproof_from_color_in_keyword_list() {
+    let keyword_tokens = lex_line("Reach, hexproof from blue", 0)
+        .expect("rewrite lexer should classify hexproof-from keyword line");
+
+    let parsed = super::clause_support::parse_ability_line_lexed(&keyword_tokens)
+        .expect("hexproof-from keyword line should parse");
+    assert_eq!(parsed.len(), 2, "{parsed:?}");
+    assert_eq!(parsed[0], crate::cards::builders::KeywordAction::Reach);
+
+    let crate::cards::builders::KeywordAction::HexproofFrom(filter) = &parsed[1] else {
+        panic!("expected hexproof-from action, got {parsed:?}");
+    };
+    assert_eq!(filter.colors, Some(crate::color::ColorSet::BLUE));
+}
+
+#[test]
 fn rewrite_lexed_triggered_and_static_entrypoints_work_natively() {
     let triggered_tokens = lex_line(
         "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34732,6 +34732,201 @@ fn assert_oracle_card_fails_strict(name: &str) {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_sporeweb_weaver_strict_regression() {
+    assert_oracle_card_parses_strict("Sporeweb Weaver");
+    let def = parse_oracle_card_definition("Sporeweb Weaver");
+    let rendered_lines = canonical_compiled_lines(&def);
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::Reach
+        )),
+        "expected Sporeweb Weaver to have reach"
+    );
+    let hexproof_from = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            if let AbilityKind::Static(static_ability) = &ability.kind {
+                if static_ability.id() == StaticAbilityId::HexproofFrom {
+                    return static_ability.hexproof_from_filter();
+                }
+            }
+            None
+        })
+        .expect("expected Sporeweb Weaver to have hexproof from blue");
+    assert_eq!(
+        hexproof_from.colors,
+        Some(crate::color::ColorSet::BLUE),
+        "expected Sporeweb Weaver hexproof-from filter to be exactly blue"
+    );
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Reach, hexproof from blue".to_string(),
+            "Whenever this creature is dealt damage, you gain 1 life, then create a 1/1 green Saproling creature token."
+                .to_string(),
+        ],
+        "unexpected Sporeweb Weaver compiled text"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sporeweb_weaver_hexproof_from_blue_blocks_only_opposing_blue_sources() {
+    let def = parse_oracle_card_definition("Sporeweb Weaver");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let weaver_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let blue_source = CardDefinitionBuilder::new(CardId::from_raw(91_200), "Blue Source")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let red_source = CardDefinitionBuilder::new(CardId::from_raw(91_201), "Red Source")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let opposing_blue = game.create_object_from_definition(&blue_source, bob, Zone::Battlefield);
+    let opposing_red = game.create_object_from_definition(&red_source, bob, Zone::Battlefield);
+    let own_blue = game.create_object_from_definition(&blue_source, alice, Zone::Battlefield);
+
+    assert_eq!(
+        crate::targeting::can_target_object(&game, weaver_id, opposing_blue, bob),
+        crate::targeting::TargetingResult::Invalid(
+            crate::targeting::TargetingInvalidReason::HasHexproofFrom
+        ),
+        "opposing blue source should be unable to target Sporeweb Weaver"
+    );
+    assert!(
+        crate::targeting::can_target_object(&game, weaver_id, opposing_red, bob).is_legal(),
+        "opposing nonblue source should be able to target Sporeweb Weaver"
+    );
+    assert!(
+        crate::targeting::can_target_object(&game, weaver_id, own_blue, alice).is_legal(),
+        "controller's blue source should be able to target their own Sporeweb Weaver"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sporeweb_weaver_damage_trigger_gains_life_and_creates_saproling() {
+    let def = parse_oracle_card_definition("Sporeweb Weaver");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let weaver_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_202), "Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            damage_source,
+            crate::events::DamageTarget::Object(weaver_id),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(&game, &damage_event) {
+        trigger_queue.add(entry);
+    }
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("put Sporeweb Weaver trigger on stack");
+    assert_eq!(game.stack.len(), 1, "expected one Weaver trigger on stack");
+
+    crate::game_loop::resolve_stack_entry(&mut game).expect("resolve Weaver trigger");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        21,
+        "Sporeweb Weaver trigger should gain 1 life"
+    );
+    let saprolings: Vec<_> = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .filter(|obj| obj.owner == alice && obj.name == "Saproling")
+        .collect();
+    assert_eq!(saprolings.len(), 1, "expected one Saproling token");
+    let saproling = saprolings[0];
+    assert_eq!(saproling.kind, crate::object::ObjectKind::Token);
+    assert_eq!(saproling.power(), Some(1));
+    assert_eq!(saproling.toughness(), Some(1));
+    assert!(saproling.subtypes.contains(&Subtype::Saproling));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sporeweb_weaver_damage_trigger_ignores_other_damaged_creatures() {
+    let def = parse_oracle_card_definition("Sporeweb Weaver");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_203), "Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let other_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_204), "Other Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            damage_source,
+            crate::events::DamageTarget::Object(other_creature),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert!(
+        crate::triggers::check_triggers(&game, &damage_event).is_empty(),
+        "Sporeweb Weaver should not trigger when another creature is dealt damage"
+    );
+    assert_eq!(game.player(alice).expect("alice exists").life, 20);
+    assert!(
+        game.battlefield
+            .iter()
+            .filter_map(|&id| game.object(id))
+            .all(|obj| obj.name != "Saproling"),
+        "no Saproling token should be created without a Weaver trigger"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_xanthic_statue_strict_regression() {
     assert_oracle_card_parses_strict("Xanthic Statue");
 }

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -362,7 +362,11 @@ pub(super) fn describe_resolution_program(
         }
 
         if !segment.default_effects.is_empty() {
-            rendered_segments.push(describe_effect_list(&segment.default_effects));
+            rendered_segments.push(
+                describe_effect_clause_list(&segment.default_effects)
+                    .map(|text| capitalize_first(&text))
+                    .unwrap_or_else(|| describe_effect_list(&segment.default_effects)),
+            );
         }
         for branch in &segment.self_replacements {
             rendered_segments.push(describe_effect_list(&branch.replacement_effects));

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -23,6 +23,9 @@ pub(super) fn is_keyword_phrase(phrase: &str) -> bool {
     if lower.starts_with("protection from ") {
         return true;
     }
+    if lower.starts_with("hexproof from ") {
+        return true;
+    }
     if lower.starts_with("partner with ") {
         return true;
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1669,6 +1669,13 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
         self.id() == StaticAbilityId::Hexproof
     }
 
+    fn hexproof_from_filter(&self) -> Option<&crate::target::ObjectFilter> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::HexproofFrom(filter) => Some(filter),
+            _ => self.leaf_static_ability()?.hexproof_from_filter(),
+        }
+    }
+
     fn has_shroud(&self) -> bool {
         self.id() == StaticAbilityId::Shroud
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sporeweb Weaver
Initial parse error:
```
parser does not yet support line family: 'Reach, hexproof from blue'; oracle-only fallback also failed: parser does not yet support line family: 'Reach, hexproof from blue'
```

Worker: i-0acbec1fc29916d60
