### PR TITLE
Fix Ironsmith parse failure: Coalition Victory

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -658,6 +658,38 @@ fn parse_revealed_or_controlled_subtype_predicate(words: &[&str]) -> Option<Pred
     ))
 }
 
+fn parse_control_land_types_and_creature_colors_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if words.len() != 13
+        || words[0] != "you"
+        || !matches!(words[1], "control" | "controls")
+        || words[2] != "land"
+        || words[3] != "of"
+        || words[4] != "each"
+        || words[5] != "basic"
+        || words[6] != "land"
+        || !matches!(words[7], "type" | "types")
+        || words[8] != "and"
+        || words[9] != "creature"
+        || words[10] != "of"
+        || words[11] != "each"
+        || !matches!(words[12], "color" | "colors")
+    {
+        return None;
+    }
+
+    Some(PredicateAst::And(
+        Box::new(PredicateAst::PlayerControlsBasicLandTypesAmongLandsOrMore {
+            player: PlayerAst::You,
+            count: 5,
+        }),
+        Box::new(PredicateAst::ValueComparison {
+            left: Value::ColorsAmong(ObjectFilter::creature().you_control()),
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: Value::Fixed(5),
+        }),
+    ))
+}
+
 pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, CardTextError> {
     let raw_words_view = GrammarFilterNormalizedWords::new(tokens);
     let raw_words = raw_words_view.to_word_refs();
@@ -786,6 +818,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_revealed_or_controlled_subtype_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_control_land_types_and_creature_colors_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -389,6 +389,8 @@ fn is_statement_verb_word(word: &str) -> bool {
             | "until"
             | "untap"
             | "untaps"
+            | "win"
+            | "wins"
     )
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1583,6 +1583,17 @@ pub(crate) fn parse_win_the_game_clause(
         return Ok(Some(EffectAst::subject_verb_win_game(PlayerAst::You)));
     }
 
+    if let Some(spec) = split_trailing_if_clause_lexed(tokens) {
+        let leading_words = ClausePatternCompatWords::new(spec.leading_tokens).to_word_refs();
+        if leading_words.as_slice() == ["you", "win", "the", "game"] {
+            return Ok(Some(EffectAst::Conditional {
+                predicate: spec.predicate,
+                if_true: vec![EffectAst::subject_verb_win_game(PlayerAst::You)],
+                if_false: Vec::new(),
+            }));
+        }
+    }
+
     if clause_words.get(4).copied() != Some("if") {
         return Ok(None);
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -471,6 +471,38 @@ fn happily_ever_after_keeps_life_draw_and_win_gate() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn coalition_victory_parses_and_renders_domain_and_color_win_condition() {
+    let oracle = "You win the game if you control a land of each basic land type and a creature of each color.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "Coalition Victory")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(oracle)
+        .expect("Coalition Victory should parse");
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("PlayerControlsBasicLandTypesAmongLandsOrMore")
+            && debug.contains("ColorsAmong")
+            && debug.contains("WinTheGameEffect"),
+        "expected Coalition Victory to lower to a conditional win effect gated by basic land types and creature colors, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "If you control a land of each basic land type and you control a creature of each color, you win the game."
+    );
+}
+
 #[test]
 fn test_creature_with_etb() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "ETB Creature")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10355,6 +10355,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::PlayerControlsBasicLandTypesAmongLandsOrMore { player, count } => {
             let subject = describe_player_filter(player);
             let verb = player_verb(&subject, "control", "controls");
+            if *count == 5 {
+                return format!("{subject} {verb} a land of each basic land type");
+            }
             let count_text = small_number_word(*count)
                 .unwrap_or_else(|| count.to_string());
             format!(
@@ -11286,6 +11289,15 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             ) = (left, operator, right)
             {
                 return "you have max speed".to_string();
+            }
+            if let (
+                Value::ColorsAmong(filter),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                Value::Fixed(5),
+            ) = (left, operator, right)
+                && *filter == ObjectFilter::creature().you_control()
+            {
+                return "you control a creature of each color".to_string();
             }
             if let (
                 Value::LifeLostThisTurn(player),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39,6 +39,133 @@ fn setup_three_player_game() -> GameState {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn coalition_victory_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_303), "Coalition Victory")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "You win the game if you control a land of each basic land type and a creature of each color.",
+        )
+        .expect("Coalition Victory should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_coalition_victory_lands(game: &mut GameState, controller: PlayerId, include_forest: bool) {
+    let lands = [
+        ("Plains", Subtype::Plains),
+        ("Island", Subtype::Island),
+        ("Swamp", Subtype::Swamp),
+        ("Mountain", Subtype::Mountain),
+    ];
+    for (name, subtype) in lands {
+        let land = CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Land])
+            .subtypes(vec![subtype])
+            .build();
+        game.create_object_from_card(&land, controller, Zone::Battlefield);
+    }
+    if include_forest {
+        let forest = CardBuilder::new(CardId::new(), "Forest")
+            .card_types(vec![CardType::Land])
+            .subtypes(vec![Subtype::Forest])
+            .build();
+        game.create_object_from_card(&forest, controller, Zone::Battlefield);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_coalition_victory_creatures(
+    game: &mut GameState,
+    controller: PlayerId,
+    include_green: bool,
+) {
+    let creatures = [
+        ("White Coalition Creature", crate::color::ColorSet::WHITE),
+        ("Blue Coalition Creature", crate::color::ColorSet::BLUE),
+        ("Black Coalition Creature", crate::color::ColorSet::BLACK),
+        ("Red Coalition Creature", crate::color::ColorSet::RED),
+    ];
+    for (name, colors) in creatures {
+        let creature = CardBuilder::new(CardId::new(), name)
+            .color_indicator(colors)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        game.create_object_from_card(&creature, controller, Zone::Battlefield);
+    }
+    if include_green {
+        let creature = CardBuilder::new(CardId::new(), "Green Coalition Creature")
+            .color_indicator(crate::color::ColorSet::GREEN)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        game.create_object_from_card(&creature, controller, Zone::Battlefield);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_coalition_victory_with_board(include_forest: bool, include_green: bool) -> GameState {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    put_coalition_victory_lands(&mut game, alice, include_forest);
+    put_coalition_victory_creatures(&mut game, alice, include_green);
+
+    let coalition_victory = coalition_victory_definition();
+    let spell_id = game.create_object_from_definition(&coalition_victory, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice));
+    resolve_stack_entry(&mut game).expect("Coalition Victory should resolve");
+    game
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn coalition_victory_wins_with_each_basic_land_type_and_creature_color() {
+    let game = resolve_coalition_victory_with_board(true, true);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    assert!(
+        game.player(bob).expect("bob exists").has_lost,
+        "Coalition Victory should make opponents lose when Alice satisfies both gates"
+    );
+    assert!(
+        !game.player(alice).expect("alice exists").has_lost,
+        "Coalition Victory should not make its controller lose"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn coalition_victory_does_not_win_without_each_basic_land_type() {
+    let game = resolve_coalition_victory_with_board(false, true);
+    let bob = PlayerId::from_index(1);
+
+    assert!(
+        !game.player(bob).expect("bob exists").has_lost,
+        "Coalition Victory should not win while its controller is missing a basic land type"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn coalition_victory_does_not_win_without_each_creature_color() {
+    let game = resolve_coalition_victory_with_board(true, false);
+    let bob = PlayerId::from_index(1);
+
+    assert!(
+        !game.player(bob).expect("bob exists").has_lost,
+        "Coalition Victory should not win while its controller is missing a creature color"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn open_the_way_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_900), "Open the Way")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -992,6 +992,47 @@ fn compile_oracle_text_strictly_compiles_aunt_may_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_coalition_victory_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Coalition Victory")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Coalition Victory --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Coalition Victory should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Coalition Victory"), "{stdout}");
+    assert!(stdout.contains("Similarity: 1.0000"), "{stdout}");
+    assert!(stdout.contains("Semantic mismatch: false"), "{stdout}");
+    assert!(
+        stdout.contains(
+            "If you control a land of each basic land type and you control a creature of each color, you win the game."
+        ),
+        "expected basic-land-type and creature-color win condition in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_aloe_alchemist_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Coalition Victory
Initial parse error:
```
compiled text dropped required semantic marker: each-basic-land-type
```

Current worker: i-045f628e15f90f198
Branch: codex/aws-card-fix-coalition-victory
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0003
