### PR TITLE
Fix Ironsmith parse failure: Anticognition

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -424,6 +424,13 @@ fn player_filter_for_turn_value(player: PlayerAst) -> Option<PlayerFilter> {
     }
 }
 
+fn graveyard_possessive_matches_subject(player: PlayerAst, possessive: &str) -> bool {
+    match player {
+        PlayerAst::You | PlayerAst::Implicit => possessive == "your",
+        _ => possessive == "their",
+    }
+}
+
 fn permanents_you_control_scope(words: &[&str]) -> Option<ObjectFilter> {
     if matches!(
         words,
@@ -1665,6 +1672,29 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         {
             return Ok(PredicateAst::PlayerLifeLessThanHalfStartingLifeTotal { player });
         }
+    }
+    if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
+        && matches!(filtered.get(subject_len).copied(), Some("has" | "have"))
+        && let Some(count_word) = filtered.get(subject_len + 1).copied()
+        && let Some(count) = count_word
+            .parse::<i32>()
+            .ok()
+            .or_else(|| parse_named_number(count_word).map(|n| n as i32))
+        && filtered.get(subject_len + 2).copied() == Some("or")
+        && filtered.get(subject_len + 3).copied() == Some("more")
+        && matches!(filtered.get(subject_len + 4).copied(), Some("card" | "cards"))
+        && filtered.get(subject_len + 5).copied() == Some("in")
+        && let Some(possessive) = filtered.get(subject_len + 6).copied()
+        && graveyard_possessive_matches_subject(player, possessive)
+        && filtered.get(subject_len + 7).copied() == Some("graveyard")
+        && filtered.len() == subject_len + 8
+        && let Some(player_filter) = player_filter_for_turn_value(player)
+    {
+        return Ok(PredicateAst::ValueComparison {
+            left: Value::CardsInGraveyard(player_filter),
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: Value::Fixed(count),
+        });
     }
     if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
         && matches!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38737,6 +38737,69 @@ fn parse_oracle_anticognition_threshold_counters_without_payment_and_scries() {
 }
 
 #[test]
+fn parse_oracle_anticognition_multiplayer_checks_any_opponent_graveyard() {
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Carol".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let carol = PlayerId::from_index(2);
+    add_graveyard_filler(&mut game, bob, 8);
+    add_graveyard_filler(&mut game, carol, 3);
+
+    for name in ["Alice Top Card", "Alice Second Card"] {
+        let card = crate::card::CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+
+    let target_card = crate::card::CardBuilder::new(CardId::new(), "Carol Creature Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .build();
+    let target_id = game.create_object_from_card(&target_card, carol, Zone::Stack);
+    let target_stable_id = game
+        .object(target_id)
+        .expect("target spell should exist")
+        .stable_id;
+    game.push_to_stack(crate::game_state::StackEntry::new(target_id, carol));
+
+    let anticognition = parse_oracle_card_definition("Anticognition");
+    let anticognition_id = game.create_object_from_definition(&anticognition, alice, Zone::Stack);
+    game.push_to_stack(
+        crate::game_state::StackEntry::new(anticognition_id, alice)
+            .with_targets(vec![crate::game_state::Target::Object(target_id)]),
+    );
+
+    game.player_mut(carol)
+        .expect("carol exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Anticognition should resolve in multiplayer");
+
+    let target_after = game
+        .find_object_by_stable_id(target_stable_id)
+        .expect("countered target spell should still be tracked");
+    assert_eq!(
+        game.object(target_after).expect("target spell exists").zone,
+        Zone::Graveyard,
+        "Anticognition should count any opponent's eight-card graveyard in multiplayer"
+    );
+    assert_eq!(
+        game.player(carol).expect("carol exists").mana_pool.total(),
+        2,
+        "threshold replacement should not offer or spend Carol's {{2}} prevention payment"
+    );
+}
+
+#[test]
 fn parse_oracle_future_replacement_followups_do_not_use_self_replacement_bridge() {
     for name in ["Faunsbane Troll", "Mawloc", "Nine-Ringed Bo"] {
         let def = parse_oracle_card_definition(name);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38529,6 +38529,213 @@ fn parse_oracle_stubborn_denial_ferocious_counters_without_payment() {
     );
 }
 
+fn add_graveyard_filler(game: &mut crate::game_state::GameState, player: PlayerId, count: usize) {
+    for idx in 0..count {
+        let filler =
+            crate::card::CardBuilder::new(CardId::new(), format!("Graveyard Filler {idx}"))
+                .card_types(vec![CardType::Instant])
+                .build();
+        game.create_object_from_card(&filler, player, Zone::Graveyard);
+    }
+}
+
+#[test]
+fn parse_oracle_anticognition_strictly_parses_and_renders_threshold_replacement() {
+    let def = parse_oracle_card_definition("Anticognition");
+
+    let program = def.spell_effect.as_ref().expect("spell effect");
+    assert_eq!(program.segments.len(), 1);
+    assert_eq!(program.segments[0].default_effects.len(), 1);
+    assert_eq!(program.segments[0].self_replacements.len(), 1);
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "Counter target creature or planeswalker spell unless its controller pays {2}. If an opponent has eight or more cards in their graveyard, instead counter that spell, then scry 2"
+        ),
+        "expected Anticognition threshold replacement and scry wording, got {rendered}"
+    );
+
+    let debug = format!("{program:?}");
+    assert!(
+        debug.contains("CardsInGraveyard")
+            && debug.contains("Opponent")
+            && debug.contains("Fixed(8)")
+            && debug.contains("ScryEffect"),
+        "expected Anticognition to lower the opponent graveyard threshold and scry structurally, got {debug}"
+    );
+}
+
+#[test]
+fn parse_oracle_anticognition_targets_only_creature_or_planeswalker_spells() {
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let creature_spell = crate::card::CardBuilder::new(CardId::new(), "Bob Creature Spell")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let creature_id = game.create_object_from_card(&creature_spell, bob, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(creature_id, bob));
+
+    let planeswalker_spell = crate::card::CardBuilder::new(CardId::new(), "Bob Planeswalker Spell")
+        .card_types(vec![CardType::Planeswalker])
+        .build();
+    let planeswalker_id = game.create_object_from_card(&planeswalker_spell, bob, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(planeswalker_id, bob));
+
+    let instant_spell = crate::card::CardBuilder::new(CardId::new(), "Bob Instant Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let instant_id = game.create_object_from_card(&instant_spell, bob, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(instant_id, bob));
+
+    let anticognition = parse_oracle_card_definition("Anticognition");
+    let anticognition_id = game.create_object_from_definition(&anticognition, alice, Zone::Stack);
+    let requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        anticognition.spell_effect.as_ref().expect("spell effect"),
+        alice,
+        Some(anticognition_id),
+        None,
+    );
+    let legal_targets = requirements
+        .first()
+        .expect("Anticognition should require a target")
+        .legal_targets
+        .clone();
+
+    assert!(
+        legal_targets.contains(&crate::game_state::Target::Object(creature_id)),
+        "creature spells should be legal Anticognition targets"
+    );
+    assert!(
+        legal_targets.contains(&crate::game_state::Target::Object(planeswalker_id)),
+        "planeswalker spells should be legal Anticognition targets"
+    );
+    assert!(
+        !legal_targets.contains(&crate::game_state::Target::Object(instant_id)),
+        "noncreature nonplaneswalker spells should not be legal Anticognition targets"
+    );
+}
+
+#[test]
+fn parse_oracle_anticognition_under_threshold_lets_target_controller_pay() {
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_graveyard_filler(&mut game, bob, 7);
+
+    let target_card = crate::card::CardBuilder::new(CardId::new(), "Bob Creature Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .build();
+    let target_id = game.create_object_from_card(&target_card, bob, Zone::Stack);
+    let target_stable_id = game
+        .object(target_id)
+        .expect("target spell should exist")
+        .stable_id;
+    game.push_to_stack(crate::game_state::StackEntry::new(target_id, bob));
+
+    let anticognition = parse_oracle_card_definition("Anticognition");
+    let anticognition_id = game.create_object_from_definition(&anticognition, alice, Zone::Stack);
+    game.push_to_stack(
+        crate::game_state::StackEntry::new(anticognition_id, alice)
+            .with_targets(vec![crate::game_state::Target::Object(target_id)]),
+    );
+
+    game.player_mut(bob)
+        .expect("bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Anticognition should resolve");
+
+    let target_after = game
+        .find_object_by_stable_id(target_stable_id)
+        .expect("target spell should still be tracked");
+    assert_eq!(
+        game.object(target_after).expect("target spell exists").zone,
+        Zone::Stack,
+        "below threshold, Bob should be able to pay {{2}} and keep the target spell on the stack"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").mana_pool.total(),
+        0,
+        "Bob should spend the {{2}} prevention payment"
+    );
+}
+
+#[test]
+fn parse_oracle_anticognition_threshold_counters_without_payment_and_scries() {
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_graveyard_filler(&mut game, bob, 8);
+
+    for name in ["Alice Top Card", "Alice Second Card"] {
+        let card = crate::card::CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+
+    let target_card = crate::card::CardBuilder::new(CardId::new(), "Bob Creature Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .build();
+    let target_id = game.create_object_from_card(&target_card, bob, Zone::Stack);
+    let target_stable_id = game
+        .object(target_id)
+        .expect("target spell should exist")
+        .stable_id;
+    game.push_to_stack(crate::game_state::StackEntry::new(target_id, bob));
+
+    let anticognition = parse_oracle_card_definition("Anticognition");
+    let anticognition_id = game.create_object_from_definition(&anticognition, alice, Zone::Stack);
+    game.push_to_stack(
+        crate::game_state::StackEntry::new(anticognition_id, alice)
+            .with_targets(vec![crate::game_state::Target::Object(target_id)]),
+    );
+
+    game.player_mut(bob)
+        .expect("bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Anticognition should resolve");
+
+    let target_after = game
+        .find_object_by_stable_id(target_stable_id)
+        .expect("countered target spell should still be tracked");
+    assert_eq!(
+        game.object(target_after).expect("target spell exists").zone,
+        Zone::Graveyard,
+        "eight-card opponent graveyard threshold should replace the payment branch with an unconditional counter"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").mana_pool.total(),
+        2,
+        "threshold replacement should not offer or spend the {{2}} prevention payment"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        2,
+        "threshold branch should execute scry 2 without moving cards out of Alice's library"
+    );
+}
+
 #[test]
 fn parse_oracle_future_replacement_followups_do_not_use_self_replacement_bridge() {
     for name in ["Faunsbane Troll", "Mawloc", "Nine-Ringed Bo"] {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -475,9 +475,80 @@ fn describe_single_self_replacement_segment(
     {
         return Some(damage_text);
     }
+    if let Some(counter_unless_text) = describe_counter_unless_self_replacement(
+        &segment.default_effects,
+        &branch.replacement_effects,
+        &default_text,
+        &condition_text,
+    ) {
+        return Some(counter_unless_text);
+    }
     Some(format!(
         "{default_text}. If {condition_text}, {} instead",
         rewrite_self_replacement_referent_phrase(&default_text, &replacement_text)
+    ))
+}
+
+fn unwrap_tagged_effect(mut effect: &Effect) -> &Effect {
+    while let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        effect = &tagged.effect;
+    }
+    effect
+}
+
+fn counter_effect_target(effect: &Effect) -> Option<&ChooseSpec> {
+    unwrap_tagged_effect(effect)
+        .downcast_ref::<crate::effects::CounterEffect>()
+        .map(|counter| &counter.target)
+}
+
+fn unless_pays_counter_target(effect: &Effect) -> Option<&ChooseSpec> {
+    let unless_pays = unwrap_tagged_effect(effect)
+        .downcast_ref::<crate::effects::UnlessPaysEffect>()?;
+    let [counter_effect] = unless_pays.effects.as_slice() else {
+        return None;
+    };
+    counter_effect_target(counter_effect)
+}
+
+fn counter_replacement_referent(target: &ChooseSpec) -> Option<&'static str> {
+    let target_text = super::normalize_common::describe_choose_spec(target).to_ascii_lowercase();
+    if target_text.contains(" spell or ability") || target_text.contains(" ability or spell") {
+        Some("that spell or ability")
+    } else if target_text.contains(" ability") && !target_text.contains(" spell") {
+        Some("that ability")
+    } else if target_text.contains(" spell") {
+        Some("that spell")
+    } else {
+        None
+    }
+}
+
+fn describe_counter_unless_self_replacement(
+    default_effects: &[Effect],
+    replacement_effects: &[Effect],
+    default_text: &str,
+    condition_text: &str,
+) -> Option<String> {
+    let [default_effect] = default_effects else {
+        return None;
+    };
+    let replacement_counter_target = counter_effect_target(replacement_effects.first()?)?;
+    let default_counter_target = unless_pays_counter_target(default_effect)?;
+    if replacement_counter_target != default_counter_target {
+        return None;
+    }
+
+    let referent = counter_replacement_referent(default_counter_target)?;
+    let mut replacement_text = format!("instead counter {referent}");
+    if replacement_effects.len() > 1 {
+        let followup_text = describe_effect_list(&replacement_effects[1..]);
+        replacement_text.push_str(", then ");
+        replacement_text.push_str(&super::normalize_common::lowercase_first(&followup_text));
+    }
+
+    Some(format!(
+        "{default_text}. If {condition_text}, {replacement_text}"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11307,6 +11307,30 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 );
             }
             if let (
+                Value::CardsInGraveyard(player),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                Value::Fixed(count),
+            ) = (left, operator, right)
+            {
+                let subject = describe_player_filter(player);
+                let count_text = small_number_word(*count as u32)
+                    .unwrap_or_else(|| count.to_string());
+                let graveyard = match player {
+                    PlayerFilter::You => "your graveyard".to_string(),
+                    PlayerFilter::Opponent | PlayerFilter::Any | PlayerFilter::NotYou => {
+                        "their graveyard".to_string()
+                    }
+                    _ => format!("{} graveyard", describe_possessive_player_filter(player)),
+                };
+                return format!(
+                    "{} {} {} or more cards in {}",
+                    subject,
+                    player_verb(&subject, "have", "has"),
+                    count_text,
+                    graveyard
+                );
+            }
+            if let (
                 Value::Count(filter),
                 crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
                 Value::Fixed(count),

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1235,11 +1235,21 @@ pub fn resolve_value(
         }
 
         Value::CardsInGraveyard(player_spec) => {
-            let player_id = resolve_player_filter(game, player_spec, ctx)?;
-            let player = game
-                .player(player_id)
-                .ok_or(ExecutionError::PlayerNotFound(player_id))?;
-            Ok(player.graveyard.len() as i32)
+            let player_ids =
+                resolve_player_filter_to_list(game, player_spec, &ctx.filter_context(game), ctx)?;
+            let mut max_count: Option<i32> = None;
+            for player_id in player_ids {
+                let player = game
+                    .player(player_id)
+                    .ok_or(ExecutionError::PlayerNotFound(player_id))?;
+                let count = player.graveyard.len() as i32;
+                max_count = Some(max_count.map_or(count, |prev| prev.max(count)));
+            }
+            Ok(max_count.ok_or_else(|| {
+                ExecutionError::UnresolvableValue(
+                    "CardsInGraveyard requires a matching player".to_string(),
+                )
+            })?)
         }
 
         Value::SpellsCastThisTurn(player_spec) => {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Anticognition
Initial parse error:
```
unsupported predicate (predicate: 'opponent has eight or more cards in their graveyard instead counter that spell'); oracle-only fallback also failed: unsupported predicate (predicate: 'opponent has eight or more cards in their graveyard instead counter that spell')
```

Current worker: i-04bc68f42b953cd34
Branch: codex/aws-card-fix-anticognition
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
