### PR TITLE
Fix Ironsmith parse failure: Calamity Bearer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -661,6 +661,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(
             parse_double_damage_from_sources_you_control_of_chosen_type_line
         ),
+        single_static_ability_ast_rule!(parse_double_damage_amount_replacement_line),
         single_static_ability_ast_rule!(parse_minimum_damage_amount_replacement_line),
         single_static_ability_ast_rule!(parse_damage_amount_replacement_line),
         single_static_ability_ast_rule!(parse_foretelling_cards_cost_modifier_line),
@@ -2917,6 +2918,122 @@ pub(crate) fn parse_damage_amount_replacement_line(
         delta,
         display,
     )))
+}
+
+pub(crate) fn parse_double_damage_amount_replacement_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let tokens = trim_edge_punctuation(tokens);
+    let words = parser_token_word_refs(&tokens);
+    if !words.starts_with(&["if"]) {
+        return Ok(None);
+    }
+
+    let Some(would_idx) = find_window_by(&words, 4, |window| {
+        window == ["would", "deal", "damage", "to"]
+    })
+    else {
+        return Ok(None);
+    };
+    let Some(source_idx) = words[..would_idx]
+        .iter()
+        .position(|word| *word == "source")
+    else {
+        return Ok(None);
+    };
+    if source_idx <= 1 {
+        return Ok(None);
+    }
+
+    let Some(tail_idx) = find_window_by(&words[would_idx + 4..], 6, |window| {
+        window == ["it", "deals", "double", "that", "damage", "to"]
+    }) else {
+        return Ok(None);
+    };
+    let replacement_start = would_idx + 4 + tail_idx;
+    let damaged_words = &words[would_idx + 4..replacement_start];
+    let replacement_target_words = &words[replacement_start + 6..];
+    if damaged_words.is_empty()
+        || replacement_target_words.len() < 2
+        || replacement_target_words.first() != Some(&"that")
+        || replacement_target_words.last() != Some(&"instead")
+    {
+        return Ok(None);
+    }
+
+    let (target_player_filter, target_object_filter) =
+        parse_damage_amount_replacement_target_filters(damaged_words)?;
+    if target_player_filter.is_none() && target_object_filter.is_none() {
+        return Ok(None);
+    }
+
+    let source_start = token_index_for_word_index(&tokens, 1).unwrap_or(0);
+    let source_end = token_index_for_word_index(&tokens, source_idx).unwrap_or(tokens.len());
+    let source_tokens = trim_lexed_commas(&tokens[source_start..source_end]);
+    let mut source_filter = if source_tokens.is_empty()
+        || parser_token_word_refs(source_tokens).as_slice() == ["a"]
+        || parser_token_word_refs(source_tokens).as_slice() == ["an"]
+    {
+        ObjectFilter::default()
+    } else {
+        parse_object_filter_lexed(source_tokens, false)?
+    };
+
+    match &words[source_idx + 1..would_idx] {
+        ["you", "control"] => source_filter = source_filter.you_control(),
+        ["an", "opponent", "controls"] | ["opponent", "controls"] => {
+            source_filter = source_filter.controlled_by(PlayerFilter::Opponent);
+        }
+        [] => {}
+        _ => return Ok(None),
+    }
+
+    let mut display = render_token_slice(&tokens).trim().to_string();
+    if !display.ends_with('.') {
+        display.push('.');
+    }
+
+    Ok(Some(StaticAbility::double_damage_amount_replacement(
+        source_filter,
+        target_player_filter,
+        target_object_filter,
+        display,
+    )))
+}
+
+fn parse_damage_amount_replacement_target_filters(
+    words: &[&str],
+) -> Result<(Option<PlayerFilter>, Option<ObjectFilter>), CardTextError> {
+    let words = strip_leading_article_words(words);
+    match words {
+        ["you"] => Ok((Some(PlayerFilter::You), None)),
+        ["opponent"] => Ok((Some(PlayerFilter::Opponent), None)),
+        ["player"] => Ok((Some(PlayerFilter::Any), None)),
+        ["enchanted", "player"] => Ok((
+            Some(PlayerFilter::TaggedPlayer(crate::TagKey::from("enchanted"))),
+            None,
+        )),
+        ["permanent"] => Ok((None, Some(ObjectFilter::permanent()))),
+        ["permanent", "or", "player"] | ["permanent", "or", "a", "player"] => {
+            Ok((Some(PlayerFilter::Any), Some(ObjectFilter::permanent())))
+        }
+        ["player", "or", "permanent"] | ["player", "or", "a", "permanent"] => {
+            Ok((Some(PlayerFilter::Any), Some(ObjectFilter::permanent())))
+        }
+        ["opponent", "or", "a", "permanent", "an", "opponent", "controls"]
+        | ["opponent", "or", "permanent", "an", "opponent", "controls"] => Ok((
+            Some(PlayerFilter::Opponent),
+            Some(ObjectFilter::permanent().controlled_by(PlayerFilter::Opponent)),
+        )),
+        _ => Ok((None, None)),
+    }
+}
+
+fn strip_leading_article_words<'a>(words: &'a [&'a str]) -> &'a [&'a str] {
+    match words {
+        ["a", rest @ ..] | ["an", rest @ ..] => rest,
+        _ => words,
+    }
 }
 
 pub(crate) fn parse_minimum_damage_amount_replacement_line(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35368,6 +35368,128 @@ fn guardian_of_the_ages_strict_parser_and_text_regression() {
     );
 }
 
+#[test]
+fn calamity_bearer_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Calamity Bearer");
+    let rendered_lines = canonical_compiled_lines(&def);
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::ModifyDamageAmountReplacement
+        )),
+        "Calamity Bearer should compile to a double-damage replacement static ability"
+    );
+    assert!(
+        rendered_lines.iter().any(|line| line
+            == "If a giant source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead."),
+        "Calamity Bearer should render its double-damage replacement clause, got {rendered_lines:?}"
+    );
+}
+
+#[test]
+fn calamity_bearer_runtime_doubles_giant_source_damage_to_players_and_permanents() {
+    let def = parse_oracle_card_definition("Calamity Bearer");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let giant_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_300), "Alice Giant")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Giant])
+            .power_toughness(PowerToughness::fixed(3, 3))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let target_permanent = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_301), "Target Permanent")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let player_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        giant_source,
+        crate::events::DamageTarget::Player(bob),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(player_damage.assignments.len(), 1);
+    assert_eq!(player_damage.assignments[0].amount, 6);
+
+    let permanent_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        giant_source,
+        crate::events::DamageTarget::Object(target_permanent),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(permanent_damage.assignments.len(), 1);
+    assert_eq!(permanent_damage.assignments[0].amount, 4);
+}
+
+#[test]
+fn calamity_bearer_runtime_ignores_non_giant_and_opposing_giant_sources() {
+    let def = parse_oracle_card_definition("Calamity Bearer");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let non_giant_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_302), "Alice Soldier")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Soldier])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let opposing_giant_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_303), "Bob Giant")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Giant])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let non_giant_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        non_giant_source,
+        crate::events::DamageTarget::Player(bob),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(non_giant_damage.assignments.len(), 1);
+    assert_eq!(non_giant_damage.assignments[0].amount, 3);
+
+    let opposing_giant_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        opposing_giant_source,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(opposing_giant_damage.assignments.len(), 1);
+    assert_eq!(opposing_giant_damage.assignments[0].amount, 3);
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_sporeweb_weaver_strict_regression() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35414,6 +35414,13 @@ fn calamity_bearer_runtime_doubles_giant_source_damage_to_players_and_permanents
         bob,
         Zone::Battlefield,
     );
+    let controller_permanent = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_304), "Controller Permanent")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
 
     let player_damage = crate::events::processing::process_damage_assignments_with_event(
         &mut game,
@@ -35426,6 +35433,17 @@ fn calamity_bearer_runtime_doubles_giant_source_damage_to_players_and_permanents
     assert_eq!(player_damage.assignments.len(), 1);
     assert_eq!(player_damage.assignments[0].amount, 6);
 
+    let controller_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        giant_source,
+        crate::events::DamageTarget::Player(alice),
+        1,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(controller_damage.assignments.len(), 1);
+    assert_eq!(controller_damage.assignments[0].amount, 2);
+
     let permanent_damage = crate::events::processing::process_damage_assignments_with_event(
         &mut game,
         giant_source,
@@ -35436,6 +35454,18 @@ fn calamity_bearer_runtime_doubles_giant_source_damage_to_players_and_permanents
     );
     assert_eq!(permanent_damage.assignments.len(), 1);
     assert_eq!(permanent_damage.assignments[0].amount, 4);
+
+    let controller_permanent_damage =
+        crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            giant_source,
+            crate::events::DamageTarget::Object(controller_permanent),
+            1,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(controller_permanent_damage.assignments.len(), 1);
+    assert_eq!(controller_permanent_damage.assignments[0].amount, 2);
 }
 
 #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Calamity Bearer
Initial parse error:
```
missing damage amount (clause: 'double that damage to that permanent or player instead'); oracle-only fallback also failed: missing damage amount (clause: 'double that damage to that permanent or player instead')
```

Current worker: i-005264c95fd4694bb
Branch: codex/aws-card-fix-calamity-bearer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0001
