### PR TITLE
Fix Ironsmith parse failure: Take the Bait

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -851,6 +851,20 @@ pub(crate) fn parse_prevent_damage_target_scope_lexed(
             ),
         ));
     }
+    if target_words.first().copied() == Some("you")
+        && let Some(and_idx) = tokens.iter().position(|token| token.is_word("and"))
+    {
+        let permanent_tokens = trim_commas(&tokens[and_idx + 1..]);
+        let filter = parse_object_filter(&permanent_tokens, false)?;
+        if filter != ObjectFilter::default() {
+            return Ok(Some(
+                EffectAst::subject_verb_prevent_all_combat_damage_to_you_and_permanents_matching(
+                    filter,
+                    crate::effect::Until::EndOfTurn,
+                ),
+            ));
+        }
+    }
 
     Err(CardTextError::ParseError(format!(
         "unsupported prevent-all target scope '{}'",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -373,6 +373,8 @@ fn is_statement_verb_word(word: &str) -> bool {
             | "mills"
             | "put"
             | "puts"
+            | "prevent"
+            | "prevents"
             | "return"
             | "returns"
             | "reveal"

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1416,6 +1416,23 @@ fn compile_subject_verb_effect(
             vec![Effect::prevent_all_combat_damage_to_you(duration.clone())],
             Vec::new(),
         )),
+        SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching {
+            duration,
+            filter,
+        } => {
+            let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            Ok((
+                vec![
+                    Effect::prevent_all_combat_damage_to_you(duration.clone()),
+                    Effect::new(crate::effects::PreventAllDamageEffect::matching_with_filter(
+                        resolved_filter,
+                        ironsmith_core::DamageFilter::combat(),
+                        duration.clone(),
+                    )),
+                ],
+                Vec::new(),
+            ))
+        }
         SubjectVerbActionAst::PreventNextTimeDamage {
             source,
             target,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -669,6 +669,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
         | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
         | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
+        | SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching { .. }
         | SubjectVerbActionAst::PreventNextTimeDamage { .. }
         | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
         | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -949,6 +949,10 @@ pub(crate) enum SubjectVerbActionAst {
     PreventAllCombatDamageToYou {
         duration: Until,
     },
+    PreventAllCombatDamageToYouAndPermanentsMatching {
+        duration: Until,
+        filter: ObjectFilter,
+    },
     PreventNextTimeDamage {
         source: PreventNextTimeDamageSourceAst,
         target: PreventNextTimeDamageTargetAst,
@@ -2056,6 +2060,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::PreventAllCombatDamageToYou { duration } => f
                 .debug_struct("PreventAllCombatDamageToYou")
                 .field("duration", duration)
+                .finish(),
+            Self::PreventAllCombatDamageToYouAndPermanentsMatching { duration, filter } => f
+                .debug_struct("PreventAllCombatDamageToYouAndPermanentsMatching")
+                .field("duration", duration)
+                .field("filter", filter)
                 .finish(),
             Self::PreventNextTimeDamage {
                 source,
@@ -3417,6 +3426,20 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::PreventAllCombatDamageToYou { duration },
+        )
+    }
+
+    pub(crate) fn subject_verb_prevent_all_combat_damage_to_you_and_permanents_matching(
+        filter: ObjectFilter,
+        duration: Until,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching {
+                duration,
+                filter,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -421,6 +421,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1743,6 +1743,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
@@ -2484,6 +2485,10 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::RevealTopChooseCardTypePutToHandRestBottom { .. }
             | SubjectVerbActionAst::GrantAbilityToSource { .. }
             | SubjectVerbActionAst::ExchangeZones { .. } => 0,
+            SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching {
+                filter,
+                ..
+            } => bind_unresolved_it_in_filter(filter, seed_tag),
             SubjectVerbActionAst::ExchangeControlHeterogeneous {
                 permanent1,
                 permanent2,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2434,6 +2434,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToYouAndPermanentsMatching { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46250,6 +46250,212 @@ fn parse_full_throttle_two_additional_combats() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_take_the_bait_strict_and_keeps_all_effect_clauses() {
+    let def = parse_oracle_card_definition("Take the Bait");
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains(
+            "Prevent all combat damage that would be dealt to you and planeswalkers you control this turn"
+        ),
+        "Take the Bait should preserve the player-and-planeswalkers prevention clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Untap all attacking creatures and goad them"),
+        "Take the Bait should preserve the attacking-creature untap/goad clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("After this phase, there is an additional combat phase"),
+        "Take the Bait should preserve the extra-combat clause, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported"),
+        "Take the Bait should parse strictly without unsupported markers, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_take_the_bait(game: &mut crate::game_state::GameState, controller: PlayerId) {
+    let def = parse_oracle_card_definition("Take the Bait");
+    let spell_id = game.create_object_from_definition(&def, controller, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(spell_id, controller));
+    crate::game_loop::resolve_stack_entry_with(
+        game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Take the Bait should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn take_the_bait_cast_restriction_requires_combat_on_opponents_turn() {
+    let def = parse_oracle_card_definition("Take the Bait");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    let spell = game
+        .object(spell_id)
+        .expect("Take the Bait should exist in hand");
+    assert!(
+        !crate::decision::spell_cast_restrictions_allow(&game, alice, spell),
+        "Take the Bait should not be cast outside combat"
+    );
+
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let spell = game
+        .object(spell_id)
+        .expect("Take the Bait should exist in hand");
+    assert!(
+        !crate::decision::spell_cast_restrictions_allow(&game, alice, spell),
+        "Take the Bait should not be cast during combat on its controller's turn"
+    );
+
+    game.turn.active_player = bob;
+    let spell = game
+        .object(spell_id)
+        .expect("Take the Bait should exist in hand");
+    assert!(
+        crate::decision::spell_cast_restrictions_allow(&game, alice, spell),
+        "Take the Bait should be castable during combat on an opponent's turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn take_the_bait_runtime_prevents_combat_damage_untaps_goads_and_adds_combat() {
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let bob_attacker = create_winds_test_creature(&mut game, "Bob Attacker", bob, 3, 3);
+    let bob_attacker_two = create_winds_test_creature(&mut game, "Second Bob Attacker", bob, 2, 2);
+    let alice_creature = create_winds_test_creature(&mut game, "Alice Creature", alice, 2, 2);
+    let bystander = create_winds_test_creature(&mut game, "Bystander", bob, 1, 1);
+    let planeswalker = crate::card::CardBuilder::new(CardId::new(), "Alice Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .build();
+    let alice_planeswalker = game.create_object_from_card(&planeswalker, alice, Zone::Battlefield);
+
+    game.tap(bob_attacker);
+    game.tap(bob_attacker_two);
+    game.tap(bystander);
+
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![
+            crate::combat_state::AttackerInfo {
+                creature: bob_attacker,
+                target: crate::combat_state::AttackTarget::Player(alice),
+            },
+            crate::combat_state::AttackerInfo {
+                creature: bob_attacker_two,
+                target: crate::combat_state::AttackTarget::Planeswalker(alice_planeswalker),
+            },
+        ],
+        blockers: std::collections::HashMap::new(),
+        ..Default::default()
+    });
+
+    resolve_take_the_bait(&mut game, alice);
+
+    assert!(
+        !game.is_tapped(bob_attacker) && !game.is_tapped(bob_attacker_two),
+        "Take the Bait should untap all attacking creatures"
+    );
+    assert!(
+        game.is_tapped(bystander),
+        "Take the Bait should not untap nonattacking creatures"
+    );
+    assert!(
+        game.is_goaded(bob_attacker) && game.is_goaded(bob_attacker_two),
+        "Take the Bait should goad every attacking creature"
+    );
+    assert!(
+        !game.is_goaded(bystander),
+        "Take the Bait should not goad nonattacking creatures"
+    );
+    assert_eq!(
+        game.turn_store.additional_phases,
+        vec![crate::game_state::Phase::Combat],
+        "Take the Bait should queue one additional combat phase"
+    );
+
+    let (damage_to_alice, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        bob_attacker,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        true,
+        crate::events::cause::EventCause::combat_damage(bob_attacker),
+    );
+    assert_eq!(damage_to_alice, 0, "combat damage to Alice should be prevented");
+
+    let (damage_to_planeswalker, _) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            bob_attacker,
+            crate::events::DamageTarget::Object(alice_planeswalker),
+            3,
+            true,
+            crate::events::cause::EventCause::combat_damage(bob_attacker),
+        );
+    assert_eq!(
+        damage_to_planeswalker, 0,
+        "combat damage to Alice's planeswalker should be prevented"
+    );
+
+    let (damage_to_creature, creature_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            bob_attacker,
+            crate::events::DamageTarget::Object(alice_creature),
+            3,
+            true,
+            crate::events::cause::EventCause::combat_damage(bob_attacker),
+        );
+    assert_eq!(
+        damage_to_creature, 3,
+        "Take the Bait should not prevent combat damage to non-planeswalker permanents"
+    );
+    assert!(!creature_prevented, "creature combat damage should not be prevented");
+
+    let (noncombat_to_planeswalker, noncombat_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            bob_attacker,
+            crate::events::DamageTarget::Object(alice_planeswalker),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        noncombat_to_planeswalker, 3,
+        "Take the Bait should not prevent noncombat damage to planeswalkers"
+    );
+    assert!(
+        !noncombat_prevented,
+        "noncombat planeswalker damage should not be prevented"
+    );
+}
+
 #[test]
 fn parse_must_be_blocked_each_combat_this_turn_if_able() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Must Be Blocked Variant")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3973,6 +3973,67 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
+    fn describe_tag_matching_untap_then_goad(effects: &[&Effect]) -> Option<String> {
+        let [tag_effect, untap_effect, goad_effect] = effects else {
+            return None;
+        };
+        let tag_matching = tag_effect.downcast_ref::<crate::effects::TagMatchingObjectsEffect>()?;
+        let untap = untap_effect.downcast_ref::<crate::effects::UntapEffect>()?;
+        let ChooseSpec::All(untap_filter) = &untap.target else {
+            return None;
+        };
+        if untap_filter != &tag_matching.filter {
+            return None;
+        }
+        let goad = goad_view(goad_effect)?;
+        if !choose_spec_references_exact_tag(&goad.target, &tag_matching.tag) {
+            return None;
+        }
+        let subject = pluralize_noun_phrase(strip_leading_article(&tag_matching.filter.description()));
+        Some(format!("Untap all {subject} and goad them"))
+    }
+
+    if let Some(compact) = describe_tag_matching_untap_then_goad(&filtered) {
+        return compact;
+    }
+
+    fn describe_you_and_matching_combat_prevention_pair(
+        first: &Effect,
+        second: &Effect,
+    ) -> Option<String> {
+        let prevent_you = first.downcast_ref::<crate::effects::PreventAllCombatDamageEffect>()?;
+        if !matches!(
+            prevent_you.target,
+            crate::effects::CombatDamagePreventionTarget::You
+        ) {
+            return None;
+        }
+        let prevent_matching = second.downcast_ref::<crate::effects::PreventAllDamageEffect>()?;
+        if prevent_matching.until != prevent_you.until
+            || !prevent_matching.damage_filter.combat_only
+            || prevent_matching.damage_filter.noncombat_only
+            || prevent_matching.damage_filter.from_source.is_some()
+            || prevent_matching.damage_filter.from_colors.is_some()
+            || prevent_matching.damage_filter.from_card_types.is_some()
+            || prevent_matching.damage_filter.from_specific_source.is_some()
+        {
+            return None;
+        }
+        let crate::prevention::PreventionTarget::PermanentsMatching(filter) =
+            &prevent_matching.target
+        else {
+            return None;
+        };
+        let timing = match prevent_you.until {
+            Until::EndOfTurn => "this turn".to_string(),
+            _ => describe_until(&prevent_you.until),
+        };
+        Some(format!(
+            "Prevent all combat damage that would be dealt to you and {} {timing}",
+            pluralize_noun_phrase(strip_leading_article(&filter.description()))
+        ))
+    }
+
     fn tagged_apply_continuous_view(
         effect: &Effect,
     ) -> Option<&crate::effects::ApplyContinuousEffect> {
@@ -12038,6 +12099,21 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         {
             parts.push(compact);
             idx += 5;
+            continue;
+        }
+        if idx + 2 < filtered.len()
+            && let Some(compact) = describe_tag_matching_untap_then_goad(&filtered[idx..idx + 3])
+        {
+            parts.push(compact);
+            idx += 3;
+            continue;
+        }
+        if idx + 1 < filtered.len()
+            && let Some(compact) =
+                describe_you_and_matching_combat_prevention_pair(filtered[idx], filtered[idx + 1])
+        {
+            parts.push(compact);
+            idx += 2;
             continue;
         }
         if idx + 1 < filtered.len()

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2307,6 +2307,27 @@ fn apply_prevention_for_damage_assignment(
             Some((shield.id, matches_current || matches_lki))
         })
         .collect();
+    let target_filter_matches: std::collections::HashMap<_, _> = match target {
+        DamageTarget::Object(object_id) => game
+            .effect_store
+            .prevention_effects
+            .shields()
+            .iter()
+            .filter_map(|shield| {
+                let crate::prevention::PreventionTarget::PermanentsMatching(filter) =
+                    &shield.protected
+                else {
+                    return None;
+                };
+                let filter_ctx = game.filter_context_for(shield.controller, Some(shield.source));
+                let matches_target = game
+                    .object(object_id)
+                    .is_some_and(|target_obj| filter.matches(target_obj, &filter_ctx, game));
+                Some((shield.id, matches_target))
+            })
+            .collect(),
+        DamageTarget::Player(_) => std::collections::HashMap::new(),
+    };
 
     let result = match target {
         DamageTarget::Player(player_id) => game
@@ -2339,6 +2360,7 @@ fn apply_prevention_for_damage_assignment(
                     &source_card_types,
                     can_prevent,
                     &source_filter_matches,
+                    &target_filter_matches,
                 )
         }
     };

--- a/crates/ironsmith-runtime/src/prevention.rs
+++ b/crates/ironsmith-runtime/src/prevention.rs
@@ -255,6 +255,7 @@ impl PreventionEffectManager {
         &self,
         permanent: ObjectId,
         controller: PlayerId,
+        target_filter_matches: &HashMap<PreventionShieldId, bool>,
     ) -> Vec<&PreventionShield> {
         self.shields
             .iter()
@@ -262,10 +263,8 @@ impl PreventionEffectManager {
             .filter(|s| match &s.protected {
                 PreventionTarget::Permanent(p) => *p == permanent,
                 PreventionTarget::YouAndPermanentsYouControl => s.controller == controller,
-                PreventionTarget::PermanentsMatching(_filter) => {
-                    // Would need object context to evaluate filter
-                    // For now, include all filter-based shields
-                    true
+                PreventionTarget::PermanentsMatching(_) => {
+                    target_filter_matches.get(&s.id).copied().unwrap_or(false)
                 }
                 PreventionTarget::All => true,
                 _ => false,
@@ -393,6 +392,7 @@ impl PreventionEffectManager {
         can_be_prevented: bool,
     ) -> u32 {
         let source_filter_matches = HashMap::new();
+        let target_filter_matches = HashMap::new();
         self.apply_prevention_to_permanent_with_follow_ups(
             permanent,
             controller,
@@ -403,6 +403,7 @@ impl PreventionEffectManager {
             source_card_types,
             can_be_prevented,
             &source_filter_matches,
+            &target_filter_matches,
         )
         .remaining
     }
@@ -419,6 +420,7 @@ impl PreventionEffectManager {
         source_card_types: &[CardType],
         can_be_prevented: bool,
         source_filter_matches: &HashMap<PreventionShieldId, bool>,
+        target_filter_matches: &HashMap<PreventionShieldId, bool>,
     ) -> PreventionApplicationResult {
         if damage == 0 {
             return PreventionApplicationResult::default();
@@ -429,7 +431,7 @@ impl PreventionEffectManager {
 
         // Find applicable shields
         let shield_ids: Vec<PreventionShieldId> = self
-            .get_shields_for_permanent(permanent, controller)
+            .get_shields_for_permanent(permanent, controller, target_filter_matches)
             .iter()
             .filter(|s| {
                 let source_filter_ok = s.damage_filter.from_source.is_none()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Take the Bait
Initial parse error:
```
parser does not yet support line family: 'Prevent all combat damage that would be dealt to you and planeswalkers you control this turn. Untap all attacking creatures and goad them. After this phase, there is an additional combat phase.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all combat damage that would be dealt to you and planeswalkers you control this turn. Untap all attacking creatures and goad them. After this phase, there is an additional combat phase.'
```

Current worker: i-0c8f75d47ae20c4d3
Branch: codex/aws-card-fix-take-the-bait
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0017
