### PR TITLE
Fix Ironsmith parse failure: Demon of Fate's Design

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -778,6 +778,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_assign_damage_as_unblocked_line),
         single_static_ability_ast_rule!(parse_fixed_mana_cost_instead_of_mana_cost_grant_line),
         single_static_ability_ast_rule!(parse_mana_value_instead_of_mana_cost_grant_line),
+        single_static_ability_ast_rule!(parse_life_mana_value_instead_of_mana_cost_grant_line),
         single_static_ability_ast_rule!(parse_as_enters_becomes_characteristics_for_filter_line),
         single_static_ability_ast_rule!(parse_enter_as_copy_as_enters_line),
         multi_static_ability_ast_rule!(
@@ -7396,6 +7397,71 @@ pub(crate) fn parse_mana_value_instead_of_mana_cost_grant_line(
     let filter = parse_spell_filter_with_grammar_entrypoint_lexed(subject_tokens);
     Ok(Some(StaticAbility::grants(crate::grant::GrantSpec::new(
         crate::grant::Grantable::mana_value_as_generic_from_hand(),
+        filter,
+        Zone::Hand,
+    ))))
+}
+
+pub(crate) fn parse_life_mana_value_instead_of_mana_cost_grant_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let tokens = if tokens
+        .last()
+        .is_some_and(|token| token.kind == TokenKind::Period)
+    {
+        &tokens[..tokens.len() - 1]
+    } else {
+        tokens
+    };
+
+    let words = super::lexer::parser_token_word_refs(tokens);
+    if !slice_starts_with(
+        words.as_slice(),
+        &[
+            "once", "during", "each", "of", "your", "turns", "you", "may", "cast",
+        ],
+    ) {
+        return Ok(None);
+    }
+
+    let Some(cast_idx) = find_index(tokens, |token| token.is_word("cast")) else {
+        return Ok(None);
+    };
+    let Some(by_idx) = find_index(tokens, |token| token.is_word("by")) else {
+        return Ok(None);
+    };
+    if by_idx <= cast_idx + 1 {
+        return Ok(None);
+    }
+    let subject_tokens = trim_lexed_commas(tokens.get(cast_idx + 1..by_idx).unwrap_or_default());
+    let subject_words = crate::runtime_backend::token_word_refs(subject_tokens);
+    if subject_tokens.is_empty()
+        || !slice_contains(&subject_words, &"spell") && !slice_contains(&subject_words, &"spells")
+    {
+        return Ok(None);
+    }
+
+    let tail_words =
+        crate::runtime_backend::token_word_refs(tokens.get(by_idx + 1..).unwrap_or_default());
+    if tail_words
+        != [
+            "paying", "life", "equal", "to", "its", "mana", "value", "rather", "than",
+            "paying", "its", "mana", "cost",
+        ]
+        && tail_words
+            != [
+                "pay", "life", "equal", "to", "its", "mana", "value", "rather", "than", "pay",
+                "its", "mana", "cost",
+            ]
+    {
+        return Ok(None);
+    }
+
+    let filter = parse_spell_filter_with_grammar_entrypoint_lexed(subject_tokens);
+    Ok(Some(StaticAbility::grants(crate::grant::GrantSpec::new(
+        crate::grant::Grantable::life_equal_mana_value_from_hand(Some(
+            crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns,
+        )),
         filter,
         Zone::Hand,
     ))))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -1107,6 +1107,18 @@ fn parse_effect_sentence_with_where_x_lexed(
                     "tap_cost_0",
                 ))))
             }
+            Some(["the", "sacrificed", sacrificed_kind, "mana", "value"])
+            | Some(["sacrificed", sacrificed_kind, "mana", "value"]) => {
+                let sacrificed_kind = sacrificed_kind.trim_end_matches('s');
+                Value::ManaValueOf(Box::new(
+                    crate::target::ChooseSpec::Tagged(TagKey::from("sacrifice_cost_0"))
+                        .with_surface_hint(crate::target::ChooseSpecSurfaceHint::SourceReference(
+                            crate::target::SourceReferenceSurface::ThisPermanentType(format!(
+                                "the sacrificed {sacrificed_kind}"
+                            )),
+                        )),
+                ))
+            }
             Some(
                 [
                     "2",

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -26,6 +26,10 @@ pub enum DerivedAlternativeCast<C> {
     EscapeFromCardManaCost { exile_count: u32 },
     /// Cast from hand by paying generic mana equal to the card's mana value.
     ManaValueAsGenericFromHand,
+    /// Cast from hand by paying life equal to the card's mana value.
+    LifeEqualManaValueFromHand {
+        usage_limit: Option<GrantUsageLimit>,
+    },
     /// Cast from the graveyard using the card's mana cost plus optional extra cost components.
     GraveyardCastFromCardManaCost {
         additional_costs: Vec<C>,
@@ -45,12 +49,14 @@ impl<C> DerivedAlternativeCast<C> {
             Self::MiracleFromCardManaCostReducedBy { .. } => "Miracle",
             Self::EscapeFromCardManaCost { .. } => "Escape",
             Self::ManaValueAsGenericFromHand => "Pay mana value",
+            Self::LifeEqualManaValueFromHand { .. } => "Pay life equal to mana value",
             Self::GraveyardCastFromCardManaCost { .. } => "Cast from graveyard",
         }
     }
 
     pub fn usage_limit(&self) -> Option<GrantUsageLimit> {
         match self {
+            Self::LifeEqualManaValueFromHand { usage_limit } => *usage_limit,
             Self::GraveyardCastFromCardManaCost { usage_limit, .. } => *usage_limit,
             _ => None,
         }
@@ -96,6 +102,10 @@ impl<C: CostComponent> DerivedAlternativeCast<C> {
             condition: None,
             exiles_after_resolution: false,
         }
+    }
+
+    pub fn life_equal_mana_value_from_hand(usage_limit: Option<GrantUsageLimit>) -> Self {
+        Self::LifeEqualManaValueFromHand { usage_limit }
     }
 
     pub fn graveyard_cast_from_cards_mana_cost_with_condition(
@@ -189,6 +199,14 @@ where
     /// to the granted card's mana value.
     pub fn mana_value_as_generic_from_hand() -> Self {
         Self::DerivedAlternativeCast(DerivedAlternativeCast::ManaValueAsGenericFromHand)
+    }
+
+    /// Create a grantable for casting from hand by paying life equal to
+    /// the granted card's mana value.
+    pub fn life_equal_mana_value_from_hand(usage_limit: Option<GrantUsageLimit>) -> Self {
+        Self::DerivedAlternativeCast(DerivedAlternativeCast::life_equal_mana_value_from_hand(
+            usage_limit,
+        ))
     }
 
     pub fn once_each_turn_graveyard_cast_from_cards_mana_cost(additional_costs: Vec<C>) -> Self {
@@ -649,6 +667,27 @@ where
             return format!(
                 "{may_prefix} pay {{X}} rather than pay the mana cost for {} you cast, where X is that spell's mana value",
                 castable_filter_description(&self.filter)
+            );
+        }
+        if let Grantable::DerivedAlternativeCast(
+            DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit },
+        ) = &self.grantable
+            && self.zone == Zone::Hand
+        {
+            let prefix = if matches!(usage_limit, Some(GrantUsageLimit::OnceDuringEachOfYourTurns))
+            {
+                "Once during each of your turns, "
+            } else {
+                ""
+            };
+            let filter_desc = castable_filter_description(&self.filter);
+            let singular_filter_desc = filter_desc
+                .strip_suffix(" spells")
+                .map(|base| format!("a {base} spell"))
+                .unwrap_or(filter_desc);
+            return format!(
+                "{prefix}{} cast {singular_filter_desc} by paying life equal to its mana value rather than paying its mana cost",
+                may_prefix.to_ascii_lowercase()
             );
         }
         if let Grantable::DerivedAlternativeCast(

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -663,6 +663,9 @@ where
                 DerivedAlternativeCast::ManaValueAsGenericFromHand => {
                     DerivedAlternativeCast::ManaValueAsGenericFromHand
                 }
+                DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit } => {
+                    DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit }
+                }
                 DerivedAlternativeCast::GraveyardCastFromCardManaCost {
                     additional_costs,
                     usage_limit,

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -341,6 +341,9 @@ fn convert_derived_alternative_cast(
         compiler::grant::DerivedAlternativeCast::ManaValueAsGenericFromHand => {
             ironsmith::grant::DerivedAlternativeCast::ManaValueAsGenericFromHand
         }
+        compiler::grant::DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit } => {
+            ironsmith::grant::DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit }
+        }
         compiler::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
             additional_costs,
             usage_limit,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17857,6 +17857,65 @@ fn parse_rooftop_storm_static_free_zombie_permission() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_demon_of_fates_design_life_cost_and_sacrifice_pump_regression() {
+    let def = parse_oracle_card_definition("Demon of Fate's Design");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains(
+            "once during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost"
+        ),
+        "expected Demon of Fate's Design life-cost cast permission, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "sacrifice another enchantment: this creature gets +x/+0 until end of turn, where x is the sacrificed enchantment's mana value"
+        ),
+        "expected Demon of Fate's Design sacrificed-enchantment pump wording, got {rendered}"
+    );
+
+    let has_life_cost_grant = def.abilities.iter().any(|ability| {
+        let AbilityKind::Static(static_ability) = &ability.kind else {
+            return false;
+        };
+        let Some(spec) = static_ability.grant_spec() else {
+            return false;
+        };
+        matches!(
+            spec.grantable,
+            crate::grant::Grantable::DerivedAlternativeCast(
+                crate::grant::DerivedAlternativeCast::LifeEqualManaValueFromHand {
+                    usage_limit: Some(crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns)
+                }
+            )
+        ) && spec.zone == Zone::Hand
+            && spec.filter.card_types == [CardType::Enchantment]
+    });
+    assert!(
+        has_life_cost_grant,
+        "expected Demon of Fate's Design to grant a once-per-turn enchantment life-cost alternative cast"
+    );
+
+    let activated_debug = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(format!("{activated:?}")),
+            _ => None,
+        })
+        .expect("Demon of Fate's Design should have an activated ability");
+    assert!(
+        activated_debug.contains("sacrifice_cost_0")
+            && activated_debug.contains("ManaValueOf")
+            && activated_debug.contains("WhereXIs"),
+        "expected sacrificed enchantment mana value to drive the pump amount, got {activated_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_creature_spell_emerge_grant_uses_hand_derived_alternative_cast() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Herigast Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6447,9 +6447,7 @@ pub(super) fn describe_demonstrative_tagged_object_spec(spec: &ChooseSpec) -> Op
 
 pub(super) fn describe_choose_spec(spec: &ChooseSpec) -> String {
     match spec {
-        ChooseSpec::SurfaceHinted { spec, hints }
-            if matches!(spec.as_ref().unhinted(), ChooseSpec::Source) =>
-        {
+        ChooseSpec::SurfaceHinted { spec, hints } => {
             match hints.iter().find_map(|hint| match hint {
                 crate::target::ChooseSpecSurfaceHint::SourceReference(surface) => Some(surface),
             }) {
@@ -6461,7 +6459,6 @@ pub(super) fn describe_choose_spec(spec: &ChooseSpec) -> String {
                 None => describe_choose_spec(spec),
             }
         }
-        ChooseSpec::SurfaceHinted { spec, .. } => describe_choose_spec(spec),
         ChooseSpec::Target(inner) => {
             if let Some(tagged_text) = describe_demonstrative_tagged_object_spec(inner.as_ref()) {
                 return tagged_text;

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3827,7 +3827,8 @@ pub(super) fn finalize_spell_cast(
             spell_obj.optional_costs_paid.mark_label_paid("Evoke");
         }
     }
-    if let Some(label) = alternative_cast_label(game, caster, new_id, &casting_method)
+    let selected_alternative_label = alternative_cast_label(game, caster, new_id, &casting_method);
+    if let Some(label) = selected_alternative_label.as_deref()
         && !label.eq_ignore_ascii_case("Parsed alternative cost")
         && !matches!(
             label.to_ascii_lowercase().as_str(),
@@ -3846,27 +3847,26 @@ pub(super) fn finalize_spell_cast(
         ..
     } = &casting_method
     {
-        let source_has_once_graveyard_cast_grant = game.object(*source).is_some_and(|source_obj| {
+        let source_has_selected_once_grant = game.object(*source).is_some_and(|source_obj| {
             source_obj.abilities.iter().any(|ability| {
                 let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
                     return false;
                 };
                 static_ability.grant_spec().is_some_and(|spec| {
+                    let Some(label) = selected_alternative_label.as_deref() else {
+                        return false;
+                    };
                     matches!(
                         spec.grantable,
-                        crate::grant::Grantable::DerivedAlternativeCast(
-                            crate::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
-                                usage_limit: Some(
-                                    crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns
-                                ),
-                                ..
-                            }
-                        )
+                        crate::grant::Grantable::DerivedAlternativeCast(ref derived)
+                            if derived.usage_limit()
+                                == Some(crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns)
+                                && derived.display_name().eq_ignore_ascii_case(label)
                     )
                 })
             })
         });
-        if source_has_once_graveyard_cast_grant {
+        if source_has_selected_once_grant {
             game.turn_store
                 .grant_cast_uses_this_turn
                 .insert((caster, *source));

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -19363,6 +19363,341 @@ fn test_bosh_iron_golem_uses_sacrificed_artifact_mana_value_for_damage() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn demon_of_fates_design_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(92_200), "Demon of Fate's Design")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Enchantment, CardType::Creature])
+        .subtypes(vec![Subtype::Demon])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .parse_text(
+            "Flying, trample\n\
+             Once during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.\n\
+             {2}{B}, Sacrifice another enchantment: This creature gets +X/+0 until end of turn, where X is the sacrificed enchantment's mana value.",
+        )
+        .expect("Demon of Fate's Design should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demon_of_fates_design_life_cost_casts_only_enchantments_once_during_your_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let demon_id = game.create_object_from_definition(
+        &demon_of_fates_design_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let enchantment = CardBuilder::new(CardId::from_raw(92_201), "Fate Test Enchantment")
+        .card_types(vec![CardType::Enchantment])
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .build();
+    let enchantment_id = game.create_object_from_card(&enchantment, alice, Zone::Hand);
+    let second_enchantment = CardBuilder::new(CardId::from_raw(92_202), "Second Fate Enchantment")
+        .card_types(vec![CardType::Enchantment])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .build();
+    let second_enchantment_id =
+        game.create_object_from_card(&second_enchantment, alice, Zone::Hand);
+    let artifact = CardBuilder::new(CardId::from_raw(92_203), "Fate Test Artifact")
+        .card_types(vec![CardType::Artifact])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .build();
+    let artifact_id = game.create_object_from_card(&artifact, alice, Zone::Hand);
+
+    game.player_mut(alice).expect("Alice exists").life = 20;
+
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::PlayFrom {
+                    source,
+                    zone: Zone::Hand,
+                    use_alternative: Some(_),
+                    ..
+                },
+            } if *spell_id == enchantment_id && *source == demon_id
+        )),
+        "Demon of Fate's Design should offer a life-cost alternative cast for enchantments"
+    );
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+                ..
+            } if *spell_id == artifact_id
+        )),
+        "Demon of Fate's Design should not grant the alternative cost to non-enchantments"
+    );
+
+    let cast_action = actions
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::PlayFrom {
+                    source,
+                    zone: Zone::Hand,
+                    use_alternative: Some(_),
+                    ..
+                },
+            } if *spell_id == enchantment_id && *source == demon_id
+        ))
+        .expect("expected Demon alternative cast action");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+    )
+    .expect("Demon alternative cast should succeed");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        17,
+        "casting the three-mana-value enchantment should cost 3 life"
+    );
+    assert!(
+        game.stack.iter().any(|entry| game
+            .object(entry.object_id)
+            .is_some_and(|object| object.name == "Fate Test Enchantment")),
+        "the enchantment should be on the stack after paying the life alternative cost"
+    );
+
+    resolve_stack_entry(&mut game).expect("enchantment spell should resolve");
+    let actions_after_use = compute_legal_actions(&game, alice);
+    assert!(
+        !actions_after_use.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+                ..
+            } if *spell_id == second_enchantment_id
+        )),
+        "Demon of Fate's Design should not offer a second life-cost enchantment cast in the same turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demon_of_fates_design_life_cost_requires_enough_life() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    game.create_object_from_definition(
+        &demon_of_fates_design_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let enchantment = CardBuilder::new(CardId::from_raw(92_204), "Expensive Fate Enchantment")
+        .card_types(vec![CardType::Enchantment])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .build();
+    let enchantment_id = game.create_object_from_card(&enchantment, alice, Zone::Hand);
+    game.player_mut(alice).expect("Alice exists").life = 2;
+
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+                ..
+            } if *spell_id == enchantment_id
+        )),
+        "Demon of Fate's Design should not offer the life-cost alternative if its mana value exceeds your life total"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demon_of_fates_design_life_cost_is_only_during_your_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+
+    game.create_object_from_definition(
+        &demon_of_fates_design_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let flash_enchantment =
+        CardDefinitionBuilder::new(CardId::from_raw(92_206), "Flash Fate Enchantment")
+            .card_types(vec![CardType::Enchantment])
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .parse_text("Flash")
+            .expect("flash enchantment should parse");
+    let enchantment_id = game.create_object_from_definition(&flash_enchantment, alice, Zone::Hand);
+    game.player_mut(alice).expect("Alice exists").life = 20;
+
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+                ..
+            } if *spell_id == enchantment_id
+        )),
+        "Demon of Fate's Design should not offer its life-cost alternative outside your turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demon_of_fates_design_sacrificed_enchantment_mana_value_sets_pump_amount() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let demon_id = game.create_object_from_definition(
+        &demon_of_fates_design_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    assert!(
+        !compute_legal_actions(&game, alice).iter().any(|action| matches!(
+            action,
+            LegalAction::ActivateAbility { source, .. } if *source == demon_id
+        )),
+        "Demon of Fate's Design should not be able to sacrifice itself for its another-enchantment cost"
+    );
+
+    let sacrificial_enchantment = CardBuilder::new(CardId::from_raw(92_205), "Sacrificial Saga")
+        .card_types(vec![CardType::Enchantment])
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::White],
+        ]))
+        .build();
+    let sacrifice_id =
+        game.create_object_from_card(&sacrificial_enchantment, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    let ability_index = game
+        .object(demon_id)
+        .expect("Demon should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Demon should have an activated ability");
+    let activate = PriorityResponse::PriorityAction(LegalAction::ActivateAbility {
+        source: demon_id,
+        ability_index,
+    });
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = AutoPassDecisionMaker;
+    let cost_order_ctx = match apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &activate,
+        &mut dm,
+    )
+    .expect("Demon activation should start")
+    {
+        GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectOptions(ctx),
+        ) => ctx,
+        other => panic!("expected next-cost chooser for Demon activation, got {other:?}"),
+    };
+    let sacrifice_cost_index = cost_order_ctx
+        .options
+        .iter()
+        .find(|option| option.description.to_ascii_lowercase().contains("sacrifice"))
+        .map(|option| option.index)
+        .expect("expected Demon sacrifice cost option");
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::NextCostChoice(sacrifice_cost_index),
+        &mut dm,
+    )
+    .expect("should choose Demon sacrifice cost first");
+    match progress {
+        GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectObjects(_),
+        ) => {}
+        other => panic!("expected sacrifice object chooser for Demon activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::SacrificeTarget(sacrifice_id),
+        &mut dm,
+    )
+    .expect("should choose the enchantment to sacrifice");
+    assert!(
+        game.stack.last().is_some_and(|entry| entry
+            .tagged_objects
+            .get(&crate::tag::TagKey::from("sacrifice_cost_0"))
+            .is_some_and(|objects| objects
+                .iter()
+                .any(|object| object.name == "Sacrificial Saga"))),
+        "Demon stack entry should remember the sacrificed enchantment"
+    );
+
+    resolve_stack_entry(&mut game).expect("Demon activation should resolve");
+    assert_eq!(
+        game.calculated_power(demon_id),
+        Some(9),
+        "Demon should get +3/+0 from the sacrificed enchantment's mana value"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_word_of_blasting_destroys_wall_and_deals_mana_value_damage_to_controller() {
     use crate::decision::LegalAction;

--- a/crates/ironsmith-runtime/src/grant.rs
+++ b/crates/ironsmith-runtime/src/grant.rs
@@ -157,6 +157,21 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
                     Vec::new(),
                 ))
             }
+            Self::LifeEqualManaValueFromHand { .. } => {
+                if card.zone != Zone::Hand {
+                    return None;
+                }
+                Some(AlternativeCastingMethod::alternative_cost(
+                    "Pay life equal to mana value",
+                    None,
+                    vec![Cost::try_from_runtime_effect(crate::effect::Effect::new(
+                        crate::effects::LoseLifeEffect::you(crate::effect::Value::ManaValueOf(
+                            Box::new(crate::target::ChooseSpec::Source),
+                        )),
+                    ))
+                    .expect("mana-value life payment should be cost-capable")],
+                ))
+            }
             Self::GraveyardCastFromCardManaCost {
                 additional_costs,
                 usage_limit,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Demon of Fate's Design
Initial parse error:
```
parser does not yet support line family: 'Once during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.'; oracle-only fallback also failed: parser does not yet support line family: 'Once during each of your turns, you may cast an enchantment spell by paying life equal to its mana value rather than paying its mana cost.'
```

Current worker: i-08c6909a3bab1ca60
Branch: codex/aws-card-fix-demon-of-fate-s-design
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0044
