### PR TITLE
Fix Ironsmith parse failure: Tainted Sigil

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -764,6 +764,24 @@ pub(crate) fn parse_life_equal_to_value(
     if matches!(
         amount_words.as_slice(),
         [
+            "equal", "to", "the", "total", "life", "lost", "by", "all", "players", "this",
+            "turn"
+        ] | [
+            "equal", "to", "total", "life", "lost", "by", "all", "players", "this",
+            "turn"
+        ] | [
+            "equal", "to", "the", "total", "amount", "of", "life", "lost", "by", "all",
+            "players", "this", "turn"
+        ] | [
+            "equal", "to", "total", "amount", "of", "life", "lost", "by", "all", "players",
+            "this", "turn"
+        ]
+    ) {
+        return Ok(Some(Value::LifeLostThisTurn(PlayerFilter::Any)));
+    }
+    if matches!(
+        amount_words.as_slice(),
+        [
             "equal", "to", "the", "life", "that", "player", "lost", "this", "turn"
         ] | [
             "equal", "to", "life", "that", "player", "lost", "this", "turn"

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -9653,6 +9653,29 @@ fn parse_each_opponent_loses_life_equal_to_that_players_life_lost_this_turn() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_tainted_sigil_strictly_parses_and_renders_total_life_lost() {
+    assert_oracle_card_parses_strict("Tainted Sigil");
+
+    let def = parse_oracle_card_definition("Tainted Sigil");
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "{T}, Sacrifice this artifact: You gain life equal to the total life lost by all players this turn."
+                .to_string(),
+        ],
+        "expected Tainted Sigil to render the all-players life-lost amount"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("LifeLostThisTurn") && debug.contains("Any"),
+        "expected Tainted Sigil to structurally use all players' life lost this turn, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_one_or_more_etb_trigger_binds_that_much_to_zone_change_count() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Artillerist Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7765,6 +7765,7 @@ pub(crate) fn describe_value(value: &Value) -> String {
             PlayerFilter::Opponent => {
                 "the total life your opponents lost this turn".to_string()
             }
+            PlayerFilter::Any => "the total life lost by all players this turn".to_string(),
             _ => format!(
                 "the total life {} lost this turn",
                 describe_player_filter(filter)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12615,6 +12615,177 @@ fn test_activation_cost_source_lki_uses_state_after_prior_costs() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn tainted_sigil_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Tainted Sigil")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{T}, Sacrifice this artifact: You gain life equal to the total life lost by all players this turn. (Damage causes loss of life.)",
+        )
+        .expect("Tainted Sigil should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_tainted_sigil_after_life_losses(
+    life_losses: &[(PlayerId, u32, bool)],
+) -> (GameState, crate::ids::StableId) {
+    use crate::decision::LegalAction;
+    use crate::decisions::context::DecisionContext;
+    use crate::events::{LifeLossEvent, RawEvent};
+    use crate::provenance::ProvNodeId;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    for (player_id, amount, from_damage) in life_losses {
+        game.player_mut(*player_id)
+            .expect("life-loss player should exist")
+            .life -= *amount as i32;
+        let event = RawEvent::new(
+            LifeLossEvent::new(*player_id, *amount, *from_damage),
+            ProvNodeId::default(),
+        );
+        game.record_turn_history_event(&event);
+    }
+
+    let sigil = tainted_sigil_definition();
+    let sigil_id = game.create_object_from_definition(&sigil, alice, Zone::Battlefield);
+    let sigil_stable_id = game
+        .object(sigil_id)
+        .expect("Tainted Sigil should exist")
+        .stable_id;
+    let ability_index = game
+        .object(sigil_id)
+        .expect("Tainted Sigil should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Tainted Sigil should have an activated ability");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = AutoPassDecisionMaker;
+    let mut progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::ActivateAbility {
+            source: sigil_id,
+            ability_index,
+        }),
+        &mut dm,
+    )
+    .expect("Tainted Sigil activation should start");
+
+    for _ in 0..4 {
+        if game.stack.len() == 1 {
+            resolve_stack_entry(&mut game).expect("Tainted Sigil ability should resolve");
+            return (game, sigil_stable_id);
+        }
+
+        progress = match progress {
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                DecisionContext::SelectOptions(ctx),
+            ) => {
+                let option = ctx
+                    .options
+                    .iter()
+                    .find(|option| {
+                        let description = option.description.to_ascii_lowercase();
+                        description.contains("tap") || description.contains("sacrifice")
+                    })
+                    .unwrap_or_else(|| {
+                        panic!("expected a tap or sacrifice cost option, got {ctx:?}")
+                    });
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(option.index),
+                    &mut dm,
+                )
+                .expect("Tainted Sigil cost choice should apply")
+            }
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                DecisionContext::SelectObjects(_),
+            ) => {
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::SacrificeTarget(sigil_id),
+                    &mut dm,
+                )
+                .expect("Tainted Sigil sacrifice choice should apply")
+            }
+            other => {
+                panic!("expected Tainted Sigil activation to advance through costs, got {other:?}")
+            }
+        };
+    }
+
+    panic!("Tainted Sigil activation did not reach the stack");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_tainted_sigil_gains_total_life_lost_by_all_players_this_turn() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let (game, sigil_stable_id) =
+        activate_tainted_sigil_after_life_losses(&[(alice, 3, false), (bob, 4, true)]);
+    let graveyard_sigil_id = game
+        .find_object_by_stable_id(sigil_stable_id)
+        .expect("Tainted Sigil should remain tracked after sacrifice");
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        24,
+        "Alice should gain the 7 total life lost by all players this turn, including damage-caused life loss"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        16,
+        "Tainted Sigil should not change the opponent's life total"
+    );
+    assert!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .graveyard
+            .contains(&graveyard_sigil_id),
+        "Tainted Sigil should be sacrificed as an activation cost"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_tainted_sigil_gains_no_life_when_no_player_lost_life_this_turn() {
+    let alice = PlayerId::from_index(0);
+
+    let (game, sigil_stable_id) = activate_tainted_sigil_after_life_losses(&[]);
+    let graveyard_sigil_id = game
+        .find_object_by_stable_id(sigil_stable_id)
+        .expect("Tainted Sigil should remain tracked after sacrifice");
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        20,
+        "Tainted Sigil should gain 0 life when no player lost life this turn"
+    );
+    assert!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .graveyard
+            .contains(&graveyard_sigil_id),
+        "Tainted Sigil should still be sacrificed when the dynamic amount is zero"
+    );
+}
+
 #[test]
 fn test_source_lki_refreshes_when_exile_source_moves_it() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tainted Sigil
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to the total life lost by all players this turn'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to the total life lost by all players this turn')
```

Current worker: i-03ed0d0535f45e738
Branch: codex/aws-card-fix-tainted-sigil
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
