### PR TITLE
Fix Ironsmith parse failure: The Aesir Escape Valhalla

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -228,7 +228,7 @@ fn compile_subject_verb_effect(
             true,
             true,
             true,
-            false,
+            true,
             Effect::gain_life,
             |value, filter| Effect::gain_life_player(value, ChooseSpec::Player(filter)),
         ),

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -470,7 +470,23 @@ fn advance_reference_frame_for_effect(
                     track_player_from_object_filter(filter, frame);
                 }
                 SubjectVerbActionAst::Exile { target, .. } => {
-                    maybe_tag_target(target, frame, id_gen, "exiled")?;
+                    let refs = lowering_reference_frame(frame);
+                    let (spec, _) = resolve_target_spec_with_choices(target, &refs)?;
+                    if matches!(spec.base(), ChooseSpec::Source) {
+                        frame.source_object_antecedent = true;
+                    }
+                    if frame.auto_tag_object_targets {
+                        if spec.is_target() {
+                            if let Some(tag) =
+                                propagated_or_generated_object_tag(&spec, id_gen, "exiled")
+                            {
+                                frame.last_object_tag = Some(tag);
+                            }
+                        } else if choose_spec_targets_object(&spec) {
+                            frame.last_object_tag = Some(crate::tag::SOURCE_EXILED_TAG.to_string());
+                        }
+                    }
+                    track_target_player(target, frame);
                 }
                 SubjectVerbActionAst::ExileAll { filter, .. } => {
                     let keep_last_object_tag =

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
@@ -281,6 +281,52 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
     }
 
     let target_words = crate::runtime_backend::token_word_refs(target_tokens);
+    if is_hand
+        && let Some(and_idx) = find_index(target_tokens, |token| token.is_word("and"))
+        && and_idx > 0
+    {
+        let left_tokens = trim_commas(&target_tokens[..and_idx]);
+        let right_tokens = trim_commas(&target_tokens[and_idx + 1..]);
+        let left_words = crate::runtime_backend::token_word_refs(&left_tokens);
+        let right_words = crate::runtime_backend::token_word_refs(&right_tokens);
+
+        let source_filter_for_words = |words: &[&str]| -> Option<ObjectFilter> {
+            if words.first().copied() != Some("this") {
+                return None;
+            }
+            let mut filter = ObjectFilter::source();
+            if let Some(subtype_word) = words.get(1).copied()
+                && let Some(subtype) = parse_subtype_word(subtype_word)
+            {
+                filter.subtypes.push(subtype);
+            }
+            Some(filter)
+        };
+        let exiled_filter_for_words = |words: &[&str]| -> Option<ObjectFilter> {
+            matches!(
+                words,
+                ["the", "exiled", "card"]
+                    | ["the", "exiled", "cards"]
+                    | ["exiled", "card"]
+                    | ["exiled", "cards"]
+            )
+            .then(|| ObjectFilter::tagged(crate::tag::SOURCE_EXILED_TAG).in_zone(Zone::Exile))
+        };
+
+        let paired_filters = source_filter_for_words(&left_words)
+            .zip(exiled_filter_for_words(&right_words))
+            .or_else(|| {
+                source_filter_for_words(&right_words).zip(exiled_filter_for_words(&left_words))
+            });
+        if let Some((source_filter, exiled_filter)) = paired_filters {
+            let mut filter = ObjectFilter::default();
+            filter.any_of = vec![source_filter, exiled_filter];
+            return Ok(wrap_return_with_delayed_timing(
+                EffectAst::subject_verb_return_all_to_hand(filter),
+                delayed_timing,
+            ));
+        }
+    }
     if let Some(and_idx) = find_index(target_tokens, |token| token.is_word("and"))
         && and_idx > 0
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -295,6 +295,21 @@ fn parse_put_counter_count_value(
             && tokens
                 .get(equal_idx + 1)
                 .is_some_and(|token| token.is_word("to"))
+        {
+            let value_tokens = trim_commas(&tokens[equal_idx + 2..]);
+            if let Some((value, used)) = parse_value(&value_tokens)
+                && used == value_tokens.len()
+            {
+                return Ok((value, 3));
+            }
+            if let Some(value) = parse_named_source_power_value(&value_tokens) {
+                return Ok((value, 3));
+            }
+        }
+        if let Some(equal_idx) = find_token_index(tokens, |token| token.is_word("equal"))
+            && tokens
+                .get(equal_idx + 1)
+                .is_some_and(|token| token.is_word("to"))
             && let Some(on_idx) =
                 find_token_index(&tokens[equal_idx + 2..], |token| token.is_word("on"))
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2841,6 +2841,7 @@ fn the_aesir_escape_valhalla_lowers_source_exiled_counter_and_return_pair() {
     let debug = format!("{def:#?}");
     assert!(debug.contains("ManaValueOf"), "{debug}");
     assert!(debug.contains("__source_exiled__"), "{debug}");
+    assert!(!debug.contains("__it__"), "{debug}");
     assert!(debug.contains("PutCountersEffect"), "{debug}");
     assert!(debug.contains("ReturnToHandEffect"), "{debug}");
     assert!(debug.contains("source: true"), "{debug}");

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2805,6 +2805,49 @@ fn rewrite_zone_counter_helpers_parse_equal_to_named_source_power_counter_amount
 }
 
 #[test]
+fn rewrite_zone_counter_helpers_parse_target_before_exiled_card_mana_value_amount() {
+    let tokens = lex_line(
+        "Put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card.",
+        0,
+    )
+    .expect("rewrite lexer should classify source-exiled mana-value counter clause");
+
+    let parsed =
+        parse_effect_sentence_lexed(&tokens).expect("source-exiled mana-value counter clause should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("PutCounters"), "{debug}");
+    assert!(debug.contains("ManaValueOf"), "{debug}");
+    assert!(debug.contains("__source_exiled__"), "{debug}");
+    assert!(debug.contains("controller: Some(You)"), "{debug}");
+}
+
+#[test]
+fn the_aesir_escape_valhalla_lowers_source_exiled_counter_and_return_pair() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "The Aesir Escape Valhalla")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Saga])
+        .mana_cost(crate::mana::ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Green],
+        ]))
+        .parse_text(
+            "I — Exile a permanent card from your graveyard. You gain life equal to its mana value.\n\
+             II — Put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card.\n\
+             III — Return this Saga and the exiled card to their owner's hand.",
+        )
+        .expect("The Aesir Escape Valhalla should parse strictly");
+
+    let debug = format!("{def:#?}");
+    assert!(debug.contains("ManaValueOf"), "{debug}");
+    assert!(debug.contains("__source_exiled__"), "{debug}");
+    assert!(debug.contains("PutCountersEffect"), "{debug}");
+    assert!(debug.contains("ReturnToHandEffect"), "{debug}");
+    assert!(debug.contains("source: true"), "{debug}");
+    assert!(debug.contains("any_of"), "{debug}");
+}
+
+#[test]
 fn rewrite_triggered_it_damage_source_binds_to_triggering_object() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Warstorm Surge Probe")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -242,6 +242,41 @@ fn is_source_exiled_cards_filter(filter: &ObjectFilter) -> bool {
     base == ObjectFilter::default()
 }
 
+fn source_and_source_exiled_return_text(filter: &ObjectFilter) -> Option<String> {
+    if filter.any_of.len() != 2 {
+        return None;
+    }
+
+    let mut source_text = None;
+    let mut has_source_exiled = false;
+    for branch in &filter.any_of {
+        if is_source_exiled_cards_filter(branch) {
+            has_source_exiled = true;
+            continue;
+        }
+
+        if branch.source {
+            let mut base = branch.clone();
+            base.source = false;
+            let is_saga = base.subtypes == [Subtype::Saga];
+            if is_saga {
+                base.subtypes.clear();
+            }
+            if base == ObjectFilter::default() {
+                source_text = Some(if is_saga { "this Saga" } else { "this card" });
+            }
+        }
+    }
+
+    if has_source_exiled {
+        source_text.map(|source_text| {
+            format!("Return {source_text} and the exiled card to their owner's hand")
+        })
+    } else {
+        None
+    }
+}
+
 fn has_vote_winners_tag(filter: &ObjectFilter) -> bool {
     filter.tagged_constraints.iter().any(|constraint| {
         constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
@@ -18837,6 +18872,9 @@ fn describe_dynamic_counter_basis(spec: &ChooseSpec, attribute: &str) -> String 
         return format!("that creature's {attribute}");
     }
     match spec.base() {
+        ChooseSpec::Tagged(tag) if tag.as_str() == crate::tag::SOURCE_EXILED_TAG => {
+            format!("the exiled card's {attribute}")
+        }
         ChooseSpec::Tagged(tag) if tag.as_str() == crate::effects::PUBLIC_REVEALED_TAG => {
             format!("the revealed card's {attribute}")
         }
@@ -26020,7 +26058,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(move_to_zone) = effect.downcast_ref::<crate::effects::MoveToZoneEffect>() {
         let target = describe_choose_spec(&move_to_zone.target);
         return match move_to_zone.zone {
-            Zone::Exile => format!("Exile {target}"),
+            Zone::Exile => {
+                if let Some(owner) = graveyard_owner_from_spec(&move_to_zone.target) {
+                    let target_text = describe_choose_spec_without_graveyard_zone(&move_to_zone.target);
+                    let from_text = match owner {
+                        Some(owner) => format!("{} graveyard", describe_possessive_player_filter(&owner)),
+                        None => "a graveyard".to_string(),
+                    };
+                    format!("Exile {target_text} from {from_text}")
+                } else {
+                    format!("Exile {target}")
+                }
+            }
             Zone::Graveyard => {
                 if let ChooseSpec::Tagged(tag) = move_to_zone.target.base()
                     && crate::cards::is_sentence_helper_tag(tag.as_str(), "exiled")
@@ -26720,6 +26769,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             describe_counter_count_with_where_x(&put_counters.amount, put_counters.counter_type)
         {
             return format!("Put {counter_text} on {target}, where X is {where_x}");
+        }
+        if let Value::ManaValueOf(spec) = &put_counters.amount
+            && matches!(spec.base(), ChooseSpec::Tagged(tag) if tag.as_str() == crate::tag::SOURCE_EXILED_TAG)
+        {
+            return format!(
+                "Put a number of {} counters on {target} equal to the mana value of the exiled card",
+                describe_counter_type(put_counters.counter_type)
+            );
         }
         if let Value::CountersOn(spec, Some(counter_type)) = &put_counters.amount
             && is_graveyard_same_stable_tagged_spec(spec)
@@ -27622,10 +27679,19 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         {
             return "Return target exiled card with flashback you own to your hand".to_string();
         }
-        if let ChooseSpec::All(filter) = &return_to_hand.spec
-            && is_source_exiled_cards_filter(filter)
+        if let ChooseSpec::All(filter) = &return_to_hand.spec {
+            if let Some(text) = source_and_source_exiled_return_text(filter) {
+                return text;
+            }
+            if is_source_exiled_cards_filter(filter)
         {
             return "Return the exiled cards to their owners' hands".to_string();
+        }
+        }
+        if let ChooseSpec::Object(filter) = &return_to_hand.spec
+            && let Some(text) = source_and_source_exiled_return_text(filter)
+        {
+            return text;
         }
         if let Some(owner) = graveyard_owner_from_spec(&return_to_hand.spec) {
             let target_text = describe_choose_spec_without_graveyard_zone(&return_to_hand.spec);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -223,6 +223,14 @@ fn describe_source_exile_with_counters_pair(first: &Effect, second: &Effect) -> 
     ))
 }
 
+fn value_is_source_exiled_mana_value(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::ManaValueOf(spec)
+            if matches!(spec.base(), ChooseSpec::Tagged(tag) if tag.as_str() == crate::tag::SOURCE_EXILED_TAG)
+    )
+}
+
 fn is_source_exiled_cards_filter(filter: &ObjectFilter) -> bool {
     if filter.zone != Some(Zone::Exile)
         || !filter.tagged_constraints.iter().any(|constraint| {
@@ -15149,6 +15157,28 @@ mod tests {
     }
 
     #[test]
+    fn describe_effect_list_compacts_exile_then_gain_life_from_its_mana_value() {
+        let exile = Effect::new(crate::effects::MoveToZoneEffect::new(
+            ChooseSpec::Object(
+                ObjectFilter::permanent()
+                    .in_zone(Zone::Graveyard)
+                    .owned_by(PlayerFilter::You),
+            )
+            .with_count(ChoiceCount::exactly(1)),
+            Zone::Exile,
+            true,
+        ));
+        let gain = Effect::gain_life(Value::ManaValueOf(Box::new(ChooseSpec::Tagged(
+            TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+        ))));
+
+        assert_eq!(
+            describe_effect_list(&[exile, gain]),
+            "Exile a card from your graveyard. you gain life equal to its mana value"
+        );
+    }
+
+    #[test]
     fn describe_effect_list_compacts_targeted_delayed_unblocked_trigger() {
         let tag = TagKey::from("__it__");
         let choose_filter = ObjectFilter::creature()
@@ -27127,6 +27157,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if matches!(gain.amount, Value::CreaturesDiedThisTurn) {
             return format!(
                 "{} {} 1 life for each creature that died this turn",
+                player,
+                player_verb(&player, "gain", "gains")
+            );
+        }
+        if value_is_source_exiled_mana_value(&gain.amount) {
+            return format!(
+                "{} {} life equal to its mana value",
                 player,
                 player_verb(&player, "gain", "gains")
             );

--- a/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
@@ -8,6 +8,8 @@ use crate::events::processing::{EventOutcome, process_zone_change_with_additiona
 use crate::filter::FilterContext;
 use crate::filter::ObjectFilterExt as _;
 use crate::game_state::GameState;
+use crate::snapshot::ObjectSnapshot;
+use crate::tag::SOURCE_EXILED_TAG;
 use crate::target::{ChooseSpec, ObjectFilter};
 use crate::zone::Zone;
 
@@ -193,6 +195,12 @@ impl EffectExecutor for MoveToZoneEffect {
                         for &new_id in &result.new_object_ids {
                             if final_zone == Zone::Exile {
                                 game.add_exiled_with_source_link(ctx.source, new_id);
+                                if let Some(object) = game.object(new_id) {
+                                    ctx.tag_object(
+                                        SOURCE_EXILED_TAG,
+                                        ObjectSnapshot::from_object(object, game),
+                                    );
+                                }
                             }
                             if final_zone == Zone::Library
                                 && !self.to_top

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -32685,6 +32685,70 @@ fn the_aesir_escape_valhalla_chapter_two_requires_a_creature_you_control_target(
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn the_aesir_escape_valhalla_without_exiled_card_adds_no_counters() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    let saga_def = the_aesir_escape_valhalla_definition();
+    let saga_id = game.create_object_from_definition(&saga_def, alice, Zone::Battlefield);
+    let saga_stable_id = game.object(saga_id).expect("saga exists").stable_id;
+
+    let target_creature = CardBuilder::new(CardId::from_raw(992_007), "Small Ally")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let target_id = game.create_object_from_card(&target_creature, alice, Zone::Battlefield);
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter I should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter I should resolve with no graveyard permanent to exile");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        20,
+        "chapter I should not gain life when no card was exiled"
+    );
+    assert!(game.exile.is_empty(), "chapter I should not exile a card");
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter II should go on the stack with a legal target");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter II should resolve without an exiled-card amount");
+
+    assert_eq!(
+        game.counter_count(target_id, CounterType::PlusOnePlusOne),
+        0,
+        "chapter II should add no counters when chapter I did not exile a card"
+    );
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter III should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter III should resolve without an exiled card");
+
+    let returned_saga_id = game
+        .find_object_by_stable_id(saga_stable_id)
+        .expect("saga should still exist after returning");
+    assert_eq!(
+        game.object(returned_saga_id).expect("returned saga exists").zone,
+        Zone::Hand,
+        "chapter III should still return this Saga to its owner's hand"
+    );
+    assert!(
+        game.exile.is_empty(),
+        "chapter III should not leave or create an exiled-card object"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_saga_precombat_main_adds_lore_counter() {
     use crate::cards::definitions::the_birth_of_meletis;
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -32524,6 +32524,113 @@ fn test_read_ahead_enters_with_choice_and_skips_lower_chapters() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn the_aesir_escape_valhalla_chapters_use_exiled_card_mana_value_and_return_pair() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    let saga_def = CardDefinitionBuilder::new(CardId::from_raw(992_001), "The Aesir Escape Valhalla")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Saga])
+        .parse_text(
+            "I — Exile a permanent card from your graveyard. You gain life equal to its mana value.\n\
+             II — Put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card.\n\
+             III — Return this Saga and the exiled card to their owner's hand.",
+        )
+        .expect("The Aesir Escape Valhalla should parse");
+    let saga_id = game.create_object_from_definition(&saga_def, alice, Zone::Battlefield);
+    let saga_stable_id = game.object(saga_id).expect("saga exists").stable_id;
+
+    let exiled_card = CardBuilder::new(CardId::from_raw(992_002), "Valhalla Relic")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let graveyard_id = game.create_object_from_card(&exiled_card, alice, Zone::Graveyard);
+    let exiled_stable_id = game
+        .object(graveyard_id)
+        .expect("graveyard card exists")
+        .stable_id;
+
+    let target_creature = CardBuilder::new(CardId::from_raw(992_003), "Small Ally")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let target_id = game.create_object_from_card(&target_creature, alice, Zone::Battlefield);
+    let opponent_creature = CardBuilder::new(CardId::from_raw(992_004), "Opposing Ally")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let opponent_target_id = game.create_object_from_card(&opponent_creature, bob, Zone::Battlefield);
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter I should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter I should resolve");
+
+    let exiled_id = game
+        .find_object_by_stable_id(exiled_stable_id)
+        .expect("exiled card should still exist");
+    assert_eq!(game.object(exiled_id).expect("exiled card exists").zone, Zone::Exile);
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        24,
+        "chapter I should gain life equal to the exiled card's mana value"
+    );
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter II should go on the stack with a legal controlled target");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter II should resolve");
+
+    assert_eq!(
+        game.counter_count(target_id, CounterType::PlusOnePlusOne),
+        4,
+        "chapter II should use the exiled card's mana value, not the target creature's mana value"
+    );
+    assert_eq!(
+        game.counter_count(opponent_target_id, CounterType::PlusOnePlusOne),
+        0,
+        "chapter II's target restriction should not put counters on an opponent's creature"
+    );
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter III should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter III should resolve");
+
+    let returned_saga_id = game
+        .find_object_by_stable_id(saga_stable_id)
+        .expect("saga should still exist after returning");
+    let returned_exiled_id = game
+        .find_object_by_stable_id(exiled_stable_id)
+        .expect("exiled card should still exist after returning");
+    assert_eq!(
+        game.object(returned_saga_id).expect("returned saga exists").zone,
+        Zone::Hand,
+        "chapter III should return this Saga to its owner's hand"
+    );
+    assert_eq!(
+        game.object(returned_exiled_id)
+            .expect("returned exiled card exists")
+            .zone,
+        Zone::Hand,
+        "chapter III should return the exiled card to its owner's hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_saga_precombat_main_adds_lore_counter() {
     use crate::cards::definitions::the_birth_of_meletis;
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -32523,15 +32523,8 @@ fn test_read_ahead_enters_with_choice_and_skips_lower_chapters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
-#[test]
-fn the_aesir_escape_valhalla_chapters_use_exiled_card_mana_value_and_return_pair() {
-    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
-    let alice = PlayerId::from_index(0);
-    let bob = PlayerId::from_index(1);
-    let mut trigger_queue = TriggerQueue::new();
-    let mut dm = SelectFirstDecisionMaker;
-
-    let saga_def = CardDefinitionBuilder::new(CardId::from_raw(992_001), "The Aesir Escape Valhalla")
+fn the_aesir_escape_valhalla_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(992_001), "The Aesir Escape Valhalla")
         .mana_cost(ManaCost::from_pips(vec![
             vec![ManaSymbol::Generic(2)],
             vec![ManaSymbol::Green],
@@ -32543,7 +32536,19 @@ fn the_aesir_escape_valhalla_chapters_use_exiled_card_mana_value_and_return_pair
              II — Put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card.\n\
              III — Return this Saga and the exiled card to their owner's hand.",
         )
-        .expect("The Aesir Escape Valhalla should parse");
+        .expect("The Aesir Escape Valhalla should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_aesir_escape_valhalla_chapters_use_exiled_card_mana_value_and_return_pair() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    let saga_def = the_aesir_escape_valhalla_definition();
     let saga_id = game.create_object_from_definition(&saga_def, alice, Zone::Battlefield);
     let saga_stable_id = game.object(saga_id).expect("saga exists").stable_id;
 
@@ -32568,7 +32573,8 @@ fn the_aesir_escape_valhalla_chapters_use_exiled_card_mana_value_and_return_pair
         .card_types(vec![CardType::Creature])
         .power_toughness(PowerToughness::fixed(1, 1))
         .build();
-    let opponent_target_id = game.create_object_from_card(&opponent_creature, bob, Zone::Battlefield);
+    let opponent_target_id =
+        game.create_object_from_card(&opponent_creature, bob, Zone::Battlefield);
 
     add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
     put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
@@ -32626,6 +32632,54 @@ fn the_aesir_escape_valhalla_chapters_use_exiled_card_mana_value_and_return_pair
             .zone,
         Zone::Hand,
         "chapter III should return the exiled card to its owner's hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_aesir_escape_valhalla_chapter_two_requires_a_creature_you_control_target() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    let saga_def = the_aesir_escape_valhalla_definition();
+    let saga_id = game.create_object_from_definition(&saga_def, alice, Zone::Battlefield);
+
+    let exiled_card = CardBuilder::new(CardId::from_raw(992_005), "Valhalla Relic")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&exiled_card, alice, Zone::Graveyard);
+
+    let opponent_creature = CardBuilder::new(CardId::from_raw(992_006), "Opposing Ally")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let opponent_target_id =
+        game.create_object_from_card(&opponent_creature, bob, Zone::Battlefield);
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter I should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("chapter I should resolve");
+
+    add_lore_counter_and_check_chapters(&mut game, saga_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("chapter II target selection should complete even with no legal target");
+
+    assert_eq!(
+        game.stack.len(),
+        0,
+        "chapter II should not go on the stack without a target creature you control"
+    );
+    assert_eq!(
+        game.counter_count(opponent_target_id, CounterType::PlusOnePlusOne),
+        0,
+        "chapter II must not target an opponent's creature to satisfy its target requirement"
     );
 }
 

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -992,6 +992,50 @@ fn compile_oracle_text_strictly_compiles_aunt_may_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_the_aesir_escape_valhalla_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("The Aesir Escape Valhalla")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name The Aesir Escape Valhalla --compare-text");
+
+    assert!(
+        output.status.success(),
+        "The Aesir Escape Valhalla should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: The Aesir Escape Valhalla"), "{stdout}");
+    assert!(stdout.contains("Similarity: 1.0000"), "{stdout}");
+    assert!(
+        stdout.contains(
+            "put a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card"
+        ),
+        "expected source-exiled mana-value counter clause in compiled comparison output, got {stdout}"
+    );
+    assert!(
+        stdout.contains("return this Saga and the exiled card to their owner's hand"),
+        "expected source-plus-exiled-card return clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_aloe_alchemist_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The Aesir Escape Valhalla
Initial parse error:
```
missing counter amount (clause: 'a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card'); oracle-only fallback also failed: missing counter amount (clause: 'a number of +1/+1 counters on target creature you control equal to the mana value of the exiled card')
```

Current worker: i-0338a12c56d3da8d1
Branch: codex/aws-card-fix-the-aesir-escape-valhalla
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0001
