### PR TITLE
Fix Ironsmith parse failure: Journey to the Lost City

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -530,10 +530,16 @@ fn tokens_after_non_keyword_label_prefix(line: &PreprocessedLine) -> Option<&[Ow
 }
 
 fn looks_like_numeric_result_prefix_lexed(tokens: &[OwnedLexToken]) -> bool {
-    matches!(
+    if !matches!(
         tokens.first().map(|token| token.kind),
         Some(TokenKind::Number)
-    ) && matches!(
+    ) {
+        return false;
+    }
+    if matches!(tokens.get(1).map(|token| token.kind), Some(TokenKind::Pipe)) {
+        return true;
+    }
+    matches!(
         tokens.get(1).map(|token| token.kind),
         Some(TokenKind::Dash | TokenKind::EmDash)
     ) && matches!(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1195,19 +1195,27 @@ fn split_leading_numeric_result_prefix_lexed<'a>(
     tokens: &'a [OwnedLexToken],
 ) -> Option<(IfResultPredicate, &'a [OwnedLexToken])> {
     let first = tokens.first()?;
-    let second = tokens.get(1)?;
-    let third = tokens.get(2)?;
     let pipe_idx = tokens
         .iter()
         .position(|token| token.kind == TokenKind::Pipe)?;
-    if pipe_idx < 3 {
-        return None;
-    }
-
     let min = match first.kind {
         TokenKind::Number => first.parser_text().parse::<i32>().ok()?,
         _ => return None,
     };
+
+    if pipe_idx == 1 {
+        let trailing_tokens = trim_lexed_commas(&tokens[pipe_idx + 1..]);
+        if trailing_tokens.is_empty() {
+            return None;
+        }
+        return Some((IfResultPredicate::Value(Comparison::Equal(min)), trailing_tokens));
+    }
+
+    let second = tokens.get(1)?;
+    let third = tokens.get(2)?;
+    if pipe_idx < 3 {
+        return None;
+    }
     if !matches!(second.kind, TokenKind::Dash | TokenKind::EmDash) {
         return None;
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -273,7 +273,22 @@ pub(crate) fn resolve_it_tag(
     refs: &ReferenceEnv,
 ) -> Result<ObjectFilter, CardTextError> {
     let mut resolved = resolve_object_filter_player_refs(filter, refs)?;
-    if let Some(tag) = refs.known_last_object_tag()
+    let preserves_source_exiled_permanents = filter.zone == Some(Zone::Exile)
+        && filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+        })
+        && [
+            crate::types::CardType::Artifact,
+            crate::types::CardType::Creature,
+            crate::types::CardType::Enchantment,
+            crate::types::CardType::Land,
+            crate::types::CardType::Planeswalker,
+            crate::types::CardType::Battle,
+        ]
+        .iter()
+        .all(|card_type| filter.card_types.contains(card_type));
+    if !preserves_source_exiled_permanents
+        && let Some(tag) = refs.known_last_object_tag()
         && tag.as_str() != crate::tag::SOURCE_EXILED_TAG
     {
         for constraint in &mut resolved.tagged_constraints {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -66,6 +66,34 @@ fn synthetic_lexed_word(word: &str) -> OwnedLexToken {
     OwnedLexToken::word(word, TextSpan::synthetic())
 }
 
+fn source_exiled_move_followed_by_sacrifice_it(
+    previous: &[OwnedLexToken],
+    current: &[OwnedLexToken],
+) -> bool {
+    let current_words = token_word_refs(current);
+    if current_words.as_slice() != ["sacrifice", "it"] {
+        return false;
+    }
+
+    grammar::words_find_phrase(previous, &["exiled", "with", "this"]).is_some()
+        && grammar::contains_word(previous, "battlefield")
+}
+
+fn rewrite_sacrifice_it_as_source(segment: &[OwnedLexToken]) -> Vec<OwnedLexToken> {
+    let span = segment
+        .first()
+        .map(|token| token.span())
+        .unwrap_or_else(TextSpan::synthetic);
+    vec![
+        segment
+            .first()
+            .cloned()
+            .unwrap_or_else(|| OwnedLexToken::word("sacrifice", span)),
+        OwnedLexToken::word("this", span),
+        OwnedLexToken::word("source", span),
+    ]
+}
+
 fn parse_choose_land_of_each_basic_land_type_segment(
     tokens: &[OwnedLexToken],
 ) -> Option<Vec<EffectAst>> {
@@ -986,6 +1014,11 @@ pub(crate) fn parse_effect_chain_inner_lexed(
             && let Some(expanded) = expand_gain_lose_followup_segment_lexed(previous, &segment)
         {
             segment = expanded;
+        }
+        if let Some(previous) = &previous_segment
+            && source_exiled_move_followed_by_sacrifice_it(previous, &segment)
+        {
+            segment = rewrite_sacrifice_it_as_source(&segment);
         }
 
         let carry_gain_duration = find_verb_lexed(&segment).is_some_and(|(verb, verb_idx)| {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -1044,6 +1044,10 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     && grammar::words_match_any_prefix(after_then, PUT_BACK_PREFIXES).is_some()
                     && grammar::contains_word(after_then, "any")
                     && grammar::contains_word(after_then, "order");
+                let allow_source_exiled_sacrifice_followup = has_back_ref
+                    && after_words.as_slice() == ["sacrifice", "it"]
+                    && grammar::words_find_phrase(before_then, &["exiled", "with", "this"])
+                        .is_some();
                 let allow_clash_followup = starts_with_clash;
                 if has_effect_head && (!has_back_ref || allow_backref_split)
                     || has_effect_head && allow_clash_followup
@@ -1057,6 +1061,7 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     || has_effect_head && allow_put_battlefield_with_counter_followup
                     || has_effect_head && allow_put_into_hand_followup
                     || has_effect_head && allow_put_back_in_any_order_followup
+                    || has_effect_head && allow_source_exiled_sacrifice_followup
                 {
                     split_point = Some(i);
                     break;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -1226,6 +1226,21 @@ pub(crate) fn parse_put_into_hand(
             .is_some_and(|token| token.is_word("all") || token.is_word("each"))
         {
             let mut filter = parse_object_filter(&target_tokens[1..], false)?;
+            if grammar::words_find_phrase(&target_tokens[1..], &["exiled", "with", "this"])
+                .is_some()
+            {
+                filter.zone = Some(Zone::Exile);
+                if grammar::contains_word(&target_tokens[1..], "permanent") {
+                    filter.card_types = vec![
+                        CardType::Artifact,
+                        CardType::Creature,
+                        CardType::Enchantment,
+                        CardType::Land,
+                        CardType::Planeswalker,
+                        CardType::Battle,
+                    ];
+                }
+            }
             if grammar::words_find_phrase(&target_tokens[1..], &["from", "it"]).is_some() {
                 filter.zone = Some(Zone::Hand);
                 if filter.owner.is_none() {
@@ -1259,6 +1274,21 @@ pub(crate) fn parse_put_into_hand(
         }
 
         let mut target = parse_target_phrase(&target_tokens)?;
+        if grammar::words_find_phrase(&target_tokens, &["among", "those", "cards"]).is_some()
+            && let Some(filter) = crate::runtime_backend::sentences::effect_sentences::zone_counter_helpers::target_object_filter_mut(&mut target)
+        {
+            filter.zone = Some(Zone::Exile);
+            if !filter
+                .tagged_constraints
+                .iter()
+                .any(|constraint| constraint.tag.as_str() == IT_TAG)
+            {
+                filter.tagged_constraints.push(crate::target::TaggedObjectConstraint {
+                    tag: TagKey::from(IT_TAG),
+                    relation: crate::target::TaggedOpbjectRelation::IsTaggedObject,
+                });
+            }
+        }
         if let Some(filter) = crate::runtime_backend::sentences::effect_sentences::zone_counter_helpers::target_object_filter_mut(&mut target)
         {
             crate::runtime_backend::sentences::effect_sentences::zone_counter_helpers::apply_exile_subject_owner_context(filter, subject);

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -587,10 +587,12 @@ pub(crate) fn parse_put_counters(tokens: &[OwnedLexToken]) -> Result<EffectAst, 
                         if !filter
                             .tagged_constraints
                             .iter()
-                            .any(|constraint| constraint.tag.as_str() == IT_TAG)
+                            .any(|constraint| {
+                                constraint.tag.as_str() == crate::tag::THOSE_CARDS_TAG
+                            })
                         {
                             filter.tagged_constraints.push(TaggedObjectConstraint {
-                                tag: TagKey::from(IT_TAG),
+                                tag: TagKey::from(crate::tag::THOSE_CARDS_TAG),
                                 relation: TaggedOpbjectRelation::IsTaggedObject,
                             });
                         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -576,7 +576,26 @@ pub(crate) fn parse_put_counters(tokens: &[OwnedLexToken]) -> Result<EffectAst, 
                 } else if tokens_reference_objects_this_way(&count_filter_tokens) {
                     this_way_object_count_value()
                 } else {
-                    Value::Count(parse_object_filter(&count_filter_tokens, false)?)
+                    let mut filter = parse_object_filter(&count_filter_tokens, false)?;
+                    if grammar::words_find_phrase(
+                        &count_filter_tokens,
+                        &["among", "those", "cards"],
+                    )
+                    .is_some()
+                    {
+                        filter.zone = Some(Zone::Exile);
+                        if !filter
+                            .tagged_constraints
+                            .iter()
+                            .any(|constraint| constraint.tag.as_str() == IT_TAG)
+                        {
+                            filter.tagged_constraints.push(TaggedObjectConstraint {
+                                tag: TagKey::from(IT_TAG),
+                                relation: TaggedOpbjectRelation::IsTaggedObject,
+                            });
+                        }
+                    }
+                    Value::Count(filter)
                 };
             if let Value::Fixed(multiplier) = count_value.clone()
                 && multiplier > 1

--- a/crates/ironsmith-compiler/src/tag.rs
+++ b/crates/ironsmith-compiler/src/tag.rs
@@ -1,1 +1,1 @@
-pub use ironsmith_core::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, TagKey};
+pub use ironsmith_core::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, THOSE_CARDS_TAG, TagKey};

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -169,7 +169,7 @@ pub use static_ability_model::{
     StaticAbilityPayload, ThisSpellCastRestrictionKind, ThisSpellCostReduction,
     ThisSpellCostReductionManaCost,
 };
-pub use tag::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, TagKey};
+pub use tag::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, THOSE_CARDS_TAG, TagKey};
 pub use target_model::{ChooseSpec, ChooseSpecSurfaceHint, SourceReferenceSurface};
 pub use trigger_model::{
     CountMode as CompilerTriggerCountMode, CounterPutOnTrigger as CompilerCounterPutOnTrigger,

--- a/crates/ironsmith-core/src/tag.rs
+++ b/crates/ironsmith-core/src/tag.rs
@@ -9,6 +9,9 @@ use std::fmt;
 /// Runtime tag for cards linked as "exiled with this source object".
 pub const SOURCE_EXILED_TAG: &str = "__source_exiled__";
 
+/// Runtime tag for cards referred to by a later "those cards" clause.
+pub const THOSE_CARDS_TAG: &str = "__those_cards__";
+
 /// Runtime tag for the creature sacrificed to an exploit action.
 pub const EXPLOITED_TAG: &str = "exploited";
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2343,7 +2343,202 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects)
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
+        .or_else(|| describe_exile_top_then_roll_table_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_exile_top_then_roll_table_structural(effects: &[Effect]) -> Option<String> {
+    let [exile_effect, roll_effect, branches @ ..] = effects else {
+        return None;
+    };
+    if branches.is_empty() {
+        return None;
+    }
+
+    let exile = exile_effect.downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()?;
+    let exiled_tag = exile.moved_tags.first()?;
+    let roll = roll_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let die = roll
+        .effect
+        .downcast_ref::<crate::effects::RollDieEffect>()?;
+    if die.sides != 20 || die.player != PlayerFilter::You {
+        return None;
+    }
+
+    let mut rendered_branches = Vec::new();
+    for branch in branches {
+        let if_effect = branch
+            .downcast_ref::<crate::effects::WithIdEffect>()
+            .and_then(|with_id| with_id.effect.downcast_ref::<crate::effects::IfEffect>())
+            .or_else(|| branch.downcast_ref::<crate::effects::IfEffect>())?;
+        if if_effect.condition != roll.id || !if_effect.else_.is_empty() {
+            return None;
+        }
+        let EffectPredicate::Value(comparison) = &if_effect.predicate else {
+            return None;
+        };
+        let result_text = describe_roll_result_comparison(comparison)?.replace('-', "—");
+        let branch_text = describe_roll_table_branch_body(&if_effect.then, exiled_tag)?;
+        rendered_branches.push(format!("{result_text} | {branch_text}"));
+    }
+
+    Some(format!(
+        "{}, then {}.\n{}",
+        describe_effect(exile_effect),
+        lowercase_first(&describe_effect(roll_effect)),
+        rendered_branches.join("\n"),
+    ))
+}
+
+fn describe_roll_table_branch_body(effects: &[Effect], exiled_tag: &TagKey) -> Option<String> {
+    if let Some(text) = describe_may_put_tagged_card_from_among_those_cards(effects, exiled_tag) {
+        return Some(text);
+    }
+    if let Some(text) =
+        describe_create_token_then_counted_counter_from_among_those_cards(effects, exiled_tag)
+    {
+        return Some(text);
+    }
+    if let Some(text) = describe_source_exiled_return_then_sacrifice_source(effects) {
+        return Some(text);
+    }
+    None
+}
+
+fn describe_may_put_tagged_card_from_among_those_cards(
+    effects: &[Effect],
+    exiled_tag: &TagKey,
+) -> Option<String> {
+    let [may_effect] = effects else {
+        return None;
+    };
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may.decider != Some(PlayerFilter::You) || may.effects.len() != 1 {
+        return None;
+    }
+    let move_to_zone = structural_unwrap_render_wrappers(&may.effects[0])
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Battlefield || move_to_zone.to_top {
+        return None;
+    }
+    let ChooseSpec::WithCount(inner, count) = &move_to_zone.target else {
+        return None;
+    };
+    if count.min != 1 || count.max != Some(1) {
+        return None;
+    }
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        return None;
+    };
+    if filter.zone != Some(Zone::Exile)
+        || !filter_references_tag(filter, exiled_tag)
+        || filter.card_types.len() != 1
+    {
+        return None;
+    }
+
+    Some(format!(
+        "You may put a {} card from among those cards onto the battlefield",
+        describe_card_type_word_local(filter.card_types[0]),
+    ))
+}
+
+fn describe_create_token_then_counted_counter_from_among_those_cards(
+    effects: &[Effect],
+    exiled_tag: &TagKey,
+) -> Option<String> {
+    let [create_effect, counter_effect] = effects else {
+        return None;
+    };
+    let tagged = create_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let create_token = tagged
+        .effect
+        .downcast_ref::<crate::effects::CreateTokenEffect>()?;
+    if create_token.count != Value::Fixed(1) || create_token.controller != PlayerFilter::You {
+        return None;
+    }
+
+    let put_counters = counter_effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if !choose_spec_references_exact_tag(&put_counters.target, &tagged.tag) {
+        return None;
+    }
+    let Value::Count(filter) = put_counters.amount.unhinted() else {
+        return None;
+    };
+    let those_cards_tag = TagKey::from(crate::tag::THOSE_CARDS_TAG);
+    if filter.zone != Some(Zone::Exile)
+        || filter.card_types.len() != 1
+        || (!filter_references_tag(filter, exiled_tag)
+            && !filter_references_tag(filter, &those_cards_tag))
+    {
+        return None;
+    }
+
+    Some(format!(
+        "{}, then put {} on it for each {} card among those cards",
+        describe_effect(create_effect),
+        describe_put_counter_phrase(&Value::Fixed(1), put_counters.counter_type),
+        describe_card_type_word_local(filter.card_types[0]),
+    ))
+}
+
+fn describe_source_exiled_return_then_sacrifice_source(effects: &[Effect]) -> Option<String> {
+    let [return_effect, sacrifice_effect] = effects else {
+        return None;
+    };
+    let return_all = return_effect.downcast_ref::<crate::effects::ReturnAllToBattlefieldEffect>()?;
+    if return_all.tapped {
+        return None;
+    }
+    let sacrifice = sacrifice_effect.downcast_ref::<crate::effects::SacrificeTargetEffect>()?;
+    if !matches!(sacrifice.target, ChooseSpec::Source) {
+        return None;
+    }
+    let filter_text = source_exiled_permanent_cards_filter_text(&return_all.filter)?;
+    Some(format!(
+        "Put all {filter_text} onto the battlefield, then sacrifice it"
+    ))
+}
+
+fn source_exiled_permanent_cards_filter_text(filter: &ObjectFilter) -> Option<String> {
+    const PERMANENT_TYPES: [CardType; 6] = [
+        CardType::Artifact,
+        CardType::Creature,
+        CardType::Enchantment,
+        CardType::Land,
+        CardType::Planeswalker,
+        CardType::Battle,
+    ];
+
+    if filter.zone != Some(Zone::Exile)
+        || !PERMANENT_TYPES
+            .iter()
+            .all(|card_type| filter.card_types.contains(card_type))
+        || filter.card_types.len() != PERMANENT_TYPES.len()
+        || !filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+        })
+    {
+        return None;
+    }
+
+    let mut base = filter.clone();
+    base.zone = None;
+    base.card_types.clear();
+    base.tagged_constraints.retain(|constraint| {
+        !(constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG)
+    });
+    if base != ObjectFilter::default() {
+        return None;
+    }
+
+    Some(
+        describe_for_each_filter(filter)
+            .replace("permanent card exiled", "permanent cards exiled")
+            .replace("card exiled", "cards exiled"),
+    )
 }
 
 fn join_or_list(items: &[String]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/effects/cards/exile_top.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/exile_top.rs
@@ -9,7 +9,7 @@ use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::snapshot::ObjectSnapshot;
-use crate::tag::TagKey;
+use crate::tag::{THOSE_CARDS_TAG, TagKey};
 use crate::target::PlayerFilter;
 use crate::zone::Zone;
 
@@ -63,6 +63,7 @@ impl EffectExecutor for ExileTopOfLibraryEffect {
         for tag in &self.moved_tags {
             ctx.clear_object_tag(tag.as_str());
         }
+        ctx.clear_object_tag(THOSE_CARDS_TAG);
 
         let top_cards = game
             .player(player_id)
@@ -74,6 +75,7 @@ impl EffectExecutor for ExileTopOfLibraryEffect {
             .unwrap_or_default();
 
         let mut moved_ids = Vec::new();
+        let mut moved_snapshots = Vec::new();
         for card_id in top_cards {
             if let Some(exiled_id) = game.move_object_by_effect(card_id, Zone::Exile) {
                 game.add_exiled_with_source_link(ctx.source, exiled_id);
@@ -81,6 +83,7 @@ impl EffectExecutor for ExileTopOfLibraryEffect {
                     && let Some(obj) = game.object(exiled_id)
                 {
                     let snapshot = ObjectSnapshot::from_object(obj, game);
+                    moved_snapshots.push(snapshot.clone());
                     for tag in &self.moved_tags {
                         ctx.tag_object(tag.clone(), snapshot.clone());
                     }
@@ -90,6 +93,9 @@ impl EffectExecutor for ExileTopOfLibraryEffect {
                 }
                 moved_ids.push(exiled_id);
             }
+        }
+        if !moved_snapshots.is_empty() && !self.moved_tags.is_empty() {
+            ctx.set_tagged_objects(TagKey::from(THOSE_CARDS_TAG), moved_snapshots);
         }
 
         view_hidden_candidate_objects(

--- a/crates/ironsmith-runtime/src/effects/cards/exile_top.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/exile_top.rs
@@ -76,6 +76,7 @@ impl EffectExecutor for ExileTopOfLibraryEffect {
         let mut moved_ids = Vec::new();
         for card_id in top_cards {
             if let Some(exiled_id) = game.move_object_by_effect(card_id, Zone::Exile) {
+                game.add_exiled_with_source_link(ctx.source, exiled_id);
                 if (!self.moved_tags.is_empty() || !self.accumulated_tags.is_empty())
                     && let Some(obj) = game.object(exiled_id)
                 {

--- a/crates/ironsmith-tools/tests/journey_to_lost_city.rs
+++ b/crates/ironsmith-tools/tests/journey_to_lost_city.rs
@@ -1,0 +1,140 @@
+use ironsmith::{
+    CardBuilder, CardId, CardType, GameState, ManaCost, ManaSymbol, Phase, PlayerId,
+    PowerToughness, Step, TriggerQueue, Zone, generate_and_queue_step_triggers,
+    put_triggers_on_stack, resolve_stack_entry,
+};
+use ironsmith_compiler::{CardDefinitionBuilder as CompilerCardDefinitionBuilder, CardType as CompilerCardType};
+
+const JOURNEY_TEXT: &str = "At the beginning of your upkeep, exile the top four cards of your library, then roll a d20.\n\
+1—9 | You may put a land card from among those cards onto the battlefield.\n\
+10—19 | Create a 2/2 green Wolf creature token, then put a +1/+1 counter on it for each creature card among those cards.\n\
+20 | Put all permanent cards exiled with this enchantment onto the battlefield, then sacrifice it.";
+
+fn journey_to_the_lost_city_definition() -> ironsmith::cards::CardDefinition {
+    let builder = CompilerCardDefinitionBuilder::new(
+        ironsmith_compiler::CardId::from_raw(91_681),
+        "Journey to the Lost City",
+    )
+    .mana_cost(ironsmith_compiler::ManaCost::from_pips(vec![
+        vec![ironsmith_compiler::ManaSymbol::Generic(3)],
+        vec![ironsmith_compiler::ManaSymbol::Green],
+    ]))
+    .card_types(vec![CompilerCardType::Enchantment]);
+
+    ironsmith_tools::compile_builder_to_runtime_definition(builder, JOURNEY_TEXT, false)
+        .expect("Journey to the Lost City should compile strictly")
+}
+
+fn setup_journey_game() -> (GameState, PlayerId, ironsmith::ObjectId) {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let journey = journey_to_the_lost_city_definition();
+    let journey_id = game.create_object_from_definition(&journey, alice, Zone::Battlefield);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(Step::Upkeep);
+    (game, alice, journey_id)
+}
+
+fn make_card(id: u64, name: &str, card_types: Vec<CardType>) -> ironsmith::Card {
+    let mut builder = CardBuilder::new(CardId::from_raw(id), name).card_types(card_types.clone());
+    if card_types.contains(&CardType::Creature) {
+        builder = builder.power_toughness(PowerToughness::fixed(2, 2));
+    }
+    builder.build()
+}
+
+#[test]
+fn journey_to_the_lost_city_strictly_compiles_and_renders_result_20_clause() {
+    let definition = journey_to_the_lost_city_definition();
+    let rendered = ironsmith::compiled_text::compiled_text_lines(&definition).join("\n");
+
+    assert!(
+        rendered.contains("If the result is 20"),
+        "expected exact d20 result branch in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("return all permanent cards exiled with this enchantment to the battlefield")
+            || rendered.contains("Return all permanent cards exiled with this enchantment to the battlefield"),
+        "expected source-linked permanent return in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Sacrifice this enchantment"),
+        "expected source sacrifice in compiled text, got {rendered}"
+    );
+}
+
+#[test]
+fn journey_to_the_lost_city_roll_20_returns_linked_permanents_and_sacrifices_itself() {
+    let (mut game, alice, journey_id) = setup_journey_game();
+    let linked_creature = make_card(91_682, "Linked Grizzly Bears", vec![CardType::Creature]);
+    let linked_land = make_card(91_683, "Linked Forest", vec![CardType::Land]);
+    let linked_instant = make_card(91_684, "Linked Instant", vec![CardType::Instant]);
+    let unlinked_land = make_card(91_685, "Unlinked Forest", vec![CardType::Land]);
+
+    let linked_creature_id = game.create_object_from_card(&linked_creature, alice, Zone::Exile);
+    let linked_land_id = game.create_object_from_card(&linked_land, alice, Zone::Exile);
+    let linked_instant_id = game.create_object_from_card(&linked_instant, alice, Zone::Exile);
+    let unlinked_land_id = game.create_object_from_card(&unlinked_land, alice, Zone::Exile);
+    game.add_exiled_with_source_link(journey_id, linked_creature_id);
+    game.add_exiled_with_source_link(journey_id, linked_land_id);
+    game.add_exiled_with_source_link(journey_id, linked_instant_id);
+    game.force_next_die_roll(20);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Journey upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Journey upkeep trigger should resolve");
+
+    assert_eq!(game.object(linked_creature_id).map(|obj| obj.zone), Some(Zone::Battlefield));
+    assert_eq!(game.object(linked_land_id).map(|obj| obj.zone), Some(Zone::Battlefield));
+    assert_eq!(game.object(linked_instant_id).map(|obj| obj.zone), Some(Zone::Exile));
+    assert_eq!(game.object(unlinked_land_id).map(|obj| obj.zone), Some(Zone::Exile));
+    assert_eq!(game.object(journey_id).map(|obj| obj.zone), Some(Zone::Graveyard));
+}
+
+#[test]
+fn journey_to_the_lost_city_non_20_roll_does_not_return_linked_permanents_or_sacrifice() {
+    let (mut game, alice, journey_id) = setup_journey_game();
+    let linked_land = make_card(91_686, "Linked Forest", vec![CardType::Land]);
+    let linked_land_id = game.create_object_from_card(&linked_land, alice, Zone::Exile);
+    game.add_exiled_with_source_link(journey_id, linked_land_id);
+    game.force_next_die_roll(1);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Journey upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Journey upkeep trigger should resolve");
+
+    assert_eq!(game.object(linked_land_id).map(|obj| obj.zone), Some(Zone::Exile));
+    assert_eq!(game.object(journey_id).map(|obj| obj.zone), Some(Zone::Battlefield));
+}
+
+#[test]
+fn journey_to_the_lost_city_exile_top_cards_are_linked_to_the_source() {
+    let (mut game, alice, journey_id) = setup_journey_game();
+    for idx in 0..4 {
+        let card = make_card(91_690 + idx, "Exiled Library Creature", vec![CardType::Creature]);
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    game.force_next_die_roll(20);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Journey upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Journey upkeep trigger should resolve");
+
+    let returned_library_cards = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id)
+                .is_some_and(|obj| obj.name == "Exiled Library Creature")
+        })
+        .count();
+    assert_eq!(returned_library_cards, 4);
+    assert!(game.get_exiled_with_source_links(journey_id).is_empty());
+}

--- a/crates/ironsmith-tools/tests/journey_to_lost_city.rs
+++ b/crates/ironsmith-tools/tests/journey_to_lost_city.rs
@@ -1,9 +1,14 @@
 use ironsmith::{
-    CardBuilder, CardId, CardType, GameState, ManaCost, ManaSymbol, Phase, PlayerId,
-    PowerToughness, Step, TriggerQueue, Zone, generate_and_queue_step_triggers,
+    BooleanContext, CardBuilder, CardId, CardType, CounterType, DecisionMaker, GameState, Phase,
+    PlayerId, PowerToughness, Step, TriggerQueue, Zone, generate_and_queue_step_triggers,
     put_triggers_on_stack, resolve_stack_entry,
 };
-use ironsmith_compiler::{CardDefinitionBuilder as CompilerCardDefinitionBuilder, CardType as CompilerCardType};
+use ironsmith::game_loop::resolve_stack_entry_with;
+use ironsmith::semantic_compare::compare_semantics_scored;
+use ironsmith_compiler::mana::{ManaCost as CompilerManaCost, ManaSymbol as CompilerManaSymbol};
+use ironsmith_compiler::{
+    CardDefinitionBuilder as CompilerCardDefinitionBuilder, CardType as CompilerCardType,
+};
 
 const JOURNEY_TEXT: &str = "At the beginning of your upkeep, exile the top four cards of your library, then roll a d20.\n\
 1—9 | You may put a land card from among those cards onto the battlefield.\n\
@@ -15,9 +20,9 @@ fn journey_to_the_lost_city_definition() -> ironsmith::cards::CardDefinition {
         ironsmith_compiler::CardId::from_raw(91_681),
         "Journey to the Lost City",
     )
-    .mana_cost(ironsmith_compiler::ManaCost::from_pips(vec![
-        vec![ironsmith_compiler::ManaSymbol::Generic(3)],
-        vec![ironsmith_compiler::ManaSymbol::Green],
+    .mana_cost(CompilerManaCost::from_pips(vec![
+        vec![CompilerManaSymbol::Generic(3)],
+        vec![CompilerManaSymbol::Green],
     ]))
     .card_types(vec![CompilerCardType::Enchantment]);
 
@@ -36,7 +41,7 @@ fn setup_journey_game() -> (GameState, PlayerId, ironsmith::ObjectId) {
     (game, alice, journey_id)
 }
 
-fn make_card(id: u64, name: &str, card_types: Vec<CardType>) -> ironsmith::Card {
+fn make_card(id: u32, name: &str, card_types: Vec<CardType>) -> ironsmith::Card {
     let mut builder = CardBuilder::new(CardId::from_raw(id), name).card_types(card_types.clone());
     if card_types.contains(&CardType::Creature) {
         builder = builder.power_toughness(PowerToughness::fixed(2, 2));
@@ -44,24 +49,107 @@ fn make_card(id: u64, name: &str, card_types: Vec<CardType>) -> ironsmith::Card 
     builder.build()
 }
 
+fn has_named_object_in_zone(game: &GameState, name: &str, zone: Zone) -> bool {
+    game.objects_in_deterministic_order()
+        .into_iter()
+        .any(|object| object.name == name && object.zone == zone)
+}
+
+struct AcceptMayDecisionMaker;
+
+impl DecisionMaker for AcceptMayDecisionMaker {
+    fn decide_boolean(&mut self, _game: &GameState, _ctx: &BooleanContext) -> bool {
+        true
+    }
+}
+
 #[test]
 fn journey_to_the_lost_city_strictly_compiles_and_renders_result_20_clause() {
     let definition = journey_to_the_lost_city_definition();
-    let rendered = ironsmith::compiled_text::compiled_text_lines(&definition).join("\n");
+    let compiled_lines = ironsmith::compiled_text::compiled_text_lines(&definition);
+    let rendered = compiled_lines.join("\n");
+    let (similarity, _, _, _, semantic_mismatch) =
+        compare_semantics_scored(JOURNEY_TEXT, &compiled_lines, None);
 
     assert!(
-        rendered.contains("If the result is 20"),
+        rendered.contains("20 | Put all permanent cards exiled with this enchantment onto the battlefield, then sacrifice it"),
         "expected exact d20 result branch in compiled text, got {rendered}"
     );
     assert!(
-        rendered.contains("return all permanent cards exiled with this enchantment to the battlefield")
-            || rendered.contains("Return all permanent cards exiled with this enchantment to the battlefield"),
-        "expected source-linked permanent return in compiled text, got {rendered}"
+        rendered.contains("1—9 | You may put a land card from among those cards onto the battlefield"),
+        "expected optional land branch to reference among those cards, got {rendered}"
     );
     assert!(
-        rendered.contains("Sacrifice this enchantment"),
-        "expected source sacrifice in compiled text, got {rendered}"
+        rendered.contains("10—19 | Create a 2/2 green Wolf creature token, then put a +1/+1 counter on it for each creature card among those cards"),
+        "expected Wolf counter branch to reference among those cards, got {rendered}"
     );
+    assert!(!semantic_mismatch, "unexpected semantic mismatch for {rendered}");
+    assert!(
+        similarity >= 0.99,
+        "expected Journey to the Lost City similarity >= 0.99, got {similarity:.4}: {rendered}"
+    );
+}
+
+#[test]
+fn journey_to_the_lost_city_roll_1_to_9_can_put_exiled_land_onto_battlefield() {
+    let (mut game, alice, journey_id) = setup_journey_game();
+    let land = make_card(91_680, "Journey Forest", vec![CardType::Land]);
+    let creature = make_card(91_681, "Journey Bear", vec![CardType::Creature]);
+    let instant = make_card(91_682, "Journey Instant", vec![CardType::Instant]);
+    let sorcery = make_card(91_683, "Journey Sorcery", vec![CardType::Sorcery]);
+    game.create_object_from_card(&land, alice, Zone::Library);
+    game.create_object_from_card(&creature, alice, Zone::Library);
+    game.create_object_from_card(&instant, alice, Zone::Library);
+    game.create_object_from_card(&sorcery, alice, Zone::Library);
+    game.force_next_die_roll(1);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Journey upkeep trigger should go on the stack");
+    let mut dm = AcceptMayDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Journey upkeep trigger should resolve");
+
+    assert!(has_named_object_in_zone(&game, "Journey Forest", Zone::Battlefield));
+    assert_eq!(game.object(journey_id).map(|obj| obj.zone), Some(Zone::Battlefield));
+}
+
+#[test]
+fn journey_to_the_lost_city_roll_10_to_19_counts_creature_cards_among_exiled_cards() {
+    let (mut game, alice, journey_id) = setup_journey_game();
+    let prior_exiled = make_card(91_709, "Previously Exiled Bear", vec![CardType::Creature]);
+    let prior_exiled_id = game.create_object_from_card(&prior_exiled, alice, Zone::Exile);
+    game.add_exiled_with_source_link(journey_id, prior_exiled_id);
+
+    for (offset, card_types) in [
+        vec![CardType::Creature],
+        vec![CardType::Creature],
+        vec![CardType::Land],
+        vec![CardType::Instant],
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let card = make_card(91_710 + offset as u32, "Journey Exiled Card", card_types);
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    game.force_next_die_roll(10);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Journey upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Journey upkeep trigger should resolve");
+
+    let wolf_id = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|&id| game.object(id).is_some_and(|obj| obj.name == "Wolf"))
+        .expect("Journey should create a Wolf token");
+    assert_eq!(game.counter_count(wolf_id, CounterType::PlusOnePlusOne), 2);
+    assert_eq!(game.object(prior_exiled_id).map(|obj| obj.zone), Some(Zone::Exile));
+    assert_eq!(game.object(journey_id).map(|obj| obj.zone), Some(Zone::Battlefield));
 }
 
 #[test]
@@ -87,11 +175,11 @@ fn journey_to_the_lost_city_roll_20_returns_linked_permanents_and_sacrifices_its
         .expect("Journey upkeep trigger should go on the stack");
     resolve_stack_entry(&mut game).expect("Journey upkeep trigger should resolve");
 
-    assert_eq!(game.object(linked_creature_id).map(|obj| obj.zone), Some(Zone::Battlefield));
-    assert_eq!(game.object(linked_land_id).map(|obj| obj.zone), Some(Zone::Battlefield));
+    assert!(has_named_object_in_zone(&game, "Linked Grizzly Bears", Zone::Battlefield));
+    assert!(has_named_object_in_zone(&game, "Linked Forest", Zone::Battlefield));
     assert_eq!(game.object(linked_instant_id).map(|obj| obj.zone), Some(Zone::Exile));
     assert_eq!(game.object(unlinked_land_id).map(|obj| obj.zone), Some(Zone::Exile));
-    assert_eq!(game.object(journey_id).map(|obj| obj.zone), Some(Zone::Graveyard));
+    assert!(has_named_object_in_zone(&game, "Journey to the Lost City", Zone::Graveyard));
 }
 
 #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Journey to the Lost City
Initial parse error:
```
unsupported put destination after 'onto' (clause: 'all permanent cards exiled with this enchantment onto the battlefield then sacrifice it'); oracle-only fallback also failed: unsupported put destination after 'onto' (clause: 'all permanent cards exiled with this enchantment onto the battlefield then sacrifice it')
```

Current worker: i-01c2f8c998cf9d5e7
Branch: codex/aws-card-fix-journey-to-the-lost-city
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0001
