### PR TITLE
Fix Ironsmith parse failure: Messenger Jays

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
@@ -1014,7 +1014,7 @@ fn rewrite_vote_count_followups_line(text: &str) -> String {
             }
             rewritten.push_str(&remaining[..marker_idx]);
             rewritten.push_str(&format!(
-                "For each {option} vote, draw a card, then discard a card"
+                "For each {option} vote, draw a card. Then discard that many cards"
             ));
             remaining = &remaining[option_end + suffix.len()..];
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
@@ -903,6 +903,41 @@ fn expand_borrow_ability_line(text: &str) -> String {
 }
 
 fn rewrite_vote_count_followups_line(text: &str) -> String {
+    fn rewrite_two_vote_count_tails(trimmed: &str, lower: &str) -> Option<String> {
+        let first_marker = " for each ";
+        let first_idx = str_find(lower, first_marker)?;
+        let after_first_idx = first_idx + first_marker.len();
+        let after_first = &lower[after_first_idx..];
+        let (first_vote_rel_idx, first_vote_marker) = str_find(after_first, " vote and ")
+            .map(|idx| (idx, " vote and "))
+            .or_else(|| str_find(after_first, " votes and ").map(|idx| (idx, " votes and ")))?;
+        let second_effect_idx = after_first_idx + first_vote_rel_idx + first_vote_marker.len();
+        let second_marker_rel_idx = str_find(&lower[second_effect_idx..], first_marker)?;
+        let second_marker_idx = second_effect_idx + second_marker_rel_idx;
+
+        let first_effect = trimmed[..first_idx].trim();
+        let first_option = trimmed[after_first_idx..after_first_idx + first_vote_rel_idx].trim();
+        let second_effect = trimmed[second_effect_idx..second_marker_idx].trim();
+        let second_tail = trimmed[second_marker_idx + first_marker.len()..].trim();
+        let second_tail_words = second_tail.split_whitespace().collect::<Vec<_>>();
+        let second_option = second_tail_words
+            .last()
+            .is_some_and(|word| matches!(*word, "vote" | "votes"))
+            .then(|| second_tail_words[..second_tail_words.len().saturating_sub(1)].join(" "))?;
+
+        if first_effect.is_empty()
+            || first_option.is_empty()
+            || second_effect.is_empty()
+            || second_option.is_empty()
+        {
+            return None;
+        }
+
+        Some(format!(
+            "For each {first_option} vote, {first_effect}. For each {second_option} vote, {second_effect}"
+        ))
+    }
+
     fn rewrite_vote_count_sentence(sentence: &str) -> String {
         let trimmed = sentence.trim();
 
@@ -935,6 +970,10 @@ fn rewrite_vote_count_followups_line(text: &str) -> String {
             }
         }
 
+        if let Some(rewritten) = rewrite_two_vote_count_tails(trimmed, lower.as_str()) {
+            return rewritten;
+        }
+
         if let Some(marker_idx) = lower.match_indices(" for each ").last().map(|(idx, _)| idx) {
             let head = trimmed[..marker_idx].trim();
             let tail = trimmed[marker_idx + " for each ".len()..].trim();
@@ -950,12 +989,45 @@ fn rewrite_vote_count_followups_line(text: &str) -> String {
         trimmed.to_string()
     }
 
+    fn rewrite_vote_draw_discard_this_way(text: String) -> String {
+        let suffix = " vote, draw a card. for each card drawn this way, discard a card";
+        let mut remaining = text.as_str();
+        let mut rewritten = String::new();
+        loop {
+            let lower = remaining.to_ascii_lowercase();
+            let Some(marker_idx) = str_find(lower.as_str(), "for each ") else {
+                rewritten.push_str(remaining);
+                break;
+            };
+            let option_start = marker_idx + "for each ".len();
+            let Some(suffix_rel_idx) = str_find(&lower[option_start..], suffix) else {
+                rewritten.push_str(&remaining[..option_start]);
+                remaining = &remaining[option_start..];
+                continue;
+            };
+            let option_end = option_start + suffix_rel_idx;
+            let option = remaining[option_start..option_end].trim();
+            if option.is_empty() {
+                rewritten.push_str(&remaining[..option_start]);
+                remaining = &remaining[option_start..];
+                continue;
+            }
+            rewritten.push_str(&remaining[..marker_idx]);
+            rewritten.push_str(&format!(
+                "For each {option} vote, draw a card, then discard a card"
+            ));
+            remaining = &remaining[option_end + suffix.len()..];
+        }
+        rewritten
+    }
+
     let had_period = str_ends_with(text.trim_end(), ".");
     let rewritten = split_period_sentences(text)
         .into_iter()
         .map(|sentence| rewrite_vote_count_sentence(sentence.as_str()))
         .collect::<Vec<_>>()
         .join(". ");
+    let rewritten = rewrite_vote_draw_discard_this_way(rewritten);
     if had_period && !rewritten.is_empty() {
         format!("{rewritten}.")
     } else {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -937,10 +937,15 @@ pub(crate) fn compile_vote_sequence(
                         push_choice(&mut choices, choice);
                     }
                 } else {
-                    post_vote_effects.push(Effect::repeat_effects(
+                    let repeat_effect = Effect::repeat_effects(
                         Value::VoteCount(option.clone()),
                         repeat_effects,
-                    ));
+                    );
+                    post_vote_effects.push(if let Some(id) = annotated.assigned_effect_id {
+                        Effect::with_id(id.0, repeat_effect)
+                    } else {
+                        repeat_effect
+                    });
                     for choice in repeat_choices {
                         push_choice(&mut choices, choice);
                     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38409,8 +38409,10 @@ fn messenger_jays_regression_compiles_councils_dilemma_vote_text() {
             && debug.contains("VoteCount(\"feather\")")
             && debug.contains("VoteCount(\"quill\")")
             && debug.contains("PutCountersEffect")
+            && debug.contains("WithIdEffect")
             && debug.contains("DrawCardsEffect")
-            && debug.contains("DiscardEffect"),
+            && debug.contains("DiscardEffect")
+            && debug.contains("EffectValue"),
         "expected Messenger Jays to lower both vote branches structurally, got {debug}"
     );
 }
@@ -38516,6 +38518,56 @@ fn messenger_jays_runtime_quill_votes_draw_then_discard() {
             .get(&crate::CounterType::PlusOnePlusOne),
         None,
         "quill votes should not put feather counters on Messenger Jays"
+    );
+}
+
+#[test]
+fn messenger_jays_runtime_quill_votes_do_not_discard_when_no_card_drawn() {
+    struct ChooseQuillVotes;
+
+    impl crate::decision::DecisionMaker for ChooseQuillVotes {
+        fn decide_options(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            ctx.options
+                .iter()
+                .find(|option| option.description.eq_ignore_ascii_case("quill"))
+                .map(|option| vec![option.index])
+                .unwrap_or_else(|| vec![1])
+        }
+    }
+
+    let def = parse_oracle_card_definition("Messenger Jays");
+    let effects = messenger_jays_etb_effects(&def);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let jays_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let filler = CardDefinitionBuilder::new(CardId::from_raw(383_842), "Filler")
+        .card_types(vec![CardType::Creature])
+        .build();
+    for _ in 0..2 {
+        game.create_object_from_definition(&filler, alice, Zone::Hand);
+    }
+
+    let mut dm = ChooseQuillVotes;
+    let mut ctx = crate::effects::ExecutionContext::new(jays_id, alice, &mut dm);
+    for effect in &effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Messenger Jays empty-library quill branch should resolve");
+    }
+
+    let alice_state = game.player(alice).expect("alice exists");
+    assert_eq!(
+        alice_state.hand.len(),
+        2,
+        "quill votes should not discard cards that were not actually drawn"
+    );
+    assert_eq!(
+        alice_state.graveyard.len(),
+        0,
+        "no card drawn this way means no card discarded"
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38380,9 +38380,143 @@ fn strict_parse_vote_regression_cards() {
         "Brago's Representative",
         "Tivit, Seller of Secrets",
         "Elrond of the White Council",
+        "Messenger Jays",
     ] {
         assert_oracle_card_parses_strict(name);
     }
+}
+
+#[test]
+fn messenger_jays_regression_compiles_councils_dilemma_vote_text() {
+    let def = parse_oracle_card_definition("Messenger Jays");
+    let lines = unprocessed_compiled_lines(&def);
+    let expected_trigger = concat!(
+        "Council's dilemma — When this creature enters, starting with you, ",
+        "each player votes for feather or quill. For each feather vote, ",
+        "put a +1/+1 counter on this creature. Draw a card for each quill vote. ",
+        "For each card drawn this way, discard a card."
+    );
+
+    assert_eq!(
+        lines,
+        vec!["Flying".to_string(), expected_trigger.to_string()],
+        "expected Messenger Jays to render its council vote trigger without unsupported text"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("VoteEffect")
+            && debug.contains("VoteCount(\"feather\")")
+            && debug.contains("VoteCount(\"quill\")")
+            && debug.contains("PutCountersEffect")
+            && debug.contains("DrawCardsEffect")
+            && debug.contains("DiscardEffect"),
+        "expected Messenger Jays to lower both vote branches structurally, got {debug}"
+    );
+}
+
+fn messenger_jays_etb_effects(def: &CardDefinition) -> Vec<Effect> {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) if triggered.trigger.display().contains("enters") => {
+                Some(triggered.effects.segments[0].default_effects.clone())
+            }
+            _ => None,
+        })
+        .expect("Messenger Jays should have an enters-the-battlefield trigger")
+}
+
+#[test]
+fn messenger_jays_runtime_feather_votes_put_counters_without_drawing() {
+    let def = parse_oracle_card_definition("Messenger Jays");
+    let effects = messenger_jays_etb_effects(&def);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let jays_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let filler = CardDefinitionBuilder::new(CardId::from_raw(383_840), "Filler")
+        .card_types(vec![CardType::Creature])
+        .build();
+    for _ in 0..2 {
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(jays_id, alice, &mut dm);
+    for effect in &effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Messenger Jays feather branch should resolve");
+    }
+
+    let jays = game.object(jays_id).expect("Messenger Jays should remain");
+    assert_eq!(
+        jays.counters.get(&crate::CounterType::PlusOnePlusOne),
+        Some(&2),
+        "two feather votes should put two +1/+1 counters on Messenger Jays"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        2,
+        "feather votes should not draw cards"
+    );
+}
+
+#[test]
+fn messenger_jays_runtime_quill_votes_draw_then_discard() {
+    struct ChooseQuillVotes;
+
+    impl crate::decision::DecisionMaker for ChooseQuillVotes {
+        fn decide_options(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            ctx.options
+                .iter()
+                .find(|option| option.description.eq_ignore_ascii_case("quill"))
+                .map(|option| vec![option.index])
+                .unwrap_or_else(|| vec![1])
+        }
+    }
+
+    let def = parse_oracle_card_definition("Messenger Jays");
+    let effects = messenger_jays_etb_effects(&def);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let jays_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let filler = CardDefinitionBuilder::new(CardId::from_raw(383_841), "Filler")
+        .card_types(vec![CardType::Creature])
+        .build();
+    for _ in 0..2 {
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+
+    let mut dm = ChooseQuillVotes;
+    let mut ctx = crate::effects::ExecutionContext::new(jays_id, alice, &mut dm);
+    for effect in &effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Messenger Jays quill branch should resolve");
+    }
+
+    let alice_state = game.player(alice).expect("alice exists");
+    assert_eq!(
+        alice_state.library.len(),
+        0,
+        "two quill votes should draw two cards"
+    );
+    assert_eq!(
+        alice_state.graveyard.len(),
+        2,
+        "each card drawn for quill votes should be discarded"
+    );
+    assert_eq!(
+        game.object(jays_id)
+            .expect("Messenger Jays should remain")
+            .counters
+            .get(&crate::CounterType::PlusOnePlusOne),
+        None,
+        "quill votes should not put feather counters on Messenger Jays"
+    );
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -31401,9 +31401,25 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 choices, suffix
             );
         }
-        return format!("Each player votes for {}{}", choices, suffix);
+        return format!("Starting with you, each player votes for {}{}", choices, suffix);
     }
     if let Some(repeat) = effect.downcast_ref::<crate::effects::RepeatEffectsEffect>() {
+        if let Value::VoteCount(option) = &repeat.count
+            && repeat.effects.len() == 2
+            && let Some(draw) = repeat.effects[0].downcast_ref::<crate::effects::DrawCardsEffect>()
+            && let Some(discard) = repeat.effects[1].downcast_ref::<crate::effects::DiscardEffect>()
+            && draw.player == PlayerFilter::You
+            && discard.player == PlayerFilter::You
+            && draw.count == Value::Fixed(1)
+            && discard.count == Value::Fixed(1)
+            && !discard.random
+            && !discard.any_number
+        {
+            return format!(
+                "Draw a card for each {} vote. For each card drawn this way, discard a card",
+                option.to_ascii_lowercase()
+            );
+        }
         let repeated = describe_effect_list(&repeat.effects);
         let repeated = repeated.trim();
         if repeated.is_empty() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2343,7 +2343,40 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects)
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
+        .or_else(|| describe_vote_with_drawn_count_followup_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_vote_with_drawn_count_followup_structural(effects: &[Effect]) -> Option<String> {
+    effects
+        .first()?
+        .downcast_ref::<crate::effects::VoteEffect>()?;
+
+    let mut saw_drawn_count_followup = false;
+    let mut sentences = vec![describe_effect(&effects[0])];
+    let mut idx = 1usize;
+    while idx < effects.len() {
+        if idx + 1 < effects.len()
+            && let Some(with_id) = effects[idx].downcast_ref::<crate::effects::WithIdEffect>()
+            && let Some(discard) = effects[idx + 1].downcast_ref::<crate::effects::DiscardEffect>()
+            && let Some(compact) = describe_draw_for_each_vote_then_discard_drawn(with_id, discard)
+        {
+            saw_drawn_count_followup = true;
+            sentences.push(compact);
+            idx += 2;
+            continue;
+        }
+
+        let rendered = describe_effect(&effects[idx]);
+        let trimmed = rendered.trim().trim_end_matches('.');
+        if trimmed.is_empty() || trimmed.contains(": ") {
+            return None;
+        }
+        sentences.push(trimmed.to_string());
+        idx += 1;
+    }
+
+    saw_drawn_count_followup.then(|| cleanup_decompiled_text(&sentences.join(". ")))
 }
 
 fn join_or_list(items: &[String]) -> Option<String> {
@@ -11971,6 +12004,15 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                 filtered[idx].downcast_ref::<crate::effects::ChooseObjectsEffect>()
             && let Some(cant) = filtered[idx + 1].downcast_ref::<crate::effects::CantEffect>()
             && let Some(compact) = describe_choose_then_cant_pile_restriction(choose, cant)
+        {
+            parts.push(compact);
+            idx += 2;
+            continue;
+        }
+        if idx + 1 < filtered.len()
+            && let Some(with_id) = filtered[idx].downcast_ref::<crate::effects::WithIdEffect>()
+            && let Some(discard) = filtered[idx + 1].downcast_ref::<crate::effects::DiscardEffect>()
+            && let Some(compact) = describe_draw_for_each_vote_then_discard_drawn(with_id, discard)
         {
             parts.push(compact);
             idx += 2;
@@ -21611,6 +21653,37 @@ pub(super) fn describe_draw_then_discard(
         text.push_str(" at random");
     }
     Some(text)
+}
+
+fn describe_draw_for_each_vote_then_discard_drawn(
+    with_id: &crate::effects::WithIdEffect,
+    discard: &crate::effects::DiscardEffect,
+) -> Option<String> {
+    let repeat = with_id
+        .effect
+        .downcast_ref::<crate::effects::RepeatEffectsEffect>()?;
+    let Value::VoteCount(option) = &repeat.count else {
+        return None;
+    };
+    let [draw_effect] = repeat.effects.as_slice() else {
+        return None;
+    };
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if draw.player != PlayerFilter::You
+        || discard.player != PlayerFilter::You
+        || draw.count != Value::Fixed(1)
+        || discard.count != Value::EffectValue(with_id.id)
+        || discard.random
+        || discard.any_number
+        || discard.card_filter.is_some()
+    {
+        return None;
+    }
+
+    Some(format!(
+        "Draw a card for each {} vote. For each card drawn this way, discard a card",
+        option.to_ascii_lowercase()
+    ))
 }
 
 fn shared_draw_partner(filter: &PlayerFilter) -> String {
@@ -31404,22 +31477,6 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return format!("Starting with you, each player votes for {}{}", choices, suffix);
     }
     if let Some(repeat) = effect.downcast_ref::<crate::effects::RepeatEffectsEffect>() {
-        if let Value::VoteCount(option) = &repeat.count
-            && repeat.effects.len() == 2
-            && let Some(draw) = repeat.effects[0].downcast_ref::<crate::effects::DrawCardsEffect>()
-            && let Some(discard) = repeat.effects[1].downcast_ref::<crate::effects::DiscardEffect>()
-            && draw.player == PlayerFilter::You
-            && discard.player == PlayerFilter::You
-            && draw.count == Value::Fixed(1)
-            && discard.count == Value::Fixed(1)
-            && !discard.random
-            && !discard.any_number
-        {
-            return format!(
-                "Draw a card for each {} vote. For each card drawn this way, discard a card",
-                option.to_ascii_lowercase()
-            );
-        }
         let repeated = describe_effect_list(&repeat.effects);
         let repeated = repeated.trim();
         if repeated.is_empty() {

--- a/crates/ironsmith-runtime/src/effects/composition/repeat_effects.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/repeat_effects.rs
@@ -26,9 +26,15 @@ impl EffectExecutor for RepeatEffectsEffect {
         let sequence = SequenceEffect::new(self.effects.clone());
         let mut all_events = Vec::new();
         let mut all_execution_facts = Vec::new();
+        let mut total_count = 0;
+        let mut saw_count = false;
 
         for _ in 0..count {
             let outcome = sequence.execute(game, ctx)?;
+            if let OutcomeValue::Count(n) = &outcome.value {
+                total_count += *n;
+                saw_count = true;
+            }
             all_events.extend(outcome.events.clone());
             all_execution_facts.extend(outcome.execution_facts.clone());
             if outcome.status.is_failure() {
@@ -43,9 +49,49 @@ impl EffectExecutor for RepeatEffectsEffect {
 
         Ok(EffectOutcome::with_details(
             OutcomeStatus::Succeeded,
-            OutcomeValue::None,
+            if saw_count {
+                OutcomeValue::Count(total_count)
+            } else {
+                OutcomeValue::None
+            },
             all_events,
             all_execution_facts,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card::CardBuilder;
+    use crate::effect::Effect;
+    use crate::ids::{CardId, PlayerId};
+    use crate::types::CardType;
+    use crate::zone::Zone;
+
+    #[test]
+    fn repeat_effects_sums_child_outcome_counts() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        for i in 0..2 {
+            let card = CardBuilder::new(CardId::from_raw(920_000 + i), "Library Card")
+                .card_types(vec![CardType::Instant])
+                .build();
+            game.create_object_from_card(&card, alice, Zone::Library);
+        }
+
+        let source = game.new_object_id();
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let effect = RepeatEffectsEffect::new(
+            3,
+            vec![Effect::new(crate::effects::DrawCardsEffect::you(1))],
+        );
+
+        let outcome = effect
+            .execute(&mut game, &mut ctx)
+            .expect("repeat draw should resolve");
+
+        assert_eq!(outcome.value, OutcomeValue::Count(2));
+        assert_eq!(game.player(alice).expect("alice exists").hand.len(), 2);
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Messenger Jays
Initial parse error:
```
parser does not yet support line family: 'Council's dilemma — When this creature enters, starting with you, each player votes for feather or quill. Put a +1/+1 counter on this creature for each feather vote and draw a card for each quill vote. For each card drawn this way, discard a card.'; oracle-only fallback also failed: parser does not yet support line family: 'Council's dilemma — When this creature enters, starting with you, each player votes for feather or quill. Put a +1/+1 counter on this creature for each feather vote and draw a card for each quill vote. For each card drawn this way, discard a card.'
```

Current worker: i-07e7693bd1d08bb0c
Branch: codex/aws-card-fix-messenger-jays
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0011
