### PR TITLE
Fix Ironsmith parse failure: Dragon Hunter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -46,6 +46,7 @@ use super::grammar::abilities::{
     is_you_may_look_top_card_any_time_line_lexed,
     is_your_opponents_play_with_hands_revealed_line_lexed,
     parse_activated_abilities_cant_be_activated_spec_lexed,
+    parse_can_block_subtype_as_though_reach_line_lexed,
     parse_creatures_assign_combat_damage_using_toughness_line_lexed,
     parse_doesnt_untap_during_untap_step_spec_lexed,
     parse_exile_to_countered_exile_instead_of_graveyard_spec_lexed,
@@ -773,6 +774,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_anthem_line),
         single_static_ability_ast_rule!(parse_flying_restriction_line),
         single_static_ability_ast_rule!(parse_can_block_only_flying_line),
+        single_static_ability_ast_rule!(parse_can_block_subtype_as_though_reach_line),
         single_static_ability_ast_rule!(parse_assign_damage_as_unblocked_line),
         single_static_ability_ast_rule!(parse_fixed_mana_cost_instead_of_mana_cost_grant_line),
         single_static_ability_ast_rule!(parse_mana_value_instead_of_mana_cost_grant_line),
@@ -7330,6 +7332,13 @@ pub(crate) fn parse_can_block_only_flying_line(
     }
 
     Ok(None)
+}
+
+pub(crate) fn parse_can_block_subtype_as_though_reach_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    Ok(parse_can_block_subtype_as_though_reach_line_lexed(tokens)
+        .map(StaticAbility::can_block_subtype_as_though_reach))
 }
 
 pub(crate) fn parse_assign_damage_as_unblocked_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2429,6 +2429,34 @@ pub(crate) fn is_can_block_only_flying_line_lexed(tokens: &[OwnedLexToken]) -> b
     )
 }
 
+pub(crate) fn parse_can_block_subtype_as_though_reach_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<crate::types::Subtype> {
+    let words = TokenWordView::new(tokens).to_word_refs();
+    let subtype_word = match words.as_slice() {
+        [
+            "this",
+            "creature",
+            "can",
+            "block",
+            subtype,
+            "as",
+            "though",
+            "it",
+            "had",
+            "reach",
+        ]
+        | [
+            "this", "can", "block", subtype, "as", "though", "it", "had", "reach",
+        ] => *subtype,
+        _ => return None,
+    };
+
+    parse_subtype_word(subtype_word)
+        .or_else(|| subtype_word.strip_suffix('s').and_then(parse_subtype_word))
+        .filter(|subtype| subtype.is_creature_type())
+}
+
 pub(crate) fn is_skulk_rules_text_line_lexed(tokens: &[OwnedLexToken]) -> bool {
     matches_any_exact_phrase_line_lexed(
         tokens,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8435,6 +8435,27 @@ fn rewrite_grammar_flying_block_probes_match_keyword_static_shapes() {
     let parsed_only_flying = super::keyword_static::parse_can_block_only_flying_line(&only_flying)
         .expect("can-block-only-flying restriction should parse");
     assert!(parsed_only_flying.is_some(), "{parsed_only_flying:?}");
+
+    let subtype_reach = lex_line(
+        "This creature can block Dragons as though it had reach.",
+        0,
+    )
+    .expect("rewrite lexer should classify subtype reach blocking clause");
+    assert_eq!(
+        super::grammar::abilities::parse_can_block_subtype_as_though_reach_line_lexed(
+            &subtype_reach,
+        ),
+        Some(crate::types::Subtype::Dragon),
+        "grammar-owned subtype reach blocking probe should match"
+    );
+    let parsed_subtype_reach =
+        super::keyword_static::parse_can_block_subtype_as_though_reach_line(&subtype_reach)
+            .expect("subtype reach blocking clause should parse")
+            .expect("subtype reach blocking clause should produce an ability");
+    assert_eq!(
+        parsed_subtype_reach.can_block_as_though_reach_subtype(),
+        Some(crate::types::Subtype::Dragon)
+    );
 }
 
 #[test]

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -199,6 +199,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     Disguise(TotalCost<C>),
     Megamorph(TotalCost<C>),
     CanBlockAdditionalCreatureEachCombat(usize),
+    CanBlockAsThoughReachForSubtype(Subtype),
     CantBeBlockedByMoreThan(usize),
     CantBeBlockedExceptByNOrMore(usize),
     CantBeBlockedByPowerOrLess(i32),
@@ -872,6 +873,9 @@ where
             }
             StaticAbilityPayload::CanBlockAdditionalCreatureEachCombat(count) => {
                 StaticAbilityPayload::CanBlockAdditionalCreatureEachCombat(count)
+            }
+            StaticAbilityPayload::CanBlockAsThoughReachForSubtype(subtype) => {
+                StaticAbilityPayload::CanBlockAsThoughReachForSubtype(subtype)
             }
             StaticAbilityPayload::CantBeBlockedByMoreThan(count) => {
                 StaticAbilityPayload::CantBeBlockedByMoreThan(count)
@@ -1877,6 +1881,27 @@ impl<
             id: Some(StaticAbilityId::CanBlockAdditionalCreatureEachCombat),
             label: "can block additional creature".to_string(),
             payload: StaticAbilityPayload::CanBlockAdditionalCreatureEachCombat(additional),
+        }
+    }
+
+    pub fn can_block_subtype_as_though_reach(subtype: Subtype) -> Self {
+        let subtype_text = subtype.to_string();
+        let plural = if subtype_text.ends_with('s') {
+            subtype_text
+        } else {
+            format!("{subtype_text}s")
+        };
+        Self {
+            id: Some(StaticAbilityId::CanBlockFlying),
+            label: format!("This creature can block {plural} as though it had reach"),
+            payload: StaticAbilityPayload::CanBlockAsThoughReachForSubtype(subtype),
+        }
+    }
+
+    pub fn can_block_as_though_reach_subtype(&self) -> Option<Subtype> {
+        match self.payload {
+            StaticAbilityPayload::CanBlockAsThoughReachForSubtype(subtype) => Some(subtype),
+            _ => None,
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18193,6 +18193,77 @@ fn parse_can_block_only_creatures_with_flying_static_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_dragon_hunter_strict_and_renders_reach_blocking_clause() {
+    assert_oracle_card_parses_strict("Dragon Hunter");
+    let def = parse_oracle_card_definition("Dragon Hunter");
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.can_block_as_though_reach_subtype() == Some(Subtype::Dragon)
+        )),
+        "expected Dragon Hunter to block Dragons as though it had reach, got {:?}",
+        def.abilities
+    );
+
+    let compiled = canonical_compiled_lines(&def).join("\n");
+    assert!(
+        compiled
+            .to_ascii_lowercase()
+            .contains("this creature can block dragons as though it had reach"),
+        "expected compiled text to keep Dragon Hunter's reach-blocking clause, got {compiled}"
+    );
+}
+
+#[test]
+fn dragon_hunter_blocks_flying_dragons_but_not_other_fliers() {
+    let dragon_hunter = parse_oracle_card_definition("Dragon Hunter");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+
+    let hunter_id = game.create_object_from_definition(&dragon_hunter, bob, Zone::Battlefield);
+    let flying_dragon = CardDefinitionBuilder::new(CardId::new(), "Flying Dragon Attacker")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dragon])
+        .flying()
+        .build();
+    let flying_dragon_id =
+        game.create_object_from_definition(&flying_dragon, alice, Zone::Battlefield);
+    let flying_bird = CardDefinitionBuilder::new(CardId::new(), "Flying Bird Attacker")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bird])
+        .flying()
+        .build();
+    let flying_bird_id =
+        game.create_object_from_definition(&flying_bird, alice, Zone::Battlefield);
+
+    let hunter = game.object(hunter_id).expect("Dragon Hunter exists").clone();
+    let dragon = game
+        .object(flying_dragon_id)
+        .expect("flying Dragon exists")
+        .clone();
+    let bird = game
+        .object(flying_bird_id)
+        .expect("flying Bird exists")
+        .clone();
+
+    assert!(
+        crate::rules::combat::can_block(&dragon, &hunter, &game),
+        "Dragon Hunter should block flying Dragons as though it had reach"
+    );
+    assert!(
+        !crate::rules::combat::can_block(&bird, &hunter, &game),
+        "Dragon Hunter should not get reach against non-Dragon fliers"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_cant_be_blocked_by_creatures_with_power_or_less_line() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Arlinn's Wolf Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -93,6 +93,10 @@ pub(crate) fn can_block_with_view(
         .as_ref()
         .map(|c| c.colors.clone())
         .unwrap_or_else(|| blocker.colors());
+    let attacker_subtypes = attacker_chars
+        .as_ref()
+        .map(|c| c.subtypes.clone())
+        .unwrap_or_else(|| attacker.subtypes.clone());
     let blocker_is_artifact = blocker_chars
         .as_ref()
         .map(|c| c.card_types.contains(&CardType::Artifact))
@@ -111,8 +115,19 @@ pub(crate) fn can_block_with_view(
     if attacker_has(StaticAbilityId::Flying) {
         let blocker_has_flying = blocker_has(StaticAbilityId::Flying);
         let blocker_has_reach = blocker_has(StaticAbilityId::Reach);
-        let blocker_can_block_flying = blocker_has(StaticAbilityId::CanBlockFlying)
-            || blocker_has(StaticAbilityId::CanBlockOnlyFlying);
+        let blocker_can_block_flying = blocker_abilities.iter().any(|ability| {
+            if ability.id() == StaticAbilityId::CanBlockOnlyFlying {
+                return true;
+            }
+
+            if ability.id() != StaticAbilityId::CanBlockFlying {
+                return false;
+            }
+
+            ability
+                .can_block_as_though_reach_subtype()
+                .map_or(true, |subtype| attacker_subtypes.contains(&subtype))
+        });
 
         if !blocker_has_flying && !blocker_has_reach && !blocker_can_block_flying {
             return false;

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -16,6 +16,7 @@ use crate::ids::{ObjectId, PlayerId};
 use crate::object::CounterType;
 use crate::snapshot::ObjectSnapshot;
 use crate::target::ObjectFilter;
+use crate::types::Subtype;
 use crate::triggers::{TriggerEvent, TriggeredAbilityEntry};
 use crate::zone::Zone;
 
@@ -128,6 +129,44 @@ impl StaticAbilityKind for CanBlockOnlyFlying {
 
     fn display(&self) -> String {
         "Can block only creatures with flying".to_string()
+    }
+}
+
+/// Can block creatures with a subtype as though this creature had reach.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CanBlockSubtypeAsThoughReach {
+    subtype: Subtype,
+}
+
+impl CanBlockSubtypeAsThoughReach {
+    pub fn new(subtype: Subtype) -> Self {
+        Self { subtype }
+    }
+
+    fn plural_subtype(&self) -> String {
+        let subtype = self.subtype.to_string();
+        if subtype.ends_with('s') {
+            subtype
+        } else {
+            format!("{subtype}s")
+        }
+    }
+}
+
+impl StaticAbilityKind for CanBlockSubtypeAsThoughReach {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::CanBlockFlying
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "This creature can block {} as though it had reach",
+            self.plural_subtype()
+        )
+    }
+
+    fn can_block_as_though_reach_subtype(&self) -> Option<Subtype> {
+        Some(self.subtype)
     }
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -522,6 +522,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Returns the attacker subtype this creature can block as though it had reach.
+    fn can_block_as_though_reach_subtype(&self) -> Option<crate::types::Subtype> {
+        None
+    }
+
     /// Returns the maximum number of creatures that can attack in a combat.
     fn max_creatures_can_attack_each_combat(&self) -> Option<usize> {
         None
@@ -1265,6 +1270,10 @@ impl StaticAbility {
         self.0.additional_blockable_attackers()
     }
 
+    pub fn can_block_as_though_reach_subtype(&self) -> Option<crate::types::Subtype> {
+        self.0.can_block_as_though_reach_subtype()
+    }
+
     pub fn max_creatures_can_attack_each_combat(&self) -> Option<usize> {
         self.0.max_creatures_can_attack_each_combat()
     }
@@ -1757,6 +1766,10 @@ impl StaticAbility {
 
     pub fn can_block_only_flying() -> Self {
         Self::new(CanBlockOnlyFlying)
+    }
+
+    pub fn can_block_subtype_as_though_reach(subtype: crate::types::Subtype) -> Self {
+        Self::new(CanBlockSubtypeAsThoughReach::new(subtype))
     }
 
     pub fn can_block_additional_creature_each_combat(additional: usize) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -932,6 +932,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::CanBlockAdditionalCreatureEachCombat(count) => {
                 StaticAbility::can_block_additional_creature_each_combat(*count)
             }
+            ironsmith_core::StaticAbilityPayload::CanBlockAsThoughReachForSubtype(subtype) => {
+                StaticAbility::can_block_subtype_as_though_reach(*subtype)
+            }
             ironsmith_core::StaticAbilityPayload::CantBeBlockedByMoreThan(count) => {
                 StaticAbility::cant_be_blocked_by_more_than(*count)
             }
@@ -1611,6 +1614,17 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
                 Some(*count)
             }
             _ => None,
+        }
+    }
+
+    fn can_block_as_though_reach_subtype(&self) -> Option<crate::types::Subtype> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::CanBlockAsThoughReachForSubtype(subtype) => {
+                Some(*subtype)
+            }
+            _ => self
+                .leaf_static_ability()
+                .and_then(|ability| ability.can_block_as_though_reach_subtype()),
         }
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dragon Hunter
Initial parse error:
```
parser does not yet support line family: 'This creature can block Dragons as though it had reach.'; oracle-only fallback also failed: parser does not yet support line family: 'This creature can block Dragons as though it had reach.'
```

Current worker: i-0f58c5d0140cfadc4
Branch: codex/aws-card-fix-dragon-hunter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0016
