### PR TITLE
Fix Ironsmith parse failure: Bright-Palm, Soul Awakener

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4490,8 +4490,16 @@ fn compile_subject_verb_effect(
             if let Some(target_count) = target_count {
                 spec = spec.with_count(*target_count);
             }
+            let count = if let Value::CountersOn(counter_source, amount_counter_type) = count
+                && matches!(counter_source.as_ref(), ChooseSpec::Source)
+                && amount_counter_type == &Some(*counter_type)
+            {
+                Value::CountersOn(Box::new(spec.clone()), Some(*counter_type))
+            } else {
+                count.clone()
+            };
             let mut put_counters =
-                crate::effects::PutCountersEffect::new(*counter_type, count.clone(), spec.clone());
+                crate::effects::PutCountersEffect::new(*counter_type, count, spec.clone());
             if let Some(target_count) = target_count {
                 put_counters = put_counters.with_target_count(*target_count);
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -5,7 +5,7 @@ use crate::cards::builders::{
 };
 use crate::effect::{EventValueSpec, Until, Value};
 use crate::static_abilities::StaticAbilityId;
-use crate::target::{ObjectFilter, PlayerFilter};
+use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::zone::Zone;
 use crate::{ChoiceCount, Supertype};
 
@@ -239,6 +239,17 @@ pub(crate) fn parse_double_counters_clause(
         return Err(CardTextError::ParseError(format!(
             "missing filter in double-counters clause (clause: '{}')",
             clause_words.join(" ")
+        )));
+    }
+
+    if starts_with_target_indicator(filter_tokens) {
+        let target = parse_target_phrase(filter_tokens)?;
+        return Ok(Some(EffectAst::subject_verb_put_counters(
+            counter_type,
+            Value::CountersOn(Box::new(ChooseSpec::Source), Some(counter_type)),
+            target,
+            None,
+            false,
         )));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9284,6 +9284,25 @@ fn rewrite_lexed_effect_sentence_parses_remove_all_named_counters_from_target() 
 }
 
 #[test]
+fn bright_palm_double_counters_clause_keeps_targeted_creature() {
+    let text = "double the number of +1/+1 counters on target creature";
+    let tokens = lex_line(text, 0).expect("Bright-Palm counter clause should lex");
+
+    let parsed = parse_effect_sentence_lexed(&tokens)
+        .expect("Bright-Palm counter clause should parse");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("PutCounters")
+            && debug.contains("CountersOn(")
+            && debug.contains("Some(TextSpan")
+            && debug.contains("card_types: [Creature]")
+            && !debug.contains("DoubleCountersOnEach"),
+        "expected Bright-Palm to double counters on one target creature, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_lexed_effect_entrypoint_matches_wrapper_comma_then_chain() {
     let text = "Discard your hand, then draw four cards.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify comma-then effect");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9710,10 +9710,11 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             format!("{} can't block", filter.description())
         }
         crate::effect::Restriction::BlockSpecificAttacker { blockers, attacker } => {
+            let blockers = pluralize_noun_phrase(strip_leading_article(&blockers.description()));
             format!(
-                "{} can't block {}",
-                blockers.description(),
-                attacker.description()
+                "{} can't be blocked by {}",
+                attacker.description(),
+                blockers
             )
         }
         crate::effect::Restriction::MustBlockSpecificAttacker { blockers, attacker } => {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14876,6 +14876,38 @@ mod tests {
     }
 
     #[test]
+    fn tagged_put_counters_then_block_specific_attacker_renders_that_creature() {
+        let counter_target = ChooseSpec::target_creature();
+        let targeted = TagKey::from("counters_0");
+        let tagged = Effect::new(crate::effects::PutCountersEffect::new(
+            crate::object::CounterType::PlusOnePlusOne,
+            Value::CountersOn(
+                Box::new(counter_target.clone()),
+                Some(crate::object::CounterType::PlusOnePlusOne),
+            ),
+            counter_target,
+        ))
+        .tag(targeted.clone());
+        let mut attacker = ObjectFilter::creature();
+        attacker.tagged_constraints.push(TaggedObjectConstraint {
+            tag: targeted,
+            relation: TaggedOpbjectRelation::IsTaggedObject,
+        });
+        let cant = Effect::new(crate::effects::CantEffect::until_end_of_turn(
+            crate::effect::Restriction::BlockSpecificAttacker {
+                blockers: ObjectFilter::creature()
+                    .with_power(crate::filter::Comparison::LessThanOrEqual(2)),
+                attacker,
+            },
+        ));
+
+        assert_eq!(
+            describe_effect_list(&[tagged, cant]),
+            "Double the number of +1/+1 counters on target creature. That creature can't be blocked by creatures with power 2 or less this turn"
+        );
+    }
+
+    #[test]
     fn choose_color_as_enters_uses_oracle_static_surface() {
         let choose_any = crate::static_abilities::StaticAbility::choose_color_as_enters(
             None,
@@ -18249,9 +18281,6 @@ pub(super) fn describe_tagged_target_then_cant_restriction(
     tagged: &crate::effects::TaggedEffect,
     cant: &crate::effects::CantEffect,
 ) -> Option<String> {
-    let target_only = tagged
-        .effect
-        .downcast_ref::<crate::effects::TargetOnlyEffect>()?;
     if cant.duration != crate::effect::Until::EndOfTurn {
         return None;
     }
@@ -18262,12 +18291,31 @@ pub(super) fn describe_tagged_target_then_cant_restriction(
                 && constraint.tag.as_str() == tagged.tag.as_str()
         })
     {
-        let subject = capitalize_first(&describe_choose_spec(&target_only.target));
         let blockers = pluralize_noun_phrase(strip_leading_article(&blockers.description()));
-        return Some(format!(
-            "{subject} can't be blocked by {blockers} this turn"
-        ));
+        if let Some(target_only) = tagged
+            .effect
+            .downcast_ref::<crate::effects::TargetOnlyEffect>()
+        {
+            let subject = capitalize_first(&describe_choose_spec(&target_only.target));
+            return Some(format!(
+                "{subject} can't be blocked by {blockers} this turn"
+            ));
+        }
+        if tagged
+            .effect
+            .downcast_ref::<crate::effects::PutCountersEffect>()
+            .is_some()
+        {
+            return Some(format!(
+                "{}. That creature can't be blocked by {blockers} this turn",
+                describe_effect(&tagged.effect)
+            ));
+        }
     }
+
+    let target_only = tagged
+        .effect
+        .downcast_ref::<crate::effects::TargetOnlyEffect>()?;
     let (filter, restriction_text) = match &cant.restriction {
         crate::effect::Restriction::Block(filter) => (filter, "can't block this turn"),
         crate::effect::Restriction::BeBlocked(filter) => (filter, "can't be blocked this turn"),
@@ -26984,6 +27032,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 "Put a {} counter on {target} for each {}",
                 describe_counter_type(put_counters.counter_type),
                 describe_for_each_count_filter(&filter)
+            );
+        }
+        if let Value::CountersOn(spec, Some(counter_type)) = &put_counters.amount
+            && !put_counters.distributed
+            && put_counters.target_count.is_none()
+            && *counter_type == put_counters.counter_type
+            && spec.unhinted() == put_counters.target.unhinted()
+        {
+            return format!(
+                "Double the number of {} counters on {target}",
+                describe_counter_type(*counter_type)
             );
         }
         if let Some((counter_text, where_x)) =

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -140,6 +140,18 @@ fn normalize_restriction_for_resolution(
         Restriction::Block(filter) => Restriction::block(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),
+        Restriction::BlockSpecificAttacker { blockers, attacker } => {
+            Restriction::block_specific_attacker(
+                blockers.clone(),
+                collapse_tagged_filter_to_specific_objects(attacker, ctx, game),
+            )
+        }
+        Restriction::MustBlockSpecificAttacker { blockers, attacker } => {
+            Restriction::must_block_specific_attacker(
+                blockers.clone(),
+                collapse_tagged_filter_to_specific_objects(attacker, ctx, game),
+            )
+        }
         _ => restriction.clone(),
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -16,7 +16,7 @@ use crate::filter::ObjectFilterExt as _;
 use crate::game_state::Phase;
 use crate::ids::CardId;
 use crate::mana::{ManaCost, ManaSymbol};
-use crate::object::ObjectKind;
+use crate::object::{CounterType, ObjectKind};
 use crate::static_abilities::StaticAbility;
 use crate::target::{ObjectRef, PlayerFilter};
 use crate::triggers::Trigger;
@@ -81,6 +81,26 @@ fn merfolk_cave_diver_definition() -> crate::cards::CardDefinition {
             "Whenever a creature you control explores, this creature gets +1/+0 until end of turn and can't be blocked this turn.",
         )
         .expect("Merfolk Cave-Diver should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn bright_palm_soul_awakener_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_945), "Bright-Palm, Soul Awakener")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::White],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Fox, Subtype::Shaman])
+        .power_toughness(PowerToughness::fixed(4, 3))
+        .parse_text(
+            "Backup 1 (When this creature enters, put a +1/+1 counter on target creature. If that's another creature, it gains the following ability until end of turn.)\n\
+             Whenever this creature attacks, double the number of +1/+1 counters on target creature. That creature can't be blocked by creatures with power 2 or less this turn.",
+        )
+        .expect("Bright-Palm, Soul Awakener should parse")
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
@@ -500,6 +520,124 @@ fn merfolk_cave_diver_ignores_opponent_creatures_exploring() {
     assert!(
         game.can_be_blocked(merfolk_id),
         "Merfolk Cave-Diver should remain blockable without a matching explore trigger"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bright_palm_soul_awakener_parses_and_renders_targeted_unblockable_clause() {
+    let bright_palm = bright_palm_soul_awakener_definition();
+    let rendered = crate::compiled_text::compiled_text_lines(&bright_palm).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("backup 1"),
+        "Bright-Palm should render backup, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("double the number of +1/+1 counters on target creature"),
+        "Bright-Palm should render targeted counter doubling, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("that creature can't be blocked by creatures with power 2 or less"),
+        "Bright-Palm should render the can't-be-blocked marker, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("each creature"),
+        "Bright-Palm must not render the target as each creature, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bright_palm_soul_awakener_attack_trigger_doubles_target_and_limits_blockers() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let bright_palm = bright_palm_soul_awakener_definition();
+    let bright_palm_id =
+        game.create_object_from_definition(&bright_palm, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(bright_palm_id);
+    game.add_counters(bright_palm_id, CounterType::PlusOnePlusOne, 2);
+
+    let bystander_id = create_creature(&mut game, "Bystander", alice, 1, 1);
+    game.add_counters(bystander_id, CounterType::PlusOnePlusOne, 3);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: bright_palm_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("Bright-Palm should be able to attack");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Bright-Palm attack trigger should go on the stack");
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Bright-Palm attack trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(bright_palm_id, CounterType::PlusOnePlusOne),
+        4,
+        "Bright-Palm should double the +1/+1 counters on the chosen target"
+    );
+    assert_eq!(
+        game.counter_count(bystander_id, CounterType::PlusOnePlusOne),
+        3,
+        "Bright-Palm should not double counters on every creature"
+    );
+
+    let small_blocker_id = create_creature(&mut game, "Small Blocker", bob, 2, 2);
+    let large_blocker_id = create_creature(&mut game, "Large Blocker", bob, 3, 3);
+    game.update_cant_effects();
+    assert!(
+        !game.can_block_attacker(small_blocker_id, bright_palm_id),
+        "creatures with power 2 or less should be unable to block the targeted creature"
+    );
+    assert!(
+        game.can_block_attacker(large_blocker_id, bright_palm_id),
+        "creatures with power 3 or greater should remain able to block the targeted creature"
+    );
+
+    let mut block_combat = CombatState::default();
+    block_combat
+        .attackers
+        .push(crate::combat_state::AttackerInfo {
+            creature: bright_palm_id,
+            target: AttackTarget::Player(bob),
+        });
+    let err = apply_blocker_declarations(
+        &mut game,
+        &mut block_combat,
+        &mut TriggerQueue::new(),
+        &[BlockerDeclaration {
+            blocker: small_blocker_id,
+            blocking: bright_palm_id,
+        }],
+        bob,
+    )
+    .expect_err("small blocker should be illegal for Bright-Palm's targeted creature");
+    assert!(
+        format!("{err:?}").contains("InvalidBlockers"),
+        "expected low-power block to be rejected, got {err:?}"
+    );
+
+    execute_cleanup_step(&mut game);
+    game.update_cant_effects();
+    assert!(
+        game.can_block_attacker(small_blocker_id, bright_palm_id),
+        "Bright-Palm's blocker restriction should expire at cleanup"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Bright-Palm, Soul Awakener
Initial parse error:
```
compiled text dropped required semantic marker: cant-be-blocked
```

Current worker: i-0358c996b1db24791
Branch: codex/aws-card-fix-bright-palm-soul-awakener
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0043
