### PR TITLE
Fix Ironsmith parse failure: Entreat the Angels

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -50,6 +50,7 @@ pub(super) enum KeywordDispatchHint {
     Epic,
     Offspring,
     Madness,
+    Miracle,
     Escape,
     MorphFamily,
     Mutate,
@@ -266,6 +267,12 @@ mod spell_keywords {
             lower: registry::lower_madness,
         },
         KeywordLineRule {
+            cst_kind: super::super::cst::KeywordLineKindCst::Miracle,
+            hints: &[KeywordDispatchHint::Miracle],
+            matches: registry::matches_miracle,
+            lower: registry::lower_miracle,
+        },
+        KeywordLineRule {
             cst_kind: super::super::cst::KeywordLineKindCst::Escape,
             hints: &[KeywordDispatchHint::Escape],
             matches: registry::matches_escape,
@@ -362,6 +369,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
             winnow::combinator::alt((
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),
                 grammar::kw("warp").value(KeywordDispatchHint::Warp),
+                grammar::kw("miracle").value(KeywordDispatchHint::Miracle),
                 grammar::kw("prowl").value(KeywordDispatchHint::AlternativeOrExertFamily),
                 grammar::kw("escalate").value(KeywordDispatchHint::Escalate),
                 grammar::kw("evoke").value(KeywordDispatchHint::Evoke),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -37,10 +37,11 @@ use super::util::{
     parse_flash_with_additional_cost_line_lexed, parse_flashback_line_lexed,
     parse_harmonize_line_lexed, parse_if_conditional_alternative_cost_line_lexed,
     parse_jump_start_line_lexed, parse_kicker_line_lexed, parse_madness_line_lexed,
-    parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_offspring_line_lexed,
-    parse_prowl_line_lexed, parse_reinforce_line_lexed, parse_replicate_line_lexed,
-    parse_retrace_line_lexed, parse_self_free_cast_alternative_cost_line_lexed,
-    parse_squad_line_lexed, parse_transmute_line_lexed, parse_warp_line_lexed,
+    parse_miracle_line_lexed, parse_morph_keyword_line_lexed, parse_multikicker_line_lexed,
+    parse_offspring_line_lexed, parse_prowl_line_lexed, parse_reinforce_line_lexed,
+    parse_replicate_line_lexed, parse_retrace_line_lexed,
+    parse_self_free_cast_alternative_cost_line_lexed, parse_squad_line_lexed,
+    parse_transmute_line_lexed, parse_warp_line_lexed,
     parse_you_may_rather_than_spell_cost_line_lexed, preserve_keyword_prefix_for_parse,
 };
 
@@ -460,6 +461,15 @@ pub(super) fn lower_madness(
     ))
 }
 
+pub(super) fn lower_miracle(
+    line: &RewriteKeywordLine,
+    tokens: &[OwnedLexToken],
+) -> Result<LineAst, CardTextError> {
+    Ok(LineAst::AlternativeCastingMethod(
+        require_keyword_parse(line, "miracle", parse_miracle_line_lexed(tokens)?)?.into(),
+    ))
+}
+
 pub(super) fn lower_morph(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
@@ -865,6 +875,13 @@ pub(super) fn matches_madness(
     tokens: &[OwnedLexToken],
 ) -> Result<bool, CardTextError> {
     Ok(parse_madness_line_lexed(tokens)?.is_some())
+}
+
+pub(super) fn matches_miracle(
+    _line: &PreprocessedLine,
+    tokens: &[OwnedLexToken],
+) -> Result<bool, CardTextError> {
+    Ok(parse_miracle_line_lexed(tokens)?.is_some())
 }
 
 pub(super) fn matches_escape(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -53,6 +53,7 @@ pub(crate) enum KeywordLineKindCst {
     Harmonize,
     Kicker,
     Madness,
+    Miracle,
     Morph,
     Mutate,
     Multikicker,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4078,6 +4078,27 @@ pub(crate) fn parse_madness_line_lexed(
     parse_madness_line(tokens)
 }
 
+pub(crate) fn parse_miracle_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    if !tokens.first().is_some_and(|token| token.is_word("miracle")) {
+        return Ok(None);
+    }
+
+    let cost_tokens = tokens.get(1..).unwrap_or_default();
+    let (cost, _) = leading_mana_cost_from_tokens(cost_tokens).ok_or_else(|| {
+        CardTextError::ParseError("miracle keyword missing mana cost".to_string())
+    })?;
+
+    Ok(Some(AlternativeCastingMethod::Miracle { cost }))
+}
+
+pub(crate) fn parse_miracle_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    parse_miracle_line(tokens)
+}
+
 pub(crate) fn parse_buyback_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<OptionalCost>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5279,6 +5279,29 @@ fn jump_start_keyword_line_is_classified_as_alternative_cast() {
 }
 
 #[test]
+fn entreat_the_angels_miracle_keyword_line_is_classified_as_miracle() {
+    let tokens = lex_line(
+        "Miracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
+        0,
+    )
+    .expect("rewrite lexer should classify Entreat the Angels miracle keyword line");
+
+    assert!(matches!(
+        super::families::keyword_families::parse_keyword_dispatch_hint(&tokens),
+        Some(super::families::keyword_families::KeywordDispatchHint::Miracle)
+    ));
+
+    let parsed = super::front_end::shared::util::parse_miracle_line_lexed(&tokens)
+        .expect("Entreat the Angels miracle keyword should not error")
+        .expect("Entreat the Angels miracle keyword should parse");
+
+    let debug = format!("{parsed:?}");
+    assert!(debug.contains("Miracle"), "{debug}");
+    assert!(debug.contains('X'), "{debug}");
+    assert!(debug.contains("White"), "{debug}");
+}
+
+#[test]
 fn equal_to_number_of_cards_you_ve_discarded_this_turn_parses() {
     let tokens = lex_line("equal to the number of cards you've discarded this turn", 0)
         .expect("rewrite lexer should classify value clause");

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -467,10 +467,45 @@ fn runtime_definition_from_core_model(
         runtime_optional_cost_from_core_model,
     )?;
     definition.abilities = combine_level_ability_statics(definition.abilities);
+    add_miracle_trigger_for_alternative_cast(&mut definition);
     if let Some(spell_effect) = &mut definition.spell_effect {
         remove_redundant_target_only_effects_in_program(spell_effect);
     }
     Ok(definition)
+}
+
+fn add_miracle_trigger_for_alternative_cast(definition: &mut ironsmith::cards::CardDefinition) {
+    if !definition
+        .alternative_casts
+        .iter()
+        .any(ironsmith::alternative_cast::AlternativeCastingMethod::is_miracle)
+    {
+        return;
+    }
+    if definition.abilities.iter().any(|ability| {
+        matches!(
+            &ability.kind,
+            ironsmith::ability::AbilityKind::Triggered(triggered)
+                if triggered.trigger == ironsmith::triggers::Trigger::miracle()
+        )
+    }) {
+        return;
+    }
+
+    definition.abilities.push(
+        ironsmith::ability::Ability {
+            kind: ironsmith::ability::AbilityKind::Triggered(ironsmith::ability::TriggeredAbility {
+                trigger: ironsmith::triggers::Trigger::miracle(),
+                effects: ironsmith::resolution::ResolutionProgram::from_effects(vec![
+                    ironsmith::effect::Effect::may_cast_for_miracle_cost(),
+                ]),
+                choices: vec![],
+                intervening_if: None,
+                presentation_label: None,
+            }),
+            functional_zones: vec![ironsmith::zone::Zone::Hand],
+        },
+    );
 }
 
 pub fn into_runtime_definition(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35496,6 +35496,201 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+fn entreat_the_angels_runtime_definition() -> CardDefinition {
+    let angel = CardDefinitionBuilder::new(CardId::new(), "Angel")
+        .color_indicator(crate::color::ColorSet::WHITE)
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Angel])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .flying()
+        .token()
+        .build();
+
+    CardDefinitionBuilder::new(CardId::new(), "Entreat the Angels")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .with_spell_effect(vec![Effect::create_tokens(angel, Value::X)])
+        .miracle(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .build()
+}
+
+#[test]
+fn entreat_the_angels_runtime_model_has_miracle_cost_and_hidden_helper_trigger() {
+    let def = entreat_the_angels_runtime_definition();
+    let lines = canonical_compiled_lines(&def);
+
+    assert!(
+        def.alternative_casts.iter().any(|method| matches!(
+            method,
+            crate::alternative_cast::AlternativeCastingMethod::Miracle { cost }
+                if cost.to_oracle() == "{X}{W}{W}"
+        )),
+        "Entreat the Angels should expose its miracle alternative cost"
+    );
+    assert!(
+        lines.iter().any(|line| line == "Miracle {X}{W}{W}."),
+        "compiled text should render Entreat the Angels' miracle keyword, got {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.contains("you may cast it for its miracle cost")),
+        "compiled text should not duplicate the structural miracle helper trigger, got {lines:?}"
+    );
+}
+
+#[test]
+fn entreat_the_angels_miracle_trigger_matches_only_first_drawn_card() {
+    use crate::triggers::matcher_trait::TriggerContext;
+
+    let def = entreat_the_angels_runtime_definition();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let entreat_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let filler = CardDefinitionBuilder::new(CardId::new(), "Filler")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let filler_id = game.create_object_from_definition(&filler, alice, Zone::Hand);
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Entreat the Angels should have a miracle helper trigger");
+    let ctx = TriggerContext::new(
+        entreat_id,
+        alice,
+        crate::filter::FilterContext::new(alice).with_source(entreat_id),
+        &game,
+    );
+    let raw_event = |event| {
+        crate::events::RawEvent::new(event, crate::provenance::ProvNodeId::default())
+    };
+
+    assert!(triggered.trigger.matches(
+        &raw_event(crate::events::other::CardsDrawnEvent::single(
+            alice, entreat_id, true,
+        )),
+        &ctx,
+    ));
+    assert!(!triggered.trigger.matches(
+        &raw_event(crate::events::other::CardsDrawnEvent::new(
+            alice,
+            vec![filler_id, entreat_id],
+            true,
+        )),
+        &ctx,
+    ));
+    assert!(!triggered.trigger.matches(
+        &raw_event(crate::events::other::CardsDrawnEvent::single(
+            alice, entreat_id, false,
+        )),
+        &ctx,
+    ));
+    assert!(!triggered.trigger.matches(
+        &raw_event(crate::events::other::CardsDrawnEvent::single(
+            bob, entreat_id, true,
+        )),
+        &ctx,
+    ));
+}
+
+#[test]
+fn entreat_the_angels_miracle_cast_uses_chosen_x_and_creates_that_many_angels() {
+    struct ChooseMiracleX(u32);
+
+    impl crate::decision::DecisionMaker for ChooseMiracleX {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+
+        fn decide_number(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::NumberContext,
+        ) -> u32 {
+            self.0.min(ctx.max)
+        }
+    }
+
+    let def = entreat_the_angels_runtime_definition();
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let entreat_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 2);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 3);
+
+    let miracle_effect = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => {
+                triggered.effects.flattened_default_effects().first().cloned()
+            }
+            _ => None,
+        })
+        .expect("Entreat the Angels should have a miracle cast effect")
+        .clone();
+    let event = crate::events::RawEvent::new(
+        crate::events::other::CardsDrawnEvent::single(alice, entreat_id, true),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut dm = ChooseMiracleX(3);
+    let mut ctx = crate::effects::ExecutionContext::new(entreat_id, alice, &mut dm)
+        .with_triggering_event(event);
+
+    miracle_effect
+        .0
+        .execute(&mut game, &mut ctx)
+        .expect("Entreat the Angels miracle effect should resolve");
+    let stack_entry = game.stack.last().expect("Entreat should be on the stack");
+    assert_eq!(stack_entry.x_value, Some(3));
+    assert!(matches!(
+        stack_entry.casting_method,
+        crate::alternative_cast::CastingMethod::Alternative(_)
+    ));
+
+    let mut resolve_dm = crate::decision::AutoPassDecisionMaker;
+    crate::game_loop::resolve_stack_entry_with(&mut game, &mut resolve_dm)
+        .expect("Entreat the Angels should resolve");
+
+    let angels: Vec<_> = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| object.name == "Angel" && object.owner == alice)
+        .collect();
+    assert_eq!(angels.len(), 3, "Entreat should create X Angel tokens");
+    assert!(angels.iter().all(|angel| {
+        angel.base_power == Some(crate::card::PtValue::Fixed(4))
+            && angel.base_toughness == Some(crate::card::PtValue::Fixed(4))
+            && angel.subtypes.contains(&Subtype::Angel)
+            && angel.has_static_ability_id(crate::static_abilities::StaticAbilityId::Flying)
+    }));
+}
+
 #[test]
 fn guardian_of_the_ages_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Guardian of the Ages");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1594,6 +1594,26 @@ fn is_suspend_helper_ability(ability: &Ability) -> bool {
             || is_suspend_cast_when_last_counter_removed_trigger(triggered))
 }
 
+fn is_miracle_helper_ability(ability: &Ability) -> bool {
+    let AbilityKind::Triggered(triggered) = &ability.kind else {
+        return false;
+    };
+    if ability.functional_zones != [Zone::Hand]
+        || triggered.trigger != crate::triggers::Trigger::miracle()
+        || !triggered.choices.is_empty()
+        || triggered.intervening_if.is_some()
+    {
+        return false;
+    }
+
+    let [effect] = triggered.effects.flattened_default_effects() else {
+        return false;
+    };
+    effect
+        .downcast_ref::<crate::effects::player::MayCastForMiracleCostEffect>()
+        .is_some()
+}
+
 fn is_conspire_helper_ability(ability: &Ability) -> bool {
     let AbilityKind::Triggered(triggered) = &ability.kind else {
         return false;
@@ -2098,10 +2118,18 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
             .alternative_casts
             .iter()
             .any(|method| matches!(method, AlternativeCastingMethod::Suspend { .. }));
+        let has_miracle = def
+            .alternative_casts
+            .iter()
+            .any(AlternativeCastingMethod::is_miracle);
         let mut ability_idx = 0usize;
         while ability_idx < def.abilities.len() {
             let ability = &def.abilities[ability_idx];
             if has_suspend && is_suspend_helper_ability(ability) {
+                ability_idx += 1;
+                continue;
+            }
+            if has_miracle && is_miracle_helper_ability(ability) {
                 ability_idx += 1;
                 continue;
             }

--- a/crates/ironsmith-runtime/src/effects/player/may_cast_miracle.rs
+++ b/crates/ironsmith-runtime/src/effects/player/may_cast_miracle.rs
@@ -115,24 +115,43 @@ impl EffectExecutor for MayCastForMiracleCostEffect {
             return Ok(EffectOutcome::resolved());
         }
 
-        // Player wants to cast for miracle cost.
-        let x_value = if miracle_cost.has_x() {
-            Some(0u32)
-        } else {
-            None
-        };
-
         // Try to pay now; if payment fails, card stays in hand.
         let Some(card_obj) = game.object(card_id) else {
             return Ok(EffectOutcome::resolved());
         };
         let effective_cost =
             crate::decision::calculate_effective_mana_cost(game, owner, card_obj, &miracle_cost);
+        let x_value = if miracle_cost.has_x() {
+            let max_x = game
+                .player(owner)
+                .map(|player| {
+                    let available = player.mana_pool.total();
+                    (0..=available)
+                        .filter(|x| player.mana_pool.can_pay(&effective_cost, *x))
+                        .max()
+                        .unwrap_or(0)
+                })
+                .unwrap_or(0);
+            let number_ctx =
+                crate::decisions::context::NumberContext::x_value(owner, card_id, max_x)
+                    .with_context_text(format!(
+                        "Choose X for {}'s miracle cost ({})",
+                        card_name,
+                        miracle_cost.to_oracle()
+                    ));
+            let chosen_x = ctx.decision_maker.decide_number(game, &number_ctx).min(max_x);
+            if ctx.decision_maker.awaiting_choice() {
+                return Ok(EffectOutcome::count(0));
+            }
+            Some(chosen_x)
+        } else {
+            None
+        };
         if !game.try_pay_mana_cost_with_reason(
             owner,
             Some(card_id),
             &effective_cost,
-            0,
+            x_value.unwrap_or(0),
             crate::costs::PaymentReason::CastSpell,
         ) {
             return Ok(EffectOutcome::resolved());

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -992,6 +992,47 @@ fn compile_oracle_text_strictly_compiles_aunt_may_from_workspace_cards() {
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_entreat_the_angels_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Entreat the Angels")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Entreat the Angels --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Entreat the Angels should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Entreat the Angels"), "{stdout}");
+    assert!(
+        stdout.contains("Create X 4/4 white Angel creature tokens with flying."),
+        "expected Entreat token creation clause in compiled comparison output, got {stdout}"
+    );
+    assert!(
+        stdout.contains("Miracle {X}{W}{W}"),
+        "expected Entreat miracle keyword in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_the_aesir_escape_valhalla_from_workspace_cards() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Entreat the Angels
Initial parse error:
```
parser does not yet support line family: 'Miracle {X}{W}{W} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)'; oracle-only fallback also failed: parser does not yet support line family: 'Miracle {X}{W}{W}'
```

Current worker: i-043ebfca044e24f0c
Branch: codex/aws-card-fix-entreat-the-angels
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0018
