### PR TITLE
Fix Ironsmith parse failure: Loxodon Lifechanter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1530,6 +1530,55 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         return None;
     }
 
+    let mut aggregate_idx = 0usize;
+    if words.get(aggregate_idx).copied() == Some("the") {
+        aggregate_idx += 1;
+    }
+    if let Some(aggregate) = words.get(aggregate_idx).copied()
+        && matches!(aggregate, "total" | "greatest")
+    {
+        aggregate_idx += 1;
+        let value_kind = if words.get(aggregate_idx).copied() == Some("power") {
+            aggregate_idx += 1;
+            "power"
+        } else if words.get(aggregate_idx).copied() == Some("toughness") {
+            aggregate_idx += 1;
+            "toughness"
+        } else if words.get(aggregate_idx).copied() == Some("mana")
+            && words.get(aggregate_idx + 1).copied() == Some("value")
+        {
+            aggregate_idx += 2;
+            "mana_value"
+        } else {
+            ""
+        };
+        if !value_kind.is_empty() && matches!(words.get(aggregate_idx), Some(&"of" | &"among")) {
+            let filter_start = aggregate_idx + 1;
+            let mut filter_end = filter_start;
+            while filter_end < words.len() && !matches!(words[filter_end], "plus" | "minus") {
+                filter_end += 1;
+            }
+            if filter_end > filter_start {
+                let filter_tokens = words[filter_start..filter_end]
+                    .iter()
+                    .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                    .collect::<Vec<_>>();
+                if let Ok(filter) = parse_object_filter(&filter_tokens, false) {
+                    let value = match (aggregate, value_kind) {
+                        ("total", "power") => Value::TotalPower(filter),
+                        ("total", "toughness") => Value::TotalToughness(filter),
+                        ("total", "mana_value") => Value::TotalManaValue(filter),
+                        ("greatest", "power") => Value::GreatestPower(filter),
+                        ("greatest", "toughness") => Value::GreatestToughness(filter),
+                        ("greatest", "mana_value") => Value::GreatestManaValue(filter),
+                        _ => return None,
+                    };
+                    return Some((value, filter_end));
+                }
+            }
+        }
+    }
+
     if matches!(
         words.get(..2),
         Some(["that", "many"]) | Some(["that", "much"]) | Some(["that", "amount"])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -14756,6 +14756,50 @@ fn parse_starting_life_total_amount_in_trigger() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_loxodon_lifechanter_oracle_text_with_total_toughness_life_amount() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(97_027), "Loxodon Lifechanter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elephant, Subtype::Cleric])
+        .power_toughness(PowerToughness::fixed(4, 6))
+        .parse_text(
+            "When this creature enters, you may have your life total become the total toughness of creatures you control.\n\
+             {5}{W}: This creature gets +X/+X until end of turn, where X is your life total.",
+        )
+        .expect("Loxodon Lifechanter oracle text should parse strictly");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("MayEffect")
+            && debug.contains("SetLifeTotalEffect")
+            && debug.contains("TotalToughness"),
+        "expected optional total-toughness life-total setter, got {debug}"
+    );
+    assert!(
+        debug.contains("LifeTotal") && debug.contains("ModifyPowerToughness"),
+        "expected activated life-total-scaled P/T modifier, got {debug}"
+    );
+
+    let joined = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        joined.contains(
+            "When this creature enters, you may have your life total become the total toughness of creatures you control."
+        ),
+        "expected Loxodon ETB wording, got {joined}"
+    );
+    assert!(
+        joined.contains(
+            "{5}{W}: This creature gets +X/+X until end of turn, where X is your life total."
+        ),
+        "expected Loxodon activated ability wording, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_starting_life_total_amount_with_extra_math_fails_strictly() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Endstone Negative Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -114,7 +114,7 @@ fn may_causative_clause(inner: &str) -> Option<String> {
     let lower = trimmed.to_ascii_lowercase();
     if ![
         "a ", "an ", "all ", "another ", "each ", "it ", "other ", "that ", "the ", "those ",
-        "target ",
+        "target ", "your ",
     ]
     .iter()
     .any(|prefix| lower.starts_with(prefix))
@@ -29649,8 +29649,8 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             );
         }
         return format!(
-            "{}'s life total becomes {}",
-            describe_player_filter(&set_life.player),
+            "{} life total becomes {}",
+            describe_possessive_player_filter(&set_life.player),
             describe_value(&set_life.amount)
         );
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39,6 +39,163 @@ fn setup_three_player_game() -> GameState {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn loxodon_lifechanter_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(97_027), "Loxodon Lifechanter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elephant, Subtype::Cleric])
+        .power_toughness(PowerToughness::fixed(4, 6))
+        .parse_text(
+            "When this creature enters, you may have your life total become the total toughness of creatures you control.\n\
+             {5}{W}: This creature gets +X/+X until end of turn, where X is your life total.",
+        )
+        .expect("Loxodon Lifechanter should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct LoxodonMayDecisionMaker {
+    accept: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for LoxodonMayDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_lifechanter_etb_sets_life_to_total_toughness_when_accepted() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.player_mut(alice).expect("Alice exists").life = 3;
+    create_creature(&mut game, "High-Toughness Ally", alice, 1, 4);
+
+    let loxodon = loxodon_lifechanter_definition();
+    let loxodon_id = game.create_object_from_definition(&loxodon, alice, Zone::Hand);
+    game.move_object_by_effect(loxodon_id, Zone::Battlefield)
+        .expect("Loxodon Lifechanter should enter the battlefield");
+
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Loxodon Lifechanter ETB trigger should stack");
+
+    let mut dm = LoxodonMayDecisionMaker { accept: true };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("accepted Loxodon Lifechanter trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        10,
+        "accepted ETB should set life to total toughness of controlled creatures, including Loxodon"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_lifechanter_etb_decline_leaves_life_unchanged() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.player_mut(alice).expect("Alice exists").life = 3;
+    create_creature(&mut game, "High-Toughness Ally", alice, 1, 4);
+
+    let loxodon = loxodon_lifechanter_definition();
+    let loxodon_id = game.create_object_from_definition(&loxodon, alice, Zone::Hand);
+    game.move_object_by_effect(loxodon_id, Zone::Battlefield)
+        .expect("Loxodon Lifechanter should enter the battlefield");
+
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Loxodon Lifechanter ETB trigger should stack");
+
+    let mut dm = LoxodonMayDecisionMaker { accept: false };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("declined Loxodon Lifechanter trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        3,
+        "declining the optional ETB should leave life total unchanged"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_lifechanter_activation_uses_current_life_total_for_pt_bonus() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice).expect("Alice exists").life = 9;
+
+    let loxodon = loxodon_lifechanter_definition();
+    let loxodon_id = game.create_object_from_definition(&loxodon, alice, Zone::Battlefield);
+    {
+        let player = game.player_mut(alice).expect("Alice exists");
+        player.mana_pool.add(ManaSymbol::Colorless, 5);
+        player.mana_pool.add(ManaSymbol::White, 1);
+    }
+
+    let ability_index = game
+        .object(loxodon_id)
+        .expect("Loxodon Lifechanter should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                format!("{:?}", activated.effects).contains("ModifyPowerToughness")
+            } else {
+                false
+            }
+        })
+        .expect("Loxodon Lifechanter should have its P/T activated ability");
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == loxodon_id && *idx == ability_index
+            )
+        })
+        .expect("Loxodon Lifechanter activation should be legal with {5}{W} available");
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Loxodon Lifechanter activation should start");
+
+    assert_eq!(game.stack.len(), 1, "activated ability should be on the stack");
+    resolve_stack_entry(&mut game).expect("Loxodon Lifechanter ability should resolve");
+
+    assert_eq!(game.calculated_power(loxodon_id), Some(13));
+    assert_eq!(game.calculated_toughness(loxodon_id), Some(15));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn open_the_way_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_900), "Open the Way")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Loxodon Lifechanter
Initial parse error:
```
missing life total amount (clause: 'the total toughness of creatures you control'); oracle-only fallback also failed: missing life total amount (clause: 'the total toughness of creatures you control')
```

Current worker: i-04259443cc278d80c
Branch: codex/aws-card-fix-loxodon-lifechanter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T051509Z-controller-dev-loop-wave0002
