### PR TITLE
Fix Ironsmith parse failure: Web of Inertia

### DIFF
--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -272,6 +272,10 @@ pub enum Restriction {
     BecomeMonarch(PlayerFilter),
     PreventDamage,
     Attack(ObjectFilter),
+    AttackPlayer {
+        attackers: ObjectFilter,
+        player: PlayerFilter,
+    },
     AttackAlone(ObjectFilter),
     Block(ObjectFilter),
     BlockSpecificAttacker {
@@ -487,6 +491,10 @@ impl Restriction {
 
     pub fn attack(filter: ObjectFilter) -> Self {
         Self::Attack(filter)
+    }
+
+    pub fn attack_player(attackers: ObjectFilter, player: PlayerFilter) -> Self {
+        Self::AttackPlayer { attackers, player }
     }
 
     pub fn attack_alone(filter: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/combat_state.rs
+++ b/crates/ironsmith-runtime/src/combat_state.rs
@@ -444,6 +444,11 @@ pub fn declare_attackers(
         {
             return Err(CombatError::CreatureCannotAttack(*creature_id));
         }
+        if let AttackTarget::Player(player_id) = target
+            && !game.can_attack_player(*creature_id, *player_id)
+        {
+            return Err(CombatError::CreatureCannotAttack(*creature_id));
+        }
 
         let abilities = static_abilities_for_object(game, creature.id, &all_effects);
         for ability in &abilities {

--- a/crates/ironsmith-runtime/src/decision/attack_block.rs
+++ b/crates/ironsmith-runtime/src/decision/attack_block.rs
@@ -104,6 +104,11 @@ fn can_declare_attack_target_preview(
     ) {
         return false;
     }
+    if let AttackTarget::Player(player_id) = target
+        && !game.can_attack_player(attacker.id, *player_id)
+    {
+        return false;
+    }
 
     let abilities = static_abilities_for_attack_preview(view, attacker);
     if abilities.iter().any(|ability| {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -987,6 +987,31 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::AttackPlayer { attackers, player } => {
+                let players = game
+                    .players
+                    .iter()
+                    .filter(|candidate| {
+                        candidate.is_in_game()
+                            && player_matches_restriction_filter(candidate.id, player)
+                    })
+                    .map(|candidate| candidate.id)
+                    .collect::<Vec<_>>();
+                if players.is_empty() {
+                    return;
+                }
+                for &obj_id in &game.battlefield {
+                    if let Some(obj) = game.object(obj_id)
+                        && attackers.matches(obj, &ctx, game)
+                    {
+                        tracker
+                            .cant_attack_players
+                            .entry(obj_id)
+                            .or_default()
+                            .extend(players.iter().copied());
+                    }
+                }
+            }
             Restriction::AttackAlone(filter) => {
                 for &obj_id in &game.battlefield {
                     if let Some(obj) = game.object(obj_id)

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -137,6 +137,10 @@ fn normalize_restriction_for_resolution(
         Restriction::Attack(filter) => Restriction::attack(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),
+        Restriction::AttackPlayer { attackers, player } => Restriction::attack_player(
+            collapse_filter_to_current_matching_objects(attackers, ctx, game),
+            player.clone(),
+        ),
         Restriction::Block(filter) => Restriction::block(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -514,6 +514,10 @@ pub struct CantEffectTracker {
     /// Example: Pacifism, Propaganda (if unpaid), Maze of Ith
     pub cant_attack: HashSet<ObjectId>,
 
+    /// Creature -> players that creature can't attack directly.
+    /// Example: "Creatures that player controls can't attack you this turn."
+    pub cant_attack_players: HashMap<ObjectId, HashSet<PlayerId>>,
+
     /// Creatures that can't attack alone.
     /// Example: "This creature can't attack alone."
     pub cant_attack_alone: HashSet<ObjectId>,
@@ -809,6 +813,12 @@ impl CantEffectTracker {
         self.cant_gain_life.extend(other.cant_gain_life);
         self.cant_search.extend(other.cant_search);
         self.cant_attack.extend(other.cant_attack);
+        for (creature, players) in other.cant_attack_players {
+            self.cant_attack_players
+                .entry(creature)
+                .or_default()
+                .extend(players);
+        }
         self.cant_attack_alone.extend(other.cant_attack_alone);
         self.cant_block.extend(other.cant_block);
         for (blocker, attackers) in other.cant_block_specific_attackers {
@@ -879,6 +889,7 @@ impl CantEffectTracker {
         self.cant_gain_life.clear();
         self.cant_search.clear();
         self.cant_attack.clear();
+        self.cant_attack_players.clear();
         self.cant_attack_alone.clear();
         self.cant_block.clear();
         self.cant_block_specific_attackers.clear();
@@ -938,6 +949,15 @@ impl CantEffectTracker {
     /// Check if a creature can attack.
     pub fn can_attack(&self, creature: ObjectId) -> bool {
         !self.cant_attack.contains(&creature)
+    }
+
+    /// Check if a creature can attack a player directly.
+    pub fn can_attack_player(&self, creature: ObjectId, player: PlayerId) -> bool {
+        self.can_attack(creature)
+            && self
+                .cant_attack_players
+                .get(&creature)
+                .is_none_or(|players| !players.contains(&player))
     }
 
     /// Check if a creature can attack alone (as the only attacker).


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Web of Inertia
Initial parse error:
```
unsupported negated restriction tail (clause: 'creatures they control can't attack you'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'creatures they control can't attack you')
```

Current worker: i-0b588bb863fb18e14
Branch: codex/aws-card-fix-web-of-inertia
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T104625Z-controller-dev-loop-wave0004
