### PR TITLE
Fix Ironsmith parse failure: Open the Way

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -887,6 +887,15 @@ fn parse_static_ability_ast_line_early_lexed(
         .replace("you ve", "youve")
         .replace("'", "");
     let rendered = rendered.trim().trim_end_matches('.').to_string();
+    if rendered == "x cant be greater than the number of players in the game" {
+        return Ok(Some(vec![
+            StaticAbility::this_spell_x_maximum(
+                Value::CountPlayers(PlayerFilter::Any),
+                "X can't be greater than the number of players in the game.",
+            )
+            .into(),
+        ]));
+    }
     if rendered == "this creature cant attack unless youve cast a creature spell this turn"
         || rendered == "this cant attack unless youve cast a creature spell this turn"
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
@@ -85,6 +85,7 @@ pub(crate) fn uses_spell_only_functional_zones(static_ability: &StaticAbility) -
         static_ability.id(),
         crate::static_abilities::StaticAbilityId::ConditionalSpellKeyword
             | crate::static_abilities::StaticAbilityId::ThisSpellCastRestriction
+            | crate::static_abilities::StaticAbilityId::ThisSpellXMaximum
             | crate::static_abilities::StaticAbilityId::ThisSpellCostReduction
             | crate::static_abilities::StaticAbilityId::ThisSpellCostReductionManaCost
     )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -1484,6 +1484,59 @@ fn parse_reveal_until_land_put_all_graveyard_bundle(
     Some(effects)
 }
 
+fn parse_consult_then_put_matches_battlefield_rest_bottom_bundle(
+    consult_sentence: &[OwnedLexToken],
+    followup_sentence: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some(parts) = super::consult_family::parse_consult_traversal_sentence(consult_sentence)?
+    else {
+        return Ok(None);
+    };
+    let Some(EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action:
+            SubjectVerbActionAst::ConsultTopOfLibrary {
+                mode: LibraryConsultModeAst::Reveal,
+                ..
+            },
+        ..
+    })) = parts.effects.last()
+    else {
+        return Ok(None);
+    };
+
+    let followup_words = crate::runtime_backend::token_word_refs(followup_sentence);
+    if !followup_words.starts_with(&["put", "those"])
+        || !followup_words.contains(&"battlefield")
+        || !followup_words.contains(&"rest")
+        || !followup_words.contains(&"bottom")
+        || !followup_words.contains(&"library")
+    {
+        return Ok(None);
+    }
+    let Some(order) = super::consult_family::parse_consult_remainder_order(&followup_words) else {
+        return Ok(None);
+    };
+
+    let enters_tapped = followup_words.contains(&"tapped");
+    let mut effects = parts.effects;
+    effects.push(EffectAst::subject_verb_move_to_zone(
+        TargetAst::Tagged(parts.match_tag.clone(), None),
+        Zone::Battlefield,
+        false,
+        ReturnControllerAst::Preserve,
+        enters_tapped,
+        None,
+    ));
+    effects.push(EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+        parts.all_tag,
+        Some(parts.match_tag),
+        order,
+        parts.player,
+    ));
+
+    Ok(Some(effects))
+}
+
 fn parse_tap_lands_then_empty_mana_pool_bundle(tokens: &[OwnedLexToken]) -> Option<Vec<EffectAst>> {
     let sentence_words = parser_words(tokens);
     let sentence_word_refs = sentence_words
@@ -1768,6 +1821,14 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
         return Some(effects);
     }
     let sentences = split_lexed_sentences(tokens);
+    if sentences.len() == 2
+        && let Ok(Some(effects)) = parse_consult_then_put_matches_battlefield_rest_bottom_bundle(
+            sentences[0],
+            sentences[1],
+        )
+    {
+        return Some(effects);
+    }
     if sentences.len() == 2
         && let Ok(Some(effects)) =
             parse_exile_then_source_leaves_return_bundle(sentences[0], sentences[1])

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
@@ -179,6 +179,13 @@ pub(crate) fn parse_consult_traversal_sentence(
             }
             filter_tokens = remaining;
             LibraryConsultStopRuleAst::MatchCount(Value::Fixed(count as i32))
+        } else if let Some((value, used)) = parse_value_from_lexed(&filter_tokens) {
+            let remaining = trim_commas(&filter_tokens[used..]).to_vec();
+            if remaining.is_empty() {
+                return Ok(None);
+            }
+            filter_tokens = remaining;
+            LibraryConsultStopRuleAst::MatchCount(value)
         } else {
             LibraryConsultStopRuleAst::FirstMatch
         };
@@ -281,13 +288,17 @@ fn parse_passive_consult_stop_rule_and_filter(
     mode: LibraryConsultModeAst,
 ) -> Result<Option<(LibraryConsultStopRuleAst, ObjectFilter)>, CardTextError> {
     let tokens = trim_commas(tokens);
-    let Some((count, used)) = parse_number(&tokens).or_else(|| {
-        TokenWordView::new(&tokens)
-            .word_refs()
-            .first()
-            .is_some_and(|word| matches!(*word, "a" | "an"))
-            .then_some((1, 1))
-    }) else {
+    let Some((count, used)) = parse_number(&tokens)
+        .map(|(count, used)| (Value::Fixed(count as i32), used))
+        .or_else(|| parse_value_from_lexed(&tokens))
+        .or_else(|| {
+            TokenWordView::new(&tokens)
+                .word_refs()
+                .first()
+                .is_some_and(|word| matches!(*word, "a" | "an"))
+                .then_some((Value::Fixed(1), 1))
+        })
+    else {
         return Ok(None);
     };
 
@@ -335,10 +346,7 @@ fn parse_passive_consult_stop_rule_and_filter(
     apply_consult_relative_mana_value_filter(&filter_tokens, &mut filter);
     filter.zone = None;
 
-    Ok(Some((
-        LibraryConsultStopRuleAst::MatchCount(Value::Fixed(count as i32)),
-        filter,
-    )))
+    Ok(Some((LibraryConsultStopRuleAst::MatchCount(count), filter)))
 }
 
 fn infer_consult_player_from_prefix(tokens: &[OwnedLexToken]) -> Option<PlayerAst> {

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -58,6 +58,7 @@ pub enum StaticAbilityId {
     Unleash,
     ConditionalSpellKeyword,
     ThisSpellCastRestriction,
+    ThisSpellXMaximum,
     Unblockable,
     FlyingRestriction,
     FlyingOnlyRestriction,
@@ -299,6 +300,7 @@ impl StaticAbilityId {
             | Unleash
             | ConditionalSpellKeyword
             | ThisSpellCastRestriction
+            | ThisSpellXMaximum
             | Unblockable
             | FlyingRestriction
             | FlyingOnlyRestriction

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -174,6 +174,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         kind: ThisSpellCastRestrictionKind,
         display: String,
     },
+    ThisSpellXMaximum {
+        maximum: Value,
+        display: String,
+    },
     LevelAbility(Box<LevelAbilityModel<T, E, C, Cond>>),
     HexproofFrom(ObjectFilter),
     Protection(ProtectionFrom),
@@ -790,6 +794,9 @@ where
             }
             StaticAbilityPayload::ThisSpellCastRestriction { kind, display } => {
                 StaticAbilityPayload::ThisSpellCastRestriction { kind, display }
+            }
+            StaticAbilityPayload::ThisSpellXMaximum { maximum, display } => {
+                StaticAbilityPayload::ThisSpellXMaximum { maximum, display }
             }
             StaticAbilityPayload::LevelAbility(level) => {
                 let level = *level;
@@ -1534,6 +1541,15 @@ impl<
             id: Some(StaticAbilityId::ThisSpellCastRestriction),
             label: display.clone(),
             payload: StaticAbilityPayload::ThisSpellCastRestriction { kind, display },
+        }
+    }
+
+    pub fn this_spell_x_maximum(maximum: Value, text: impl Into<String>) -> Self {
+        let display = text.into();
+        Self {
+            id: Some(StaticAbilityId::ThisSpellXMaximum),
+            label: display.clone(),
+            payload: StaticAbilityPayload::ThisSpellXMaximum { maximum, display },
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7655,6 +7655,43 @@ fn empty_the_laboratory_keeps_dynamic_sacrifice_and_consult_sequence() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn open_the_way_parses_x_cap_and_reveal_x_lands() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Open the Way")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "X can't be greater than the number of players in the game.\n\
+             Reveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
+        )
+        .expect("Open the Way should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("X can't be greater than the number of players in the game")
+            && rendered.contains("until you reveal X land cards")
+            && rendered.contains("Put those land cards onto the battlefield tapped")
+            && rendered.contains("the rest on the bottom of your library in a random order"),
+        "expected Open the Way X cap and reveal/battlefield/bottom text, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def);
+    assert!(
+        debug.contains("ThisSpellXMaximum")
+            && debug.contains("CountPlayers")
+            && debug.contains("MatchCount(X)")
+            && debug.contains("ConsultTopOfLibraryEffect")
+            && debug.contains("enters_tapped: true")
+            && debug.contains("PutTaggedRemainderOnLibraryBottomEffect"),
+        "expected Open the Way to lower to an X cap plus X-count consult/move/bottom effects, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn costume_shop_keeps_visit_sticker_effect() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Costume Shop")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -7810,9 +7810,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             };
             let selection = describe_search_selection_with_cards(&consult.filter.description());
             let stop_text = match &consult.stop_rule {
-                crate::effects::ConsultTopOfLibraryStopRule::FirstMatch => selection,
+                crate::effects::ConsultTopOfLibraryStopRule::FirstMatch => selection.clone(),
                 crate::effects::ConsultTopOfLibraryStopRule::MatchCount(Value::Fixed(1)) => {
-                    selection
+                    selection.clone()
                 }
                 crate::effects::ConsultTopOfLibraryStopRule::MatchCount(count) => format!(
                     "{} {}",
@@ -7885,15 +7885,29 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             };
             let selection = describe_search_selection_with_cards(&consult.filter.description());
             let stop_text = match &consult.stop_rule {
-                crate::effects::ConsultTopOfLibraryStopRule::FirstMatch => selection,
+                crate::effects::ConsultTopOfLibraryStopRule::FirstMatch => selection.clone(),
                 crate::effects::ConsultTopOfLibraryStopRule::MatchCount(Value::Fixed(1)) => {
-                    selection
+                    selection.clone()
                 }
                 crate::effects::ConsultTopOfLibraryStopRule::MatchCount(count) => format!(
                     "{} {}",
                     describe_value(count),
                     pluralize_noun_phrase(&selection)
                 ),
+            };
+            let moved_phrase = match &consult.stop_rule {
+                crate::effects::ConsultTopOfLibraryStopRule::FirstMatch
+                | crate::effects::ConsultTopOfLibraryStopRule::MatchCount(Value::Fixed(1)) => {
+                    "that card".to_string()
+                }
+                crate::effects::ConsultTopOfLibraryStopRule::MatchCount(_) => {
+                    format!("those {}", pluralize_noun_phrase(&selection))
+                }
+            };
+            let tapped_suffix = if move_to_zone.enters_tapped {
+                " tapped"
+            } else {
+                ""
             };
             let order_text = match remainder.order {
                 crate::effects::consult_helpers::LibraryBottomOrder::Random => {
@@ -7907,11 +7921,11 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
 
             if player == "you" {
                 Some(format!(
-                    "{player} {reveal_verb} cards from the top of {library_owner} library until {pronoun} {pronoun_reveal_verb} {stop_text}, put that card onto the battlefield, then put the rest on the bottom of {library_owner} library{order_text}"
+                    "{player} {reveal_verb} cards from the top of {library_owner} library until {pronoun} {pronoun_reveal_verb} {stop_text}. Put {moved_phrase} onto the battlefield{tapped_suffix} and the rest on the bottom of {library_owner} library{order_text}"
                 ))
             } else {
                 Some(format!(
-                    "{player} {reveal_verb} cards from the top of {library_owner} library until {pronoun} {pronoun_reveal_verb} {stop_text}, then {player} {put_verb} that card onto the battlefield and {put_verb} the rest on the bottom of {library_owner} library{order_text}"
+                    "{player} {reveal_verb} cards from the top of {library_owner} library until {pronoun} {pronoun_reveal_verb} {stop_text}, then {player} {put_verb} {moved_phrase} onto the battlefield{tapped_suffix} and {put_verb} the rest on the bottom of {library_owner} library{order_text}"
                 ))
             }
         }

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -398,6 +398,29 @@ pub(super) fn max_x_from_non_mana_costs(
     max_x
 }
 
+fn max_x_from_static_abilities(game: &GameState, caster: PlayerId, source: ObjectId) -> Option<u32> {
+    let spell = game.object(source)?;
+    let mut max_x = None;
+    for ability in &spell.abilities {
+        if !ability.functional_zones.contains(&Zone::Stack) {
+            continue;
+        }
+        let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
+            continue;
+        };
+        let Some(value) = static_ability.this_spell_x_maximum_value() else {
+            continue;
+        };
+        let ctx = crate::effects::ExecutionContext::new_default(source, caster);
+        let Ok(resolved) = crate::effects::helpers::resolve_value(game, &value, &ctx) else {
+            continue;
+        };
+        let resolved = resolved.max(0) as u32;
+        max_x = Some(max_x.map_or(resolved, |prev: u32| prev.min(resolved)));
+    }
+    max_x
+}
+
 pub(super) fn activation_cost_steps_reference_x(steps: &[ActivationCostStep]) -> bool {
     steps.iter().any(|step| match step {
         ActivationCostStep::Cost(cost) => cost_references_x(cost),
@@ -464,6 +487,10 @@ pub(super) fn compute_spell_cast_x_bounds(
 
     if let Some(max_cost) = max_x_from_non_mana_costs(game, caster, stack_id, &non_mana_costs) {
         max_x = Some(max_x.map_or(max_cost, |prev| prev.min(max_cost)));
+    }
+
+    if let Some(max_static) = max_x_from_static_abilities(game, caster, stack_id) {
+        max_x = Some(max_x.map_or(max_static, |prev| prev.min(max_static)));
     }
 
     (true, max_x.unwrap_or(0))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -34,6 +34,123 @@ fn setup_three_player_game() -> GameState {
     )
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn open_the_way_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_900), "Open the Way")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "X can't be greater than the number of players in the game.\n\
+             Reveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.",
+        )
+        .expect("Open the Way should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn open_the_way_x_choice_is_capped_by_players_in_game() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let charlie = PlayerId::from_index(2);
+
+    let forest = crate::cards::definitions::basic_forest();
+    for _ in 0..8 {
+        game.create_object_from_definition(&forest, alice, Zone::Battlefield);
+    }
+
+    let open_the_way = open_the_way_definition();
+    let spell_id = game.create_object_from_definition(&open_the_way, alice, Zone::Stack);
+    let mana_cost = game.object(spell_id).unwrap().mana_cost.clone();
+
+    let (needs_x, max_x) = compute_spell_cast_x_bounds(
+        &game,
+        alice,
+        spell_id,
+        &CastingMethod::Normal,
+        mana_cost.as_ref(),
+    );
+    assert!(needs_x, "Open the Way should ask for X while being cast");
+    assert_eq!(max_x, 3, "three players in game should cap X at 3");
+
+    game.player_mut(charlie).unwrap().has_lost = true;
+    let (_, max_x_after_player_lost) = compute_spell_cast_x_bounds(
+        &game,
+        alice,
+        spell_id,
+        &CastingMethod::Normal,
+        mana_cost.as_ref(),
+    );
+    assert_eq!(
+        max_x_after_player_lost, 2,
+        "players no longer in the game should stop increasing Open the Way's X cap"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn open_the_way_reveals_x_lands_to_battlefield_tapped_and_bottoms_rest() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let open_the_way = open_the_way_definition();
+    let spell_id = game.create_object_from_definition(&open_the_way, alice, Zone::Stack);
+    game.object_mut(spell_id).unwrap().x_value = Some(2);
+    let spell_stable = game.object(spell_id).unwrap().stable_id;
+
+    let forest = crate::cards::definitions::basic_forest();
+    let second_land = game.create_object_from_definition(&forest, alice, Zone::Library);
+    let filler = CardBuilder::new(CardId::from_raw(72_901), "Filler Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let filler_id = game.create_object_from_card(&filler, alice, Zone::Library);
+    let top_land = game.create_object_from_definition(&forest, alice, Zone::Library);
+    let second_land_stable = game.object(second_land).unwrap().stable_id;
+    let filler_stable = game.object(filler_id).unwrap().stable_id;
+    let top_land_stable = game.object(top_land).unwrap().stable_id;
+
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice)
+            .with_x(2)
+            .with_source_info(
+                game.object(spell_id).unwrap().stable_id,
+                "Open the Way".to_string(),
+            ),
+    );
+    resolve_stack_entry(&mut game).expect("Open the Way should resolve");
+
+    for stable_id in [top_land_stable, second_land_stable] {
+        let land_id = game
+            .find_object_by_stable_id(stable_id)
+            .expect("revealed land should still exist after changing zones");
+        assert!(
+            game.battlefield.contains(&land_id),
+            "revealed land {land_id:?} should be on the battlefield"
+        );
+        assert!(
+            game.is_tapped(land_id),
+            "revealed land {land_id:?} should enter tapped"
+        );
+    }
+    let filler_id = game
+        .find_object_by_stable_id(filler_stable)
+        .expect("filler card should still exist after bottoming");
+    assert!(
+        game.player(alice).unwrap().library.contains(&filler_id),
+        "nonmatching revealed cards should be put on the bottom of the library"
+    );
+    let resolved_spell_id = game
+        .find_object_by_stable_id(spell_stable)
+        .expect("Open the Way should still exist after resolving");
+    assert!(
+        game.player(alice).unwrap().graveyard.contains(&resolved_spell_id),
+        "Open the Way should move to its owner's graveyard after resolving"
+    );
+}
+
 #[test]
 fn regeneration_count_tracks_used_shields_until_cleanup() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3629,6 +3629,36 @@ impl StaticAbilityKind for ThisSpellCastRestriction {
     }
 }
 
+/// "X can't be greater than ..." spell-casting X restriction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThisSpellXMaximum {
+    pub maximum: crate::effect::Value,
+    pub display: String,
+}
+
+impl ThisSpellXMaximum {
+    pub fn new(maximum: crate::effect::Value, display: impl Into<String>) -> Self {
+        Self {
+            maximum,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for ThisSpellXMaximum {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::ThisSpellXMaximum
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn this_spell_x_maximum_value(&self) -> Option<crate::effect::Value> {
+        Some(self.maximum.clone())
+    }
+}
+
 /// "Each opponent's maximum hand size is equal to seven minus the number of card types in your graveyard."
 #[derive(Debug, Clone, PartialEq)]
 pub struct MaximumHandSizeSevenMinusYourGraveyardCardTypes {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -891,6 +891,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Return the maximum legal value for X while casting this spell, if any.
+    fn this_spell_x_maximum_value(&self) -> Option<crate::effect::Value> {
+        None
+    }
+
     /// Return a pregame-action descriptor, if this ability creates one.
     fn pregame_action_kind(&self) -> Option<PregameActionKind> {
         None
@@ -1075,6 +1080,10 @@ impl StaticAbility {
 
     pub fn this_spell_cast_restriction_kind(&self) -> Option<ThisSpellCastRestrictionKind> {
         self.0.this_spell_cast_restriction_kind()
+    }
+
+    pub fn this_spell_x_maximum_value(&self) -> Option<crate::effect::Value> {
+        self.0.this_spell_x_maximum_value()
     }
 
     pub fn pregame_action_kind(&self) -> Option<PregameActionKind> {
@@ -2475,6 +2484,13 @@ impl StaticAbility {
         display: impl Into<String>,
     ) -> Self {
         Self::new(ThisSpellCastRestriction::new(kind, display))
+    }
+
+    pub fn this_spell_x_maximum(
+        maximum: crate::effect::Value,
+        display: impl Into<String>,
+    ) -> Self {
+        Self::new(ThisSpellXMaximum::new(maximum, display))
     }
 
     pub fn damage_not_removed_during_cleanup() -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -110,6 +110,11 @@ impl StaticAbilityModelInterpreter {
                     display
                 )
             }
+            ironsmith_core::StaticAbilityPayload::ThisSpellXMaximum { maximum, display } => {
+                format!(
+                    "ThisSpellXMaximum {{ maximum: {maximum:?}, display: {display:?} }}"
+                )
+            }
             payload => format!("{payload:?}"),
         }
     }
@@ -1131,6 +1136,9 @@ impl StaticAbilityModelInterpreter {
                     display.clone(),
                 )
             }
+            ironsmith_core::StaticAbilityPayload::ThisSpellXMaximum { maximum, display } => {
+                StaticAbility::this_spell_x_maximum(maximum.clone(), display.clone())
+            }
             ironsmith_core::StaticAbilityPayload::MinimumSpellTotalMana(amount) => {
                 StaticAbility::minimum_spell_total_mana(*amount)
             }
@@ -1913,6 +1921,10 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
     fn this_spell_cast_restriction_kind(&self) -> Option<super::ThisSpellCastRestrictionKind> {
         self.leaf_static_ability()?
             .this_spell_cast_restriction_kind()
+    }
+
+    fn this_spell_x_maximum_value(&self) -> Option<crate::effect::Value> {
+        self.leaf_static_ability()?.this_spell_x_maximum_value()
     }
 
     fn generic_attack_tax_per_attacker_against_you(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Open the Way
Initial parse error:
```
unsupported subject target phrase (clause: 'x'); oracle-only fallback also failed: unsupported subject target phrase (clause: 'x')
```

Worker: i-0bf9d97f19c424c5f
