### PR TITLE
Fix Ironsmith parse failure: Living Conundrum

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2125,6 +2125,20 @@ pub(crate) fn parse_static_condition_clause(
         return Ok(condition);
     }
 
+    if clause_words == ["there", "are", "no", "cards", "in", "your", "library"]
+        || clause_words == ["your", "library", "has", "no", "cards", "in", "it"]
+    {
+        return Ok(crate::ConditionExpr::CountComparison {
+            count: AnthemCountExpression::MatchingFilter(
+                ObjectFilter::default()
+                    .in_zone(Zone::Library)
+                    .owned_by(PlayerFilter::You),
+            ),
+            comparison: crate::effect::Comparison::Equal(0),
+            display: Some("there are no cards in your library".to_string()),
+        });
+    }
+
     if clause_words.len() >= 6
         && clause_words[0] == "you"
         && clause_words[1] == "have"
@@ -6362,7 +6376,11 @@ pub(crate) fn parse_has_base_power_toughness_and_granted_keywords_static_line(
         return Ok(None);
     }
 
-    let subject_tokens = trim_commas(&tokens[..has_idx]);
+    let (condition, subject_start) = match parse_anthem_prefix_condition(tokens, has_idx) {
+        Ok(parsed) => parsed,
+        Err(_) => return Ok(None),
+    };
+    let subject_tokens = trim_commas(&tokens[subject_start..has_idx]);
     if subject_tokens.is_empty() {
         return Ok(None);
     }
@@ -6427,21 +6445,48 @@ pub(crate) fn parse_has_base_power_toughness_and_granted_keywords_static_line(
     let mut compiled = Vec::new();
     match subject {
         AnthemSubjectAst::Source => {
-            compiled.push(
-                StaticAbility::set_base_power_toughness(ObjectFilter::source(), power, toughness)
-                    .into(),
-            );
-            compiled.extend(granted.into_iter().map(StaticAbilityAst::KeywordAction));
+            let source_filter = if anthem_word_slice_starts_with(
+                &subject_words,
+                &["this", "creature"],
+            ) {
+                ObjectFilter::source().with_type(CardType::Creature)
+            } else {
+                ObjectFilter::source()
+            };
+            let set_base =
+                StaticAbility::set_base_power_toughness(source_filter, power, toughness).into();
+            compiled.push(if let Some(condition) = condition.clone() {
+                StaticAbilityAst::ConditionalStaticAbility {
+                    ability: Box::new(set_base),
+                    condition,
+                }
+            } else {
+                set_base
+            });
+            compiled.extend(granted.into_iter().map(|action| {
+                if let Some(condition) = condition.clone() {
+                    StaticAbilityAst::ConditionalKeywordAction { action, condition }
+                } else {
+                    StaticAbilityAst::KeywordAction(action)
+                }
+            }));
         }
         AnthemSubjectAst::Filter(filter) => {
-            compiled.push(
-                StaticAbility::set_base_power_toughness(filter.clone(), power, toughness).into(),
-            );
+            let set_base =
+                StaticAbility::set_base_power_toughness(filter.clone(), power, toughness).into();
+            compiled.push(if let Some(condition) = condition.clone() {
+                StaticAbilityAst::ConditionalStaticAbility {
+                    ability: Box::new(set_base),
+                    condition,
+                }
+            } else {
+                set_base
+            });
             for action in granted {
                 compiled.push(StaticAbilityAst::GrantKeywordAction {
                     filter: filter.clone(),
                     action,
-                    condition: None,
+                    condition: condition.clone(),
                 });
             }
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -17,6 +17,7 @@ use super::grammar::abilities::{
     is_discard_or_redirect_replacement_line_lexed, is_doctors_companion_marker_line_lexed,
     is_double_damage_from_sources_you_control_of_chosen_type_line_lexed,
     is_draw_replace_exile_top_face_down_line_lexed, is_draw_replacement_double_line_lexed,
+    is_draw_replacement_skip_empty_library_line_lexed,
     is_during_your_turn_prevent_all_damage_to_source_line_lexed,
     is_effect_discard_to_library_replacement_line_lexed,
     is_enchanted_land_is_chosen_type_line_lexed,
@@ -613,6 +614,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_draw_replace_exile_top_face_down_line),
         single_static_ability_ast_rule!(parse_draw_replacement_exile_top_and_play_line),
         single_static_ability_ast_rule!(parse_draw_replacement_double_line),
+        single_static_ability_ast_rule!(parse_draw_replacement_skip_empty_library_line),
         single_static_ability_ast_rule!(parse_keyword_action_replacement_line),
         single_static_ability_ast_rule!(parse_exile_to_exile_instead_of_graveyard_line),
         single_static_ability_ast_rule!(parse_exile_to_countered_exile_instead_of_graveyard_line),
@@ -8198,6 +8200,16 @@ pub(crate) fn parse_draw_replacement_double_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     if is_draw_replacement_double_line_lexed(tokens) {
         return Ok(Some(StaticAbility::draw_replacement_double()));
+    }
+
+    Ok(None)
+}
+
+pub(crate) fn parse_draw_replacement_skip_empty_library_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_draw_replacement_skip_empty_library_line_lexed(tokens) {
+        return Ok(Some(StaticAbility::draw_replacement_skip_empty_library()));
     }
 
     Ok(None)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -1597,6 +1597,17 @@ pub(crate) fn is_draw_replacement_double_line_lexed(tokens: &[OwnedLexToken]) ->
         ]
 }
 
+pub(crate) fn is_draw_replacement_skip_empty_library_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    let words = TokenWordView::new(tokens).word_refs();
+    words
+        == [
+            "if", "you", "would", "draw", "a", "card", "while", "your", "library", "has",
+            "no", "cards", "in", "it", "skip", "that", "draw", "instead",
+        ]
+}
+
 pub(crate) fn is_effect_discard_to_library_replacement_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7775,6 +7775,28 @@ fn rewrite_grammar_draw_replace_exile_top_face_down_probe_matches_static_shape()
 }
 
 #[test]
+fn rewrite_grammar_living_conundrum_empty_library_draw_skip_matches_static_shape() {
+    let tokens = lex_line(
+        "If you would draw a card while your library has no cards in it, skip that draw instead.",
+        0,
+    )
+    .expect("rewrite lexer should classify Living Conundrum draw-skip replacement line");
+
+    assert!(
+        super::grammar::abilities::is_draw_replacement_skip_empty_library_line_lexed(&tokens),
+        "grammar-owned empty-library draw-skip replacement probe should match"
+    );
+
+    let parsed = super::keyword_static::parse_draw_replacement_skip_empty_library_line(&tokens)
+        .expect("empty-library draw-skip replacement static line should parse");
+    assert!(matches!(
+        parsed,
+        Some(ability)
+            if ability.id() == crate::static_abilities::StaticAbilityId::DrawReplacementSkipEmptyLibrary
+    ));
+}
+
+#[test]
 fn rewrite_grammar_replacement_static_probes_match_keyword_static_shapes() {
     let library_tokens = lex_line(
         "If an effect causes you to discard a card, you may discard it to the top of your library instead of into your graveyard.",
@@ -7822,7 +7844,9 @@ fn rewrite_grammar_replacement_static_probes_match_keyword_static_shapes() {
         .expect("type-addition static line should parse");
     assert!(matches!(
         parsed_artifact_land,
-        Some(ability) if ability.id() == crate::static_abilities::StaticAbilityId::AddCardTypes
+        Some(abilities) if abilities.iter().any(|ability| {
+            ability.id() == crate::static_abilities::StaticAbilityId::AddCardTypes
+        })
     ));
 
     let discard_tokens = lex_line(

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -213,6 +213,7 @@ pub enum StaticAbilityId {
     DrawReplacementExileTopFaceDown,
     DrawReplacementExileTopAndPlay,
     DrawReplacementDouble,
+    DrawReplacementSkipEmptyLibrary,
     KeywordActionReplacement,
     ExileToCounteredExileInsteadOfGraveyard,
     ExileToExileInsteadOfGraveyard,
@@ -454,6 +455,7 @@ impl StaticAbilityId {
             | DrawReplacementExileTopFaceDown
             | DrawReplacementExileTopAndPlay
             | DrawReplacementDouble
+            | DrawReplacementSkipEmptyLibrary
             | KeywordActionReplacement
             | ExileToCounteredExileInsteadOfGraveyard
             | ExileToExileInsteadOfGraveyard

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3209,6 +3209,14 @@ impl<
         }
     }
 
+    pub fn draw_replacement_skip_empty_library() -> Self {
+        Self {
+            id: Some(StaticAbilityId::DrawReplacementSkipEmptyLibrary),
+            label: "draw replacement skip empty library".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
+
     pub fn draw_replacement_exile_top_and_play(count: u32) -> Self {
         Self {
             id: Some(StaticAbilityId::DrawReplacementExileTopAndPlay),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34738,6 +34738,105 @@ fn parse_xanthic_statue_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_living_conundrum_strict_regression() {
+    assert_oracle_card_parses_strict("Living Conundrum");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn living_conundrum_compiled_text_keeps_empty_library_clauses() {
+    let def = parse_oracle_card_definition("Living Conundrum");
+    let lines = canonical_compiled_lines(&def);
+
+    assert!(
+        lines.iter().any(|line| {
+            line == "If you would draw a card while your library has no cards in it, skip that draw instead."
+        }),
+        "Living Conundrum should render the empty-library draw-skip replacement, got {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.contains("base power and toughness 10/10")
+                && line.contains("flying")
+                && line.contains("vigilance")
+                && line.contains("no cards in your library")
+        }),
+        "Living Conundrum should render the empty-library characteristic bonus, got {lines:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn living_conundrum_empty_library_replacement_and_bonus_are_active() {
+    let def = parse_oracle_card_definition("Living Conundrum");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert_eq!(game.player(alice).expect("alice should exist").library.len(), 0);
+    game.update_replacement_effects();
+    assert!(
+        game.effect_store
+            .replacement_effects
+            .effects()
+            .iter()
+            .any(|replacement| {
+                replacement.source == source_id
+                    && matches!(
+                        replacement.replacement,
+                        crate::replacement::ReplacementAction::Skip
+                    )
+                    && replacement
+                        .matcher
+                        .as_ref()
+                        .is_some_and(|matcher| matcher.display().contains("no cards in it"))
+            }),
+        "Living Conundrum should register an empty-library draw-skip replacement"
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    let outcome = crate::effects::DrawCardsEffect::you(1)
+        .execute(&mut game, &mut ctx)
+        .expect("Living Conundrum draw replacement should resolve");
+    assert_eq!(outcome.count_or_zero(), 0);
+    assert_eq!(game.player(alice).expect("alice should exist").hand.len(), 0);
+
+    assert_eq!(game.calculated_power(source_id), Some(10));
+    assert_eq!(game.calculated_toughness(source_id), Some(10));
+    assert!(game.object_has_static_ability_id(source_id, StaticAbilityId::Flying));
+    assert!(game.object_has_static_ability_id(source_id, StaticAbilityId::Vigilance));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn living_conundrum_nonempty_library_does_not_skip_or_gain_bonus() {
+    let def = parse_oracle_card_definition("Living Conundrum");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let library_card = CardDefinitionBuilder::new(CardId::new(), "Library Card")
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_definition(&library_card, alice, Zone::Library);
+
+    assert_ne!(game.calculated_power(source_id), Some(10));
+    assert_ne!(game.calculated_toughness(source_id), Some(10));
+    assert!(!game.object_has_static_ability_id(source_id, StaticAbilityId::Flying));
+    assert!(!game.object_has_static_ability_id(source_id, StaticAbilityId::Vigilance));
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    let outcome = crate::effects::DrawCardsEffect::you(1)
+        .execute(&mut game, &mut ctx)
+        .expect("nonempty-library draw should proceed normally");
+    assert_eq!(outcome.count_or_zero(), 1);
+    assert_eq!(game.player(alice).expect("alice should exist").hand.len(), 1);
+    assert_eq!(game.player(alice).expect("alice should exist").library.len(), 0);
+    assert_eq!(game.calculated_power(source_id), Some(10));
+    assert_eq!(game.calculated_toughness(source_id), Some(10));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_wave_of_rats_strict_regression() {
     assert_oracle_card_parses_strict("Wave of Rats");
 }

--- a/crates/ironsmith-runtime/src/events/cards/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/cards/matchers.rs
@@ -59,6 +59,52 @@ impl ReplacementMatcher for WouldDrawCardMatcher {
     }
 }
 
+/// Matches when a player would draw a card while that player's library is empty.
+#[derive(Debug, Clone)]
+pub struct WouldDrawCardWhileLibraryEmptyMatcher {
+    pub player_filter: PlayerFilter,
+}
+
+impl WouldDrawCardWhileLibraryEmptyMatcher {
+    pub fn new(player_filter: PlayerFilter) -> Self {
+        Self { player_filter }
+    }
+
+    /// Matches when you (the controller) would draw from an empty library.
+    pub fn you() -> Self {
+        Self::new(PlayerFilter::You)
+    }
+}
+
+impl ReplacementMatcher for WouldDrawCardWhileLibraryEmptyMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        if event.event_kind() != EventKind::Draw {
+            return false;
+        }
+
+        let Some(draw) = downcast_event::<DrawEvent>(event) else {
+            return false;
+        };
+
+        self.player_filter
+            .matches_player(draw.player, &ctx.filter_ctx)
+            && ctx
+                .game
+                .player(draw.player)
+                .is_some_and(|player| player.library.is_empty())
+    }
+
+    fn display(&self) -> String {
+        match &self.player_filter {
+            PlayerFilter::You => {
+                "When you would draw a card while your library has no cards in it".to_string()
+            }
+            _ => "When a player would draw a card while their library has no cards in it"
+                .to_string(),
+        }
+    }
+}
+
 /// Matches when a player would draw their first card each turn.
 #[derive(Debug, Clone)]
 pub struct WouldDrawFirstCardMatcher {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -206,6 +206,9 @@ impl StaticAbility {
                 )
             }
             Some(StaticAbilityId::DrawReplacementDouble) => Self::draw_replacement_double(),
+            Some(StaticAbilityId::DrawReplacementSkipEmptyLibrary) => {
+                Self::draw_replacement_skip_empty_library()
+            }
             Some(StaticAbilityId::ExileWouldDieInstead) => {
                 Self::exile_would_die_instead(crate::target::ObjectFilter::creature())
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -16,7 +16,9 @@ use crate::color::Color;
 use crate::compiled_text::describe_value;
 use crate::effect::{Condition, Effect, EventValueSpec, Value};
 use crate::events::cards::DiscardEvent;
-use crate::events::cards::matchers::{WouldDiscardMatcher, WouldDrawCardMatcher};
+use crate::events::cards::matchers::{
+    WouldDiscardMatcher, WouldDrawCardMatcher, WouldDrawCardWhileLibraryEmptyMatcher,
+};
 use crate::events::cause::CauseType;
 use crate::events::context::EventContext;
 use crate::events::damage::DamageEvent;
@@ -3789,6 +3791,34 @@ impl StaticAbilityKind for DrawReplacementDouble {
             controller,
             WouldDrawCardMatcher::you(),
             ReplacementAction::Instead(vec![Effect::new(crate::effects::DrawCardsEffect::you(2))]),
+        ))
+    }
+}
+
+/// "If you would draw a card while your library has no cards in it, skip that draw instead."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DrawReplacementSkipEmptyLibrary;
+
+impl StaticAbilityKind for DrawReplacementSkipEmptyLibrary {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::DrawReplacementSkipEmptyLibrary
+    }
+
+    fn display(&self) -> String {
+        "If you would draw a card while your library has no cards in it, skip that draw instead."
+            .to_string()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            WouldDrawCardWhileLibraryEmptyMatcher::you(),
+            ReplacementAction::Skip,
         ))
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2703,6 +2703,10 @@ impl StaticAbility {
         Self::new(DrawReplacementDouble)
     }
 
+    pub fn draw_replacement_skip_empty_library() -> Self {
+        Self::new(DrawReplacementSkipEmptyLibrary)
+    }
+
     pub fn draw_replacement_exile_top_and_play(count: u32) -> Self {
         Self::new(DrawReplacementExileTopAndPlay::new(count))
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Living Conundrum
Initial parse error:
```
unsupported skip clause (clause: 'that draw instead'); oracle-only fallback also failed: unsupported skip clause (clause: 'that draw instead')
```

Worker: i-04343d8836b9773f6
