### PR TITLE
Fix Ironsmith parse failure: Arden Angel

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1219,6 +1219,16 @@ impl Effect {
         Self::new(crate::effects::RollDieEffect::new(player, sides))
     }
 
+    pub fn roll_die_with_die_text(
+        sides: u32,
+        player: crate::target::PlayerFilter,
+        die_text: Option<String>,
+    ) -> Self {
+        Self::new(crate::effects::RollDieEffect::new_with_die_text(
+            player, sides, die_text,
+        ))
+    }
+
     pub fn fight(a: crate::target::ChooseSpec, b: crate::target::ChooseSpec) -> Self {
         Self::new(crate::effects::FightEffect::new(a, b))
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -718,21 +718,47 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     for (phrase, zone) in [
+        (["this", "is", "in", "your", "hand"].as_slice(), Zone::Hand),
         (
             ["this", "card", "is", "in", "your", "hand"].as_slice(),
             Zone::Hand,
+        ),
+        (
+            ["this", "is", "in", "your", "graveyard"].as_slice(),
+            Zone::Graveyard,
         ),
         (
             ["this", "card", "is", "in", "your", "graveyard"].as_slice(),
             Zone::Graveyard,
         ),
         (
-            ["this", "card", "is", "in", "your", "library"].as_slice(),
+            ["this", "creature", "is", "in", "your", "graveyard"].as_slice(),
+            Zone::Graveyard,
+        ),
+        (
+            ["this", "permanent", "is", "in", "your", "graveyard"].as_slice(),
+            Zone::Graveyard,
+        ),
+        (
+            ["this", "object", "is", "in", "your", "graveyard"].as_slice(),
+            Zone::Graveyard,
+        ),
+        (
+            ["this", "is", "in", "your", "library"].as_slice(),
             Zone::Library,
         ),
         (
+            ["this", "card", "is", "in", "your", "library"].as_slice(),
+            Zone::Library,
+        ),
+        (["this", "is", "in", "exile"].as_slice(), Zone::Exile),
+        (
             ["this", "card", "is", "in", "exile"].as_slice(),
             Zone::Exile,
+        ),
+        (
+            ["this", "is", "in", "the", "command", "zone"].as_slice(),
+            Zone::Command,
         ),
         (
             ["this", "card", "is", "in", "the", "command", "zone"].as_slice(),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -518,6 +518,14 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
             crate::effect::Comparison::GreaterThan(0),
         ));
     }
+    if words.len() == 3
+        && words[0] == "result"
+        && matches!(words[1], "is" | "was")
+        && let Some(value) = ironsmith_core::parse_cardinal_word(words[2])
+            .and_then(|value| i32::try_from(value).ok())
+    {
+        return Some(IfResultPredicate::Value(Comparison::Equal(value)));
+    }
     if words.len() >= 3
         && words[0] == "you"
         && (words[1] == "win" || words[1] == "won")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -572,9 +572,13 @@ fn compile_subject_verb_effect(
                 Effect::flip_coin(subject.into_player_filter())
             })
         }
-        SubjectVerbActionAst::RollDie { sides } => {
+        SubjectVerbActionAst::RollDie { sides, die_text } => {
             compile_player_role_effect(role, player, ctx, false, false, true, |subject| {
-                Effect::roll_die(*sides, subject.into_player_filter())
+                Effect::roll_die_with_die_text(
+                    *sides,
+                    subject.into_player_filter(),
+                    die_text.clone(),
+                )
             })
         }
         SubjectVerbActionAst::ShuffleHandAndGraveyardIntoLibrary => {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -826,11 +826,19 @@ pub(super) fn infer_rewrite_triggered_functional_zones(
 
     let normalized = normalized_line.to_ascii_lowercase();
     for (needle, zone) in [
+        ("if this is in your hand", Zone::Hand),
         ("if this card is in your hand", Zone::Hand),
+        ("if this is in your graveyard", Zone::Graveyard),
         ("if this card is in your graveyard", Zone::Graveyard),
+        ("if this creature is in your graveyard", Zone::Graveyard),
+        ("if this permanent is in your graveyard", Zone::Graveyard),
+        ("if this object is in your graveyard", Zone::Graveyard),
+        ("if this is in your library", Zone::Library),
         ("if this card is in your library", Zone::Library),
+        ("if this is in exile", Zone::Exile),
         ("if this card is in exile", Zone::Exile),
         ("if this card is exiled", Zone::Exile),
+        ("if this is in the command zone", Zone::Command),
         ("if this card is in the command zone", Zone::Command),
     ] {
         if str_contains(normalized.as_str(), needle) {
@@ -838,7 +846,8 @@ pub(super) fn infer_rewrite_triggered_functional_zones(
             break;
         }
     }
-    if str_contains(normalized.as_str(), "return this card from your graveyard")
+    if (str_contains(normalized.as_str(), "return this from your graveyard")
+        || str_contains(normalized.as_str(), "return this card from your graveyard"))
         && !trigger_references_attached_object(trigger)
     {
         zones = vec![Zone::Graveyard];

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
@@ -77,11 +77,19 @@ pub(super) fn infer_triggered_ability_functional_zones(
 
     let normalized = normalized_line.to_ascii_lowercase();
     for (needle, zone) in [
+        ("if this is in your hand", Zone::Hand),
         ("if this card is in your hand", Zone::Hand),
+        ("if this is in your graveyard", Zone::Graveyard),
         ("if this card is in your graveyard", Zone::Graveyard),
+        ("if this creature is in your graveyard", Zone::Graveyard),
+        ("if this permanent is in your graveyard", Zone::Graveyard),
+        ("if this object is in your graveyard", Zone::Graveyard),
+        ("if this is in your library", Zone::Library),
         ("if this card is in your library", Zone::Library),
+        ("if this is in exile", Zone::Exile),
         ("if this card is in exile", Zone::Exile),
         ("if this card is exiled", Zone::Exile),
+        ("if this is in the command zone", Zone::Command),
         ("if this card is in the command zone", Zone::Command),
     ] {
         if str_contains(normalized.as_str(), needle) {
@@ -89,7 +97,8 @@ pub(super) fn infer_triggered_ability_functional_zones(
             break;
         }
     }
-    if str_contains(normalized.as_str(), "return this card from your graveyard")
+    if (str_contains(normalized.as_str(), "return this from your graveyard")
+        || str_contains(normalized.as_str(), "return this card from your graveyard"))
         && !trigger_references_attached_object(trigger)
     {
         zones = vec![Zone::Graveyard];

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -741,6 +741,7 @@ pub(crate) enum SubjectVerbActionAst {
     FlipCoin,
     RollDie {
         sides: u32,
+        die_text: Option<String>,
     },
     ShuffleHandAndGraveyardIntoLibrary,
     ShuffleGraveyardIntoLibrary,
@@ -1727,7 +1728,16 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             }
             Self::Clash { opponent } => f.debug_tuple("Clash").field(opponent).finish(),
             Self::FlipCoin => f.write_str("FlipCoin"),
-            Self::RollDie { sides } => f.debug_tuple("RollDie").field(sides).finish(),
+            Self::RollDie { sides, die_text } => {
+                if let Some(die_text) = die_text {
+                    f.debug_struct("RollDie")
+                        .field("sides", sides)
+                        .field("die_text", die_text)
+                        .finish()
+                } else {
+                    f.debug_tuple("RollDie").field(sides).finish()
+                }
+            }
             Self::ShuffleHandAndGraveyardIntoLibrary => {
                 f.write_str("ShuffleHandAndGraveyardIntoLibrary")
             }
@@ -5315,10 +5325,18 @@ impl EffectAst {
     }
 
     pub(crate) fn subject_verb_roll_die(player: PlayerAst, sides: u32) -> Self {
+        Self::subject_verb_roll_die_with_die_text(player, sides, None)
+    }
+
+    pub(crate) fn subject_verb_roll_die_with_die_text(
+        player: PlayerAst,
+        sides: u32,
+        die_text: Option<String>,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::AffectedPlayer,
             player,
-            SubjectVerbActionAst::RollDie { sides },
+            SubjectVerbActionAst::RollDie { sides, die_text },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -226,6 +226,11 @@ pub(crate) fn parse_roll(
     tokens: &[OwnedLexToken],
     subject: Option<SubjectAst>,
 ) -> Result<EffectAst, CardTextError> {
+    fn parse_sided_die_word(word: &str) -> Option<u32> {
+        let prefix = word.strip_suffix("-sided")?;
+        ironsmith_core::parse_cardinal_word(prefix).or_else(|| prefix.parse::<u32>().ok())
+    }
+
     let player = match subject.unwrap_or(SubjectAst::This) {
         SubjectAst::Player(player) => player,
         SubjectAst::This => PlayerAst::Implicit,
@@ -243,16 +248,56 @@ pub(crate) fn parse_roll(
         ));
     };
     let die_word = die_word.to_ascii_lowercase();
+    let die_noun = die_tokens
+        .iter()
+        .filter_map(OwnedLexToken::as_word)
+        .map(str::to_ascii_lowercase)
+        .take(3)
+        .collect::<Vec<_>>();
+    let die_text = match die_noun.as_slice() {
+        [sided, noun] if sided.ends_with("-sided") && matches!(noun.as_str(), "die" | "dice") => {
+            Some(format!("{sided} {noun}"))
+        }
+        [number, sided, noun] if sided == "sided" && matches!(noun.as_str(), "die" | "dice") => {
+            Some(format!("{number}-sided {noun}"))
+        }
+        _ => None,
+    };
     let Some(sides) = die_word
         .strip_prefix('d')
         .and_then(|sides| sides.parse::<u32>().ok())
+        .or_else(|| {
+            let has_die_noun = die_tokens
+                .get(1)
+                .and_then(OwnedLexToken::as_word)
+                .is_some_and(|word| matches!(word, "die" | "dice"));
+            has_die_noun.then(|| parse_sided_die_word(&die_word)).flatten()
+        })
+        .or_else(|| {
+            let has_sided_die_noun = die_tokens
+                .get(1)
+                .and_then(OwnedLexToken::as_word)
+                .is_some_and(|word| word == "sided")
+                && die_tokens
+                    .get(2)
+                    .and_then(OwnedLexToken::as_word)
+                    .is_some_and(|word| matches!(word, "die" | "dice"));
+            has_sided_die_noun
+                .then(|| {
+                    ironsmith_core::parse_cardinal_word(&die_word)
+                        .or_else(|| die_word.parse::<u32>().ok())
+                })
+                .flatten()
+        })
     else {
         return Err(CardTextError::ParseError(format!(
             "unsupported roll clause (clause: '{}')",
             crate::runtime_backend::token_word_refs(tokens).join(" ")
         )));
     };
-    Ok(EffectAst::subject_verb_roll_die(player, sides))
+    Ok(EffectAst::subject_verb_roll_die_with_die_text(
+        player, sides, die_text,
+    ))
 }
 
 pub(crate) fn parse_regenerate(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
@@ -477,6 +477,22 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
         )));
     }
 
+    let source_from_graveyard_target = if is_battlefield
+        && target_words.len() > 3
+        && target_words[target_words.len() - 3..] == ["from", "your", "graveyard"]
+    {
+        let prefix_word_len = target_words.len() - 3;
+        let prefix_token_len = token_index_for_word_index(target_tokens, prefix_word_len)
+            .unwrap_or(target_tokens.len());
+        let prefix_tokens = trim_commas(&target_tokens[..prefix_token_len]);
+        match parse_target_phrase(&prefix_tokens) {
+            Ok(TargetAst::Source(span)) => Some(TargetAst::Source(span)),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
     let mut count_value = None;
     let (target_tokens, dynamic_count) = if target_words
         .get(..2)
@@ -499,7 +515,9 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
     } else {
         (target_tokens, false)
     };
-    let mut target = if matches!(
+    let mut target = if let Some(target) = source_from_graveyard_target {
+        target
+    } else if matches!(
         target_words.as_slice(),
         ["it"]
             | ["them"]

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -4124,11 +4124,24 @@ impl ControlCombatChoicesThisTurnEffect {
 pub struct RollDieEffect {
     pub player: PlayerFilter,
     pub sides: u32,
+    pub die_text: Option<String>,
 }
 
 impl RollDieEffect {
     pub fn new(player: PlayerFilter, sides: u32) -> Self {
-        Self { player, sides }
+        Self {
+            player,
+            sides,
+            die_text: None,
+        }
+    }
+
+    pub fn new_with_die_text(player: PlayerFilter, sides: u32, die_text: Option<String>) -> Self {
+        Self {
+            player,
+            sides,
+            die_text,
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3767,6 +3767,44 @@ fn test_parse_aberrant_mind_sorcerer_rolls_and_branch_ranges() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_arden_angel_rolls_four_sided_die_and_returns_itself_from_graveyard() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Arden Angel")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Angel])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Flying\nAt the beginning of your upkeep, if Arden Angel is in your graveyard, roll a four-sided die. If the result is 1, return Arden Angel from your graveyard to the battlefield.",
+        )
+        .expect("Arden Angel should parse strictly");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(debug.contains("RollDieEffect"), "{debug}");
+    assert!(debug.contains("sides: 4"), "{debug}");
+    assert!(debug.contains("SourceIsInZone(Graveyard)"), "{debug}");
+    assert!(
+        debug.contains("ReturnFromGraveyardToBattlefieldEffect")
+            && debug.contains("FullName(\"Arden Angel\")")
+            && !debug.contains("ChooseObjectsEffect"),
+        "expected Arden Angel to return itself, not choose an Angel card, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("if Arden Angel is in your graveyard"),
+        "expected named graveyard intervening-if condition, got {rendered}"
+    );
+    assert!(
+        rendered.contains("roll a four-sided die") && rendered.contains("If the result is 1"),
+        "expected four-sided die and exact-result branch wording, got {rendered}"
+    );
+    assert!(
+        rendered.contains("return Arden Angel from your graveyard to the battlefield"),
+        "expected named self-return wording, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_clown_car_compiled_text_keeps_odd_even_branches_and_token_identity() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Clown Car")
         .card_types(vec![CardType::Artifact, CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13322,7 +13322,10 @@ fn describe_triggered_inline_ability(
     let mut line = describe_trigger_surface_with_frequency(triggered, trigger_frequency);
     if let Some(condition) = intervening_condition {
         line.push_str(", if ");
-        line.push_str(&describe_condition(&condition));
+        line.push_str(&describe_trigger_intervening_condition(
+            &condition,
+            triggered,
+        ));
     }
 
     let mut clauses = Vec::new();
@@ -13398,6 +13401,52 @@ fn describe_triggered_inline_ability(
     line = normalize_modal_named_source_etb_surface(line, triggered, self_subject);
     line = normalize_spellcast_trigger_mana_value_surface(triggered, line);
     apply_triggered_presentation_label(triggered, line)
+}
+
+fn describe_trigger_intervening_condition(
+    condition: &Condition,
+    triggered: &crate::ability::TriggeredAbility,
+) -> String {
+    if matches!(condition, Condition::SourceIsInZone(Zone::Graveyard))
+        && let Some(subject) = source_return_from_graveyard_subject(triggered)
+    {
+        return format!("{subject} is in your graveyard");
+    }
+    describe_condition(condition)
+}
+
+fn source_return_from_graveyard_subject(
+    triggered: &crate::ability::TriggeredAbility,
+) -> Option<String> {
+    triggered
+        .effects
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .find_map(source_return_from_graveyard_subject_in_effect)
+}
+
+fn source_return_from_graveyard_subject_in_effect(effect: &Effect) -> Option<String> {
+    if let Some(return_to_battlefield) = effect
+        .downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()
+        && matches!(return_to_battlefield.target.unhinted(), ChooseSpec::Source)
+    {
+        return Some(describe_choose_spec(&return_to_battlefield.target));
+    }
+    if let Some(if_effect) = effect.downcast_ref::<crate::effects::IfEffect>() {
+        return if_effect
+            .then
+            .iter()
+            .chain(if_effect.else_.iter())
+            .find_map(source_return_from_graveyard_subject_in_effect);
+    }
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return source_return_from_graveyard_subject_in_effect(&tagged.effect);
+    }
+    if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+        return source_return_from_graveyard_subject_in_effect(&with_id.effect);
+    }
+    None
 }
 
 fn normalize_modal_named_source_etb_surface(
@@ -22952,7 +23001,9 @@ fn describe_with_id_if_clause(
             let player = describe_player_filter(&roll_die.player);
             let result_text = describe_roll_result_comparison(cmp)?;
             let verb = player_verb(&player, "roll", "rolls");
-            if player == "you" {
+            if matches!(cmp, Comparison::Equal(_)) {
+                format!("If the result is {result_text}")
+            } else if player == "you" {
                 format!("If you roll {result_text}")
             } else {
                 format!("If {player} {verb} {result_text}")
@@ -22972,7 +23023,9 @@ fn describe_with_id_if_clause(
                 let player = describe_player_filter(&roll_die.player);
                 let result_text = describe_roll_result_comparison(cmp)?;
                 let verb = player_verb(&player, "roll", "rolls");
-                if player == "you" {
+                if matches!(cmp, Comparison::Equal(_)) {
+                    format!("If the result is {result_text}")
+                } else if player == "you" {
                     format!("If you roll {result_text}")
                 } else {
                     format!("If {player} {verb} {result_text}")
@@ -26666,6 +26719,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(return_to_battlefield) =
         effect.downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()
     {
+        if matches!(return_to_battlefield.target.unhinted(), ChooseSpec::Source) {
+            return format!(
+                "Return {} from your graveyard to the battlefield{}",
+                describe_choose_spec(&return_to_battlefield.target),
+                if return_to_battlefield.tapped {
+                    " tapped"
+                } else {
+                    ""
+                }
+            );
+        }
         if let Some(owner) = graveyard_owner_from_spec(&return_to_battlefield.target) {
             let target_text =
                 describe_choose_spec_without_graveyard_zone(&return_to_battlefield.target);
@@ -28135,13 +28199,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(roll_die) = effect.downcast_ref::<crate::effects::RollDieEffect>() {
         let player = describe_player_filter(&roll_die.player);
+        let die_text = roll_die
+            .die_text
+            .clone()
+            .unwrap_or_else(|| format!("d{}", roll_die.sides));
         if player == "you" {
-            return format!("Roll a d{}", roll_die.sides);
+            return format!("Roll a {die_text}");
         }
         return format!(
-            "{player} {} a d{}",
+            "{player} {} a {die_text}",
             player_verb(&player, "roll", "rolls"),
-            roll_die.sides
         );
     }
     if let Some(flip_coin) = effect.downcast_ref::<crate::effects::FlipCoinEffect>() {
@@ -34301,7 +34368,10 @@ pub(super) fn describe_ability(
             let mut line = format!("Triggered ability {index}: {trigger_surface}");
             if let Some(condition) = intervening_condition {
                 line.push_str(", if ");
-                line.push_str(&describe_condition(&condition));
+                line.push_str(&describe_trigger_intervening_condition(
+                    &condition,
+                    triggered,
+                ));
             }
             let mut clauses = Vec::new();
             if !triggered.choices.is_empty()

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -2870,6 +2870,16 @@ impl Effect {
         Self::new(RollDieEffect::new(player, sides))
     }
 
+    /// Roll a die, preserving source text such as "four-sided die" for rendering.
+    pub fn roll_die_with_die_text(
+        sides: u32,
+        player: PlayerFilter,
+        die_text: Option<String>,
+    ) -> Self {
+        use crate::effects::RollDieEffect;
+        Self::new(RollDieEffect::new_with_die_text(player, sides, die_text))
+    }
+
     // === Effect composition builders ===
 
     /// Wrap an effect with an ID for later reference.

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1259,9 +1259,10 @@ where
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::RollDieEffect>(&effect) {
-        return Ok(Effect::new(crate::effects::RollDieEffect::new(
+        return Ok(Effect::new(crate::effects::RollDieEffect::new_with_die_text(
             payload.player.clone(),
             payload.sides,
+            payload.die_text.clone(),
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::EmitGiftGivenEffect>(&effect) {

--- a/crates/ironsmith-runtime/src/effects/player/roll_die.rs
+++ b/crates/ironsmith-runtime/src/effects/player/roll_die.rs
@@ -9,11 +9,24 @@ use crate::target::PlayerFilter;
 pub struct RollDieEffect {
     pub player: PlayerFilter,
     pub sides: u32,
+    pub die_text: Option<String>,
 }
 
 impl RollDieEffect {
     pub fn new(player: PlayerFilter, sides: u32) -> Self {
-        Self { player, sides }
+        Self {
+            player,
+            sides,
+            die_text: None,
+        }
+    }
+
+    pub fn new_with_die_text(player: PlayerFilter, sides: u32, die_text: Option<String>) -> Self {
+        Self {
+            player,
+            sides,
+            die_text,
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -15591,6 +15591,109 @@ fn clown_car_etb_applies_odd_even_result_branches_per_die_for_x_rolls() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn arden_angel_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Arden Angel")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Angel])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Flying\nAt the beginning of your upkeep, if Arden Angel is in your graveyard, roll a four-sided die. If the result is 1, return Arden Angel from your graveyard to the battlefield.",
+        )
+        .expect("Arden Angel should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn arden_angel_upkeep_roll_one_returns_from_graveyard_to_battlefield() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let arden = arden_angel_definition();
+    let arden_id = game.create_object_from_definition(&arden, alice, Zone::Graveyard);
+    let arden_stable_id = game.object(arden_id).expect("Arden Angel exists").stable_id;
+    game.force_next_die_roll(1);
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Arden Angel should trigger from its controller's graveyard during upkeep"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Arden Angel upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Arden Angel upkeep trigger should resolve");
+
+    let returned_id = game
+        .find_object_by_stable_id(arden_stable_id)
+        .expect("Arden Angel should still be trackable after returning");
+    assert!(
+        game.object(returned_id)
+            .is_some_and(|object| object.zone == Zone::Battlefield),
+        "rolling 1 should return Arden Angel to the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn arden_angel_upkeep_non_one_roll_leaves_it_in_graveyard() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let arden = arden_angel_definition();
+    let arden_id = game.create_object_from_definition(&arden, alice, Zone::Graveyard);
+    let arden_stable_id = game.object(arden_id).expect("Arden Angel exists").stable_id;
+    game.force_next_die_roll(2);
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Arden Angel should trigger");
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Arden Angel upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Arden Angel upkeep trigger should resolve");
+
+    let arden_id = game
+        .find_object_by_stable_id(arden_stable_id)
+        .expect("Arden Angel should still be trackable after resolving");
+    assert!(
+        game.object(arden_id)
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "rolling a non-1 should leave Arden Angel in the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn arden_angel_does_not_trigger_when_not_in_graveyard() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    let arden = arden_angel_definition();
+    game.create_object_from_definition(&arden, alice, Zone::Battlefield);
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Arden Angel's upkeep ability should only function from the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_fallen_shinobi_trigger_exiles_top_two_cards_and_grants_play_permission() {
     use crate::decision::compute_legal_actions;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Arden Angel
Initial parse error:
```
unsupported roll clause (clause: 'a four-sided die'); oracle-only fallback also failed: unsupported roll clause (clause: 'a four-sided die')
```

Current worker: i-0bc6df00751ea6d4c
Branch: codex/aws-card-fix-arden-angel
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
