### PR TITLE
Fix Ironsmith parse failure: Painter's Servant

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -672,6 +672,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_all_permanents_colorless_line),
         single_static_ability_ast_rule!(parse_all_cards_spells_permanents_colorless_line),
         multi_static_ability_ast_rule!(parse_all_are_color_and_type_addition_line),
+        single_static_ability_ast_rule!(parse_all_cards_spells_permanents_add_chosen_color_line),
         single_static_ability_ast_rule!(parse_all_creatures_are_color_line),
         single_static_ability_ast_rule!(parse_protection_from_colored_spells_line),
         single_static_ability_ast_rule!(parse_nonbasic_lands_are_basic_land_type_line),
@@ -6177,6 +6178,45 @@ pub(crate) fn parse_all_cards_spells_permanents_colorless_line(
     {
         return Ok(Some(StaticAbility::make_colorless(ObjectFilter::default())));
     }
+    Ok(None)
+}
+
+pub(crate) fn parse_all_cards_spells_permanents_add_chosen_color_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if matches!(
+        words.as_slice(),
+        [
+            "all",
+            "cards",
+            "that",
+            "aren",
+            "t",
+            "on",
+            "the",
+            "battlefield",
+            "spells",
+            "and",
+            "permanents",
+            "are",
+            "the",
+            "chosen",
+            "color",
+            "in",
+            "addition",
+            "to",
+            "their",
+            "other",
+            "colors"
+        ]
+    ) {
+        return Ok(Some(StaticAbility::add_chosen_color(
+            ObjectFilter::default(),
+            "All cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors.",
+        )));
+    }
+
     Ok(None)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6184,15 +6184,14 @@ pub(crate) fn parse_all_cards_spells_permanents_colorless_line(
 pub(crate) fn parse_all_cards_spells_permanents_add_chosen_color_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
-    let words = crate::runtime_backend::token_word_refs(tokens);
+    let words = parser_token_word_refs(tokens);
     if matches!(
         words.as_slice(),
         [
             "all",
             "cards",
             "that",
-            "aren",
-            "t",
+            "arent",
             "on",
             "the",
             "battlefield",
@@ -6213,7 +6212,7 @@ pub(crate) fn parse_all_cards_spells_permanents_add_chosen_color_line(
     ) {
         return Ok(Some(StaticAbility::add_chosen_color(
             ObjectFilter::default(),
-            "All cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors.",
+            render_token_slice(tokens),
         )));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8796,6 +8796,50 @@ fn rewrite_grammar_chosen_type_static_line_probes_match_keyword_static_shapes() 
 }
 
 #[test]
+fn rewrite_static_line_supports_painters_servant_chosen_color_clause() {
+    let tokens = lex_line(
+        "All cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors.",
+        0,
+    )
+    .expect("rewrite lexer should classify Painter's Servant chosen-color line");
+
+    assert_eq!(
+        super::lexer::parser_token_word_refs(&tokens),
+        vec![
+            "all",
+            "cards",
+            "that",
+            "arent",
+            "on",
+            "the",
+            "battlefield",
+            "spells",
+            "and",
+            "permanents",
+            "are",
+            "the",
+            "chosen",
+            "color",
+            "in",
+            "addition",
+            "to",
+            "their",
+            "other",
+            "colors",
+        ]
+    );
+
+    let parsed =
+        super::keyword_static::parse_all_cards_spells_permanents_add_chosen_color_line(&tokens)
+            .expect("Painter's Servant chosen-color line should parse");
+
+    assert!(matches!(
+        parsed,
+        Some(ability) if ability.id() == crate::static_abilities::StaticAbilityId::AddChosenColor
+    ));
+}
+
+#[test]
 fn rewrite_lexed_triggered_line_supports_tivit_vote_trigger_body() {
     let triggered_tokens = lex_line(
         "Whenever this creature enters the battlefield or deals combat damage to a player, starting with you, each player votes for evidence or bribery. For each evidence vote, investigate. For each bribery vote, create a Treasure token. You may vote an additional time.",

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -162,6 +162,7 @@ pub enum StaticAbilityId {
     VoteAdditionalVoteWhileVoting,
     EnchantedLandIsChosenType,
     AddChosenCreatureType,
+    AddChosenColor,
     SetChosenColor,
     RedirectDamageToSource,
     RedirectDamageToSourceController,
@@ -408,6 +409,7 @@ impl StaticAbilityId {
             | VoteAdditionalVoteWhileVoting
             | EnchantedLandIsChosenType
             | AddChosenCreatureType
+            | AddChosenColor
             | SetChosenColor
             | RedirectDamageToSource
             | RedirectDamageToSourceController
@@ -649,6 +651,7 @@ impl StaticAbilityId {
                 | AddSubtypes
                 | SetLandSubtypes
                 | AddColors
+                | AddChosenColor
                 | SetColors
         )
     }

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -245,6 +245,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         filter: ObjectFilter,
         display: String,
     },
+    AddChosenColor {
+        filter: ObjectFilter,
+        display: String,
+    },
     SetChosenColor {
         filter: ObjectFilter,
         display: String,
@@ -936,6 +940,9 @@ where
             }
             StaticAbilityPayload::AddChosenCreatureType { filter, display } => {
                 StaticAbilityPayload::AddChosenCreatureType { filter, display }
+            }
+            StaticAbilityPayload::AddChosenColor { filter, display } => {
+                StaticAbilityPayload::AddChosenColor { filter, display }
             }
             StaticAbilityPayload::SetChosenColor { filter, display } => {
                 StaticAbilityPayload::SetChosenColor { filter, display }
@@ -2860,6 +2867,14 @@ impl<
             id: Some(StaticAbilityId::AddChosenCreatureType),
             label: display.clone(),
             payload: StaticAbilityPayload::AddChosenCreatureType { filter, display },
+        }
+    }
+    pub fn add_chosen_color(filter: ObjectFilter, display: impl Into<String>) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::AddChosenColor),
+            label: display.clone(),
+            payload: StaticAbilityPayload::AddChosenColor { filter, display },
         }
     }
     pub fn set_chosen_color(filter: ObjectFilter, display: impl Into<String>) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2695,6 +2695,137 @@ fn test_chosen_creature_type_static_adds_selected_subtype() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn painters_servant_definition() -> CardDefinition {
+    parse_oracle_card_definition("Painter's Servant")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn painters_servant_strict_parse_and_compiled_text_regression() {
+    let def = painters_servant_definition();
+    let ids: Vec<StaticAbilityId> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(ids.contains(&StaticAbilityId::ChooseColorAsEnters));
+    assert!(ids.contains(&StaticAbilityId::AddChosenColor));
+    assert!(
+        !ids.contains(&StaticAbilityId::RuleFallbackText)
+            && !ids.contains(&StaticAbilityId::UnsupportedParserLine),
+        "expected strict Painter's Servant static abilities, got {ids:?}"
+    );
+
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join("\n");
+    assert_eq!(
+        rendered,
+        "As this creature enters, choose a color.\nAll cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors."
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn painters_servant_adds_chosen_color_to_permanents_spells_and_nonbattlefield_cards() {
+    let def = painters_servant_definition();
+    let red_creature = CardDefinitionBuilder::new(CardId::from_raw(391), "Red Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("")
+        .expect("red creature definition");
+    let green_spell = CardDefinitionBuilder::new(CardId::from_raw(392), "Green Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text("Draw a card.")
+        .expect("green spell definition");
+    let colorless_artifact =
+        CardDefinitionBuilder::new(CardId::from_raw(393), "Colorless Artifact")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text("")
+            .expect("colorless artifact definition");
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let servant_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.set_chosen_color(servant_id, Color::Blue);
+    let permanent_id = game.create_object_from_definition(&red_creature, alice, Zone::Battlefield);
+    let hand_card_id = game.create_object_from_definition(&green_spell, alice, Zone::Hand);
+    let graveyard_card_id =
+        game.create_object_from_definition(&green_spell, alice, Zone::Graveyard);
+    let exile_card_id = game.create_object_from_definition(&green_spell, alice, Zone::Exile);
+    let library_card_id = game.create_object_from_definition(&green_spell, alice, Zone::Library);
+    let spell_id = game.create_object_from_definition(&green_spell, alice, Zone::Stack);
+    let colorless_id =
+        game.create_object_from_definition(&colorless_artifact, alice, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    let permanent_colors = game.current_colors(permanent_id).expect("permanent colors");
+    assert!(permanent_colors.contains(Color::Red));
+    assert!(permanent_colors.contains(Color::Blue));
+
+    let hand_card_colors = game.current_colors(hand_card_id).expect("hand card colors");
+    assert!(hand_card_colors.contains(Color::Green));
+    assert!(hand_card_colors.contains(Color::Blue));
+
+    let graveyard_card_colors = game
+        .current_colors(graveyard_card_id)
+        .expect("graveyard card colors");
+    assert!(graveyard_card_colors.contains(Color::Green));
+    assert!(graveyard_card_colors.contains(Color::Blue));
+
+    let exile_card_colors = game.current_colors(exile_card_id).expect("exile card colors");
+    assert!(exile_card_colors.contains(Color::Green));
+    assert!(exile_card_colors.contains(Color::Blue));
+
+    let library_card_colors = game
+        .current_colors(library_card_id)
+        .expect("library card colors");
+    assert!(library_card_colors.contains(Color::Green));
+    assert!(library_card_colors.contains(Color::Blue));
+
+    let spell_colors = game.current_colors(spell_id).expect("spell colors");
+    assert!(spell_colors.contains(Color::Green));
+    assert!(spell_colors.contains(Color::Blue));
+
+    let artifact_colors = game.current_colors(colorless_id).expect("artifact colors");
+    assert!(artifact_colors.contains(Color::Blue));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn painters_servant_does_not_add_color_without_a_chosen_color() {
+    let def = painters_servant_definition();
+    let red_creature = CardDefinitionBuilder::new(CardId::from_raw(394), "Red Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("")
+        .expect("red creature definition");
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let permanent_id = game.create_object_from_definition(&red_creature, alice, Zone::Battlefield);
+    let hand_card_id = game.create_object_from_definition(&red_creature, alice, Zone::Hand);
+    game.refresh_continuous_state();
+
+    let colors = game.current_colors(permanent_id).expect("permanent colors");
+    assert!(colors.contains(Color::Red));
+    assert!(!colors.contains(Color::Blue));
+
+    let hand_colors = game.current_colors(hand_card_id).expect("hand card colors");
+    assert!(hand_colors.contains(Color::Red));
+    assert!(!hand_colors.contains(Color::Blue));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_roaming_throne_variant_duplicates_matching_creature_triggers() {
     let throne_def = CardDefinitionBuilder::new(CardId::from_raw(1), "Roaming Throne Variant")

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -3940,6 +3940,50 @@ impl StaticAbilityKind for AddChosenCreatureTypeForFilter {
     }
 }
 
+/// "Objects are the chosen color in addition to their other colors."
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddChosenColorForFilter {
+    pub filter: ObjectFilter,
+    pub display: String,
+}
+
+impl AddChosenColorForFilter {
+    pub fn new(filter: ObjectFilter, display: String) -> Self {
+        Self { filter, display }
+    }
+}
+
+impl StaticAbilityKind for AddChosenColorForFilter {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::AddChosenColor
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_effects(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+        game: &GameState,
+    ) -> Vec<ContinuousEffect> {
+        let Some(chosen_color) = game.chosen_color(source) else {
+            return Vec::new();
+        };
+
+        vec![
+            ContinuousEffect::new(
+                source,
+                controller,
+                effect_target_for_filter(source, &self.filter),
+                Modification::AddColors(crate::color::ColorSet::from(chosen_color)),
+            )
+            .with_source_type(EffectSourceType::StaticAbility),
+        ]
+    }
+}
+
 /// "This permanent is the chosen color."
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetChosenColorForFilter {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2541,6 +2541,10 @@ impl StaticAbility {
         Self::new(AddChosenCreatureTypeForFilter::new(filter, display))
     }
 
+    pub fn add_chosen_color(filter: crate::target::ObjectFilter, display: String) -> Self {
+        Self::new(AddChosenColorForFilter::new(filter, display))
+    }
+
     pub fn set_chosen_color(filter: crate::target::ObjectFilter, display: String) -> Self {
         Self::new(SetChosenColorForFilter::new(filter, display))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1014,6 +1014,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::AddChosenCreatureType { filter, display } => {
                 StaticAbility::add_chosen_creature_type(filter.clone(), display.clone())
             }
+            ironsmith_core::StaticAbilityPayload::AddChosenColor { filter, display } => {
+                StaticAbility::add_chosen_color(filter.clone(), display.clone())
+            }
             ironsmith_core::StaticAbilityPayload::SetChosenColor { filter, display } => {
                 StaticAbility::set_chosen_color(filter.clone(), display.clone())
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Painter's Servant
Initial parse error:
```
parser does not yet support line family: 'All cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors.'; oracle-only fallback also failed: parser does not yet support line family: 'All cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors.'
```

Current worker: i-090ad75b43eec4c94
Branch: codex/aws-card-fix-painter-s-servant
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0003
