### PR TITLE
Fix Ironsmith parse failure: Trystan, Callous Cultivator // Trystan, Penitent Culler

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -31,6 +31,15 @@ fn this_enters_battlefield_trigger_spec(
     }
 }
 
+fn this_transforms_trigger_spec(
+    surface: Option<crate::target::SourceReferenceSurface>,
+) -> TriggerSpec {
+    match surface {
+        Some(surface) => TriggerSpec::ThisTransformsWithSurface(surface),
+        None => TriggerSpec::ThisTransforms,
+    }
+}
+
 pub(crate) fn split_trigger_or_index(tokens: &[OwnedLexToken]) -> Option<usize> {
     tokens.iter().enumerate().find_map(|(idx, token)| {
         if !token.is_word("or") {
@@ -1053,7 +1062,9 @@ pub(crate) fn parse_trigger_clause_lexed(
                     Box::new(this_enters_battlefield_trigger_spec(
                         source_reference_surface_for_trigger_subject(subject_tokens),
                     )),
-                    Box::new(TriggerSpec::ThisTransforms),
+                    Box::new(this_transforms_trigger_spec(
+                        source_reference_surface_for_trigger_subject(subject_tokens),
+                    )),
                 ));
             }
         }
@@ -1242,6 +1253,24 @@ pub(crate) fn parse_trigger_clause_lexed(
                     cause_filter,
                 }
             });
+        }
+    }
+
+    if let Some(transforms_word_idx) =
+        find_index(&words, |word| *word == "transforms" || *word == "transform")
+    {
+        let transforms_token_idx = word_view
+            .token_index_for_word_index(transforms_word_idx)
+            .unwrap_or(tokens.len());
+        let subject_tokens = &tokens[..transforms_token_idx];
+        let subject_word_view = ActivationRestrictionCompatWords::new(subject_tokens);
+        let subject_words = subject_word_view.to_word_refs();
+        if is_source_reference_words(&subject_words)
+            && words.get(transforms_word_idx + 1) == Some(&"into")
+        {
+            return Ok(this_transforms_trigger_spec(
+                source_reference_surface_for_trigger_subject(subject_tokens),
+            ));
         }
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1041,6 +1041,22 @@ pub(crate) fn parse_trigger_clause_lexed(
         }
 
         let subject_tokens = &tokens[..enters_token_idx];
+        if words.get(enters_word_idx + 1..enters_word_idx + 4)
+            == Some(&["or", "transforms", "into"][..])
+            || words.get(enters_word_idx + 1..enters_word_idx + 4)
+                == Some(&["or", "transform", "into"][..])
+        {
+            let subject_word_view = ActivationRestrictionCompatWords::new(subject_tokens);
+            let subject_words = subject_word_view.to_word_refs();
+            if is_source_reference_words(&subject_words) {
+                return Ok(TriggerSpec::Either(
+                    Box::new(this_enters_battlefield_trigger_spec(
+                        source_reference_surface_for_trigger_subject(subject_tokens),
+                    )),
+                    Box::new(TriggerSpec::ThisTransforms),
+                ));
+            }
+        }
         if let Some(or_idx) =
             find_index(subject_tokens, |token: &OwnedLexToken| token.is_word("or"))
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -658,6 +658,40 @@ fn parse_revealed_or_controlled_subtype_predicate(words: &[&str]) -> Option<Pred
     ))
 }
 
+fn parse_card_in_your_graveyard_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if words.len() < 6 || words[0] != "there" || words[1] != "is" {
+        return None;
+    }
+
+    let in_idx = words
+        .iter()
+        .enumerate()
+        .skip(2)
+        .find_map(|(idx, word)| (*word == "in").then_some(idx))?;
+    if in_idx <= 2 {
+        return None;
+    }
+    if !matches!(
+        &words[in_idx..],
+        ["in", "your", "graveyard"] | ["in", "graveyard"] | ["in", "the", "graveyard"]
+    ) {
+        return None;
+    }
+
+    let descriptor_tokens = words[2..in_idx]
+        .iter()
+        .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+        .collect::<Vec<_>>();
+    let mut filter = parse_object_filter(&descriptor_tokens, false).ok()?;
+    filter.zone = Some(Zone::Graveyard);
+    filter.owner = Some(PlayerFilter::You);
+
+    Some(PredicateAst::PlayerControls {
+        player: PlayerAst::You,
+        filter,
+    })
+}
+
 pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, CardTextError> {
     let raw_words_view = GrammarFilterNormalizedWords::new(tokens);
     let raw_words = raw_words_view.to_word_refs();
@@ -790,6 +824,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_graveyard_threshold_predicate(&filtered)? {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_card_in_your_graveyard_predicate(&filtered) {
         return Ok(predicate);
     }
 
@@ -3864,6 +3902,31 @@ mod tests {
         assert_eq!(
             parsed,
             PredicateAst::CreatureCardPutIntoYourGraveyardThisTurn
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_card_in_your_graveyard_existence() -> Result<(), CardTextError> {
+        let tokens = lex_line("If there is an Elf card in your graveyard", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        let mut expected_filter = ObjectFilter::default()
+            .with_subtype(parse_subtype_word("elf").expect("elf subtype"))
+            .in_zone(Zone::Graveyard);
+        expected_filter.owner = Some(PlayerFilter::You);
+        assert_eq!(
+            parsed,
+            PredicateAst::PlayerControls {
+                player: PlayerAst::You,
+                filter: expected_filter,
+            }
         );
         Ok(())
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -367,6 +367,9 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             )
         }
         TriggerSpec::ThisTransforms => Trigger::transforms(),
+        TriggerSpec::ThisTransformsWithSurface(surface) => {
+            Trigger::transforms_with_surface(surface.clone())
+        }
         TriggerSpec::ThisDealsCombatDamageToPlayer => Trigger::this_deals_combat_damage_to_player(),
         TriggerSpec::DealsCombatDamageToPlayer { source, player } => {
             Trigger::deals_combat_damage_to_player(source, player)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -366,6 +366,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
                     .this(),
             )
         }
+        TriggerSpec::ThisTransforms => Trigger::transforms(),
         TriggerSpec::ThisDealsCombatDamageToPlayer => Trigger::this_deals_combat_damage_to_player(),
         TriggerSpec::DealsCombatDamageToPlayer { source, player } => {
             Trigger::deals_combat_damage_to_player(source, player)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -311,6 +311,7 @@ pub(crate) enum TriggerSpec {
         from: Zone,
         owner: Option<PlayerFilter>,
     },
+    ThisTransforms,
     ThisDealsCombatDamageToPlayer,
     DealsCombatDamageToPlayer {
         source: ObjectFilter,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -312,6 +312,7 @@ pub(crate) enum TriggerSpec {
         owner: Option<PlayerFilter>,
     },
     ThisTransforms,
+    ThisTransformsWithSurface(crate::target::SourceReferenceSurface),
     ThisDealsCombatDamageToPlayer,
     DealsCombatDamageToPlayer {
         source: ObjectFilter,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8998,9 +8998,9 @@ fn rewrite_lexed_trigger_clause_parses_common_native_shapes() {
     assert!(
         matches!(
             enters_or_transforms,
-            Ok(crate::cards::builders::TriggerSpec::Either(left, right))
-                if matches!(*left, crate::cards::builders::TriggerSpec::ThisEntersBattlefield)
-                    && matches!(*right, crate::cards::builders::TriggerSpec::ThisTransforms)
+            Ok(crate::cards::builders::TriggerSpec::Either(ref left, ref right))
+                if matches!(left.as_ref(), crate::cards::builders::TriggerSpec::ThisEntersBattlefield)
+                    && matches!(right.as_ref(), crate::cards::builders::TriggerSpec::ThisTransforms)
         ),
         "expected enter-or-transform trigger pair, got {enters_or_transforms:?}"
     );

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8950,6 +8950,8 @@ fn rewrite_lexed_trigger_clause_parses_common_native_shapes() {
         0,
     )
     .expect("rewrite lexer should classify enter-or-transform trigger probe");
+    let transforms_tokens = lex_line("this creature transforms into Trystan, Penitent Culler", 0)
+        .expect("rewrite lexer should classify standalone transforms trigger probe");
 
     assert!(matches!(
         super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
@@ -9000,9 +9002,25 @@ fn rewrite_lexed_trigger_clause_parses_common_native_shapes() {
             enters_or_transforms,
             Ok(crate::cards::builders::TriggerSpec::Either(ref left, ref right))
                 if matches!(left.as_ref(), crate::cards::builders::TriggerSpec::ThisEntersBattlefield)
-                    && matches!(right.as_ref(), crate::cards::builders::TriggerSpec::ThisTransforms)
+                    && matches!(
+                        right.as_ref(),
+                        crate::cards::builders::TriggerSpec::ThisTransforms
+                            | crate::cards::builders::TriggerSpec::ThisTransformsWithSurface(_)
+                    )
         ),
         "expected enter-or-transform trigger pair, got {enters_or_transforms:?}"
+    );
+    let transforms =
+        super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
+            &transforms_tokens,
+        );
+    assert!(
+        matches!(
+            transforms,
+            Ok(crate::cards::builders::TriggerSpec::ThisTransforms)
+                | Ok(crate::cards::builders::TriggerSpec::ThisTransformsWithSurface(_))
+        ),
+        "expected standalone transform trigger, got {transforms:?}"
     );
     assert!(matches!(
         super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8945,6 +8945,11 @@ fn rewrite_lexed_trigger_clause_parses_common_native_shapes() {
     .expect("rewrite lexer should classify exile zone-change trigger probe");
     let dealt_combat_damage_tokens = lex_line("this creature is dealt combat damage", 0)
         .expect("rewrite lexer should classify dealt-combat-damage trigger probe");
+    let enters_or_transforms_tokens = lex_line(
+        "this creature enters or transforms into Trystan, Callous Cultivator",
+        0,
+    )
+    .expect("rewrite lexer should classify enter-or-transform trigger probe");
 
     assert!(matches!(
         super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
@@ -8986,6 +8991,19 @@ fn rewrite_lexed_trigger_clause_parses_common_native_shapes() {
                 | crate::cards::builders::TriggerSpec::EntersBattlefield { .. }
         )
     ));
+    let enters_or_transforms =
+        super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
+            &enters_or_transforms_tokens,
+        );
+    assert!(
+        matches!(
+            enters_or_transforms,
+            Ok(crate::cards::builders::TriggerSpec::Either(left, right))
+                if matches!(*left, crate::cards::builders::TriggerSpec::ThisEntersBattlefield)
+                    && matches!(*right, crate::cards::builders::TriggerSpec::ThisTransforms)
+        ),
+        "expected enter-or-transform trigger pair, got {enters_or_transforms:?}"
+    );
     assert!(matches!(
         super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
             &spell_tokens,

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -263,6 +263,9 @@ pub enum TriggerKind {
     DayNightChanged,
     ThisEntersBattlefield,
     ThisTransforms,
+    ThisTransformsWithSurface {
+        surface: SourceReferenceSurface,
+    },
     YouCastThisSpell,
     KeywordActionMatchingObject {
         action: KeywordActionKind,
@@ -924,6 +927,12 @@ impl Trigger {
     }
     pub fn transforms() -> Self {
         Self::typed("this_transforms", TriggerKind::ThisTransforms)
+    }
+    pub fn transforms_with_surface(surface: SourceReferenceSurface) -> Self {
+        Self::typed(
+            "this_transforms",
+            TriggerKind::ThisTransformsWithSurface { surface },
+        )
     }
     pub fn you_cast_this_spell() -> Self {
         Self::typed("you_cast_this_spell", TriggerKind::YouCastThisSpell)

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -262,6 +262,7 @@ pub enum TriggerKind {
     },
     DayNightChanged,
     ThisEntersBattlefield,
+    ThisTransforms,
     YouCastThisSpell,
     KeywordActionMatchingObject {
         action: KeywordActionKind,
@@ -920,6 +921,9 @@ impl Trigger {
             "this_enters_battlefield",
             TriggerKind::ThisEntersBattlefield,
         )
+    }
+    pub fn transforms() -> Self {
+        Self::typed("this_transforms", TriggerKind::ThisTransforms)
     }
     pub fn you_cast_this_spell() -> Self {
         Self::typed("you_cast_this_spell", TriggerKind::YouCastThisSpell)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35402,6 +35402,39 @@ fn trystan_callous_cultivator_strict_parser_and_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn trystan_penitent_culler_strict_parser_and_text_regression() {
+    let oracle = "Deathtouch\n\
+        Whenever this creature transforms into Trystan, Penitent Culler, mill three cards, then you may exile an Elf card from your graveyard. If you do, each opponent loses 2 life.\n\
+        At the beginning of your first main phase, you may pay {G}. If you do, transform Trystan.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "Trystan, Penitent Culler")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Trystan, Penitent Culler should parse strictly");
+
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Whenever this creature transforms into Trystan, Penitent Culler")
+            && rendered.contains("mill three cards")
+            && rendered.contains("You may exile an Elf card")
+            && rendered.contains("If you do, each opponent loses 2 life")
+            && rendered.contains("At the beginning of your first main phase, you may pay {G}")
+            && rendered.contains("If you do, transform Trystan"),
+        "expected Penitent Culler transform trigger, optional Elf exile, opponent life loss, and green transform trigger, got {rendered}"
+    );
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Triggered(triggered)
+                if triggered.trigger.display().contains("transforms into")
+                    && triggered.effects.iter().any(|effect| format!("{effect:?}").contains("Mill"))
+        )),
+        "expected Penitent Culler to compile a standalone transform triggered ability"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_sporeweb_weaver_strict_regression() {
     assert_oracle_card_parses_strict("Sporeweb Weaver");
     let def = parse_oracle_card_definition("Sporeweb Weaver");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35371,13 +35371,21 @@ fn guardian_of_the_ages_strict_parser_and_text_regression() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn trystan_callous_cultivator_strict_parser_and_text_regression() {
-    let def = parse_oracle_card_definition(
-        "Trystan, Callous Cultivator // Trystan, Penitent Culler",
-    );
+    let oracle = oracle_text_by_name()
+        .get("Trystan, Callous Cultivator")
+        .expect("Trystan oracle text should be indexed")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Trystan, Callous Cultivator")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Trystan, Callous Cultivator should parse strictly");
 
     let rendered = canonical_compiled_lines(&def).join("\n");
     assert!(
-        rendered.contains("Whenever this creature enters or transforms into Trystan")
+        rendered.contains(
+            "Whenever this creature enters or transforms into Trystan, Callous Cultivator"
+        )
             && rendered.contains("mill three cards")
             && rendered.contains("Then if there is an Elf card in your graveyard, you gain 2 life"),
         "expected Trystan's enter-or-transform trigger and Elf-card graveyard condition, got {rendered}"

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35370,6 +35370,30 @@ fn guardian_of_the_ages_strict_parser_and_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn trystan_callous_cultivator_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition(
+        "Trystan, Callous Cultivator // Trystan, Penitent Culler",
+    );
+
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Whenever this creature enters or transforms into Trystan")
+            && rendered.contains("mill three cards")
+            && rendered.contains("Then if there is an Elf card in your graveyard, you gain 2 life"),
+        "expected Trystan's enter-or-transform trigger and Elf-card graveyard condition, got {rendered}"
+    );
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Triggered(triggered)
+                if triggered.trigger.display().contains("enters or transforms")
+        )),
+        "expected Trystan to compile an enter-or-transform triggered ability"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_sporeweb_weaver_strict_regression() {
     assert_oracle_card_parses_strict("Sporeweb Weaver");
     let def = parse_oracle_card_definition("Sporeweb Weaver");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -752,6 +752,9 @@ fn substitute_legendary_source_reference(
     }
 
     let lower = line.to_ascii_lowercase();
+    if lower.contains("transforms into this creature") {
+        return line.replace("transforms into this creature", &format!("transforms into {}", card.name));
+    }
     let uses_named_source_surface = lower.starts_with("this creature gets ")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.contains(": this creature gets ")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10216,6 +10216,25 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::PlayerControls { player, filter } => {
             let subject = describe_player_filter(player);
+            if matches!(
+                filter.zone,
+                Some(
+                    Zone::Graveyard
+                        | Zone::Hand
+                        | Zone::Library
+                        | Zone::Exile
+                        | Zone::Command
+                )
+            ) {
+                let mut described_filter = filter.clone();
+                if described_filter.owner.is_none() {
+                    described_filter.owner = Some(player.clone());
+                }
+                return format!(
+                    "there is {}",
+                    with_indefinite_article(&described_filter.description())
+                );
+            }
             if is_owned_player_zone(filter.zone) {
                 let object_text = with_indefinite_article(&describe_owned_player_zone_filter(
                     player, filter,
@@ -10234,23 +10253,6 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 .is_some_and(|controller| controller == player)
             {
                 described_filter.controller = None;
-            }
-            if matches!(
-                described_filter.zone,
-                Some(
-                    Zone::Graveyard
-                        | Zone::Hand
-                        | Zone::Library
-                        | Zone::Exile
-                        | Zone::Command
-                )
-            ) {
-                // For non-battlefield zones, the condition is about card presence rather than
-                // "control". Prefer oracle-style existential phrasing.
-                if described_filter.owner.is_none() {
-                    described_filter.owner = Some(player.clone());
-                }
-                return format!("there is {}", described_filter.description());
             }
             if described_filter.could_be_targeted_by.is_some() {
                 let described =

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -239,6 +239,55 @@ pub(super) fn lowercase_may_clause(text: &str) -> String {
     text.to_string()
 }
 
+fn should_lowercase_trigger_effect_tail(tail: &str) -> bool {
+    let Some(first) = tail.split_whitespace().next() else {
+        return false;
+    };
+    let first = first.trim_matches(|ch: char| !ch.is_ascii_alphabetic());
+    matches!(
+        first,
+        "A" | "An"
+            | "The"
+            | "This"
+            | "That"
+            | "Those"
+            | "It"
+            | "They"
+            | "If"
+            | "Then"
+            | "You"
+            | "Add"
+            | "Attach"
+            | "Cast"
+            | "Choose"
+            | "Copy"
+            | "Counter"
+            | "Create"
+            | "Destroy"
+            | "Discard"
+            | "Draw"
+            | "Exile"
+            | "Fight"
+            | "Gain"
+            | "Lose"
+            | "Mill"
+            | "Pay"
+            | "Play"
+            | "Put"
+            | "Regenerate"
+            | "Reveal"
+            | "Return"
+            | "Sacrifice"
+            | "Scry"
+            | "Search"
+            | "Shuffle"
+            | "Surveil"
+            | "Tap"
+            | "Transform"
+            | "Untap"
+    )
+}
+
 pub(super) fn describe_mana_pool_owner(filter: &PlayerFilter) -> String {
     let player = describe_player_filter(filter);
     if player == "you" || player == "target you" {
@@ -5534,6 +5583,7 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             .chars()
             .next()
             .is_some_and(|ch| ch.is_ascii_uppercase())
+        && should_lowercase_trigger_effect_tail(tail)
     {
         normalized = format!("{head}, {}", lowercase_first(tail));
     }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27512,6 +27512,22 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(mill) = effect.downcast_ref::<crate::effects::MillEffect>() {
+        if mill.player == PlayerFilter::You {
+            if mill.count == Value::X {
+                return "Mill X cards".to_string();
+            }
+            if value_prefers_where_x(&mill.count)
+                && let Some(where_x) = describe_where_x_basis(&mill.count)
+            {
+                return format!("Mill X cards, where X is {where_x}");
+            }
+            let count_text = describe_card_count(&mill.count);
+            if let Some(rest) = count_text.strip_prefix("the number of ") {
+                let basis = singularize_for_each_basis(rest.strip_suffix(" cards").unwrap_or(rest));
+                return format!("Mill a card for each {basis}");
+            }
+            return format!("Mill {count_text}");
+        }
         let player = describe_player_filter(&mill.player);
         if mill.count == Value::X {
             return format!(

--- a/crates/ironsmith-runtime/src/effects/permanents/transform.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/transform.rs
@@ -678,7 +678,7 @@ mod tests {
             .expect("converted permanent should keep an entry timestamp");
         assert!(after_ts > before_ts);
 
-        let trigger = TransformsTrigger;
+        let trigger = TransformsTrigger::new();
         let trigger_ctx = TriggerContext::for_source(source, alice, &game);
         assert!(
             !trigger.matches(&outcome.events[0], &trigger_ctx),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -90,6 +90,37 @@ fn trystan_callous_cultivator_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn trystan_penitent_culler_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_921), "Trystan, Penitent Culler")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf, Subtype::Warlock])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Deathtouch\n\
+             Whenever this creature transforms into Trystan, Penitent Culler, mill three cards, then you may exile an Elf card from your graveyard. If you do, each opponent loses 2 life.\n\
+             At the beginning of your first main phase, you may pay {G}. If you do, transform Trystan.",
+        )
+        .expect("Trystan, Penitent Culler should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn trystan_linked_face_definitions() -> (
+    crate::cards::CardDefinition,
+    crate::cards::CardDefinition,
+) {
+    let mut front = trystan_callous_cultivator_definition();
+    let mut back = trystan_penitent_culler_definition();
+    front.card.other_face = Some(back.card.id);
+    front.card.other_face_name = Some(back.card.name.clone());
+    front.card.linked_face_layout = LinkedFaceLayout::TransformLike;
+    back.card.other_face = Some(front.card.id);
+    back.card.other_face_name = Some(front.card.name.clone());
+    back.card.linked_face_layout = LinkedFaceLayout::TransformLike;
+    (front, back)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn trystan_test_card(name: &str, subtypes: Vec<Subtype>) -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), name)
         .card_types(vec![CardType::Creature])
@@ -328,6 +359,145 @@ fn trystan_callous_cultivator_transform_trigger_uses_same_elf_graveyard_conditio
         game.player(alice).expect("alice exists").life,
         22,
         "Trystan should gain 2 life from the transform trigger when an Elf card is in your graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_penitent_culler_transform_trigger_exiles_milled_elf_and_each_opponent_loses_life() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let trystan = trystan_penitent_culler_definition();
+    let trystan_id = game.create_object_from_definition(&trystan, alice, Zone::Battlefield);
+    let elf = trystan_test_card("Trystan Test Elf", vec![Subtype::Elf]);
+    let non_elf = trystan_test_card("Trystan Test Soldier", vec![Subtype::Soldier]);
+    game.create_object_from_definition(&elf, alice, Zone::Library);
+    game.create_object_from_definition(&non_elf, alice, Zone::Library);
+    game.create_object_from_definition(&non_elf, alice, Zone::Library);
+
+    let transformed = TriggerEvent::new_with_provenance(
+        crate::events::other::TransformedEvent::new(trystan_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &transformed) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Trystan, Penitent Culler transform trigger should stack");
+    assert_eq!(game.stack.len(), 1, "expected Penitent Culler transform trigger");
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Penitent Culler transform trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").graveyard.len(),
+        2,
+        "Penitent Culler should mill three cards and exile the milled Elf card"
+    );
+    assert!(
+        game.exile.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.subtypes.contains(&Subtype::Elf))
+        }),
+        "Penitent Culler should exile an Elf card from your graveyard"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        18,
+        "Bob should lose 2 life when the Elf card is exiled"
+    );
+    assert_eq!(
+        game.player(charlie).expect("charlie exists").life,
+        18,
+        "Charlie should lose 2 life when the Elf card is exiled"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        20,
+        "Penitent Culler should affect each opponent, not its controller"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_penitent_culler_transform_trigger_can_decline_exiling_elf() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let trystan = trystan_penitent_culler_definition();
+    let trystan_id = game.create_object_from_definition(&trystan, alice, Zone::Battlefield);
+    let elf = trystan_test_card("Trystan Test Elf", vec![Subtype::Elf]);
+    let non_elf = trystan_test_card("Trystan Test Soldier", vec![Subtype::Soldier]);
+    game.create_object_from_definition(&elf, alice, Zone::Library);
+    game.create_object_from_definition(&non_elf, alice, Zone::Library);
+    game.create_object_from_definition(&non_elf, alice, Zone::Library);
+
+    let transformed = TriggerEvent::new_with_provenance(
+        crate::events::other::TransformedEvent::new(trystan_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &transformed) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Trystan, Penitent Culler transform trigger should stack");
+    resolve_stack_entry(&mut game).expect("Penitent Culler transform trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").graveyard.len(),
+        3,
+        "declining the optional exile should leave all milled cards in your graveyard"
+    );
+    assert!(game.exile.is_empty(), "declining the optional exile should exile no cards");
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        20,
+        "opponents should not lose life when no Elf card is exiled"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_penitent_culler_first_main_phase_green_payment_transforms_to_front_face() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let (front, back) = trystan_linked_face_definitions();
+    game.register_linked_face_definition(&front);
+    game.register_linked_face_definition(&back);
+    let trystan_id = game.create_object_from_definition(&back, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 1);
+
+    let first_main = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfPrecombatMainPhaseEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &first_main) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Penitent Culler first-main-phase trigger should stack");
+    assert_eq!(game.stack.len(), 1, "expected first-main-phase transform trigger");
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Penitent Culler first-main-phase trigger should resolve");
+
+    assert_eq!(
+        game.object(trystan_id).expect("Trystan should still exist").name,
+        front.card.name,
+        "paying {{G}} during the first main phase trigger should transform to the front face"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.green,
+        0,
+        "the {{G}} payment should be spent"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -68,6 +68,37 @@ fn desmond_miles_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn trystan_callous_cultivator_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(
+        CardId::from_raw(72_920),
+        "Trystan, Callous Cultivator // Trystan, Penitent Culler",
+    )
+    .mana_cost(ManaCost::from_pips(vec![
+        vec![ManaSymbol::Generic(2)],
+        vec![ManaSymbol::Green],
+    ]))
+    .supertypes(vec![Supertype::Legendary])
+    .card_types(vec![CardType::Creature])
+    .subtypes(vec![Subtype::Elf, Subtype::Druid])
+    .power_toughness(PowerToughness::fixed(3, 4))
+    .parse_text(
+        "Deathtouch\n\
+         Whenever this creature enters or transforms into Trystan, Callous Cultivator, mill three cards. Then if there is an Elf card in your graveyard, you gain 2 life.\n\
+         At the beginning of your first main phase, you may pay {B}. If you do, transform Trystan.",
+    )
+    .expect("Trystan, Callous Cultivator should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn trystan_test_card(name: &str, subtypes: Vec<Subtype>) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .subtypes(subtypes)
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn merfolk_cave_diver_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_930), "Merfolk Cave-Diver")
         .mana_cost(ManaCost::from_pips(vec![
@@ -192,6 +223,111 @@ fn desmond_miles_counts_other_assassins_and_assassin_cards_in_your_graveyard() {
         game.calculated_power(desmond_id),
         Some(3),
         "an Assassin card in your graveyard should add another +1/+0"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_callous_cultivator_enters_gains_life_when_elf_card_is_in_your_graveyard() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let trystan = trystan_callous_cultivator_definition();
+    let trystan_id = game.create_object_from_definition(&trystan, alice, Zone::Hand);
+    let elf = trystan_test_card("Trystan Test Elf", vec![Subtype::Elf]);
+    let non_elf = trystan_test_card("Trystan Test Soldier", vec![Subtype::Soldier]);
+    game.create_object_from_definition(&elf, alice, Zone::Graveyard);
+    for _ in 0..3 {
+        game.create_object_from_definition(&non_elf, alice, Zone::Library);
+    }
+
+    assert!(
+        game.move_object_by_effect(trystan_id, Zone::Battlefield)
+            .is_some(),
+        "Trystan should enter the battlefield"
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("Trystan trigger should stack");
+    assert_eq!(game.stack.len(), 1, "expected Trystan enter trigger");
+    resolve_stack_entry(&mut game).expect("Trystan enter trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        22,
+        "Trystan should gain 2 life when an Elf card is in your graveyard"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").graveyard.len(),
+        4,
+        "Trystan should mill three cards before checking the Elf-card condition"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_callous_cultivator_enters_does_not_gain_life_without_elf_card_in_your_graveyard() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let trystan = trystan_callous_cultivator_definition();
+    let trystan_id = game.create_object_from_definition(&trystan, alice, Zone::Hand);
+    let non_elf = trystan_test_card("Trystan Test Soldier", vec![Subtype::Soldier]);
+    for _ in 0..3 {
+        game.create_object_from_definition(&non_elf, alice, Zone::Library);
+    }
+
+    assert!(
+        game.move_object_by_effect(trystan_id, Zone::Battlefield)
+            .is_some(),
+        "Trystan should enter the battlefield"
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("Trystan trigger should stack");
+    resolve_stack_entry(&mut game).expect("Trystan enter trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        20,
+        "Trystan should not gain life without an Elf card in your graveyard"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").graveyard.len(),
+        3,
+        "Trystan should still mill three cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_callous_cultivator_transform_trigger_uses_same_elf_graveyard_condition() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let trystan = trystan_callous_cultivator_definition();
+    let trystan_id = game.create_object_from_definition(&trystan, alice, Zone::Battlefield);
+    let elf = trystan_test_card("Trystan Test Elf", vec![Subtype::Elf]);
+    let non_elf = trystan_test_card("Trystan Test Soldier", vec![Subtype::Soldier]);
+    game.create_object_from_definition(&elf, alice, Zone::Graveyard);
+    for _ in 0..3 {
+        game.create_object_from_definition(&non_elf, alice, Zone::Library);
+    }
+
+    let transformed = TriggerEvent::new_with_provenance(
+        crate::events::other::TransformedEvent::new(trystan_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &transformed) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Trystan transform trigger should stack");
+    assert_eq!(game.stack.len(), 1, "expected Trystan transform trigger");
+    resolve_stack_entry(&mut game).expect("Trystan transform trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        22,
+        "Trystan should gain 2 life from the transform trigger when an Elf card is in your graveyard"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -462,6 +462,87 @@ fn trystan_penitent_culler_transform_trigger_can_decline_exiling_elf() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn trystan_callous_cultivator_first_main_phase_black_payment_transforms_to_back_face() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let (front, back) = trystan_linked_face_definitions();
+    game.register_linked_face_definition(&front);
+    game.register_linked_face_definition(&back);
+    let trystan_id = game.create_object_from_definition(&front, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+
+    let first_main = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfPrecombatMainPhaseEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &first_main) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Callous Cultivator first-main-phase trigger should stack");
+    assert_eq!(game.stack.len(), 1, "expected first-main-phase transform trigger");
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Callous Cultivator first-main-phase trigger should resolve");
+
+    assert_eq!(
+        game.object(trystan_id).expect("Trystan should still exist").name,
+        back.card.name,
+        "paying {{B}} during the first main phase trigger should transform to the back face"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.black,
+        0,
+        "the {{B}} payment should be spent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_callous_cultivator_first_main_phase_can_decline_black_payment() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let (front, back) = trystan_linked_face_definitions();
+    game.register_linked_face_definition(&front);
+    game.register_linked_face_definition(&back);
+    let trystan_id = game.create_object_from_definition(&front, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+
+    let first_main = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfPrecombatMainPhaseEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &first_main) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Callous Cultivator first-main-phase trigger should stack");
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Callous Cultivator first-main-phase trigger should resolve");
+
+    assert_eq!(
+        game.object(trystan_id).expect("Trystan should still exist").name,
+        front.card.name,
+        "declining the {{B}} payment should leave Trystan on the front face"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.black,
+        1,
+        "declining the optional payment should not spend black mana"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn trystan_penitent_culler_first_main_phase_green_payment_transforms_to_front_face() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);
@@ -498,6 +579,46 @@ fn trystan_penitent_culler_first_main_phase_green_payment_transforms_to_front_fa
         game.player(alice).expect("alice exists").mana_pool.green,
         0,
         "the {{G}} payment should be spent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trystan_penitent_culler_first_main_phase_can_decline_green_payment() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let (front, back) = trystan_linked_face_definitions();
+    game.register_linked_face_definition(&front);
+    game.register_linked_face_definition(&back);
+    let trystan_id = game.create_object_from_definition(&back, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 1);
+
+    let first_main = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfPrecombatMainPhaseEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &first_main) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Penitent Culler first-main-phase trigger should stack");
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Penitent Culler first-main-phase trigger should resolve");
+
+    assert_eq!(
+        game.object(trystan_id).expect("Trystan should still exist").name,
+        back.card.name,
+        "declining the {{G}} payment should leave Trystan on the back face"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.green,
+        1,
+        "declining the optional payment should not spend green mana"
     );
 }
 

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -906,7 +906,12 @@ impl Trigger {
 
     /// Create a "when this permanent transforms" trigger.
     pub fn transforms() -> Self {
-        Self::new(TransformsTrigger)
+        Self::new(TransformsTrigger::new())
+    }
+
+    /// Create a transform trigger preserving the parsed source-reference surface.
+    pub fn transforms_with_surface(surface: crate::target::SourceReferenceSurface) -> Self {
+        Self::new(TransformsTrigger::new().this_surface(surface))
     }
 
     /// Create a "when this creature becomes monstrous" trigger.

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -386,6 +386,7 @@ pub(crate) fn interpret_trigger_model(
         }
         TriggerKind::DayNightChanged => crate::triggers::Trigger::day_night_changed(),
         TriggerKind::ThisEntersBattlefield => crate::triggers::Trigger::this_enters_battlefield(),
+        TriggerKind::ThisTransforms => crate::triggers::Trigger::transforms(),
         TriggerKind::YouCastThisSpell => crate::triggers::Trigger::you_cast_this_spell(),
         TriggerKind::KeywordActionMatchingObject {
             action,

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -387,6 +387,9 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::DayNightChanged => crate::triggers::Trigger::day_night_changed(),
         TriggerKind::ThisEntersBattlefield => crate::triggers::Trigger::this_enters_battlefield(),
         TriggerKind::ThisTransforms => crate::triggers::Trigger::transforms(),
+        TriggerKind::ThisTransformsWithSurface { surface } => {
+            crate::triggers::Trigger::transforms_with_surface(surface)
+        }
         TriggerKind::YouCastThisSpell => crate::triggers::Trigger::you_cast_this_spell(),
         TriggerKind::KeywordActionMatchingObject {
             action,

--- a/crates/ironsmith-runtime/src/triggers/other/transforms.rs
+++ b/crates/ironsmith-runtime/src/triggers/other/transforms.rs
@@ -2,11 +2,42 @@
 
 use crate::events::EventKind;
 use crate::events::other::TransformedEvent;
+use crate::target::SourceReferenceSurface;
 use crate::triggers::TriggerEvent;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct TransformsTrigger;
+pub struct TransformsTrigger {
+    pub this_object_surface: Option<SourceReferenceSurface>,
+}
+
+impl TransformsTrigger {
+    pub fn new() -> Self {
+        Self {
+            this_object_surface: None,
+        }
+    }
+
+    pub fn this_surface(mut self, surface: SourceReferenceSurface) -> Self {
+        self.this_object_surface = Some(surface);
+        self
+    }
+
+    pub(crate) fn this_subject_text(&self) -> String {
+        match &self.this_object_surface {
+            Some(SourceReferenceSurface::FullName(text))
+            | Some(SourceReferenceSurface::ShortName(text))
+            | Some(SourceReferenceSurface::ThisPermanentType(text)) => text.clone(),
+            None => "this creature".to_string(),
+        }
+    }
+}
+
+impl Default for TransformsTrigger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl TriggerMatcher for TransformsTrigger {
     fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
@@ -20,7 +51,11 @@ impl TriggerMatcher for TransformsTrigger {
     }
 
     fn display(&self) -> String {
-        "When this permanent transforms".to_string()
+        format!(
+            "Whenever {} transforms into {}",
+            self.this_subject_text(),
+            self.this_subject_text()
+        )
     }
 }
 
@@ -30,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_display() {
-        let trigger = TransformsTrigger;
+        let trigger = TransformsTrigger::new();
         assert!(trigger.display().contains("transforms"));
     }
 }

--- a/crates/ironsmith-runtime/src/triggers/special/or_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/special/or_trigger.rs
@@ -1,7 +1,9 @@
 //! Or trigger combinator - matches if any of the inner triggers match.
 
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
-use crate::triggers::{ThisAttacksTrigger, Trigger, TriggerEvent, ZoneChangeTrigger, ZonePattern};
+use crate::triggers::{
+    ThisAttacksTrigger, TransformsTrigger, Trigger, TriggerEvent, ZoneChangeTrigger, ZonePattern,
+};
 use crate::zone::Zone;
 
 /// A trigger that matches if any of the inner triggers match.
@@ -69,6 +71,39 @@ impl OrTrigger {
         };
         Some(format!("Whenever {subject} {action}"))
     }
+
+    fn self_enters_or_transforms_display(&self) -> Option<String> {
+        let [first, second] = self.triggers.as_slice() else {
+            return None;
+        };
+        let zone_change = if let (Some(zone_change), Some(_)) = (
+            first.downcast_ref::<ZoneChangeTrigger>(),
+            second.downcast_ref::<TransformsTrigger>(),
+        ) {
+            zone_change
+        } else if let (Some(_), Some(zone_change)) = (
+            first.downcast_ref::<TransformsTrigger>(),
+            second.downcast_ref::<ZoneChangeTrigger>(),
+        ) {
+            zone_change
+        } else {
+            return None;
+        };
+
+        if !zone_change.this_object
+            || zone_change.from != ZonePattern::Any
+            || zone_change.to != ZonePattern::Specific(Zone::Battlefield)
+            || zone_change.player != crate::triggers::PlayerRelation::Any
+            || zone_change.cause_filter.is_some()
+        {
+            return None;
+        }
+
+        let subject = zone_change.this_subject_text("creature");
+        Some(format!(
+            "Whenever {subject} enters or transforms into {subject}"
+        ))
+    }
 }
 
 impl TriggerMatcher for OrTrigger {
@@ -105,6 +140,9 @@ impl TriggerMatcher for OrTrigger {
             return self.triggers[0].display();
         }
         if let Some(display) = self.self_enters_or_attacks_display() {
+            return display;
+        }
+        if let Some(display) = self.self_enters_or_transforms_display() {
             return display;
         }
         // Combine displays with "or", stripping leading "When"/"Whenever" from

--- a/crates/ironsmith-tools/src/bin/compile_oracle_text.rs
+++ b/crates/ironsmith-tools/src/bin/compile_oracle_text.rs
@@ -9,7 +9,8 @@ use ironsmith_registry::CardRegistry as RegistryCardRegistry;
 use ironsmith_tools::{
     CompilationSnapshot, ParseStatus, build_parse_input,
     compile_authoritative_snapshot_from_payload, compile_definition_from_payload,
-    default_cards_path, load_card_by_name, parse_card_definition_with_runtime_builder,
+    default_cards_path, load_card_by_name, load_card_payloads_by_name,
+    parse_card_definition_with_runtime_builder,
 };
 
 const DEFAULT_PROBE_NAME: &str = "Parser Probe";
@@ -227,6 +228,43 @@ fn compile_job_for_name(
         }
         (None, None) => Err(format!("unknown card name: {name}")),
     }
+}
+
+fn compile_jobs_for_name(
+    cards_path: &str,
+    name: &str,
+    input_text: Option<&str>,
+) -> Result<Vec<CompileJob>, String> {
+    if input_text.is_none() {
+        let payloads = load_card_payloads_by_name(cards_path, name).map_err(|err| err.to_string())?;
+        if !payloads.is_empty() {
+            return payloads
+                .into_iter()
+                .map(|card| {
+                    let name = card.name.clone();
+                    let oracle_text = card.oracle_text.clone();
+                    let parse_input = card.parse_input.clone();
+                    let authoritative_snapshot = {
+                        let _scope = card_parse_trace::scope("authoritative snapshot");
+                        compile_authoritative_snapshot_from_payload(&card)
+                    };
+                    let compiled_definition = {
+                        let _scope = card_parse_trace::scope("display definition");
+                        compile_definition_from_payload(&card).ok()
+                    };
+                    Ok(CompileJob {
+                        name,
+                        oracle_text,
+                        parse_input,
+                        authoritative_snapshot: Some(authoritative_snapshot),
+                        compiled_definition,
+                    })
+                })
+                .collect();
+        }
+    }
+
+    compile_job_for_name(cards_path, name, input_text).map(|job| vec![job])
 }
 
 fn write_compiled_job<W: Write>(
@@ -450,20 +488,25 @@ fn main() -> Result<(), String> {
     }
 
     let mut stdout = io::stdout().lock();
-    for (idx, name) in names.iter().enumerate() {
-        let compile_one = || -> Result<Vec<u8>, String> {
+    let mut output_idx = 0;
+    for name in names.iter() {
+        let compile_one = || -> Result<Vec<Vec<u8>>, String> {
             card_parse_trace::event(format!("Trace: {name}"));
-            let job = compile_job_for_name(&cards_path, name, input_text.as_deref())?;
-            let mut output = Vec::new();
-            if compare_text {
-                write_compare_text_job(&mut output, &job)?;
-            } else {
-                write_compiled_job(&mut output, &job, detailed, raw, show_definition)?;
-            }
-            Ok(output)
+            compile_jobs_for_name(&cards_path, name, input_text.as_deref())?
+                .iter()
+                .map(|job| {
+                    let mut output = Vec::new();
+                    if compare_text {
+                        write_compare_text_job(&mut output, job)?;
+                    } else {
+                        write_compiled_job(&mut output, job, detailed, raw, show_definition)?;
+                    }
+                    Ok(output)
+                })
+                .collect()
         };
 
-        let output = if trace {
+        let outputs = if trace {
             let (result, report) = card_parse_trace::capture(compile_one);
             if !report.is_empty() {
                 eprint!("{}", report.render());
@@ -473,12 +516,15 @@ fn main() -> Result<(), String> {
             compile_one()?
         };
 
-        if idx > 0 {
-            writeln!(stdout).map_err(|err| format!("failed to write compile output: {err}"))?;
+        for output in outputs {
+            if output_idx > 0 {
+                writeln!(stdout).map_err(|err| format!("failed to write compile output: {err}"))?;
+            }
+            stdout
+                .write_all(&output)
+                .map_err(|err| format!("failed to write compile output: {err}"))?;
+            output_idx += 1;
         }
-        stdout
-            .write_all(&output)
-            .map_err(|err| format!("failed to write compile output: {err}"))?;
     }
 
     Ok(())

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -357,6 +357,67 @@ pub fn load_card_by_name(path: &str, name: &str) -> Result<Option<CardPayload>, 
     Ok(cards.get(&normalized).cloned())
 }
 
+pub fn load_card_payloads_by_name(
+    path: &str,
+    name: &str,
+) -> Result<Vec<CardPayload>, Box<dyn Error>> {
+    let raw = fs::read_to_string(path)?;
+    let cards: Vec<Value> = serde_json::from_str(&raw)?;
+    let normalized = normalize_lookup_name(name);
+
+    for card in &cards {
+        if card
+            .get("digital")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let card_name = card
+            .get("name")
+            .and_then(Value::as_str)
+            .map(normalize_lookup_name);
+        let card_name_matches = card_name.as_deref() == Some(normalized.as_str());
+        let supported = card_is_legal_in_supported_paper_format(card);
+        let face_match_indexes = matching_face_indexes(card, &normalized);
+        if !supported && !card_name_matches && face_match_indexes.is_empty() {
+            continue;
+        }
+
+        if card_name_matches {
+            if linked_face_layout_from_card(card).is_some()
+                && let Some(faces) = card.get("card_faces").and_then(Value::as_array)
+            {
+                let payloads = (0..faces.len())
+                    .filter_map(|idx| build_card_payload_for_face(card, idx))
+                    .collect::<Vec<_>>();
+                if !payloads.is_empty() {
+                    return Ok(payloads);
+                }
+            }
+            if let Some(record) = build_registry_card_record_with_explicit_includes(
+                card,
+                &BTreeSet::new(),
+            ) {
+                return Ok(vec![record.payload]);
+            }
+        }
+
+        if !face_match_indexes.is_empty() {
+            let payloads = face_match_indexes
+                .into_iter()
+                .filter_map(|idx| build_card_payload_for_face(card, idx))
+                .collect::<Vec<_>>();
+            if !payloads.is_empty() {
+                return Ok(payloads);
+            }
+        }
+    }
+
+    Ok(Vec::new())
+}
+
 pub fn parse_card_with_fallback(name: &str, parse_input: &str) -> ParseAttempt {
     let strict_attempt = parse_card(name, parse_input, false);
     if strict_attempt.status == ParseStatus::StrictCompiled {
@@ -2567,6 +2628,99 @@ fn get_second_face(card: &Value) -> Option<&Value> {
     card.get("card_faces")
         .and_then(Value::as_array)
         .and_then(|faces| faces.get(1))
+}
+
+fn matching_face_indexes(card: &Value, normalized_name: &str) -> Vec<usize> {
+    card.get("card_faces")
+        .and_then(Value::as_array)
+        .map(|faces| {
+            faces
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, face)| {
+                    let face_name = face.get("name").and_then(Value::as_str)?.trim();
+                    (normalize_lookup_name(face_name) == normalized_name).then_some(idx)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn build_card_payload_for_face(card: &Value, face_index: usize) -> Option<CardPayload> {
+    let faces = card.get("card_faces")?.as_array()?;
+    let face = faces.get(face_index)?;
+    let name = face.get("name")?.as_str()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+
+    let raw_oracle_text = face
+        .get("oracle_text")
+        .and_then(value_to_string)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let oracle_text = strip_parenthetical_text(&raw_oracle_text);
+    let mana_cost = pick_field_preferring_face(card, Some(face), "mana_cost");
+    let type_line = pick_field_preferring_face(card, Some(face), "type_line");
+    let power = pick_field_preferring_face(card, Some(face), "power");
+    let toughness = pick_field_preferring_face(card, Some(face), "toughness");
+    let loyalty = pick_field_preferring_face(card, Some(face), "loyalty");
+    let defense = pick_field_preferring_face(card, Some(face), "defense");
+
+    let mut metadata_lines = Vec::new();
+    if let Some(mana_cost) = mana_cost
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        metadata_lines.push(format!("Mana cost: {}", mana_cost.trim()));
+    }
+    if let Some(type_line) = type_line
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        metadata_lines.push(format!("Type: {}", type_line.trim()));
+    }
+    if let (Some(power), Some(toughness)) = (power.as_deref(), toughness.as_deref())
+        && !power.trim().is_empty()
+        && !toughness.trim().is_empty()
+    {
+        metadata_lines.push(format!(
+            "Power/Toughness: {}/{}",
+            power.trim(),
+            toughness.trim()
+        ));
+    }
+    if let Some(loyalty) = loyalty.as_deref().filter(|value| !value.trim().is_empty()) {
+        metadata_lines.push(format!("Loyalty: {}", loyalty.trim()));
+    }
+    if let Some(defense) = defense.as_deref().filter(|value| !value.trim().is_empty()) {
+        metadata_lines.push(format!("Defense: {}", defense.trim()));
+    }
+
+    let linked_face_layout = linked_face_layout_from_card(card);
+    let other_face_name = linked_face_layout.and_then(|_| {
+        faces
+            .iter()
+            .enumerate()
+            .find(|(idx, _)| *idx != face_index)
+            .and_then(|(_, other_face)| other_face.get("name"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    });
+
+    Some(CardPayload {
+        name: name.to_string(),
+        parse_name: None,
+        oracle_text,
+        raw_oracle_text: raw_oracle_text.clone(),
+        metadata_lines: metadata_lines.clone(),
+        parse_input: build_parse_input(&metadata_lines, &raw_oracle_text),
+        other_face_name,
+        linked_face_layout,
+    })
 }
 
 fn value_to_string(value: &Value) -> Option<String> {

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -992,6 +992,45 @@ fn compile_oracle_text_strictly_compiles_aunt_may_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_trystan_callous_cultivator_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Trystan, Callous Cultivator // Trystan, Penitent Culler")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Trystan --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Trystan should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Trystan, Callous Cultivator"), "{stdout}");
+    assert!(stdout.contains("Similarity: 1.0000"), "{stdout}");
+    assert!(
+        stdout.contains("enters or transforms into Trystan")
+            && stdout.contains("if there is an Elf card in your graveyard, you gain 2 life"),
+        "expected Trystan transform trigger and Elf-card graveyard clause, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_aloe_alchemist_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1022,11 +1022,19 @@ fn compile_oracle_text_strictly_compiles_trystan_callous_cultivator_from_workspa
     let stdout =
         String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
     assert!(stdout.contains("Name: Trystan, Callous Cultivator"), "{stdout}");
+    assert!(stdout.contains("Name: Trystan, Penitent Culler"), "{stdout}");
     assert!(stdout.contains("Similarity: 1.0000"), "{stdout}");
     assert!(
         stdout.contains("enters or transforms into Trystan, Callous Cultivator")
             && stdout.contains("if there is an Elf card in your graveyard, you gain 2 life"),
         "expected Trystan transform trigger and Elf-card graveyard clause, got {stdout}"
+    );
+    assert!(
+        stdout.contains("transforms into Trystan, Penitent Culler")
+            && stdout.contains("you may exile an Elf card from your graveyard")
+            && stdout.contains("each opponent loses 2 life")
+            && stdout.contains("you may pay {G}"),
+        "expected Penitent Culler trigger, Elf-card exile, opponent life loss, and green transform clause, got {stdout}"
     );
 }
 

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1024,7 +1024,7 @@ fn compile_oracle_text_strictly_compiles_trystan_callous_cultivator_from_workspa
     assert!(stdout.contains("Name: Trystan, Callous Cultivator"), "{stdout}");
     assert!(stdout.contains("Similarity: 1.0000"), "{stdout}");
     assert!(
-        stdout.contains("enters or transforms into Trystan")
+        stdout.contains("enters or transforms into Trystan, Callous Cultivator")
             && stdout.contains("if there is an Elf card in your graveyard, you gain 2 life"),
         "expected Trystan transform trigger and Elf-card graveyard clause, got {stdout}"
     );


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Trystan, Callous Cultivator // Trystan, Penitent Culler
Initial parse error:
```
unsupported predicate (predicate: 'there is elf card in your graveyard'); oracle-only fallback also failed: unsupported predicate (predicate: 'there is elf card in your graveyard')
```

Current worker: i-038fb54b80bcd9d4d
Branch: codex/aws-card-fix-trystan-callous-cultivator-trystan-penitent-cull
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0001
