### PR TITLE
Fix Ironsmith parse failure: Guardian of the Ages

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1248,6 +1248,38 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         });
     }
 
+    if let Some(has_idx) = find_index(&filtered, |word| *word == "has" || *word == "have")
+        && has_idx > 0
+        && has_idx + 1 < filtered.len()
+    {
+        let subject_words = &filtered[..has_idx];
+        let is_source_subject = is_source_reference_words(subject_words)
+            || matches!(subject_words, ["it"] | ["its"]);
+        if is_source_subject
+            && let Some((constraint, consumed)) =
+                parse_filter_keyword_constraint_words(&filtered[has_idx + 1..])
+            && has_idx + 1 + consumed == filtered.len()
+        {
+            let mut filter = if matches!(subject_words, ["this" | "thiss" | "it" | "its"])
+            {
+                ObjectFilter::default()
+            } else if let Some(descriptor_words) = subject_words
+                .strip_prefix(&["this"])
+                .or_else(|| subject_words.strip_prefix(&["thiss"]))
+            {
+                let descriptor_tokens = descriptor_words
+                    .iter()
+                    .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                    .collect::<Vec<_>>();
+                parse_object_filter(&descriptor_tokens, false).unwrap_or_default()
+            } else {
+                ObjectFilter::default()
+            };
+            apply_filter_keyword_constraint(&mut filter, constraint, false);
+            return Ok(PredicateAst::SourceMatches(filter));
+        }
+    }
+
     if matches!(
         filtered.as_slice(),
         [
@@ -3891,6 +3923,25 @@ mod tests {
         let parsed = parse_predicate(&predicate_tokens)?;
 
         assert_eq!(parsed, PredicateAst::SourcePowerAtLeast(7));
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_source_has_keyword() -> Result<(), CardTextError> {
+        let tokens = lex_line("If this creature has defender", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        let mut expected_filter = ObjectFilter::creature();
+        expected_filter
+            .static_abilities
+            .push(crate::static_abilities::StaticAbilityId::Defender);
+        assert_eq!(parsed, PredicateAst::SourceMatches(expected_filter));
         Ok(())
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1260,21 +1260,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
                 parse_filter_keyword_constraint_words(&filtered[has_idx + 1..])
             && has_idx + 1 + consumed == filtered.len()
         {
-            let mut filter = if matches!(subject_words, ["this" | "thiss" | "it" | "its"])
-            {
-                ObjectFilter::default()
-            } else if let Some(descriptor_words) = subject_words
-                .strip_prefix(&["this"])
-                .or_else(|| subject_words.strip_prefix(&["thiss"]))
-            {
-                let descriptor_tokens = descriptor_words
-                    .iter()
-                    .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
-                    .collect::<Vec<_>>();
-                parse_object_filter(&descriptor_tokens, false).unwrap_or_default()
-            } else {
-                ObjectFilter::default()
-            };
+            let mut filter = ObjectFilter::default();
             apply_filter_keyword_constraint(&mut filter, constraint, false);
             return Ok(PredicateAst::SourceMatches(filter));
         }
@@ -3937,7 +3923,7 @@ mod tests {
 
         let parsed = parse_predicate(&predicate_tokens)?;
 
-        let mut expected_filter = ObjectFilter::creature();
+        let mut expected_filter = ObjectFilter::default();
         expected_filter
             .static_abilities
             .push(crate::static_abilities::StaticAbilityId::Defender);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/condition_antecedent.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/condition_antecedent.rs
@@ -172,7 +172,12 @@ fn retarget_it_animation_target_to_source(target: &mut TargetAst) {
 
 pub(crate) fn retarget_it_animation_to_source(effect: &mut EffectAst) {
     if let EffectAst::SubjectVerb(subject_verb) = effect
-        && let SubjectVerbActionAst::BecomeBasePtCreature { target, .. } = &mut subject_verb.action
+        && let SubjectVerbActionAst::BecomeBasePtCreature { target, .. }
+        | SubjectVerbActionAst::GrantAbilitiesToTarget { target, .. }
+        | SubjectVerbActionAst::GrantToTarget { target, .. }
+        | SubjectVerbActionAst::RemoveAbilitiesFromTarget { target, .. }
+        | SubjectVerbActionAst::GrantAbilitiesChoiceToTarget { target, .. } =
+            &mut subject_verb.action
     {
         retarget_it_animation_target_to_source(target);
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35183,16 +35183,7 @@ fn assert_oracle_card_fails_strict(name: &str) {
 
 #[test]
 fn guardian_of_the_ages_strict_parser_and_text_regression() {
-    let def = CardDefinitionBuilder::new(CardId::new(), "Guardian of the Ages")
-        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
-        .card_types(vec![CardType::Artifact, CardType::Creature])
-        .subtypes(vec![Subtype::Golem])
-        .power_toughness(PowerToughness::fixed(7, 7))
-        .parse_text(
-            "Defender\n\
-             When a creature attacks you or a planeswalker you control, if this creature has defender, it loses defender and gains trample.",
-        )
-        .expect("Guardian of the Ages should parse strictly");
+    let def = parse_oracle_card_definition("Guardian of the Ages");
 
     let rendered_lines = canonical_compiled_lines(&def);
     assert_eq!(
@@ -35216,7 +35207,7 @@ fn guardian_of_the_ages_strict_parser_and_text_regression() {
         matches!(
             triggered.intervening_if.as_ref(),
             Some(crate::ConditionExpr::SourceMatches(filter))
-                if filter.card_types.as_slice() == [CardType::Creature]
+                if filter.card_types.is_empty()
                     && filter.static_abilities.as_slice() == [StaticAbilityId::Defender]
         ),
         "Guardian of the Ages should gate the trigger on the source having defender, got {:?}",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35181,6 +35181,49 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+#[test]
+fn guardian_of_the_ages_strict_parser_and_text_regression() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Guardian of the Ages")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Golem])
+        .power_toughness(PowerToughness::fixed(7, 7))
+        .parse_text(
+            "Defender\n\
+             When a creature attacks you or a planeswalker you control, if this creature has defender, it loses defender and gains trample.",
+        )
+        .expect("Guardian of the Ages should parse strictly");
+
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Defender".to_string(),
+            "Whenever a creature attacks you or a planeswalker you control, if this creature has defender, this creature loses defender and gains trample.".to_string(),
+        ],
+        "Guardian of the Ages should render the source-keyword intervening-if clause"
+    );
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Guardian of the Ages should have an attack trigger");
+    assert!(
+        matches!(
+            triggered.intervening_if.as_ref(),
+            Some(crate::ConditionExpr::SourceMatches(filter))
+                if filter.card_types.as_slice() == [CardType::Creature]
+                    && filter.static_abilities.as_slice() == [StaticAbilityId::Defender]
+        ),
+        "Guardian of the Ages should gate the trigger on the source having defender, got {:?}",
+        triggered.intervening_if
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_sporeweb_weaver_strict_regression() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10143,6 +10143,67 @@ fn describe_counter_constraint_phrase(counter: crate::filter::CounterConstraint)
     }
 }
 
+fn describe_source_matches_keyword_condition(filter: &ObjectFilter) -> Option<String> {
+    if filter.static_abilities.len() != 1
+        || !filter.excluded_static_abilities.is_empty()
+        || !filter.ability_markers.is_empty()
+        || !filter.excluded_ability_markers.is_empty()
+    {
+        return None;
+    }
+
+    let label = describe_source_condition_static_ability(filter.static_abilities[0])?;
+    let mut subject_filter = filter.clone();
+    subject_filter.static_abilities.clear();
+    let subject = subject_filter.description();
+    let subject = strip_leading_article(&subject);
+    if subject == "permanent" || subject == "source" {
+        Some(format!("this source has {label}"))
+    } else if subject.starts_with("this ") {
+        Some(format!("{subject} has {label}"))
+    } else {
+        Some(format!("this {subject} has {label}"))
+    }
+}
+
+fn describe_source_condition_static_ability(
+    ability_id: crate::static_abilities::StaticAbilityId,
+) -> Option<&'static str> {
+    use crate::static_abilities::StaticAbilityId::*;
+    match ability_id {
+        Flying => Some("flying"),
+        FirstStrike => Some("first strike"),
+        DoubleStrike => Some("double strike"),
+        Deathtouch => Some("deathtouch"),
+        Defender => Some("defender"),
+        Flash => Some("flash"),
+        Haste => Some("haste"),
+        Hexproof => Some("hexproof"),
+        Indestructible => Some("indestructible"),
+        Intimidate => Some("intimidate"),
+        Lifelink => Some("lifelink"),
+        Menace => Some("menace"),
+        Reach => Some("reach"),
+        Skulk => Some("skulk"),
+        Shroud => Some("shroud"),
+        Trample => Some("trample"),
+        Vigilance => Some("vigilance"),
+        Fear => Some("fear"),
+        Flanking => Some("flanking"),
+        Landwalk => Some("landwalk"),
+        Bloodthirst => Some("bloodthirst"),
+        Morph => Some("morph"),
+        Disguise => Some("disguise"),
+        Megamorph => Some("megamorph"),
+        Shadow => Some("shadow"),
+        Horsemanship => Some("horsemanship"),
+        Wither => Some("wither"),
+        Infect => Some("infect"),
+        Changeling => Some("changeling"),
+        _ => None,
+    }
+}
+
 pub(super) fn describe_condition(condition: &Condition) -> String {
     if let Some(compact) = describe_happily_ever_after_condition(condition) {
         return compact;
@@ -10717,6 +10778,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::SourceIsFaceDown => "this source is transformed".to_string(),
         Condition::SourceMatches(filter) => {
+            if let Some(text) = describe_source_matches_keyword_condition(filter) {
+                return text;
+            }
             let desc = filter.description();
             let stripped = strip_leading_article(&desc).to_ascii_lowercase();
             if stripped == "permanent" {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -623,6 +623,150 @@ fn guardian_of_the_ages_loses_defender_and_stops_triggering() {
     );
 }
 
+#[test]
+fn guardian_of_the_ages_source_defender_condition_is_not_type_gated() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let guardian = CardDefinitionBuilder::new(CardId::from_raw(72_143), "Guardian of the Ages")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Defender\n\
+             When a creature attacks you or a planeswalker you control, if this creature has defender, it loses defender and gains trample.",
+        )
+        .expect("Guardian of the Ages should parse");
+    let guardian_id = game.create_object_from_definition(&guardian, alice, Zone::Battlefield);
+
+    let attacker = create_creature(&mut game, "Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(attacker);
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("attacking Guardian's controller should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Guardian of the Ages trigger should go on stack");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "self-reference should check whether the source has defender, not whether it is currently a creature"
+    );
+    resolve_stack_entry(&mut game).expect("Guardian of the Ages trigger should resolve");
+
+    assert!(
+        !game.object_has_ability(guardian_id, &StaticAbility::defender()),
+        "Guardian of the Ages should lose defender after its trigger resolves"
+    );
+    assert!(
+        game.object_has_ability(guardian_id, &StaticAbility::trample()),
+        "Guardian of the Ages should gain trample after its trigger resolves"
+    );
+}
+
+#[test]
+fn guardian_of_the_ages_triggers_for_planeswalker_you_control_only() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let guardian = CardDefinitionBuilder::new(CardId::from_raw(72_144), "Guardian of the Ages")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Golem])
+        .power_toughness(PowerToughness::fixed(7, 7))
+        .parse_text(
+            "Defender\n\
+             When a creature attacks you or a planeswalker you control, if this creature has defender, it loses defender and gains trample.",
+        )
+        .expect("Guardian of the Ages should parse");
+    let guardian_id = game.create_object_from_definition(&guardian, alice, Zone::Battlefield);
+
+    let alice_planeswalker = CardBuilder::new(CardId::from_raw(72_145), "Alice Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(4)
+        .build();
+    let alice_planeswalker_id =
+        game.create_object_from_card(&alice_planeswalker, alice, Zone::Battlefield);
+    let bob_planeswalker = CardBuilder::new(CardId::from_raw(72_146), "Bob Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(4)
+        .build();
+    let bob_planeswalker_id =
+        game.create_object_from_card(&bob_planeswalker, bob, Zone::Battlefield);
+
+    let alice_attacker = create_creature(&mut game, "Alice Attacker", alice, 2, 2);
+    game.remove_summoning_sickness(alice_attacker);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: alice_attacker,
+            target: AttackTarget::Planeswalker(bob_planeswalker_id),
+        }],
+    )
+    .expect("attacking an opponent's planeswalker should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("empty trigger queue should process");
+    assert!(
+        game.stack.is_empty(),
+        "Guardian of the Ages should not trigger for attacks at an opponent's planeswalker"
+    );
+
+    let bob_attacker = create_creature(&mut game, "Bob Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(bob_attacker);
+    game.turn.active_player = bob;
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: bob_attacker,
+            target: AttackTarget::Planeswalker(alice_planeswalker_id),
+        }],
+    )
+    .expect("attacking Guardian's controller's planeswalker should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Guardian of the Ages planeswalker attack trigger should go on stack");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "Guardian should trigger for attacks at a planeswalker its controller controls"
+    );
+    resolve_stack_entry(&mut game).expect("Guardian of the Ages trigger should resolve");
+
+    assert!(
+        !game.object_has_ability(guardian_id, &StaticAbility::defender()),
+        "Guardian of the Ages should lose defender after a planeswalker attack trigger resolves"
+    );
+    assert!(
+        game.object_has_ability(guardian_id, &StaticAbility::trample()),
+        "Guardian of the Ages should gain trample after a planeswalker attack trigger resolves"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn sharpened_pitchfork_boosts_only_humans_but_always_grants_first_strike() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -542,6 +542,87 @@ fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup()
     );
 }
 
+#[test]
+fn guardian_of_the_ages_loses_defender_and_stops_triggering() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let guardian = CardDefinitionBuilder::new(CardId::from_raw(72_141), "Guardian of the Ages")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Golem])
+        .power_toughness(PowerToughness::fixed(7, 7))
+        .parse_text(
+            "Defender\n\
+             When a creature attacks you or a planeswalker you control, if this creature has defender, it loses defender and gains trample.",
+        )
+        .expect("Guardian of the Ages should parse");
+    let guardian_id = game.create_object_from_definition(&guardian, alice, Zone::Battlefield);
+
+    assert!(
+        game.object_has_ability(guardian_id, &StaticAbility::defender()),
+        "Guardian of the Ages should start with defender"
+    );
+    assert!(
+        !game.object_has_ability(guardian_id, &StaticAbility::trample()),
+        "Guardian of the Ages should not start with trample"
+    );
+
+    let first_attacker = create_creature(&mut game, "First Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(first_attacker);
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: first_attacker,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("attacking Guardian's controller should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Guardian of the Ages trigger should go on stack");
+    assert_eq!(game.stack.len(), 1, "Guardian should trigger while it has defender");
+    resolve_stack_entry(&mut game).expect("Guardian of the Ages trigger should resolve");
+
+    assert!(
+        !game.object_has_ability(guardian_id, &StaticAbility::defender()),
+        "Guardian of the Ages should lose defender after its trigger resolves"
+    );
+    assert!(
+        game.object_has_ability(guardian_id, &StaticAbility::trample()),
+        "Guardian of the Ages should gain trample after its trigger resolves"
+    );
+
+    let second_attacker = create_creature(&mut game, "Second Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(second_attacker);
+    let mut second_combat = CombatState::default();
+    let mut second_trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut second_combat,
+        &mut second_trigger_queue,
+        &[AttackerDeclaration {
+            creature: second_attacker,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("a later attack should be legal");
+    put_triggers_on_stack(&mut game, &mut second_trigger_queue)
+        .expect("empty trigger queue should still process");
+    assert!(
+        game.stack.is_empty(),
+        "Guardian of the Ages should not trigger once it no longer has defender"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn sharpened_pitchfork_boosts_only_humans_but_always_grants_first_strike() {

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks_you.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks_you.rs
@@ -104,6 +104,29 @@ impl AttacksYouTrigger {
             .count();
         (count > 0).then_some(count as i32)
     }
+
+    fn singular_subject_description(&self) -> String {
+        let subject = self.filter.description();
+        let lower = subject.to_ascii_lowercase();
+        if lower.starts_with("a ")
+            || lower.starts_with("an ")
+            || lower.starts_with("the ")
+            || lower.starts_with("another ")
+            || lower.starts_with("this ")
+            || lower.starts_with("that ")
+            || lower.starts_with("target ")
+        {
+            return subject;
+        }
+
+        let first = lower.chars().next().unwrap_or('a');
+        let article = if matches!(first, 'a' | 'e' | 'i' | 'o' | 'u') {
+            "an"
+        } else {
+            "a"
+        };
+        format!("{article} {subject}")
+    }
 }
 
 impl TriggerMatcher for AttacksYouTrigger {
@@ -145,7 +168,7 @@ impl TriggerMatcher for AttacksYouTrigger {
         }
         format!(
             "Whenever {} attacks you or a planeswalker you control",
-            self.filter.description()
+            self.singular_subject_description()
         )
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Guardian of the Ages
Initial parse error:
```
unsupported predicate (predicate: 'this creature has defender'); oracle-only fallback also failed: unsupported predicate (predicate: 'this creature has defender')
```

Current worker: i-04d07b170c36e6577
Branch: codex/aws-card-fix-guardian-of-the-ages
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0003
