### PR TITLE
Fix Ironsmith parse failure: Eldrazi Guacamole Tightrope

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -216,7 +216,7 @@ fn supported_keyword_marker_text(text: &str) -> bool {
     text.starts_with("prototype ")
         || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
-        || is_ticket_power_toughness_sticker_marker_line(&text)
+        || is_ticket_sticker_marker_line(&text)
         || text == "this creature crews vehicles using its toughness rather than its power."
         || is_power_greater_marker("this creature crews vehicles as though its power were ")
         || is_power_greater_marker(
@@ -230,8 +230,8 @@ fn supported_keyword_marker_text(text: &str) -> bool {
         ) && text.ends_with("'s crew cost."))
 }
 
-fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
-    let Some((cost, pt_text)) = text.split_once('—') else {
+fn is_ticket_sticker_marker_line(text: &str) -> bool {
+    let Some((cost, body_text)) = text.split_once('—') else {
         return false;
     };
 
@@ -245,14 +245,7 @@ fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
         return false;
     }
 
-    let pt = pt_text.trim();
-    let Some((power, toughness)) = pt.split_once('/') else {
-        return false;
-    };
-    !power.is_empty()
-        && !toughness.is_empty()
-        && power.chars().all(|c| c.is_ascii_digit())
-        && toughness.chars().all(|c| c.is_ascii_digit())
+    !body_text.trim().is_empty()
 }
 
 fn trim_outer_quotes(tokens: &[OwnedLexToken]) -> &[OwnedLexToken] {
@@ -887,6 +880,11 @@ fn parse_static_ability_ast_line_early_lexed(
         .replace("you ve", "youve")
         .replace("'", "");
     let rendered = rendered.trim().trim_end_matches('.').to_string();
+    let marker_text = render_token_slice(tokens);
+    if is_ticket_sticker_marker_line(&marker_text) {
+        return Ok(Some(vec![keyword_static_marker(tokens).into()]));
+    }
+
     if rendered == "this creature cant attack unless youve cast a creature spell this turn"
         || rendered == "this cant attack unless youve cast a creature spell this turn"
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -199,12 +199,12 @@ fn supported_keyword_marker_text(text: &str) -> bool {
         || text.starts_with("prototype ")
         || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
-        || is_ticket_power_toughness_sticker_marker_line(&text)
+        || is_ticket_sticker_marker_line(&text)
         || text.starts_with("dredge ")
 }
 
-fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
-    let Some((cost, pt_text)) = text.split_once('—') else {
+fn is_ticket_sticker_marker_line(text: &str) -> bool {
+    let Some((cost, body_text)) = text.split_once('—') else {
         return false;
     };
 
@@ -218,14 +218,7 @@ fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
         return false;
     }
 
-    let pt = pt_text.trim();
-    let Some((power, toughness)) = pt.split_once('/') else {
-        return false;
-    };
-    !power.is_empty()
-        && !toughness.is_empty()
-        && power.chars().all(|c| c.is_ascii_digit())
-        && toughness.chars().all(|c| c.is_ascii_digit())
+    !body_text.trim().is_empty()
 }
 
 fn lower_keyword_action_or_err(action: KeywordAction) -> Result<StaticAbility, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -14,7 +14,49 @@ pub(super) fn run_trailing_keyword_activation_line_family(
 pub(super) fn run_labeled_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
+    if is_sticker_sheet_ticket_marker_line(ctx) {
+        let Some(static_line) = parse_static_line_cst(ctx.line)? else {
+            return Err(CardTextError::ParseError(format!(
+                "parser could not lower sticker ticket marker line: '{}'",
+                ctx.line.info.raw_line
+            )));
+        };
+        return Ok(Some(LineDispatchResult::single(
+            RewriteLineCst::Static(static_line),
+            ctx.idx + 1,
+        )));
+    }
+
     try_parse_labeled_line_dispatch(ctx.preprocessed, ctx.idx, ctx.line, ctx.allow_unsupported)
+}
+
+fn is_sticker_sheet_ticket_marker_line(ctx: &LineDispatchContext<'_>) -> bool {
+    let is_sticker_sheet = ctx.preprocessed.items.iter().any(|item| {
+        matches!(
+            item,
+            PreprocessedItem::Metadata(metadata)
+                if matches!(
+                    &metadata.value,
+                    crate::runtime_backend::MetadataLine::TypeLine(value)
+                        if value.eq_ignore_ascii_case("Stickers")
+                )
+        )
+    });
+    if !is_sticker_sheet {
+        return false;
+    }
+
+    let Some((cost, body)) = ctx.line.info.raw_line.split_once('—') else {
+        return false;
+    };
+    let mut remainder = cost.trim().to_ascii_lowercase();
+    let mut saw_ticket_symbol = false;
+    while let Some(next) = remainder.strip_prefix("{tk}") {
+        saw_ticket_symbol = true;
+        remainder = next.trim_start().to_string();
+    }
+
+    saw_ticket_symbol && remainder.is_empty() && !body.trim().is_empty()
 }
 
 pub(super) fn run_triggered_line_family(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -933,12 +933,12 @@ fn supported_keyword_marker_text(text: &str) -> bool {
         || text.starts_with("prototype ")
         || text.starts_with("more than meets the eye ")
         || text.starts_with("splice onto ")
-        || is_ticket_power_toughness_sticker_marker_line(&text)
+        || is_ticket_sticker_marker_line(&text)
         || text.starts_with("dredge ")
 }
 
-fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
-    let Some((cost, pt_text)) = text.split_once('—') else {
+fn is_ticket_sticker_marker_line(text: &str) -> bool {
+    let Some((cost, body_text)) = text.split_once('—') else {
         return false;
     };
 
@@ -952,14 +952,7 @@ fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
         return false;
     }
 
-    let pt = pt_text.trim();
-    let Some((power, toughness)) = pt.split_once('/') else {
-        return false;
-    };
-    !power.is_empty()
-        && !toughness.is_empty()
-        && power.chars().all(|c| c.is_ascii_digit())
-        && toughness.chars().all(|c| c.is_ascii_digit())
+    !body_text.trim().is_empty()
 }
 
 fn rewrite_lower_keyword_action_or_err(

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -4387,11 +4387,11 @@ fn supported_keyword_marker_text(text: &str) -> bool {
     text == "compleated"
         || text.starts_with("prototype ")
         || text.starts_with("splice onto ")
-        || is_ticket_power_toughness_sticker_marker_line(&text)
+        || is_ticket_sticker_marker_line(&text)
 }
 
-fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
-    let Some((cost, pt_text)) = text.split_once('—') else {
+fn is_ticket_sticker_marker_line(text: &str) -> bool {
+    let Some((cost, body_text)) = text.split_once('—') else {
         return false;
     };
 
@@ -4405,14 +4405,7 @@ fn is_ticket_power_toughness_sticker_marker_line(text: &str) -> bool {
         return false;
     }
 
-    let pt = pt_text.trim();
-    let Some((power, toughness)) = pt.split_once('/') else {
-        return false;
-    };
-    !power.is_empty()
-        && !toughness.is_empty()
-        && power.chars().all(|c| c.is_ascii_digit())
-        && toughness.chars().all(|c| c.is_ascii_digit())
+    !body_text.trim().is_empty()
 }
 
 fn parse_standalone_bolster_marker(text: &str) -> Option<u32> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7680,6 +7680,81 @@ fn costume_shop_keeps_visit_sticker_effect() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn eldrazi_guacamole_tightrope_ticket_sticker_lines_parse_strictly() {
+    let text = concat!(
+        "Type: Stickers\n",
+        "{TK}{TK} — Haste\n",
+        "{TK}{TK}{TK}{TK}{TK} — You may cast this card from your graveyard by ",
+        "paying 2 life in addition to paying its other costs.\n",
+        "{TK}{TK} — 1/4\n",
+        "{TK}{TK}{TK} — 5/3",
+    );
+    let def = CardDefinitionBuilder::new(CardId::from_raw(58_3538), "Eldrazi Guacamole Tightrope")
+        .parse_text(text)
+        .expect("Eldrazi Guacamole Tightrope should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("{tk}{tk}{tk}{tk}{tk} — you may cast this card from your graveyard by paying 2 life in addition to paying its other costs"),
+        "expected ticket graveyard-cast sticker row to be preserved, got {rendered}"
+    );
+    assert!(
+        rendered.contains("{tk}{tk} — haste")
+            && rendered.contains("{tk}{tk} — 1/4")
+            && rendered.contains("{tk}{tk}{tk} — 5/3"),
+        "expected all Eldrazi Guacamole Tightrope sticker rows to render, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported") && !rendered.contains("chosen option"),
+        "sticker rows should compile as marker text without fallback or chosen-option conditions: {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn eldrazi_guacamole_tightrope_sticker_marker_does_not_grant_graveyard_casting() {
+    let text = concat!(
+        "Type: Stickers\n",
+        "{TK}{TK} — Haste\n",
+        "{TK}{TK}{TK}{TK}{TK} — You may cast this card from your graveyard by ",
+        "paying 2 life in addition to paying its other costs.\n",
+        "{TK}{TK} — 1/4\n",
+        "{TK}{TK}{TK} — 5/3",
+    );
+    let def = CardDefinitionBuilder::new(CardId::from_raw(58_3539), "Eldrazi Guacamole Tightrope")
+        .parse_text(text)
+        .expect("Eldrazi Guacamole Tightrope should parse strictly");
+
+    let debug = format!("{:?}", def.abilities).to_ascii_lowercase();
+    assert!(
+        debug.contains("keywordmarker") && debug.contains("paying 2 life"),
+        "expected graveyard-cast sticker row to remain marker text, got {debug}"
+    );
+    assert!(
+        !debug.contains("grantstaticability") && !debug.contains("graveyardcastfromcardmanacost"),
+        "sticker marker text should not create an intrinsic graveyard-cast permission: {debug}"
+    );
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let card_id = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+
+    assert!(
+        !game
+            .effect_store
+            .grant_registry
+            .card_can_play_from_zone(&game, card_id, Zone::Graveyard, alice),
+        "sticker marker text should not grant cast-from-graveyard runtime permission"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_adapt_activation_with_reminder_text_without_fallback_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Adapt Probe")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Eldrazi Guacamole Tightrope
Initial parse error:
```
parser does not yet support line family: '{TK}{TK}{TK}{TK}{TK} — You may cast this card from your graveyard by paying 2 life in addition to paying its other costs.'; oracle-only fallback also failed: parser does not yet support line family: '{TK}{TK}{TK}{TK}{TK} — You may cast this card from your graveyard by paying 2 life in addition to paying its other costs.'
```

Worker: i-0630a7dc14094e4c7
