### PR TITLE
Fix Ironsmith parse failure: Essence Channeler

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2150,6 +2150,14 @@ pub(crate) fn parse_static_condition_clause(
         return Ok(crate::ConditionExpr::LifeTotalOrLess(life as i32));
     }
 
+    if clause_words == ["youve", "lost", "life", "this", "turn"]
+        || clause_words == ["you", "lost", "life", "this", "turn"]
+    {
+        return Ok(crate::ConditionExpr::PlayerLostLifeThisTurn {
+            player: PlayerFilter::You,
+        });
+    }
+
     if let Some(condition) = parse_devotion_static_condition(&clause_words)? {
         return Ok(condition);
     }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -681,6 +681,9 @@ pub enum Condition {
     },
     AttackedThisTurn,
     OpponentLostLifeThisTurn,
+    PlayerLostLifeThisTurn {
+        player: PlayerFilter,
+    },
     PermanentLeftBattlefieldThisTurn,
     PermanentLeftBattlefieldUnderYourControlThisTurn,
     ObjectEnteredBattlefieldThisTurn(ObjectFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35683,6 +35683,197 @@ fn calamity_bearer_runtime_ignores_non_giant_and_opposing_giant_sources() {
 }
 
 #[test]
+fn essence_channeler_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Essence Channeler");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("as long as you've lost life this turn"),
+        "Essence Channeler should render the life-loss static condition, got {rendered}"
+    );
+    assert!(
+        rendered.contains("This creature has flying and has vigilance"),
+        "Essence Channeler should render both conditional keywords, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever you gain life, put a +1/+1 counter on this creature."),
+        "Essence Channeler should render its life-gain counter trigger, got {rendered}"
+    );
+    assert!(
+        rendered.contains("When this creature dies, put its counters on target creature you control."),
+        "Essence Channeler should render its dies counter-transfer trigger, got {rendered}"
+    );
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("PlayerLostLifeThisTurn { player: You }")
+            && abilities_debug.contains("YouGainLifeTrigger")
+            && abilities_debug.contains("MoveAllCountersEffect"),
+        "Essence Channeler should compile to typed life-loss, life-gain, and counter-transfer models, got {abilities_debug}"
+    );
+}
+
+#[test]
+fn essence_channeler_conditional_keywords_require_controller_lost_life() {
+    let def = parse_oracle_card_definition("Essence Channeler");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let channeler_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    game.refresh_continuous_state();
+    assert!(
+        !game.object_has_ability(channeler_id, &crate::static_abilities::StaticAbility::flying())
+            && !game.object_has_ability(channeler_id, &crate::static_abilities::StaticAbility::vigilance()),
+        "Essence Channeler should not have flying or vigilance before its controller loses life"
+    );
+
+    let opponent_lost_life = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::LifeLossEvent::from_effect(bob, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.stage_turn_history_event(&opponent_lost_life);
+    game.refresh_continuous_state();
+    assert!(
+        !game.object_has_ability(channeler_id, &crate::static_abilities::StaticAbility::flying())
+            && !game.object_has_ability(channeler_id, &crate::static_abilities::StaticAbility::vigilance()),
+        "Essence Channeler's condition should care that its controller lost life, not an opponent"
+    );
+
+    let controller_lost_life = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::LifeLossEvent::from_effect(alice, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.stage_turn_history_event(&controller_lost_life);
+    game.refresh_continuous_state();
+    assert!(
+        game.object_has_ability(channeler_id, &crate::static_abilities::StaticAbility::flying())
+            && game.object_has_ability(channeler_id, &crate::static_abilities::StaticAbility::vigilance()),
+        "Essence Channeler should gain flying and vigilance after its controller loses life"
+    );
+}
+
+#[test]
+fn essence_channeler_life_gain_trigger_adds_counter_only_for_controller() {
+    let def = parse_oracle_card_definition("Essence Channeler");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let channeler_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let opponent_gain = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::LifeGainEvent::new(bob, 3),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        crate::triggers::check_triggers(&game, &opponent_gain)
+            .into_iter()
+            .all(|entry| entry.source != channeler_id),
+        "Essence Channeler should not trigger when an opponent gains life"
+    );
+
+    let controller_gain = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::LifeGainEvent::new(alice, 3),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(&game, &controller_gain)
+        .into_iter()
+        .filter(|entry| entry.source == channeler_id)
+    {
+        trigger_queue.add(entry);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Essence Channeler should trigger once when its controller gains life"
+    );
+
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("put Essence Channeler life-gain trigger on stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("resolve Essence Channeler life-gain trigger");
+
+    assert_eq!(
+        game.counter_count(channeler_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Essence Channeler should put a +1/+1 counter on itself"
+    );
+}
+
+#[test]
+fn essence_channeler_dies_trigger_moves_counters_to_controlled_creature() {
+    let def = parse_oracle_card_definition("Essence Channeler");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let channeler_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let alice_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_301), "Allied Bat")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let bob_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_302), "Opposing Bat")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.add_counters(channeler_id, crate::object::CounterType::PlusOnePlusOne, 2)
+        .expect("add counters to Essence Channeler");
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(channeler_id)
+            .expect("Essence Channeler should be on the battlefield"),
+        &game,
+    );
+    game.move_object_by_effect(channeler_id, Zone::Graveyard);
+
+    let dies_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            channeler_id,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(&game, &dies_event)
+        .into_iter()
+        .filter(|entry| entry.source == channeler_id)
+    {
+        trigger_queue.add(entry);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Essence Channeler should trigger once when it dies"
+    );
+
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("put Essence Channeler dies trigger on stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("resolve Essence Channeler dies trigger");
+
+    assert_eq!(
+        game.counter_count(alice_creature, crate::object::CounterType::PlusOnePlusOne),
+        2,
+        "Essence Channeler should move its counters to a target creature its controller controls"
+    );
+    assert_eq!(
+        game.counter_count(bob_creature, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Essence Channeler should not target an opponent's creature for its dies trigger"
+    );
+}
+
+#[test]
 fn rebbec_architect_of_ascension_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Rebbec, Architect of Ascension");
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10636,6 +10636,12 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::OpponentLostLifeThisTurn => {
             "an opponent was dealt damage this turn".to_string()
         }
+        Condition::PlayerLostLifeThisTurn { player } => match player {
+            PlayerFilter::You => "you've lost life this turn".to_string(),
+            PlayerFilter::Opponent => "an opponent lost life this turn".to_string(),
+            PlayerFilter::Any => "a player lost life this turn".to_string(),
+            _ => "that player lost life this turn".to_string(),
+        },
         Condition::PermanentLeftBattlefieldThisTurn => {
             "a permanent left the battlefield this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -761,6 +761,16 @@ fn evaluate_condition_shared_core(
                     .player_lost_life_this_turn(*opponent)
             }))
         }
+        Condition::PlayerLostLifeThisTurn { player } => {
+            let Some(player_id) = resolve_condition_player_simple(game, ctx.controller, player) else {
+                return Some(false);
+            };
+            Some(
+                game.turn_store
+                    .turn_history
+                    .player_lost_life_this_turn(player_id),
+            )
+        }
         Condition::PermanentLeftBattlefieldThisTurn => Some(
             game.turn_store
                 .turn_history
@@ -936,6 +946,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::CastSpellThisTurn => {}
         Condition::AttackedThisTurn => {}
         Condition::OpponentLostLifeThisTurn => {}
+        Condition::PlayerLostLifeThisTurn { .. } => {}
         Condition::PermanentLeftBattlefieldThisTurn => {}
         Condition::PermanentLeftBattlefieldUnderYourControlThisTurn => {}
         Condition::ObjectEnteredBattlefieldThisTurn(..) => {}
@@ -1805,6 +1816,7 @@ pub fn evaluate_condition_external(
         | Condition::CastSpellThisTurn
         | Condition::AttackedThisTurn
         | Condition::OpponentLostLifeThisTurn
+        | Condition::PlayerLostLifeThisTurn { .. }
         | Condition::PermanentLeftBattlefieldThisTurn
         | Condition::PermanentLeftBattlefieldUnderYourControlThisTurn
         | Condition::ObjectEnteredBattlefieldThisTurn(_)
@@ -2427,6 +2439,14 @@ fn evaluate_condition_simple(
                 .turn_history
                 .total_life_gained_for_players(&[player_id])
                 >= *count
+        }
+        Condition::PlayerLostLifeThisTurn { player } => {
+            let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
+                return false;
+            };
+            game.turn_store
+                .turn_history
+                .player_lost_life_this_turn(player_id)
         }
         Condition::CreatureDiedThisTurnOrMore(count) => {
             game.turn_store
@@ -3078,6 +3098,13 @@ fn evaluate_condition(
                 .turn_history
                 .total_life_gained_for_players(&[player_id])
                 >= *count)
+        }
+        Condition::PlayerLostLifeThisTurn { player } => {
+            let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
+            Ok(game
+                .turn_store
+                .turn_history
+                .player_lost_life_this_turn(player_id))
         }
         Condition::CreatureDiedThisTurnOrMore(count) => Ok(game
             .turn_store

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -8787,6 +8787,7 @@ impl GameState {
         self.turn_store
             .turn_history
             .stage_event(event, object_snapshot, source_snapshot);
+        self.mark_continuous_state_dirty();
     }
 
     pub(crate) fn record_turn_history_event(&mut self, event: &crate::triggers::TriggerEvent) {
@@ -8794,6 +8795,7 @@ impl GameState {
         self.turn_store
             .turn_history
             .record_event(event, object_snapshot, source_snapshot);
+        self.mark_continuous_state_dirty();
     }
 
     pub fn queue_trigger_event(

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -951,6 +951,18 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
                 "as long as there are {count} or more card types among cards in {graveyard_owner} graveyard"
             )
         }
+        crate::ConditionExpr::PlayerLostLifeThisTurn { player } => match player {
+            crate::target::PlayerFilter::You => {
+                "as long as you've lost life this turn".to_string()
+            }
+            crate::target::PlayerFilter::Opponent => {
+                "as long as an opponent lost life this turn".to_string()
+            }
+            crate::target::PlayerFilter::Any => {
+                "as long as a player lost life this turn".to_string()
+            }
+            _ => "as long as that player lost life this turn".to_string(),
+        },
         crate::ConditionExpr::PlayerCardsInHandOrFewer { player, count } => {
             let subject = match player {
                 crate::target::PlayerFilter::You => "you",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Essence Channeler
Initial parse error:
```
unsupported static condition clause (clause: 'youve lost life this turn'); oracle-only fallback also failed: unsupported static condition clause (clause: 'youve lost life this turn')
```

Current worker: i-03cbddf23ffb916b4
Branch: codex/aws-card-fix-essence-channeler
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0011
