### PR TITLE
Fix Ironsmith parse failure: Eelectrocute

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -906,6 +906,65 @@ pub(crate) fn parse_permission_clause_spec_lexed(
         }));
     }
 
+    if matches!(
+        rest_words.as_slice(),
+        [
+            "this",
+            "card",
+            "from",
+            "your",
+            "graveyard",
+            "as",
+            "long",
+            "as",
+            "youve" | "you've",
+            "rolled",
+            "a",
+            result,
+            "this",
+            "turn",
+            "if",
+            "you",
+            "cast",
+            "it",
+            "this",
+            "way",
+            "and",
+            "it",
+            "would",
+            "be",
+            "put",
+            "into",
+            "your",
+            "graveyard",
+            "exile",
+            "it",
+            "instead",
+        ] if result.parse::<u32>().is_ok()
+    ) {
+        let result = rest_words[11].parse::<u32>().map_err(|_| {
+            CardTextError::ParseError("invalid die roll graveyard-cast condition".to_string())
+        })?;
+        return Ok(Some(PermissionClauseSpec::GrantBySpec {
+            player,
+            spec: crate::grant::GrantSpec::new(
+                crate::grant::Grantable::graveyard_cast_from_cards_mana_cost_with_condition(
+                    crate::static_abilities::ThisSpellCastCondition::ConditionExpr {
+                        condition: crate::ConditionExpr::PlayerRolledResultThisTurn {
+                            player: crate::target::PlayerFilter::You,
+                            result,
+                        },
+                        display: format!("you've rolled a {result} this turn"),
+                    },
+                    true,
+                ),
+                ObjectFilter::source(),
+                Zone::Graveyard,
+            ),
+            lifetime: PermissionLifetime::Static,
+        }));
+    }
+
     if allow_land && let Some(after_lands) = strip_prefix_phrase(rest_tokens, &["lands"]) {
         let zone_words = token_word_refs(after_lands);
         if zone_words == ["from", "the", "top", "of", "your", "library"] {

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AlternativeCastingMethod, CardType, CostComponent, ManaCost, ObjectFilter, PlayerFilter, Zone,
+    AlternativeCastingMethod, CardType, CostComponent, ManaCost, ObjectFilter, PlayerFilter,
+    ThisSpellCostCondition, Zone,
 };
 
 pub trait GrantStaticAbility: Clone + PartialEq {
@@ -29,6 +30,8 @@ pub enum DerivedAlternativeCast<C> {
     GraveyardCastFromCardManaCost {
         additional_costs: Vec<C>,
         usage_limit: Option<GrantUsageLimit>,
+        condition: Option<ThisSpellCostCondition>,
+        exiles_after_resolution: bool,
     },
 }
 
@@ -90,6 +93,20 @@ impl<C: CostComponent> DerivedAlternativeCast<C> {
         Self::GraveyardCastFromCardManaCost {
             additional_costs,
             usage_limit: Some(GrantUsageLimit::OnceDuringEachOfYourTurns),
+            condition: None,
+            exiles_after_resolution: false,
+        }
+    }
+
+    pub fn graveyard_cast_from_cards_mana_cost_with_condition(
+        condition: ThisSpellCostCondition,
+        exiles_after_resolution: bool,
+    ) -> Self {
+        Self::GraveyardCastFromCardManaCost {
+            additional_costs: Vec::new(),
+            usage_limit: None,
+            condition: Some(condition),
+            exiles_after_resolution,
         }
     }
 }
@@ -178,6 +195,18 @@ where
         Self::DerivedAlternativeCast(
             DerivedAlternativeCast::once_each_turn_graveyard_cast_from_cards_mana_cost(
                 additional_costs,
+            ),
+        )
+    }
+
+    pub fn graveyard_cast_from_cards_mana_cost_with_condition(
+        condition: ThisSpellCostCondition,
+        exiles_after_resolution: bool,
+    ) -> Self {
+        Self::DerivedAlternativeCast(
+            DerivedAlternativeCast::graveyard_cast_from_cards_mana_cost_with_condition(
+                condition,
+                exiles_after_resolution,
             ),
         )
     }
@@ -625,6 +654,8 @@ where
             DerivedAlternativeCast::GraveyardCastFromCardManaCost {
                 additional_costs,
                 usage_limit,
+                condition,
+                exiles_after_resolution,
             },
         ) = &self.grantable
             && self.zone == Zone::Graveyard
@@ -642,6 +673,19 @@ where
                         .join(", ")
                 )
             };
+            if self.filter == ObjectFilter::source() {
+                let mut line = format!("{may_prefix} cast this card from your graveyard");
+                if let Some(condition) = condition
+                    && let Some(condition_text) = describe_cast_condition(condition)
+                {
+                    line.push_str(" as long as ");
+                    line.push_str(&condition_text);
+                }
+                if *exiles_after_resolution {
+                    line.push_str(". If you cast it this way and it would be put into your graveyard, exile it instead");
+                }
+                return line;
+            }
             let prefix = if matches!(
                 usage_limit,
                 Some(GrantUsageLimit::OnceDuringEachOfYourTurns)
@@ -674,5 +718,15 @@ where
             zone_name(self.zone),
             self.grantable.display()
         )
+    }
+}
+
+fn describe_cast_condition(condition: &ThisSpellCostCondition) -> Option<String> {
+    match condition {
+        ThisSpellCostCondition::Always => None,
+        ThisSpellCostCondition::ConditionExpr { display, .. } => Some(display.clone()),
+        ThisSpellCostCondition::YourTurn => Some("it's your turn".to_string()),
+        ThisSpellCostCondition::NotYourTurn => Some("it isn't your turn".to_string()),
+        _ => Some("the condition is true".to_string()),
     }
 }

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -635,6 +635,8 @@ where
                 DerivedAlternativeCast::GraveyardCastFromCardManaCost {
                     additional_costs,
                     usage_limit,
+                    condition,
+                    exiles_after_resolution,
                 } => {
                     let mut mapped = Vec::with_capacity(additional_costs.len());
                     for cost in additional_costs {
@@ -643,6 +645,8 @@ where
                     DerivedAlternativeCast::GraveyardCastFromCardManaCost {
                         additional_costs: mapped,
                         usage_limit,
+                        condition,
+                        exiles_after_resolution,
                     }
                 }
             })

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -639,6 +639,10 @@ pub enum Condition {
     PlayerCommittedCrimeThisTurn {
         player: PlayerFilter,
     },
+    PlayerRolledResultThisTurn {
+        player: PlayerFilter,
+        result: u32,
+    },
     PlayerCompletedDungeon {
         player: PlayerFilter,
         dungeon_name: Option<String>,

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -344,12 +344,16 @@ fn convert_derived_alternative_cast(
         compiler::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
             additional_costs,
             usage_limit,
+            condition,
+            exiles_after_resolution,
         } => ironsmith::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
             additional_costs: additional_costs
                 .into_iter()
                 .map(runtime_cost_from_core_model)
                 .collect::<Result<Vec<_>, _>>()?,
             usage_limit,
+            condition,
+            exiles_after_resolution,
         },
     })
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1476,6 +1476,32 @@ fn test_parse_marang_river_prowler_graveyard_cast_condition() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_eelectrocute_roll_six_graveyard_cast_condition_and_exile_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Eelectrocute")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Eelectrocute deals 2 damage to any target.\nYou may cast this card from your graveyard as long as you've rolled a 6 this turn. If you cast it this way and it would be put into your graveyard, exile it instead.",
+        )
+        .expect("Eelectrocute should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+    assert!(
+        rendered.contains("Eelectrocute deals 2 damage to any target")
+            && rendered.contains("You may cast this card from your graveyard as long as you've rolled a 6 this turn")
+            && rendered.contains("If you cast it this way and it would be put into your graveyard, exile it instead")
+            && debug.contains("PlayerRolledResultThisTurn")
+            && debug.contains("exiles_after_resolution: true"),
+        "expected Eelectrocute parser/text output to preserve roll-six graveyard casting and exile-after-resolution semantics, got rendered={rendered}; debug={debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_max_speed_draw_replacement_static_ability() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Vnwxt Parse Test")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10523,6 +10523,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::PlayerCommittedCrimeThisTurn { player } => {
             format!("{} committed a crime this turn", describe_player_filter(player))
         }
+        Condition::PlayerRolledResultThisTurn { player, result } => {
+            format!("{} rolled a {result} this turn", describe_player_filter(player))
+        }
         Condition::PlayerCompletedDungeon {
             player,
             dungeon_name,

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1040,6 +1040,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::PlayerHasInitiative { .. } => {}
         Condition::PlayerHasCitysBlessing { .. } => {}
         Condition::PlayerCommittedCrimeThisTurn { .. } => {}
+        Condition::PlayerRolledResultThisTurn { .. } => {}
         Condition::PlayerCompletedDungeon { .. } => {}
         Condition::PlayerGraveyardHasCardsAtLeast { .. } => {}
     }
@@ -1318,6 +1319,14 @@ pub fn evaluate_condition_external(
             game.turn_store
                 .turn_history
                 .player_committed_crime_this_turn(player_id)
+        }
+        Condition::PlayerRolledResultThisTurn { player, result } => {
+            let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
+                return false;
+            };
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(player_id, *result)
         }
         Condition::PlayerCompletedDungeon {
             player,
@@ -2323,6 +2332,14 @@ fn evaluate_condition_simple(
                 .turn_history
                 .player_committed_crime_this_turn(player_id)
         }
+        Condition::PlayerRolledResultThisTurn { player, result } => {
+            let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
+                return false;
+            };
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(player_id, *result)
+        }
         Condition::PlayerCompletedDungeon {
             player,
             dungeon_name,
@@ -2971,6 +2988,13 @@ fn evaluate_condition(
                 .turn_store
                 .turn_history
                 .player_committed_crime_this_turn(player_id))
+        }
+        Condition::PlayerRolledResultThisTurn { player, result } => {
+            let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
+            Ok(game
+                .turn_store
+                .turn_history
+                .player_rolled_result_this_turn(player_id, *result))
         }
         Condition::PlayerCompletedDungeon {
             player,

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -1476,6 +1476,31 @@ pub(crate) fn can_cast_spell_with_context(
     };
     let spell_for_checks = cast_view.as_ref().unwrap_or(spell);
 
+    if let Some(method) = match casting_method {
+        CastingMethod::Alternative(idx) => spell.alternative_casts.get(*idx).cloned(),
+        CastingMethod::PlayFrom {
+            use_alternative: Some(idx),
+            zone,
+            ..
+        }
+        | CastingMethod::SplitOtherHalfPlayFrom {
+            use_alternative: idx,
+            zone,
+            ..
+        } => resolve_play_from_alternative_method(game, player, spell, *zone, *idx)
+            .or_else(|| spell.cast_alternative_method.clone()),
+        _ => spell.cast_alternative_method.clone(),
+    } && let Some(condition) = method.cast_condition()
+        && !crate::static_abilities::this_spell_cost_condition_is_active_for_cast(
+            game,
+            spell.id,
+            condition,
+            &[],
+        )
+    {
+        return false;
+    }
+
     let restrictions_started_at = PerfTimer::start();
     if violates_any_cant_cast_restriction(game, player, spell_for_checks) {
         ctx.add_restrictions_ms(restrictions_started_at.elapsed_ms());
@@ -1691,6 +1716,31 @@ pub(crate) fn can_cast_with_cost_with_context(
         None
     };
     let spell_for_checks = cast_view.as_ref().unwrap_or(spell);
+
+    if let Some(method) = match casting_method {
+        CastingMethod::Alternative(idx) => spell.alternative_casts.get(*idx).cloned(),
+        CastingMethod::PlayFrom {
+            use_alternative: Some(idx),
+            zone,
+            ..
+        }
+        | CastingMethod::SplitOtherHalfPlayFrom {
+            use_alternative: idx,
+            zone,
+            ..
+        } => resolve_play_from_alternative_method(game, player, spell, *zone, *idx)
+            .or_else(|| spell.cast_alternative_method.clone()),
+        _ => spell.cast_alternative_method.clone(),
+    } && let Some(condition) = method.cast_condition()
+        && !crate::static_abilities::this_spell_cost_condition_is_active_for_cast(
+            game,
+            spell_id,
+            condition,
+            &[],
+        )
+    {
+        return false;
+    }
 
     let restrictions_started_at = PerfTimer::start();
     if violates_any_cant_cast_restriction(game, player, spell_for_checks) {

--- a/crates/ironsmith-runtime/src/effects/player/roll_die.rs
+++ b/crates/ironsmith-runtime/src/effects/player/roll_die.rs
@@ -23,12 +23,15 @@ impl EffectExecutor for RollDieEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        let _player = resolve_player_filter(game, &self.player, ctx)?;
+        let player = resolve_player_filter(game, &self.player, ctx)?;
         if self.sides == 0 {
             return Ok(EffectOutcome::count(0));
         }
         if let Some(forced) = game.take_forced_die_roll() {
             let clamped = forced.clamp(1, self.sides);
+            game.turn_store
+                .turn_history
+                .record_die_roll(player, clamped);
             return Ok(
                 EffectOutcome::count(clamped as i32)
                     .with_execution_fact(ExecutionFact::ChosenNumber(clamped)),
@@ -37,10 +40,12 @@ impl EffectExecutor for RollDieEffect {
 
         let mut faces: Vec<u32> = (1..=self.sides).collect();
         game.shuffle_slice(&mut faces);
-        Ok(
-            EffectOutcome::count(faces[0] as i32)
-                .with_execution_fact(ExecutionFact::ChosenNumber(faces[0])),
-        )
+        let result = faces[0];
+        game.turn_store
+            .turn_history
+            .record_die_roll(player, result);
+        Ok(EffectOutcome::count(result as i32)
+            .with_execution_fact(ExecutionFact::ChosenNumber(result)))
     }
 }
 
@@ -97,6 +102,12 @@ mod tests {
         .expect("die roll should resolve");
 
         assert_eq!(outcome.as_count(), Some(6));
+        assert!(
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(alice, 6),
+            "die rolls should be available to this-turn roll conditions"
+        );
         assert_eq!(
             game.irreversible_random_count(),
             before,

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -1208,6 +1208,7 @@ pub(super) fn resolve_stack_entry_full(
                         *zone,
                         *idx,
                     )
+                    .or_else(|| obj.cast_alternative_method.clone())
                     .map(|m| m.exiles_after_resolution())
                     .unwrap_or(false)
                 }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -19564,6 +19564,204 @@ fn test_marang_river_prowler_castable_from_graveyard_with_green_permanent() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn eelectrocute_definition() -> crate::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_615), "Eelectrocute")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Eelectrocute deals 2 damage to any target.\nYou may cast this card from your graveyard as long as you've rolled a 6 this turn. If you cast it this way and it would be put into your graveyard, exile it instead.",
+        )
+        .expect("Eelectrocute should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_eelectrocute_not_castable_from_graveyard_without_rolled_six() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+    game.turn_store.turn_history.record_die_roll(alice, 5);
+
+    let eelectrocute = eelectrocute_definition();
+    let eelectrocute_id = game.create_object_from_definition(&eelectrocute, alice, Zone::Graveyard);
+
+    let actions = compute_legal_actions(&game, alice);
+    let graveyard_cast = actions.iter().find(|action| {
+        matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+            } if *spell_id == eelectrocute_id
+        )
+    });
+    assert!(
+        graveyard_cast.is_none(),
+        "Eelectrocute should not be castable from graveyard unless you rolled a 6 this turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_eelectrocute_cast_from_graveyard_after_rolled_six_exiles_after_resolution() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+    game.turn_store.turn_history.record_die_roll(alice, 6);
+
+    let eelectrocute = eelectrocute_definition();
+    let eelectrocute_id = game.create_object_from_definition(&eelectrocute, alice, Zone::Graveyard);
+
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Graveyard,
+                    casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+                } if *spell_id == eelectrocute_id
+            )
+        })
+        .expect("Eelectrocute should be castable from graveyard after rolling a 6");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+        &mut dm,
+    )
+    .expect("Eelectrocute graveyard cast should start");
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("choosing player target should complete Eelectrocute cast");
+
+    resolve_stack_entry(&mut game).expect("Eelectrocute should resolve");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        18,
+        "Eelectrocute should deal 2 damage to the chosen target"
+    );
+    assert!(
+        game.exile.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Eelectrocute")
+        }),
+        "Eelectrocute cast from the graveyard this way should be exiled after resolution"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_eelectrocute_normal_cast_goes_to_graveyard_not_exile() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+
+    let eelectrocute = eelectrocute_definition();
+    let eelectrocute_id = game.create_object_from_definition(&eelectrocute, alice, Zone::Hand);
+
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Hand,
+                    casting_method: CastingMethod::Normal,
+                } if *spell_id == eelectrocute_id
+            )
+        })
+        .expect("Eelectrocute should be normally castable from hand");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+        &mut dm,
+    )
+    .expect("Eelectrocute hand cast should start");
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("choosing player target should complete normal Eelectrocute cast");
+
+    resolve_stack_entry(&mut game).expect("Eelectrocute should resolve");
+
+    let player = game.player(alice).expect("Alice should exist");
+    assert!(
+        player.graveyard.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Eelectrocute")
+        }),
+        "normally cast Eelectrocute should go to graveyard"
+    );
+    assert!(
+        !game.exile.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Eelectrocute")
+        }),
+        "normally cast Eelectrocute should not be exiled"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_flashback_appears_in_legal_actions_from_graveyard() {
     use crate::cards::definitions::think_twice;

--- a/crates/ironsmith-runtime/src/grant.rs
+++ b/crates/ironsmith-runtime/src/grant.rs
@@ -158,7 +158,10 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
                 ))
             }
             Self::GraveyardCastFromCardManaCost {
-                additional_costs, ..
+                additional_costs,
+                usage_limit,
+                condition,
+                exiles_after_resolution,
             } => {
                 let mana_cost = card.mana_cost.clone()?;
                 if card.zone != Zone::Graveyard {
@@ -171,8 +174,14 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
                     "Cast from graveyard",
                     Zone::Graveyard,
                     TotalCost::from_costs(costs),
-                    Some(crate::static_abilities::ThisSpellCostCondition::YourTurn),
-                    false,
+                    condition.clone().or_else(|| {
+                        matches!(
+                            usage_limit,
+                            Some(crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns)
+                        )
+                        .then_some(crate::static_abilities::ThisSpellCostCondition::YourTurn)
+                    }),
+                    *exiles_after_resolution,
                 ))
             }
         }
@@ -182,8 +191,25 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::card::CardBuilder;
+    use crate::ids::{CardId, ObjectId, PlayerId};
+    use crate::mana::{ManaCost, ManaSymbol};
+    use crate::static_abilities::ThisSpellCostCondition;
     use crate::target::{ObjectFilter, PlayerFilter};
     use crate::types::CardType;
+
+    fn graveyard_card_object() -> Object {
+        let card = CardBuilder::new(CardId::from_raw(91_500), "Graveyard Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .card_types(vec![CardType::Instant])
+            .build();
+        Object::from_card(
+            ObjectId::from_raw(91_500),
+            &card,
+            PlayerId::from_index(0),
+            Zone::Graveyard,
+        )
+    }
 
     #[test]
     fn test_grantable_display() {
@@ -273,6 +299,40 @@ mod tests {
             "grant zone already scopes graveyard land permissions"
         );
         assert_eq!(spec.display(), "You may play lands from your graveyard");
+    }
+
+    #[test]
+    fn test_once_during_your_turn_graveyard_cast_keeps_turn_condition() {
+        let method = DerivedAlternativeCast::GraveyardCastFromCardManaCost {
+            additional_costs: Vec::new(),
+            usage_limit: Some(GrantUsageLimit::OnceDuringEachOfYourTurns),
+            condition: None,
+            exiles_after_resolution: false,
+        }
+        .materialize_for(&graveyard_card_object())
+        .expect("graveyard cast grant should produce an alternative method");
+
+        assert!(matches!(
+            method.cast_condition(),
+            Some(ThisSpellCostCondition::YourTurn)
+        ));
+        assert!(!method.exiles_after_resolution());
+    }
+
+    #[test]
+    fn test_explicit_graveyard_cast_condition_and_exile_are_preserved() {
+        let method = DerivedAlternativeCast::graveyard_cast_from_cards_mana_cost_with_condition(
+            ThisSpellCostCondition::NotYourTurn,
+            true,
+        )
+        .materialize_for(&graveyard_card_object())
+        .expect("conditional graveyard cast grant should produce an alternative method");
+
+        assert!(matches!(
+            method.cast_condition(),
+            Some(ThisSpellCostCondition::NotYourTurn)
+        ));
+        assert!(method.exiles_after_resolution());
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -41,6 +41,7 @@ pub struct TurnHistory {
     pub mana_spent_to_cast_spells_this_turn: HashMap<PlayerId, u32>,
     pub players_attacked_this_turn: HashSet<PlayerId>,
     pub players_tapped_land_for_mana_this_turn: HashSet<PlayerId>,
+    pub die_rolls_this_turn: HashMap<PlayerId, Vec<u32>>,
     pub creatures_attacked_this_turn: HashSet<ObjectId>,
     pub creature_attack_counts_this_turn: HashMap<ObjectId, u32>,
     pub crewed_this_turn: HashMap<ObjectId, Vec<ObjectId>>,
@@ -63,6 +64,7 @@ impl TurnHistory {
         self.mana_spent_to_cast_spells_this_turn.clear();
         self.players_attacked_this_turn.clear();
         self.players_tapped_land_for_mana_this_turn.clear();
+        self.die_rolls_this_turn.clear();
         self.creatures_attacked_this_turn.clear();
         self.creature_attack_counts_this_turn.clear();
         self.crewed_this_turn.clear();
@@ -664,6 +666,19 @@ impl TurnHistory {
                     event.player == player && event.action == KeywordActionKind::CommitCrime
                 })
         })
+    }
+
+    pub fn record_die_roll(&mut self, player: PlayerId, result: u32) {
+        self.die_rolls_this_turn
+            .entry(player)
+            .or_default()
+            .push(result);
+    }
+
+    pub fn player_rolled_result_this_turn(&self, player: PlayerId, result: u32) -> bool {
+        self.die_rolls_this_turn
+            .get(&player)
+            .is_some_and(|rolls| rolls.contains(&result))
     }
 
     pub fn player_sacrificed_artifact_this_turn(&self, player: PlayerId) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Eelectrocute
Initial parse error:
```
parser does not yet support line family: 'You may cast this card from your graveyard as long as you've rolled a 6 this turn. If you cast it this way and it would be put into your graveyard, exile it instead.'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast this card from your graveyard as long as you've rolled a 6 this turn. If you cast it this way and it would be put into your graveyard, exile it instead.'
```

Worker: i-002d6a193a382ce7e
