### PR TITLE
Fix Ironsmith parse failure: Nashi, Searcher in the Dark

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3208,6 +3208,8 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
             | ["you", "dont", "put", "it", "into", "your", "hand"]
             | ["you", "didnt", "put", "it", "into", "your", "hand"]
             | ["you", "did", "not", "put", "it", "into", "your", "hand"]
+            | ["you", "put", "no", "card", "into", "your", "hand", "this", "way"]
+            | ["you", "put", "no", "cards", "into", "your", "hand", "this", "way"]
     );
     if didnt_put_into_hand {
         return Ok(PredicateAst::Not(Box::new(
@@ -3629,6 +3631,29 @@ mod tests {
     #[test]
     fn parse_predicate_supports_if_you_dont_put_it_into_your_hand() -> Result<(), CardTextError> {
         let tokens = lex_line("If you don't put it into your hand", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::Not(Box::new(PredicateAst::PlayerTaggedObjectMatches {
+                player: PlayerAst::You,
+                tag: TagKey::from(IT_TAG),
+                filter: ObjectFilter::default().in_zone(Zone::Hand),
+            }))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_if_you_put_no_cards_into_your_hand_this_way()
+    -> Result<(), CardTextError> {
+        let tokens = lex_line("If you put no cards into your hand this way", 0)?;
         let predicate_tokens = tokens
             .iter()
             .filter(|token| !token.is_word("if"))

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -3550,6 +3550,7 @@ fn compile_subject_verb_effect(
         }
         SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard {
             filter,
+            count,
             reveal,
             if_not_chosen,
         } => {
@@ -3580,7 +3581,7 @@ fn compile_subject_verb_effect(
             let choose = Effect::new(
                 crate::effects::ChooseObjectsEffect::new(
                     choose_filter,
-                    ChoiceCount::up_to(1),
+                    *count,
                     chooser,
                     chosen_tag_key.clone(),
                 )

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1339,6 +1339,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     ChooseFromLookedCardsIntoHandRestIntoGraveyard {
         filter: ObjectFilter,
+        count: ChoiceCount,
         reveal: bool,
         if_not_chosen: Vec<EffectAst>,
     },
@@ -2681,11 +2682,13 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .finish(),
             Self::ChooseFromLookedCardsIntoHandRestIntoGraveyard {
                 filter,
+                count,
                 reveal,
                 if_not_chosen,
             } => f
                 .debug_struct("ChooseFromLookedCardsIntoHandRestIntoGraveyard")
                 .field("filter", filter)
+                .field("count", count)
                 .field("reveal", reveal)
                 .field("if_not_chosen", if_not_chosen)
                 .finish(),
@@ -4414,6 +4417,7 @@ impl EffectAst {
     pub(crate) fn subject_verb_choose_from_looked_cards_into_hand_rest_into_graveyard(
         player: PlayerAst,
         filter: ObjectFilter,
+        count: ChoiceCount,
         reveal: bool,
         if_not_chosen: Vec<EffectAst>,
     ) -> Self {
@@ -4422,6 +4426,7 @@ impl EffectAst {
             player,
             SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard {
                 filter,
+                count,
                 reveal,
                 if_not_chosen,
             },

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/consult_family.rs
@@ -485,10 +485,12 @@ fn parse_if_you_dont_remainder_inner<'a>(
                 grammar::phrase(&["if", "you", "dont"]),
                 grammar::phrase(&["if", "you", "don't"]),
                 grammar::phrase(&["if", "you", "do", "not"]),
+                grammar::phrase(&["if", "you", "put", "no", "card", "into", "your", "hand", "this", "way"]),
+                grammar::phrase(&["if", "you", "put", "no", "cards", "into", "your", "hand", "this", "way"]),
             ))
             .context(StrContext::Label("if-you-don't prefix"))
             .context(StrContext::Expected(StrContextValue::Description(
-                "if you don't",
+                "if you don't or if you put no cards into your hand this way",
             ))),
             cut_err(grammar::comma())
                 .context(StrContext::Label("if-you-don't separator"))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/looked_cards_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/looked_cards_family.rs
@@ -442,7 +442,8 @@ fn split_reveal_filter_segments(tokens: &[OwnedLexToken]) -> Vec<Vec<OwnedLexTok
         .enumerate()
         .any(|(idx, token)| token.is_word("or") && !is_comparison_or_delimiter(tokens, idx));
     for (idx, token) in tokens.iter().enumerate() {
-        let is_separator = (token.is_word("or") && !is_comparison_or_delimiter(tokens, idx))
+        let is_separator = ((token.is_word("or") || token.is_word("and/or"))
+            && !is_comparison_or_delimiter(tokens, idx))
             || (has_noncomparison_or && token.is_comma());
         if is_separator {
             while current.last().is_some_and(|entry| entry.is_word("and")) {
@@ -568,7 +569,8 @@ pub(crate) fn parse_looked_card_reveal_filter(tokens: &[OwnedLexToken]) -> Optio
     }
 
     let has_noncomparison_or = filter_tokens.iter().enumerate().any(|(idx, token)| {
-        token.is_word("or") && !is_comparison_or_delimiter(&filter_tokens, idx)
+        (token.is_word("or") || token.is_word("and/or"))
+            && !is_comparison_or_delimiter(&filter_tokens, idx)
     });
     if has_noncomparison_or {
         let shared_card_suffix = matches!(words_all_refs.last().copied(), Some("card" | "cards"));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -1000,7 +1000,7 @@ fn parse_may_put_filtered_card_from_among_into_hand(
     tokens: &[OwnedLexToken],
     default_player: PlayerAst,
     zone: Zone,
-) -> Result<Option<(PlayerAst, ObjectFilter)>, CardTextError> {
+) -> Result<Option<(PlayerAst, ObjectFilter, ChoiceCount)>, CardTextError> {
     let sentence_tokens = trim_commas(tokens);
     let Some(action_match) = parse_leading_may_action_lexed(&sentence_tokens, &["put"], true)
     else {
@@ -1025,8 +1025,16 @@ fn parse_may_put_filtered_card_from_among_into_hand(
     if looks_like_keyword_bundle_choice_filter(&action_tokens[..filter_end]) {
         return Ok(None);
     }
+    let (filter_start, count) = if action_word_refs.starts_with(&["any", "number", "of"]) {
+        (
+            action_words.token_index_for_word_index(3).unwrap_or(filter_end),
+            ChoiceCount::any_number(),
+        )
+    } else {
+        (0, ChoiceCount::up_to(1))
+    };
     let mut filter =
-        if let Some(filter) = parse_looked_card_choice_filter(&action_tokens[..filter_end]) {
+        if let Some(filter) = parse_looked_card_choice_filter(&action_tokens[filter_start..filter_end]) {
             filter
         } else {
             return Ok(None);
@@ -1040,7 +1048,7 @@ fn parse_may_put_filtered_card_from_among_into_hand(
         return Ok(None);
     }
 
-    Ok(Some((chooser, filter)))
+    Ok(Some((chooser, filter, count)))
 }
 
 fn retarget_source_self_animate_effect(effect: EffectAst) -> EffectAst {
@@ -1410,7 +1418,7 @@ pub(crate) fn parse_mill_then_may_put_from_among_into_hand(
         return Ok(None);
     };
 
-    let Some((chooser, filter)) =
+    let Some((chooser, filter, count)) =
         parse_may_put_filtered_card_from_among_into_hand(second, *player, Zone::Graveyard)?
     else {
         return Ok(None);
@@ -1421,6 +1429,7 @@ pub(crate) fn parse_mill_then_may_put_from_among_into_hand(
         EffectAst::subject_verb_choose_from_looked_cards_into_hand_rest_into_graveyard(
             chooser,
             filter,
+            count,
             false,
             Vec::new(),
         ),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -961,6 +961,7 @@ pub(crate) fn parse_top_cards_put_match_into_hand_rest_graveyard(
         EffectAst::subject_verb_choose_from_looked_cards_into_hand_rest_into_graveyard(
             chooser,
             filter,
+            ChoiceCount::up_to(1),
             reveal_chosen,
             Vec::new(),
         ),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -67,6 +67,7 @@ fn first_word_look(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
 
 fn first_word_mill(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
     sentence_head_word_is(sentences, sentence_idx, "mill")
+        || sentence_head_is(sentences, sentence_idx, ("you", Some("mill")))
 }
 
 fn first_word_search(sentences: &[SentenceInput], sentence_idx: usize) -> bool {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35031,6 +35031,199 @@ fn assert_oracle_card_fails_strict(name: &str) {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_nashi_searcher_in_the_dark_strict_regression() {
+    assert_oracle_card_parses_strict("Nashi, Searcher in the Dark");
+    let def = parse_oracle_card_definition("Nashi, Searcher in the Dark");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Whenever this creature deals combat damage to a player, you mill that many cards. You may put any number of legendary and/or enchantment cards from among them into your hand. If you put no cards into your hand this way, put a +1/+1 counter on Nashi."),
+        "expected Nashi's mill-choice/counter branch to render from structured effects, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nashi_searcher_in_the_dark_lowers_any_number_legendary_or_enchantment_choice() {
+    let def = parse_oracle_card_definition("Nashi, Searcher in the Dark");
+    let debug = format!("{def:#?}");
+
+    assert!(
+        debug.contains("ChooseObjectsEffect")
+            && debug.contains("max: None")
+            && debug.contains("Legendary")
+            && debug.contains("Enchantment")
+            && debug.contains("DidNotHappen"),
+        "expected Nashi to choose any number of milled legendary and/or enchantment cards and branch if none moved, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct NashiChooseNamedCards {
+    names: Vec<&'static str>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for NashiChooseNamedCards {
+    fn decide_objects(
+        &mut self,
+        game: &crate::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .filter_map(|candidate| {
+                let object = game.object(candidate.id)?;
+                self.names
+                    .iter()
+                    .any(|name| object.name == *name)
+                    .then_some(candidate.id)
+            })
+            .take(ctx.max.unwrap_or(ctx.candidates.len()))
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn nashi_runtime_fixture() -> (
+    crate::GameState,
+    PlayerId,
+    ObjectId,
+    crate::ids::StableId,
+    crate::ids::StableId,
+    crate::ids::StableId,
+    crate::resolution::ResolutionProgram,
+) {
+    let def = parse_oracle_card_definition("Nashi, Searcher in the Dark");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Nashi should have a combat-damage triggered ability");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let nashi = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let legendary_sorcery = CardDefinitionBuilder::new(CardId::new(), "The Elderspell")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let enchantment = CardDefinitionBuilder::new(CardId::new(), "Omen of the Sea")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Elite Vanguard")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .build();
+    let legendary_id = game.create_object_from_definition(&legendary_sorcery, alice, Zone::Library);
+    let enchantment_id = game.create_object_from_definition(&enchantment, alice, Zone::Library);
+    let creature_id = game.create_object_from_definition(&creature, alice, Zone::Library);
+    let legendary_stable = game.object(legendary_id).expect("legendary card exists").stable_id;
+    let enchantment_stable = game
+        .object(enchantment_id)
+        .expect("enchantment card exists")
+        .stable_id;
+    let creature_stable = game.object(creature_id).expect("creature card exists").stable_id;
+
+    (
+        game,
+        alice,
+        nashi,
+        legendary_stable,
+        enchantment_stable,
+        creature_stable,
+        triggered.effects.clone(),
+    )
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn zone_for_stable_id(game: &crate::GameState, stable_id: crate::ids::StableId) -> Option<Zone> {
+    game.find_object_by_stable_id(stable_id)
+        .and_then(|id| game.object(id))
+        .map(|object| object.zone)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nashi_searcher_in_the_dark_puts_chosen_milled_cards_into_hand_without_counter() {
+    let (mut game, alice, nashi, legendary_stable, enchantment_stable, creature_stable, effects) =
+        nashi_runtime_fixture();
+    let mut dm = NashiChooseNamedCards {
+        names: vec!["The Elderspell", "Omen of the Sea"],
+    };
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            nashi,
+            crate::events::DamageTarget::Player(PlayerId::from_index(1)),
+            3,
+            true,
+            crate::events::cause::EventCause::from_combat_damage(nashi, alice),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new(nashi, alice, &mut dm)
+        .with_triggering_event(damage_event)
+        .with_event_value_amount(3);
+
+    crate::game_loop::execute_resolution_program(&mut game, &mut ctx, alice, nashi, &effects, None, &[])
+        .expect("Nashi trigger should resolve when cards are chosen");
+
+    assert_eq!(zone_for_stable_id(&game, legendary_stable), Some(Zone::Hand));
+    assert_eq!(zone_for_stable_id(&game, enchantment_stable), Some(Zone::Hand));
+    assert_eq!(
+        zone_for_stable_id(&game, creature_stable),
+        Some(Zone::Graveyard),
+        "nonlegendary nonenchantment milled card should remain in the graveyard"
+    );
+    assert_eq!(
+        game.counter_count(nashi, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Nashi should not get a counter when at least one card is put into hand this way"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nashi_searcher_in_the_dark_gets_counter_when_no_milled_cards_are_chosen() {
+    let (mut game, alice, nashi, legendary_stable, enchantment_stable, creature_stable, effects) =
+        nashi_runtime_fixture();
+    let mut dm = NashiChooseNamedCards { names: Vec::new() };
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            nashi,
+            crate::events::DamageTarget::Player(PlayerId::from_index(1)),
+            3,
+            true,
+            crate::events::cause::EventCause::from_combat_damage(nashi, alice),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new(nashi, alice, &mut dm)
+        .with_triggering_event(damage_event)
+        .with_event_value_amount(3);
+
+    crate::game_loop::execute_resolution_program(&mut game, &mut ctx, alice, nashi, &effects, None, &[])
+        .expect("Nashi trigger should resolve when no cards are chosen");
+
+    for stable_id in [legendary_stable, enchantment_stable, creature_stable] {
+        assert_eq!(
+            zone_for_stable_id(&game, stable_id),
+            Some(Zone::Graveyard),
+            "unchosen milled cards should stay in the graveyard"
+        );
+    }
+    assert_eq!(
+        game.counter_count(nashi, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Nashi should get a +1/+1 counter when no cards are put into hand this way"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_sporeweb_weaver_strict_regression() {
     assert_oracle_card_parses_strict("Sporeweb Weaver");
     let def = parse_oracle_card_definition("Sporeweb Weaver");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12033,6 +12033,29 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 2;
             continue;
         }
+        if idx + 3 < filtered.len()
+            && let Some(tagged_mill) = filtered[idx].downcast_ref::<crate::effects::TaggedEffect>()
+            && let Some(mill) = tagged_mill
+                .effect
+                .downcast_ref::<crate::effects::MillEffect>()
+            && let Some(choose) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some((Some(move_to_hand_with_id), move_to_hand)) =
+                for_each_tagged_for_compaction(filtered[idx + 2])
+            && let Some(if_effect) = filtered[idx + 3].downcast_ref::<crate::effects::IfEffect>()
+            && let Some(compact) = describe_tagged_mill_then_put_milled_card_into_hand_then_if_not(
+                tagged_mill,
+                mill,
+                choose,
+                move_to_hand_with_id,
+                move_to_hand,
+                if_effect,
+            )
+        {
+            parts.push(compact);
+            idx += 4;
+            continue;
+        }
         if idx + 2 < filtered.len()
             && let Some(tagged_mill) = filtered[idx].downcast_ref::<crate::effects::TaggedEffect>()
             && let Some(mill) = tagged_mill
@@ -21740,12 +21763,18 @@ fn describe_choose_filter_from_tagged_cards(
         Some(Zone::Library | Zone::Graveyard)
     ) || choose.is_search
         || choose.count.min > 1
-        || choose.count.max != Some(1)
         || choose.count.dynamic_x
         || choose.count.random
     {
         return None;
     }
+    let count_prefix = if choose.count.min == 0 && choose.count.max.is_none() {
+        "any number of "
+    } else if choose.count.max == Some(1) {
+        ""
+    } else {
+        return None;
+    };
     let references_source = choose.filter.tagged_constraints.iter().any(|constraint| {
         matches!(
             constraint.relation,
@@ -21765,7 +21794,31 @@ fn describe_choose_filter_from_tagged_cards(
         ) && constraint.tag.as_str() == source_tag)
     });
     if base_filter == ObjectFilter::default() {
-        return Some("a card".to_string());
+        return Some(format!("{count_prefix}a card"));
+    }
+    if !count_prefix.is_empty() && !base_filter.any_of.is_empty() {
+        let mut without_branches = base_filter.clone();
+        let branches = std::mem::take(&mut without_branches.any_of);
+        if without_branches == ObjectFilter::default() {
+            let mut parts = Vec::new();
+            for branch in branches {
+                let mut branch_text = branch.description();
+                branch_text = strip_leading_article(&branch_text).to_string();
+                if let Some(rest) = branch_text.strip_suffix(" permanent") {
+                    branch_text = rest.to_string();
+                }
+                if let Some(rest) = branch_text.strip_suffix(" cards") {
+                    branch_text = rest.to_string();
+                } else if let Some(rest) = branch_text.strip_suffix(" card") {
+                    branch_text = rest.to_string();
+                }
+                if branch_text.is_empty() {
+                    return None;
+                }
+                parts.push(branch_text);
+            }
+            return Some(format!("{count_prefix}{} cards", parts.join(" and/or ")));
+        }
     }
 
     let filter_text = base_filter.description();
@@ -21782,12 +21835,16 @@ fn describe_choose_filter_from_tagged_cards(
     if !card_desc.contains(" card") {
         card_desc = format!("{card_desc} card");
     }
-    Some(with_indefinite_article(&card_desc))
+    if count_prefix.is_empty() {
+        Some(with_indefinite_article(&card_desc))
+    } else {
+        Some(format!("{count_prefix}{card_desc}"))
+    }
 }
 
 fn describe_tagged_mill_clause(mill: &crate::effects::MillEffect) -> String {
     if matches!(mill.player, PlayerFilter::You) {
-        format!("Mill {}", describe_card_count(&mill.count))
+        format!("You mill {}", describe_card_count(&mill.count))
     } else {
         let player = describe_player_filter(&mill.player);
         format!(
@@ -21814,8 +21871,50 @@ pub(super) fn describe_tagged_mill_then_put_milled_card_into_hand(
     let hand = describe_possessive_player_filter(&choose.chooser);
     let may = if choose.count.min == 0 { " may" } else { "" };
     Some(format!(
-        "{mill_clause}. You{may} put {chosen} from among the cards milled this way into {hand} hand"
+        "{mill_clause}. You{may} put {chosen} from among them into {hand} hand"
     ))
+}
+
+pub(super) fn describe_tagged_mill_then_put_milled_card_into_hand_then_if_not(
+    tagged_mill: &crate::effects::TaggedEffect,
+    mill: &crate::effects::MillEffect,
+    choose: &crate::effects::ChooseObjectsEffect,
+    move_to_hand_with_id: &crate::effects::WithIdEffect,
+    move_to_hand: &crate::effects::ForEachTaggedEffect,
+    if_effect: &crate::effects::IfEffect,
+) -> Option<String> {
+    let base = describe_tagged_mill_then_put_milled_card_into_hand(
+        tagged_mill,
+        mill,
+        choose,
+        move_to_hand,
+    )?;
+    let follow_up = if choose.count.min == 0 && choose.count.max.is_none() {
+        if if_effect.condition != move_to_hand_with_id.id
+            || if_effect.predicate != EffectPredicate::DidNotHappen
+            || !if_effect.else_.is_empty()
+        {
+            return None;
+        }
+        let then_text = describe_effect_list(&if_effect.then);
+        if then_text.is_empty() {
+            return None;
+        }
+        if choose.chooser == PlayerFilter::You {
+            format!("If you put no cards into your hand this way, {then_text}")
+        } else {
+            let who = describe_player_filter(&choose.chooser);
+            let hand = describe_possessive_player_filter(&choose.chooser);
+            format!("If {who} put no cards into {hand} hand this way, {then_text}")
+        }
+    } else {
+        describe_if_didnt_put_card_into_hand_this_way(
+            &choose.chooser,
+            move_to_hand_with_id.id,
+            if_effect,
+        )?
+    };
+    Some(format!("{base}. {follow_up}"))
 }
 
 pub(super) fn describe_tagged_mill_then_may_put_milled_card_into_hand(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nashi, Searcher in the Dark
Initial parse error:
```
unsupported predicate (predicate: 'you put no cards into your hand this way'); oracle-only fallback also failed: unsupported predicate (predicate: 'you put no cards into your hand this way')
```

Current worker: i-0f680461ebcb6e4ee
Branch: codex/aws-card-fix-nashi-searcher-in-the-dark
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0001
