### PR TITLE
Fix Ironsmith parse failure: Rise from the Grave

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2478,6 +2478,17 @@ fn compile_subject_verb_effect(
                 duration.clone(),
             ))
         }),
+        SubjectVerbActionAst::AddColors {
+            target,
+            colors,
+            duration,
+        } => compile_tagged_effect_for_target(target, ctx, "colored", |spec| {
+            Effect::new(crate::effects::ApplyContinuousEffect::with_spec(
+                spec,
+                crate::continuous::Modification::AddColors(*colors),
+                duration.clone(),
+            ))
+        }),
         SubjectVerbActionAst::AddAllSubtypesOfFamily {
             target,
             family,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -150,6 +150,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::AddCardTypes { target, .. }
             | SubjectVerbActionAst::RemoveCardTypes { target, .. }
             | SubjectVerbActionAst::AddSubtypes { target, .. }
+            | SubjectVerbActionAst::AddColors { target, .. }
             | SubjectVerbActionAst::AddAllSubtypesOfFamily { target, .. }
             | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { target, .. }
             | SubjectVerbActionAst::BecomeBasicLandType { target, .. }
@@ -698,6 +699,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::AddCardTypes { .. }
         | SubjectVerbActionAst::RemoveCardTypes { .. }
         | SubjectVerbActionAst::AddSubtypes { .. }
+        | SubjectVerbActionAst::AddColors { .. }
         | SubjectVerbActionAst::AddAllSubtypesOfFamily { .. }
         | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { .. }
         | SubjectVerbActionAst::BecomeAuraEnchantment { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1137,6 +1137,11 @@ pub(crate) enum SubjectVerbActionAst {
         subtypes: Vec<Subtype>,
         duration: Until,
     },
+    AddColors {
+        target: TargetAst,
+        colors: ColorSet,
+        duration: Until,
+    },
     AddAllSubtypesOfFamily {
         target: TargetAst,
         family: SubtypeFamily,
@@ -2406,6 +2411,16 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("AddSubtypes")
                 .field("target", target)
                 .field("subtypes", subtypes)
+                .field("duration", duration)
+                .finish(),
+            Self::AddColors {
+                target,
+                colors,
+                duration,
+            } => f
+                .debug_struct("AddColors")
+                .field("target", target)
+                .field("colors", colors)
                 .field("duration", duration)
                 .finish(),
             Self::AddAllSubtypesOfFamily {
@@ -3962,6 +3977,22 @@ impl EffectAst {
             SubjectVerbActionAst::AddSubtypes {
                 target,
                 subtypes,
+                duration,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_add_colors(
+        target: TargetAst,
+        colors: ColorSet,
+        duration: Until,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::AddColors {
+                target,
+                colors,
                 duration,
             },
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -471,6 +471,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::AddCardTypes { .. }
             | SubjectVerbActionAst::RemoveCardTypes { .. }
             | SubjectVerbActionAst::AddSubtypes { .. }
+            | SubjectVerbActionAst::AddColors { .. }
             | SubjectVerbActionAst::AddAllSubtypesOfFamily { .. }
             | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { .. }
             | SubjectVerbActionAst::BecomeAuraEnchantment { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -826,6 +826,9 @@ fn advance_reference_frame_for_effect(
                 | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "subtyped")?;
                 }
+                SubjectVerbActionAst::AddColors { target, .. } => {
+                    maybe_tag_target(target, frame, id_gen, "colored")?;
+                }
                 SubjectVerbActionAst::SetColors { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "set_colors")?;
                 }
@@ -1772,6 +1775,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::AddCardTypes { .. }
             | SubjectVerbActionAst::RemoveCardTypes { .. }
             | SubjectVerbActionAst::AddSubtypes { .. }
+            | SubjectVerbActionAst::AddColors { .. }
             | SubjectVerbActionAst::AddAllSubtypesOfFamily { .. }
             | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { .. }
             | SubjectVerbActionAst::BecomeAuraEnchantment { .. }
@@ -2613,6 +2617,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             SubjectVerbActionAst::AddCardTypes { target, .. }
             | SubjectVerbActionAst::RemoveCardTypes { target, .. }
             | SubjectVerbActionAst::AddSubtypes { target, .. }
+            | SubjectVerbActionAst::AddColors { target, .. }
             | SubjectVerbActionAst::AddAllSubtypesOfFamily { target, .. }
             | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { target, .. }
             | SubjectVerbActionAst::BecomeAuraEnchantment { target, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -1236,6 +1236,7 @@ fn effect_duration_for_gain_followup_carry(effect: &EffectAst) -> Option<Until> 
                 | SubjectVerbActionAst::AddCardTypes { duration, .. }
                 | SubjectVerbActionAst::RemoveCardTypes { duration, .. }
                 | SubjectVerbActionAst::AddSubtypes { duration, .. }
+                | SubjectVerbActionAst::AddColors { duration, .. }
                 | SubjectVerbActionAst::AddAllSubtypesOfFamily { duration, .. }
                 | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { duration, .. }
                 | SubjectVerbActionAst::SetColors { duration, .. }
@@ -1299,6 +1300,10 @@ fn apply_carried_effect_duration(effect: &mut EffectAst, duration: &Until) {
                     ..
                 }
                 | SubjectVerbActionAst::AddSubtypes {
+                    duration: effect_duration,
+                    ..
+                }
+                | SubjectVerbActionAst::AddColors {
                     duration: effect_duration,
                     ..
                 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2483,6 +2483,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::AddCardTypes { .. }
             | SubjectVerbActionAst::RemoveCardTypes { .. }
             | SubjectVerbActionAst::AddSubtypes { .. }
+            | SubjectVerbActionAst::AddColors { .. }
             | SubjectVerbActionAst::AddAllSubtypesOfFamily { .. }
             | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { .. }
             | SubjectVerbActionAst::BecomeAuraEnchantment { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
@@ -373,6 +373,113 @@ fn parse_exile_replacement_subject_verb_sentence(
     Ok(Some(vec![effect]))
 }
 
+fn passive_addition_tail_len(words: &[&str]) -> Option<(usize, bool)> {
+    for (tail, adds_colors) in [
+        (&["in", "addition", "to", "its", "other", "colors", "and", "types"][..], true),
+        (&["in", "addition", "to", "their", "other", "colors", "and", "types"][..], true),
+        (&["in", "addition", "to", "its", "other", "colors", "and", "creature", "types"][..], true),
+        (&["in", "addition", "to", "their", "other", "colors", "and", "creature", "types"][..], true),
+        (&["in", "addition", "to", "its", "other", "types"][..], false),
+        (&["in", "addition", "to", "their", "other", "types"][..], false),
+        (&["in", "addition", "to", "its", "other", "creature", "types"][..], false),
+        (&["in", "addition", "to", "their", "other", "creature", "types"][..], false),
+    ] {
+        if slice_ends_with(words, tail) {
+            return Some((tail.len(), adds_colors));
+        }
+    }
+    None
+}
+
+fn parse_passive_color_type_addition_sentence(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let word_view = TokenWordView::new(tokens);
+    let words = word_view.to_word_refs();
+    let Some((tail_len, adds_colors)) = passive_addition_tail_len(&words) else {
+        return Ok(None);
+    };
+    let Some(is_word_idx) = words.iter().position(|word| matches!(*word, "is" | "are")) else {
+        return Ok(None);
+    };
+    if is_word_idx + 1 >= words.len().saturating_sub(tail_len) {
+        return Ok(None);
+    }
+
+    let subject_tokens = &tokens[..token_index_for_word_index(tokens, is_word_idx).unwrap_or(0)];
+    let descriptor_start = token_index_for_word_index(tokens, is_word_idx + 1).unwrap_or(tokens.len());
+    let descriptor_end_word_idx = words.len().saturating_sub(tail_len);
+    let descriptor_end = token_index_for_word_index(tokens, descriptor_end_word_idx).unwrap_or(tokens.len());
+    let descriptor_tokens = &tokens[descriptor_start..descriptor_end];
+    let subject_words = TokenWordView::new(subject_tokens).to_word_refs();
+
+    let target = if matches!(
+        subject_words.as_slice(),
+        ["it"]
+            | ["that", "card"]
+            | ["that", "creature"]
+            | ["that", "permanent"]
+            | ["those", "cards"]
+            | ["each", "of", "them"]
+    ) {
+        TargetAst::Tagged(TagKey::from(IT_TAG), Some(TextSpan::synthetic()))
+    } else {
+        parse_target_phrase(subject_tokens)?
+    };
+
+    let mut colors = crate::color::ColorSet::new();
+    let mut card_types = Vec::new();
+    let mut subtypes = Vec::<Subtype>::new();
+    for word in TokenWordView::new(descriptor_tokens).to_word_refs() {
+        if matches!(word, "a" | "an" | "and") {
+            continue;
+        }
+        if let Some(color) = parse_color(word) {
+            colors = colors.union(color);
+            continue;
+        }
+        if let Some(card_type) = parse_card_type(word) {
+            if !card_types.contains(&card_type) {
+                card_types.push(card_type);
+            }
+            continue;
+        }
+        if let Some(subtype) = super::parse_subtype_word(word) {
+            if !subtypes.contains(&subtype) {
+                subtypes.push(subtype);
+            }
+            continue;
+        }
+        return Ok(None);
+    }
+
+    let mut effects = Vec::new();
+    if !colors.is_empty() {
+        let color_effect = if adds_colors {
+            EffectAst::subject_verb_add_colors(target.clone(), colors, Until::Forever)
+        } else {
+            EffectAst::subject_verb_set_colors(target.clone(), colors, Until::Forever)
+        };
+        effects.push(color_effect);
+    }
+    if !card_types.is_empty() {
+        effects.push(EffectAst::subject_verb_add_card_types(
+            target.clone(),
+            card_types,
+            Until::Forever,
+        ));
+    }
+    if !subtypes.is_empty() {
+        effects.push(EffectAst::subject_verb_add_subtypes(
+            target,
+            subtypes,
+            Until::Forever,
+        ));
+    }
+
+    Ok((!effects.is_empty()).then_some(effects))
+}
+
 pub(crate) fn parse_subject_verb_extension_sentence(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
@@ -420,6 +527,10 @@ pub(crate) fn parse_subject_verb_extension_sentence(
     one!(
         "verb=Exile subject=implicit recognizer=instead-replacement",
         parse_zone_replacement_subject_verb(tokens)
+    );
+    many!(
+        "verb=Is subject=explicit recognizer=passive-color-type-addition",
+        parse_passive_color_type_addition_sentence(tokens)
     );
     many!(
         "verb=When subject=implicit recognizer=delayed-trigger-this-turn",

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/mod.rs
@@ -27,8 +27,9 @@ use super::super::token_primitives::{
     slice_starts_with,
 };
 use super::super::util::{
-    is_article, is_source_reference_words, parse_card_type, parse_filter_counter_constraint_words,
-    parse_subject, parse_target_phrase, parse_value, token_index_for_word_index, words,
+    is_article, is_source_reference_words, parse_card_type, parse_color,
+    parse_filter_counter_constraint_words, parse_subject, parse_target_phrase, parse_value,
+    token_index_for_word_index, words,
 };
 use super::sentence_helpers::*;
 use super::zone_handlers::collapse_leading_signed_pt_modifier_tokens;
@@ -47,7 +48,7 @@ use crate::object::CounterType;
 use crate::target::{
     ChooseSpec, ObjectFilter, PlayerFilter, TaggedObjectConstraint, TaggedOpbjectRelation,
 };
-use crate::types::CardType;
+use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
 use ironsmith_core::ValueSurfaceHint;
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -869,6 +869,7 @@ fn parse_effect_sentence_with_where_x_lexed(
             | SubjectVerbActionAst::AddCardTypes { target, .. }
             | SubjectVerbActionAst::RemoveCardTypes { target, .. }
             | SubjectVerbActionAst::AddSubtypes { target, .. }
+            | SubjectVerbActionAst::AddColors { target, .. }
             | SubjectVerbActionAst::AddAllSubtypesOfFamily { target, .. }
             | SubjectVerbActionAst::RemoveAllSubtypesOfFamily { target, .. }
             | SubjectVerbActionAst::BecomeBasicLandType { target, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -1848,6 +1848,10 @@ fn apply_gain_clause_duration_to_leading_effect(effect: &mut EffectAst, duration
                     duration: effect_duration,
                     ..
                 }
+                | SubjectVerbActionAst::AddColors {
+                    duration: effect_duration,
+                    ..
+                }
                 | SubjectVerbActionAst::AddAllSubtypesOfFamily {
                     duration: effect_duration,
                     ..

--- a/crates/ironsmith-core/src/continuous_model.rs
+++ b/crates/ironsmith-core/src/continuous_model.rs
@@ -31,6 +31,7 @@ pub enum CompiledContinuousModification<StaticAbility, Ability> {
     AddSubtypes(Vec<Subtype>),
     AddAllSubtypesOfFamily(SubtypeFamily),
     RemoveAllSubtypesOfFamily(SubtypeFamily),
+    AddColors(ColorSet),
     SetColors(ColorSet),
     SetPowerToughness {
         power: Value,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39472,6 +39472,44 @@ fn parse_portal_to_phyrexia_subtype_followup_sentence() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_rise_from_the_grave_color_and_subtype_followup_sentence() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Rise from the Grave")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
+        )
+        .expect("Rise from the Grave should parse strictly");
+
+    let spell_effect = def.spell_effect.as_ref().expect("expected spell effect");
+    let effects = &spell_effect.segments[0].default_effects;
+    let debug = format!("{spell_effect:#?}");
+    assert!(
+        debug.contains("MoveToZoneEffect")
+            && debug.contains("AddColors")
+            && debug.contains("AddSubtypes")
+            && debug.contains("Zombie"),
+        "expected return, add-black, and add-Zombie effects, got {debug}"
+    );
+
+    let score_path = crate::compiled_text::compile_effect_list(effects);
+    assert_eq!(
+        score_path,
+        "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black zombie in addition to its other colors and types"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("that creature is a black zombie in addition to its other colors and types"),
+        "expected combined color/type followup rendering, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_ghost_vacuum_base_pt_and_subtype_followup_sentence() {
     CardDefinitionBuilder::new(CardId::new(), "Ghost Vacuum Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39486,13 +39486,60 @@ fn parse_rise_from_the_grave_color_and_subtype_followup_sentence() {
 
     let spell_effect = def.spell_effect.as_ref().expect("expected spell effect");
     let effects = &spell_effect.segments[0].default_effects;
-    let debug = format!("{spell_effect:#?}");
-    assert!(
-        debug.contains("MoveToZoneEffect")
-            && debug.contains("AddColors")
-            && debug.contains("AddSubtypes")
-            && debug.contains("Zombie"),
-        "expected return, add-black, and add-Zombie effects, got {debug}"
+    assert_eq!(effects.len(), 3, "expected return, color, and subtype effects");
+
+    let moved = effects[0]
+        .downcast_ref::<TaggedEffect>()
+        .expect("returned creature should be tagged");
+    let move_to_battlefield = moved
+        .effect
+        .downcast_ref::<MoveToZoneEffect>()
+        .expect("first effect should return a creature card");
+    assert_eq!(move_to_battlefield.zone, Zone::Battlefield);
+    match move_to_battlefield.target.base() {
+        ChooseSpec::Object(filter) => {
+            assert_eq!(filter.zone, Some(Zone::Graveyard));
+            assert!(filter.card_types.contains(&CardType::Creature));
+        }
+        other => panic!("Rise should target a creature card in a graveyard, got {other:?}"),
+    }
+
+    let color_effect = effects[1]
+        .downcast_ref::<TaggedEffect>()
+        .and_then(|tagged| {
+            tagged
+                .effect
+                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+        })
+        .expect("second effect should add black to the returned creature");
+    assert!(matches!(
+        color_effect.target_spec.as_ref(),
+        Some(ChooseSpec::Tagged(tag)) if tag == &moved.tag
+    ));
+    assert_eq!(
+        color_effect.modification,
+        Some(crate::continuous::Modification::AddColors(
+            crate::color::ColorSet::BLACK,
+        ))
+    );
+
+    let subtype_effect = effects[2]
+        .downcast_ref::<TaggedEffect>()
+        .and_then(|tagged| {
+            tagged
+                .effect
+                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+        })
+        .expect("third effect should add Zombie to the returned creature");
+    assert!(matches!(
+        subtype_effect.target_spec.as_ref(),
+        Some(ChooseSpec::Tagged(tag)) if tag == &moved.tag
+    ));
+    assert_eq!(
+        subtype_effect.modification,
+        Some(crate::continuous::Modification::AddSubtypes(vec![
+            Subtype::Zombie,
+        ]))
     );
 
     let score_path = crate::compiled_text::compile_effect_list(effects);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8284,6 +8284,18 @@ pub(super) fn describe_apply_continuous_clauses(
                 describe_token_color_words(*colors, false)
             ));
         }
+        crate::continuous::Modification::AddColors(colors) => {
+            let verb = if plural_target { "become" } else { "becomes" };
+            let other_colors = if plural_target {
+                "their other colors"
+            } else {
+                "its other colors"
+            };
+            clauses.push(format!(
+                "{verb} {} in addition to {other_colors}",
+                describe_token_color_words(*colors, false)
+            ));
+        }
         crate::continuous::Modification::AddCardTypes(card_types) => {
             let mut words: Vec<String> = card_types
                 .iter()
@@ -9056,6 +9068,60 @@ fn describe_attack_block_if_able_apply_continuous(
     }
 }
 
+fn describe_color_subtype_addition_pair(
+    first: &crate::effects::ApplyContinuousEffect,
+    second: &crate::effects::ApplyContinuousEffect,
+    target: &str,
+    plural_target: bool,
+) -> Option<String> {
+    if !first.additional_modifications.is_empty()
+        || !second.additional_modifications.is_empty()
+        || !first.runtime_modifications.is_empty()
+        || !second.runtime_modifications.is_empty()
+    {
+        return None;
+    }
+
+    let (colors, subtypes) = match (&first.modification, &second.modification) {
+        (
+            Some(crate::continuous::Modification::AddColors(colors)),
+            Some(crate::continuous::Modification::AddSubtypes(subtypes)),
+        ) => (*colors, subtypes),
+        (
+            Some(crate::continuous::Modification::AddSubtypes(subtypes)),
+            Some(crate::continuous::Modification::AddColors(colors)),
+        ) => (*colors, subtypes),
+        _ => return None,
+    };
+    if colors.is_empty() || subtypes.is_empty() {
+        return None;
+    }
+
+    let subtype_words = subtypes
+        .iter()
+        .map(|subtype| subtype.to_string().to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let descriptor = format!("{} {subtype_words}", describe_token_color_words(colors, false));
+    let descriptor = if plural_target {
+        pluralize_noun_phrase(&descriptor)
+    } else {
+        with_indefinite_article(&descriptor)
+    };
+    let verb = if plural_target { "become" } else { "becomes" };
+    let other = if plural_target {
+        "their other colors and types"
+    } else {
+        "its other colors and types"
+    };
+    let mut text = format!("{target} {verb} {descriptor} in addition to {other}");
+    if let Some(tail) = describe_apply_continuous_tail(first) {
+        text.push(' ');
+        text.push_str(&tail);
+    }
+    Some(text)
+}
+
 pub(super) fn describe_compact_apply_continuous_pair(
     first: &crate::effects::ApplyContinuousEffect,
     second: &crate::effects::ApplyContinuousEffect,
@@ -9071,6 +9137,9 @@ pub(super) fn describe_compact_apply_continuous_pair(
     }
 
     let (target, plural_target) = describe_apply_continuous_target(first);
+    if let Some(text) = describe_color_subtype_addition_pair(first, second, &target, plural_target) {
+        return Some(text);
+    }
     let mut clauses = describe_apply_continuous_clauses(first, plural_target);
     clauses.extend(describe_apply_continuous_clauses(second, plural_target));
     if clauses.is_empty() {
@@ -9127,6 +9196,9 @@ pub(super) fn describe_compact_tagged_apply_continuous_pair(
     }
 
     let (target, plural_target) = describe_apply_continuous_target(first);
+    if let Some(text) = describe_color_subtype_addition_pair(first, second, &target, plural_target) {
+        return Some(text);
+    }
     if tagged_apply_pair_preserves_animated_land(first, second)
         && (first.until == second.until || matches!(second.until, Until::Forever))
         && (first.condition == second.condition || second.condition.is_none())

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2749,6 +2749,97 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         effect
     }
 
+    fn effect_tag(effect: &Effect) -> Option<&crate::TagKey> {
+        if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+            return Some(&tagged.tag);
+        }
+        if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+            return Some(&tag_all.tag);
+        }
+        None
+    }
+
+    fn tagged_apply_continuous(effect: &Effect) -> Option<&crate::effects::ApplyContinuousEffect> {
+        unwrap_wrapped_effect(effect).downcast_ref::<crate::effects::ApplyContinuousEffect>()
+    }
+
+    fn apply_targets_tag(
+        apply: &crate::effects::ApplyContinuousEffect,
+        tag: &crate::TagKey,
+    ) -> bool {
+        matches!(apply.target_spec.as_ref(), Some(ChooseSpec::Tagged(candidate)) if candidate == tag)
+    }
+
+    fn describe_move_then_color_subtype_addition(effects: &[&Effect]) -> Option<String> {
+        let [move_effect, color_effect, subtype_effect] = effects else {
+            return None;
+        };
+        let moved_tag = effect_tag(move_effect)?;
+        let move_to_zone = unwrap_wrapped_effect(move_effect)
+            .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+        if move_to_zone.zone != Zone::Battlefield {
+            return None;
+        }
+
+        let first_apply = tagged_apply_continuous(color_effect)?;
+        let second_apply = tagged_apply_continuous(subtype_effect)?;
+        if first_apply.until != second_apply.until
+            || first_apply.condition != second_apply.condition
+            || !apply_targets_tag(first_apply, moved_tag)
+            || !apply_targets_tag(second_apply, moved_tag)
+            || !first_apply.additional_modifications.is_empty()
+            || !second_apply.additional_modifications.is_empty()
+            || !first_apply.runtime_modifications.is_empty()
+            || !second_apply.runtime_modifications.is_empty()
+        {
+            return None;
+        }
+
+        let (colors, subtypes) = match (&first_apply.modification, &second_apply.modification) {
+            (
+                Some(crate::continuous::Modification::AddColors(colors)),
+                Some(crate::continuous::Modification::AddSubtypes(subtypes)),
+            ) => (*colors, subtypes),
+            (
+                Some(crate::continuous::Modification::AddSubtypes(subtypes)),
+                Some(crate::continuous::Modification::AddColors(colors)),
+            ) => (*colors, subtypes),
+            _ => return None,
+        };
+        if colors.is_empty() || subtypes.is_empty() {
+            return None;
+        }
+
+        let mut move_text = describe_effect(move_effect).replace(" in a graveyard", " from a graveyard");
+        move_text = move_text.replace(" in your graveyard", " from your graveyard");
+        move_text = move_text.replace(" in an opponent's graveyard", " from an opponent's graveyard");
+        let lower_move = move_text.to_ascii_lowercase();
+        let followup_subject = if lower_move.contains("creature card") {
+            "That creature"
+        } else if lower_move.contains("permanent card") {
+            "That permanent"
+        } else {
+            "That card"
+        };
+        let subtype_words = subtypes
+            .iter()
+            .map(|subtype| subtype.to_string().to_ascii_lowercase())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let descriptor = with_indefinite_article(&format!(
+            "{} {subtype_words}",
+            describe_token_color_words(colors, false)
+        ));
+        let mut followup = format!(
+            "{followup_subject} is {descriptor} in addition to its other colors and types"
+        );
+        if !matches!(first_apply.until, Until::Forever) {
+            followup.push(' ');
+            followup.push_str(&describe_until(&first_apply.until));
+        }
+        Some(format!("{move_text}. {followup}"))
+    }
+
     fn describe_consult_reveal_put_battlefield_then_bottom(effects: &[&Effect]) -> Option<String> {
         let [consult_effect, move_effect, bottom_effect] = effects else {
             return None;
@@ -2840,6 +2931,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     if let Some(compact) = describe_consult_reveal_put_battlefield_then_bottom(&raw_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_move_then_color_subtype_addition(&raw_effects) {
         return compact;
     }
 
@@ -4552,7 +4646,6 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             return Some(apply);
         }
         if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>()
-            && is_implicit_reference_tag(tagged.tag.as_str())
             && let Some(apply) = tagged
                 .effect
                 .downcast_ref::<crate::effects::ApplyContinuousEffect>()
@@ -12282,6 +12375,18 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
         return Some(cleanup_decompiled_text(&lowercase_first(
             compact_trimmed.trim_end_matches('.'),
         )));
+    }
+    if !compact_trimmed.is_empty()
+        && compact_trimmed.contains(". That ")
+        && compact_trimmed.contains(" in addition to its other colors and types")
+        && !compact_trimmed.starts_with("If ")
+        && !compact_trimmed.starts_with("When ")
+        && !compact_trimmed.starts_with("Whenever ")
+        && !compact_trimmed.starts_with("At ")
+    {
+        return Some(cleanup_decompiled_text(
+            compact_trimmed.trim_end_matches('.'),
+        ));
     }
     if !compact_trimmed.is_empty()
         && compact_trimmed.contains(" until ")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4646,6 +4646,7 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             return Some(apply);
         }
         if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>()
+            && is_implicit_reference_tag(tagged.tag.as_str())
             && let Some(apply) = tagged
                 .effect
                 .downcast_ref::<crate::effects::ApplyContinuousEffect>()

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -469,6 +469,9 @@ impl Modification {
             ironsmith_core::CompiledContinuousModification::RemoveAllSubtypesOfFamily(family) => {
                 Self::RemoveAllSubtypesOfFamily(family)
             }
+            ironsmith_core::CompiledContinuousModification::AddColors(colors) => {
+                Self::AddColors(colors)
+            }
             ironsmith_core::CompiledContinuousModification::SetColors(colors) => {
                 Self::SetColors(colors)
             }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -84,6 +84,20 @@ fn merfolk_cave_diver_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn rise_from_the_grave_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_940), "Rise from the Grave")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Put target creature card from a graveyard onto the battlefield under your control. That creature is a black Zombie in addition to its other colors and types.",
+        )
+        .expect("Rise from the Grave should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn explore_event_for(game: &GameState, controller: PlayerId, source: ObjectId) -> TriggerEvent {
     let snapshot = game
         .object(source)
@@ -447,6 +461,94 @@ fn open_the_way_reveals_x_lands_to_battlefield_tapped_and_bottoms_rest() {
     assert!(
         game.player(alice).unwrap().graveyard.contains(&resolved_spell_id),
         "Open the Way should move to its owner's graveyard after resolving"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rise_from_the_grave_returns_creature_under_your_control_black_zombie() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let spell = rise_from_the_grave_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    let target_card = CardBuilder::new(CardId::from_raw(72_941), "Emerald Bear")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .color_indicator(crate::color::ColorSet::GREEN)
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_card(&target_card, bob, Zone::Graveyard);
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
+
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_targets(vec![Target::Object(target_id)]));
+    resolve_stack_entry(&mut game).expect("Rise from the Grave should resolve");
+
+    let returned_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("returned creature should still exist");
+    assert!(
+        game.battlefield.contains(&returned_id),
+        "target creature card should move from graveyard to battlefield"
+    );
+    assert_eq!(
+        game.controller_of(game.object(returned_id).expect("returned object exists")),
+        alice,
+        "returned creature should be under the spell controller's control"
+    );
+    assert_eq!(
+        game.current_colors(returned_id),
+        Some(crate::color::ColorSet::GREEN.union(crate::color::ColorSet::BLACK)),
+        "returned creature should keep green and add black"
+    );
+    let subtypes = game.calculated_subtypes(returned_id);
+    assert!(
+        subtypes.contains(&Subtype::Bear) && subtypes.contains(&Subtype::Zombie),
+        "returned creature should keep Bear and add Zombie, got {subtypes:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rise_from_the_grave_targets_only_creature_cards_in_graveyards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell = rise_from_the_grave_definition();
+    let effects = spell.spell_effect.as_ref().expect("expected spell effects");
+
+    let graveyard_creature = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(72_942), "Graveyard Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Graveyard,
+    );
+    let graveyard_artifact = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(72_943), "Graveyard Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Graveyard,
+    );
+    let battlefield_creature = create_creature(&mut game, "Battlefield Creature", bob, 2, 2);
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(requirements.len(), 1, "Rise should have one target requirement");
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(graveyard_creature)),
+        "creature cards in graveyards should be legal targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(graveyard_artifact)),
+        "noncreature cards in graveyards should not be legal targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(battlefield_creature)),
+        "battlefield creatures should not be legal targets, got {legal_targets:?}"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rise from the Grave
Initial parse error:
```
could not find verb in effect clause (clause: 'that creature is a black zombie in addition to its other colors and types'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'that creature is a black zombie in addition to its other colors and types'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0bbfd1774ef915616
Branch: codex/aws-card-fix-rise-from-the-grave
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0001
