### PR TITLE
Fix Ironsmith parse failure: The Fugitive Doctor

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -601,7 +601,9 @@ fn parse_explicit_flashback_grant_to_target(
         return Ok(None);
     };
     let target = parse_target_phrase(subject_tokens)?;
-    let total_cost = crate::cost::TotalCost::mana(ManaCost::from_pips(vec![pips]));
+    let total_cost = crate::cost::TotalCost::mana(ManaCost::from_pips(
+        pips.into_iter().map(|pip| vec![pip]).collect(),
+    ));
     Ok(Some(EffectAst::subject_verb_grant_to_target(
         target,
         crate::grant::Grantable::AlternativeCast(
@@ -816,6 +818,17 @@ fn parse_simple_ability_modifier_clause_lexed(
     ));
     if ability_tokens.is_empty() {
         return Ok(None);
+    }
+
+    if !losing {
+        let subject_tokens = trim_trailing_also(trim_lexed_commas(
+            &tokens[subject_start_token_idx..verb_token_idx],
+        ));
+        if let Some(effect) =
+            parse_explicit_flashback_grant_to_target(subject_tokens, &ability_tokens, &duration)?
+        {
+            return Ok(Some(effect));
+        }
     }
 
     let ability_word_refs = GainAbilityWordView::new(&ability_tokens).to_word_refs();
@@ -1035,6 +1048,13 @@ pub(crate) fn parse_simple_ability_modifier_clause(
     let ability_tokens = trim_edge_punctuation(&ability_token_storage);
     if ability_tokens.is_empty() {
         return Ok(None);
+    }
+
+    if !losing
+        && let Some(effect) =
+            parse_explicit_flashback_grant_to_target(&subject_tokens, &ability_tokens, &duration)?
+    {
+        return Ok(Some(effect));
     }
 
     let ability_word_refs = GainAbilityWordView::new(&ability_tokens).to_word_refs();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -18,8 +18,8 @@ use super::super::token_primitives::{
     str_contains as string_contains,
 };
 use super::super::util::{
-    is_article, is_source_reference_words, parse_mana_symbol, parse_target_phrase,
-    span_from_tokens, token_index_for_word_index, trim_commas,
+    is_article, is_source_reference_words, mana_pips_from_token, parse_mana_symbol,
+    parse_target_phrase, span_from_tokens, token_index_for_word_index, trim_commas,
 };
 use super::clause_dispatch::parse_become_clause;
 use super::dispatch_inner::trim_edge_punctuation;
@@ -558,6 +558,57 @@ pub(crate) fn parse_simple_ability_duration(
         ));
     }
     None
+}
+
+fn grant_duration_from_until(duration: &Until) -> Option<crate::grant::GrantDuration> {
+    match duration {
+        Until::Forever => Some(crate::grant::GrantDuration::Forever),
+        Until::EndOfTurn => Some(crate::grant::GrantDuration::UntilEndOfTurn),
+        Until::YourNextTurn | Until::YourNextTurnEnd => {
+            Some(crate::grant::GrantDuration::UntilYourNextTurnEnd)
+        }
+        _ => None,
+    }
+}
+
+fn parse_explicit_flashback_grant_to_target(
+    subject_tokens: &[OwnedLexToken],
+    ability_tokens: &[OwnedLexToken],
+    duration: &Until,
+) -> Result<Option<EffectAst>, CardTextError> {
+    let ability_tokens = trim_edge_punctuation(ability_tokens);
+    if ability_tokens
+        .first()
+        .and_then(OwnedLexToken::as_word)
+        != Some("flashback")
+    {
+        return Ok(None);
+    }
+
+    let mut pips = Vec::new();
+    for token in trim_commas(&ability_tokens[1..]) {
+        if let Some(group) = mana_pips_from_token(&token) {
+            pips.extend(group);
+        } else {
+            return Ok(None);
+        }
+    }
+    if pips.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(grant_duration) = grant_duration_from_until(duration) else {
+        return Ok(None);
+    };
+    let target = parse_target_phrase(subject_tokens)?;
+    let total_cost = crate::cost::TotalCost::mana(ManaCost::from_pips(vec![pips]));
+    Ok(Some(EffectAst::subject_verb_grant_to_target(
+        target,
+        crate::grant::Grantable::AlternativeCast(
+            crate::alternative_cast::AlternativeCastingMethod::Flashback { total_cost },
+        ),
+        grant_duration,
+    )))
 }
 
 fn words_start_nested_triggered_ability(words_after_verb: &[&str]) -> bool {
@@ -1272,6 +1323,15 @@ pub(crate) fn parse_gain_ability_sentence(
         return Ok(None);
     }
     let ability_tokens = trim_commas(&tokens[ability_start_token_idx..ability_end_token_idx]);
+
+    if !losing {
+        let subject_tokens = trim_commas(&tokens[subject_start_token_idx..gain_token_idx]);
+        if let Some(effect) =
+            parse_explicit_flashback_grant_to_target(&subject_tokens, &ability_tokens, &duration)?
+        {
+            return Ok(Some(vec![effect]));
+        }
+    }
 
     let (mut abilities, grant_is_choice) =
         parse_granted_abilities_for_gain_clause(&ability_tokens, &word_list, !losing)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5280,7 +5280,7 @@ fn target_gains_explicit_flashback_cost_until_end_of_turn_parses_as_grant() {
 
     assert!(debug.contains("GrantToTarget"), "{debug}");
     assert!(debug.contains("Flashback"), "{debug}");
-    assert!(debug.contains("Generic(2)"), "{debug}");
+    assert!(debug.contains("Generic") && debug.contains("2"), "{debug}");
     assert!(debug.contains("Red"), "{debug}");
     assert!(debug.contains("Green"), "{debug}");
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5267,6 +5267,25 @@ fn rewrite_lower_routes_next_spell_cost_reduction_filters_through_grammar_entryp
 }
 
 #[test]
+fn target_gains_explicit_flashback_cost_until_end_of_turn_parses_as_grant() {
+    let tokens = lex_line(
+        "target instant or sorcery card in your graveyard gains flashback {2}{R}{G} until end of turn",
+        0,
+    )
+    .expect("explicit flashback grant should lex");
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("explicit flashback grant should parse as an effect sentence");
+    let debug = format!("{effects:#?}");
+
+    assert!(debug.contains("GrantToTarget"), "{debug}");
+    assert!(debug.contains("Flashback"), "{debug}");
+    assert!(debug.contains("Generic(2)"), "{debug}");
+    assert!(debug.contains("Red"), "{debug}");
+    assert!(debug.contains("Green"), "{debug}");
+}
+
+#[test]
 fn rewrite_anthem_grant_static_parses_flashback_tail_without_word_view() {
     let tokens = lex_line(
         "During your turn, each instant and sorcery card in your graveyard has flashback. Its flashback cost is equal to its mana cost.",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45806,3 +45806,160 @@ fn loot_the_key_to_everything_runtime_grants_play_permission_until_end_of_turn()
         "expected Loot play permission to allow lands as well as spells, got {debug}"
     );
 }
+
+fn the_fugitive_doctor_reflexive_flashback_grant(
+    def: &CardDefinition,
+) -> (
+    &crate::effects::WithIdEffect,
+    &crate::effects::ReflexiveTriggerEffect,
+    &crate::effects::GrantEffect,
+) {
+    for ability in &def.abilities {
+        let AbilityKind::Triggered(triggered) = &ability.kind else {
+            continue;
+        };
+        for segment in &triggered.effects.segments {
+            for effect in &segment.default_effects {
+                let Some(reflexive) =
+                    effect.downcast_ref::<crate::effects::ReflexiveTriggerEffect>()
+                else {
+                    continue;
+                };
+                let grant = reflexive
+                    .effects
+                    .iter()
+                    .find_map(|effect| effect.downcast_ref::<crate::effects::GrantEffect>())
+                    .expect("The Fugitive Doctor reflexive trigger should grant flashback");
+                let condition = segment
+                    .default_effects
+                    .iter()
+                    .find_map(|effect| effect.downcast_ref::<crate::effects::WithIdEffect>())
+                    .filter(|with_id| with_id.id == reflexive.condition)
+                    .expect(
+                        "The Fugitive Doctor reflexive trigger should depend on a tracked prior effect",
+                    );
+                return (condition, reflexive, grant);
+            }
+        }
+    }
+
+    panic!("The Fugitive Doctor should compile its attack follow-up as a reflexive flashback grant")
+}
+
+#[test]
+fn parse_oracle_the_fugitive_doctor_strictly_parses_reflexive_flashback_grant() {
+    assert_oracle_card_parses_strict("The Fugitive Doctor");
+    let def = parse_oracle_card_definition("The Fugitive Doctor");
+    let (condition, reflexive, grant) = the_fugitive_doctor_reflexive_flashback_grant(&def);
+    let debug = format!("{:#?}", def.abilities);
+    let condition_debug = format!("{:#?}", condition.effect);
+
+    assert!(!debug.contains("KeywordFallbackText"), "{debug}");
+    assert!(debug.contains("ReflexiveTriggerEffect"), "{debug}");
+    assert!(matches!(
+        reflexive.predicate,
+        crate::effect::EffectPredicate::Happened
+    ));
+    assert!(condition_debug.contains("MayEffect"), "{condition_debug}");
+    assert!(condition_debug.contains("Sacrifice"), "{condition_debug}");
+    assert!(condition_debug.contains("Clue"), "{condition_debug}");
+    assert!(matches!(
+        &grant.grantable,
+        crate::grant::Grantable::AlternativeCast(
+            crate::alternative_cast::AlternativeCastingMethod::Flashback { .. }
+        )
+    ));
+}
+
+#[test]
+fn the_fugitive_doctor_compiled_text_keeps_flashback_cost_clause() {
+    let def = parse_oracle_card_definition("The Fugitive Doctor");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("When you do, target instant or sorcery card in your graveyard gains flashback {2}{R}{G} until end of turn"),
+        "expected rendered The Fugitive Doctor text to keep the reflexive flashback-cost grant, got {rendered}"
+    );
+}
+
+#[test]
+fn the_fugitive_doctor_runtime_grants_exact_flashback_cost_to_target_card() {
+    let def = parse_oracle_card_definition("The Fugitive Doctor");
+    let (_condition, _reflexive, grant) = the_fugitive_doctor_reflexive_flashback_grant(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target_def =
+        CardDefinitionBuilder::new(CardId::new(), "The Fugitive Doctor Target Instant")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+            .card_types(vec![CardType::Instant])
+            .build();
+    let target_id = game.create_object_from_definition(&target_def, alice, Zone::Graveyard);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    ctx.targets = vec![crate::effects::ResolvedTarget::Object(target_id)];
+    let result = grant
+        .execute(&mut game, &mut ctx)
+        .expect("The Fugitive Doctor grant effect should resolve");
+
+    assert_eq!(result.status, crate::effect::OutcomeStatus::Succeeded);
+    let granted_casts = game
+        .effect_store
+        .grant_registry
+        .granted_alternative_casts_for_card(&game, target_id, Zone::Graveyard, alice);
+    let method = granted_casts
+        .first()
+        .map(|grant| &grant.method)
+        .expect("target card should receive a granted flashback method");
+    let crate::alternative_cast::AlternativeCastingMethod::Flashback { total_cost } = method else {
+        panic!("expected granted flashback, got {method:?}");
+    };
+    assert_eq!(total_cost.display(), "{2}{R}{G}");
+}
+
+#[test]
+fn the_fugitive_doctor_flashback_target_legality_requires_your_graveyard_instant_or_sorcery() {
+    let def = parse_oracle_card_definition("The Fugitive Doctor");
+    let (_condition, _reflexive, grant) = the_fugitive_doctor_reflexive_flashback_grant(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let instant = CardDefinitionBuilder::new(CardId::new(), "The Fugitive Doctor Legal Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let sorcery = CardDefinitionBuilder::new(CardId::new(), "The Fugitive Doctor Legal Sorcery")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let creature =
+        CardDefinitionBuilder::new(CardId::new(), "The Fugitive Doctor Illegal Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+    let alice_instant_graveyard =
+        game.create_object_from_definition(&instant, alice, Zone::Graveyard);
+    let alice_sorcery_graveyard =
+        game.create_object_from_definition(&sorcery, alice, Zone::Graveyard);
+    let alice_creature_graveyard =
+        game.create_object_from_definition(&creature, alice, Zone::Graveyard);
+    let bob_instant_graveyard = game.create_object_from_definition(&instant, bob, Zone::Graveyard);
+    let alice_instant_hand = game.create_object_from_definition(&instant, alice, Zone::Hand);
+
+    let legal_targets = crate::targeting::compute_legal_targets(
+        &game,
+        &grant.target,
+        alice,
+        Some(source_id),
+    );
+
+    assert!(legal_targets.contains(&crate::game_state::Target::Object(alice_instant_graveyard)));
+    assert!(legal_targets.contains(&crate::game_state::Target::Object(alice_sorcery_graveyard)));
+    assert!(!legal_targets.contains(&crate::game_state::Target::Object(
+        alice_creature_graveyard
+    )));
+    assert!(!legal_targets.contains(&crate::game_state::Target::Object(bob_instant_graveyard)));
+    assert!(!legal_targets.contains(&crate::game_state::Target::Object(alice_instant_hand)));
+}

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45919,6 +45919,133 @@ fn the_fugitive_doctor_runtime_grants_exact_flashback_cost_to_target_card() {
 }
 
 #[test]
+fn the_fugitive_doctor_granted_flashback_cast_uses_granted_cost_and_exiles() {
+    let def = parse_oracle_card_definition("The Fugitive Doctor");
+    let (_condition, _reflexive, grant) = the_fugitive_doctor_reflexive_flashback_grant(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target_def =
+        CardDefinitionBuilder::new(CardId::new(), "The Fugitive Doctor Cost Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+            .card_types(vec![CardType::Instant])
+            .build();
+    let target_id = game.create_object_from_definition(&target_def, alice, Zone::Graveyard);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    ctx.targets = vec![crate::effects::ResolvedTarget::Object(target_id)];
+    grant
+        .execute(&mut game, &mut ctx)
+        .expect("The Fugitive Doctor grant effect should resolve");
+
+    game.player_mut(alice)
+        .expect("alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+    let printed_cost_only_actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        !printed_cost_only_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                ..
+            } if *spell_id == target_id
+        )),
+        "granted flashback should not be castable for the target card's printed {{U}} cost"
+    );
+
+    let mana_pool = &mut game
+        .player_mut(alice)
+        .expect("alice should exist")
+        .mana_pool;
+    mana_pool.empty();
+    mana_pool.add(ManaSymbol::Colorless, 2);
+    mana_pool.add(ManaSymbol::Red, 1);
+    mana_pool.add(ManaSymbol::Green, 1);
+
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    let cast_action = actions
+        .iter()
+        .find_map(|action| match action {
+            crate::decision::LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method,
+            } if *spell_id == target_id => Some(casting_method.clone()),
+            _ => None,
+        })
+        .expect("granted flashback should be castable for {2}{R}{G}");
+    assert!(
+        matches!(
+            cast_action,
+            crate::alternative_cast::CastingMethod::PlayFrom {
+                zone: Zone::Graveyard,
+                use_alternative: Some(_),
+                ..
+            }
+        ),
+        "granted flashback should preserve the granted method index, got {cast_action:?}"
+    );
+    let spell = game
+        .object(target_id)
+        .expect("target spell should still be in the graveyard");
+    let payable_cost = crate::decision::spell_mana_cost_for_cast(
+        &game,
+        alice,
+        spell,
+        &cast_action,
+        Zone::Graveyard,
+    )
+    .expect("granted flashback should have a payable mana cost");
+    assert_eq!(
+        payable_cost,
+        ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Green],
+        ])
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let mut state = crate::PriorityLoopState::new(game.players_in_game());
+    crate::apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &crate::PriorityResponse::PriorityAction(crate::decision::LegalAction::CastSpell {
+            spell_id: target_id,
+            from_zone: Zone::Graveyard,
+            casting_method: cast_action,
+        }),
+    )
+    .expect("casting the granted flashback spell should succeed");
+
+    assert_eq!(
+        game.player(alice)
+            .expect("alice should exist")
+            .mana_pool
+            .total(),
+        0,
+        "casting through granted flashback should pay {{2}}{{R}}{{G}}"
+    );
+    crate::resolve_stack_entry(&mut game).expect("granted flashback spell should resolve");
+    assert!(
+        game.exile.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|obj| obj.name == "The Fugitive Doctor Cost Probe")
+        }),
+        "the granted flashback spell should be exiled after resolving"
+    );
+}
+
+#[test]
 fn the_fugitive_doctor_flashback_target_legality_requires_your_graveyard_instant_or_sorcery() {
     let def = parse_oracle_card_definition("The Fugitive Doctor");
     let (_condition, _reflexive, grant) = the_fugitive_doctor_reflexive_flashback_grant(&def);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -30848,6 +30848,19 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 .granted_inline_ability()
                 .map(describe_inline_ability)
                 .unwrap_or_else(|| lowercase_first(&ability.display())),
+            crate::grant::Grantable::AlternativeCast(method) => {
+                let mut text = lowercase_first(method.name());
+                let cost_text = method
+                    .total_cost()
+                    .map(|cost| cost.display())
+                    .or_else(|| method.mana_cost().map(|cost| cost.to_oracle()))
+                    .filter(|cost| cost != "Free");
+                if let Some(cost_text) = cost_text {
+                    text.push(' ');
+                    text.push_str(&cost_text);
+                }
+                text
+            }
             _ => grant.grantable.display(),
         };
         return format!(

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -182,7 +182,11 @@ fn append_graveyard_granted_alternative_cast_actions_for_card(
                 }
             }
             crate::alternative_cast::AlternativeCastingMethod::Flashback { .. } => {
-                CastingMethod::GrantedFlashback
+                CastingMethod::PlayFrom {
+                    source: grant.source_id,
+                    zone: Zone::Graveyard,
+                    use_alternative: Some(base_alt_idx + offset),
+                }
             }
             crate::alternative_cast::AlternativeCastingMethod::FromZone {
                 zone: Zone::Graveyard,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The Fugitive Doctor
Initial parse error:
```
compiled card still contains unsupported parser fallback marker KeywordFallbackText; oracle-only fallback also failed: compiled card still contains unsupported parser fallback marker KeywordFallbackText
```

Current worker: i-07df57a893da63b22
Branch: codex/aws-card-fix-the-fugitive-doctor
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0003
