### PR TITLE
Fix Ironsmith parse failure: Locke, Treasure Hunter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -42,6 +42,7 @@ pub(crate) enum PermissionClauseSpec {
         player: PlayerAst,
         allow_land: bool,
         as_copy: bool,
+        single_spell: bool,
         without_paying_mana_cost: bool,
         lifetime: PermissionLifetime,
     },
@@ -62,6 +63,7 @@ struct PermissionLead {
 struct TaggedPermissionTarget {
     tag: TagKey,
     as_copy: bool,
+    single_spell: bool,
 }
 
 fn parse_permission_lead_inner<'a>(
@@ -101,92 +103,121 @@ fn parse_tagged_cast_or_play_target_inner<'a>(
 ) -> Result<TaggedPermissionTarget, ErrMode<ContextError>> {
     alt((
         alt((
-            grammar::phrase(&["spells", "from", "among", "those", "cards"]).value(
-                TaggedPermissionTarget {
-                    tag: TagKey::from(IT_TAG),
-                    as_copy: false,
-                },
-            ),
+            alt((
+                grammar::phrase(&["spells", "from", "among", "those", "cards"]).value(
+                    TaggedPermissionTarget {
+                        tag: TagKey::from(IT_TAG),
+                        as_copy: false,
+                        single_spell: false,
+                    },
+                ),
+                grammar::phrase(&["a", "spell", "from", "among", "those", "cards"]).value(
+                    TaggedPermissionTarget {
+                        tag: TagKey::from(IT_TAG),
+                        as_copy: false,
+                        single_spell: true,
+                    },
+                ),
+            )),
             grammar::phrase(&["spells", "from", "among", "them"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["one", "of", "those", "cards"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["one", "of", "those", "card"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["one", "of", "them"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["it"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["them"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["that", "card"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["those", "cards"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
         )),
         alt((
             grammar::phrase(&["that", "spell"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             grammar::phrase(&["those", "spells"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
+                single_spell: false,
             }),
             alt((
                 grammar::phrase(&["that", "exiled", "card"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(IT_TAG),
                     as_copy: false,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["the", "exiled", "card"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
                     as_copy: false,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["that", "revealed", "card"]).value(TaggedPermissionTarget {
                     tag: TagKey::from("__last_revealed__"),
                     as_copy: false,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["the", "revealed", "card"]).value(TaggedPermissionTarget {
                     tag: TagKey::from("__last_revealed__"),
                     as_copy: false,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["the", "card"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(IT_TAG),
                     as_copy: false,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["the", "cards"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(IT_TAG),
                     as_copy: false,
+                    single_spell: false,
                 }),
             )),
             alt((
                 grammar::phrase(&["the", "copy"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(IT_TAG),
                     as_copy: true,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["that", "copy"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(IT_TAG),
                     as_copy: true,
+                    single_spell: false,
                 }),
                 grammar::phrase(&["a", "copy"]).value(TaggedPermissionTarget {
                     tag: TagKey::from(IT_TAG),
                     as_copy: true,
+                    single_spell: false,
                 }),
             )),
         )),
@@ -836,6 +867,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
             player,
             allow_land,
             as_copy: target_ref.as_copy,
+            single_spell: target_ref.single_spell,
             without_paying_mana_cost,
             lifetime,
         }));
@@ -1173,6 +1205,7 @@ pub(crate) fn parse_until_end_of_turn_may_play_tagged_clause(
             player,
             allow_land,
             as_copy: false,
+            single_spell,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::UntilEndOfTurn,
         }) if player == PlayerAst::You => Ok(Some(
@@ -1182,6 +1215,7 @@ pub(crate) fn parse_until_end_of_turn_may_play_tagged_clause(
                 allow_land,
                 without_paying_mana_cost,
                 false,
+                single_spell,
             ),
         )),
         _ => Ok(None),
@@ -1197,6 +1231,7 @@ pub(crate) fn parse_until_your_next_turn_may_play_tagged_clause(
             player,
             allow_land: true,
             as_copy: false,
+            single_spell: _,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::UntilYourNextTurn,
         }) if matches!(player, PlayerAst::You | PlayerAst::Implicit) => Ok(Some(
@@ -1542,6 +1577,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
                                         lead.allow_land,
                                         without_paying_mana_cost,
                                         allow_any_color_for_cast,
+                                        target_ref.single_spell,
                                     )
                                 };
                                 EffectAst::Conditional {
@@ -1570,6 +1606,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             player,
             allow_land,
             as_copy,
+            single_spell: _,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::Immediate,
         }) => {
@@ -1595,6 +1632,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             player,
             allow_land,
             as_copy: false,
+            single_spell,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::ThisTurn | PermissionLifetime::UntilEndOfTurn,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
@@ -1604,6 +1642,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                single_spell,
             ),
         )),
         Some(PermissionClauseSpec::Tagged {
@@ -1611,6 +1650,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             player,
             allow_land,
             as_copy: false,
+            single_spell: _,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::UntilYourNextTurn,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
@@ -1659,6 +1699,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             player,
             allow_land,
             as_copy: false,
+            single_spell: _,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::ForAsLongAsExiled,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
@@ -1674,6 +1715,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             player,
             allow_land,
             as_copy: false,
+            single_spell: _,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::ForAsLongAsYouControlSource,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -4604,6 +4604,7 @@ mod parse_compile_tests {
                 false,
                 false,
                 false,
+                false,
             ),
         ];
 
@@ -4642,6 +4643,7 @@ mod parse_compile_tests {
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 TagKey::from(IT_TAG),
                 PlayerAst::You,
+                false,
                 false,
                 false,
                 false,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1794,6 +1794,7 @@ fn compile_subject_verb_effect(
             allow_land,
             without_paying_mana_cost,
             allow_any_color_for_cast,
+            single_spell,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -1812,13 +1813,15 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            let mut effects = vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+            let grant = crate::effects::GrantPlayTaggedEffect::new(
                 resolved_tag.clone(),
                 player_filter.clone(),
                 crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn,
                 *allow_land,
                 *allow_any_color_for_cast,
-            ))];
+            )
+            .with_single_spell(*single_spell);
+            let mut effects = vec![Effect::new(grant)];
             if *without_paying_mana_cost {
                 effects.push(Effect::new(
                     crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect::new(

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1013,6 +1013,7 @@ pub(crate) enum SubjectVerbActionAst {
         allow_land: bool,
         without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
+        single_spell: bool,
     },
     GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn {
         tag: TagKey,
@@ -2160,6 +2161,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                single_spell,
             } => f
                 .debug_struct("GrantPlayTaggedUntilEndOfTurn")
                 .field("tag", tag)
@@ -2167,6 +2169,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("allow_land", allow_land)
                 .field("without_paying_mana_cost", without_paying_mana_cost)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .field("single_spell", single_spell)
                 .finish(),
             Self::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn {
                 tag,
@@ -3588,6 +3591,7 @@ impl EffectAst {
         allow_land: bool,
         without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
+        single_spell: bool,
     ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
@@ -3598,6 +3602,7 @@ impl EffectAst {
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                single_spell,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -3178,6 +3178,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false,
             ),
         ];
 
@@ -3206,6 +3207,7 @@ mod tests {
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 TagKey::from(IT_TAG),
                 PlayerAst::You,
+                false,
                 false,
                 false,
                 false,
@@ -3271,6 +3273,7 @@ mod tests {
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 TagKey::from(IT_TAG),
                 PlayerAst::You,
+                false,
                 false,
                 false,
                 false,
@@ -3412,6 +3415,7 @@ mod tests {
                     false,
                     false,
                     false,
+                    false,
                 ),
             ],
             if_false: vec![
@@ -3422,6 +3426,7 @@ mod tests {
                 EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                     TagKey::from(IT_TAG),
                     PlayerAst::You,
+                    false,
                     false,
                     false,
                     false,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -108,6 +108,7 @@ fn parse_exile_top_library_then_play_bundle(
                     allow_land,
                     without_paying_mana_cost,
                     allow_any_color_for_cast,
+                    single_spell,
                     ..
                 },
             ..
@@ -115,9 +116,10 @@ fn parse_exile_top_library_then_play_bundle(
             tag,
             player,
             allow_land,
-            without_paying_mana_cost,
-            allow_any_color_for_cast,
-        ),
+                    without_paying_mana_cost,
+                    allow_any_color_for_cast,
+                    single_spell,
+                ),
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
             action:
                 SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
@@ -926,6 +926,7 @@ pub(crate) fn consult_cast_effects(
                         clause.allow_land,
                         without_paying_mana_cost,
                         false,
+                        false,
                     )
                 };
                 vec![grant]
@@ -949,7 +950,7 @@ pub(crate) fn consult_cast_effects(
                 ));
             }
             vec![
-                EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(match_tag.clone(), clause.caster, false, false, false),
+                EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(match_tag.clone(), clause.caster, false, false, false, false),
                 EffectAst::subject_verb_grant_tagged_spell_alternative_cost_pay_life_by_mana_value_until_end_of_turn(match_tag.clone(), clause.caster),
             ]
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -1842,6 +1842,7 @@ pub(crate) fn parse_look_at_top_split_hand_bottom_exile_then_play_exiled(
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                single_spell,
                 ..
             },
         ..
@@ -1919,10 +1920,11 @@ pub(crate) fn parse_look_at_top_split_hand_bottom_exile_then_play_exiled(
     effects.push(EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
         exiled_tag,
         permission_player,
-        allow_land,
-        without_paying_mana_cost,
-        allow_any_color_for_cast,
-    ));
+                allow_land,
+                without_paying_mana_cost,
+                allow_any_color_for_cast,
+                single_spell,
+            ));
 
     Ok(Some(effects))
 }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3423,6 +3423,7 @@ pub struct GrantPlayTaggedEffect {
     pub duration: GrantPlayTaggedDuration,
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
+    pub single_spell: bool,
 }
 
 impl GrantPlayTaggedEffect {
@@ -3439,7 +3440,13 @@ impl GrantPlayTaggedEffect {
             duration,
             allow_land,
             allow_any_color_for_cast,
+            single_spell: false,
         }
+    }
+
+    pub fn with_single_spell(mut self, single_spell: bool) -> Self {
+        self.single_spell = single_spell;
+        self
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42975,6 +42975,246 @@ fn parse_etali_attack_exiles_each_players_top_card_and_casts_any_number() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn locke_treasure_hunter_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(475), "Locke, Treasure Hunter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Rogue])
+        .power_toughness(PowerToughness::fixed(2, 3))
+        .parse_text(
+            "Locke can't be blocked by creatures with greater power.\n\
+             Mug — Whenever Locke attacks, each player mills a card. If a land card was milled this way, create a Treasure token. Until end of turn, you may cast a spell from among those cards.",
+        )
+        .expect("Locke, Treasure Hunter should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn locke_treasure_hunter_trigger(
+    def: &CardDefinition,
+) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Locke, Treasure Hunter should have a Mug attack trigger")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn count_treasures_controlled_by(
+    game: &crate::game_state::GameState,
+    player: PlayerId,
+) -> usize {
+    game.objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| {
+            game.controller_of(object) == player && object.has_subtype(Subtype::Treasure)
+        })
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn graveyard_object_named(
+    game: &crate::game_state::GameState,
+    player: PlayerId,
+    name: &str,
+) -> ObjectId {
+    game.player(player)
+        .expect("player should exist")
+        .graveyard
+        .iter()
+        .copied()
+        .find(|id| game.object(*id).is_some_and(|object| object.name == name))
+        .unwrap_or_else(|| panic!("expected {name} in player's graveyard"))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_locke_treasure_hunter_strict_and_renders_mug_mill_permission() {
+    let def = locke_treasure_hunter_definition();
+    let trigger = locke_treasure_hunter_trigger(&def);
+    let trigger_debug = format!("{:?}", trigger.trigger);
+    assert!(
+        trigger_debug.contains("ThisAttacks"),
+        "Locke, Treasure Hunter should trigger when Locke attacks, got {trigger_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Mug — Whenever this creature attacks"),
+        "expected Locke's Mug label and attack trigger in compiled text, got {rendered}"
+    );
+    let effects_debug = format!("{:?}", trigger.effects);
+    assert!(
+        effects_debug.contains("single_spell: true"),
+        "Locke's singular cast permission should be retained for runtime enforcement, got {effects_debug}"
+    );
+    assert!(
+        rendered.contains("each player mills a card")
+            && rendered.contains("If a land card was milled this way, create a Treasure token")
+            && rendered.contains("Until end of turn, you may cast a spell from among those cards"),
+        "expected Locke's mill, land branch, and temporary cast permission, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn locke_treasure_hunter_mug_mills_players_creates_treasure_and_grants_cast_permission() {
+    let def = locke_treasure_hunter_definition();
+    let trigger = locke_treasure_hunter_trigger(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let alice_land = crate::card::CardBuilder::new(CardId::from_raw(90_001), "Alice Mountain")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Mountain])
+        .build();
+    let bob_spell = crate::card::CardBuilder::new(CardId::from_raw(90_002), "Bob Shock")
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&alice_land, alice, Zone::Library);
+    game.create_object_from_card(&bob_spell, bob, Zone::Library);
+
+    let attack_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::new(
+            source,
+            crate::triggers::AttackEventTarget::Player(bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_triggering_event(attack_event);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &trigger.effects,
+        None,
+        &[],
+    )
+    .expect("Locke, Treasure Hunter Mug trigger should resolve");
+
+    let alice_land_id = graveyard_object_named(&game, alice, "Alice Mountain");
+    let bob_spell_id = graveyard_object_named(&game, bob, "Bob Shock");
+    assert_eq!(
+        count_treasures_controlled_by(&game, alice),
+        1,
+        "milling a land card this way should create one Treasure"
+    );
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            bob_spell_id,
+            Zone::Graveyard,
+            alice,
+        ),
+        "Locke should let Alice cast a milled spell card from among those cards this turn"
+    );
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            alice_land_id,
+            Zone::Graveyard,
+            alice,
+        ),
+        "Locke's cast-only permission should not grant land play permission"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn locke_treasure_hunter_mug_without_milled_land_does_not_create_treasure() {
+    let def = locke_treasure_hunter_definition();
+    let trigger = locke_treasure_hunter_trigger(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let alice_spell = crate::card::CardBuilder::new(CardId::from_raw(90_003), "Alice Opt")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let bob_spell = crate::card::CardBuilder::new(CardId::from_raw(90_004), "Bob Strike")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    game.create_object_from_card(&alice_spell, alice, Zone::Library);
+    game.create_object_from_card(&bob_spell, bob, Zone::Library);
+
+    let attack_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::new(
+            source,
+            crate::triggers::AttackEventTarget::Player(bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_triggering_event(attack_event);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &trigger.effects,
+        None,
+        &[],
+    )
+    .expect("Locke, Treasure Hunter Mug trigger should resolve without a milled land");
+
+    let alice_spell_id = graveyard_object_named(&game, alice, "Alice Opt");
+    let bob_spell_id = graveyard_object_named(&game, bob, "Bob Strike");
+    assert_eq!(
+        count_treasures_controlled_by(&game, alice),
+        0,
+        "Locke should not create a Treasure when no land card was milled this way"
+    );
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            alice_spell_id,
+            Zone::Graveyard,
+            alice,
+        ) && game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            bob_spell_id,
+            Zone::Graveyard,
+            alice,
+        ),
+        "Locke should still grant temporary cast permission for spell cards milled this way"
+    );
+    let alice_spell_stable_id = game
+        .object(alice_spell_id)
+        .expect("Alice Opt should still be in the graveyard")
+        .stable_id;
+    game.effect_store
+        .grant_registry
+        .consume_one_shot_play_from_grant(source, alice_spell_stable_id);
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            bob_spell_id,
+            Zone::Graveyard,
+            alice,
+        ),
+        "after Alice casts one spell from Locke's milled cards, the remaining milled spell should no longer be castable"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_day_of_black_sun_destroy_those_creatures_reuses_ability_loss_filter() {
     let def = parse_oracle_card_definition("Day of Black Sun");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10780,6 +10780,67 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::TaggedObjectMatches(tag, filter) => {
             let desc = filter.description();
+            if tag.as_str().starts_with("milled_")
+                && filter.zone.is_none()
+                && filter.controller.is_none()
+                && filter.owner.is_none()
+                && filter.card_types.len() == 1
+                && filter.all_card_types.is_empty()
+                && filter.excluded_card_types.is_empty()
+                && filter.subtypes.is_empty()
+                && filter.excluded_subtypes.is_empty()
+                && filter.supertypes.is_empty()
+                && filter.excluded_supertypes.is_empty()
+                && filter.colors.is_none()
+                && filter.excluded_colors.is_empty()
+                && !filter.colorless
+                && !filter.multicolored
+                && !filter.monocolored
+                && filter.all_colors.is_none()
+                && filter.exactly_two_colors.is_none()
+                && !filter.historic
+                && !filter.nonhistoric
+                && !filter.token
+                && !filter.nontoken
+                && filter.face_down.is_none()
+                && !filter.other
+                && !filter.tapped
+                && !filter.untapped
+                && !filter.attacking
+                && !filter.nonattacking
+                && !filter.blocking
+                && !filter.nonblocking
+                && !filter.blocked
+                && !filter.unblocked
+                && !filter.entered_since_your_last_turn_ended
+                && filter.power.is_none()
+                && filter.toughness.is_none()
+                && filter.mana_value.is_none()
+                && filter.mana_value_eq_counters_on_source.is_none()
+                && !filter.has_mana_cost
+                && !filter.has_tap_activated_ability
+                && !filter.no_abilities
+                && !filter.no_x_in_cost
+                && !filter.has_x_in_cost
+                && filter.with_counter.is_none()
+                && filter.without_counter.is_none()
+                && filter.name.is_none()
+                && filter.excluded_name.is_none()
+                && filter.alternative_cast.is_none()
+                && filter.static_abilities.is_empty()
+                && filter.excluded_static_abilities.is_empty()
+                && filter.ability_markers.is_empty()
+                && filter.excluded_ability_markers.is_empty()
+                && !filter.is_commander
+                && !filter.noncommander
+                && filter.tagged_constraints.is_empty()
+                && filter.specific.is_none()
+                && filter.any_of.is_empty()
+                && !filter.source
+            {
+                let card_type = describe_card_type_word_local(filter.card_types[0]);
+                return format!("a {card_type} card was milled this way");
+            }
             if crate::cards::is_sentence_helper_tag(tag.as_str(), "exiled")
                 && filter.zone == Some(Zone::Exile)
             {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12186,7 +12186,10 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         }
         let mut rendered = describe_effect(filtered[idx]);
         if !rendered.is_empty() {
-            if !parts.is_empty() && rendered.starts_with("If ") {
+            if !parts.is_empty()
+                && rendered.starts_with("If ")
+                && !rendered.contains("milled this way")
+            {
                 rendered = format!("Then {}", lowercase_first(&rendered));
                 if let Some(comma_idx) = rendered.find(", ") {
                     let tail = lowercase_first(&rendered[comma_idx + 2..]);
@@ -30735,7 +30738,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else {
             "cast"
         };
-        let helper_tag = grant_play_tagged.tag.as_str().starts_with("targeted_")
+        let tag_text = grant_play_tagged.tag.as_str();
+        let helper_tag = tag_text.starts_with("targeted_")
+            || tag_text.starts_with("milled_")
             || grant_play_tagged.tag.as_str().starts_with("__source_")
             || grant_play_tagged.tag.as_str() == "__it__"
             || matches!(
@@ -30747,7 +30752,15 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "chosen")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "searched");
-        let object_text = if grant_play_tagged.tag.as_str().starts_with("targeted_")
+        let object_text = if tag_text.starts_with("milled_") {
+            if grant_play_tagged.single_spell && !grant_play_tagged.allow_land {
+                "a spell from among those cards".to_string()
+            } else if grant_play_tagged.allow_land {
+                "cards from among those cards".to_string()
+            } else {
+                "spells from among those cards".to_string()
+            }
+        } else if grant_play_tagged.tag.as_str().starts_with("targeted_")
             || grant_play_tagged.tag.as_str().starts_with("__source_")
             || grant_play_tagged.tag.as_str() == "__it__"
             || matches!(
@@ -30792,6 +30805,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             };
             return format!(
                 "{} may {verb} {object_text} {timing}, and you may spend mana as though it were mana of any color to cast {pronoun}",
+                describe_player_filter(&grant_play_tagged.player),
+            );
+        }
+        if tag_text.starts_with("milled_")
+            && grant_play_tagged.single_spell
+            && !grant_play_tagged.allow_land
+            && grant_play_tagged.duration == crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+        {
+            return format!(
+                "Until end of turn, {} may cast a spell from among those cards",
                 describe_player_filter(&grant_play_tagged.player),
             );
         }

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1019,13 +1019,15 @@ where
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::GrantPlayTaggedEffect>(&effect) {
-        return Ok(Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+        let grant = crate::effects::GrantPlayTaggedEffect::new(
             payload.tag.clone(),
             payload.player.clone(),
             payload.duration,
             payload.allow_land,
             payload.allow_any_color_for_cast,
-        )));
+        )
+        .with_single_spell(payload.single_spell);
+        return Ok(Effect::new(grant));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::LocalRewriteEffect<M::Effect>>(&effect)
     {

--- a/crates/ironsmith-runtime/src/effects/composition/tagging_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/tagging_runtime.rs
@@ -131,7 +131,7 @@ pub(crate) fn apply_tagged_runtime_state(
             })
             .collect::<Vec<_>>();
         if !snapshots.is_empty() {
-            ctx.set_tagged_objects(tag, snapshots);
+            ctx.tag_objects_unique(tag, snapshots);
             return;
         }
     }
@@ -151,7 +151,7 @@ pub(crate) fn apply_tagged_runtime_state(
             })
             .collect::<Vec<_>>();
         if !snapshots.is_empty() {
-            ctx.set_tagged_objects(tag, snapshots);
+            ctx.tag_objects_unique(tag, snapshots);
             return;
         }
     }

--- a/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
@@ -19,6 +19,7 @@ pub struct GrantPlayTaggedEffect {
     pub duration: GrantPlayTaggedDuration,
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
+    pub single_spell: bool,
 }
 
 impl GrantPlayTaggedEffect {
@@ -35,7 +36,13 @@ impl GrantPlayTaggedEffect {
             duration,
             allow_land,
             allow_any_color_for_cast,
+            single_spell: false,
         }
+    }
+
+    pub fn with_single_spell(mut self, single_spell: bool) -> Self {
+        self.single_spell = single_spell;
+        self
     }
 
     pub fn until_your_next_turn(tag: impl Into<TagKey>, player: PlayerFilter) -> Self {
@@ -149,6 +156,9 @@ impl EffectExecutor for GrantPlayTaggedEffect {
         let mut granted = 0usize;
         let mut seen = std::collections::HashSet::new();
         let mut mana_permission_stable_ids = Vec::new();
+        let one_shot_group = self
+            .single_spell
+            .then(|| game.effect_store.grant_registry.next_one_shot_play_from_group_id());
         for snapshot in snapshots {
             let mut object_id = snapshot.object_id;
             if game.object(object_id).is_none() {
@@ -170,7 +180,13 @@ impl EffectExecutor for GrantPlayTaggedEffect {
                 mana_permission_stable_ids.push(object.stable_id);
             }
 
-            let source = if self.duration == GrantPlayTaggedDuration::ForAsLongAsYouControlSource {
+            let source = if let Some(group_id) = one_shot_group {
+                GrantSource::EffectOneShotPlayFrom {
+                    source_id: ctx.source,
+                    expires_end_of_turn,
+                    group_id,
+                }
+            } else if self.duration == GrantPlayTaggedDuration::ForAsLongAsYouControlSource {
                 GrantSource::EffectWhileControlled {
                     source_id: ctx.source,
                     controller: player_id,
@@ -181,7 +197,9 @@ impl EffectExecutor for GrantPlayTaggedEffect {
                     expires_end_of_turn,
                 }
             };
-            if self.duration == GrantPlayTaggedDuration::ForAsLongAsExiled {
+            if self.duration == GrantPlayTaggedDuration::ForAsLongAsExiled
+                || one_shot_group.is_some()
+            {
                 game.effect_store.grant_registry.grant_to_stable_card(
                     object_id,
                     object.stable_id,

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3872,6 +3872,17 @@ pub(super) fn finalize_spell_cast(
                 .insert((caster, *source));
         }
     }
+    if let CastingMethod::PlayFrom {
+        source,
+        use_alternative: None,
+        ..
+    } = &casting_method
+        && let Some(stable_id) = game.object(new_id).map(|spell_obj| spell_obj.stable_id)
+    {
+        game.effect_store
+            .grant_registry
+            .consume_one_shot_play_from_grant(*source, stable_id);
+    }
 
     // Create stack entry with targets, X value, casting method, optional costs, and chosen modes
     let mut entry = StackEntry::new(new_id, caster)

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -29,6 +29,12 @@ pub enum GrantSource {
         /// Turn number when this grant expires (at end of that turn).
         expires_end_of_turn: u32,
     },
+    /// From a temporary permission that allows one spell from a tagged group.
+    EffectOneShotPlayFrom {
+        source_id: ObjectId,
+        expires_end_of_turn: u32,
+        group_id: u64,
+    },
     /// From a resolving effect that lasts while the source remains controlled by a player.
     EffectWhileControlled {
         source_id: ObjectId,
@@ -55,6 +61,7 @@ impl GrantSource {
     pub fn source_id(&self) -> ObjectId {
         match self {
             GrantSource::Effect { source_id, .. } => *source_id,
+            GrantSource::EffectOneShotPlayFrom { source_id, .. } => *source_id,
             GrantSource::EffectWhileControlled { source_id, .. } => *source_id,
             GrantSource::StaticAbility { source_id } => *source_id,
         }
@@ -64,6 +71,10 @@ impl GrantSource {
     pub fn is_valid(&self, game: &crate::game_state::GameState) -> bool {
         match self {
             GrantSource::Effect {
+                expires_end_of_turn,
+                ..
+            }
+            | GrantSource::EffectOneShotPlayFrom {
                 expires_end_of_turn,
                 ..
             } => {
@@ -87,6 +98,10 @@ impl GrantSource {
     pub fn is_valid_raw(&self, turn_number: u32, battlefield: &[ObjectId]) -> bool {
         match self {
             GrantSource::Effect {
+                expires_end_of_turn,
+                ..
+            }
+            | GrantSource::EffectOneShotPlayFrom {
                 expires_end_of_turn,
                 ..
             } => {
@@ -131,6 +146,11 @@ impl GrantSource {
             GrantSource::Effect {
                 expires_end_of_turn,
                 source_id,
+            }
+            | GrantSource::EffectOneShotPlayFrom {
+                expires_end_of_turn,
+                source_id,
+                ..
             } => GrantLifetime::UntilEndOfTurn {
                 source_id: *source_id,
                 turn: *expires_end_of_turn,
@@ -191,6 +211,7 @@ pub struct Grant {
 pub struct GrantRegistry {
     /// All grants (unified storage).
     pub grants: Vec<Grant>,
+    next_one_shot_play_from_group_id: u64,
 }
 
 impl GrantRegistry {
@@ -202,6 +223,42 @@ impl GrantRegistry {
     /// Add a grant to the registry.
     pub fn add_grant(&mut self, grant: Grant) {
         self.grants.push(grant);
+    }
+
+    pub fn next_one_shot_play_from_group_id(&mut self) -> u64 {
+        let group_id = self.next_one_shot_play_from_group_id;
+        self.next_one_shot_play_from_group_id += 1;
+        group_id
+    }
+
+    pub fn consume_one_shot_play_from_grant(
+        &mut self,
+        source_id: ObjectId,
+        card_stable_id: StableId,
+    ) {
+        let Some(group_id) = self.grants.iter().find_map(|grant| match grant.source {
+            GrantSource::EffectOneShotPlayFrom {
+                source_id: grant_source,
+                group_id,
+                ..
+            } if grant_source == source_id
+                && grant.target_stable_id == Some(card_stable_id)
+                && matches!(grant.grantable, Grantable::PlayFrom) => Some(group_id),
+            _ => None,
+        }) else {
+            return;
+        };
+
+        self.grants.retain(|grant| {
+            !matches!(
+                grant.source,
+                GrantSource::EffectOneShotPlayFrom {
+                    source_id: grant_source,
+                    group_id: grant_group,
+                    ..
+                } if grant_source == source_id && grant_group == group_id
+            )
+        });
     }
 
     /// Add a grant for a specific card.
@@ -508,6 +565,7 @@ impl GrantRegistry {
         self.grants.retain(|grant| {
             !matches!(&grant.source,
                 GrantSource::Effect { source_id: sid, .. } |
+                GrantSource::EffectOneShotPlayFrom { source_id: sid, .. } |
                 GrantSource::EffectWhileControlled { source_id: sid, .. } |
                 GrantSource::StaticAbility { source_id: sid }
                 if *sid == source_id


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Locke, Treasure Hunter
Initial parse error:
```
parser does not yet support line family: 'Mug — Whenever Locke attacks, each player mills a card. If a land card was milled this way, create a Treasure token. Until end of turn, you may cast a spell from among those cards.'; oracle-only fallback also failed: parser does not yet support line family: 'Mug — Whenever Locke attacks, each player mills a card. If a land card was milled this way, create a Treasure token. Until end of turn, you may cast a spell from among those cards.'
```

Current worker: i-058f0ef4bce1f1e21
Branch: codex/aws-card-fix-locke-treasure-hunter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T051509Z-controller-dev-loop-wave0001
