### PR TITLE
Fix Ironsmith parse failure: Desmond Miles

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -3006,6 +3006,10 @@ pub(crate) fn parse_anthem_for_each_expression(
         });
     }
 
+    if let Some(filter) = parse_compound_anthem_count_filter(rest) {
+        return Ok(AnthemCountExpression::MatchingFilter(filter));
+    }
+
     let rest_words = crate::runtime_backend::token_word_refs(rest);
     if let Some(counter_word_idx) =
         anthem_find_word_index(&rest_words, |word| matches!(word, "counter" | "counters"))
@@ -3031,6 +3035,61 @@ pub(crate) fn parse_anthem_for_each_expression(
         ))
     })?;
     Ok(AnthemCountExpression::MatchingFilter(filter))
+}
+
+fn parse_compound_anthem_count_filter(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    let filter_words = crate::runtime_backend::token_word_refs(tokens);
+    let should_try_split = filter_words.iter().any(|word| *word == "and")
+        && filter_words.iter().any(|word| *word == "graveyard")
+        && filter_words
+            .iter()
+            .any(|word| matches!(*word, "control" | "controls" | "own" | "owns"));
+    if !should_try_split {
+        return None;
+    }
+
+    let mut segments = Vec::new();
+    let mut start = 0usize;
+    for (idx, token) in tokens.iter().enumerate() {
+        if token.is_word("and")
+            && tokens
+                .get(idx + 1)
+                .is_some_and(|next| next.is_word("each") || next.is_word("every"))
+        {
+            if start == idx {
+                return None;
+            }
+            segments.push(&tokens[start..idx]);
+            start = idx + 1;
+        }
+    }
+    if segments.is_empty() {
+        return None;
+    }
+    segments.push(&tokens[start..]);
+
+    let mut branches = Vec::new();
+    for segment in segments {
+        let mut segment = trim_commas(segment);
+        if segment
+            .first()
+            .is_some_and(|token| token.is_word("each") || token.is_word("every"))
+        {
+            segment.drain(..1);
+        }
+        if segment.is_empty() {
+            return None;
+        }
+        branches.push(parse_object_filter(&segment, false).ok()?);
+    }
+
+    if branches.len() < 2 {
+        return None;
+    }
+
+    let mut combined = ObjectFilter::default();
+    combined.any_of = branches;
+    Some(combined)
 }
 
 pub(crate) fn parse_anthem_prefix_condition(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -876,6 +876,20 @@ pub(crate) fn parse_value_binding_clause(tokens: &[OwnedLexToken]) -> Option<Val
             return Some(Value::HalfLifeTotalRoundedDown(PlayerFilter::You));
         }
         Some(["your", "speed"]) => return Some(Value::Speed(PlayerFilter::You)),
+        Some([
+            "the",
+            "amount",
+            "of",
+            "damage",
+            "it",
+            "dealt",
+            "to",
+            "that",
+            "player",
+        ])
+        | Some([
+            "amount", "of", "damage", "it", "dealt", "to", "that", "player",
+        ]) => return Some(Value::EventValue(EventValueSpec::Amount)),
         Some(["the", "number", "of", "opponents", "you", "have"])
         | Some(["number", "of", "opponents", "you", "have"])
         | Some(["the", "number", "of", "opponents"])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33020,6 +33020,48 @@ fn parse_oracle_sarkhan_dragon_ascendant_behold_regression() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn desmond_miles_test_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Desmond Miles")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(1, 3))
+        .parse_text(
+            "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
+        )
+        .expect("Desmond Miles should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_desmond_miles_strict_and_renders_compound_count_and_surveil_x() {
+    let def = desmond_miles_test_definition();
+    let debug = format!("{def:#?}");
+    let compact_debug = debug.split_whitespace().collect::<String>();
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        debug.contains("any_of")
+            && debug.contains("other: true")
+            && debug.contains("zone: Some(Graveyard)")
+            && compact_debug.contains("EventValue(Amount"),
+        "expected Desmond Miles to lower compound count and surveil event amount structurally, got {debug}"
+    );
+    assert!(
+        rendered.contains(
+            "Desmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard."
+        ),
+        "expected Desmond Miles compound count wording, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player."
+        ),
+        "expected Desmond Miles combat-damage surveil-X wording, got {rendered}"
+    );
+}
+
 #[test]
 fn parse_oracle_nadaar_enters_or_attacks_surface_regression() {
     let def = parse_oracle_card_definition("Nadaar, Selfless Paladin");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -668,6 +668,36 @@ fn substitute_pregame_card_self_reference(line: &str, subject: &str, card_name: 
         .replace(&capitalized, card_name)
 }
 
+fn substitute_legendary_source_reference(
+    line: &str,
+    card: &crate::card::Card,
+    subject: &str,
+) -> String {
+    if subject != "this creature"
+        || !card.supertypes.contains(&Supertype::Legendary)
+        || card.name.contains(" // ")
+    {
+        return line.to_string();
+    }
+
+    let lower = line.to_ascii_lowercase();
+    let uses_named_source_surface = lower.starts_with("this creature gets ")
+        || lower.starts_with("whenever this creature deals combat damage to a player")
+        || lower.contains(": this creature gets ")
+        || lower.contains(": whenever this creature deals combat damage to a player");
+    if !uses_named_source_surface {
+        return line.to_string();
+    }
+
+    let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
+    if source_name.is_empty() {
+        return line.to_string();
+    }
+
+    line.replace("This creature", source_name)
+        .replace("this creature", source_name)
+}
+
 fn capitalize_first_ascii(s: &str) -> String {
     let mut chars = s.chars();
     match chars.next() {
@@ -2129,6 +2159,9 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                 for line in &mut ability_lines {
                     *line = substitute_pregame_card_self_reference(line, subject, &def.card.name);
                 }
+            }
+            for line in &mut ability_lines {
+                *line = substitute_legendary_source_reference(line, &def.card, subject);
             }
             output.extend(ability_lines);
             ability_idx += 1;

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13270,6 +13270,23 @@ fn describe_triggered_resolution_text(
         return Some("discover again for the same value".to_string());
     }
 
+    if triggered
+        .trigger
+        .downcast_ref::<crate::triggers::ThisDealsCombatDamageToPlayerTrigger>()
+        .is_some()
+        && let [segment] = triggered.effects.segments.as_slice()
+        && segment.self_replacements.is_empty()
+        && let [effect] = segment.default_effects.as_slice()
+        && let Some(surveil) = effect.downcast_ref::<crate::effects::SurveilEffect>()
+        && surveil.player == PlayerFilter::You
+        && value_prefers_where_x(&surveil.count)
+        && matches!(surveil.count.unhinted(), Value::EventValue(EventValueSpec::Amount))
+    {
+        return Some(
+            "surveil X, where X is the amount of damage it dealt to that player".to_string(),
+        );
+    }
+
     if triggered.effects.is_empty() {
         return None;
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -55,6 +55,19 @@ fn open_the_way_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn desmond_miles_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_910), "Desmond Miles")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(1, 3))
+        .parse_text(
+            "Menace\nDesmond Miles gets +1/+0 for each other Assassin you control and each Assassin card in your graveyard.\nWhenever Desmond Miles deals combat damage to a player, surveil X, where X is the amount of damage it dealt to that player.",
+        )
+        .expect("Desmond Miles should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn open_the_way_x_choice_is_capped_by_players_in_game() {
     let mut game = setup_three_player_game();
@@ -91,6 +104,152 @@ fn open_the_way_x_choice_is_capped_by_players_in_game() {
     assert_eq!(
         max_x_after_player_lost, 2,
         "players no longer in the game should stop increasing Open the Way's X cap"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn desmond_miles_counts_other_assassins_and_assassin_cards_in_your_graveyard() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let desmond = desmond_miles_definition();
+    let desmond_id = game.create_object_from_definition(&desmond, alice, Zone::Battlefield);
+    assert_eq!(
+        game.calculated_power(desmond_id),
+        Some(1),
+        "Desmond should not count itself as another Assassin"
+    );
+
+    let bystander = CardBuilder::new(CardId::from_raw(72_911), "Bystander")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&bystander, alice, Zone::Battlefield);
+    assert_eq!(
+        game.calculated_power(desmond_id),
+        Some(1),
+        "non-Assassins you control should not increase Desmond's power"
+    );
+
+    let assassin = CardBuilder::new(CardId::from_raw(72_912), "Assassin Ally")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&assassin, bob, Zone::Battlefield);
+    game.create_object_from_card(&assassin, alice, Zone::Hand);
+    assert_eq!(
+        game.calculated_power(desmond_id),
+        Some(1),
+        "opponents' Assassins and non-graveyard Assassin cards should not count"
+    );
+
+    game.create_object_from_card(&assassin, alice, Zone::Battlefield);
+    assert_eq!(
+        game.calculated_power(desmond_id),
+        Some(2),
+        "another Assassin you control should add +1/+0"
+    );
+
+    game.create_object_from_card(&assassin, alice, Zone::Graveyard);
+    assert_eq!(
+        game.calculated_power(desmond_id),
+        Some(3),
+        "an Assassin card in your graveyard should add another +1/+0"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn desmond_miles_combat_damage_trigger_surveils_equal_to_damage_and_ignores_noncombat() {
+    #[derive(Default)]
+    struct RecordingSurveilDecisionMaker {
+        viewed_cards: usize,
+        partition_description: String,
+    }
+
+    impl DecisionMaker for RecordingSurveilDecisionMaker {
+        fn view_cards(
+            &mut self,
+            _game: &GameState,
+            _viewer: PlayerId,
+            cards: &[ObjectId],
+            _ctx: &crate::decisions::context::ViewCardsContext,
+        ) {
+            self.viewed_cards = cards.len();
+        }
+
+        fn decide_partition(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::PartitionContext,
+        ) -> Vec<ObjectId> {
+            self.partition_description = ctx.description.clone();
+            ctx.cards
+                .first()
+                .map(|(id, _)| vec![*id])
+                .unwrap_or_default()
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let desmond = desmond_miles_definition();
+    let desmond_id = game.create_object_from_definition(&desmond, alice, Zone::Battlefield);
+    for idx in 0..4 {
+        let card = CardBuilder::new(CardId::from_raw(72_920 + idx), format!("Library Card {idx}"))
+            .card_types(vec![CardType::Creature])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+
+    let noncombat_damage = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            desmond_id,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        crate::triggers::check_triggers(&game, &noncombat_damage).is_empty(),
+        "Desmond should not trigger from noncombat damage"
+    );
+
+    let combat_damage = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            desmond_id,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            true,
+            crate::events::cause::EventCause::combat_damage(desmond_id),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &combat_damage) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(trigger_queue.entries.len(), 1, "combat damage should trigger once");
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Desmond combat-damage trigger should go on the stack");
+    let mut dm = RecordingSurveilDecisionMaker::default();
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Desmond surveil trigger should resolve");
+
+    assert_eq!(dm.viewed_cards, 3, "surveil X should use the damage amount");
+    assert_eq!(dm.partition_description, "Surveil 3");
+    assert_eq!(
+        game.player(alice).expect("alice exists").graveyard.len(),
+        1,
+        "the test decision maker should put one surveilled card into the graveyard"
     );
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -647,6 +647,36 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
 }
 
 fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Option<String> {
+    if let AnthemCountExpression::MatchingFilter(filter) = expr
+        && !filter.any_of.is_empty()
+        && filter
+            .any_of
+            .iter()
+            .any(|branch| branch.zone == Some(Zone::Graveyard))
+    {
+        let parts: Vec<String> = filter
+            .any_of
+            .iter()
+            .map(|branch| {
+                let mut text = strip_article(branch.description());
+                if let Some(rest) = text.strip_prefix("another ") {
+                    text = format!("other {rest}");
+                }
+                text
+            })
+            .collect();
+        let mut iter = parts.into_iter();
+        let first = iter.next()?;
+        let rest = iter
+            .map(|part| format!("each {part}"))
+            .collect::<Vec<_>>()
+            .join(" and ");
+        if rest.is_empty() {
+            return Some(first);
+        }
+        return Some(format!("{first} and {rest}"));
+    }
+
     match expr {
         AnthemCountExpression::MatchingFilter(filter) if filter.zone == Some(Zone::Battlefield) => {
             Some(strip_article(filter.description()))


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Desmond Miles
Initial parse error:
```
unsupported 'for each' filter in anthem clause (clause: 'for each other assassin you control and each assassin card in your graveyard'); oracle-only fallback also failed: unsupported 'for each' filter in anthem clause (clause: 'for each other assassin you control and each assassin card in your graveyard')
```

Current worker: i-0c7316d6879fc23e1
Branch: codex/aws-card-fix-desmond-miles
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
