### PR TITLE
Fix Ironsmith parse failure: Heroism

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -659,7 +659,12 @@ pub(crate) fn parse_prevent_damage_sentence_lexed(
         let source_tokens = &core_tokens[5..];
         if source_tokens
             .first()
-            .is_some_and(|token| token.is_word("target"))
+            .is_some_and(|token| {
+                token.is_word("target")
+                    || token.is_word("that")
+                    || token.is_word("this")
+                    || token.is_word("it")
+            })
         {
             let (source, has_color_condition) =
                 parse_prevent_damage_source_target_lexed(source_tokens, &words)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -36,7 +36,8 @@ use super::chain_carry::{parse_leading_player_may, remove_first_word, remove_thr
 use super::clause_pattern_helpers::extract_subject_player;
 use super::clause_primitives::run_clause_primitives;
 use super::dispatch_inner::{
-    parse_additional_phase_sentence, parse_take_extra_turn_sentence, trim_edge_punctuation,
+    parse_additional_phase_sentence, parse_prevent_damage_sentence, parse_take_extra_turn_sentence,
+    trim_edge_punctuation,
 };
 use super::for_each_helpers::{
     has_demonstrative_object_reference, is_mana_replacement_clause_words,
@@ -365,6 +366,41 @@ fn clause_may_contain_cast_or_play_permission(tokens: &[OwnedLexToken]) -> bool 
         })
 }
 
+fn parse_for_each_prevent_damage_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let Some(prevent_idx) = find_token_index(tokens, |token| token.is_word("prevent")) else {
+        return Ok(None);
+    };
+    let subject_tokens = trim_commas(&tokens[..prevent_idx]);
+    let Some(filter) = parse_for_each_object_subject(&subject_tokens)? else {
+        return Ok(None);
+    };
+
+    let unless_idx = tokens[prevent_idx..]
+        .iter()
+        .position(|token| token.is_word("unless"))
+        .map(|idx| prevent_idx + idx);
+    let prevent_tokens = trim_commas(match unless_idx {
+        Some(idx) => &tokens[prevent_idx..idx],
+        None => &tokens[prevent_idx..],
+    });
+    let Some(prevent_effect) = parse_prevent_damage_sentence(&prevent_tokens)? else {
+        return Ok(None);
+    };
+
+    let effects = if let Some(idx) = unless_idx {
+        if let Some(unless_effect) = try_build_unless(vec![prevent_effect.clone()], tokens, idx)? {
+            vec![unless_effect]
+        } else {
+            vec![prevent_effect]
+        }
+    } else {
+        vec![prevent_effect]
+    };
+    Ok(Some(EffectAst::ForEachObject { filter, effects }))
+}
+
 pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
     if tokens.is_empty() {
         return Err(CardTextError::ParseError("empty effect clause".to_string()));
@@ -406,6 +442,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
 
     let clause_word_view = ClauseDispatchCompatWords::new(tokens);
     let clause_words = clause_word_view.to_word_refs();
+
+    if let Some(effect) = parse_for_each_prevent_damage_clause(tokens)? {
+        return Ok(effect);
+    }
 
     if word_slice_starts_with(&clause_words, &["cast", "any", "number", "of", "spells"])
         && find_word_sequence_index(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11156,6 +11156,55 @@ fn test_guard_dogs_keeps_color_sharing_prevention_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_heroism_parses_for_each_attacking_red_prevention_unless_pays() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Heroism")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Sacrifice a white creature: For each attacking red creature, prevent all combat \
+             damage that would be dealt by that creature this turn unless its controller pays {2}{R}.",
+        )
+        .expect("Heroism should parse strictly");
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Activated(_))),
+        "Heroism should compile to an activated ability"
+    );
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("ForEachObject")
+            && ability_debug.contains("attacking: true")
+            && ability_debug.contains("UnlessPaysEffect")
+            && ability_debug.contains("PreventAllCombatDamageEffect")
+            && ability_debug.contains("ControllerOf")
+            && ability_debug.contains("__it__"),
+        "expected per-attacking-creature unless-pays prevention structure, got {ability_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("for each")
+            && (rendered.contains("red attacking creature")
+                || rendered.contains("attacking red creature"))
+            && rendered.contains(
+                "prevent all combat damage that would be dealt by that creature this turn"
+            )
+            && rendered.contains("unless its controller pays {2}{r}")
+            && !rendered.contains("creature sources"),
+        "expected Heroism prevention/unless text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_static_prevent_all_combat_damage_to_this_creature_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Everdawn Champion Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -98,6 +98,11 @@ pub(super) fn describe_player_filter(filter: &PlayerFilter) -> String {
         {
             "equipped creature's controller".to_string()
         }
+        PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(tag))
+            if tag.as_str() == "__it__" =>
+        {
+            "its controller".to_string()
+        }
         PlayerFilter::ControllerOf(crate::target::ObjectRef::Target) => {
             "its controller".to_string()
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -18089,6 +18089,78 @@ pub(super) fn describe_for_each_filter(filter: &ObjectFilter) -> String {
     base
 }
 
+fn describe_for_each_prevent_combat_damage_unless_pays(
+    for_each: &crate::effects::ForEachObject,
+) -> Option<String> {
+    let [effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let unless_pays = effect.downcast_ref::<crate::effects::UnlessPaysEffect>()?;
+    let [prevent_effect] = unless_pays.effects.as_slice() else {
+        return None;
+    };
+    let prevents_iterated_until_eot = prevent_effect
+        .downcast_ref::<crate::effects::PreventAllCombatDamageFromEffect>()
+        .is_some_and(|prevent_from| {
+            matches!(prevent_from.source, ChooseSpec::Iterated)
+                && matches!(prevent_from.until, Until::EndOfTurn)
+        })
+        || prevent_effect
+            .downcast_ref::<crate::effects::PreventAllCombatDamageEffect>()
+            .is_some_and(|prevent_combat| {
+                matches!(
+                    prevent_combat.target,
+                    crate::effects::CombatDamagePreventionTarget::From(ChooseSpec::Iterated)
+                )
+                    && matches!(prevent_combat.until, Until::EndOfTurn)
+            });
+    if !prevents_iterated_until_eot {
+        return None;
+    }
+
+    let filter_text = strip_indefinite_article(&for_each.filter.description()).to_string();
+    let source_text = if for_each
+        .filter
+        .card_types
+        .contains(&crate::types::CardType::Creature)
+    {
+        "that creature"
+    } else {
+        "that object"
+    };
+    let payer = describe_player_filter(&unless_pays.player);
+    let payment = describe_total_cost_payment(&unless_pays.cost);
+    Some(format!(
+        "For each {filter_text}, prevent all combat damage that would be dealt by {source_text} this turn unless {payer} pays {payment}"
+    ))
+}
+
+fn filter_is_tagged_it(filter: &ObjectFilter) -> bool {
+    filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag.as_str() == "__it__"
+    })
+}
+
+fn describe_tagged_it_damage_source(filter: &ObjectFilter) -> Option<&'static str> {
+    if !filter_is_tagged_it(filter) {
+        return None;
+    }
+    if filter.card_types.contains(&crate::types::CardType::Creature) {
+        return Some("that creature");
+    }
+    if filter.card_types.contains(&crate::types::CardType::Artifact) {
+        return Some("that artifact");
+    }
+    if filter.card_types.contains(&crate::types::CardType::Enchantment) {
+        return Some("that enchantment");
+    }
+    if filter.card_types.contains(&crate::types::CardType::Land) {
+        return Some("that land");
+    }
+    Some("that object")
+}
+
 pub(super) fn describe_tagged_this_way_action(filter: &ObjectFilter) -> Option<&'static str> {
     filter.tagged_constraints.iter().find_map(|constraint| {
         if constraint.relation != crate::filter::TaggedOpbjectRelation::IsTaggedObject {
@@ -25280,6 +25352,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(compact) = describe_for_each_devotion_damage(for_each) {
             return compact;
         }
+        if let Some(compact) = describe_for_each_prevent_combat_damage_unless_pays(for_each) {
+            return compact;
+        }
         if for_each.effects.len() == 1
             && let Some(put) =
                 for_each.effects[0].downcast_ref::<crate::effects::PutCountersEffect>()
@@ -30067,6 +30142,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         }
         if matches!(prevent_all.until, Until::EndOfTurn) {
             if matches!(prevent_all.target, crate::prevention::PreventionTarget::All) {
+                if prevent_all.damage_filter.combat_only
+                    && let Some(source_filter) = &prevent_all.damage_filter.from_source
+                    && let Some(source_text) = describe_tagged_it_damage_source(source_filter)
+                {
+                    return format!(
+                        "Prevent all combat damage that would be dealt by {source_text} this turn"
+                    );
+                }
                 if let Some(source_phrase) = damage_type
                     .strip_prefix("all damage from ")
                     .and_then(|rest| rest.strip_suffix(" sources"))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30292,6 +30292,266 @@ fn test_the_stasis_coffin_activation_grants_protection_and_exiles_itself() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn heroism_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(30_267), "Heroism")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Sacrifice a white creature: For each attacking red creature, prevent all combat \
+             damage that would be dealt by that creature this turn unless its controller pays {2}{R}.",
+        )
+        .expect("Heroism should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn colored_test_creature(
+    game: &mut GameState,
+    name: &str,
+    owner: PlayerId,
+    color: crate::color::ColorSet,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .color_indicator(color)
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_heroism(
+    game: &mut GameState,
+    controller: PlayerId,
+    heroism_id: ObjectId,
+    sacrifice_id: ObjectId,
+    dm: &mut impl DecisionMaker,
+) {
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let ability_index = game
+        .object(heroism_id)
+        .expect("Heroism should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Heroism should have an activated ability");
+    let activate_action = compute_legal_actions(game, controller)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == heroism_id && *idx == ability_index
+            )
+        })
+        .expect("Heroism activation should be legal with a white creature to sacrifice");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut progress = apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        dm,
+    )
+    .expect("Heroism activation should start");
+
+    while let crate::decision::GameProgress::NeedsDecisionCtx(decision) = progress {
+        progress = match decision {
+            crate::decisions::context::DecisionContext::SelectOptions(ctx) => {
+                let choice = ctx
+                    .options
+                    .iter()
+                    .find(|option| {
+                        option.legal
+                            && option
+                                .description
+                                .to_ascii_lowercase()
+                                .contains("sacrifice")
+                    })
+                    .or_else(|| ctx.options.iter().find(|option| option.legal))
+                    .map(|option| option.index)
+                    .expect("Heroism should offer a legal sacrifice-cost choice");
+                apply_priority_response_with_dm(
+                    game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(choice),
+                    dm,
+                )
+                .expect("Heroism sacrifice-cost choice should continue activation")
+            }
+            crate::decisions::context::DecisionContext::SelectObjects(_) => {
+                apply_priority_response_with_dm(
+                    game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::SacrificeTarget(sacrifice_id),
+                    dm,
+                )
+                .expect("Heroism should accept the selected white creature sacrifice")
+            }
+            crate::decisions::context::DecisionContext::Priority(_) => break,
+            other => panic!("unexpected decision while activating Heroism: {:?}", other),
+        };
+
+        if game.stack.len() == 1 {
+            break;
+        }
+    }
+
+    assert_eq!(game.stack.len(), 1, "Heroism ability should be on the stack");
+    assert!(
+        game.object(sacrifice_id)
+            .map(|object| object.zone != Zone::Battlefield)
+            .unwrap_or(true),
+        "Heroism should sacrifice the chosen white creature as an activation cost"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[derive(Debug, Default)]
+struct PayUnlessDecisionMaker;
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for PayUnlessDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        true
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_heroism_prevents_unpaid_attacking_red_creature_damage_only() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let heroism_id =
+        game.create_object_from_definition(&heroism_definition(), alice, Zone::Battlefield);
+    let sacrifice_id = colored_test_creature(
+        &mut game,
+        "Heroism Cost Bearer",
+        alice,
+        crate::color::ColorSet::WHITE,
+        1,
+        1,
+    );
+    let red_attacker = colored_test_creature(
+        &mut game,
+        "Red Attacker",
+        bob,
+        crate::color::ColorSet::RED,
+        3,
+        3,
+    );
+    let colorless_attacker = create_creature(&mut game, "Colorless Attacker", bob, 2, 2);
+
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareBlockers);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: red_attacker,
+        target: AttackTarget::Player(alice),
+    });
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: colorless_attacker,
+        target: AttackTarget::Player(alice),
+    });
+    combat.blockers.insert(red_attacker, Vec::new());
+    combat.blockers.insert(colorless_attacker, Vec::new());
+    game.combat = Some(combat.clone());
+
+    let mut dm = AutoPassDecisionMaker;
+    activate_heroism(&mut game, alice, heroism_id, sacrifice_id, &mut dm);
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Heroism ability should resolve");
+
+    game.turn.step = Some(crate::game_state::Step::CombatDamage);
+    let events = execute_combat_damage_step(&mut game, &combat, false);
+    assert_eq!(events.len(), 2, "both attackers should assign combat damage");
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        18,
+        "Heroism should prevent unpaid red attacker damage while leaving nonred attacker damage"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_heroism_controller_payment_allows_red_attacker_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let heroism_id =
+        game.create_object_from_definition(&heroism_definition(), alice, Zone::Battlefield);
+    let sacrifice_id = colored_test_creature(
+        &mut game,
+        "Heroism Cost Bearer",
+        alice,
+        crate::color::ColorSet::WHITE,
+        1,
+        1,
+    );
+    let red_attacker = colored_test_creature(
+        &mut game,
+        "Paying Red Attacker",
+        bob,
+        crate::color::ColorSet::RED,
+        3,
+        3,
+    );
+    game.player_mut(bob)
+        .expect("Bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    game.player_mut(bob)
+        .expect("Bob exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareBlockers);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: red_attacker,
+        target: AttackTarget::Player(alice),
+    });
+    combat.blockers.insert(red_attacker, Vec::new());
+    game.combat = Some(combat.clone());
+
+    let mut dm = PayUnlessDecisionMaker;
+    activate_heroism(&mut game, alice, heroism_id, sacrifice_id, &mut dm);
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Heroism ability should resolve after attacker controller pays");
+
+    game.turn.step = Some(crate::game_state::Step::CombatDamage);
+    let events = execute_combat_damage_step(&mut game, &combat, false);
+    assert_eq!(events.len(), 1, "the red attacker should assign combat damage");
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        17,
+        "paying {{2}}{{R}} should stop Heroism from preventing that red attacker's damage"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_elsewhere_flask_activation_changes_land_type_until_cleanup() {
     use crate::cards::builders::CardDefinitionBuilder;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Heroism
Initial parse error:
```
could not find verb in effect clause (clause: 'for each attacking red creature prevent all combat damage that would be dealt by that creature this turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'for each attacking red creature prevent all combat damage that would be dealt by that creature this turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-02fbf4b32a903ff3f
Branch: codex/aws-card-fix-heroism
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
