### PR TITLE
Fix Ironsmith parse failure: Castle Garenbrig

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -766,6 +766,9 @@ fn parse_filter_mana_usage_restriction_sentence_lexed(
     if spec_words.is_empty() {
         return None;
     }
+    if let Some(restriction) = parse_cast_or_activate_mana_usage_restriction_words(&spec_words) {
+        return Some(restriction);
+    }
     let special_filter = parse_special_mana_usage_spell_filter_words(&spec_words);
     if special_filter.is_none()
         && spec_words.iter().any(|word| {
@@ -813,6 +816,37 @@ fn parse_filter_mana_usage_restriction_sentence_lexed(
         grant_uncounterable,
         enters_with_counters: vec![],
         granted_abilities: vec![],
+    })
+}
+
+fn parse_cast_or_activate_mana_usage_restriction_words(
+    words: &[&str],
+) -> Option<ManaUsageRestriction> {
+    let or_idx = words.iter().position(|word| *word == "or")?;
+    let cast_words = &words[..or_idx];
+    let ability_words = &words[or_idx + 1..];
+    if !matches!(
+        ability_words,
+        ["activate", "abilities", "of", "creatures"]
+            | ["activate", "an", "ability", "of", "a", "creature"]
+            | ["activate", "abilities", "of", "a", "creature"]
+            | ["activate", "a", "creature", "ability"]
+            | ["activate", "creature", "abilities"]
+    ) {
+        return None;
+    }
+
+    let spell_words = strip_optional_leading_article(cast_words);
+    let spell_filter = match spell_words {
+        ["creature", "spell" | "spells"] => {
+            ObjectFilter::default().with_type(crate::types::CardType::Creature)
+        }
+        _ => return None,
+    };
+
+    Some(ManaUsageRestriction::CastSpellOrActivateAbility {
+        spell_filter,
+        ability_source_filter: ObjectFilter::creature(),
     })
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -1,6 +1,8 @@
 use super::super::effect_ast_traversal::for_each_nested_effects_mut;
 use super::super::ir::RewriteActivatedLine;
 use super::*;
+use crate::effect::Value;
+use crate::runtime_backend::util::parse_value;
 use ironsmith_core::TotalCostKind;
 
 fn activated_effect_may_be_mana_ability_lexed(tokens: &[OwnedLexToken]) -> bool {
@@ -185,12 +187,30 @@ fn extract_fixed_mana_output_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<ManaS
         return None;
     }
 
-    let mana: Vec<_> = tokens[add_idx + 1..]
+    let mana_tokens = &tokens[add_idx + 1..];
+    let first_mana_idx = mana_tokens
+        .iter()
+        .position(|token| matches!(token.kind, TokenKind::ManaGroup))?;
+    let repeat_count = if first_mana_idx == 0 {
+        1usize
+    } else {
+        match parse_value(&mana_tokens[..first_mana_idx]) {
+            Some((Value::Fixed(count), used)) if used == first_mana_idx && count > 0 => {
+                usize::try_from(count).ok()?
+            }
+            _ => return None,
+        }
+    };
+
+    let mana: Vec<_> = mana_tokens[first_mana_idx..]
         .iter()
         .try_fold(Vec::new(), |mut acc, token| match token.kind {
             TokenKind::ManaGroup => {
                 let inner = token.slice.trim_start_matches('{').trim_end_matches('}');
-                acc.push(parse_mana_symbol(inner).ok()?);
+                let symbol = parse_mana_symbol(inner).ok()?;
+                for _ in 0..repeat_count {
+                    acc.push(symbol);
+                }
                 Some(acc)
             }
             TokenKind::Period | TokenKind::Comma => Some(acc),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2549,6 +2549,55 @@ fn rewrite_activate_ability_mana_restriction_parses() {
 }
 
 #[test]
+fn rewrite_cast_or_activate_mana_restriction_parses_creature_sources() {
+    let tokens = lex_line(
+        "Spend this mana only to cast creature spells or activate abilities of creatures.",
+        0,
+    )
+    .expect("rewrite lexer should classify compound mana restriction");
+
+    match parse_mana_usage_restriction_sentence_lexed(&tokens) {
+        Some(crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility {
+            spell_filter,
+            ability_source_filter,
+        }) => {
+            assert_eq!(spell_filter.card_types, vec![CardType::Creature]);
+            assert_eq!(ability_source_filter.card_types, vec![CardType::Creature]);
+            assert_eq!(ability_source_filter.zone, Some(crate::zone::Zone::Battlefield));
+        }
+        other => panic!("expected compound cast-or-activate mana restriction, got {other:?}"),
+    }
+}
+
+#[test]
+fn rewrite_activation_line_preserves_spelled_out_fixed_mana_output() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Castle Garenbrig")
+        .card_types(vec![CardType::Land])
+        .parse_text(
+            "{2}{G}{G}, {T}: Add six {G}. Spend this mana only to cast creature spells or activate abilities of creatures.",
+        )
+        .expect("Castle Garenbrig-style activated line should parse");
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            crate::ability::AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("expected activated ability");
+    assert_eq!(
+        activated.mana_output,
+        Some(vec![ManaSymbol::Green; 6]),
+        "expected spelled-out fixed mana amount to produce six green mana"
+    );
+    assert!(matches!(
+        activated.mana_usage_restrictions.as_slice(),
+        [crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility { .. }]
+    ));
+}
+
+#[test]
 fn rewrite_cant_be_spent_mana_restriction_parses_as_positive_filter() {
     let tokens = lex_line("This mana can't be spent to cast nonartifact spells.", 0)
         .expect("rewrite lexer should classify negative mana restriction");

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -38,6 +38,10 @@ pub enum ManaUsageRestriction {
         enters_with_counters: Vec<(crate::CounterType, u32)>,
         granted_abilities: Vec<StaticAbilityId>,
     },
+    CastSpellOrActivateAbility {
+        spell_filter: ObjectFilter,
+        ability_source_filter: ObjectFilter,
+    },
     ActivateAbility,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35993,6 +35993,66 @@ fn james_wandering_dad_follow_him_models_activate_only_mana_usage_restriction() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn castle_garenbrig_parses_strict_regression() {
+    assert_oracle_card_parses_strict("Castle Garenbrig");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn castle_garenbrig_compiled_text_keeps_compound_spend_restriction() {
+    let def = parse_oracle_card_definition("Castle Garenbrig");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains(
+            "spend this mana only to cast creature spells or activate abilities of creatures"
+        ),
+        "expected Castle Garenbrig compiled text to preserve compound spend restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn castle_garenbrig_models_compound_mana_usage_restriction() {
+    let def = parse_oracle_card_definition("Castle Garenbrig");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated
+                    .mana_usage_restrictions
+                    .iter()
+                    .any(|restriction| {
+                        matches!(
+                            restriction,
+                            crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility { .. }
+                        )
+                    }) => Some(activated),
+            _ => None,
+        })
+        .expect("Castle Garenbrig should have a restricted mana ability");
+
+    let [crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility {
+        spell_filter,
+        ability_source_filter,
+    }] = activated.mana_usage_restrictions.as_slice()
+    else {
+        panic!(
+            "expected one compound mana usage restriction, got {:?}",
+            activated.mana_usage_restrictions
+        );
+    };
+    assert_eq!(activated.mana_symbols(), &[ManaSymbol::Green; 6]);
+    assert_eq!(spell_filter.card_types, vec![CardType::Creature]);
+    assert_eq!(ability_source_filter.card_types, vec![CardType::Creature]);
+    assert_eq!(ability_source_filter.zone, Some(Zone::Battlefield));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn jetfire_ingenious_scientist_card_parses_strictly() {
     let def = parse_oracle_card_definition("Jetfire, Ingenious Scientist // Jetfire, Air Guardian");
     assert!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12890,14 +12890,7 @@ pub(super) fn describe_inline_ability_with_self_subject(
             let mana_symbols = activated.mana_symbols();
             if !mana_symbols.is_empty() {
                 payload.push_str("Add ");
-                payload.push_str(
-                    &mana_symbols
-                        .iter()
-                        .copied()
-                        .map(describe_mana_symbol)
-                        .collect::<Vec<_>>()
-                        .join(""),
-                );
+                payload.push_str(&describe_fixed_mana_symbols_for_add(mana_symbols));
             } else if !activated.effects.is_empty() {
                 let rendered =
                     super::ast_render::describe_mana_ability_resolution_program(&activated.effects)
@@ -27100,17 +27093,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(add_mana) = effect.downcast_ref::<crate::effects::AddManaEffect>() {
-        let mana = add_mana
-            .mana
-            .iter()
-            .copied()
-            .map(describe_mana_symbol)
-            .collect::<Vec<_>>()
-            .join("");
+        let mana = describe_fixed_mana_symbols_for_add(&add_mana.mana);
         if matches!(add_mana.player, PlayerFilter::ChosenPlayer) {
             return format!(
                 "A player of your choice adds {}",
-                if mana.is_empty() { "{0}" } else { &mana }
+                if mana.is_empty() { "{0}" } else { mana.as_str() }
             );
         }
         if !matches!(add_mana.player, PlayerFilter::You) {
@@ -27119,12 +27106,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 "{} {} {}",
                 player,
                 player_verb(&player, "add", "adds"),
-                if mana.is_empty() { "{0}" } else { &mana }
+                if mana.is_empty() { "{0}" } else { mana.as_str() }
             );
         }
         return format!(
             "Add {}{}",
-            if mana.is_empty() { "{0}" } else { &mana },
+            if mana.is_empty() { "{0}" } else { mana.as_str() },
             describe_add_mana_destination_suffix(&add_mana.player)
         );
     }
@@ -31354,10 +31341,47 @@ fn describe_mana_usage_restriction(
             line.push_str(&bonuses.join(" and "));
             Some(line)
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility {
+            spell_filter,
+            ability_source_filter,
+        } => {
+            let spell_text = describe_mana_usage_spell_filter_target_with_options(
+                spell_filter,
+                activated
+                    .and_then(activated_mana_output_amount)
+                    .is_some_and(|amount| amount > 1),
+            )?;
+            let ability_text = describe_mana_usage_ability_source_filter(ability_source_filter)?;
+            Some(format!(
+                "Spend this mana only to cast {spell_text} or activate {ability_text}"
+            ))
+        }
         crate::ability::ManaUsageRestriction::ActivateAbility => {
             Some("Spend this mana only to activate abilities".to_string())
         }
     }
+}
+
+fn describe_mana_usage_ability_source_filter(filter: &ObjectFilter) -> Option<String> {
+    if filter == &ObjectFilter::creature() {
+        return Some("abilities of creatures".to_string());
+    }
+    None
+}
+
+fn describe_fixed_mana_symbols_for_add(mana: &[ManaSymbol]) -> String {
+    if mana.len() == 6
+        && let Some(first) = mana.first().copied()
+        && mana.iter().all(|symbol| *symbol == first)
+    {
+        let count = small_number_word(mana.len() as u32).unwrap_or_else(|| mana.len().to_string());
+        return format!("{} {}", count, describe_mana_symbol(first));
+    }
+    mana.iter()
+        .copied()
+        .map(describe_mana_symbol)
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 fn activated_mana_output_amount(activated: &crate::ability::ActivatedAbility) -> Option<i32> {
@@ -31407,6 +31431,14 @@ fn describe_mana_usage_spell_filter_target_with_options(
         .unwrap_or_else(|| describe_cast_limit_spell_filter(filter));
     if described.is_empty() {
         return None;
+    }
+    if pluralize_origin_spell {
+        if described == "spell" {
+            return Some("spells".to_string());
+        }
+        if let Some(singular) = described.strip_suffix(" spell") {
+            return Some(format!("{singular} spells"));
+        }
     }
     if described == "spell" {
         return Some("a spell".to_string());
@@ -34421,12 +34453,7 @@ pub(super) fn describe_ability(
             let add_text = if !mana_symbols.is_empty() {
                 Some(format!(
                     "Add {}",
-                    mana_symbols
-                        .iter()
-                        .copied()
-                        .map(describe_mana_symbol)
-                        .collect::<Vec<_>>()
-                        .join("")
+                    describe_fixed_mana_symbols_for_add(mana_symbols)
                 ))
             } else {
                 None
@@ -34529,14 +34556,7 @@ pub(super) fn describe_ability(
                 if !mana_symbols.is_empty() {
                     line.push(' ');
                     line.push_str("Add ");
-                    line.push_str(
-                        &mana_symbols
-                            .iter()
-                            .copied()
-                            .map(describe_mana_symbol)
-                            .collect::<Vec<_>>()
-                            .join(""),
-                    );
+                    line.push_str(&describe_fixed_mana_symbols_for_add(mana_symbols));
                 } else if !activated.effects.is_empty() {
                     line.push(' ');
                     let effects =

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -724,6 +724,7 @@ fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRe
             restrict_to_matching_spell,
             ..
         } => *restrict_to_matching_spell,
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility { .. } => true,
         crate::ability::ManaUsageRestriction::ActivateAbility => true,
     }
 }
@@ -772,6 +773,7 @@ fn restriction_bonus_applies_to_payment_source(
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, payment_source)
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility { .. } => false,
         crate::ability::ManaUsageRestriction::ActivateAbility => false,
     }
 }
@@ -836,6 +838,25 @@ pub(super) fn payment_source_matches_restriction(
                 return true;
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, Some(source_obj.id))
+        }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility {
+            spell_filter,
+            ability_source_filter,
+        } => {
+            if source_obj.zone == Zone::Stack {
+                return cast_spell_filter_matches_payment_source(
+                    game,
+                    unit,
+                    spell_filter,
+                    Some(source_obj.id),
+                );
+            }
+            let Some(mana_source) = game.object(unit.source) else {
+                return false;
+            };
+            let filter_ctx =
+                game.filter_context_for(game.controller_of(mana_source), Some(unit.source));
+            ability_source_filter.matches(source_obj, &filter_ctx, game)
         }
         crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
     }
@@ -976,6 +997,7 @@ pub(super) fn apply_spent_mana_bonuses(
                 enters_with_counters,
                 granted_abilities,
             ),
+            crate::ability::ManaUsageRestriction::CastSpellOrActivateAbility { .. } => continue,
             crate::ability::ManaUsageRestriction::ActivateAbility => continue,
         };
 
@@ -4801,6 +4823,142 @@ mod priority_mana_tests {
         assert!(
             spend_pool_symbol(&mut game, alice, ManaSymbol::Colorless, Some(spell_id)).is_none(),
             "James restricted mana should not be spendable to cast spells"
+        );
+    }
+
+    #[test]
+    fn castle_garenbrig_restricted_mana_pays_creature_spells_or_creature_abilities_only() {
+        let alice = PlayerId::from_index(0);
+        let castle = CardDefinitionBuilder::new(CardId::new(), "Castle Garenbrig")
+            .card_types(vec![CardType::Land])
+            .parse_text(
+                "Castle Garenbrig enters tapped unless you control a Forest.\n\
+                 {T}: Add {G}.\n\
+                 {2}{G}{G}, {T}: Add six {G}. Spend this mana only to cast creature spells or activate abilities of creatures.",
+            )
+            .expect("Castle Garenbrig should parse its compound restricted mana ability");
+
+        let restriction = castle
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Activated(activated) => activated
+                    .mana_usage_restrictions
+                    .iter()
+                    .find(|restriction| {
+                        matches!(
+                            restriction,
+                            ManaUsageRestriction::CastSpellOrActivateAbility { .. }
+                        )
+                    })
+                    .cloned(),
+                _ => None,
+            })
+            .expect("Castle Garenbrig should carry a compound mana usage restriction");
+
+        let mut game = setup_game();
+        let castle_id = game.create_object_from_definition(&castle, alice, Zone::Battlefield);
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Green,
+                source: castle_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction.clone()],
+            });
+        let creature_spell = CardDefinitionBuilder::new(CardId::new(), "Creature Spell")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let creature_spell_id =
+            game.create_object_from_definition(&creature_spell, alice, Zone::Stack);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(creature_spell_id))
+                .is_some(),
+            "Castle Garenbrig mana should be spendable to cast creature spells"
+        );
+
+        let mut game = setup_game();
+        let castle_id = game.create_object_from_definition(&castle, alice, Zone::Battlefield);
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Green,
+                source: castle_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction.clone()],
+            });
+        let creature_source = CardDefinitionBuilder::new(CardId::new(), "Creature Ability Source")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let creature_source_id =
+            game.create_object_from_definition(&creature_source, alice, Zone::Battlefield);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(creature_source_id))
+                .is_some(),
+            "Castle Garenbrig mana should be spendable to activate abilities of creatures"
+        );
+
+        let mut game = setup_game();
+        let castle_id = game.create_object_from_definition(&castle, alice, Zone::Battlefield);
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Green,
+                source: castle_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction.clone()],
+            });
+        let noncreature_spell = CardDefinitionBuilder::new(CardId::new(), "Instant Spell")
+            .card_types(vec![CardType::Instant])
+            .build();
+        let noncreature_spell_id =
+            game.create_object_from_definition(&noncreature_spell, alice, Zone::Stack);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(noncreature_spell_id))
+                .is_none(),
+            "Castle Garenbrig mana should not be spendable to cast noncreature spells"
+        );
+
+        let mut game = setup_game();
+        let castle_id = game.create_object_from_definition(&castle, alice, Zone::Battlefield);
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Green,
+                source: castle_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction.clone()],
+            });
+        let creature_card = CardDefinitionBuilder::new(CardId::new(), "Creature Card Source")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let creature_card_id =
+            game.create_object_from_definition(&creature_card, alice, Zone::Graveyard);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(creature_card_id))
+                .is_none(),
+            "Castle Garenbrig mana should only activate abilities of creature permanents"
+        );
+
+        let mut game = setup_game();
+        let castle_id = game.create_object_from_definition(&castle, alice, Zone::Battlefield);
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Green,
+                source: castle_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction],
+            });
+        let artifact_source = CardDefinitionBuilder::new(CardId::new(), "Artifact Ability Source")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_source_id =
+            game.create_object_from_definition(&artifact_source, alice, Zone::Battlefield);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(artifact_source_id))
+                .is_none(),
+            "Castle Garenbrig mana should not be spendable to activate noncreature abilities"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Castle Garenbrig
Initial parse error:
```
compiled text dropped required semantic marker: spend-this-mana-only
```

Current worker: i-078e2d4cb4de17db2
Branch: codex/aws-card-fix-castle-garenbrig
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
