### PR TITLE
Fix Ironsmith parse failure: Dredger's Insight

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1459,6 +1459,55 @@ pub(crate) fn parse_trigger_clause_lexed(
         }
     }
 
+    for (tail, during_your_turn) in [
+        (
+            ["leaves", "your", "graveyard", "during", "your", "turn"].as_slice(),
+            true,
+        ),
+        (
+            ["leave", "your", "graveyard", "during", "your", "turn"].as_slice(),
+            true,
+        ),
+        (["leaves", "your", "graveyard"].as_slice(), false),
+        (["leave", "your", "graveyard"].as_slice(), false),
+    ] {
+        if slice_ends_with(&words, tail) {
+            let subject_word_len = words.len().saturating_sub(tail.len());
+            let mut subject_tokens = ActivationRestrictionCompatWords::new(tokens)
+                .token_index_for_word_index(subject_word_len)
+                .map(|idx| &tokens[..idx])
+                .unwrap_or_default();
+            let one_or_more = has_leading_one_or_more(subject_tokens);
+            subject_tokens = strip_leading_one_or_more_lexed(subject_tokens);
+            let subject_view = ActivationRestrictionCompatWords::new(subject_tokens);
+            let subject_words = subject_view.to_word_refs();
+            let mut filter = if matches!(subject_words.as_slice(), ["card"] | ["cards"]) {
+                ObjectFilter::default()
+            } else {
+                parse_object_filter_lexed(subject_tokens, false).map_err(|_| {
+                    CardTextError::ParseError(format!(
+                        "unsupported card filter in cards-leave-your-graveyard trigger clause (clause: '{}')",
+                        words.join(" ")
+                    ))
+                })?
+            };
+            filter.zone = None;
+            filter.controller = None;
+            filter.owner = None;
+            if subject_words
+                .iter()
+                .any(|word| matches!(*word, "card" | "cards"))
+            {
+                filter.nontoken = true;
+            }
+            return Ok(TriggerSpec::CardsLeaveYourGraveyard {
+                filter,
+                one_or_more,
+                during_your_turn,
+            });
+        }
+    }
+
     for tail in [
         ["is", "put", "into", "a", "graveyard", "from", "anywhere"].as_slice(),
         ["are", "put", "into", "a", "graveyard", "from", "anywhere"].as_slice(),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -3551,6 +3551,7 @@ fn compile_subject_verb_effect(
         SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard {
             filter,
             reveal,
+            from_among_milled_cards_surface,
             if_not_chosen,
         } => {
             use crate::effect::Condition;
@@ -3577,15 +3578,17 @@ fn compile_subject_verb_effect(
 
             let chosen_tag = ctx.next_tag("chosen");
             let chosen_tag_key: TagKey = chosen_tag.as_str().into();
-            let choose = Effect::new(
-                crate::effects::ChooseObjectsEffect::new(
-                    choose_filter,
-                    ChoiceCount::up_to(1),
-                    chooser,
-                    chosen_tag_key.clone(),
-                )
-                .in_zone(source_zone),
-            );
+            let mut choose_objects = crate::effects::ChooseObjectsEffect::new(
+                choose_filter,
+                ChoiceCount::up_to(1),
+                chooser,
+                chosen_tag_key.clone(),
+            )
+            .in_zone(source_zone);
+            if *from_among_milled_cards_surface {
+                choose_objects = choose_objects.with_description("from among the milled cards");
+            }
+            let choose = Effect::new(choose_objects);
 
             let mut compiled = vec![choose];
             if *reveal {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -236,6 +236,11 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             }
             Trigger::new(trigger)
         }
+        TriggerSpec::CardsLeaveYourGraveyard {
+            filter,
+            one_or_more,
+            during_your_turn,
+        } => Trigger::cards_leave_your_graveyard(filter, one_or_more, during_your_turn),
         TriggerSpec::CounterPutOn {
             filter,
             counter_type,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -247,6 +247,11 @@ pub(crate) enum TriggerSpec {
         one_or_more: bool,
         during_turn: Option<PlayerFilter>,
     },
+    CardsLeaveYourGraveyard {
+        filter: ObjectFilter,
+        one_or_more: bool,
+        during_your_turn: bool,
+    },
     CounterPutOn {
         filter: ObjectFilter,
         counter_type: Option<CounterType>,
@@ -1340,6 +1345,7 @@ pub(crate) enum SubjectVerbActionAst {
     ChooseFromLookedCardsIntoHandRestIntoGraveyard {
         filter: ObjectFilter,
         reveal: bool,
+        from_among_milled_cards_surface: bool,
         if_not_chosen: Vec<EffectAst>,
     },
     ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary {
@@ -2682,11 +2688,16 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::ChooseFromLookedCardsIntoHandRestIntoGraveyard {
                 filter,
                 reveal,
+                from_among_milled_cards_surface,
                 if_not_chosen,
             } => f
                 .debug_struct("ChooseFromLookedCardsIntoHandRestIntoGraveyard")
                 .field("filter", filter)
                 .field("reveal", reveal)
+                .field(
+                    "from_among_milled_cards_surface",
+                    from_among_milled_cards_surface,
+                )
                 .field("if_not_chosen", if_not_chosen)
                 .finish(),
             Self::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary {
@@ -4415,6 +4426,7 @@ impl EffectAst {
         player: PlayerAst,
         filter: ObjectFilter,
         reveal: bool,
+        from_among_milled_cards_surface: bool,
         if_not_chosen: Vec<EffectAst>,
     ) -> Self {
         Self::subject_verb(
@@ -4423,6 +4435,7 @@ impl EffectAst {
             SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard {
                 filter,
                 reveal,
+                from_among_milled_cards_surface,
                 if_not_chosen,
             },
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1141,6 +1141,39 @@ fn effect_reference_resolution_state(env: &ReferenceEnv) -> EffectReferenceResol
     }
 }
 
+fn effects_need_prior_object_tag(effects: &[EffectAst]) -> bool {
+    effects.iter().any(effect_needs_prior_object_tag)
+}
+
+fn effect_needs_prior_object_tag(effect: &EffectAst) -> bool {
+    match effect {
+        EffectAst::SubjectVerb(SubjectVerbEffectAst { action, .. }) => matches!(
+            action,
+            SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { .. }
+                | SubjectVerbActionAst::PutSomeIntoHandRestOnBottomOfLibrary { .. }
+                | SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard { .. }
+                | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary { .. }
+                | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeIntoHandRestOnBottomOfLibrary { .. }
+                | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+                | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. }
+        ),
+        EffectAst::May { effects }
+        | EffectAst::MayByPlayer { effects, .. }
+        | EffectAst::UnlessPays { effects, .. }
+        | EffectAst::IfResult { effects, .. }
+        | EffectAst::WhenResult { effects, .. }
+        | EffectAst::ForEachOpponent { effects }
+        | EffectAst::ForEachPlayer { effects }
+        | EffectAst::ForEachObject { effects, .. }
+        | EffectAst::ForEachTagged { effects, .. }
+        | EffectAst::ForEachTaggedPlayer { effects, .. } => effects_need_prior_object_tag(effects),
+        EffectAst::Conditional {
+            if_true, if_false, ..
+        } => effects_need_prior_object_tag(if_true) || effects_need_prior_object_tag(if_false),
+        _ => false,
+    }
+}
+
 fn annotate_effect_sequence_with_env_internal(
     effects: &[EffectAst],
     mut current_env: ReferenceEnv,
@@ -1169,6 +1202,7 @@ fn annotate_effect_sequence_with_env_internal(
             effects_reference_it_tag(remaining)
                 || effects_reference_its_controller(remaining)
                 || effects_reference_tag(remaining, "damaged_0")
+                || effects_need_prior_object_tag(remaining)
         };
         let assigned_effect_id =
             maybe_assign_effect_result_id(effects, idx, id_gen, in_env.allow_life_event_value);

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -409,6 +409,11 @@ pub(super) fn find_from_among_looked_cards_phrase(
         })
         .or_else(|| {
             word_view
+                .find_phrase_start(&["from", "among", "the", "milled", "cards"])
+                .map(|idx| (idx, 5usize))
+        })
+        .or_else(|| {
+            word_view
                 .find_phrase_start(&["from", "among", "them"])
                 .map(|idx| (idx, 3usize))
         })

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -1000,7 +1000,7 @@ fn parse_may_put_filtered_card_from_among_into_hand(
     tokens: &[OwnedLexToken],
     default_player: PlayerAst,
     zone: Zone,
-) -> Result<Option<(PlayerAst, ObjectFilter)>, CardTextError> {
+) -> Result<Option<(PlayerAst, ObjectFilter, bool)>, CardTextError> {
     let sentence_tokens = trim_commas(tokens);
     let Some(action_match) = parse_leading_may_action_lexed(&sentence_tokens, &["put"], true)
     else {
@@ -1019,6 +1019,9 @@ fn parse_may_put_filtered_card_from_among_into_hand(
     else {
         return Ok(None);
     };
+    let from_among_milled_cards_surface = action_word_refs
+        .get(from_among_word_idx..from_among_word_idx + from_among_len)
+        == Some(["from", "among", "the", "milled", "cards"].as_slice());
     let filter_end = action_words
         .token_index_for_word_index(from_among_word_idx)
         .unwrap_or(action_tokens.len());
@@ -1040,7 +1043,7 @@ fn parse_may_put_filtered_card_from_among_into_hand(
         return Ok(None);
     }
 
-    Ok(Some((chooser, filter)))
+    Ok(Some((chooser, filter, from_among_milled_cards_surface)))
 }
 
 fn retarget_source_self_animate_effect(effect: EffectAst) -> EffectAst {
@@ -1410,7 +1413,7 @@ pub(crate) fn parse_mill_then_may_put_from_among_into_hand(
         return Ok(None);
     };
 
-    let Some((chooser, filter)) =
+    let Some((chooser, filter, from_among_milled_cards_surface)) =
         parse_may_put_filtered_card_from_among_into_hand(second, *player, Zone::Graveyard)?
     else {
         return Ok(None);
@@ -1422,6 +1425,7 @@ pub(crate) fn parse_mill_then_may_put_from_among_into_hand(
             chooser,
             filter,
             false,
+            from_among_milled_cards_surface,
             Vec::new(),
         ),
     ]))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -962,6 +962,7 @@ pub(crate) fn parse_top_cards_put_match_into_hand_rest_graveyard(
             chooser,
             filter,
             reveal_chosen,
+            false,
             Vec::new(),
         ),
     );

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9059,6 +9059,40 @@ fn rewrite_lexed_triggered_line_parses_ketramose_exile_trigger() {
 }
 
 #[test]
+fn rewrite_lexed_triggered_line_parses_dredgers_insight_graveyard_leave_trigger() {
+    let text = "Whenever one or more artifact and/or creature cards leave your graveyard, you gain 1 life.";
+    let tokens = lex_line(text, 0)
+        .expect("rewrite lexer should classify Dredger's Insight triggered line");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("Dredger's Insight graveyard-leave triggered line should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("CardsLeaveYourGraveyard"), "{debug}");
+    assert!(debug.contains("one_or_more: true"), "{debug}");
+    assert!(debug.contains("Artifact"), "{debug}");
+    assert!(debug.contains("Creature"), "{debug}");
+    assert!(debug.contains("GainLife"), "{debug}");
+}
+
+#[test]
+fn rewrite_lexed_triggered_line_parses_dredgers_insight_milled_card_choice() {
+    let text = "When this enchantment enters, mill four cards. You may put an artifact, creature, or land card from among the milled cards into your hand.";
+    let tokens = lex_line(text, 0)
+        .expect("rewrite lexer should classify Dredger's Insight enters triggered line");
+
+    let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+        .expect("Dredger's Insight mill-and-choose triggered line should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("Mill"), "{debug}");
+    assert!(debug.contains("ChooseFromLookedCardsIntoHandRestIntoGraveyard"), "{debug}");
+    assert!(debug.contains("Artifact"), "{debug}");
+    assert!(debug.contains("Creature"), "{debug}");
+    assert!(debug.contains("Land"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_triggered_line_parses_stonebinders_familiar_trigger() {
     let text = "Whenever one or more cards are put into exile during your turn, put a +1/+1 counter on this creature. This ability triggers only once each turn.";
     let tokens = lex_line(text, 0)

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -215,6 +215,11 @@ pub enum TriggerKind {
     PutIntoGraveyard {
         filter: ObjectFilter,
     },
+    CardsLeaveYourGraveyard {
+        filter: ObjectFilter,
+        one_or_more: bool,
+        during_your_turn: bool,
+    },
     DiesCreatureDealtDamageByThisTurn {
         victim: ObjectFilter,
         damager: DamagedBySource,
@@ -763,6 +768,20 @@ impl Trigger {
         Self::typed(
             "put_into_graveyard",
             TriggerKind::PutIntoGraveyard { filter },
+        )
+    }
+    pub fn cards_leave_your_graveyard(
+        filter: ObjectFilter,
+        one_or_more: bool,
+        during_your_turn: bool,
+    ) -> Self {
+        Self::typed(
+            "cards_leave_your_graveyard",
+            TriggerKind::CardsLeaveYourGraveyard {
+                filter,
+                one_or_more,
+                during_your_turn,
+            },
         )
     }
     pub fn creature_dealt_damage_by_this_creature_this_turn_dies(victim: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35031,6 +35031,179 @@ fn assert_oracle_card_fails_strict(name: &str) {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_dredgers_insight_strict_regression() {
+    assert_oracle_card_parses_strict("Dredger's Insight");
+    let def = parse_oracle_card_definition("Dredger's Insight");
+    let rendered_lines = canonical_compiled_lines(&def);
+
+    assert!(
+        rendered_lines.iter().any(|line| {
+            line
+                == "Whenever one or more artifact and/or creature cards leave your graveyard, you gain 1 life."
+        }),
+        "expected Dredger's Insight graveyard-leave trigger text, got {rendered_lines:?}"
+    );
+    assert!(
+        rendered_lines.iter().any(|line| {
+            line.to_ascii_lowercase().contains("mill four cards")
+                && line.contains("artifact")
+                && line.contains("creature")
+                && line.contains("land card from among the milled cards")
+                && line.contains("into your hand")
+        }),
+        "expected Dredger's Insight mill choice text, got {rendered_lines:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dredgers_insight_trigger_matches_only_own_artifact_or_creature_cards_and_gains_life() {
+    let def = parse_oracle_card_definition("Dredger's Insight");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered
+                .trigger
+                .display()
+                .contains("leave your graveyard")
+                .then_some(triggered),
+            _ => None,
+        })
+        .expect("Dredger's Insight should have a graveyard-leave triggered ability");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source_id = ObjectId::from_raw(910_001);
+    let ctx = crate::triggers::TriggerContext::for_source(source_id, alice, &game);
+
+    let leave_event = |snapshot: crate::snapshot::ObjectSnapshot| {
+        crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::zones::ZoneChangeEvent::with_cause(
+                snapshot.object_id,
+                Zone::Graveyard,
+                Zone::Exile,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        )
+    };
+    let snapshot = |id, owner, name, card_types| {
+        crate::snapshot::ObjectSnapshot::for_testing(ObjectId::from_raw(id), owner, name)
+            .with_card_types(card_types)
+    };
+
+    let artifact_event = leave_event(snapshot(
+        910_010,
+        alice,
+        "Milled Bauble",
+        vec![CardType::Artifact],
+    ));
+    assert!(
+        triggered.trigger.matches(&artifact_event, &ctx),
+        "Dredger's Insight should trigger when your artifact card leaves your graveyard"
+    );
+    assert_eq!(
+        triggered.trigger.trigger_count_with_context(&artifact_event, &ctx),
+        1,
+        "Dredger's Insight is a one-or-more trigger"
+    );
+
+    let creature_event = leave_event(snapshot(
+        910_011,
+        alice,
+        "Milled Creature",
+        vec![CardType::Creature],
+    ));
+    assert!(
+        triggered.trigger.matches(&creature_event, &ctx),
+        "Dredger's Insight should trigger when your creature card leaves your graveyard"
+    );
+
+    let batch_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::batch_with_snapshots(
+            vec![ObjectId::from_raw(910_020), ObjectId::from_raw(910_021)],
+            Zone::Graveyard,
+            Zone::Exile,
+            crate::events::cause::EventCause::effect(),
+            vec![
+                snapshot(910_020, alice, "Batch Bauble", vec![CardType::Artifact]),
+                snapshot(910_021, alice, "Batch Creature", vec![CardType::Creature]),
+            ],
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        triggered.trigger.matches(&batch_event, &ctx),
+        "Dredger's Insight should trigger when one or more matching cards leave together"
+    );
+    assert_eq!(
+        triggered.trigger.trigger_count_with_context(&batch_event, &ctx),
+        1,
+        "Dredger's Insight should trigger only once for a batch of matching cards"
+    );
+
+    let land_event = leave_event(snapshot(910_012, alice, "Milled Land", vec![CardType::Land]));
+    assert!(
+        !triggered.trigger.matches(&land_event, &ctx),
+        "Dredger's Insight should not trigger when only a land card leaves your graveyard"
+    );
+
+    let opponent_artifact_event = leave_event(snapshot(
+        910_013,
+        bob,
+        "Opponent Bauble",
+        vec![CardType::Artifact],
+    ));
+    assert!(
+        !triggered.trigger.matches(&opponent_artifact_event, &ctx),
+        "Dredger's Insight should not trigger for an opponent's graveyard"
+    );
+
+    let gain_life = triggered.effects.segments[0].default_effects[0]
+        .downcast_ref::<GainLifeEffect>()
+        .expect("Dredger's Insight trigger should gain life");
+    let mut exec_ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    gain_life
+        .execute(&mut game, &mut exec_ctx)
+        .expect("Dredger's Insight life gain should resolve");
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        21,
+        "Dredger's Insight should gain exactly 1 life when its trigger resolves"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dredgers_insight_etb_choice_is_limited_to_milled_artifact_creature_or_land_cards() {
+    let def = parse_oracle_card_definition("Dredger's Insight");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered.trigger.display().contains("enters") => Some(triggered),
+            _ => None,
+        })
+        .expect("Dredger's Insight should have an enters trigger");
+    let effects = &triggered.effects.segments[0].default_effects;
+    let debug = format!("{effects:#?}");
+    assert!(debug.contains("MillEffect"), "{debug}");
+    assert!(debug.contains("Fixed") && debug.contains("4"), "{debug}");
+    assert!(debug.contains("ChooseObjectsEffect"), "{debug}");
+    assert!(debug.contains("min: 0"), "{debug}");
+    assert!(debug.contains("Graveyard"), "{debug}");
+    assert!(debug.contains("Artifact"), "{debug}");
+    assert!(debug.contains("Creature"), "{debug}");
+    assert!(debug.contains("Land"), "{debug}");
+    assert!(debug.contains("milled_") && debug.contains("IsTaggedObject"), "{debug}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_sporeweb_weaver_strict_regression() {
     assert_oracle_card_parses_strict("Sporeweb Weaver");
     let def = parse_oracle_card_definition("Sporeweb Weaver");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -20149,6 +20149,30 @@ pub(super) fn describe_choose_filter_from_looked_cards(
         return Some("a card".to_string());
     }
 
+    if base_filter.card_types.is_empty()
+        && base_filter.all_card_types.is_empty()
+        && base_filter.subtypes.is_empty()
+        && base_filter.static_abilities.is_empty()
+        && !base_filter.any_of.is_empty()
+    {
+        let mut type_words = Vec::new();
+        for candidate in &base_filter.any_of {
+            if candidate.card_types.len() != 1
+                || !candidate.all_card_types.is_empty()
+                || !candidate.subtypes.is_empty()
+                || !candidate.static_abilities.is_empty()
+                || !candidate.any_of.is_empty()
+            {
+                type_words.clear();
+                break;
+            }
+            type_words.push(describe_card_type_word_local(candidate.card_types[0]).to_string());
+        }
+        if let Some(joined) = join_or_list(&type_words) {
+            return Some(with_indefinite_article(&format!("{joined} card")));
+        }
+    }
+
     let filter_text = base_filter.description();
     let mut card_desc = filter_text
         .split(" in ")
@@ -21798,6 +21822,14 @@ fn describe_tagged_mill_clause(mill: &crate::effects::MillEffect) -> String {
     }
 }
 
+fn describe_milled_cards_reference(choose: &crate::effects::ChooseObjectsEffect) -> &'static str {
+    if choose.description == "from among the milled cards" {
+        "from among the milled cards"
+    } else {
+        "from among the cards milled this way"
+    }
+}
+
 pub(super) fn describe_tagged_mill_then_put_milled_card_into_hand(
     tagged_mill: &crate::effects::TaggedEffect,
     mill: &crate::effects::MillEffect,
@@ -21813,8 +21845,9 @@ pub(super) fn describe_tagged_mill_then_put_milled_card_into_hand(
     let mill_clause = describe_tagged_mill_clause(mill);
     let hand = describe_possessive_player_filter(&choose.chooser);
     let may = if choose.count.min == 0 { " may" } else { "" };
+    let milled_cards_reference = describe_milled_cards_reference(choose);
     Some(format!(
-        "{mill_clause}. You{may} put {chosen} from among the cards milled this way into {hand} hand"
+        "{mill_clause}. You{may} put {chosen} {milled_cards_reference} into {hand} hand"
     ))
 }
 
@@ -21850,8 +21883,9 @@ pub(super) fn describe_tagged_mill_then_may_put_milled_card_into_hand(
     let chosen = describe_choose_filter_from_tagged_cards(choose, tagged_mill.tag.as_str())?;
     let mill_clause = describe_tagged_mill_clause(mill);
     let hand = describe_possessive_player_filter(&choose.chooser);
+    let milled_cards_reference = describe_milled_cards_reference(choose);
     Some(format!(
-        "{mill_clause}. You may put {chosen} from among the cards milled this way into {hand} hand"
+        "{mill_clause}. You may put {chosen} {milled_cards_reference} into {hand} hand"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -303,6 +303,15 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::PutIntoGraveyard { filter } => {
             crate::triggers::Trigger::put_into_graveyard(filter)
         }
+        TriggerKind::CardsLeaveYourGraveyard {
+            filter,
+            one_or_more,
+            during_your_turn,
+        } => crate::triggers::Trigger::cards_leave_your_graveyard(
+            filter,
+            one_or_more,
+            during_your_turn,
+        ),
         TriggerKind::DiesCreatureDealtDamageByThisTurn { victim, damager } => match damager {
             DamagedBySource::ThisCreature => {
                 crate::triggers::Trigger::creature_dealt_damage_by_this_creature_this_turn_dies(

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/cards_leave_your_graveyard.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/cards_leave_your_graveyard.rs
@@ -41,22 +41,16 @@ impl CardsLeaveYourGraveyardTrigger {
             return 0;
         }
 
-        // move_object emits single-object zone changes with a pre-move snapshot.
-        if zc.objects.len() == 1
-            && let Some(snapshot) = zc.snapshot.as_ref()
-        {
-            if snapshot.owner != ctx.controller {
-                return 0;
-            }
-
-            return if self
-                .filter
-                .matches_snapshot(snapshot, &ctx.filter_ctx, ctx.game)
-            {
-                1
-            } else {
-                0
-            };
+        let snapshots = zc.snapshots();
+        if !snapshots.is_empty() {
+            return snapshots
+                .iter()
+                .filter(|snapshot| snapshot.owner == ctx.controller)
+                .filter(|snapshot| {
+                    self.filter
+                        .matches_snapshot(snapshot, &ctx.filter_ctx, ctx.game)
+                })
+                .count() as u32;
         }
 
         let mut count = 0u32;
@@ -135,6 +129,16 @@ impl TriggerMatcher for CardsLeaveYourGraveyardTrigger {
         event
             .downcast::<ZoneChangeEvent>()
             .map(|zc| zc.count() as u32)
+            .unwrap_or(1)
+    }
+
+    fn trigger_count_with_context(&self, event: &TriggerEvent, ctx: &TriggerContext) -> u32 {
+        if self.one_or_more {
+            return 1;
+        }
+        event
+            .downcast::<ZoneChangeEvent>()
+            .map(|zc| self.matching_count(zc, ctx))
             .unwrap_or(1)
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dredger's Insight
Initial parse error:
```
unsupported triggered line: 'Whenever one or more artifact and/or creature cards leave your graveyard, you gain 1 life.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever one or more artifact and/or creature cards leave your graveyard, you gain 1 life.'
```

Current worker: i-0c6012d0a679a1266
Branch: codex/aws-card-fix-dredger-s-insight
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
