### PR TITLE
Fix Ironsmith parse failure: Tetsuo Umezawa

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -1373,6 +1373,18 @@ pub(crate) fn parse_negated_object_restriction_clause(
             Restriction::phase_out(filter)
         }
         ["be", "targeted"] => Restriction::be_targeted(filter),
+        _ if slice_starts_with(&remainder_words, &["be", "the", "target", "of"])
+            && remainder_words.len() > 4 =>
+        {
+            let source_filter = parse_spell_restriction_subject_filter(&remainder_words[4..])
+                .ok_or_else(|| {
+                    CardTextError::ParseError(format!(
+                        "unsupported negated restriction target source (clause: '{}')",
+                        crate::runtime_backend::token_word_refs(tokens).join(" ")
+                    ))
+                })?;
+            Restriction::be_targeted_by(filter, source_filter)
+        }
         _ if remainder_words.first() == Some(&"block") && remainder_words.len() > 1 => {
             let attacker_tokens = trim_commas(&remainder_tokens[1..]);
             let attacker_filter = parse_subject_object_filter(&attacker_tokens)?

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -1209,6 +1209,33 @@ pub(super) fn parse_object_filter_inner(
         }
     }
 
+    if segments.len() > 1
+        && all_words
+            .iter()
+            .any(|word| matches!(*word, "creature" | "creatures"))
+        && segment_words_lists
+            .iter()
+            .any(|segment| segment.iter().any(|word| word == "tapped"))
+        && segment_words_lists
+            .iter()
+            .any(|segment| segment.iter().any(|word| word == "blocking"))
+    {
+        let mut base = filter.clone();
+        base.any_of.clear();
+        base.tapped = false;
+        base.blocking = false;
+
+        let mut tapped_branch = base.clone();
+        tapped_branch.tapped = true;
+
+        let mut blocking_branch = base;
+        blocking_branch.blocking = true;
+
+        let mut disjunction = ObjectFilter::default();
+        disjunction.any_of = vec![tapped_branch, blocking_branch];
+        filter = disjunction;
+    }
+
     let permanent_type_defaults = vec![
         CardType::Artifact,
         CardType::Creature,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -1106,6 +1106,18 @@ pub(crate) fn restriction_references_tag(
             .any(|constraint| constraint.tag.as_str() == tag);
     }
 
+    if let Restriction::BeTargetedBy(target_filter, source_filter) = restriction {
+        let target_references = target_filter
+            .tagged_constraints
+            .iter()
+            .any(|constraint| constraint.tag.as_str() == tag);
+        let source_references = source_filter
+            .tagged_constraints
+            .iter()
+            .any(|constraint| constraint.tag.as_str() == tag);
+        return target_references || source_references;
+    }
+
     if let Restriction::BlockSpecificAttacker { blockers, attacker } = restriction {
         let blockers_reference = blockers
             .tagged_constraints

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -475,6 +475,12 @@ pub(crate) fn resolve_restriction_it_tag(
             Restriction::have_counters_placed(resolve_it_tag(filter, refs)?)
         }
         Restriction::BeTargeted(filter) => Restriction::be_targeted(resolve_it_tag(filter, refs)?),
+        Restriction::BeTargetedBy(target_filter, source_filter) => {
+            Restriction::be_targeted_by(
+                resolve_it_tag(target_filter, refs)?,
+                resolve_it_tag(source_filter, refs)?,
+            )
+        }
         Restriction::BeTargetedPlayer(player) => {
             Restriction::BeTargetedPlayer(resolve_contextual_player_filter(player, refs)?)
         }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -291,6 +291,7 @@ pub enum Restriction {
     BeSacrificed(ObjectFilter),
     HaveCountersPlaced(ObjectFilter),
     BeTargeted(ObjectFilter),
+    BeTargetedBy(ObjectFilter, ObjectFilter),
     BeTargetedPlayer(PlayerFilter),
     BeTargetedPlayerFrom(PlayerFilter, ObjectFilter),
     BeCountered(ObjectFilter),
@@ -539,6 +540,10 @@ impl Restriction {
 
     pub fn be_targeted(filter: ObjectFilter) -> Self {
         Self::BeTargeted(filter)
+    }
+
+    pub fn be_targeted_by(target_filter: ObjectFilter, source_filter: ObjectFilter) -> Self {
+        Self::BeTargetedBy(target_filter, source_filter)
     }
 
     pub fn be_targeted_player(filter: PlayerFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45384,3 +45384,196 @@ fn loot_the_key_to_everything_runtime_grants_play_permission_until_end_of_turn()
         "expected Loot play permission to allow lands as well as spells, got {debug}"
     );
 }
+
+#[test]
+fn parse_oracle_tetsuo_umezawa_strict_regression_and_compiled_text_clause() {
+    let def = parse_oracle_card_definition("Tetsuo Umezawa");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("can't be the target of aura spells"),
+        "expected Tetsuo Umezawa compiled text to preserve the Aura-spell target restriction, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("destroy target tapped or blocking creature"),
+        "expected Tetsuo Umezawa compiled text to preserve the activated destroy target clause, got {rendered}"
+    );
+}
+
+#[test]
+fn tetsuo_umezawa_runtime_aura_spell_target_restriction_blocks_any_controller() {
+    let def = parse_oracle_card_definition("Tetsuo Umezawa");
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = crate::ids::PlayerId::from_index(0);
+    let bob = crate::ids::PlayerId::from_index(1);
+    let tetsuo_id = game.create_object_from_definition(&def, alice, crate::zone::Zone::Battlefield);
+    game.update_cant_effects();
+
+    let aura_spell = CardDefinitionBuilder::new(CardId::new(), "Aura Spell Probe")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .build();
+    let alice_aura =
+        game.create_object_from_definition(&aura_spell, alice, crate::zone::Zone::Stack);
+    let bob_aura = game.create_object_from_definition(&aura_spell, bob, crate::zone::Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(alice_aura, alice));
+    game.push_to_stack(crate::game_state::StackEntry::new(bob_aura, bob));
+
+    assert!(
+        matches!(
+            crate::targeting::can_target_object(&game, tetsuo_id, alice_aura, alice),
+            crate::targeting::TargetingResult::Invalid(
+                crate::targeting::TargetingInvalidReason::CantBeTargeted
+            )
+        ),
+        "Tetsuo Umezawa should not be targetable by its controller's Aura spells"
+    );
+    assert!(
+        matches!(
+            crate::targeting::can_target_object(&game, tetsuo_id, bob_aura, bob),
+            crate::targeting::TargetingResult::Invalid(
+                crate::targeting::TargetingInvalidReason::CantBeTargeted
+            )
+        ),
+        "Tetsuo Umezawa should not be targetable by opponents' Aura spells"
+    );
+}
+
+#[test]
+fn tetsuo_umezawa_runtime_target_restriction_allows_non_aura_spells() {
+    let def = parse_oracle_card_definition("Tetsuo Umezawa");
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = crate::ids::PlayerId::from_index(0);
+    let bob = crate::ids::PlayerId::from_index(1);
+    let tetsuo_id = game.create_object_from_definition(&def, alice, crate::zone::Zone::Battlefield);
+    game.update_cant_effects();
+
+    let instant_spell = CardDefinitionBuilder::new(CardId::new(), "Instant Probe")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let instant_id =
+        game.create_object_from_definition(&instant_spell, bob, crate::zone::Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(instant_id, bob));
+
+    assert!(
+        matches!(
+            crate::targeting::can_target_object(&game, tetsuo_id, instant_id, bob),
+            crate::targeting::TargetingResult::Legal { .. }
+        ),
+        "Tetsuo Umezawa's restriction should not block non-Aura spells"
+    );
+}
+
+#[test]
+fn tetsuo_umezawa_runtime_destroy_ability_requires_tapped_or_blocking_target() {
+    let def = parse_oracle_card_definition("Tetsuo Umezawa");
+    let destroy = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .find_map(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::DestroyEffect>()
+                        .cloned()
+                })
+        })
+        .expect("Tetsuo Umezawa should compile a destroy effect");
+
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = crate::ids::PlayerId::from_index(0);
+    let bob = crate::ids::PlayerId::from_index(1);
+    let tetsuo_id = game.create_object_from_definition(&def, alice, crate::zone::Zone::Battlefield);
+    let tapped_target = CardDefinitionBuilder::new(CardId::new(), "Tapped Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let untapped_target = CardDefinitionBuilder::new(CardId::new(), "Untapped Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let blocking_target = CardDefinitionBuilder::new(CardId::new(), "Blocking Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let attacking_target = CardDefinitionBuilder::new(CardId::new(), "Attacking Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let tapped_id =
+        game.create_object_from_definition(&tapped_target, bob, crate::zone::Zone::Battlefield);
+    let untapped_id =
+        game.create_object_from_definition(&untapped_target, bob, crate::zone::Zone::Battlefield);
+    let blocking_id =
+        game.create_object_from_definition(&blocking_target, bob, crate::zone::Zone::Battlefield);
+    let attacking_id = game.create_object_from_definition(
+        &attacking_target,
+        alice,
+        crate::zone::Zone::Battlefield,
+    );
+    game.tap(tapped_id);
+
+    let mut valid_ctx = crate::effects::ExecutionContext::new_default(tetsuo_id, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(tapped_id)]);
+    let valid_outcome = destroy
+        .execute(&mut game, &mut valid_ctx)
+        .expect("destroying a tapped target should execute");
+    assert_eq!(valid_outcome.status, crate::effect::OutcomeStatus::Succeeded);
+    assert!(
+        game.objects_in_zone(crate::zone::Zone::Graveyard)
+            .iter()
+            .filter_map(|id| game.object(*id))
+        .any(|object| object.name == "Tapped Target"),
+        "Tetsuo Umezawa should destroy a tapped target creature"
+    );
+
+    let mut blockers = HashMap::new();
+    blockers.insert(attacking_id, vec![blocking_id]);
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: attacking_id,
+            target: crate::combat_state::AttackTarget::Player(bob),
+        }],
+        blockers,
+        ..Default::default()
+    });
+
+    let mut blocking_ctx = crate::effects::ExecutionContext::new_default(tetsuo_id, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(blocking_id)]);
+    let blocking_outcome = destroy
+        .execute(&mut game, &mut blocking_ctx)
+        .expect("destroying a blocking target should execute");
+    assert_eq!(blocking_outcome.status, crate::effect::OutcomeStatus::Succeeded);
+    assert!(
+        game.objects_in_zone(crate::zone::Zone::Graveyard)
+            .iter()
+            .filter_map(|id| game.object(*id))
+            .any(|object| object.name == "Blocking Target"),
+        "Tetsuo Umezawa should destroy an untapped blocking target creature"
+    );
+
+    let mut invalid_ctx = crate::effects::ExecutionContext::new_default(tetsuo_id, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(untapped_id)]);
+    let invalid_outcome = destroy
+        .execute(&mut game, &mut invalid_ctx)
+        .expect("invalid untapped target should be reported without panicking");
+    assert_eq!(
+        invalid_outcome.status,
+        crate::effect::OutcomeStatus::TargetInvalid,
+        "untapped nonblocking creature should not satisfy Tetsuo Umezawa's target restriction"
+    );
+    assert_eq!(
+        game.object(untapped_id)
+            .expect("untapped target should remain tracked")
+            .zone,
+        crate::zone::Zone::Battlefield,
+        "invalid target should remain on the battlefield"
+    );
+}

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -13,8 +13,30 @@ pub(super) fn ast_compiled_lines(def: &CardDefinition) -> Vec<RawRenderedLine> {
     stacker::maybe_grow(1024 * 1024, 8 * 1024 * 1024, || compiled_lines_inner(def))
         .into_iter()
         .map(|line| rewrite_self_exile_cost_source(def, &line))
+        .map(|line| rewrite_source_target_restriction_subject(def, &line))
         .map(RawRenderedLine)
         .collect()
+}
+
+pub(super) fn rewrite_source_target_restriction_subject(
+    def: &CardDefinition,
+    line: &str,
+) -> String {
+    if def.card.name.trim().is_empty() {
+        return line.to_string();
+    }
+
+    for prefix in [
+        "This creature can't be the target of ",
+        "This permanent can't be the target of ",
+        "This can't be the target of ",
+    ] {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            return format!("{} can't be the target of {rest}", def.card.name);
+        }
+    }
+
+    line.to_string()
 }
 
 fn rewrite_self_exile_cost_source(def: &CardDefinition, line: &str) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -40,11 +40,11 @@ pub fn debug_compiled_lines(def: &CardDefinition) -> Vec<String> {
 
 /// Render the structured compiled-text surface used for DB scoring.
 pub fn compiled_text_lines(def: &CardDefinition) -> Vec<String> {
-    normalize_ast_surface_lines(debug_compiled_lines(def))
+    normalize_ast_surface_lines(def, debug_compiled_lines(def))
 }
 
 pub fn unprocessed_compiled_lines(def: &CardDefinition) -> Vec<String> {
-    normalize_ast_surface_lines(debug_compiled_lines(def))
+    normalize_ast_surface_lines(def, debug_compiled_lines(def))
 }
 
 /// Render a single ability using the same surface renderer as compiled oracle text.
@@ -55,7 +55,7 @@ pub fn ability_surface_text(ability: &Ability) -> String {
     self::render_effects::describe_inline_ability(ability)
 }
 
-fn normalize_ast_surface_lines(lines: Vec<String>) -> Vec<String> {
+fn normalize_ast_surface_lines(def: &CardDefinition, lines: Vec<String>) -> Vec<String> {
     let lines: Vec<String> = lines
         .into_iter()
         .map(|line| normalize_common_semantic_phrasing(&line))
@@ -63,6 +63,7 @@ fn normalize_ast_surface_lines(lines: Vec<String>) -> Vec<String> {
     merge_ast_surface_lines(lines)
         .into_iter()
         .map(finalize_ast_surface_line)
+        .map(|line| rewrite_source_target_restriction_subject(def, &line))
         .flat_map(expand_finalized_ast_surface_line)
         .collect()
 }

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -1733,6 +1733,12 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
         .replace("card ins ", "cards in ")
         .replace("Card ins ", "Cards in ");
     normalized = normalized
+        .replace("tapped creature or blocking creature", "tapped or blocking creature")
+        .replace("Tapped creature or blocking creature", "Tapped or blocking creature");
+    normalized = normalized
+        .replace("target of aura spells", "target of Aura spells")
+        .replace("target of aura spell", "target of Aura spell");
+    normalized = normalized
         .replace(
             "If you control a creature with power 4 or greater, counter target noncreature spell instead",
             "If you control a creature with power 4 or greater, instead counter target noncreature spell",
@@ -9663,6 +9669,18 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
         }
         crate::effect::Restriction::BeTargeted(filter) => {
             format!("{} can't be targeted", filter.description())
+        }
+        crate::effect::Restriction::BeTargetedBy(target_filter, source_filter) => {
+            let subject = if target_filter.source
+                && target_filter.card_types.is_empty()
+                && target_filter.subtypes.is_empty()
+            {
+                "This".to_string()
+            } else {
+                capitalize_first(&target_filter.description())
+            };
+            let source = pluralize_noun_phrase(&source_filter.description()).replace("aura", "Aura");
+            format!("{subject} can't be the target of {source}")
         }
         crate::effect::Restriction::BeTargetedPlayer(filter) => {
             format!("{} can't be targeted", describe_player_set_filter(filter))

--- a/crates/ironsmith-runtime/src/compiled_text/oracle_style.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/oracle_style.rs
@@ -1,5 +1,5 @@
 use super::*;
 
 pub fn canonical_compiled_lines(def: &CardDefinition) -> Vec<String> {
-    super::normalize_ast_surface_lines(super::debug_compiled_lines(def))
+    super::normalize_ast_surface_lines(def, super::debug_compiled_lines(def))
 }

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -1138,6 +1138,25 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::BeTargetedBy(target_filter, source_filter) => {
+                let candidate_ids = game
+                    .objects_in_zone(Zone::Battlefield)
+                    .into_iter()
+                    .chain(game.objects_in_zone(Zone::Stack));
+                for obj_id in candidate_ids {
+                    if let Some(obj) = game.object(obj_id)
+                        && target_filter.matches(obj, &ctx, game)
+                    {
+                        tracker.cant_target_objects_from.push(
+                            crate::game_state::ObjectCantBeTargetedFrom {
+                                object: obj_id,
+                                source_filter: source_filter.clone(),
+                                controller,
+                            },
+                        );
+                    }
+                }
+            }
             Restriction::BeTargetedPlayer(filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -644,6 +644,9 @@ pub struct CantEffectTracker {
     /// Players that can't be targeted by sources matching a filter.
     pub cant_target_players_from: Vec<PlayerCantBeTargetedFrom>,
 
+    /// Permanents that can't be targeted by sources matching a filter.
+    pub cant_target_objects_from: Vec<ObjectCantBeTargetedFrom>,
+
     /// Permanents that can't be countered while on the stack.
     /// Example: Vexing Shusher, Prowling Serpopard
     pub cant_be_countered: HashSet<ObjectId>,
@@ -660,6 +663,13 @@ pub struct CantEffectTracker {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlayerCantBeTargetedFrom {
     pub player: PlayerId,
+    pub source_filter: crate::target::ObjectFilter,
+    pub controller: PlayerId,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectCantBeTargetedFrom {
+    pub object: ObjectId,
     pub source_filter: crate::target::ObjectFilter,
     pub controller: PlayerId,
 }
@@ -868,6 +878,8 @@ impl CantEffectTracker {
         self.cant_target_players.extend(other.cant_target_players);
         self.cant_target_players_from
             .extend(other.cant_target_players_from.clone());
+        self.cant_target_objects_from
+            .extend(other.cant_target_objects_from.clone());
         self.cant_be_countered.extend(other.cant_be_countered);
         self.cant_transform.extend(other.cant_transform);
         self.cant_phase_out.extend(other.cant_phase_out);
@@ -910,6 +922,7 @@ impl CantEffectTracker {
         self.cant_be_targeted.clear();
         self.cant_target_players.clear();
         self.cant_target_players_from.clear();
+        self.cant_target_objects_from.clear();
         self.cant_be_countered.clear();
         self.cant_transform.clear();
         self.cant_phase_out.clear();
@@ -1211,6 +1224,46 @@ impl CantEffectTracker {
             }
             let filter_ctx = game.filter_context_for(restriction.controller, Some(source_id));
             restriction.source_filter.matches(source, &filter_ctx, game)
+        })
+    }
+
+    /// Check if a permanent can be targeted by a specific source.
+    pub fn can_target_object_from_source(
+        &self,
+        game: &GameState,
+        object: ObjectId,
+        source_id: ObjectId,
+    ) -> bool {
+        let Some(source) = game.object(source_id) else {
+            return true;
+        };
+
+        !self.cant_target_objects_from.iter().any(|restriction| {
+            if restriction.object != object {
+                return false;
+            }
+            let mut filter_ctx = game.filter_context_for(restriction.controller, Some(source_id));
+            filter_ctx.caster = Some(game.controller_of(source));
+            restriction.source_filter.matches(source, &filter_ctx, game)
+        })
+    }
+
+    /// Check if a permanent can be targeted using a source's last known information.
+    pub fn can_target_object_from_source_snapshot(
+        &self,
+        game: &GameState,
+        object: ObjectId,
+        source_snapshot: &crate::snapshot::ObjectSnapshot,
+    ) -> bool {
+        !self.cant_target_objects_from.iter().any(|restriction| {
+            if restriction.object != object {
+                return false;
+            }
+            let mut filter_ctx = game.filter_context_for(restriction.controller, None);
+            filter_ctx.caster = Some(source_snapshot.controller);
+            restriction
+                .source_filter
+                .matches_snapshot(source_snapshot, &filter_ctx, game)
         })
     }
 

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -119,6 +119,14 @@ pub(crate) fn can_target_object_with_view_and_source_snapshot(
         return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
     }
 
+    if !game
+        .effect_store
+        .cant_effects
+        .can_target_object_from_source(game, target_id, source_id)
+    {
+        return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
+    }
+
     TargetingResult::legal()
 }
 
@@ -164,6 +172,14 @@ fn can_target_object_from_source_snapshot_with_view(
     }
 
     if game.is_untargetable(target_id) && game.controller_of(target) != caster {
+        return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
+    }
+
+    if !game
+        .effect_store
+        .cant_effects
+        .can_target_object_from_source_snapshot(game, target_id, source_snapshot)
+    {
         return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tetsuo Umezawa
Initial parse error:
```
unsupported negated restriction tail (clause: 'this can't be the target of aura spells'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'this can't be the target of aura spells')
```

Current worker: i-05f017d44c981a50e
Branch: codex/aws-card-fix-tetsuo-umezawa
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T051509Z-controller-dev-loop-wave0012
