### PR TITLE
Fix Ironsmith parse failure: The End

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -138,7 +138,8 @@ pub(crate) use control_flow_handlers::{
 pub(crate) use effect_dispatch::compile_effect;
 pub(crate) use iterated_player_validation::validate_iterated_player_bindings_in_lowered_effects;
 pub(crate) use player_effect_helpers::{
-    LoweredSubject, SubjectBindingMode, SubjectRole, compile_player_dual_effect,
+    LoweredSubject, SubjectBindingMode, SubjectRole, bind_target_object_refs_to_tag_in_filter,
+    bind_target_object_refs_to_tag_in_player_filter, compile_player_dual_effect,
     compile_player_effect_from_resolved_filter, compile_player_filter_effect,
     compile_player_role_effect, compile_player_value_effect,
 };

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -194,13 +194,22 @@ fn compile_subject_verb_effect(
             Effect::target_draws,
         ),
         SubjectVerbActionAst::DrawForEachTaggedMatching { tag, filter } => {
+            let prior_player_filter = ctx.last_player_filter.clone();
             let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
+            let mut player_filter = subject.into_player_filter();
             let resolved_tag = resolve_it_tag_key(tag, &current_reference_env(ctx))?;
-            let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            let mut resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            if let Some(tag) = prior_player_filter
+                .as_ref()
+                .and_then(tagged_object_reference_from_player_filter)
+            {
+                bind_target_object_refs_to_tag_in_player_filter(&mut player_filter, &tag);
+                bind_target_object_refs_to_tag_in_filter(&mut resolved_filter, &tag);
+            }
             Ok((
                 vec![Effect::new(
                     crate::effects::DrawForEachTaggedMatchingEffect::new(
-                        subject.into_player_filter(),
+                        player_filter,
                         resolved_tag,
                         resolved_filter,
                     ),
@@ -5340,6 +5349,21 @@ fn compile_subject_verb_effect(
             effects.push(effect);
             Ok((effects, subject.into_choices()))
         }
+    }
+}
+
+fn tagged_object_reference_from_player_filter(filter: &PlayerFilter) -> Option<TagKey> {
+    match filter {
+        PlayerFilter::ControllerOf(ObjectRef::Tagged(tag))
+        | PlayerFilter::OwnerOf(ObjectRef::Tagged(tag))
+        | PlayerFilter::AliasedControllerOf(ObjectRef::Tagged(tag))
+        | PlayerFilter::AliasedOwnerOf(ObjectRef::Tagged(tag)) => Some(tag.clone()),
+        PlayerFilter::Target(inner) => tagged_object_reference_from_player_filter(inner),
+        PlayerFilter::Excluding { base, excluded } => {
+            tagged_object_reference_from_player_filter(base)
+                .or_else(|| tagged_object_reference_from_player_filter(excluded))
+        }
+        _ => None,
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
@@ -241,6 +241,7 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
         } => {
             let subject = LoweredSubject::resolve_chooser(*player, ctx, true, true, false)?;
             let chooser = subject.as_chooser();
+            let last_object_tag = ctx.last_object_tag.clone().map(TagKey::from);
             let references_revealed_hand = filter.zone == Some(Zone::Hand)
                 && filter.owner.is_none()
                 && filter.controller.is_none()
@@ -264,6 +265,9 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
                         !matches!(constraint.relation, TaggedOpbjectRelation::IsTaggedObject)
                     });
                 }
+            }
+            if let Some(tag) = last_object_tag.as_ref() {
+                bind_target_object_refs_to_tag_in_filter(&mut resolved_filter, tag);
             }
             if !matches!(chooser, PlayerFilter::ChosenPlayer) {
                 preserve_chooser_relative_player_filters(filter, &mut resolved_filter, &chooser);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/player_effect_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/player_effect_helpers.rs
@@ -295,9 +295,13 @@ impl LoweredSubject {
     pub(crate) fn bind_library_filter(
         &self,
         filter: &ObjectFilter,
-        _ctx: &mut EffectLoweringContext,
+        ctx: &mut EffectLoweringContext,
     ) -> Result<ObjectFilter, CardTextError> {
-        let mut resolved = filter.clone();
+        let last_object_tag = ctx.last_object_tag.clone().map(TagKey::from);
+        let mut resolved = self.resolve_object_refs_and_bind_player_refs_in_filter(filter, ctx)?;
+        if let Some(tag) = last_object_tag.as_ref() {
+            bind_target_object_refs_to_tag_in_filter(&mut resolved, tag);
+        }
         if resolved.zone.is_none() {
             resolved.zone = Some(Zone::Library);
         }
@@ -415,6 +419,66 @@ impl LoweredSubject {
 
     pub(crate) fn build_target_prelude_if_needed(&self, effect: Effect) -> Vec<Effect> {
         self.prepend_target_prelude_if_needed(effect)
+    }
+}
+
+pub(crate) fn bind_target_object_refs_to_tag_in_filter(filter: &mut ObjectFilter, tag: &TagKey) {
+    if let Some(owner) = filter.owner.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(owner, tag);
+    }
+    if let Some(controller) = filter.controller.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(controller, tag);
+    }
+    if let Some(cast_by) = filter.cast_by.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(cast_by, tag);
+    }
+    if let Some(targets_player) = filter.targets_player.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(targets_player, tag);
+    }
+    if let Some(targets_object) = filter.targets_object.as_mut() {
+        bind_target_object_refs_to_tag_in_filter(targets_object, tag);
+    }
+    if let Some(targets_only_player) = filter.targets_only_player.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(targets_only_player, tag);
+    }
+    if let Some(targets_only_object) = filter.targets_only_object.as_mut() {
+        bind_target_object_refs_to_tag_in_filter(targets_only_object, tag);
+    }
+    if let Some(targetability) = filter.could_be_targeted_by.as_mut() {
+        bind_target_object_ref_to_tag(&mut targetability.stack_object, tag);
+    }
+    if let Some(attacking_player) = filter.attacking_player_or_planeswalker_controlled_by.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(attacking_player, tag);
+    }
+    if let Some(entered_controller) = filter.entered_battlefield_controller.as_mut() {
+        bind_target_object_refs_to_tag_in_player_filter(entered_controller, tag);
+    }
+    for nested in &mut filter.any_of {
+        bind_target_object_refs_to_tag_in_filter(nested, tag);
+    }
+}
+
+pub(crate) fn bind_target_object_refs_to_tag_in_player_filter(
+    filter: &mut PlayerFilter,
+    tag: &TagKey,
+) {
+    match filter {
+        PlayerFilter::Target(inner) => bind_target_object_refs_to_tag_in_player_filter(inner, tag),
+        PlayerFilter::Excluding { base, excluded } => {
+            bind_target_object_refs_to_tag_in_player_filter(base, tag);
+            bind_target_object_refs_to_tag_in_player_filter(excluded, tag);
+        }
+        PlayerFilter::ControllerOf(reference)
+        | PlayerFilter::OwnerOf(reference)
+        | PlayerFilter::AliasedControllerOf(reference)
+        | PlayerFilter::AliasedOwnerOf(reference) => bind_target_object_ref_to_tag(reference, tag),
+        _ => {}
+    }
+}
+
+fn bind_target_object_ref_to_tag(reference: &mut ObjectRef, tag: &TagKey) {
+    if matches!(reference, ObjectRef::Target) {
+        *reference = ObjectRef::tagged(tag.clone());
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40830,6 +40830,223 @@ fn parse_oracle_necromentia_uses_shared_subject_role_lowering() {
 }
 
 #[test]
+fn parse_oracle_the_end_strict_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("The End");
+    let rendered_lines = crate::compiled_text::compiled_text_lines(&def);
+    assert_eq!(
+        rendered_lines.as_slice(),
+        [
+            "This spell costs {2} less to cast if your life total is 5 or less.",
+            "Exile target creature or planeswalker. Search its controller's graveyard, hand, and library for any number of cards with the same name as that permanent and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
+        ],
+        "The End compiled text should match its oracle text exactly"
+    );
+    let rendered = rendered_lines.join("\n");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        !lower.contains("tagged object") && !lower.contains("tagged '"),
+        "The End compiled text should not expose internal tagged-object markers, got {rendered}"
+    );
+}
+
+#[test]
+fn parse_oracle_the_end_lowers_controller_search_draw_and_life_cost_condition() {
+    let def = parse_oracle_card_definition("The End");
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+            _ => None,
+        })
+        .expect("The End should have a conditional this-spell cost reduction");
+    assert!(matches!(reduction.reduction, crate::effect::Value::Fixed(2)));
+    assert!(matches!(
+        reduction.condition,
+        crate::static_abilities::ThisSpellCostCondition::YouLifeTotalOrLess(5)
+    ));
+
+    let program = def.spell_effect.as_ref().expect("The End spell effect");
+    let effects = &program.segments[0].default_effects;
+    let search = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<ChooseObjectsEffect>())
+        .expect("The End should search the target permanent controller's zones");
+    assert!(
+        search.is_search,
+        "search choice should be marked as search: {search:#?}"
+    );
+    assert_eq!(search.chooser, PlayerFilter::You);
+    assert!(
+        matches!(
+            search.filter.owner,
+            Some(PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(_)))
+        ),
+        "The End search owner should follow the exiled target tag, got {search:#?}"
+    );
+    let Some(PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(target_tag))) =
+        search.filter.owner.as_ref()
+    else {
+        panic!("The End search owner should follow the exiled target tag, got {search:#?}");
+    };
+    assert_eq!(search.zone, Some(Zone::Graveyard));
+    assert_eq!(search.additional_zones, vec![Zone::Hand, Zone::Library]);
+    assert!(
+        search.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag == *target_tag
+                && constraint.relation == crate::filter::TaggedOpbjectRelation::SameNameAsTagged
+        }),
+        "The End search should constrain cards to the exiled target's name, got {search:#?}"
+    );
+
+    let draw = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::DrawForEachTaggedMatchingEffect>())
+        .expect("The End should draw for matching cards exiled from hand this way");
+    assert_eq!(draw.tag, search.tag);
+    assert!(matches!(
+        draw.player,
+        PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(_))
+            | PlayerFilter::ControllerOf(crate::target::ObjectRef::Target)
+    ));
+    assert_eq!(draw.filter.zone, Some(Zone::Hand));
+    assert!(
+        matches!(
+            draw.filter.owner,
+            Some(PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(_)))
+                | Some(PlayerFilter::ControllerOf(crate::target::ObjectRef::Target))
+        ),
+        "The End draw count should count cards from the exiled target controller's hand, got {draw:#?}"
+    );
+}
+
+#[test]
+fn the_end_cost_reduction_condition_tracks_controller_life_total_boundary() {
+    let def = parse_oracle_card_definition("The End");
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+            _ => None,
+        })
+        .expect("The End should have a conditional this-spell cost reduction");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    game.players[0].life = 6;
+    assert!(
+        !crate::static_abilities::this_spell_cost_condition_is_active_for_cast(
+            &game,
+            source,
+            &reduction.condition,
+            &[],
+        ),
+        "The End cost reduction should be inactive above five life"
+    );
+    game.players[0].life = 5;
+    assert!(
+        crate::static_abilities::this_spell_cost_condition_is_active_for_cast(
+            &game,
+            source,
+            &reduction.condition,
+            &[],
+        ),
+        "The End cost reduction should be active at five life"
+    );
+}
+
+#[test]
+fn the_end_exiles_target_controller_same_name_cards_and_draws_for_hand_exiles() {
+    struct TheEndDecisionMaker;
+
+    impl crate::decision::DecisionMaker for TheEndDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            _game: &crate::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.max.unwrap_or(ctx.candidates.len()))
+                .collect()
+        }
+    }
+
+    fn simple_creature(name: &str) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    }
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let def = parse_oracle_card_definition("The End");
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    let hedge_witch = simple_creature("Hedge Witch");
+    let opt = simple_creature("Opt");
+    let island = simple_creature("Island");
+    let target = game.create_object_from_card(&hedge_witch, bob, Zone::Battlefield);
+    game.create_object_from_card(&hedge_witch, bob, Zone::Hand);
+    game.create_object_from_card(&hedge_witch, bob, Zone::Hand);
+    game.create_object_from_card(&hedge_witch, bob, Zone::Graveyard);
+    game.create_object_from_card(&hedge_witch, bob, Zone::Library);
+    game.create_object_from_card(&opt, bob, Zone::Hand);
+    game.create_object_from_card(&island, bob, Zone::Library);
+    game.create_object_from_card(&island, bob, Zone::Library);
+    game.create_object_from_card(&hedge_witch, alice, Zone::Hand);
+
+    let mut dm = TheEndDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)]);
+    ctx.snapshot_targets(&game);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        def.spell_effect.as_ref().expect("The End spell effect"),
+        None,
+        &[],
+    )
+    .expect("The End should resolve");
+
+    let exiled_bob_hedge_witches = game
+        .objects_in_deterministic_order()
+        .into_iter()
+        .filter(|object| {
+            object.owner == bob && object.name == "Hedge Witch" && object.zone == Zone::Exile
+        })
+        .count();
+    assert_eq!(
+        exiled_bob_hedge_witches, 5,
+        "The End should exile the target plus same-name cards from its controller's hand, graveyard, and library"
+    );
+    let alice_hand_hedge_witches = game
+        .objects_in_deterministic_order()
+        .into_iter()
+        .filter(|object| {
+            object.owner == alice && object.name == "Hedge Witch" && object.zone == Zone::Hand
+        })
+        .count();
+    assert_eq!(
+        alice_hand_hedge_witches, 1,
+        "The End should not search other players' zones for same-name cards"
+    );
+    assert_eq!(
+        game.players[1].hand.len(),
+        3,
+        "Bob should keep the nonmatching hand card and draw two cards for the two hand cards exiled this way"
+    );
+}
+
+#[test]
 fn parse_oracle_garruk_emblem_search_stays_inside_quoted_text() {
     let cases = [
         (

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1763,6 +1763,18 @@ fn describe_structural_counter_keyword_bundle(abilities: &[Ability]) -> Option<(
     None
 }
 
+fn is_this_spell_cost_reduction_ability(ability: &Ability) -> bool {
+    matches!(
+        &ability.kind,
+        AbilityKind::Static(static_ability)
+            if matches!(
+                static_ability.id(),
+                crate::static_abilities::StaticAbilityId::ThisSpellCostReduction
+                    | crate::static_abilities::StaticAbilityId::ThisSpellCostReductionManaCost
+            )
+    )
+}
+
 fn is_ascend_condition(condition: &Condition) -> bool {
     let Condition::And(left, right) = condition else {
         return false;
@@ -2101,6 +2113,10 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
         let mut ability_idx = 0usize;
         while ability_idx < def.abilities.len() {
             let ability = &def.abilities[ability_idx];
+            if spell_like_card && is_this_spell_cost_reduction_ability(ability) {
+                ability_idx += 1;
+                continue;
+            }
             if has_suspend && is_suspend_helper_ability(ability) {
                 ability_idx += 1;
                 continue;
@@ -2256,6 +2272,18 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
     }
     if !spell_like_card {
         push_abilities(&mut out);
+    }
+    if spell_like_card {
+        for (ability_idx, ability) in def.abilities.iter().enumerate() {
+            if is_this_spell_cost_reduction_ability(ability) {
+                out.extend(describe_ability(
+                    ability_idx + 1,
+                    ability,
+                    subject,
+                    rewrite_it_deals,
+                ));
+            }
+        }
     }
     if let Some(spell_effects) = &def.spell_effect
         && !spell_effects.is_empty()

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -1466,6 +1466,51 @@ pub(super) fn normalize_same_name_search_bundle_clause(line: &str) -> Option<Str
     Some(rewritten)
 }
 
+pub(super) fn normalize_target_exile_same_name_search_draw_clause(line: &str) -> Option<String> {
+    let (before_search, search_tail) = split_once_ascii_ci(
+        line,
+        ", you search its controller's graveyard, hand, and library for ",
+    )
+    .or_else(|| {
+        split_once_ascii_ci(
+            line,
+            ", you search that object's controller's graveyard, hand, and library for ",
+        )
+    })?;
+    let (selection, after_selection) = split_once_ascii_ci(
+        search_tail,
+        ", for each card searched for this way, exile the tagged object '",
+    )?;
+    let (_tag, after_tag) = after_selection.split_once('\'')?;
+    let after_tag = strip_prefix_ascii_ci(
+        after_tag,
+        ", shuffle its controller's library, then its controller draws a card for each card exiled from their hand this way.",
+    )
+    .or_else(|| {
+        strip_prefix_ascii_ci(
+            after_tag,
+            ", shuffle that object's controller's library, then that object's controller draws a card for each card exiled from their hand this way.",
+        )
+    })?;
+    if !after_tag.trim().is_empty() {
+        return None;
+    }
+
+    let selection = selection
+        .trim()
+        .replace("any number permanents", "any number of cards")
+        .replace("any number permanent", "any number of cards")
+        .replace("all permanents", "all cards")
+        .replace("all permanent", "all cards")
+        .replace(
+            " with the same name as that object that object's controller owns",
+            " with the same name as that permanent",
+        );
+    Some(format!(
+        "{before_search}. Search its controller's graveyard, hand, and library for {selection} and exile them. That player shuffles, then draws a card for each card exiled from their hand this way."
+    ))
+}
+
 fn normalize_zero_zero_token_with_base_pt(line: &str) -> Option<String> {
     let (before_create, create_tail) = split_once_ascii_ci(line, "Create a 0/0 ")
         .or_else(|| split_once_ascii_ci(line, "Create an 0/0 "))?;
@@ -2205,6 +2250,9 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
         normalized = rewritten;
     }
     if let Some(rewritten) = normalize_same_name_search_bundle_clause(&normalized) {
+        normalized = rewritten;
+    }
+    if let Some(rewritten) = normalize_target_exile_same_name_search_draw_clause(&normalized) {
         normalized = rewritten;
     }
     if let Some(rewritten) = normalize_repeated_dynamic_buff(&normalized) {

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -1108,7 +1108,9 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
         ThisSpellCostCondition::Always => None,
         ThisSpellCostCondition::YourTurn => Some("it's your turn".to_string()),
         ThisSpellCostCondition::NotYourTurn => Some("it isn't your turn".to_string()),
-        ThisSpellCostCondition::YouLifeTotalOrLess(n) => Some(format!("you have {n} or less life")),
+        ThisSpellCostCondition::YouLifeTotalOrLess(n) => {
+            Some(format!("your life total is {n} or less"))
+        }
         ThisSpellCostCondition::OpponentHasNoCardsInHand => {
             Some("an opponent has no cards in hand".to_string())
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The End
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-00a4e996e1681df8f
Branch: codex/aws-card-fix-the-end
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0018
