### PR TITLE
Fix Ironsmith parse failure: Keeper of the Flame

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -3166,6 +3166,13 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
         ));
     }
 
+    if let Some(filter) = parse_life_advantage_player_target_filter(&remaining_words) {
+        return Ok(wrap_target_count(
+            TargetAst::Player(filter, target_span),
+            target_count,
+        ));
+    }
+
     if remaining_words.as_slice() == ["player", "on", "your", "team"]
         || remaining_words.as_slice() == ["players", "on", "your", "team"]
     {
@@ -3764,6 +3771,47 @@ fn parse_hand_advantage_player_target_filter(words: &[&str]) -> Option<PlayerFil
     Some(PlayerFilter::CardsInHandAtLeastMoreThanYou {
         base: Box::new(base),
         count,
+    })
+}
+
+fn parse_life_advantage_player_target_filter(words: &[&str]) -> Option<PlayerFilter> {
+    let (base, mut idx) = match words.first().copied()? {
+        "opponent" | "opponents" => (PlayerFilter::Opponent, 1),
+        "player" | "players" => (PlayerFilter::Any, 1),
+        _ => return None,
+    };
+
+    if !matches!(words.get(idx).copied(), Some("who" | "that")) {
+        return None;
+    }
+    idx += 1;
+    if words.get(idx).copied() != Some("has") {
+        return None;
+    }
+    idx += 1;
+
+    if words.get(idx).copied() != Some("more")
+        || words.get(idx + 1).copied() != Some("life")
+        || words.get(idx + 2).copied() != Some("than")
+        || words.get(idx + 3).copied() != Some("you")
+    {
+        return None;
+    }
+    idx += 4;
+
+    if words.get(idx).copied() == Some("do") {
+        idx += 1;
+    }
+
+    if idx < words.len() {
+        let rest = &words[idx..];
+        if rest != ["as", "you", "activate", "this", "ability"] {
+            return None;
+        }
+    }
+
+    Some(PlayerFilter::HasMoreLifeThanYou {
+        base: Box::new(base),
     })
 }
 

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -154,6 +154,9 @@ pub enum PlayerFilter {
         base: Box<PlayerFilter>,
         count: u32,
     },
+    HasMoreLifeThanYou {
+        base: Box<PlayerFilter>,
+    },
     MaxSpeed {
         base: Box<PlayerFilter>,
         has_max_speed: bool,
@@ -208,6 +211,7 @@ impl PlayerFilter {
             Self::IteratedPlayer => true,
             Self::Target(inner) => inner.mentions_iterated_player(),
             Self::CardsInHandAtLeastMoreThanYou { base, .. } => base.mentions_iterated_player(),
+            Self::HasMoreLifeThanYou { base } => base.mentions_iterated_player(),
             Self::MaxSpeed { base, .. } => base.mentions_iterated_player(),
             Self::Excluding { base, excluded } => {
                 base.mentions_iterated_player() || excluded.mentions_iterated_player()
@@ -262,9 +266,15 @@ impl PlayerFilter {
             Self::CardsInHandAtLeastMoreThanYou { base, count } => {
                 let count_text = crate::cardinal_word(*count).unwrap_or_else(|| count.to_string());
                 format!(
-                    "{} who has at least {} more cards in hand than you do",
+                    "{} who has at least {} more cards in hand than you do as you activate this ability",
                     base.description(),
                     count_text
+                )
+            }
+            Self::HasMoreLifeThanYou { base } => {
+                format!(
+                    "{} who has more life than you do as you activate this ability",
+                    base.description()
                 )
             }
             Self::MaxSpeed {
@@ -1169,6 +1179,9 @@ impl ObjectFilter {
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
+                PlayerFilter::HasMoreLifeThanYou { .. } => {
+                    parts.push(describe_possessive_player_filter(ctrl));
+                }
                 PlayerFilter::MaxSpeed { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
@@ -1244,6 +1257,9 @@ impl ObjectFilter {
                     card_type.to_string().to_ascii_lowercase()
                 ),
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => {
+                    format!("{} owns", describe_player_filter(owner))
+                }
+                PlayerFilter::HasMoreLifeThanYou { .. } => {
                     format!("{} owns", describe_player_filter(owner))
                 }
                 PlayerFilter::MaxSpeed { .. } => {
@@ -2171,7 +2187,13 @@ fn describe_possessive_player_filter(filter: &PlayerFilter) -> String {
         PlayerFilter::CardsInHandAtLeastMoreThanYou { base, count } => {
             let count_text = crate::cardinal_word(*count).unwrap_or_else(|| count.to_string());
             format!(
-                "{} who has at least {count_text} more cards in hand than you do's",
+                "{} who has at least {count_text} more cards in hand than you do as you activate this ability's",
+                describe_player_filter(base)
+            )
+        }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            format!(
+                "{} who has more life than you do as you activate this ability's",
                 describe_player_filter(base)
             )
         }
@@ -2237,7 +2259,13 @@ pub(crate) fn describe_player_filter(filter: &PlayerFilter) -> String {
         PlayerFilter::CardsInHandAtLeastMoreThanYou { base, count } => {
             let count_text = crate::cardinal_word(*count).unwrap_or_else(|| count.to_string());
             format!(
-                "{} who has at least {count_text} more cards in hand than you do",
+                "{} who has at least {count_text} more cards in hand than you do as you activate this ability",
+                describe_player_filter(base)
+            )
+        }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            format!(
+                "{} who has more life than you do as you activate this ability",
                 describe_player_filter(base)
             )
         }

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -448,6 +448,7 @@ where
                     card_type.to_string().to_ascii_lowercase()
                 ),
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => "That player may".to_string(),
+                PlayerFilter::HasMoreLifeThanYou { .. } => "That player may".to_string(),
                 PlayerFilter::MaxSpeed { .. } => "That player may".to_string(),
                 PlayerFilter::ChosenPlayer => "The chosen player may".to_string(),
                 PlayerFilter::TaggedPlayer(_)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11056,6 +11056,37 @@ fn test_keeper_of_the_mind_target_condition_survives_rendering() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_keeper_of_the_flame_life_target_condition_parses_and_renders() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Keeper of the Flame")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red], vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "{R}, {T}: Choose target opponent who has more life than you do as you activate this ability. This creature deals 2 damage to that player.",
+        )
+        .expect("parse Keeper of the Flame ability");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("HasMoreLifeThanYou")
+            && debug.contains("base: Opponent")
+            && debug.contains("TargetOnlyEffect")
+            && debug.contains("DealDamageEffect"),
+        "expected a life-gated opponent target followed by damage, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" | ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains(
+            "choose target opponent who has more life than you do as you activate this ability"
+        ) && rendered.contains("this creature deals 2 damage to that player"),
+        "expected Keeper of the Flame target condition and damage text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_untap_another_target_permanent_rendering() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Untap Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -50,7 +50,13 @@ pub(super) fn describe_player_filter(filter: &PlayerFilter) -> String {
         PlayerFilter::CardsInHandAtLeastMoreThanYou { base, count } => {
             let count_text = small_number_word(*count).unwrap_or_else(|| count.to_string());
             format!(
-                "{} who has at least {count_text} more cards in hand than you do",
+                "{} who has at least {count_text} more cards in hand than you do as you activate this ability",
+                strip_leading_article(&describe_player_filter(base))
+            )
+        }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            format!(
+                "{} who has more life than you do as you activate this ability",
                 strip_leading_article(&describe_player_filter(base))
             )
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2033,7 +2033,8 @@ fn choose_spec_contains_hand_advantage_player_filter(spec: &ChooseSpec) -> bool 
 
 fn player_filter_contains_hand_advantage_filter(filter: &PlayerFilter) -> bool {
     match filter {
-        PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => true,
+        PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+        | PlayerFilter::HasMoreLifeThanYou { .. } => true,
         PlayerFilter::Target(inner) => player_filter_contains_hand_advantage_filter(inner),
         PlayerFilter::Excluding { base, excluded } => {
             player_filter_contains_hand_advantage_filter(base)
@@ -5401,6 +5402,35 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         ))
     }
 
+    fn describe_target_only_then_damage_that_player(
+        target_only: &crate::effects::TargetOnlyEffect,
+        damage: &crate::effects::DealDamageEffect,
+    ) -> Option<String> {
+        let ChooseSpec::Target(target_inner) = &target_only.target else {
+            return None;
+        };
+        let ChooseSpec::Player(chosen_filter) = target_inner.as_ref() else {
+            return None;
+        };
+        let ChooseSpec::Player(PlayerFilter::Target(damage_filter)) = &damage.target else {
+            return None;
+        };
+        if chosen_filter != damage_filter.as_ref() {
+            return None;
+        }
+
+        let damage_text = describe_effect_impl(&Effect::new(damage.clone()));
+        let damage_target = describe_choose_spec(&damage.target);
+        if !damage_text.contains(&damage_target) {
+            return None;
+        }
+        Some(format!(
+            "Choose {}. {}",
+            describe_choose_spec(&target_only.target),
+            damage_text.replace(&damage_target, "that player")
+        ))
+    }
+
     fn downcast_exile<'a>(effect: &'a Effect) -> Option<&'a crate::effects::ExileEffect> {
         if let Some(exile) = effect.downcast_ref::<crate::effects::ExileEffect>() {
             return Some(exile);
@@ -7849,6 +7879,15 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
     if let Some(compact) = render_search_reveal_opponent_choose_rest_bundle(&filtered) {
         return compact;
+    }
+
+    if effects.len() == 2
+        && let Some(target_only) = effects[0].downcast_ref::<crate::effects::TargetOnlyEffect>()
+        && let Some(damage) = unwrap_tag_wrappers(&effects[1])
+            .downcast_ref::<crate::effects::DealDamageEffect>()
+        && let Some(rendered) = describe_target_only_then_damage_that_player(target_only, damage)
+    {
+        return rendered;
     }
 
     if effects.len() == 2

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -2601,7 +2601,9 @@ fn resolve_condition_player_simple(
                 _ => None,
             }
         }
-        PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } | PlayerFilter::MaxSpeed { .. } => {
+        PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+        | PlayerFilter::HasMoreLifeThanYou { .. }
+        | PlayerFilter::MaxSpeed { .. } => {
             let filter_ctx = crate::target::FilterContext::new(controller)
                 .with_opponents(
                     game.players

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -853,6 +853,7 @@ fn object_matches_filter_with_chars(
             | PlayerFilter::LowestLifeTied
             | PlayerFilter::MostCardsInHand
             | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+            | PlayerFilter::HasMoreLifeThanYou { .. }
             | PlayerFilter::MaxSpeed { .. }
             | PlayerFilter::CastCardTypeThisTurn(_)
             | PlayerFilter::Teammate

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2064,6 +2064,7 @@ pub fn resolve_player_filter(
         | PlayerFilter::LowestLifeTied
         | PlayerFilter::CastCardTypeThisTurn(_)
         | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+        | PlayerFilter::HasMoreLifeThanYou { .. }
         | PlayerFilter::MaxSpeed { .. } => {
             let filter_ctx = ctx.filter_context(game);
             let mut players = resolve_player_filter_to_list(game, spec, &filter_ctx, ctx)?;
@@ -3190,7 +3191,8 @@ pub(crate) fn resolve_player_filter_to_list(
             })
             .map(|player| player.id)
             .collect()),
-        PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => Ok(game
+        PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+        | PlayerFilter::HasMoreLifeThanYou { .. } => Ok(game
             .players
             .iter()
             .filter(|player| player.is_in_game())

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1128,6 +1128,7 @@ impl PlayerFilterExt for PlayerFilter {
             PlayerFilter::CardsInHandAtLeastMoreThanYou { base, .. } => {
                 base.matches_player(player, ctx)
             }
+            PlayerFilter::HasMoreLifeThanYou { base } => base.matches_player(player, ctx),
             PlayerFilter::MaxSpeed { .. } => false,
             PlayerFilter::ChosenPlayer => ctx.chosen_player.is_some_and(|chosen| chosen == player),
             PlayerFilter::TaggedPlayer(tag) => ctx
@@ -1190,6 +1191,17 @@ pub(crate) fn player_filter_matches_game(
             let candidate_hand = game.player(player).map(|p| p.hand.len()).unwrap_or(0);
             let your_hand = game.player(you).map(|p| p.hand.len()).unwrap_or(0);
             candidate_hand >= your_hand.saturating_add(*count as usize)
+        }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            if !player_filter_matches_game(base, player, game, ctx) {
+                return false;
+            }
+            let Some(you) = ctx.you else {
+                return false;
+            };
+            let candidate_life = game.player(player).map(|p| p.life).unwrap_or(0);
+            let your_life = game.player(you).map(|p| p.life).unwrap_or(0);
+            candidate_life > your_life
         }
         PlayerFilter::MaxSpeed {
             base,
@@ -2975,6 +2987,9 @@ impl ObjectFilterExt for ObjectFilter {
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
+                PlayerFilter::HasMoreLifeThanYou { .. } => {
+                    parts.push(describe_possessive_player_filter(ctrl));
+                }
                 PlayerFilter::MaxSpeed { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
@@ -3049,6 +3064,9 @@ impl ObjectFilterExt for ObjectFilter {
                     "the player who has the most cards in hand owns".to_string()
                 }
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => {
+                    format!("{} owns", describe_player_filter(owner))
+                }
+                PlayerFilter::HasMoreLifeThanYou { .. } => {
                     format!("{} owns", describe_player_filter(owner))
                 }
                 PlayerFilter::MaxSpeed { .. } => {
@@ -4099,6 +4117,7 @@ fn describe_possessive_player_filter(filter: &PlayerFilter) -> String {
         PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => {
             format!("{}'s", describe_player_filter(filter))
         }
+        PlayerFilter::HasMoreLifeThanYou { .. } => format!("{}'s", describe_player_filter(filter)),
         PlayerFilter::MaxSpeed { .. } => format!("{}'s", describe_player_filter(filter)),
         PlayerFilter::ChosenPlayer => "the chosen player's".to_string(),
         PlayerFilter::TaggedPlayer(_) => "that player's".to_string(),
@@ -4151,7 +4170,13 @@ pub(crate) fn describe_player_filter(filter: &PlayerFilter) -> String {
         PlayerFilter::CardsInHandAtLeastMoreThanYou { base, count } => {
             let count_text = count.to_string();
             format!(
-                "{} who has at least {count_text} more cards in hand than you do",
+                "{} who has at least {count_text} more cards in hand than you do as you activate this ability",
+                describe_player_filter(base)
+            )
+        }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            format!(
+                "{} who has more life than you do as you activate this ability",
                 describe_player_filter(base)
             )
         }

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -57,6 +57,7 @@ fn player_filter_references_target_player(filter: &crate::target::PlayerFilter) 
                 || player_filter_references_target_player(excluded)
         }
         PlayerFilter::CardsInHandAtLeastMoreThanYou { base, .. }
+        | PlayerFilter::HasMoreLifeThanYou { base }
         | PlayerFilter::MaxSpeed { base, .. } => player_filter_references_target_player(base),
         _ => false,
     }

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -1240,6 +1240,9 @@ fn specialize_iterated_player_filter(filter: &PlayerFilter, player: PlayerId) ->
                 count: *count,
             }
         }
+        PlayerFilter::HasMoreLifeThanYou { base } => PlayerFilter::HasMoreLifeThanYou {
+            base: Box::new(specialize_iterated_player_filter(base, player)),
+        },
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,
@@ -1918,6 +1921,13 @@ pub fn player_matches_filter_with_combat(
             let your_hand = game.player(controller).map(|p| p.hand.len()).unwrap_or(0);
             candidate_hand >= your_hand.saturating_add(*count as usize)
         }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            player_matches_filter_with_combat(player_id, base, game, controller, combat)
+                && game
+                    .player(player_id)
+                    .zip(game.player(controller))
+                    .is_some_and(|(candidate, you)| candidate.life > you.life)
+        }
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,
@@ -2187,6 +2197,68 @@ fn replace_damaged_player_choose_spec(spec: &mut crate::target::ChooseSpec, play
     }
 }
 
+// Activation-time comparisons are target-selection gates; resolution only rechecks
+// that the chosen player still satisfies the underlying player class.
+fn player_filter_for_resolution_target_validation(
+    filter: &crate::target::PlayerFilter,
+) -> crate::target::PlayerFilter {
+    use crate::target::PlayerFilter;
+
+    match filter {
+        PlayerFilter::CardsInHandAtLeastMoreThanYou { base, .. }
+        | PlayerFilter::HasMoreLifeThanYou { base } => {
+            player_filter_for_resolution_target_validation(base)
+        }
+        PlayerFilter::Target(inner) => PlayerFilter::Target(Box::new(
+            player_filter_for_resolution_target_validation(inner),
+        )),
+        PlayerFilter::Excluding { base, excluded } => PlayerFilter::Excluding {
+            base: Box::new(player_filter_for_resolution_target_validation(base)),
+            excluded: Box::new(player_filter_for_resolution_target_validation(excluded)),
+        },
+        PlayerFilter::MaxSpeed {
+            base,
+            has_max_speed,
+        } => PlayerFilter::MaxSpeed {
+            base: Box::new(player_filter_for_resolution_target_validation(base)),
+            has_max_speed: *has_max_speed,
+        },
+        _ => filter.clone(),
+    }
+}
+
+fn choose_spec_for_resolution_target_validation(
+    spec: &crate::target::ChooseSpec,
+) -> crate::target::ChooseSpec {
+    use crate::target::ChooseSpec;
+
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, hints } => ChooseSpec::SurfaceHinted {
+            spec: Box::new(choose_spec_for_resolution_target_validation(spec)),
+            hints: hints.clone(),
+        },
+        ChooseSpec::Target(inner) => ChooseSpec::Target(Box::new(
+            choose_spec_for_resolution_target_validation(inner),
+        )),
+        ChooseSpec::WithCount(inner, count) => ChooseSpec::WithCount(
+            Box::new(choose_spec_for_resolution_target_validation(inner)),
+            *count,
+        ),
+        ChooseSpec::WithCountValue(inner, count, value) => ChooseSpec::WithCountValue(
+            Box::new(choose_spec_for_resolution_target_validation(inner)),
+            *count,
+            value.clone(),
+        ),
+        ChooseSpec::Player(filter) => ChooseSpec::Player(
+            player_filter_for_resolution_target_validation(filter),
+        ),
+        ChooseSpec::PlayerOrPlaneswalker(filter) => ChooseSpec::PlayerOrPlaneswalker(
+            player_filter_for_resolution_target_validation(filter),
+        ),
+        _ => spec.clone(),
+    }
+}
+
 pub(super) fn validate_stack_entry_targets_with_view(
     game: &GameState,
     entry: &StackEntry,
@@ -2211,6 +2283,7 @@ pub(super) fn validate_stack_entry_targets_with_view(
                 &assignment.spec,
                 entry.triggering_event.as_ref(),
             );
+            let resolved_spec = choose_spec_for_resolution_target_validation(&resolved_spec);
             let legal_targets = compute_legal_targets_with_source_snapshot_and_view(
                 game,
                 &resolved_spec,
@@ -2275,6 +2348,7 @@ pub(super) fn validate_stack_entry_targets_with_view(
         .map(|spec| {
             let resolved_spec =
                 choose_spec_with_damaged_player_from_event(spec, entry.triggering_event.as_ref());
+            let resolved_spec = choose_spec_for_resolution_target_validation(&resolved_spec);
             if entry.defending_player.is_some() {
                 return compute_legal_targets_with_tagged_objects_combat_context_and_view(
                     game,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -98,6 +98,106 @@ fn rise_from_the_grave_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn keeper_of_the_flame_activation_requires_higher_life_opponent_and_damages_that_player() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice).expect("Alice should exist").life = 20;
+    game.player_mut(bob).expect("Bob should exist").life = 20;
+
+    let keeper_def = keeper_of_the_flame_definition();
+    let keeper_id = game.create_object_from_definition(&keeper_def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(keeper_id);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. }
+                    if source == keeper_id
+            )),
+        "Keeper of the Flame should not be activatable without a higher-life opponent target"
+    );
+
+    game.player_mut(bob).expect("Bob should exist").life = 21;
+    let ability_index = game
+        .object(keeper_id)
+        .expect("Keeper of the Flame should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Keeper of the Flame should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                if *source == keeper_id && *idx == ability_index
+        ))
+        .expect("Keeper of the Flame activation should be legal once Bob has more life");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Keeper of the Flame activation should start");
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Keeper of the Flame, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("choosing the higher-life opponent should complete activation");
+
+    game.player_mut(bob).expect("Bob should exist").life = 18;
+
+    resolve_stack_entry(&mut game).expect("Keeper of the Flame ability should resolve");
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        16,
+        "Keeper of the Flame should remember that the chosen player had more life during activation"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn keeper_of_the_flame_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_950), "Keeper of the Flame")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red], vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(1, 2))
+        .parse_text(
+            "{R}, {T}: Choose target opponent who has more life than you do as you activate this ability. This creature deals 2 damage to that player.",
+        )
+        .expect("Keeper of the Flame should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn explore_event_for(game: &GameState, controller: PlayerId, source: ObjectId) -> TriggerEvent {
     let snapshot = game
         .object(source)

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1155,6 +1155,9 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             crate::target::PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => {
                 "as long as that player is the monarch".to_string()
             }
+            crate::target::PlayerFilter::HasMoreLifeThanYou { .. } => {
+                "as long as that player is the monarch".to_string()
+            }
             crate::target::PlayerFilter::MaxSpeed { .. } => {
                 "as long as that player is the monarch".to_string()
             }

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -1975,6 +1975,13 @@ pub fn player_filter_matches_with_context(
                     candidate.hand.len() >= your_hand.saturating_add(*count as usize)
                 })
         }
+        PlayerFilter::HasMoreLifeThanYou { base } => {
+            player_filter_matches_with_context(base, player, controller, game, defending_player)
+                && game
+                    .player(player)
+                    .zip(game.player(controller))
+                    .is_some_and(|(candidate, you)| candidate.life > you.life)
+        }
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -104,6 +104,7 @@ pub(crate) fn describe_player_filter_subject(filter: &PlayerFilter) -> String {
         | PlayerFilter::LowestLifeTied
         | PlayerFilter::MostCardsInHand
         | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+        | PlayerFilter::HasMoreLifeThanYou { .. }
         | PlayerFilter::MaxSpeed { .. }
         | PlayerFilter::CastCardTypeThisTurn(_)
         | PlayerFilter::ChosenPlayer
@@ -142,6 +143,7 @@ pub(crate) fn describe_player_filter_possessive(filter: &PlayerFilter) -> String
         | PlayerFilter::LowestLifeTied
         | PlayerFilter::MostCardsInHand
         | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+        | PlayerFilter::HasMoreLifeThanYou { .. }
         | PlayerFilter::MaxSpeed { .. }
         | PlayerFilter::CastCardTypeThisTurn(_)
         | PlayerFilter::ChosenPlayer

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
@@ -275,8 +275,9 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
                 PlayerFilter::MostCardsInHand => {
                     "the player who has the most cards in hand".to_string()
                 }
-                PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => player_filter.description(),
-                PlayerFilter::MaxSpeed { .. } => player_filter.description(),
+                PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
+                | PlayerFilter::HasMoreLifeThanYou { .. }
+                | PlayerFilter::MaxSpeed { .. } => player_filter.description(),
                 PlayerFilter::CastCardTypeThisTurn(card_type) => format!(
                     "a player who cast one or more {} spells this turn",
                     card_type.to_string().to_ascii_lowercase()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Keeper of the Flame
Initial parse error:
```
unsupported target phrase (clause: 'opponent who has more life than you do as you activate this ability'); oracle-only fallback also failed: unsupported target phrase (clause: 'opponent who has more life than you do as you activate this ability')
```

Current worker: i-0dd0de8f5568e5345
Branch: codex/aws-card-fix-keeper-of-the-flame
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0017
