### PR TITLE
Fix Ironsmith parse failure: Cogwork Librarian

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -3,14 +3,15 @@ use super::line_family_handlers::{
     run_assign_damage_as_unblocked_enchanted_creature_controller_line_family,
     run_champion_line_family, run_championed_with_this_trigger_line_family,
     run_colon_nonactivation_statement_line_family, run_combined_static_line_family,
-    run_escape_enters_with_counter_line_family, run_freerunning_line_family,
-    run_graveyard_cast_control_condition_line_family, run_keyword_line_family,
-    run_labeled_line_family, run_learn_line_family, run_max_speed_labeled_line_family,
-    run_non_turn_conditional_untap_line_family, run_partner_variant_keyword_line_family,
-    run_partner_with_keyword_line_family, run_split_top_and_face_down_look_line_family,
-    run_split_top_look_and_top_land_play_line_family, run_start_your_engines_line_family,
-    run_statement_line_family, run_statement_probe_line_family, run_static_line_family,
-    run_station_line_family, run_station_threshold_line_family, run_surge_line_family,
+    run_draft_rule_line_family, run_escape_enters_with_counter_line_family,
+    run_freerunning_line_family, run_graveyard_cast_control_condition_line_family,
+    run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
+    run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
+    run_partner_variant_keyword_line_family, run_partner_with_keyword_line_family,
+    run_split_top_and_face_down_look_line_family, run_split_top_look_and_top_land_play_line_family,
+    run_start_your_engines_line_family, run_statement_line_family,
+    run_statement_probe_line_family, run_static_line_family, run_station_line_family,
+    run_station_threshold_line_family, run_surge_line_family,
     run_trailing_keyword_activation_line_family, run_triggered_line_family,
     run_unsupported_line_family, run_ward_or_echo_static_prefix_line_family,
 };
@@ -49,7 +50,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 29] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 30] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -103,6 +104,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 29] = [
         priority: 37,
         heads: &["learn"],
         run: run_learn_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "draft-rule-line",
+        priority: 37,
+        heads: &["draft", "as", "during", "immediately", "each"],
+        run: run_draft_rule_line_family,
     },
     LineFamilyRuleDef {
         id: "split-top-and-face-down-look-line",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -204,6 +204,37 @@ pub(super) fn run_start_your_engines_line_family(
     )))
 }
 
+pub(super) fn run_draft_rule_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    if !is_draft_rule_line(ctx.line.info.raw_line.as_str()) {
+        return Ok(None);
+    }
+
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Static(StaticLineCst {
+            info: ctx.line.info.clone(),
+            text: ctx.line.info.normalized.normalized.clone(),
+            parse_tokens: ctx.line.tokens.clone(),
+            chosen_option_label: None,
+        }),
+        ctx.idx + 1,
+    )))
+}
+
+fn is_draft_rule_line(raw_line: &str) -> bool {
+    let lower = raw_line.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return false;
+    }
+
+    lower.trim_end_matches('.') == "draft this card face up"
+        || lower.starts_with("as you draft ")
+        || lower.starts_with("during the draft, ")
+        || lower.starts_with("immediately after the draft, ")
+        || lower.starts_with("each player passes ") && lower.contains("booster pack")
+}
+
 pub(super) fn run_learn_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1312,6 +1312,14 @@ fn lower_rewrite_static_to_chunk_impl(
             chosen_option_label,
         );
     }
+    if is_draft_rule_static_line(raw) {
+        return wrap_chosen_option_static_chunk(
+            LineAst::StaticAbility(
+                StaticAbility::draft_rule_text(raw.trim_end_matches('.').to_string()).into(),
+            ),
+            chosen_option_label,
+        );
+    }
     if is_first_equip_cost_alternative_lowering_line(&line.text) {
         let display = capitalize_first_equip_cost_alternative_display(&line.text);
         return wrap_chosen_option_static_chunk(
@@ -1446,6 +1454,15 @@ fn looks_like_ability_word_marker_text(text: &str, parse_tokens: &[OwnedLexToken
     }
     let words = token_word_refs(parse_tokens);
     !words.is_empty() && words.len() <= 4
+}
+
+fn is_draft_rule_static_line(raw: &str) -> bool {
+    let lower = raw.trim().to_ascii_lowercase();
+    lower.trim_end_matches('.') == "draft this card face up"
+        || lower.starts_with("as you draft ")
+        || lower.starts_with("during the draft, ")
+        || lower.starts_with("immediately after the draft, ")
+        || lower.starts_with("each player passes ") && lower.contains("booster pack")
 }
 
 fn parse_additional_land_play_static_count_from_text(text: &str) -> Option<u32> {

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -240,6 +240,7 @@ pub enum StaticAbilityId {
     DiscardOrRedirectReplacement,
     PayLifeOrEnterTappedReplacement,
     PregameAction,
+    DraftRuleText,
     KeywordText,
     KeywordMarker,
     KeywordFallbackText,
@@ -487,6 +488,7 @@ impl StaticAbilityId {
             | DiscardOrRedirectReplacement
             | PayLifeOrEnterTappedReplacement
             | PregameAction
+            | DraftRuleText
             | KeywordText
             | KeywordMarker
             | KeywordFallbackText

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1671,6 +1671,10 @@ impl<
         Self::identified(StaticAbilityId::KeywordFallbackText, text)
     }
 
+    pub fn draft_rule_text(text: impl Into<String>) -> Self {
+        Self::identified(StaticAbilityId::DraftRuleText, text)
+    }
+
     pub fn rule_fallback_text(text: impl Into<String>) -> Self {
         Self::identified(StaticAbilityId::RuleFallbackText, text)
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -445,6 +445,73 @@ fn dream_thiefs_bandana_keeps_look_exile_and_while_exiled_permission() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn cogwork_librarian_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Cogwork Librarian");
+
+    assert_eq!(
+        canonical_compiled_lines(&def),
+        vec![
+            "Draft this card face up.".to_string(),
+            "As you draft a card, you may draft an additional card from that booster pack. If you do, put this card into that booster pack."
+                .to_string(),
+        ],
+        "Cogwork Librarian should preserve its draft face-up and booster-pack clauses"
+    );
+    assert!(
+        def.abilities.iter().all(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => {
+                static_ability.id() == StaticAbilityId::DraftRuleText
+            }
+            _ => false,
+        }),
+        "Cogwork Librarian's draft-only text should compile as static rule text, got {:#?}",
+        def.abilities
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cogwork_librarian_draft_rules_do_not_create_runtime_effects() {
+    let oracle = oracle_text_by_name()
+        .get("Cogwork Librarian")
+        .expect("Cogwork Librarian oracle text should be available")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Cogwork Librarian")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Construct])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(oracle)
+        .expect("Cogwork Librarian should parse strictly");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let librarian = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert_eq!(game.current_power(librarian), Some(3));
+    assert_eq!(game.current_toughness(librarian), Some(3));
+    assert!(game.object_has_card_type(librarian, CardType::Artifact));
+    assert!(game.object_has_card_type(librarian, CardType::Creature));
+
+    let draft_static_abilities = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(draft_static_abilities.len(), 2);
+    for ability in draft_static_abilities {
+        assert_eq!(ability.id(), StaticAbilityId::DraftRuleText);
+        assert!(ability.generate_effects(librarian, alice, &game).is_empty());
+        assert!(ability.generate_replacement_effect(librarian, alice).is_none());
+        assert!(ability.pregame_action_kind().is_none());
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn happily_ever_after_keeps_life_draw_and_win_gate() {
     let lines = [
         "When this enchantment enters, each player gains 5 life and draws a card.",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -34743,6 +34743,7 @@ pub(super) fn describe_ability(
             let prefer_safe_label_text = matches!(
                 static_ability.id(),
                 crate::static_abilities::StaticAbilityId::KeywordMarker
+                    | crate::static_abilities::StaticAbilityId::DraftRuleText
                     | crate::static_abilities::StaticAbilityId::KeywordFallbackText
                     | crate::static_abilities::StaticAbilityId::RuleFallbackText
                     | crate::static_abilities::StaticAbilityId::UnsupportedParserLine

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -242,6 +242,7 @@ impl StaticAbility {
                 Self::enters_tapped_unless_two_or_more_opponents()
             }
             Some(StaticAbilityId::CanBeCommander) => Self::can_be_commander(),
+            Some(StaticAbilityId::DraftRuleText) => Self::draft_rule_text(label),
             Some(StaticAbilityId::KeywordText) => Self::keyword_text(label),
             Some(StaticAbilityId::KeywordMarker) => Self::keyword_marker(label),
             Some(StaticAbilityId::KeywordFallbackText) => Self::keyword_fallback_text(label),

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -4751,6 +4751,28 @@ impl StaticAbilityKind for KeywordText {
     }
 }
 
+/// Draft-only rule text from Conspiracy-style cards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DraftRuleText {
+    pub text: String,
+}
+
+impl DraftRuleText {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+impl StaticAbilityKind for DraftRuleText {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::DraftRuleText
+    }
+
+    fn display(&self) -> String {
+        self.text.clone()
+    }
+}
+
 // =============================================================================
 // Placeholder / Marker Abilities
 // =============================================================================

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2951,6 +2951,10 @@ impl StaticAbility {
         Self::new(KeywordText::new(text))
     }
 
+    pub fn draft_rule_text(text: impl Into<String>) -> Self {
+        Self::new(DraftRuleText::new(text))
+    }
+
     pub fn rule_fallback_text(text: impl Into<String>) -> Self {
         Self::new(RuleFallbackText::new(text))
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cogwork Librarian
Initial parse error:
```
parser does not yet support line family: 'Draft this card face up.'; oracle-only fallback also failed: parser does not yet support line family: 'Draft this card face up.'
```

Current worker: i-02e91baeaba0a0c8a
Branch: codex/aws-card-fix-cogwork-librarian
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0018
