### PR TITLE
Fix Ironsmith parse failure: Singe-Mind Ogre

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -216,7 +216,7 @@ fn compile_subject_verb_effect(
             true,
             true,
             true,
-            false,
+            true,
             Effect::lose_life,
             Effect::lose_life_player,
         ),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -1094,6 +1094,40 @@ pub(crate) fn parse_effect_chain_inner_lexed(
             previous_segment = Some(segment);
             continue;
         }
+        let primitive_segment_effects = if let Some(effects) = run_subject_verb_primitives_lexed(
+            &segment,
+            PRE_CONDITIONAL_SUBJECT_VERB_PRIMITIVES,
+            &PRE_CONDITIONAL_SUBJECT_VERB_PRIMITIVE_INDEX,
+        )? {
+            Some(effects)
+        } else {
+            run_subject_verb_primitives_lexed(
+                &segment,
+                POST_CONDITIONAL_SUBJECT_VERB_PRIMITIVES,
+                &POST_CONDITIONAL_SUBJECT_VERB_PRIMITIVE_INDEX,
+            )?
+        };
+        if let Some(segment_effects) = primitive_segment_effects {
+            for mut effect in segment_effects {
+                if let Some(context) = carried_context {
+                    maybe_apply_carried_player_with_clause_lexed(&mut effect, context, &segment);
+                }
+                if (carry_gain_duration || carry_leading_duration)
+                    && let Some(duration) = &carried_duration
+                {
+                    apply_carried_effect_duration(&mut effect, duration);
+                }
+                if let Some(context) = explicit_player_for_carry(&effect) {
+                    carried_context = Some(context);
+                }
+                if let Some(duration) = effect_duration_for_gain_followup_carry(&effect) {
+                    carried_duration = Some(duration);
+                }
+                effects.push(effect);
+            }
+            previous_segment = Some(segment);
+            continue;
+        }
         if let Some(followup) = parse_token_copy_followup_sentence_lexed(&segment)
             && try_apply_token_copy_followup(&mut effects, followup)?
         {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -9275,6 +9275,47 @@ fn test_parse_ignite_memories_keeps_random_hand_reveal_and_damage_link() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_singe_mind_ogre_keeps_random_hand_reveal_and_life_loss_link() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Singe-Mind Ogre")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Ogre, Subtype::Mutant])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "When this creature enters, target player reveals a card at random from their hand, then loses life equal to that card's mana value.",
+        )
+        .expect("Singe-Mind Ogre should parse");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("ChooseObjectsEffect")
+            && debug.contains("random: true")
+            && debug.contains("zone: Some(Hand)")
+            && debug.contains("RevealTaggedEffect")
+            && debug.contains("LoseLifeEffect")
+            && debug.contains("ManaValueOf"),
+        "expected random hand selection, reveal, and mana-value life-loss linkage, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("when this creature enters")
+            && rendered.contains("target player reveals a card at random from their hand")
+            && rendered.contains("then loses life equal to that card's mana value")
+            && !rendered.contains("reveal it")
+            && !rendered.contains("choose exactly 1 at random"),
+        "expected Singe-Mind Ogre compiled text to preserve the random reveal and life-loss link, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_word_of_blasting_uses_destroyed_wall_mana_value_for_damage() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Word of Blasting")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -7116,7 +7116,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             loser = "that player".to_string();
         }
         let lose_verb = player_verb(&loser, "lose", "loses");
-        let loss_clause = if loser.eq_ignore_ascii_case(player) {
+        let same_revealing_player = loser.eq_ignore_ascii_case(player)
+            || (matches!(choose.chooser, PlayerFilter::Target(_)) && loser == "that player");
+        let loss_clause = if same_revealing_player {
             format!("{lose_verb} life equal to that card's mana value")
         } else {
             format!("{loser} {lose_verb} life equal to that card's mana value")

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1429,7 +1429,7 @@ impl DecisionMaker for CaptureRevealDecisionMaker {
         _game: &GameState,
         _ctx: &crate::decisions::context::SelectObjectsContext,
     ) -> Vec<ObjectId> {
-        panic!("Ignite Memories should not prompt for object selection when revealing at random");
+        panic!("random hand reveal should not prompt for object selection");
     }
 
     fn view_cards(
@@ -2390,6 +2390,112 @@ fn ignite_memories_reveals_a_random_card_from_target_players_hand_and_damages_th
         game.player(bob).expect("bob exists").life,
         bob_life_before - expected_damage,
         "Ignite Memories should deal damage equal to the revealed card's mana value"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn singe_mind_ogre_reveals_a_random_card_from_target_players_hand_and_makes_them_lose_life() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let singe_mind_ogre = CardDefinitionBuilder::new(CardId::from_raw(70_010), "Singe-Mind Ogre")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Ogre, Subtype::Mutant])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "When this creature enters, target player reveals a card at random from their hand, then loses life equal to that card's mana value.",
+        )
+        .expect("Singe-Mind Ogre should parse");
+
+    let low_card = CardBuilder::new(CardId::from_raw(70_011), "Low Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let high_card = CardBuilder::new(CardId::from_raw(70_012), "High Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+
+    let low_id = game.create_object_from_card(&low_card, bob, Zone::Hand);
+    let high_id = game.create_object_from_card(&high_card, bob, Zone::Hand);
+    let source_id = game.create_object_from_definition(&singe_mind_ogre, alice, Zone::Battlefield);
+    let triggered_effects = game
+        .object(source_id)
+        .expect("Singe-Mind Ogre should be on the battlefield")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.effects.clone()),
+            _ => None,
+        })
+        .expect("Singe-Mind Ogre should have an enters trigger");
+    game.stack.push(
+        crate::game_state::StackEntry::ability(source_id, alice, triggered_effects)
+            .with_targets(vec![crate::game_state::Target::Player(bob)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::target_player(),
+                range: 0..1,
+            }])
+            .with_triggering_event(TriggerEvent::new_with_provenance(
+                EnterBattlefieldEvent::new(source_id, Zone::Hand),
+                crate::provenance::ProvNodeId::default(),
+            )),
+    );
+
+    let bob_life_before = game.player(bob).expect("bob exists").life;
+    let mut dm = CaptureRevealDecisionMaker::default();
+
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Singe-Mind Ogre trigger should resolve");
+
+    assert!(
+        dm.view_calls.len() >= 2,
+        "the random reveal should be shown to all players"
+    );
+    let mut unique_reveals = dm
+        .view_calls
+        .iter()
+        .map(|(_, subject, zone, public, cards)| {
+            assert_eq!(
+                *subject, bob,
+                "the revealed card should come from Bob's hand"
+            );
+            assert_eq!(*zone, Zone::Hand, "the reveal should come from hand");
+            assert!(*public, "the reveal should be public");
+            assert_eq!(cards.len(), 1, "only one card should be revealed");
+            cards[0]
+        })
+        .collect::<Vec<_>>();
+    unique_reveals.sort();
+    unique_reveals.dedup();
+    assert_eq!(
+        unique_reveals.len(),
+        1,
+        "the same random card should be shown to each viewer"
+    );
+
+    let revealed_id = unique_reveals[0];
+    assert!(
+        revealed_id == low_id || revealed_id == high_id,
+        "the revealed card should come from Bob's hand"
+    );
+
+    let revealed_card = game.object(revealed_id).expect("revealed card exists");
+    let expected_life_loss = revealed_card
+        .mana_cost
+        .as_ref()
+        .expect("revealed card should have a mana cost")
+        .mana_value() as i32;
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        bob_life_before - expected_life_loss,
+        "Singe-Mind Ogre should make that player lose life equal to the revealed card's mana value"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Singe-Mind Ogre
Initial parse error:
```
compiled text dropped required semantic marker: at-random
```

Current worker: i-0b1c8075a4612cd53
Branch: codex/aws-card-fix-singe-mind-ogre
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0043
