### PR TITLE
Fix Ironsmith parse failure: Emrakul, the World Anew

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -31,6 +31,15 @@ fn this_enters_battlefield_trigger_spec(
     }
 }
 
+fn this_leaves_battlefield_trigger_spec(
+    surface: Option<crate::target::SourceReferenceSurface>,
+) -> TriggerSpec {
+    match surface {
+        Some(surface) => TriggerSpec::ThisLeavesBattlefieldWithSurface(surface),
+        None => TriggerSpec::ThisLeavesBattlefield,
+    }
+}
+
 pub(crate) fn split_trigger_or_index(tokens: &[OwnedLexToken]) -> Option<usize> {
     tokens.iter().enumerate().find_map(|(idx, token)| {
         if !token.is_word("or") {
@@ -927,6 +936,12 @@ pub(crate) fn parse_trigger_clause_lexed(
             .token_index_for_word_index(leaves_word_idx)
             .unwrap_or(tokens.len());
         let subject_tokens = &tokens[..leaves_token_idx];
+
+        if let Some(surface) =
+            source_reference_surface_for_trigger_subject(strip_leading_trigger_intro(subject_tokens))
+        {
+            return Ok(this_leaves_battlefield_trigger_spec(Some(surface)));
+        }
 
         if let Some(or_idx) =
             find_index(subject_tokens, |token: &OwnedLexToken| token.is_word("or"))

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -190,6 +190,17 @@ fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if value == "spells" || value == "spell" {
+            return Some(KeywordAction::ProtectionFromFilter(ObjectFilter::spell()));
+        }
+        if matches!(value, "permanent" | "permanents")
+            && words.get(idx + 2..idx + 7)
+                == Some(&["that", "were", "cast", "this", "turn"][..])
+        {
+            let mut filter = ObjectFilter::permanent();
+            filter.cast_this_turn = true;
+            return Some(KeywordAction::ProtectionFromFilter(filter));
+        }
         if matches!(value, "permanent" | "permanents")
             && words.get(idx + 2).copied() == Some("with")
         {
@@ -540,6 +551,17 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
 
         let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
             let value = *words.get(idx + 1)?;
+            if value == "spells" || value == "spell" {
+                return Some(KeywordAction::ProtectionFromFilter(ObjectFilter::spell()));
+            }
+            if matches!(value, "permanent" | "permanents")
+                && words.get(idx + 2..idx + 7)
+                    == Some(&["that", "were", "cast", "this", "turn"][..])
+            {
+                let mut filter = ObjectFilter::permanent();
+                filter.cast_this_turn = true;
+                return Some(KeywordAction::ProtectionFromFilter(filter));
+            }
             if matches!(value, "permanent" | "permanents")
                 && words.get(idx + 2).copied() == Some("with")
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
@@ -87,6 +87,17 @@ pub(crate) fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<Key
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if value == "spells" || value == "spell" {
+            return Some(KeywordAction::ProtectionFromFilter(ObjectFilter::spell()));
+        }
+        if matches!(value, "permanent" | "permanents")
+            && words.get(idx + 2..idx + 7)
+                == Some(&["that", "were", "cast", "this", "turn"][..])
+        {
+            let mut filter = ObjectFilter::permanent();
+            filter.cast_this_turn = true;
+            return Some(KeywordAction::ProtectionFromFilter(filter));
+        }
         if matches!(value, "permanent" | "permanents")
             && words.get(idx + 2).copied() == Some("with")
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -925,6 +925,11 @@ fn normalize_named_source_trigger_for_builder(
     let trimmed = text.trim();
     let lower = trimmed.to_ascii_lowercase();
     if let Some((trigger_head, effect_body)) = str_split_once(lower.as_str(), ",") {
+        if trigger_head.contains(" leaves the battlefield")
+            && normalized_line_mentions_source_alias(builder, trigger_head)
+        {
+            return None;
+        }
         let rewritten_head =
             normalize_named_source_trigger_head_for_builder(builder, trigger_head)?;
         let names = source_name_aliases_for_builder(builder);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
@@ -459,6 +459,8 @@ fn replace_names_with_map(
                         | b"deals"
                         | b"enter"
                         | b"enters"
+                        | b"leave"
+                        | b"leaves"
                         | b"power"
                         | b"toughness"
                 )

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4055,11 +4055,15 @@ pub(crate) fn parse_madness_line(
         .enumerate()
         .find_map(|(idx, token)| token.is_comma().then_some(idx))
         .unwrap_or(cost_tokens.len());
-    let cost_tokens = &cost_tokens[..cost_end];
+    let cost_tokens = strip_leading_keyword_cost_separator(&cost_tokens[..cost_end]);
     if cost_tokens.is_empty() {
         return Err(CardTextError::ParseError(
             "madness keyword missing mana cost".to_string(),
         ));
+    }
+
+    if let Some(mana_cost) = parse_pay_repeated_mana_symbol_cost(cost_tokens) {
+        return Ok(Some(AlternativeCastingMethod::Madness { cost: mana_cost }));
     }
 
     let total_cost = parse_activation_cost(cost_tokens)?;
@@ -4074,6 +4078,42 @@ pub(crate) fn parse_madness_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
     parse_madness_line(tokens)
+}
+
+fn strip_leading_keyword_cost_separator(tokens: &[OwnedLexToken]) -> &[OwnedLexToken] {
+    if matches!(tokens.first().map(|token| token.kind), Some(TokenKind::Dash | TokenKind::EmDash)) {
+        tokens.get(1..).unwrap_or_default()
+    } else {
+        tokens
+    }
+}
+
+fn parse_pay_repeated_mana_symbol_cost(tokens: &[OwnedLexToken]) -> Option<ManaCost> {
+    let mut end = tokens.len();
+    while end > 0 && tokens[end - 1].kind == TokenKind::Period {
+        end -= 1;
+    }
+    let tokens = &tokens[..end];
+    if tokens.len() != 3 || !tokens[0].is_word("pay") {
+        return None;
+    }
+
+    let count = tokens[1]
+        .parser_text()
+        .parse::<u8>()
+        .ok()
+        .or_else(|| {
+            ironsmith_core::parse_cardinal_word(tokens[1].parser_text())
+                .and_then(|value| value.try_into().ok())
+        })?;
+    let pip = mana_pips_from_token(&tokens[2])?;
+    if pip.len() != 1 {
+        return None;
+    }
+
+    Some(ManaCost::from_pips(
+        (0..count).map(|_| pip.clone()).collect(),
+    ))
 }
 
 pub(crate) fn parse_buyback_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -56,6 +56,12 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             )
         }
         TriggerSpec::ThisLeavesBattlefield => Trigger::this_leaves_battlefield(),
+        TriggerSpec::ThisLeavesBattlefieldWithSurface(surface) => Trigger::new(
+            crate::triggers::ZoneChangeTrigger::new()
+                .from(crate::zone::Zone::Battlefield)
+                .this()
+                .this_surface(surface.clone()),
+        ),
         TriggerSpec::ThisMutates => Trigger::this_mutates(),
         TriggerSpec::ThisBecomesMonstrous => Trigger::this_becomes_monstrous(),
         TriggerSpec::ThisBecomesTapped => Trigger::becomes_tapped(),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -127,6 +127,7 @@ pub(crate) enum TriggerSpec {
         marker: String,
     },
     ThisLeavesBattlefield,
+    ThisLeavesBattlefieldWithSurface(crate::target::SourceReferenceSurface),
     ThisMutates,
     ThisBecomesMonstrous,
     ThisBecomesTapped,

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -346,6 +346,7 @@ pub struct ObjectFilter {
     pub zone: Option<Zone>,
     pub controller: Option<PlayerFilter>,
     pub cast_by: Option<PlayerFilter>,
+    pub cast_this_turn: bool,
     pub first_spell_cast_each_turn: bool,
     pub owner: Option<PlayerFilter>,
     pub single_graveyard: bool,
@@ -1212,6 +1213,9 @@ impl ObjectFilter {
 
         if let Some(cast_by) = &self.cast_by {
             post_noun_qualifiers.push(format!("cast by {}", describe_player_filter(cast_by)));
+        }
+        if self.cast_this_turn {
+            post_noun_qualifiers.push("cast this turn".to_string());
         }
         if self.first_spell_cast_each_turn {
             post_noun_qualifiers.push("first spell cast each turn".to_string());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13143,6 +13143,34 @@ fn parse_protection_from_spells_that_are_one_or_more_colors() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_emrakul_the_world_anew_strict_oracle_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(124_001), "Emrakul, the World Anew")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(12)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi])
+        .power_toughness(PowerToughness::fixed(12, 12))
+        .parse_text(
+            "When you cast this spell, gain control of all creatures target player controls.\n\
+             Flying, protection from spells and from permanents that were cast this turn\n\
+             When Emrakul leaves the battlefield, sacrifice all creatures you control.\n\
+             Madness—Pay six {C}.",
+        )
+        .expect("Emrakul, the World Anew should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert_eq!(
+        rendered,
+        "When you cast this spell, gain control of all creatures target player controls.\n\
+         Flying, protection from spells and from permanents that were cast this turn\n\
+         When Emrakul leaves the battlefield, sacrifice all creatures you control.\n\
+         Madness—Pay six {C}.",
+        "Emrakul's strict parser output should preserve every oracle clause"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_exile_face_down_manifest_tail_fails_instead_of_partial_exile() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Ghastly Conscription Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1818,7 +1818,7 @@ pub(super) fn describe_alternative_cast_line(
             }
             line
         }
-        AlternativeCastingMethod::Madness { cost } => format!("Madness {}", cost.to_oracle()),
+        AlternativeCastingMethod::Madness { cost } => render_madness_cost(cost),
         AlternativeCastingMethod::Miracle { cost } => format!("Miracle {}", cost.to_oracle()),
         AlternativeCastingMethod::FlashWithAdditionalCost {
             additional_cost, ..
@@ -1918,6 +1918,19 @@ pub(super) fn describe_alternative_cast_line(
             }
         }
     }
+}
+
+fn render_madness_cost(cost: &crate::mana::ManaCost) -> String {
+    let pips = cost.pips();
+    if !pips.is_empty()
+        && pips
+            .iter()
+            .all(|pip| matches!(pip.as_slice(), [crate::mana::ManaSymbol::Colorless]))
+    {
+        let amount = small_number_word(pips.len() as u32).unwrap_or_else(|| pips.len().to_string());
+        return format!("Madness—Pay {amount} {{C}}");
+    }
+    format!("Madness {}", cost.to_oracle())
 }
 
 fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8847,6 +8847,9 @@ pub(super) fn describe_apply_continuous_effect(
             [crate::effects::continuous::RuntimeModification::ChangeControllerToEffectController]
         )
     {
+        if let Some(text) = describe_gain_control_target_player_creatures(effect) {
+            return Some(text);
+        }
         let mut text = format!("Gain control of {target}");
         if !matches!(effect.until, Until::Forever) {
             text.push(' ');
@@ -9235,6 +9238,28 @@ pub(super) fn describe_tag_attached_then_tap_or_untap(
         return Some(format!("Untap {attached_object}"));
     }
     None
+}
+
+fn describe_gain_control_target_player_creatures(
+    effect: &crate::effects::ApplyContinuousEffect,
+) -> Option<String> {
+    if !matches!(effect.until, Until::Forever) {
+        return None;
+    }
+    let crate::continuous::EffectTarget::Filter(filter) = &effect.target else {
+        return None;
+    };
+    if filter.zone != Some(Zone::Battlefield)
+        || filter.card_types != [CardType::Creature]
+        || filter.controller.is_none()
+    {
+        return None;
+    }
+    let Some(PlayerFilter::Target(player)) = &filter.controller else {
+        return None;
+    };
+    let player = describe_player_filter(&PlayerFilter::Target(player.clone()));
+    Some(format!("Gain control of all creatures {player} controls"))
 }
 
 fn object_filter_references_tag(filter: &ObjectFilter, tag: &str) -> bool {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17685,7 +17685,11 @@ fn describe_sacrifice_effect(sacrifice: SacrificeView<'_>) -> String {
         } else if let Some(rest) = noun.strip_prefix("an ") {
             noun = rest.to_string();
         }
-        return format!("{player} {verb} all {}", pluralize_noun_phrase(&noun));
+        let subject = pluralize_noun_phrase(&noun);
+        if matches!(sacrifice.player, PlayerFilter::You) {
+            return format!("Sacrifice all {subject}");
+        }
+        return format!("{player} {verb} all {subject}");
     }
     if matches!(sacrifice.count, Value::Fixed(value) if *value == 1) {
         let description = sacrifice.filter.description();

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1858,6 +1858,16 @@ impl ObjectFilterExt for ObjectFilter {
             }
         }
 
+        if self.cast_this_turn
+            && game
+                .turn_store
+                .turn_history
+                .spell_cast_order(object.id)
+                .is_none()
+        {
+            return false;
+        }
+
         if self.first_spell_cast_each_turn
             && game.turn_store.turn_history.spell_cast_order(object.id) != Some(1)
         {
@@ -2471,6 +2481,17 @@ impl ObjectFilterExt for ObjectFilter {
             if !caster_filter.matches_player(cast_player, ctx) {
                 return false;
             }
+        }
+
+        if self.cast_this_turn
+            && snapshot.cast_order_this_turn.is_none()
+            && game
+                .turn_store
+                .turn_history
+                .spell_cast_order(snapshot.object_id)
+                .is_none()
+        {
+            return false;
         }
 
         if self.first_spell_cast_each_turn

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12091,6 +12091,197 @@ fn test_resolution_target_validation_uses_source_lki_for_protection() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn emrakul_the_world_anew_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(124_010), "Emrakul, the World Anew")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(12)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi])
+        .power_toughness(PowerToughness::fixed(12, 12))
+        .parse_text(
+            "When you cast this spell, gain control of all creatures target player controls.\n\
+             Flying, protection from spells and from permanents that were cast this turn\n\
+             When Emrakul leaves the battlefield, sacrifice all creatures you control.\n\
+             Madness—Pay six {C}.",
+        )
+        .expect("Emrakul, the World Anew should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn stage_spell_cast_for_test(game: &mut GameState, object_id: ObjectId, caster: PlayerId) {
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(object_id, caster, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.stage_turn_history_event(&event);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_cast_trigger_gains_control_of_target_players_creatures() {
+    #[derive(Debug)]
+    struct ChoosePlayerDecisionMaker {
+        player: PlayerId,
+    }
+
+    impl DecisionMaker for ChoosePlayerDecisionMaker {
+        fn decide_targets(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<Target> {
+            ctx.requirements
+                .iter()
+                .map(|requirement| {
+                    let target = Target::Player(self.player);
+                    assert!(
+                        requirement.legal_targets.contains(&target),
+                        "chosen Emrakul target player should be legal"
+                    );
+                    target
+                })
+                .collect()
+        }
+    }
+
+    let mut game = setup_three_player_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let bob_first = create_creature(&mut game, "Bob Creature One", bob, 2, 2);
+    let bob_second = create_creature(&mut game, "Bob Creature Two", bob, 3, 3);
+    let charlie_creature = create_creature(&mut game, "Charlie Creature", charlie, 4, 4);
+    let alice_creature = create_creature(&mut game, "Alice Creature", alice, 1, 1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, alice, Zone::Stack);
+    let (emrakul_stable_id, emrakul_name) = game
+        .object(emrakul_id)
+        .map(|object| (object.stable_id, object.name.clone()))
+        .expect("Emrakul spell should exist on the stack");
+    game.push_to_stack(
+        StackEntry::new(emrakul_id, alice).with_source_info(emrakul_stable_id, emrakul_name),
+    );
+
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(emrakul_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+    put_triggers_on_stack_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut ChoosePlayerDecisionMaker { player: bob },
+    )
+    .expect("Emrakul's cast trigger should go on the stack");
+
+    resolve_stack_entry(&mut game).expect("Emrakul's cast trigger should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(game.current_controller(bob_first), Some(alice));
+    assert_eq!(game.current_controller(bob_second), Some(alice));
+    assert_eq!(game.current_controller(charlie_creature), Some(charlie));
+    assert_eq!(game.current_controller(alice_creature), Some(alice));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_leaves_trigger_sacrifices_only_your_creatures() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, alice, Zone::Battlefield);
+    let alice_first = create_creature(&mut game, "Alice Creature One", alice, 2, 2);
+    let alice_second = create_creature(&mut game, "Alice Creature Two", alice, 3, 3);
+    let bob_creature = create_creature(&mut game, "Bob Creature", bob, 4, 4);
+
+    game.move_object_by_effect(emrakul_id, Zone::Graveyard)
+        .expect("Emrakul should move to the graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Emrakul's leaves trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Emrakul's leaves trigger should resolve");
+
+    assert!(!game.battlefield.contains(&alice_first));
+    assert!(!game.battlefield.contains(&alice_second));
+    assert!(game.battlefield.contains(&bob_creature));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_protection_rejects_spell_targets() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, bob, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    let spell = CardDefinitionBuilder::new(CardId::from_raw(124_011), "Targeting Spell")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Destroy target creature.")
+        .expect("targeted spell should parse");
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    assert!(
+        crate::targeting::has_protection_from_source(&game, emrakul_id, spell_id),
+        "Emrakul should have protection from spell sources"
+    );
+    let entry = StackEntry::new(spell_id, alice).with_targets(vec![Target::Object(emrakul_id)]);
+
+    let (valid_targets, _, all_targets_invalid) = validate_stack_entry_targets(&game, &entry);
+    assert!(valid_targets.is_empty(), "Emrakul should have protection from spells");
+    assert!(all_targets_invalid, "a spell with only Emrakul as target should fizzle");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_protection_only_rejects_permanents_cast_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, bob, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    let cast_source = create_creature(&mut game, "Fresh Ability Source", alice, 2, 2);
+    stage_spell_cast_for_test(&mut game, cast_source, alice);
+    let cast_entry = StackEntry::ability(
+        cast_source,
+        alice,
+        vec![Effect::deal_damage(1, ChooseSpec::AnyTarget)],
+    )
+    .with_targets(vec![Target::Object(emrakul_id)]);
+    let (cast_valid_targets, _, cast_all_invalid) = validate_stack_entry_targets(&game, &cast_entry);
+    assert!(
+        cast_valid_targets.is_empty(),
+        "Emrakul should have protection from permanents that were cast this turn"
+    );
+    assert!(cast_all_invalid);
+
+    let old_source = create_creature(&mut game, "Old Ability Source", alice, 2, 2);
+    let old_entry = StackEntry::ability(
+        old_source,
+        alice,
+        vec![Effect::deal_damage(1, ChooseSpec::AnyTarget)],
+    )
+    .with_targets(vec![Target::Object(emrakul_id)]);
+    let (old_valid_targets, _, old_all_invalid) = validate_stack_entry_targets(&game, &old_entry);
+    assert_eq!(
+        old_valid_targets,
+        vec![crate::effects::ResolvedTarget::Object(emrakul_id)],
+        "Emrakul should not have protection from permanents that were not cast this turn"
+    );
+    assert!(!old_all_invalid);
+}
+
 #[test]
 fn test_resolution_player_target_validation_uses_source_lki_for_source_filter() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -116,6 +116,14 @@ impl StaticAbilityKind for Protection {
 }
 
 fn describe_protection_permanent_filter(filter: &ObjectFilter) -> String {
+    if *filter == ObjectFilter::spell() {
+        return "spells".to_string();
+    }
+    let mut cast_this_turn_permanent_filter = ObjectFilter::permanent();
+    cast_this_turn_permanent_filter.cast_this_turn = true;
+    if *filter == cast_this_turn_permanent_filter {
+        return "permanents that were cast this turn".to_string();
+    }
     if filter.card_types.is_empty()
         && filter.all_card_types.is_empty()
         && filter.subtypes.len() == 1

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -321,8 +321,11 @@ pub(crate) fn source_matches_protection_with_view(
         ProtectionFrom::CardType(card_type) => view.object_has_card_type(source.id, *card_type),
         // Protection from permanents matching a filter
         ProtectionFrom::Permanents(filter) => {
-            // Use active player for context since we don't have a specific controller
-            let filter_ctx = game.filter_context_for(game.turn.active_player, None);
+            let controller = game.controller_of(source);
+            let mut filter_ctx = game.filter_context_for(controller, Some(source.id));
+            if source.zone == Zone::Stack {
+                filter_ctx.caster = Some(controller);
+            }
             filter.matches(source, &filter_ctx, game)
         }
         // Protection from everything
@@ -347,7 +350,10 @@ fn source_snapshot_matches_protection(
         ProtectionFrom::ChosenColor => false,
         ProtectionFrom::CardType(card_type) => source.card_types.contains(card_type),
         ProtectionFrom::Permanents(filter) => {
-            let filter_ctx = game.filter_context_for(game.turn.active_player, None);
+            let mut filter_ctx = game.filter_context_for(source.controller, Some(source.object_id));
+            if source.zone == Zone::Stack {
+                filter_ctx.caster = Some(source.controller);
+            }
             filter.matches_snapshot(source, &filter_ctx, game)
         }
         ProtectionFrom::Everything => true,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Emrakul, the World Anew
Initial parse error:
```
parser does not yet support line family: 'Flying, protection from spells and from permanents that were cast this turn'; oracle-only fallback also failed: parser does not yet support line family: 'Flying, protection from spells and from permanents that were cast this turn'
```

Current worker: i-09adb857cf7c6125c
Branch: codex/aws-card-fix-emrakul-the-world-anew
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T051509Z-controller-dev-loop-wave0001
