### PR TITLE
Fix Ironsmith parse failure: Rebbec, Architect of Ascension

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -417,6 +417,13 @@ impl CardDefinitionBuilder {
                 ))
             }
             KeywordAction::ProtectionFromFilter(filter) => self.protection_from_filter(filter),
+            KeywordAction::ProtectionFromEachManaValueAmong(filter) => self.with_ability(
+                crate::ability::Ability::static_ability(
+                    crate::static_abilities::StaticAbility::protection(
+                        crate::ability::ProtectionFrom::EachManaValueAmong(filter),
+                    ),
+                ),
+            ),
             KeywordAction::ProtectionFromCardType(card_type) => {
                 self.protection_from_card_type(card_type)
             }

--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -138,6 +138,7 @@ pub enum KeywordAction {
     ProtectionFromChosenPlayer,
     ProtectionFromChosenColor,
     ProtectionFromFilter(ObjectFilter),
+    ProtectionFromEachManaValueAmong(ObjectFilter),
     ProtectionFromCardType(CardType),
     ProtectionFromSubtype(Subtype),
     Unblockable,
@@ -244,6 +245,7 @@ impl KeywordAction {
                 | Self::ProtectionFromChosenPlayer
                 | Self::ProtectionFromChosenColor
                 | Self::ProtectionFromFilter(_)
+                | Self::ProtectionFromEachManaValueAmong(_)
                 | Self::ProtectionFromCardType(_)
                 | Self::ProtectionFromSubtype(_)
                 | Self::Unblockable
@@ -408,6 +410,9 @@ impl KeywordAction {
             Self::ProtectionFromChosenColor => "Protection from the chosen color".to_string(),
             Self::ProtectionFromFilter(filter) => {
                 format!("Protection from {}", filter.description())
+            }
+            Self::ProtectionFromEachManaValueAmong(filter) => {
+                format!("Protection from each mana value among {}", filter.description())
             }
             Self::ProtectionFromCardType(card_type) => {
                 format!(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -12,6 +12,7 @@ use super::activation_and_restrictions::keyword_action_costs::maybe_strip_leadin
 use super::activation_and_restrictions::{
     parse_ability_phrase, parse_single_word_keyword_action, parse_triggered_times_each_turn_lexed,
 };
+use super::object_filters::parse_object_filter_lexed;
 use super::grammar::primitives::{
     TokenWordView, split_lexed_slices_on_and, split_lexed_slices_on_commas_or_semicolons,
 };
@@ -69,6 +70,21 @@ fn protection_from_colored_spells_action(words: &[&str]) -> Option<KeywordAction
     let mut filter = ObjectFilter::spell();
     filter.colors = Some(all_colors);
     Some(KeywordAction::ProtectionFromFilter(filter))
+}
+
+fn protection_from_each_mana_value_among_action(
+    words: &[&str],
+    tokens: &[OwnedLexToken],
+) -> Option<KeywordAction> {
+    let prefix = ["protection", "from", "each", "mana", "value", "among"];
+    if !word_slice_starts_with(words, &prefix) || words.len() == prefix.len() {
+        return None;
+    }
+    let words_view = TokenWordView::new(tokens);
+    let filter_start = words_view.token_index_for_word_index(prefix.len())?;
+    let filter_tokens = trim_commas(&tokens[filter_start..]);
+    let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
+    Some(KeywordAction::ProtectionFromEachManaValueAmong(filter))
 }
 
 fn word_slice_ends_with(words: &[&str], expected: &[&str]) -> bool {
@@ -190,6 +206,16 @@ fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if value == "each"
+            && words.get(idx + 2).copied() == Some("mana")
+            && words.get(idx + 3).copied() == Some("value")
+            && words.get(idx + 4).copied() == Some("among")
+        {
+            let filter_start = words_view.token_index_for_word_index(idx + 5)?;
+            let filter_tokens = trim_commas(&tokens[filter_start..]);
+            let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
+            return Some(KeywordAction::ProtectionFromEachManaValueAmong(filter));
+        }
         if matches!(value, "permanent" | "permanents")
             && words.get(idx + 2).copied() == Some("with")
         {
@@ -526,6 +552,9 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
         if let Some(action) = protection_from_colored_spells_action(&words) {
             return Some(vec![action]);
         }
+        if let Some(action) = protection_from_each_mana_value_among_action(&words, tokens) {
+            return Some(vec![action]);
+        }
         let first_word_idx = if words.first().copied() == Some("and") {
             1
         } else {
@@ -540,6 +569,16 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
 
         let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
             let value = *words.get(idx + 1)?;
+            if value == "each"
+                && words.get(idx + 2).copied() == Some("mana")
+                && words.get(idx + 3).copied() == Some("value")
+                && words.get(idx + 4).copied() == Some("among")
+            {
+                let filter_start = words_view.token_index_for_word_index(idx + 5)?;
+                let filter_tokens = trim_commas(&tokens[filter_start..]);
+                let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
+                return Some(KeywordAction::ProtectionFromEachManaValueAmong(filter));
+            }
             if matches!(value, "permanent" | "permanents")
                 && words.get(idx + 2).copied() == Some("with")
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
@@ -1,13 +1,3 @@
-fn parser_text_words(tokens: &[OwnedLexToken]) -> Vec<&str> {
-    tokens
-        .iter()
-        .filter_map(|token| match token.kind {
-            TokenKind::Word | TokenKind::Number | TokenKind::Tilde => Some(token.parser_text()),
-            _ => None,
-        })
-        .collect()
-}
-
 pub(crate) fn parse_ability_line(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
     if let Some(actions) = parse_flashback_keyword_line(tokens) {
         return Some(actions);
@@ -69,7 +59,8 @@ pub(crate) fn reject_unimplemented_keyword_actions(
 }
 
 pub(crate) fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
-    let words = parser_text_words(tokens);
+    let words_view = crate::runtime_backend::lexer::TokenWordView::new(tokens);
+    let words = words_view.word_refs();
     let first_word_idx = if words.first().copied() == Some("and") {
         1
     } else {
@@ -87,6 +78,16 @@ pub(crate) fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<Key
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if value == "each"
+            && words.get(idx + 2).copied() == Some("mana")
+            && words.get(idx + 3).copied() == Some("value")
+            && words.get(idx + 4).copied() == Some("among")
+        {
+            let filter_start = words_view.token_index_for_word_index(idx + 5)?;
+            let filter_tokens = trim_commas(&tokens[filter_start..]);
+            let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
+            return Some(KeywordAction::ProtectionFromEachManaValueAmong(filter));
+        }
         if matches!(value, "permanent" | "permanents")
             && words.get(idx + 2).copied() == Some("with")
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -168,6 +168,9 @@ pub(crate) fn static_ability_for_keyword_action(action: KeywordAction) -> Option
         KeywordAction::ProtectionFromFilter(filter) => Some(StaticAbility::protection(
             crate::ability::ProtectionFrom::Permanents(filter),
         )),
+        KeywordAction::ProtectionFromEachManaValueAmong(filter) => Some(StaticAbility::protection(
+            crate::ability::ProtectionFrom::EachManaValueAmong(filter),
+        )),
         KeywordAction::ProtectionFromCardType(card_type) => Some(StaticAbility::protection(
             crate::ability::ProtectionFrom::CardType(card_type),
         )),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -902,6 +902,9 @@ pub(crate) fn rewrite_static_ability_for_keyword_action(
         KeywordAction::ProtectionFromFilter(filter) => Some(StaticAbility::protection(
             crate::ability::ProtectionFrom::Permanents(filter),
         )),
+        KeywordAction::ProtectionFromEachManaValueAmong(filter) => Some(StaticAbility::protection(
+            crate::ability::ProtectionFrom::EachManaValueAmong(filter),
+        )),
         KeywordAction::ProtectionFromCardType(card_type) => Some(StaticAbility::protection(
             crate::ability::ProtectionFrom::CardType(card_type),
         )),

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -74,6 +74,7 @@ pub enum ProtectionFrom {
     Creatures,
     CardType(CardType),
     Permanents(ObjectFilter),
+    EachManaValueAmong(ObjectFilter),
     ChosenPlayer,
     ChosenColor,
     Everything,

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -592,6 +592,7 @@ pub(crate) enum KeywordAction {
     ProtectionFromChosenPlayer,
     ProtectionFromChosenColor,
     ProtectionFromFilter(ObjectFilter),
+    ProtectionFromEachManaValueAmong(ObjectFilter),
     ProtectionFromCardType(CardType),
     ProtectionFromSubtype(Subtype),
     Unblockable,
@@ -697,6 +698,7 @@ impl KeywordAction {
                 | Self::ProtectionFromChosenPlayer
                 | Self::ProtectionFromChosenColor
                 | Self::ProtectionFromFilter(_)
+                | Self::ProtectionFromEachManaValueAmong(_)
                 | Self::ProtectionFromCardType(_)
                 | Self::ProtectionFromSubtype(_)
                 | Self::Unblockable
@@ -854,6 +856,9 @@ impl KeywordAction {
             Self::ProtectionFromChosenColor => "Protection from the chosen color".to_string(),
             Self::ProtectionFromFilter(filter) => {
                 format!("Protection from {}", filter.description())
+            }
+            Self::ProtectionFromEachManaValueAmong(filter) => {
+                format!("Protection from each mana value among {}", filter.description())
             }
             Self::ProtectionFromCardType(card_type) => format!(
                 "Protection from {}",
@@ -1755,6 +1760,11 @@ impl CardDefinitionBuilder {
                 StaticAbility::protection(crate::ability::ProtectionFrom::ChosenColor),
             )),
             KeywordAction::ProtectionFromFilter(filter) => self.protection_from_filter(filter),
+            KeywordAction::ProtectionFromEachManaValueAmong(filter) => self.with_ability(
+                Ability::static_ability(StaticAbility::protection(
+                    crate::ability::ProtectionFrom::EachManaValueAmong(filter),
+                )),
+            ),
             KeywordAction::ProtectionFromCardType(card_type) => {
                 self.protection_from_card_type(card_type)
             }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35392,6 +35392,150 @@ fn rebbec_architect_of_ascension_strict_parser_and_text_regression() {
     );
 }
 
+fn rebbec_runtime_test_card(
+    name: &str,
+    card_types: Vec<CardType>,
+    mana_value: u8,
+    power_toughness: Option<(i32, i32)>,
+) -> CardDefinition {
+    let mut builder = CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(mana_value)]]));
+    if let Some((power, toughness)) = power_toughness {
+        builder = builder.power_toughness(PowerToughness::fixed(power, toughness));
+    }
+    builder.build()
+}
+
+#[test]
+fn rebbec_architect_of_ascension_runtime_targeting_uses_controller_artifact_mana_values() {
+    let rebbec = parse_oracle_card_definition("Rebbec, Architect of Ascension");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+
+    game.create_object_from_definition(&rebbec, alice, Zone::Battlefield);
+    let protected_artifact = rebbec_runtime_test_card(
+        "Alice Rebbec-Protected Mana Rock",
+        vec![CardType::Artifact],
+        2,
+        None,
+    );
+    let protected_id =
+        game.create_object_from_definition(&protected_artifact, alice, Zone::Battlefield);
+    let matching_spell = rebbec_runtime_test_card(
+        "Mana Value Two Targeting Spell",
+        vec![CardType::Instant],
+        2,
+        None,
+    );
+    let matching_spell_id = game.create_object_from_definition(&matching_spell, bob, Zone::Stack);
+    let nonmatching_spell = rebbec_runtime_test_card(
+        "Mana Value Three Targeting Spell",
+        vec![CardType::Instant],
+        3,
+        None,
+    );
+    let nonmatching_spell_id =
+        game.create_object_from_definition(&nonmatching_spell, bob, Zone::Stack);
+    let opponent_artifact = rebbec_runtime_test_card(
+        "Opponent Artifact With Mana Value Three",
+        vec![CardType::Artifact],
+        3,
+        None,
+    );
+    game.create_object_from_definition(&opponent_artifact, bob, Zone::Battlefield);
+    let bob_artifact = rebbec_runtime_test_card(
+        "Bob Artifact With Matching Mana Value",
+        vec![CardType::Artifact],
+        2,
+        None,
+    );
+    let bob_artifact_id =
+        game.create_object_from_definition(&bob_artifact, bob, Zone::Battlefield);
+
+    assert!(
+        !crate::targeting::can_target_object(&game, protected_id, matching_spell_id, bob)
+            .is_legal(),
+        "Rebbec, Architect of Ascension should make Alice's artifact illegal to target from sources whose mana value matches Alice's artifacts"
+    );
+    assert!(
+        crate::targeting::can_target_object(&game, protected_id, nonmatching_spell_id, bob)
+            .is_legal(),
+        "Rebbec, Architect of Ascension should not count Bob's artifacts when checking Alice's protected artifact"
+    );
+    assert!(
+        crate::targeting::can_target_object(&game, bob_artifact_id, matching_spell_id, bob)
+            .is_legal(),
+        "Rebbec, Architect of Ascension should not grant protection to artifacts controlled by another player"
+    );
+}
+
+#[test]
+fn rebbec_architect_of_ascension_runtime_blocking_uses_controller_artifact_mana_values() {
+    let rebbec = parse_oracle_card_definition("Rebbec, Architect of Ascension");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+
+    game.create_object_from_definition(&rebbec, alice, Zone::Battlefield);
+    let attacker_def = rebbec_runtime_test_card(
+        "Alice Rebbec-Protected Artifact Creature",
+        vec![CardType::Artifact, CardType::Creature],
+        2,
+        Some((2, 2)),
+    );
+    let attacker_id = game.create_object_from_definition(&attacker_def, alice, Zone::Battlefield);
+    let matching_blocker_def = rebbec_runtime_test_card(
+        "Mana Value Two Blocker",
+        vec![CardType::Creature],
+        2,
+        Some((2, 2)),
+    );
+    let matching_blocker_id =
+        game.create_object_from_definition(&matching_blocker_def, bob, Zone::Battlefield);
+    let nonmatching_blocker_def = rebbec_runtime_test_card(
+        "Mana Value Three Blocker",
+        vec![CardType::Creature],
+        3,
+        Some((3, 3)),
+    );
+    let nonmatching_blocker_id =
+        game.create_object_from_definition(&nonmatching_blocker_def, bob, Zone::Battlefield);
+    let opponent_artifact = rebbec_runtime_test_card(
+        "Opponent Artifact With Mana Value Three",
+        vec![CardType::Artifact],
+        3,
+        None,
+    );
+    game.create_object_from_definition(&opponent_artifact, bob, Zone::Battlefield);
+
+    let attacker = game.object(attacker_id).expect("attacker exists").clone();
+    let matching_blocker = game
+        .object(matching_blocker_id)
+        .expect("matching blocker exists")
+        .clone();
+    let nonmatching_blocker = game
+        .object(nonmatching_blocker_id)
+        .expect("nonmatching blocker exists")
+        .clone();
+
+    assert!(
+        !crate::rules::combat::can_block(&attacker, &matching_blocker, &game),
+        "Rebbec, Architect of Ascension should stop blockers whose mana value matches Alice's artifacts"
+    );
+    assert!(
+        crate::rules::combat::can_block(&attacker, &nonmatching_blocker, &game),
+        "Rebbec, Architect of Ascension should not count Bob's artifacts when checking Alice's protected attacker"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_sporeweb_weaver_strict_regression() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35368,6 +35368,30 @@ fn guardian_of_the_ages_strict_parser_and_text_regression() {
     );
 }
 
+#[test]
+fn rebbec_architect_of_ascension_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Rebbec, Architect of Ascension");
+
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Artifacts you control have protection from each mana value among artifacts you control."
+                .to_string(),
+            "Partner".to_string(),
+        ],
+        "Rebbec, Architect of Ascension should render mana-value protection exactly"
+    );
+
+    let ability_debug = format!("{:?}", def.abilities);
+    assert!(
+        ability_debug.contains("GrantAbility")
+            && ability_debug.contains("EachManaValueAmong")
+            && ability_debug.contains("Artifact"),
+        "Rebbec, Architect of Ascension should structurally grant artifact mana-value protection, got {ability_debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_sporeweb_weaver_strict_regression() {

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -752,7 +752,7 @@ mod tests {
         obj.abilities.push(Ability::static_ability(static_ability));
     }
 
-    fn set_mana_value(obj: &mut Object, mana_value: u32) {
+    fn set_mana_value(obj: &mut Object, mana_value: u8) {
         obj.mana_cost = Some(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(mana_value)]]));
     }
 

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -382,6 +382,25 @@ fn protection_prevents_blocking_with_view(
             let ctx = FilterContext::new(game.controller_of(attacker)).with_source(attacker.id);
             filter.matches(blocker, &ctx, game)
         }
+        ProtectionFrom::EachManaValueAmong(filter) => {
+            let blocker_mana_value = blocker
+                .mana_cost
+                .as_ref()
+                .map_or(0, |cost| cost.mana_value() as i32);
+            let ctx = FilterContext::new(game.controller_of(attacker)).with_source(attacker.id);
+            let zone = filter.zone.unwrap_or(crate::zone::Zone::Battlefield);
+            game.objects_in_zone(zone).into_iter().any(|object_id| {
+                let Some(object) = game.object(object_id) else {
+                    return false;
+                };
+                filter.matches(object, &ctx, game)
+                    && object
+                        .mana_cost
+                        .as_ref()
+                        .map_or(0, |cost| cost.mana_value() as i32)
+                        == blocker_mana_value
+            })
+        }
         ProtectionFrom::Everything => true,
         ProtectionFrom::Colorless => blocker_colors.is_empty(),
         ProtectionFrom::ChosenPlayer => game
@@ -670,7 +689,9 @@ mod tests {
     use crate::cost::OptionalCostsPaid;
     use crate::game_state::GameState;
     use crate::ids::{ObjectId, PlayerId, StableId};
+    use crate::mana::{ManaCost, ManaSymbol};
     use crate::static_abilities::StaticAbility;
+    use crate::target::PlayerFilter;
     use crate::zone::Zone;
     use std::collections::HashMap;
 
@@ -729,6 +750,10 @@ mod tests {
 
     fn add_ability(obj: &mut Object, static_ability: StaticAbility) {
         obj.abilities.push(Ability::static_ability(static_ability));
+    }
+
+    fn set_mana_value(obj: &mut Object, mana_value: u32) {
+        obj.mana_cost = Some(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(mana_value)]]));
     }
 
     #[test]
@@ -1295,6 +1320,58 @@ mod tests {
 
         // Blue can block protection from red
         assert!(can_block(&protected, &blue_blocker, &game));
+    }
+
+    #[test]
+    fn rebbec_architect_of_ascension_mana_value_protection_blocks_only_matching_values_you_control() {
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let mut attacker = make_creature("Rebbec-protected artifact creature", 2, 2);
+        attacker.id = ObjectId::from_raw(2100);
+        attacker.owner = alice;
+        attacker.card_types.push(CardType::Artifact);
+        set_mana_value(&mut attacker, 2);
+        add_ability(
+            &mut attacker,
+            StaticAbility::protection(ProtectionFrom::EachManaValueAmong(
+                crate::target::ObjectFilter::artifact().controlled_by(PlayerFilter::You),
+            )),
+        );
+
+        let mut matching_blocker = make_creature("Matching Mana Value Blocker", 2, 2);
+        matching_blocker.id = ObjectId::from_raw(2101);
+        matching_blocker.owner = bob;
+        set_mana_value(&mut matching_blocker, 2);
+
+        let mut nonmatching_blocker = make_creature("Different Mana Value Blocker", 3, 3);
+        nonmatching_blocker.id = ObjectId::from_raw(2102);
+        nonmatching_blocker.owner = bob;
+        set_mana_value(&mut nonmatching_blocker, 3);
+
+        let mut opponents_artifact_with_nonmatching_value =
+            make_creature("Opponent Artifact With Mana Value Three", 0, 1);
+        opponents_artifact_with_nonmatching_value.id = ObjectId::from_raw(2103);
+        opponents_artifact_with_nonmatching_value.owner = bob;
+        opponents_artifact_with_nonmatching_value
+            .card_types
+            .push(CardType::Artifact);
+        set_mana_value(&mut opponents_artifact_with_nonmatching_value, 3);
+
+        let mut game = test_game_state();
+        game.add_object(attacker.clone());
+        game.add_object(matching_blocker.clone());
+        game.add_object(nonmatching_blocker.clone());
+        game.add_object(opponents_artifact_with_nonmatching_value);
+
+        assert!(
+            !can_block(&attacker, &matching_blocker, &game),
+            "Rebbec, Architect of Ascension should stop blockers whose mana value is among artifacts the attacker controller controls"
+        );
+        assert!(
+            can_block(&attacker, &nonmatching_blocker, &game),
+            "Rebbec, Architect of Ascension should not count artifacts controlled by the defending player for the attacker's mana-value set"
+        );
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1995,6 +1995,9 @@ impl StaticAbilityKind for GrantAbility {
             grant_subject_text(&self.filter)
         };
         let mut ability_text = self.ability.display();
+        if self.ability.is_keyword() {
+            ability_text = lowercase_first_ascii(&ability_text);
+        }
         if matches!(
             ability_text.split_whitespace().next(),
             Some("If" | "When" | "Whenever" | "At")
@@ -4083,6 +4086,9 @@ impl StaticAbilityKind for GrantObjectAbilityForFilter {
         }
 
         let filter_desc = self.filter.description();
+        if matches!(&self.ability.kind, AbilityKind::Static(static_ability) if static_ability.is_keyword()) {
+            ability_text = lowercase_first_ascii(&ability_text);
+        }
         let rendered_ability = match self.ability.kind {
             AbilityKind::Activated(_) | AbilityKind::Triggered(_) => {
                 if !ability_text.ends_with('.') {

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -99,6 +99,10 @@ impl StaticAbilityKind for Protection {
                 };
                 format!("Protection from {description}")
             }
+            ProtectionFrom::EachManaValueAmong(filter) => format!(
+                "Protection from each mana value among {}",
+                describe_protection_mana_value_scope(filter)
+            ),
         }
     }
 
@@ -113,6 +117,34 @@ impl StaticAbilityKind for Protection {
     fn protection_from(&self) -> Option<&ProtectionFrom> {
         Some(&self.from)
     }
+}
+
+fn describe_protection_mana_value_scope(filter: &ObjectFilter) -> String {
+    let description = filter.description();
+    pluralize_leading_subject(&description).unwrap_or(description)
+}
+
+fn pluralize_leading_subject(description: &str) -> Option<String> {
+    let description = description
+        .strip_prefix("an ")
+        .or_else(|| description.strip_prefix("a "))
+        .unwrap_or(description);
+    for (singular, plural) in [
+        ("artifact", "artifacts"),
+        ("creature", "creatures"),
+        ("enchantment", "enchantments"),
+        ("land", "lands"),
+        ("permanent", "permanents"),
+        ("spell", "spells"),
+    ] {
+        if description == singular {
+            return Some(plural.to_string());
+        }
+        if let Some(rest) = description.strip_prefix(&format!("{singular} ")) {
+            return Some(format!("{plural} {rest}"));
+        }
+    }
+    None
 }
 
 fn describe_protection_permanent_filter(filter: &ObjectFilter) -> String {

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -923,7 +923,7 @@ mod tests {
         obj
     }
 
-    fn create_artifact(id: u32, name: &str, controller: PlayerId, mana_value: u32) -> Object {
+    fn create_artifact(id: u32, name: &str, controller: PlayerId, mana_value: u8) -> Object {
         let card = CardBuilder::new(CardId::from_raw(id), name)
             .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(mana_value)]]))
             .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -236,6 +236,9 @@ pub(crate) fn has_protection_from_source_with_view(
                 crate::ability::ProtectionFrom::ChosenColor => game
                     .chosen_color(target_id)
                     .is_some_and(|chosen| view.object_colors(source_id).contains(chosen)),
+                crate::ability::ProtectionFrom::EachManaValueAmong(filter) => {
+                    source_mana_value_matches_scope(game, target_id, source, filter)
+                }
                 _ => source_matches_protection_with_view(source, protection_from, game, view),
             };
             if matches {
@@ -272,6 +275,9 @@ fn has_protection_from_source_snapshot_with_view(
                 crate::ability::ProtectionFrom::ChosenColor => game
                     .chosen_color(target_id)
                     .is_some_and(|chosen| source_snapshot.colors.contains(chosen)),
+                crate::ability::ProtectionFrom::EachManaValueAmong(filter) => {
+                    source_snapshot_mana_value_matches_scope(game, target_id, source_snapshot, filter)
+                }
                 _ => source_snapshot_matches_protection(source_snapshot, protection_from, game),
             };
             if matches {
@@ -325,6 +331,7 @@ pub(crate) fn source_matches_protection_with_view(
             let filter_ctx = game.filter_context_for(game.turn.active_player, None);
             filter.matches(source, &filter_ctx, game)
         }
+        ProtectionFrom::EachManaValueAmong(_) => false,
         // Protection from everything
         ProtectionFrom::Everything => true,
         // Protection from colorless (sources with no colors)
@@ -350,9 +357,62 @@ fn source_snapshot_matches_protection(
             let filter_ctx = game.filter_context_for(game.turn.active_player, None);
             filter.matches_snapshot(source, &filter_ctx, game)
         }
+        ProtectionFrom::EachManaValueAmong(_) => false,
         ProtectionFrom::Everything => true,
         ProtectionFrom::Colorless => source.colors.is_empty(),
     }
+}
+
+fn source_mana_value_matches_scope(
+    game: &GameState,
+    protected_id: ObjectId,
+    source: &Object,
+    scope: &ObjectFilter,
+) -> bool {
+    object_mana_value(source)
+        .is_some_and(|mana_value| mana_value_matches_scope(game, protected_id, mana_value, scope))
+}
+
+fn source_snapshot_mana_value_matches_scope(
+    game: &GameState,
+    protected_id: ObjectId,
+    source: &ObjectSnapshot,
+    scope: &ObjectFilter,
+) -> bool {
+    snapshot_mana_value(source)
+        .is_some_and(|mana_value| mana_value_matches_scope(game, protected_id, mana_value, scope))
+}
+
+fn mana_value_matches_scope(
+    game: &GameState,
+    protected_id: ObjectId,
+    mana_value: i32,
+    scope: &ObjectFilter,
+) -> bool {
+    let Some(protected) = game.object(protected_id) else {
+        return false;
+    };
+    let filter_ctx = game.filter_context_for(game.controller_of(protected), Some(protected_id));
+    let zone = scope.zone.unwrap_or(Zone::Battlefield);
+    game.objects_in_zone(zone).into_iter().any(|object_id| {
+        let Some(object) = game.object(object_id) else {
+            return false;
+        };
+        scope.matches(object, &filter_ctx, game) && object_mana_value(object) == Some(mana_value)
+    })
+}
+
+fn object_mana_value(object: &Object) -> Option<i32> {
+    Some(object.mana_cost.as_ref().map_or(0, |cost| cost.mana_value() as i32))
+}
+
+fn snapshot_mana_value(snapshot: &ObjectSnapshot) -> Option<i32> {
+    Some(
+        snapshot
+            .mana_cost
+            .as_ref()
+            .map_or(0, |cost| cost.mana_value() as i32),
+    )
 }
 
 /// Compute all legal targets for a target specification.
@@ -863,6 +923,20 @@ mod tests {
         obj
     }
 
+    fn create_artifact(id: u32, name: &str, controller: PlayerId, mana_value: u32) -> Object {
+        let card = CardBuilder::new(CardId::from_raw(id), name)
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(mana_value)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+
+        Object::from_card(
+            ObjectId::from_raw(id as u64),
+            &card,
+            controller,
+            Zone::Battlefield,
+        )
+    }
+
     fn create_battle(id: u32, name: &str, controller: PlayerId) -> Object {
         let card = CardBuilder::new(CardId::from_raw(id), name)
             .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
@@ -1361,6 +1435,46 @@ mod tests {
             result,
             TargetingResult::Invalid(TargetingInvalidReason::HasProtection)
         ));
+    }
+
+    #[test]
+    fn rebbec_architect_of_ascension_mana_value_protection_targets_only_matching_values_you_control() {
+        let mut game = create_test_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let mut protected = create_artifact(1, "Rebbec-protected artifact", bob, 2);
+        add_static_ability(
+            &mut protected,
+            StaticAbility::protection(ProtectionFrom::EachManaValueAmong(
+                ObjectFilter::artifact().controlled_by(PlayerFilter::You),
+            )),
+        );
+        let protected_id = protected.id;
+
+        let matching_source = create_artifact(2, "Mana Value Two Source", alice, 2);
+        let matching_source_id = matching_source.id;
+        let nonmatching_source = create_artifact(3, "Mana Value Three Source", alice, 3);
+        let nonmatching_source_id = nonmatching_source.id;
+        let opponent_artifact_same_as_nonmatching =
+            create_artifact(4, "Opponent Artifact With Mana Value Three", alice, 3);
+
+        game.add_object(protected);
+        game.add_object(matching_source);
+        game.add_object(nonmatching_source);
+        game.add_object(opponent_artifact_same_as_nonmatching);
+
+        let result = can_target_object(&game, protected_id, matching_source_id, alice);
+        assert!(
+            matches!(result, TargetingResult::Invalid(TargetingInvalidReason::HasProtection)),
+            "Rebbec, Architect of Ascension should make the artifact illegal to target from a source whose mana value is among artifacts its controller controls"
+        );
+
+        let result = can_target_object(&game, protected_id, nonmatching_source_id, alice);
+        assert!(
+            result.is_legal(),
+            "Rebbec, Architect of Ascension should not count artifacts controlled by another player for the protected artifact's mana-value set"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rebbec, Architect of Ascension
Initial parse error:
```
parser does not yet support line family: 'Artifacts you control have protection from each mana value among artifacts you control.'; oracle-only fallback also failed: parser does not yet support line family: 'Artifacts you control have protection from each mana value among artifacts you control.'
```

Current worker: i-0d1a7b9420ad7ebe8
Branch: codex/aws-card-fix-rebbec-architect-of-ascension
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0001
