### PR TITLE
Fix Ironsmith parse failure: Blood Scrivener

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -105,7 +105,7 @@ use crate::color::{Color, ColorSet};
 #[allow(unused_imports)]
 use crate::cost::TotalCost;
 #[allow(unused_imports)]
-use crate::effect::{Effect, EventValueSpec, Value};
+use crate::effect::{Condition, Effect, EventValueSpec, Value};
 #[allow(unused_imports)]
 use crate::mana::{ManaCost, ManaSymbol};
 #[allow(unused_imports)]
@@ -612,6 +612,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_effect_discard_to_library_replacement_line),
         single_static_ability_ast_rule!(parse_draw_replace_exile_top_face_down_line),
         single_static_ability_ast_rule!(parse_draw_replacement_exile_top_and_play_line),
+        single_static_ability_ast_rule!(parse_conditional_draw_replacement_line),
         single_static_ability_ast_rule!(parse_draw_replacement_double_line),
         single_static_ability_ast_rule!(parse_keyword_action_replacement_line),
         single_static_ability_ast_rule!(parse_exile_to_exile_instead_of_graveyard_line),
@@ -8201,6 +8202,106 @@ pub(crate) fn parse_draw_replacement_double_line(
     }
 
     Ok(None)
+}
+
+fn parse_conditional_draw_replacement_amount(word: &str) -> Option<u32> {
+    word.parse::<u32>()
+        .ok()
+        .or_else(|| parse_named_number(word))
+}
+
+pub(crate) fn parse_conditional_draw_replacement_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = parser_token_word_refs(tokens);
+    let draw_subject_len = if slice_starts_with(
+        &words,
+        &["if", "you", "would", "draw", "a", "card", "while"],
+    ) {
+        7
+    } else if slice_starts_with(
+        &words,
+        &["if", "you", "would", "draw", "card", "while"],
+    ) {
+        6
+    } else {
+        return Ok(None);
+    };
+
+    let Some(instead_idx) = find_index(&words[draw_subject_len..], |word| *word == "instead")
+    else {
+        return Ok(None);
+    };
+    let instead_idx = draw_subject_len + instead_idx;
+    if words[draw_subject_len..instead_idx] != ["you", "have", "no", "cards", "in", "hand"] {
+        return Ok(None);
+    }
+
+    let effect_words = &words[instead_idx + 1..];
+    let draw_idx = if effect_words.first().copied() == Some("you") {
+        1
+    } else {
+        0
+    };
+    if effect_words.get(draw_idx).copied() != Some("draw") {
+        return Ok(None);
+    }
+    let Some(draw_count_word) = effect_words.get(draw_idx + 1).copied() else {
+        return Ok(None);
+    };
+    let Some(draw_count) = parse_conditional_draw_replacement_amount(draw_count_word) else {
+        return Ok(None);
+    };
+    if !matches!(effect_words.get(draw_idx + 2).copied(), Some("card" | "cards")) {
+        return Ok(None);
+    }
+
+    let mut next_idx = draw_idx + 3;
+    if effect_words.get(next_idx).copied() == Some("instead") {
+        next_idx += 1;
+    }
+
+    let mut replacement_effects = vec![Effect::draw(draw_count as i32)];
+    let mut life_loss = None;
+    if next_idx < effect_words.len() {
+        let tail = &effect_words[next_idx..];
+        if tail.len() != 5
+            || tail[0] != "and"
+            || tail[1] != "you"
+            || tail[2] != "lose"
+            || tail[4] != "life"
+        {
+            return Ok(None);
+        }
+        let Some(amount) = parse_conditional_draw_replacement_amount(tail[3]) else {
+            return Ok(None);
+        };
+        life_loss = Some(amount);
+        replacement_effects.push(Effect::lose_life(amount as i32));
+    }
+
+    let draw_amount_text = match draw_count {
+        1 => "a".to_string(),
+        2 => "two".to_string(),
+        3 => "three".to_string(),
+        4 => "four".to_string(),
+        5 => "five".to_string(),
+        _ => draw_count.to_string(),
+    };
+    let draw_card_text = if draw_count == 1 { "card" } else { "cards" };
+    let mut display = format!(
+        "If you would draw a card while you have no cards in hand, instead you draw {draw_amount_text} {draw_card_text}"
+    );
+    if let Some(amount) = life_loss {
+        display.push_str(&format!(" and you lose {amount} life"));
+    }
+    display.push('.');
+
+    Ok(Some(StaticAbility::conditional_draw_replacement(
+        Condition::Not(Box::new(Condition::CardsInHandOrMore(1))),
+        replacement_effects,
+        display,
+    )))
 }
 
 fn keyword_action_replacement_subject_explores(words: &[&str]) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1075,6 +1075,23 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         }
     }
 
+    if let Some(while_idx) = find_index(&filtered, |word| *word == "while")
+        && while_idx > 0
+        && while_idx + 1 < filtered.len()
+    {
+        let left_tokens = filtered[..while_idx]
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        let right_tokens = filtered[while_idx + 1..]
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        let left = parse_predicate(&left_tokens)?;
+        let right = parse_predicate(&right_tokens)?;
+        return Ok(PredicateAst::And(Box::new(left), Box::new(right)));
+    }
+
     if filtered.as_slice() == ["this", "tapped"]
         || filtered.as_slice() == ["thiss", "tapped"]
         || ((filtered.first().copied() == Some("this")
@@ -3694,6 +3711,29 @@ mod tests {
             PredicateAst::PlayerWouldDrawCard {
                 player: PlayerAst::You
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_would_draw_while_no_cards_in_hand() -> Result<(), CardTextError> {
+        let tokens = lex_line("If you would draw a card while you have no cards in hand", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::And(
+                Box::new(PredicateAst::PlayerWouldDrawCard {
+                    player: PlayerAst::You,
+                }),
+                Box::new(PredicateAst::YouHaveNoCardsInHand),
+            )
         );
         Ok(())
     }

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -213,6 +213,7 @@ pub enum StaticAbilityId {
     DrawReplacementExileTopFaceDown,
     DrawReplacementExileTopAndPlay,
     DrawReplacementDouble,
+    ConditionalDrawReplacement,
     KeywordActionReplacement,
     ExileToCounteredExileInsteadOfGraveyard,
     ExileToExileInsteadOfGraveyard,
@@ -454,6 +455,7 @@ impl StaticAbilityId {
             | DrawReplacementExileTopFaceDown
             | DrawReplacementExileTopAndPlay
             | DrawReplacementDouble
+            | ConditionalDrawReplacement
             | KeywordActionReplacement
             | ExileToCounteredExileInsteadOfGraveyard
             | ExileToExileInsteadOfGraveyard

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -407,6 +407,11 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         replacement_effects: Vec<E>,
         display: String,
     },
+    ConditionalDrawReplacement {
+        condition: Condition,
+        replacement_effects: Vec<E>,
+        display: String,
+    },
     CharacteristicDefiningPt {
         power: Value,
         toughness: Value,
@@ -1235,6 +1240,18 @@ where
             } => StaticAbilityPayload::KeywordActionReplacement {
                 action,
                 source_filter,
+                replacement_effects: replacement_effects
+                    .into_iter()
+                    .map(map_effect)
+                    .collect::<Result<Vec<_>, _>>()?,
+                display,
+            },
+            StaticAbilityPayload::ConditionalDrawReplacement {
+                condition,
+                replacement_effects,
+                display,
+            } => StaticAbilityPayload::ConditionalDrawReplacement {
+                condition,
                 replacement_effects: replacement_effects
                     .into_iter()
                     .map(map_effect)
@@ -3206,6 +3223,23 @@ impl<
             id: Some(StaticAbilityId::DrawReplacementDouble),
             label: "draw replacement double".into(),
             payload: StaticAbilityPayload::None,
+        }
+    }
+
+    pub fn conditional_draw_replacement(
+        condition: Condition,
+        replacement_effects: Vec<E>,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::ConditionalDrawReplacement),
+            label: display.clone(),
+            payload: StaticAbilityPayload::ConditionalDrawReplacement {
+                condition,
+                replacement_effects,
+                display,
+            },
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7,9 +7,9 @@ use crate::compiled_text::{
 };
 use crate::effects::{
     AddManaEffect, ChooseModeEffect, ChooseObjectsEffect, ConsultTopOfLibraryEffect,
-    CreateTokenEffect, DestroyEffect, EffectExecutor, GainLifeEffect, MoveToZoneEffect,
-    ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect, TaggedEffect, TargetOnlyEffect,
-    UntapEffect,
+    CreateTokenEffect, DestroyEffect, DrawCardsEffect, EffectExecutor, GainLifeEffect,
+    MoveToZoneEffect, ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect, TaggedEffect,
+    TargetOnlyEffect, UntapEffect,
 };
 use crate::object::AuraAttachmentFilter;
 use crate::static_abilities::StaticAbilityId;
@@ -1491,6 +1491,101 @@ fn test_parse_max_speed_draw_replacement_static_ability() {
             && rendered.contains("max speed"),
         "expected max-speed draw replacement static ability, got {rendered}"
     );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_blood_scrivener_strictly_parses_conditional_draw_replacement() {
+    assert_oracle_card_parses_strict("Blood Scrivener");
+    let def = parse_oracle_card_definition("Blood Scrivener");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::ConditionalDrawReplacement
+        )),
+        "Blood Scrivener should compile to a conditional draw replacement static ability, got {def:#?}"
+    );
+    assert!(
+        def.spell_effect.is_none(),
+        "Blood Scrivener's replacement text should not lower as a spell effect"
+    );
+    assert!(
+        rendered.contains("If you would draw a card while you have no cards in hand")
+            && rendered.contains("instead draw two cards and you lose 1 life"),
+        "expected Blood Scrivener conditional draw-replacement text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_blood_scrivener_library_cards(
+    game: &mut crate::game_state::GameState,
+    player: PlayerId,
+    count: u32,
+) {
+    for index in 0..count {
+        game.create_object_from_card(
+            &crate::card::CardBuilder::new(
+                CardId::from_raw(20_000 + index),
+                &format!("Blood Scrivener Library Card {index}"),
+            )
+            .card_types(vec![CardType::Creature])
+            .build(),
+            player,
+            Zone::Library,
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn blood_scrivener_replaces_draw_when_controller_has_no_cards_in_hand() {
+    let def = parse_oracle_card_definition("Blood Scrivener");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let blood_scrivener = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    add_blood_scrivener_library_cards(&mut game, alice, 3);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(blood_scrivener, alice, &mut dm);
+    let result = DrawCardsEffect::you(1)
+        .execute(&mut game, &mut ctx)
+        .expect("Blood Scrivener replacement draw should resolve");
+
+    assert_eq!(result.value, crate::effect::OutcomeValue::Count(2));
+    assert_eq!(game.player(alice).unwrap().hand.len(), 2);
+    assert_eq!(game.player(alice).unwrap().library.len(), 1);
+    assert_eq!(game.life_total(alice), 19);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn blood_scrivener_does_not_replace_draw_when_controller_has_cards_in_hand() {
+    let def = parse_oracle_card_definition("Blood Scrivener");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let blood_scrivener = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(20_100), "Blood Scrivener Hand Card")
+            .card_types(vec![CardType::Creature])
+            .build(),
+        alice,
+        Zone::Hand,
+    );
+    add_blood_scrivener_library_cards(&mut game, alice, 2);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(blood_scrivener, alice, &mut dm);
+    let result = DrawCardsEffect::you(1)
+        .execute(&mut game, &mut ctx)
+        .expect("normal draw should resolve");
+
+    assert_eq!(result.value, crate::effect::OutcomeValue::Count(1));
+    assert_eq!(game.player(alice).unwrap().hand.len(), 2);
+    assert_eq!(game.player(alice).unwrap().library.len(), 1);
+    assert_eq!(game.life_total(alice), 20);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/effects/cards/draw_cards.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/draw_cards.rs
@@ -23,6 +23,7 @@ fn execute_draw_replacement_effects(
     ctx: &mut ExecutionContext,
     effects: Vec<Effect>,
     effect_id: crate::replacement::ReplacementEffectId,
+    replaced_player: PlayerId,
 ) -> Result<EffectOutcome, ExecutionError> {
     let replacement_effect = game
         .effect_store
@@ -79,7 +80,17 @@ fn execute_draw_replacement_effects(
             .remove(&key);
     }
 
-    execution_result
+    execution_result.map(|mut outcome| {
+        let drawn_count = outcome
+            .events
+            .iter()
+            .filter_map(|event| event.downcast::<CardsDrawnEvent>())
+            .filter(|event| event.player == replaced_player)
+            .map(|event| event.amount() as i32)
+            .sum();
+        outcome.value = crate::effect::OutcomeValue::Count(drawn_count);
+        outcome
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -310,7 +321,7 @@ impl EffectExecutor for DrawCardsEffect {
                 TraitEventResult::Prevented => continue,
                 TraitEventResult::Replaced { effects, effect_id } => {
                     let replacement_outcome =
-                        execute_draw_replacement_effects(game, ctx, effects, effect_id)?;
+                        execute_draw_replacement_effects(game, ctx, effects, effect_id, player_id)?;
                     replacement_count += replacement_outcome.count_or_zero();
                     events.extend(replacement_outcome.events);
                     continue;

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3793,6 +3793,89 @@ impl StaticAbilityKind for DrawReplacementDouble {
     }
 }
 
+/// "If you would draw a card while [condition], [effects] instead."
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConditionalDrawReplacement {
+    pub condition: Condition,
+    pub replacement_effects: Vec<Effect>,
+    pub display: String,
+}
+
+impl ConditionalDrawReplacement {
+    pub fn new(
+        condition: Condition,
+        replacement_effects: Vec<Effect>,
+        display: impl Into<String>,
+    ) -> Self {
+        Self {
+            condition,
+            replacement_effects,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for ConditionalDrawReplacement {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::ConditionalDrawReplacement
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            ConditionalWouldDrawCardMatcher {
+                condition: self.condition.clone(),
+                display: self.display.clone(),
+            },
+            ReplacementAction::Instead(self.replacement_effects.clone()),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ConditionalWouldDrawCardMatcher {
+    condition: Condition,
+    display: String,
+}
+
+impl ReplacementMatcher for ConditionalWouldDrawCardMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        if !WouldDrawCardMatcher::you().matches_event(event, ctx) {
+            return false;
+        }
+
+        let Some(source) = ctx.source else {
+            return false;
+        };
+        let eval_ctx = crate::condition_eval::ExternalEvaluationContext {
+            controller: ctx.controller,
+            source,
+            defending_player: None,
+            attacking_player: None,
+            filter_source: None,
+            triggering_event: None,
+            trigger_identity: None,
+            ability_index: None,
+            options: Default::default(),
+        };
+
+        crate::condition_eval::evaluate_condition_external(ctx.game, &self.condition, &eval_ctx)
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+}
+
 /// "If you would draw a card, exile the top N cards of your library instead. You may play those
 /// cards this turn."
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2703,6 +2703,18 @@ impl StaticAbility {
         Self::new(DrawReplacementDouble)
     }
 
+    pub fn conditional_draw_replacement(
+        condition: crate::effect::Condition,
+        replacement_effects: Vec<crate::effect::Effect>,
+        display: impl Into<String>,
+    ) -> Self {
+        Self::new(ConditionalDrawReplacement::new(
+            condition,
+            replacement_effects,
+            display,
+        ))
+    }
+
     pub fn draw_replacement_exile_top_and_play(count: u32) -> Self {
         Self::new(DrawReplacementExileTopAndPlay::new(count))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1285,6 +1285,15 @@ impl StaticAbilityModelInterpreter {
                 replacement_effects.clone(),
                 display.clone(),
             ),
+            ironsmith_core::StaticAbilityPayload::ConditionalDrawReplacement {
+                condition,
+                replacement_effects,
+                display,
+            } => StaticAbility::conditional_draw_replacement(
+                condition.clone(),
+                replacement_effects.clone(),
+                display.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::CharacteristicDefiningPt {
                 power,
                 toughness,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Blood Scrivener
Initial parse error:
```
unsupported predicate (predicate: 'you would draw card while you have no cards in hand'); oracle-only fallback also failed: unsupported predicate (predicate: 'you would draw card while you have no cards in hand')
```

Worker: i-0cfdef373125fd9b8
