### PR TITLE
Fix Ironsmith parse failure: Merfolk Cave-Diver

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -171,6 +171,12 @@ impl GenericTopLevelProgram {
 pub(crate) fn parse_top_level_subject_verb_recognition(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<(&'static str, Vec<EffectAst>)>, CardTextError> {
+    if let Some(effects) = parse_source_gets_unblockable_subject_verb(tokens)? {
+        return Ok(Some((
+            "subject-verb verb=Get subject=source recognizer=source-pump-unblockable",
+            effects,
+        )));
+    }
     if let Some(effects) = parse_source_gets_filter_gains_subject_verb(tokens)? {
         return Ok(Some((
             "subject-verb verb=Get subject=source recognizer=source-pump-filter-gain",
@@ -240,6 +246,73 @@ pub(crate) fn parse_top_level_subject_verb_recognition(
         let route = program.route();
         (route, program.lower())
     }))
+}
+
+fn parse_source_gets_unblockable_subject_verb(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(get_idx) = words
+        .iter()
+        .position(|word| matches!(*word, "get" | "gets"))
+    else {
+        return Ok(None);
+    };
+    let source_words = &words[..get_idx];
+    if !matches!(
+        source_words,
+        ["this"] | ["this", "creature"] | ["this", "permanent"]
+    ) {
+        return Ok(None);
+    }
+
+    let collapsed_modifier_tail = collapse_leading_signed_pt_modifier_tokens(&tokens[get_idx + 1..]);
+    let modifier_tail = collapsed_modifier_tail
+        .as_deref()
+        .unwrap_or(&tokens[get_idx + 1..]);
+    let modifier_words = crate::runtime_backend::token_word_refs(modifier_tail);
+    let Some(modifier_word) = modifier_words.first().copied() else {
+        return Ok(None);
+    };
+    let Ok((power, toughness)) =
+        crate::runtime_backend::keyword_static::parse_pt_modifier_values(modifier_word)
+    else {
+        return Ok(None);
+    };
+
+    let tail = &modifier_words[1..];
+    if !matches!(
+        tail,
+        [
+            "until",
+            "end",
+            "of",
+            "turn",
+            "and",
+            "cant" | "can't",
+            "be",
+            "blocked",
+            "this",
+            "turn"
+        ]
+    ) {
+        return Ok(None);
+    }
+
+    Ok(Some(vec![
+        EffectAst::subject_verb_pump(
+            power,
+            toughness,
+            TargetAst::Source(None),
+            Until::EndOfTurn,
+            None,
+        ),
+        EffectAst::subject_verb_cant(
+            crate::effect::Restriction::be_blocked(ObjectFilter::source()),
+            Until::EndOfTurn,
+            None,
+        ),
+    ]))
 }
 
 fn parse_source_gets_filter_gains_subject_verb(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7723,6 +7723,28 @@ fn test_parse_explore_trigger_subject_without_fallback_marker() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_merfolk_cave_diver_strictly_parses_pump_unblockable_explore_trigger() {
+    let def = parse_oracle_card_definition("Merfolk Cave-Diver");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "Whenever a creature you control explores, this creature gets +1/+0 until end of turn and can't be blocked this turn."
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("KeywordAction")
+            && debug.contains("Explore")
+            && debug.contains("ModifyPowerToughness")
+            && debug.contains("CantEffect")
+            && debug.contains("BeBlocked"),
+        "expected Merfolk Cave-Diver to lower to explore-triggered pump plus can't-be-blocked effects, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_explore_trigger_revealed_card_filter() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Nicanzil Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -7068,6 +7068,42 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         Some("This creature gains shroud and can't be blocked this turn".to_string())
     }
 
+    fn describe_source_pump_unblockable_bundle(filtered: &[&Effect]) -> Option<String> {
+        let [apply_effect, cant_effect] = filtered else {
+            return None;
+        };
+        let apply = apply_continuous_for_compaction(apply_effect)?;
+        if apply.until != Until::EndOfTurn
+            || apply.condition.is_some()
+            || apply.modification.is_some()
+            || !apply.additional_modifications.is_empty()
+            || !matches!(apply.target, crate::continuous::EffectTarget::Source)
+        {
+            return None;
+        }
+        let [crate::effects::continuous::RuntimeModification::ModifyPowerToughness {
+            power,
+            toughness,
+        }] = apply.runtime_modifications.as_slice()
+        else {
+            return None;
+        };
+
+        let cant = cant_effect.downcast_ref::<crate::effects::CantEffect>()?;
+        let crate::effect::Restriction::BeBlocked(filter) = &cant.restriction else {
+            return None;
+        };
+        if cant.duration != Until::EndOfTurn || !filter.source {
+            return None;
+        }
+
+        Some(format!(
+            "This creature gets {}/{} until end of turn and can't be blocked this turn",
+            describe_signed_value(power),
+            describe_toughness_delta_with_power_context(power, toughness),
+        ))
+    }
+
     fn describe_tap_freeze_bundle(filtered: &[&Effect]) -> Option<String> {
         let [tap_effect, cant_effect] = filtered else {
             return None;
@@ -7644,6 +7680,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_self_unblockable_bundle(&filtered) {
+        return compact;
+    }
+    if let Some(compact) = describe_source_pump_unblockable_bundle(&filtered) {
         return compact;
     }
     if let Some(compact) = describe_tap_freeze_bundle(&filtered) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -68,6 +68,39 @@ fn desmond_miles_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn merfolk_cave_diver_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_930), "Merfolk Cave-Diver")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Merfolk, Subtype::Scout])
+        .power_toughness(PowerToughness::fixed(2, 4))
+        .parse_text(
+            "Whenever a creature you control explores, this creature gets +1/+0 until end of turn and can't be blocked this turn.",
+        )
+        .expect("Merfolk Cave-Diver should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn explore_event_for(game: &GameState, controller: PlayerId, source: ObjectId) -> TriggerEvent {
+    let snapshot = game
+        .object(source)
+        .map(|object| crate::snapshot::ObjectSnapshot::from_object(object, game));
+    TriggerEvent::new_with_provenance(
+        crate::events::KeywordActionEvent::new(
+            crate::events::KeywordActionKind::Explore,
+            controller,
+            source,
+            1,
+        )
+        .with_snapshot(snapshot),
+        crate::provenance::ProvNodeId::default(),
+    )
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn open_the_way_x_choice_is_capped_by_players_in_game() {
     let mut game = setup_three_player_game();
@@ -250,6 +283,109 @@ fn desmond_miles_combat_damage_trigger_surveils_equal_to_damage_and_ignores_nonc
         game.player(alice).expect("alice exists").graveyard.len(),
         1,
         "the test decision maker should put one surveilled card into the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn merfolk_cave_diver_triggers_on_your_creature_exploring_and_expires_at_cleanup() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let merfolk = merfolk_cave_diver_definition();
+    let merfolk_id = game.create_object_from_definition(&merfolk, alice, Zone::Battlefield);
+    let explorer_id = create_creature(&mut game, "Friendly Explorer", alice, 1, 1);
+    let blocker_id = create_creature(&mut game, "Ground Blocker", bob, 2, 2);
+
+    let event = explore_event_for(&game, alice, explorer_id);
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Merfolk Cave-Diver should trigger when a creature you control explores"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Merfolk Cave-Diver trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Merfolk Cave-Diver trigger should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.calculated_power(merfolk_id),
+        Some(3),
+        "Merfolk Cave-Diver should get +1/+0 after the explore trigger resolves"
+    );
+    assert_eq!(
+        game.calculated_toughness(merfolk_id),
+        Some(4),
+        "Merfolk Cave-Diver should not get a toughness bonus"
+    );
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: merfolk_id,
+        target: AttackTarget::Player(bob),
+    });
+    let mut blocker_queue = TriggerQueue::new();
+    let err = apply_blocker_declarations(
+        &mut game,
+        &mut combat,
+        &mut blocker_queue,
+        &[BlockerDeclaration {
+            blocker: blocker_id,
+            blocking: merfolk_id,
+        }],
+        bob,
+    )
+    .expect_err("Merfolk Cave-Diver shouldn't be blockable after the trigger resolves");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidBlockers"),
+        "expected blocking Merfolk Cave-Diver to be rejected, got {msg}"
+    );
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.calculated_power(merfolk_id),
+        Some(2),
+        "Merfolk Cave-Diver's +1/+0 should expire during cleanup"
+    );
+    assert!(
+        game.can_be_blocked(merfolk_id),
+        "Merfolk Cave-Diver's can't-be-blocked restriction should expire during cleanup"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn merfolk_cave_diver_ignores_opponent_creatures_exploring() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let merfolk = merfolk_cave_diver_definition();
+    let merfolk_id = game.create_object_from_definition(&merfolk, alice, Zone::Battlefield);
+    let opposing_explorer_id = create_creature(&mut game, "Opposing Explorer", bob, 1, 1);
+
+    let event = explore_event_for(&game, bob, opposing_explorer_id);
+    let triggers = crate::triggers::check_triggers(&game, &event);
+    assert!(
+        triggers.is_empty(),
+        "Merfolk Cave-Diver should not trigger when an opponent's creature explores"
+    );
+    assert_eq!(
+        game.calculated_power(merfolk_id),
+        Some(2),
+        "Merfolk Cave-Diver should not be pumped by an opponent's explore event"
+    );
+    assert!(
+        game.can_be_blocked(merfolk_id),
+        "Merfolk Cave-Diver should remain blockable without a matching explore trigger"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Merfolk Cave-Diver
Initial parse error:
```
unsupported trailing gets clause (clause: '+1/+0 until end of turn and can't be blocked this turn'); oracle-only fallback also failed: unsupported trailing gets clause (clause: '+1/+0 until end of turn and can't be blocked this turn')
```

Current worker: i-085387cb40a373db3
Branch: codex/aws-card-fix-merfolk-cave-diver
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0004
