### PR TITLE
Fix Ironsmith parse failure: Harsh Judgment

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -601,6 +601,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         ),
         single_static_ability_ast_rule!(parse_replace_damage_with_counters_instead_line),
         single_static_ability_ast_rule!(parse_choose_color_as_enters_line),
+        single_static_ability_ast_rule!(parse_damage_redirect_to_source_controller_line),
         single_static_ability_ast_rule!(parse_damage_redirect_to_source_line),
         single_static_ability_ast_rule!(
             parse_no_more_than_creatures_can_attack_or_block_each_combat_line
@@ -3496,6 +3497,52 @@ pub(crate) fn parse_damage_redirect_to_source_line(
         ));
     }
     Ok(None)
+}
+
+pub(crate) fn parse_damage_redirect_to_source_controller_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.first() != Some(&"if") {
+        return Ok(None);
+    }
+
+    let Some(would_idx) = find_window_by(&words, 5, |window| {
+        window == ["would", "deal", "damage", "to", "you"]
+    }) else {
+        return Ok(None);
+    };
+    let tail = &words[would_idx + 5..];
+    if tail != [
+        "it",
+        "deals",
+        "that",
+        "damage",
+        "to",
+        "its",
+        "controller",
+        "instead",
+    ] {
+        return Ok(None);
+    }
+    if would_idx <= 1 {
+        return Ok(None);
+    }
+
+    let source_start = token_index_for_word_index(tokens, 1).unwrap_or(0);
+    let source_end = token_index_for_word_index(tokens, would_idx).unwrap_or(tokens.len());
+    let source_tokens = trim_lexed_commas(&tokens[source_start..source_end]);
+    let source_filter = parse_object_filter_lexed(source_tokens, false)?;
+    let mut display = render_token_slice(tokens).trim().to_string();
+    if !display.ends_with('.') {
+        display.push('.');
+    }
+
+    Ok(Some(StaticAbility::redirect_damage_to_source_controller(
+        source_filter,
+        PlayerFilter::You,
+        display,
+    )))
 }
 
 pub(crate) fn parse_no_more_than_creatures_can_attack_or_block_each_combat_line(

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -163,6 +163,7 @@ pub enum StaticAbilityId {
     AddChosenCreatureType,
     SetChosenColor,
     RedirectDamageToSource,
+    RedirectDamageToSourceController,
     PreventAllDamageDealtByThisPermanent,
     PreventAllCombatDamageDealtByThisPermanent,
     PreventAllDamageDealtToCreatures,
@@ -404,6 +405,7 @@ impl StaticAbilityId {
             | AddChosenCreatureType
             | SetChosenColor
             | RedirectDamageToSource
+            | RedirectDamageToSourceController
             | PreventAllDamageDealtByThisPermanent
             | PreventAllCombatDamageDealtByThisPermanent
             | PreventAllDamageDealtToCreatures

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -351,6 +351,11 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         toughness: i32,
     },
     DoubleDamageFromSourcesYouControlOfChosenType(String),
+    RedirectDamageToSourceController {
+        source_filter: ObjectFilter,
+        target_player_filter: PlayerFilter,
+        display: String,
+    },
     AdditionalLandPlays(u32),
     RevealFirstCardYouDrawEachTurn {
         optional: bool,
@@ -1132,6 +1137,15 @@ where
             StaticAbilityPayload::DoubleDamageFromSourcesYouControlOfChosenType(display) => {
                 StaticAbilityPayload::DoubleDamageFromSourcesYouControlOfChosenType(display)
             }
+            StaticAbilityPayload::RedirectDamageToSourceController {
+                source_filter,
+                target_player_filter,
+                display,
+            } => StaticAbilityPayload::RedirectDamageToSourceController {
+                source_filter,
+                target_player_filter,
+                display,
+            },
             StaticAbilityPayload::AdditionalLandPlays(count) => {
                 StaticAbilityPayload::AdditionalLandPlays(count)
             }
@@ -2852,6 +2866,23 @@ impl<
             id: Some(StaticAbilityId::DoubleDamageFromSourcesYouControlOfChosenType),
             label: display.clone(),
             payload: StaticAbilityPayload::DoubleDamageFromSourcesYouControlOfChosenType(display),
+        }
+    }
+
+    pub fn redirect_damage_to_source_controller(
+        source_filter: ObjectFilter,
+        target_player_filter: PlayerFilter,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::RedirectDamageToSourceController),
+            label: display.clone(),
+            payload: StaticAbilityPayload::RedirectDamageToSourceController {
+                source_filter,
+                target_player_filter,
+                display,
+            },
         }
     }
     pub fn with_enter_as_copy_as_enters(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -21284,6 +21284,41 @@ fn parse_damage_redirect_to_source_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn harsh_judgment_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Harsh Judgment");
+
+    let ids: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        ids.contains(&StaticAbilityId::ChooseColorAsEnters),
+        "expected Harsh Judgment to choose a color as it enters, got {ids:?}"
+    );
+    assert!(
+        ids.contains(&StaticAbilityId::RedirectDamageToSourceController),
+        "expected Harsh Judgment damage redirect replacement, got {ids:?}"
+    );
+
+    let compiled = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        compiled.contains("As this enchantment enters, choose a color."),
+        "expected choose-color clause in compiled text, got {compiled}"
+    );
+    assert!(
+        compiled.contains(
+            "If an instant or sorcery spell of the chosen color would deal damage to you, it deals that damage to its controller instead."
+        ),
+        "expected Harsh Judgment redirect clause in compiled text, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_red_noncombat_damage_minimum_replacement_line() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Deepest Might Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -108,8 +108,7 @@ pub(super) fn apply_trait_replacement(
         }
 
         ReplacementAction::Redirect { target, which } => {
-            let modified =
-                apply_trait_redirect(&event, target, which, effect.controller, effect.source);
+            let modified = apply_trait_redirect(game, &event, target, which, effect.controller);
             match modified {
                 Some(e) => TraitApplyResult::Modified(e),
                 None => TraitApplyResult::Unchanged(event),
@@ -130,8 +129,13 @@ pub(super) fn apply_trait_replacement(
             let Some(damage) = downcast_event::<DamageEvent>(event.inner()) else {
                 return TraitApplyResult::Unchanged(event);
             };
-            let Some(new_target) =
-                resolve_trait_redirect_target(event.inner(), target, which, effect.controller)
+            let Some(new_target) = resolve_trait_redirect_target(
+                game,
+                event.inner(),
+                target,
+                which,
+                effect.controller,
+            )
             else {
                 return TraitApplyResult::Unchanged(event);
             };
@@ -818,14 +822,19 @@ fn apply_trait_enter_with_characteristics(
 }
 
 fn apply_trait_redirect(
+    game: &GameState,
     event: &Event,
     redirect_target: &RedirectTarget,
     which: &RedirectWhich,
     effect_controller: PlayerId,
-    _effect_source: crate::ids::ObjectId,
 ) -> Option<Event> {
-    let new_target =
-        resolve_trait_redirect_target(event.inner(), redirect_target, which, effect_controller)?;
+    let new_target = resolve_trait_redirect_target(
+        game,
+        event.inner(),
+        redirect_target,
+        which,
+        effect_controller,
+    )?;
     let redirectable = event.inner().redirectable_targets();
     let selected = match which {
         RedirectWhich::First => redirectable.first(),
@@ -839,6 +848,7 @@ fn apply_trait_redirect(
 }
 
 fn resolve_trait_redirect_target(
+    game: &GameState,
     event: &dyn crate::events::traits::GameEventType,
     redirect_target: &RedirectTarget,
     which: &RedirectWhich,
@@ -856,6 +866,10 @@ fn resolve_trait_redirect_target(
         RedirectTarget::ToPlayer(player_id) => Target::Player(*player_id),
         RedirectTarget::ToObject(object_id) => Target::Object(*object_id),
         RedirectTarget::ToSource => Target::Object(event.source_object()?),
+        RedirectTarget::ToSourceController => {
+            let source = event.source_object()?;
+            Target::Player(game.current_controller(source)?)
+        }
     };
 
     if !selected.valid_redirect_types.is_valid(&new_target) {

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -268,6 +268,9 @@ pub enum RedirectTarget {
 
     /// Redirect to the source of the effect
     ToSource,
+
+    /// Redirect to the controller of the event source.
+    ToSourceController,
 }
 
 /// Which target to redirect in a multi-target event.

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -2774,6 +2774,60 @@ impl StaticAbilityKind for DoubleDamageFromSourcesYouControlOfChosenType {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct RedirectDamageToSourceController {
+    pub source_filter: ObjectFilter,
+    pub target_player_filter: PlayerFilter,
+    pub display: String,
+}
+
+impl RedirectDamageToSourceController {
+    pub fn new(
+        source_filter: ObjectFilter,
+        target_player_filter: PlayerFilter,
+        display: impl Into<String>,
+    ) -> Self {
+        Self {
+            source_filter,
+            target_player_filter,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for RedirectDamageToSourceController {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::RedirectDamageToSourceController
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            DamageAmountReplacementMatcher {
+                source_filter: self.source_filter.clone(),
+                target_player_filter: Some(self.target_player_filter.clone()),
+                target_object_filter: None,
+                condition: None,
+                noncombat_only: false,
+                amount_less_than: None,
+            },
+            ReplacementAction::Redirect {
+                target: RedirectTarget::ToSourceController,
+                which: RedirectWhich::First,
+            },
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ModifyDamageAmountReplacement {
     pub source_filter: ObjectFilter,
     pub target_player_filter: Option<PlayerFilter>,
@@ -2854,15 +2908,27 @@ impl DamageAmountReplacementMatcher {
         ctx: &crate::events::context::EventContext<'_>,
     ) -> bool {
         let current = ctx.game.object(damage.source).is_some_and(|source| {
+            let filter_ctx = if source.zone == Zone::Stack {
+                ctx.filter_ctx
+                    .clone()
+                    .with_caster(ctx.game.current_controller(damage.source))
+            } else {
+                ctx.filter_ctx.clone()
+            };
             self.source_filter
-                .matches(source, &ctx.filter_ctx, ctx.game)
+                .matches(source, &filter_ctx, ctx.game)
         });
         let lki = ctx
             .event_source_snapshot
             .filter(|snapshot| snapshot.object_id == damage.source)
             .is_some_and(|snapshot| {
+                let filter_ctx = if snapshot.zone == Zone::Stack {
+                    ctx.filter_ctx.clone().with_caster(Some(snapshot.controller))
+                } else {
+                    ctx.filter_ctx.clone()
+                };
                 self.source_filter
-                    .matches_snapshot(snapshot, &ctx.filter_ctx, ctx.game)
+                    .matches_snapshot(snapshot, &filter_ctx, ctx.game)
             });
         current || lki
     }
@@ -5016,6 +5082,164 @@ mod tests {
             EventCause::from_effect(source, alice),
         );
         assert_eq!(permanent_damage.assignments[0].amount, 5);
+    }
+
+    #[test]
+    fn harsh_judgment_redirects_chosen_color_spell_damage_to_source_controller() {
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+        let harsh_judgment = CardBuilder::new(CardId::from_raw(19001), "Harsh Judgment")
+            .card_types(vec![CardType::Enchantment])
+            .build();
+        let harsh_judgment_id =
+            game.create_object_from_card(&harsh_judgment, alice, Zone::Battlefield);
+        game.set_chosen_color(harsh_judgment_id, Color::White);
+
+        let white_spell = CardBuilder::new(CardId::from_raw(19002), "White Instant")
+            .mana_cost(crate::mana::ManaCost::from_pips(vec![vec![
+                crate::mana::ManaSymbol::White,
+            ]]))
+            .card_types(vec![CardType::Instant])
+            .build();
+        let white_spell_id = game.create_object_from_card(&white_spell, bob, Zone::Stack);
+        assert_eq!(game.current_controller(white_spell_id), Some(bob));
+
+        let ability = RedirectDamageToSourceController::new(
+            ObjectFilter::instant_or_sorcery().of_chosen_color(),
+            PlayerFilter::You,
+            "If instant or sorcery spell of the chosen color would deal damage to you, it deals that damage to its controller instead.",
+        );
+        let replacement = ability
+            .generate_replacement_effect(harsh_judgment_id, alice)
+            .expect("Harsh Judgment should generate a replacement effect");
+        let matching_event = DamageEvent::with_cause(
+            white_spell_id,
+            DamageTarget::Player(alice),
+            4,
+            false,
+            EventCause::from_effect(white_spell_id, bob),
+        );
+        let matching_ctx = EventContext::for_replacement_effect(alice, harsh_judgment_id, &game);
+        assert!(
+            replacement
+                .matcher
+                .as_ref()
+                .expect("replacement should have a matcher")
+                .matches_event(&matching_event, &matching_ctx),
+            "Harsh Judgment replacement should match chosen-color spell damage to you"
+        );
+        game.effect_store
+            .replacement_effects
+            .add_resolution_effect(replacement);
+
+        let damage = process_damage_assignments_with_event(
+            &mut game,
+            white_spell_id,
+            DamageTarget::Player(alice),
+            4,
+            false,
+            EventCause::from_effect(white_spell_id, bob),
+        );
+
+        assert_eq!(damage.assignments.len(), 1);
+        assert_eq!(damage.assignments[0].target, DamageTarget::Player(bob));
+        assert_eq!(damage.assignments[0].amount, 4);
+    }
+
+    #[test]
+    fn harsh_judgment_handles_sorcery_nonchosen_color_and_other_target_branches() {
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+        let harsh_judgment = CardBuilder::new(CardId::from_raw(19003), "Harsh Judgment")
+            .card_types(vec![CardType::Enchantment])
+            .build();
+        let harsh_judgment_id =
+            game.create_object_from_card(&harsh_judgment, alice, Zone::Battlefield);
+        game.set_chosen_color(harsh_judgment_id, Color::White);
+
+        let red_spell = CardBuilder::new(CardId::from_raw(19004), "Red Instant")
+            .mana_cost(crate::mana::ManaCost::from_pips(vec![vec![
+                crate::mana::ManaSymbol::Red,
+            ]]))
+            .card_types(vec![CardType::Instant])
+            .build();
+        let red_spell_id = game.create_object_from_card(&red_spell, bob, Zone::Stack);
+
+        let white_spell = CardBuilder::new(CardId::from_raw(19005), "White Sorcery")
+            .mana_cost(crate::mana::ManaCost::from_pips(vec![vec![
+                crate::mana::ManaSymbol::White,
+            ]]))
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        let white_spell_id = game.create_object_from_card(&white_spell, bob, Zone::Stack);
+
+        let target_creature = CardBuilder::new(CardId::from_raw(19006), "Target Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let target_creature_id =
+            game.create_object_from_card(&target_creature, alice, Zone::Battlefield);
+
+        let ability = RedirectDamageToSourceController::new(
+            ObjectFilter::instant_or_sorcery().of_chosen_color(),
+            PlayerFilter::You,
+            "If instant or sorcery spell of the chosen color would deal damage to you, it deals that damage to its controller instead.",
+        );
+        let replacement = ability
+            .generate_replacement_effect(harsh_judgment_id, alice)
+            .expect("Harsh Judgment should generate a replacement effect");
+        game.effect_store
+            .replacement_effects
+            .add_resolution_effect(replacement);
+
+        let nonchosen_damage = process_damage_assignments_with_event(
+            &mut game,
+            red_spell_id,
+            DamageTarget::Player(alice),
+            3,
+            false,
+            EventCause::from_effect(red_spell_id, bob),
+        );
+        assert_eq!(nonchosen_damage.assignments.len(), 1);
+        assert_eq!(
+            nonchosen_damage.assignments[0].target,
+            DamageTarget::Player(alice)
+        );
+        assert_eq!(nonchosen_damage.assignments[0].amount, 3);
+
+        let other_target_damage = process_damage_assignments_with_event(
+            &mut game,
+            white_spell_id,
+            DamageTarget::Object(target_creature_id),
+            2,
+            false,
+            EventCause::from_effect(white_spell_id, bob),
+        );
+        assert_eq!(other_target_damage.assignments.len(), 1);
+        assert_eq!(
+            other_target_damage.assignments[0].target,
+            DamageTarget::Object(target_creature_id)
+        );
+        assert_eq!(other_target_damage.assignments[0].amount, 2);
+
+        let chosen_sorcery_damage = process_damage_assignments_with_event(
+            &mut game,
+            white_spell_id,
+            DamageTarget::Player(alice),
+            5,
+            false,
+            EventCause::from_effect(white_spell_id, bob),
+        );
+        assert_eq!(chosen_sorcery_damage.assignments.len(), 1);
+        assert_eq!(
+            chosen_sorcery_damage.assignments[0].target,
+            DamageTarget::Player(bob)
+        );
+        assert_eq!(chosen_sorcery_damage.assignments[0].amount, 5);
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2610,6 +2610,18 @@ impl StaticAbility {
         Self::new(DoubleDamageFromSourcesYouControlOfChosenType::new(display))
     }
 
+    pub fn redirect_damage_to_source_controller(
+        source_filter: crate::target::ObjectFilter,
+        target_player_filter: crate::target::PlayerFilter,
+        display: String,
+    ) -> Self {
+        Self::new(RedirectDamageToSourceController::new(
+            source_filter,
+            target_player_filter,
+            display,
+        ))
+    }
+
     pub fn modify_damage_amount_replacement(
         source_filter: crate::target::ObjectFilter,
         target_player_filter: Option<crate::target::PlayerFilter>,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1177,6 +1177,15 @@ impl StaticAbilityModelInterpreter {
             ) => StaticAbility::double_damage_from_sources_you_control_of_chosen_type(
                 display.clone(),
             ),
+            ironsmith_core::StaticAbilityPayload::RedirectDamageToSourceController {
+                source_filter,
+                target_player_filter,
+                display,
+            } => StaticAbility::redirect_damage_to_source_controller(
+                source_filter.clone(),
+                target_player_filter.clone(),
+                display.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::AdditionalLandPlays(count) => {
                 StaticAbility::additional_land_plays(*count)
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Harsh Judgment
Initial parse error:
```
missing damage keyword; oracle-only fallback also failed: missing damage keyword
```

Worker: i-0182b04d003fcb120
