### PR TITLE
Fix Ironsmith parse failure: Xorn

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6900,6 +6900,48 @@ pub(crate) fn parse_double_token_creation_replacement_line(
         )));
     }
 
+    let add_one_prefix = ["if", "you", "would", "create", "one", "or", "more"];
+    if slice_starts_with(&line_words, &add_one_prefix)
+        && let Some(token_idx) = line_words[add_one_prefix.len()..]
+            .iter()
+            .position(|word| matches!(*word, "token" | "tokens"))
+            .map(|idx| idx + add_one_prefix.len())
+    {
+        let descriptor = &line_words[add_one_prefix.len()..token_idx];
+        let additional_prefix = [
+            "instead",
+            "create",
+            "those",
+            "tokens",
+            "plus",
+            "an",
+            "additional",
+        ];
+        let after_token = &line_words[token_idx + 1..];
+        if !descriptor.is_empty()
+            && slice_starts_with(after_token, &additional_prefix)
+            && after_token.last() == Some(&"token")
+            && &after_token[additional_prefix.len()..after_token.len() - 1] == descriptor
+        {
+            let mut token_filter = ObjectFilter::default().token();
+            for word in descriptor {
+                if let Some(card_type) = parse_card_type(word) {
+                    token_filter = token_filter.with_type(card_type);
+                } else if let Some(subtype) = parse_subtype_flexible(word) {
+                    token_filter = token_filter.with_subtype(subtype);
+                } else {
+                    return Ok(None);
+                }
+            }
+            return Ok(Some(StaticAbility::add_token_creation_replacement(
+                PlayerFilter::You,
+                token_filter,
+                1,
+                display_text_for_tokens(tokens, true),
+            )));
+        }
+    }
+
     Ok(None)
 }
 

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -220,6 +220,7 @@ pub enum StaticAbilityId {
     ModifyDamageAmountReplacement,
     DoubleCountersReplacement,
     DoubleTokenCreationReplacement,
+    AddTokenCreationReplacement,
     CreaturesEnteringDontCauseAbilitiesToTrigger,
     DuplicateMatchingTriggeredAbilities,
     SuppressMatchingTriggeredAbilities,
@@ -461,6 +462,7 @@ impl StaticAbilityId {
             | ModifyDamageAmountReplacement
             | DoubleCountersReplacement
             | DoubleTokenCreationReplacement
+            | AddTokenCreationReplacement
             | CreaturesEnteringDontCauseAbilitiesToTrigger
             | DuplicateMatchingTriggeredAbilities
             | SuppressMatchingTriggeredAbilities

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -401,6 +401,12 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         controller: PlayerFilter,
         display: String,
     },
+    AddTokenCreationReplacement {
+        controller: PlayerFilter,
+        token_filter: ObjectFilter,
+        additional: i32,
+        display: String,
+    },
     KeywordActionReplacement {
         action: KeywordActionKind,
         source_filter: ObjectFilter,
@@ -1225,6 +1231,17 @@ where
                 display,
             } => StaticAbilityPayload::DoubleTokenCreationReplacement {
                 controller,
+                display,
+            },
+            StaticAbilityPayload::AddTokenCreationReplacement {
+                controller,
+                token_filter,
+                additional,
+                display,
+            } => StaticAbilityPayload::AddTokenCreationReplacement {
+                controller,
+                token_filter,
+                additional,
                 display,
             },
             StaticAbilityPayload::KeywordActionReplacement {
@@ -3409,6 +3426,25 @@ impl<
             label: display.clone(),
             payload: StaticAbilityPayload::DoubleTokenCreationReplacement {
                 controller,
+                display,
+            },
+        }
+    }
+
+    pub fn add_token_creation_replacement(
+        controller: PlayerFilter,
+        token_filter: ObjectFilter,
+        additional: i32,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::AddTokenCreationReplacement),
+            label: display.clone(),
+            payload: StaticAbilityPayload::AddTokenCreationReplacement {
+                controller,
+                token_filter,
+                additional,
                 display,
             },
         }

--- a/crates/ironsmith-runtime/src/effects/tokens/create_token.rs
+++ b/crates/ironsmith-runtime/src/effects/tokens/create_token.rs
@@ -6,6 +6,7 @@ use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_value;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
+use crate::ids::ObjectId;
 use crate::object::Object;
 use crate::target::ChooseSpec;
 use crate::zone::Zone;
@@ -70,10 +71,13 @@ impl EffectExecutor for CreateTokenEffect {
         let controller_id =
             crate::effects::helpers::resolve_player_filter(game, &self.controller, ctx)?;
         let base_count = resolve_value(game, &self.count, ctx)?.max(0) as u32;
-        let replaced_count = crate::events::processing::process_token_creation_with_event(
+        let token_preview =
+            Object::from_token_definition(ObjectId::from_raw(0), &self.token, controller_id);
+        let replaced_count = crate::events::processing::process_token_creation_for_token_with_event(
             game,
             controller_id,
             base_count,
+            Some(token_preview),
             ctx.cause.clone(),
             &mut ctx.decision_maker,
         ) as usize;
@@ -204,7 +208,9 @@ mod tests {
     use crate::card::PowerToughness;
     use crate::cards::CardDefinitionBuilder;
     use crate::cards::definitions::tayam_luminous_enigma;
+    use crate::cards::tokens::treasure_token_definition;
     use crate::color::{Color, ColorSet};
+    use crate::compiled_text::canonical_compiled_lines;
     use crate::ids::{CardId, PlayerId};
     use crate::object::{CounterType, ObjectKind};
     use crate::static_abilities::StaticAbility;
@@ -261,6 +267,27 @@ mod tests {
             .subtypes(vec![Subtype::Spirit])
             .power_toughness(PowerToughness::fixed(1, 1))
             .build()
+    }
+
+    fn xorn_definition() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Xorn")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Elemental])
+            .parse_text(
+                "If you would create one or more Treasure tokens, instead create those tokens plus an additional Treasure token.",
+            )
+            .expect("Xorn should parse strictly")
+    }
+
+    #[test]
+    fn xorn_strict_parser_and_compiled_text_regression() {
+        let def = xorn_definition();
+        let rendered = canonical_compiled_lines(&def).join(" ");
+
+        assert_eq!(
+            rendered,
+            "If you would create one or more treasure tokens, instead create those tokens plus an additional treasure token."
+        );
     }
 
     #[test]
@@ -392,6 +419,84 @@ mod tests {
         assert_eq!(ids.len(), 1);
         let token = game.object(ids[0]).expect("token should exist");
         assert_eq!(game.controller_of(token), bob);
+    }
+
+    #[test]
+    fn xorn_adds_one_treasure_token_to_your_treasure_creation() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let xorn = xorn_definition();
+        game.create_object_from_definition(&xorn, alice, Zone::Battlefield);
+        game.refresh_continuous_state();
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let result = CreateTokenEffect::you(treasure_token_definition(), 2)
+            .execute(&mut game, &mut ctx)
+            .unwrap();
+
+        let crate::effect::OutcomeValue::Objects(ids) = result.value else {
+            panic!("Expected Objects result");
+        };
+        assert_eq!(ids.len(), 3, "Xorn should add exactly one Treasure token");
+        assert!(ids.iter().all(|id| {
+            game.object(*id).is_some_and(|token| {
+                token.name == "Treasure" && token.subtypes.contains(&Subtype::Treasure)
+            })
+        }));
+    }
+
+    #[test]
+    fn xorn_does_not_add_tokens_to_non_treasure_token_creation() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let xorn = xorn_definition();
+        game.create_object_from_definition(&xorn, alice, Zone::Battlefield);
+        game.refresh_continuous_state();
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let result = CreateTokenEffect::you(soldier_token(), 2)
+            .execute(&mut game, &mut ctx)
+            .unwrap();
+
+        let crate::effect::OutcomeValue::Objects(ids) = result.value else {
+            panic!("Expected Objects result");
+        };
+        assert_eq!(ids.len(), 2, "Xorn should ignore non-Treasure tokens");
+    }
+
+    #[test]
+    fn xorn_does_not_add_tokens_to_other_players_treasure_creation() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = game.new_object_id();
+        let xorn = xorn_definition();
+        game.create_object_from_definition(&xorn, alice, Zone::Battlefield);
+        game.refresh_continuous_state();
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let result = CreateTokenEffect::new(
+            treasure_token_definition(),
+            2,
+            PlayerFilter::Specific(bob),
+        )
+        .execute(&mut game, &mut ctx)
+        .unwrap();
+
+        let crate::effect::OutcomeValue::Objects(ids) = result.value else {
+            panic!("Expected Objects result");
+        };
+        assert_eq!(
+            ids.len(),
+            2,
+            "Xorn should only affect its controller's Treasure creation"
+        );
+        assert!(ids.iter().all(|id| {
+            game.object(*id)
+                .is_some_and(|token| game.controller_of(token) == bob)
+        }));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/effects/tokens/create_token_copy.rs
+++ b/crates/ironsmith-runtime/src/effects/tokens/create_token_copy.rs
@@ -9,8 +9,9 @@ use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_objects_for_effect, resolve_player_filter, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
-use crate::ids::PlayerId;
+use crate::ids::{ObjectId, PlayerId};
 use crate::object::Object;
+use crate::snapshot::ObjectSnapshot;
 use crate::static_abilities::StaticAbility;
 use crate::target::ChooseSpec;
 use crate::types::CardType;
@@ -119,6 +120,68 @@ fn choose_attack_target(
         .cloned()
 }
 
+fn build_token_copy_object(
+    effect: &CreateTokenCopyEffect,
+    id: ObjectId,
+    controller_id: PlayerId,
+    target_object: Option<&Object>,
+    copy_snapshot: Option<&ObjectSnapshot>,
+    resolved_target_id: ObjectId,
+    half_power: i32,
+    half_toughness: i32,
+    static_abilities_to_grant: &[StaticAbility],
+) -> Result<Object, ExecutionError> {
+    let mut token = if let Some(snapshot) = copy_snapshot {
+        Object::token_copy_from_snapshot(snapshot, id, controller_id)
+    } else {
+        let target = target_object.ok_or(ExecutionError::ObjectNotFound(resolved_target_id))?;
+        Object::token_copy_of(target, id, controller_id)
+    };
+
+    if let Some(CopyPtAdjustment::HalfRoundUp) = effect.pt_adjustment {
+        token.base_power = Some(PtValue::Fixed(half_power));
+        token.base_toughness = Some(PtValue::Fixed(half_toughness));
+    }
+    if let Some((power, toughness)) = effect.set_base_power_toughness {
+        token.base_power = Some(PtValue::Fixed(power));
+        token.base_toughness = Some(PtValue::Fixed(toughness));
+    }
+    if let Some(colors) = effect.set_colors {
+        token.color_override = Some(colors);
+    }
+    if effect.clear_mana_cost {
+        token.mana_cost = None;
+    }
+    if let Some(card_types) = &effect.set_card_types {
+        token.card_types = card_types.clone();
+    }
+    if let Some(subtypes) = &effect.set_subtypes {
+        token.subtypes = subtypes.clone();
+    }
+    for card_type in &effect.added_card_types {
+        if !token.card_types.contains(card_type) {
+            token.card_types.push(*card_type);
+        }
+    }
+    for subtype in &effect.added_subtypes {
+        if !token.subtypes.contains(subtype) {
+            token.subtypes.push(*subtype);
+        }
+    }
+    if !effect.removed_supertypes.is_empty() {
+        token
+            .supertypes
+            .retain(|supertype| !effect.removed_supertypes.contains(supertype));
+    }
+    for static_ability in static_abilities_to_grant {
+        token
+            .abilities
+            .push(Ability::static_ability(static_ability.clone()));
+    }
+
+    Ok(token)
+}
+
 impl EffectExecutor for CreateTokenCopyEffect {
     fn execute(
         &self,
@@ -127,14 +190,6 @@ impl EffectExecutor for CreateTokenCopyEffect {
     ) -> Result<EffectOutcome, ExecutionError> {
         let controller_id = resolve_player_filter(game, &self.controller, ctx)?;
         let base_count = resolve_value(game, &self.count, ctx)?.max(0) as u32;
-        let replaced_count = crate::events::processing::process_token_creation_with_event(
-            game,
-            controller_id,
-            base_count,
-            ctx.cause.clone(),
-            &mut ctx.decision_maker,
-        ) as usize;
-        let count = replaced_count.min(remaining_token_slots(game, controller_id));
 
         // Resolve target from spec (supports tagged/spec-specific references)
         let target_ids = resolve_objects_for_effect(game, ctx, &self.target)?;
@@ -190,9 +245,6 @@ impl EffectExecutor for CreateTokenCopyEffect {
         }
         static_abilities_to_grant.extend(self.granted_static_abilities.iter().cloned());
 
-        let mut created_ids = Vec::with_capacity(count);
-        let mut events = Vec::with_capacity(count);
-
         let (half_power, half_toughness) = match self.pt_adjustment {
             Some(CopyPtAdjustment::HalfRoundUp) => {
                 let (power, toughness) = if let Some(snapshot) = copy_snapshot {
@@ -208,58 +260,44 @@ impl EffectExecutor for CreateTokenCopyEffect {
             None => (0, 0),
         };
 
+        let token_preview = build_token_copy_object(
+            self,
+            ObjectId::from_raw(0),
+            controller_id,
+            target_object.as_ref(),
+            copy_snapshot,
+            resolved_target_id,
+            half_power,
+            half_toughness,
+            &static_abilities_to_grant,
+        )?;
+        let replaced_count = crate::events::processing::process_token_creation_for_token_with_event(
+            game,
+            controller_id,
+            base_count,
+            Some(token_preview),
+            ctx.cause.clone(),
+            &mut ctx.decision_maker,
+        ) as usize;
+        let count = replaced_count.min(remaining_token_slots(game, controller_id));
+
+        let mut created_ids = Vec::with_capacity(count);
+        let mut events = Vec::with_capacity(count);
+
         for _ in 0..count {
             let id = game.new_object_id();
-            let mut token = if let Some(snapshot) = copy_snapshot {
-                Object::token_copy_from_snapshot(snapshot, id, controller_id)
-            } else {
-                let target = target_object
-                    .as_ref()
-                    .ok_or(ExecutionError::ObjectNotFound(resolved_target_id))?;
-                Object::token_copy_of(target, id, controller_id)
-            };
+            let mut token = build_token_copy_object(
+                self,
+                id,
+                controller_id,
+                target_object.as_ref(),
+                copy_snapshot,
+                resolved_target_id,
+                half_power,
+                half_toughness,
+                &static_abilities_to_grant,
+            )?;
             token.zone = Zone::Command;
-
-            if let Some(CopyPtAdjustment::HalfRoundUp) = self.pt_adjustment {
-                token.base_power = Some(PtValue::Fixed(half_power));
-                token.base_toughness = Some(PtValue::Fixed(half_toughness));
-            }
-            if let Some((power, toughness)) = self.set_base_power_toughness {
-                token.base_power = Some(PtValue::Fixed(power));
-                token.base_toughness = Some(PtValue::Fixed(toughness));
-            }
-            if let Some(colors) = self.set_colors {
-                token.color_override = Some(colors);
-            }
-            if self.clear_mana_cost {
-                token.mana_cost = None;
-            }
-            if let Some(card_types) = &self.set_card_types {
-                token.card_types = card_types.clone();
-            }
-            if let Some(subtypes) = &self.set_subtypes {
-                token.subtypes = subtypes.clone();
-            }
-            for card_type in &self.added_card_types {
-                if !token.card_types.contains(card_type) {
-                    token.card_types.push(*card_type);
-                }
-            }
-            for subtype in &self.added_subtypes {
-                if !token.subtypes.contains(subtype) {
-                    token.subtypes.push(*subtype);
-                }
-            }
-            if !self.removed_supertypes.is_empty() {
-                token
-                    .supertypes
-                    .retain(|supertype| !self.removed_supertypes.contains(supertype));
-            }
-            for static_ability in &static_abilities_to_grant {
-                token
-                    .abilities
-                    .push(Ability::static_ability(static_ability.clone()));
-            }
             let token_is_creature = token.is_creature();
 
             game.add_object(token);
@@ -330,7 +368,7 @@ mod tests {
     use super::*;
     use crate::ability::AbilityKind;
     use crate::card::{CardBuilder, PowerToughness};
-    use crate::cards::CardDefinitionBuilder;
+    use crate::cards::{CardDefinition, CardDefinitionBuilder};
     use crate::effects::ResolvedTarget;
     use crate::ids::{CardId, ObjectId, PlayerId};
     use crate::mana::{ManaCost, ManaSymbol};
@@ -339,7 +377,7 @@ mod tests {
     use crate::static_abilities::{StaticAbility, StaticAbilityId};
     use crate::target::ObjectFilter;
     use crate::test_prelude::*;
-    use crate::types::CardType;
+    use crate::types::{CardType, Subtype};
 
     fn setup_game() -> GameState {
         crate::tests::test_helpers::setup_two_player_game()
@@ -372,6 +410,32 @@ mod tests {
         let obj = Object::from_card(id, &card, controller, Zone::Battlefield);
         game.add_object(obj);
         id
+    }
+
+    fn treasure_token_definition() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Treasure")
+            .token()
+            .card_types(vec![CardType::Artifact])
+            .subtypes(vec![Subtype::Treasure])
+            .build()
+    }
+
+    fn clue_token_definition() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Clue")
+            .token()
+            .card_types(vec![CardType::Artifact])
+            .subtypes(vec![Subtype::Clue])
+            .build()
+    }
+
+    fn xorn_definition() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Xorn")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Elemental])
+            .parse_text(
+                "If you would create one or more Treasure tokens, instead create those tokens plus an additional Treasure token.",
+            )
+            .expect("Xorn should parse strictly")
     }
 
     #[test]
@@ -579,6 +643,109 @@ mod tests {
                 token.name == "Grizzly Bears" && token.kind == ObjectKind::Token
             })
         }));
+    }
+
+    #[test]
+    fn xorn_adds_one_token_when_copying_a_treasure_token() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let treasure_id = game.create_object_from_definition(
+            &treasure_token_definition(),
+            alice,
+            Zone::Battlefield,
+        );
+        let source = game.new_object_id();
+        game.create_object_from_definition(&xorn_definition(), alice, Zone::Battlefield);
+        game.refresh_continuous_state();
+
+        let mut ctx = ExecutionContext::new_default(source, alice)
+            .with_targets(vec![ResolvedTarget::Object(treasure_id)]);
+        let effect = CreateTokenCopyEffect::new(
+            ChooseSpec::Object(ObjectFilter::artifact().with_subtype(Subtype::Treasure)),
+            1,
+            PlayerFilter::You,
+        );
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        let crate::effect::OutcomeValue::Objects(ids) = result.value else {
+            panic!("Expected Objects result");
+        };
+        assert_eq!(ids.len(), 2, "Xorn should add one Treasure token copy");
+        assert!(ids.iter().all(|id| {
+            game.object(*id).is_some_and(|token| {
+                token.name == "Treasure"
+                    && token.kind == ObjectKind::Token
+                    && token.subtypes.contains(&Subtype::Treasure)
+                    && game.controller_of(token) == alice
+            })
+        }));
+    }
+
+    #[test]
+    fn xorn_does_not_add_tokens_when_copying_non_treasure_tokens() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let clue_id = game.create_object_from_definition(
+            &clue_token_definition(),
+            alice,
+            Zone::Battlefield,
+        );
+        let source = game.new_object_id();
+        game.create_object_from_definition(&xorn_definition(), alice, Zone::Battlefield);
+        game.refresh_continuous_state();
+
+        let mut ctx = ExecutionContext::new_default(source, alice)
+            .with_targets(vec![ResolvedTarget::Object(clue_id)]);
+        let effect = CreateTokenCopyEffect::new(
+            ChooseSpec::Object(ObjectFilter::artifact().with_subtype(Subtype::Clue)),
+            1,
+            PlayerFilter::You,
+        );
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        let crate::effect::OutcomeValue::Objects(ids) = result.value else {
+            panic!("Expected Objects result");
+        };
+        assert_eq!(ids.len(), 1, "Xorn should ignore non-Treasure token copies");
+        let token = game.object(ids[0]).expect("token should exist");
+        assert_eq!(token.name, "Clue");
+        assert!(token.subtypes.contains(&Subtype::Clue));
+    }
+
+    #[test]
+    fn xorn_does_not_add_tokens_to_other_players_treasure_token_copies() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let treasure_id = game.create_object_from_definition(
+            &treasure_token_definition(),
+            bob,
+            Zone::Battlefield,
+        );
+        let source = game.new_object_id();
+        game.create_object_from_definition(&xorn_definition(), alice, Zone::Battlefield);
+        game.refresh_continuous_state();
+
+        let mut ctx = ExecutionContext::new_default(source, alice)
+            .with_targets(vec![ResolvedTarget::Object(treasure_id)]);
+        let effect = CreateTokenCopyEffect::new(
+            ChooseSpec::Object(ObjectFilter::artifact().with_subtype(Subtype::Treasure)),
+            1,
+            PlayerFilter::Specific(bob),
+        );
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        let crate::effect::OutcomeValue::Objects(ids) = result.value else {
+            panic!("Expected Objects result");
+        };
+        assert_eq!(
+            ids.len(),
+            1,
+            "Xorn should only affect its controller's Treasure token copies"
+        );
+        let token = game.object(ids[0]).expect("token should exist");
+        assert_eq!(token.name, "Treasure");
+        assert_eq!(game.controller_of(token), bob);
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/events/mod.rs
+++ b/crates/ironsmith-runtime/src/events/mod.rs
@@ -367,6 +367,19 @@ impl Event {
         )
     }
 
+    /// Create a token creation event with known token characteristics.
+    pub fn create_tokens_with_token(
+        controller: PlayerId,
+        count: u32,
+        token: crate::object::Object,
+        cause: EventCause,
+    ) -> Self {
+        Self::new_with_provenance(
+            CreateTokensEvent::with_token_cause(controller, count, token, cause),
+            ProvNodeId::default(),
+        )
+    }
+
     /// Create a remove counters event.
     pub fn remove_counters(target: ObjectId, counter_type: CounterType, count: u32) -> Self {
         Self::new_with_provenance(

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2532,13 +2532,31 @@ pub fn process_token_creation_with_event(
     cause: crate::events::cause::EventCause,
     dm: &mut (impl DecisionMaker + ?Sized),
 ) -> u32 {
+    process_token_creation_for_token_with_event(game, controller, count, None, cause, dm)
+}
+
+/// Process a token creation event with known token characteristics.
+///
+/// Returns the final number of tokens to create.
+pub fn process_token_creation_for_token_with_event(
+    game: &mut GameState,
+    controller: PlayerId,
+    count: u32,
+    token: Option<crate::object::Object>,
+    cause: crate::events::cause::EventCause,
+    dm: &mut (impl DecisionMaker + ?Sized),
+) -> u32 {
     use crate::events::{CreateTokensEvent, downcast_event};
 
     if count == 0 {
         return 0;
     }
 
-    let event = Event::create_tokens(controller, count, cause);
+    let event = if let Some(token) = token {
+        Event::create_tokens_with_token(controller, count, token, cause)
+    } else {
+        Event::create_tokens(controller, count, cause)
+    };
     let result = process_with_dm(game, event, dm);
 
     match result {

--- a/crates/ironsmith-runtime/src/events/tokens/create_tokens.rs
+++ b/crates/ironsmith-runtime/src/events/tokens/create_tokens.rs
@@ -6,6 +6,7 @@ use crate::events::cause::EventCause;
 use crate::events::traits::{EventKind, GameEventType};
 use crate::game_state::GameState;
 use crate::ids::PlayerId;
+use crate::object::Object;
 
 /// An event representing one effect creating one or more tokens for a player.
 #[derive(Debug, Clone)]
@@ -16,6 +17,8 @@ pub struct CreateTokensEvent {
     pub count: u32,
     /// What caused the token creation.
     pub cause: EventCause,
+    /// Characteristics of the token being created, when known before creation.
+    pub token: Option<Object>,
 }
 
 impl CreateTokensEvent {
@@ -24,6 +27,21 @@ impl CreateTokensEvent {
             controller,
             count,
             cause,
+            token: None,
+        }
+    }
+
+    pub fn with_token_cause(
+        controller: PlayerId,
+        count: u32,
+        token: Object,
+        cause: EventCause,
+    ) -> Self {
+        Self {
+            controller,
+            count,
+            cause,
+            token: Some(token),
         }
     }
 

--- a/crates/ironsmith-runtime/src/events/tokens/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/tokens/matchers.rs
@@ -3,8 +3,9 @@
 use crate::events::cause::{CauseFilter, CauseFilterRuntimeExt as _};
 use crate::events::context::EventContext;
 use crate::events::traits::{EventKind, GameEventType, ReplacementMatcher, downcast_event};
+use crate::filter::ObjectFilterExt as _;
 use crate::filter::PlayerFilterExt as _;
-use crate::target::PlayerFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 
 use super::CreateTokensEvent;
 
@@ -13,6 +14,7 @@ use super::CreateTokensEvent;
 pub struct WouldCreateTokensUnderControlMatcher {
     pub controller_filter: PlayerFilter,
     pub cause_filter: CauseFilter,
+    pub token_filter: Option<ObjectFilter>,
 }
 
 impl WouldCreateTokensUnderControlMatcher {
@@ -20,11 +22,17 @@ impl WouldCreateTokensUnderControlMatcher {
         Self {
             controller_filter,
             cause_filter: CauseFilter::effect_like(),
+            token_filter: None,
         }
     }
 
     pub fn with_cause_filter(mut self, cause_filter: CauseFilter) -> Self {
         self.cause_filter = cause_filter;
+        self
+    }
+
+    pub fn with_token_filter(mut self, token_filter: ObjectFilter) -> Self {
+        self.token_filter = Some(token_filter);
         self
     }
 }
@@ -39,15 +47,27 @@ impl ReplacementMatcher for WouldCreateTokensUnderControlMatcher {
             return false;
         };
 
-        create_tokens.count > 0
-            && self
+        if create_tokens.count == 0
+            || !self
                 .controller_filter
                 .matches_player(create_tokens.controller, &ctx.filter_ctx)
-            && self.cause_filter.matches(
+            || !self.cause_filter.matches(
                 &create_tokens.cause,
                 ctx.game,
                 create_tokens.affected_player(ctx.game),
             )
+        {
+            return false;
+        }
+
+        if let Some(token_filter) = &self.token_filter {
+            return create_tokens
+                .token
+                .as_ref()
+                .is_some_and(|token| token_filter.matches(token, &ctx.filter_ctx, ctx.game));
+        }
+
+        true
     }
 
     fn display(&self) -> String {

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3251,6 +3251,56 @@ impl StaticAbilityKind for DoubleTokenCreationReplacement {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddTokenCreationReplacement {
+    pub controller: PlayerFilter,
+    pub token_filter: ObjectFilter,
+    pub additional: i32,
+    pub display: String,
+}
+
+impl AddTokenCreationReplacement {
+    pub fn new(
+        controller: PlayerFilter,
+        token_filter: ObjectFilter,
+        additional: i32,
+        display: impl Into<String>,
+    ) -> Self {
+        Self {
+            controller,
+            token_filter,
+            additional,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for AddTokenCreationReplacement {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::AddTokenCreationReplacement
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            crate::events::tokens::matchers::WouldCreateTokensUnderControlMatcher::new(
+                self.controller.clone(),
+            )
+            .with_token_filter(self.token_filter.clone()),
+            ReplacementAction::Modify(crate::replacement::EventModification::Add(self.additional)),
+        ))
+    }
+}
+
 /// Can be your commander.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CanBeCommander;

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2677,6 +2677,20 @@ impl StaticAbility {
         Self::new(DoubleTokenCreationReplacement::new(controller, display))
     }
 
+    pub fn add_token_creation_replacement(
+        controller: crate::target::PlayerFilter,
+        token_filter: crate::target::ObjectFilter,
+        additional: i32,
+        display: String,
+    ) -> Self {
+        Self::new(AddTokenCreationReplacement::new(
+            controller,
+            token_filter,
+            additional,
+            display,
+        ))
+    }
+
     pub fn effect_discard_to_library_replacement() -> Self {
         Self::new(EffectDiscardToLibraryReplacement)
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1274,6 +1274,17 @@ impl StaticAbilityModelInterpreter {
                 controller.clone(),
                 display.clone(),
             ),
+            ironsmith_core::StaticAbilityPayload::AddTokenCreationReplacement {
+                controller,
+                token_filter,
+                additional,
+                display,
+            } => StaticAbility::add_token_creation_replacement(
+                controller.clone(),
+                token_filter.clone(),
+                *additional,
+                display.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::KeywordActionReplacement {
                 action,
                 source_filter,

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1031,6 +1031,46 @@ fn compile_oracle_text_strictly_compiles_aloe_alchemist_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_xorn_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Xorn")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Xorn --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Xorn should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Xorn"), "{stdout}");
+    assert!(stdout.contains("Semantic mismatch: false"), "{stdout}");
+    assert!(
+        stdout.contains(
+            "If you would create one or more treasure tokens, instead create those tokens plus an additional treasure token."
+        ),
+        "expected Xorn replacement text in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_zagoth_mamba_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Xorn
Initial parse error:
```
unsupported predicate (predicate: 'you would create one or more treasure tokens'); oracle-only fallback also failed: unsupported predicate (predicate: 'you would create one or more treasure tokens')
```

Worker: i-0928aa3b785c1aa88
