### PR TITLE
Fix Ironsmith parse failure: Silverquill Lecturer

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -371,6 +371,7 @@ impl CardDefinitionBuilder {
             KeywordAction::Assist => self.assist(),
             KeywordAction::SplitSecond => self.split_second(),
             KeywordAction::Cascade => self.cascade(),
+            KeywordAction::Demonstrate => self.demonstrate(),
             KeywordAction::Rebound => self.rebound(),
             KeywordAction::Sunburst => self.sunburst(),
             KeywordAction::ReadAhead => self.read_ahead(),
@@ -1733,6 +1734,15 @@ impl CardDefinitionBuilder {
         self.with_ability(
             crate::ability::Ability::static_ability(
                 crate::static_abilities::StaticAbility::cascade(),
+            )
+            .in_zones(vec![crate::zone::Zone::Stack]),
+        )
+    }
+
+    pub fn demonstrate(self) -> Self {
+        self.with_ability(
+            crate::ability::Ability::static_ability(
+                crate::static_abilities::StaticAbility::demonstrate(),
             )
             .in_zones(vec![crate::zone::Zone::Stack]),
         )

--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -41,6 +41,7 @@ pub enum KeywordAction {
     Prowess,
     Exalted,
     Cascade,
+    Demonstrate,
     Storm,
     Toxic(u32),
     BattleCry,
@@ -195,6 +196,7 @@ impl KeywordAction {
                 | Self::Prowess
                 | Self::Exalted
                 | Self::Cascade
+                | Self::Demonstrate
                 | Self::Storm
                 | Self::Toxic(_)
                 | Self::BattleCry
@@ -308,6 +310,7 @@ impl KeywordAction {
             Self::Prowess => "Prowess".to_string(),
             Self::Exalted => "Exalted".to_string(),
             Self::Cascade => "Cascade".to_string(),
+            Self::Demonstrate => "Demonstrate".to_string(),
             Self::Storm => "Storm".to_string(),
             Self::Toxic(amount) => format!("Toxic {amount}"),
             Self::BattleCry => "Battle cry".to_string(),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -640,6 +640,7 @@ pub(crate) fn parse_single_word_keyword_action(word: &str) -> Option<KeywordActi
         "prowess" => Some(KeywordAction::Prowess),
         "exalted" => Some(KeywordAction::Exalted),
         "cascade" => Some(KeywordAction::Cascade),
+        "demonstrate" => Some(KeywordAction::Demonstrate),
         "storm" => Some(KeywordAction::Storm),
         "rebound" => Some(KeywordAction::Rebound),
         "ascend" => Some(KeywordAction::Ascend),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -871,8 +871,10 @@ pub(crate) fn parse_granted_keyword_static_line(
         }
 
         let keyword_words = crate::runtime_backend::token_word_refs(&keyword_tokens);
-        let ignore_keyword_reminder =
-            matches!(keyword_words.first().copied(), Some("unearth" | "conspire"));
+        let ignore_keyword_reminder = matches!(
+            keyword_words.first().copied(),
+            Some("unearth" | "conspire" | "demonstrate")
+        );
         if !ignore_keyword_reminder {
             return Err(CardTextError::ParseError(format!(
                 "unsupported trailing granted-keyword clause (clause: '{}')",

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -60,6 +60,7 @@ pub(crate) fn static_ability_for_keyword_action(action: KeywordAction) -> Option
         KeywordAction::Prowess => Some(StaticAbility::keyword_marker("prowess".to_string())),
         KeywordAction::Exalted => Some(StaticAbility::keyword_marker("exalted".to_string())),
         KeywordAction::Cascade => Some(StaticAbility::cascade()),
+        KeywordAction::Demonstrate => Some(StaticAbility::demonstrate()),
         KeywordAction::Storm => Some(StaticAbility::keyword_marker("storm".to_string())),
         KeywordAction::Toxic(amount) => {
             Some(StaticAbility::keyword_marker(format!("toxic {amount}")))

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -793,6 +793,7 @@ pub(crate) fn rewrite_static_ability_for_keyword_action(
         KeywordAction::Prowess => Some(StaticAbility::keyword_marker("prowess".to_string())),
         KeywordAction::Exalted => Some(StaticAbility::keyword_marker("exalted".to_string())),
         KeywordAction::Cascade => Some(StaticAbility::cascade()),
+        KeywordAction::Demonstrate => Some(StaticAbility::demonstrate()),
         KeywordAction::Storm => Some(StaticAbility::keyword_marker("storm".to_string())),
         KeywordAction::Toxic(amount) => {
             Some(StaticAbility::keyword_marker(format!("toxic {amount}")))

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -54,6 +54,7 @@ pub enum StaticAbilityId {
     SplitSecond,
     Rebound,
     Cascade,
+    Demonstrate,
     ReadAhead,
     Unleash,
     ConditionalSpellKeyword,

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1992,6 +1992,10 @@ impl<
         Self::identified(StaticAbilityId::Cascade, "cascade")
     }
 
+    pub fn demonstrate() -> Self {
+        Self::identified(StaticAbilityId::Demonstrate, "demonstrate")
+    }
+
     pub fn read_ahead() -> Self {
         Self::identified(StaticAbilityId::ReadAhead, "read ahead")
     }

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -494,6 +494,7 @@ pub(crate) enum KeywordAction {
     Prowess,
     Exalted,
     Cascade,
+    Demonstrate,
     Storm,
     Toxic(u32),
     BattleCry,
@@ -648,6 +649,7 @@ impl KeywordAction {
                 | Self::Prowess
                 | Self::Exalted
                 | Self::Cascade
+                | Self::Demonstrate
                 | Self::Storm
                 | Self::Toxic(_)
                 | Self::BattleCry
@@ -760,6 +762,7 @@ impl KeywordAction {
             Self::Prowess => "Prowess".to_string(),
             Self::Exalted => "Exalted".to_string(),
             Self::Cascade => "Cascade".to_string(),
+            Self::Demonstrate => "Demonstrate".to_string(),
             Self::Storm => "Storm".to_string(),
             Self::Toxic(amount) => format!("Toxic {amount}"),
             Self::BattleCry => "Battle cry".to_string(),
@@ -1621,6 +1624,7 @@ impl CardDefinitionBuilder {
             KeywordAction::Prowess => self.prowess(),
             KeywordAction::Exalted => self.exalted(),
             KeywordAction::Cascade => self.cascade(),
+            KeywordAction::Demonstrate => self.demonstrate(),
             KeywordAction::Storm => self.storm(),
             KeywordAction::Toxic(amount) => self.toxic(amount),
             KeywordAction::BattleCry => self.battle_cry(),
@@ -3274,6 +3278,15 @@ impl CardDefinitionBuilder {
     pub fn cascade(self) -> Self {
         self.with_ability(
             Ability::static_ability(StaticAbility::cascade()).in_zones(vec![Zone::Stack]),
+        )
+    }
+
+    /// Add demonstrate.
+    ///
+    /// Demonstrate triggers when this spell is cast and may copy it for its caster and an opponent.
+    pub fn demonstrate(self) -> Self {
+        self.with_ability(
+            Ability::static_ability(StaticAbility::demonstrate()).in_zones(vec![Zone::Stack]),
         )
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5585,6 +5585,33 @@ fn test_parse_spells_you_cast_have_cascade_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_silverquill_lecturer_grants_demonstrate_to_creature_spells() {
+    let oracle = "Creature spells you cast have demonstrate. (Whenever you cast a creature spell, you may copy it. If you do, choose an opponent to also copy it. Each copy becomes a token.)";
+    let def = CardDefinitionBuilder::new(CardId::from_raw(665370), "Silverquill Lecturer")
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Silverquill Lecturer should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Creature spells you cast have demonstrate"),
+        "expected demonstrate grant in render output, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever you cast a creature spell, you may copy it")
+            && rendered.contains("Each copy becomes a token"),
+        "expected demonstrate reminder text in compiled output, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("GrantAbility") && debug.contains("Demonstrate"),
+        "expected granted demonstrate static ability, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_colorless_spells_from_hand_have_double_cascade_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Zhulodok Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -784,6 +784,9 @@ pub(super) fn resolve_stack_entry_full(
                 if let Some(perm) = game.object_mut(entry.object_id) {
                     perm.optional_costs_paid = entry.optional_costs_paid.clone();
                     perm.cast_tagged_objects = entry.tagged_objects.clone();
+                    if perm.kind == crate::object::ObjectKind::SpellCopy {
+                        perm.kind = crate::object::ObjectKind::Token;
+                    }
                 }
 
                 // Interactive replacement was already processed above - skip second ETB processing
@@ -838,6 +841,9 @@ pub(super) fn resolve_stack_entry_full(
             if let Some(perm) = game.object_mut(entry.object_id) {
                 perm.optional_costs_paid = entry.optional_costs_paid.clone();
                 perm.cast_tagged_objects = entry.tagged_objects.clone();
+                if perm.kind == crate::object::ObjectKind::SpellCopy {
+                    perm.kind = crate::object::ObjectKind::Token;
+                }
                 // Preserve Convoke/Improvise contributors for later triggered ability resolution.
                 perm.keyword_payment_contributions_to_cast =
                     entry.keyword_payment_contributions.clone();

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -17,7 +17,7 @@ use crate::filter::{PlayerFilterExt, TaggedConstraintSubject, TaggedOpbjectRelat
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::object::CounterType;
-use crate::target::ObjectFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype, SubtypeFamily, Supertype};
 use crate::zone::Zone;
 
@@ -2002,6 +2002,11 @@ impl StaticAbilityKind for GrantAbility {
             ability_text = format!("\"{ability_text}\"");
         }
         let mut text = match self.ability.id() {
+            StaticAbilityId::Demonstrate if filter_is_you_cast_creature_spells(&self.filter) => {
+                format!(
+                    "{subject} have demonstrate. (Whenever you cast a creature spell, you may copy it. If you do, choose an opponent to also copy it. Each copy becomes a token.)"
+                )
+            }
             StaticAbilityId::Unblockable => format!("{subject} can't be blocked"),
             StaticAbilityId::CantAttack => format!("{subject} can't attack"),
             StaticAbilityId::CantBlock => format!("{subject} can't block"),
@@ -2086,6 +2091,12 @@ impl StaticAbilityKind for GrantAbility {
         };
         static_condition_is_active(condition, game, source, game.controller_of(source_obj))
     }
+}
+
+fn filter_is_you_cast_creature_spells(filter: &ObjectFilter) -> bool {
+    filter.cast_by == Some(PlayerFilter::You)
+        && filter.card_types == vec![CardType::Creature]
+        && filter.zone.is_none()
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -1648,6 +1648,10 @@ impl StaticAbility {
         Self::new(Cascade)
     }
 
+    pub fn demonstrate() -> Self {
+        Self::new(Demonstrate)
+    }
+
     pub fn read_ahead() -> Self {
         Self::new(ReadAhead)
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -312,6 +312,7 @@ impl StaticAbilityModelInterpreter {
                 | StaticAbilityId::SplitSecond
                 | StaticAbilityId::Rebound
                 | StaticAbilityId::Cascade
+                | StaticAbilityId::Demonstrate
                 | StaticAbilityId::ReadAhead
                 | StaticAbilityId::Unleash
                 | StaticAbilityId::Bloodthirst

--- a/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
@@ -302,6 +302,26 @@ impl StaticAbilityKind for Cascade {
     }
 }
 
+/// "Demonstrate" spell keyword.
+///
+/// Runtime handling is performed as a synthetic cast trigger in `triggers/check.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Demonstrate;
+
+impl StaticAbilityKind for Demonstrate {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::Demonstrate
+    }
+
+    fn display(&self) -> String {
+        "Demonstrate".to_string()
+    }
+
+    fn is_keyword(&self) -> bool {
+        true
+    }
+}
+
 /// "For each {B} in a cost, you may pay 2 life rather than pay that mana."
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BlackManaMayBePaidWithLife;

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -1296,6 +1296,75 @@ pub(crate) fn check_triggers_with_view(
         }
     }
 
+    // Demonstrate: When a spell with demonstrate is cast, its caster may copy it.
+    // If they do, they choose an opponent to also copy it.
+    if trigger_event.kind() == crate::events::traits::EventKind::SpellCast
+        && let Some(cast) = trigger_event.downcast::<crate::events::spells::SpellCastEvent>()
+        && let Some(entry) = game.stack.iter().find(|e| e.object_id == cast.spell)
+        && let Some(obj) = game.object(cast.spell)
+    {
+        let view = crate::derived_view::DerivedGameView::from_refreshed_state(game);
+        let native_demonstrate_count = view
+            .static_abilities_rc(cast.spell)
+            .map(|abilities| {
+                abilities
+                    .iter()
+                    .filter(|static_ability| {
+                        static_ability.id()
+                            == crate::static_abilities::StaticAbilityId::Demonstrate
+                    })
+                    .count()
+            })
+            .unwrap_or(0);
+        let granted_demonstrate_count = game
+            .temporary_granted_spell_abilities(cast.spell, cast.caster)
+            .into_iter()
+            .filter(|ability| {
+                ability.id() == crate::static_abilities::StaticAbilityId::Demonstrate
+            })
+            .count();
+        let demonstrate_count = native_demonstrate_count + granted_demonstrate_count;
+        if demonstrate_count > 0 {
+            let chosen_opponent_tag = crate::tag::TagKey::from("demonstrate_opponent");
+            let ability = TriggeredAbility {
+                trigger: Trigger::you_cast_this_spell(),
+                effects: ResolutionProgram::from_effects(vec![Effect::may(vec![
+                    Effect::copy_spell(crate::target::ChooseSpec::Source),
+                    Effect::choose_player(
+                        crate::target::PlayerFilter::You,
+                        crate::target::PlayerFilter::Opponent,
+                        chosen_opponent_tag.clone(),
+                    ),
+                    Effect::new(crate::effects::CopySpellEffect::new_for_player(
+                        crate::target::ChooseSpec::Source,
+                        1,
+                        crate::target::PlayerFilter::TaggedPlayer(chosen_opponent_tag),
+                    )),
+                ])]),
+                choices: vec![],
+                intervening_if: None,
+                presentation_label: None,
+            };
+            let trigger_identity = compute_trigger_identity(&ability);
+
+            for _ in 0..demonstrate_count {
+                triggered.push(TriggeredAbilityEntry {
+                    source: cast.spell,
+                    controller: cast.caster,
+                    x_value: entry.x_value,
+                    event_value_amount: None,
+                    ability: ability.clone(),
+                    triggering_event: trigger_event.clone(),
+                    source_stable_id: obj.stable_id,
+                    source_name: obj.name.clone(),
+                    source_snapshot: None,
+                    tagged_objects: tagged_objects_for_trigger_event(game, trigger_event),
+                    trigger_identity,
+                });
+            }
+        }
+    }
+
     // Replicate: When a spell with Replicate is cast, it triggers to copy itself for each time
     // its Replicate cost was paid. (We model this as a synthetic triggered ability so it
     // stacks and can be responded to like the real mechanic.)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Silverquill Lecturer
Initial parse error:
```
parser does not yet support line family: 'Creature spells you cast have demonstrate. (Whenever you cast a creature spell, you may copy it. If you do, choose an opponent to also copy it. Each copy becomes a token.)'; oracle-only fallback also failed: parser does not yet support line family: 'Creature spells you cast have demonstrate.'
```

Current worker: i-0336ff539199baa41
Branch: codex/aws-card-fix-silverquill-lecturer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0003
