### PR TITLE
Fix Ironsmith parse failure: Orzhov Advokist

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -1291,6 +1291,9 @@ pub(crate) fn parse_negated_object_restriction_clause(
     let restriction = match remainder_words.as_slice() {
         ["attack"] => Restriction::attack(filter),
         ["attack", "this", "turn"] => Restriction::attack(filter),
+        ["attack", "you", "or", "planeswalkers", "you", "control"] => {
+            Restriction::attack_player_or_planeswalkers_controlled_by(filter, PlayerFilter::You)
+        }
         ["attack", "alone"] => Restriction::attack_alone(filter),
         ["attack", "alone", "this", "turn"] => Restriction::attack_alone(filter),
         ["attack", "or", "block"] => Restriction::attack_or_block(filter),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -1133,6 +1133,13 @@ pub(crate) fn restriction_references_tag(
         return blockers_reference || attacker_reference;
     }
 
+    if let Restriction::AttackPlayerOrPlaneswalkersControlledBy { attackers, .. } = restriction {
+        return attackers
+            .tagged_constraints
+            .iter()
+            .any(|constraint| constraint.tag.as_str() == tag);
+    }
+
     false
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -444,6 +444,12 @@ pub(crate) fn resolve_restriction_it_tag(
             Restriction::BecomeMonarch(resolve_contextual_player_filter(player, refs)?)
         }
         Restriction::Attack(filter) => Restriction::attack(resolve_it_tag(filter, refs)?),
+        Restriction::AttackPlayerOrPlaneswalkersControlledBy { attackers, player } => {
+            Restriction::attack_player_or_planeswalkers_controlled_by(
+                resolve_it_tag(attackers, refs)?,
+                resolve_contextual_player_filter(player, refs)?,
+            )
+        }
         Restriction::Block(filter) => Restriction::block(resolve_it_tag(filter, refs)?),
         Restriction::BlockSpecificAttacker { blockers, attacker } => {
             Restriction::block_specific_attacker(

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -3024,6 +3024,9 @@ fn bind_unresolved_it_in_restriction(
             bind_unresolved_it_in_filter(blockers, seed_tag)
                 + bind_unresolved_it_in_filter(attacker, seed_tag)
         }
+        Restriction::AttackPlayerOrPlaneswalkersControlledBy { attackers, .. } => {
+            bind_unresolved_it_in_filter(attackers, seed_tag)
+        }
         _ => 0,
     }
 }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -272,6 +272,10 @@ pub enum Restriction {
     BecomeMonarch(PlayerFilter),
     PreventDamage,
     Attack(ObjectFilter),
+    AttackPlayerOrPlaneswalkersControlledBy {
+        attackers: ObjectFilter,
+        player: PlayerFilter,
+    },
     AttackAlone(ObjectFilter),
     Block(ObjectFilter),
     BlockSpecificAttacker {
@@ -487,6 +491,13 @@ impl Restriction {
 
     pub fn attack(filter: ObjectFilter) -> Self {
         Self::Attack(filter)
+    }
+
+    pub fn attack_player_or_planeswalkers_controlled_by(
+        attackers: ObjectFilter,
+        player: PlayerFilter,
+    ) -> Self {
+        Self::AttackPlayerOrPlaneswalkersControlledBy { attackers, player }
     }
 
     pub fn attack_alone(filter: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18862,6 +18862,58 @@ fn parse_fixed_attack_tax_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_orzhov_advokist_strictly_and_renders_attack_defender_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Orzhov Advokist")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Advisor])
+        .power_toughness(PowerToughness::fixed(1, 4))
+        .parse_text(
+            "At the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. If a player does, creatures that player controls can't attack you or planeswalkers you control until your next turn.",
+        )
+        .expect("Orzhov Advokist should parse strictly");
+
+    let ids: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !ids.contains(&StaticAbilityId::RuleFallbackText)
+            && !ids.contains(&StaticAbilityId::UnsupportedParserLine),
+        "Orzhov Advokist should not emit parser fallback placeholders, got {ids:?}"
+    );
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Orzhov Advokist should compile to a triggered upkeep ability"
+    );
+
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains("if a player does"),
+        "expected compiled text to preserve the per-player conditional, got {compiled}"
+    );
+    assert!(
+        compiled.contains(
+            "creatures that player controls can't attack you or planeswalkers you control until your next turn"
+        ),
+        "expected compiled text to include the attack-defender restriction, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_morph_keyword_line() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Morph Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9703,6 +9703,35 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
         crate::effect::Restriction::Attack(filter) => {
             format!("{} can't attack", filter.description())
         }
+        crate::effect::Restriction::AttackPlayerOrPlaneswalkersControlledBy {
+            attackers,
+            player,
+        } => {
+            let attacker_text = if attackers
+                == &crate::target::ObjectFilter::creature()
+                    .controlled_by(PlayerFilter::IteratedPlayer)
+            {
+                "creatures that player controls".to_string()
+            } else {
+                attackers.description()
+            };
+            let planeswalker_controller = match player {
+                PlayerFilter::You => "you control".to_string(),
+                PlayerFilter::Opponent => "your opponents control".to_string(),
+                PlayerFilter::Any => "players control".to_string(),
+                PlayerFilter::IteratedPlayer => "that player controls".to_string(),
+                PlayerFilter::Target(inner) if inner.as_ref() == &PlayerFilter::You => {
+                    "you control".to_string()
+                }
+                _ => format!("{} controls", describe_player_filter(player)),
+            };
+            format!(
+                "{} can't attack {} or planeswalkers {}",
+                attacker_text,
+                describe_player_filter(player),
+                planeswalker_controller
+            )
+        }
         crate::effect::Restriction::AttackAlone(filter) => {
             format!("{} can't attack alone", filter.description())
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -23380,6 +23380,29 @@ fn describe_with_id_if_clause(
                 }
             }
         }
+    } else if let Some(for_players) = with_id
+        .effect
+        .downcast_ref::<crate::effects::ForPlayersEffect>()
+    {
+        if for_players.effects.len() == 1
+            && for_players.effects[0]
+                .downcast_ref::<crate::effects::MayEffect>()
+                .is_some()
+        {
+            let who = describe_player_filter(&for_players.filter);
+            match if_effect.predicate {
+                EffectPredicate::DidNotHappen => format!("If {who} doesn't"),
+                _ => format!("If {who} does"),
+            }
+        } else {
+            match if_effect.predicate {
+                EffectPredicate::Happened => "If it happened".to_string(),
+                EffectPredicate::HappenedNotReplaced => {
+                    "If it happened and wasn't replaced".to_string()
+                }
+                _ => format!("If {}", describe_effect_predicate(&if_effect.predicate)),
+            }
+        }
     } else if let Some(roll_die) = with_id
         .effect
         .downcast_ref::<crate::effects::RollDieEffect>()
@@ -26030,6 +26053,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 inner = rest.to_string();
             }
             inner = normalize_you_verb_phrase(&inner);
+            inner = lowercase_first(&inner);
             return format!("For each {each_player}, that player may {inner}");
         }
         let player_filter_text = describe_player_filter(&for_players.filter);

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -987,6 +987,28 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::AttackPlayerOrPlaneswalkersControlledBy { attackers, player } => {
+                let defenders = game
+                    .players
+                    .iter()
+                    .filter(|player_state| {
+                        player_state.is_in_game()
+                            && player_matches_restriction_filter(player_state.id, player)
+                    })
+                    .map(|player_state| player_state.id)
+                    .collect::<Vec<_>>();
+                if defenders.is_empty() {
+                    return;
+                }
+
+                for &obj_id in &game.battlefield {
+                    if let Some(obj) = game.object(obj_id)
+                        && attackers.matches(obj, &ctx, game)
+                    {
+                        tracker.add_cant_attack_defenders(obj_id, defenders.iter().copied());
+                    }
+                }
+            }
             Restriction::AttackAlone(filter) => {
                 for &obj_id in &game.battlefield {
                     if let Some(obj) = game.object(obj_id)

--- a/crates/ironsmith-runtime/src/effects/composition/if_effect.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/if_effect.rs
@@ -7,6 +7,70 @@ use crate::game_state::GameState;
 use crate::target::ChooseSpec;
 pub type IfEffect = ironsmith_core::IfEffect<crate::effect::Effect>;
 
+fn object_filter_mentions_iterated_player(filter: &crate::target::ObjectFilter) -> bool {
+    filter
+        .controller
+        .as_ref()
+        .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter
+            .owner
+            .as_ref()
+            .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter
+            .targets_player
+            .as_ref()
+            .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter
+            .targets_only_player
+            .as_ref()
+            .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter
+            .attacking_player_or_planeswalker_controlled_by
+            .as_ref()
+            .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter
+            .attached_to_player
+            .as_ref()
+            .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter
+            .entered_battlefield_controller
+            .as_ref()
+            .is_some_and(crate::target::PlayerFilter::mentions_iterated_player)
+        || filter.any_of.iter().any(object_filter_mentions_iterated_player)
+}
+
+fn restriction_mentions_iterated_player(restriction: &crate::effect::Restriction) -> bool {
+    match restriction {
+        crate::effect::Restriction::AttackPlayerOrPlaneswalkersControlledBy {
+            attackers,
+            player,
+        } => {
+            object_filter_mentions_iterated_player(attackers) || player.mentions_iterated_player()
+        }
+        _ => false,
+    }
+}
+
+fn effect_mentions_iterated_player(effect: &crate::effect::Effect) -> bool {
+    if let Some(cant) = effect.downcast_ref::<crate::effects::CantEffect>()
+        && restriction_mentions_iterated_player(&cant.restriction)
+    {
+        return true;
+    }
+
+    let mut found = false;
+    effect.visit_child_effects(&mut |child| {
+        if effect_mentions_iterated_player(child) {
+            found = true;
+        }
+    });
+    found
+}
+
+fn effect_list_mentions_iterated_player(effects: &[crate::effect::Effect]) -> bool {
+    effects.iter().any(effect_mentions_iterated_player)
+}
+
 /// Effect that branches based on a prior effect's result.
 ///
 /// Looks up the result of an effect executed with `WithId`, evaluates the predicate,
@@ -54,6 +118,39 @@ impl EffectExecutor for IfEffect {
         let outcome = ctx
             .get_outcome(self.condition)
             .ok_or(ExecutionError::EffectNotFound(self.condition))?;
+
+        if matches!(self.predicate, EffectPredicate::Happened | EffectPredicate::DidNotHappen)
+            && (effect_list_mentions_iterated_player(&self.then)
+                || effect_list_mentions_iterated_player(&self.else_))
+            && let Some(player_counts) = outcome
+                .execution_facts
+                .iter()
+                .find_map(|fact| match fact {
+                    ExecutionFact::PlayerCounts(counts) => Some(counts.clone()),
+                    _ => None,
+                })
+        {
+            let mut outcomes = Vec::new();
+            for (player_id, count) in player_counts {
+                let predicate_matches = match self.predicate {
+                    EffectPredicate::Happened => count > 0,
+                    EffectPredicate::DidNotHappen => count <= 0,
+                    _ => false,
+                };
+                let branch = if predicate_matches {
+                    &self.then
+                } else {
+                    &self.else_
+                };
+                ctx.with_temp_iterated_player(Some(player_id), |ctx| {
+                    for eff in branch {
+                        outcomes.push(execute_effect(game, eff, ctx)?);
+                    }
+                    Ok::<(), ExecutionError>(())
+                })?;
+            }
+            return Ok(EffectOutcome::aggregate(outcomes));
+        }
 
         let match_repetitions = if let EffectPredicate::Value(cmp) = &self.predicate {
             let chosen_numbers = outcome

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -137,6 +137,12 @@ fn normalize_restriction_for_resolution(
         Restriction::Attack(filter) => Restriction::attack(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),
+        Restriction::AttackPlayerOrPlaneswalkersControlledBy { attackers, player } => {
+            Restriction::attack_player_or_planeswalkers_controlled_by(
+                collapse_filter_to_current_matching_objects(attackers, ctx, game),
+                player.clone(),
+            )
+        }
         Restriction::Block(filter) => Restriction::block(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -514,6 +514,10 @@ pub struct CantEffectTracker {
     /// Example: Pacifism, Propaganda (if unpaid), Maze of Ith
     pub cant_attack: HashSet<ObjectId>,
 
+    /// Creature -> defending players this creature can't attack or attack planeswalkers of.
+    /// Example: "Creatures that player controls can't attack you or planeswalkers you control."
+    pub cant_attack_defenders: HashMap<ObjectId, HashSet<PlayerId>>,
+
     /// Creatures that can't attack alone.
     /// Example: "This creature can't attack alone."
     pub cant_attack_alone: HashSet<ObjectId>,
@@ -809,6 +813,12 @@ impl CantEffectTracker {
         self.cant_gain_life.extend(other.cant_gain_life);
         self.cant_search.extend(other.cant_search);
         self.cant_attack.extend(other.cant_attack);
+        for (creature, defenders) in other.cant_attack_defenders {
+            self.cant_attack_defenders
+                .entry(creature)
+                .or_default()
+                .extend(defenders);
+        }
         self.cant_attack_alone.extend(other.cant_attack_alone);
         self.cant_block.extend(other.cant_block);
         for (blocker, attackers) in other.cant_block_specific_attackers {
@@ -879,6 +889,7 @@ impl CantEffectTracker {
         self.cant_gain_life.clear();
         self.cant_search.clear();
         self.cant_attack.clear();
+        self.cant_attack_defenders.clear();
         self.cant_attack_alone.clear();
         self.cant_block.clear();
         self.cant_block_specific_attackers.clear();
@@ -938,6 +949,19 @@ impl CantEffectTracker {
     /// Check if a creature can attack.
     pub fn can_attack(&self, creature: ObjectId) -> bool {
         !self.cant_attack.contains(&creature)
+    }
+
+    /// Check if a creature can attack a defending player or planeswalker they control.
+    pub fn can_attack_defending_player(
+        &self,
+        creature: ObjectId,
+        defending_player: PlayerId,
+    ) -> bool {
+        self.can_attack(creature)
+            && self
+                .cant_attack_defenders
+                .get(&creature)
+                .is_none_or(|defenders| !defenders.contains(&defending_player))
     }
 
     /// Check if a creature can attack alone (as the only attacker).
@@ -1237,6 +1261,17 @@ impl CantEffectTracker {
     /// Add a creature to the "can't attack" set.
     pub fn add_cant_attack(&mut self, creature: ObjectId) {
         self.cant_attack.insert(creature);
+    }
+
+    /// Add defender-specific attack prohibitions for a creature.
+    pub fn add_cant_attack_defenders<I>(&mut self, creature: ObjectId, defenders: I)
+    where
+        I: IntoIterator<Item = PlayerId>,
+    {
+        self.cant_attack_defenders
+            .entry(creature)
+            .or_default()
+            .extend(defenders);
     }
 
     /// Add a creature to the "can't attack alone" set.
@@ -3027,6 +3062,17 @@ impl GameState {
     /// Can the creature attack?
     pub fn can_attack(&self, creature: ObjectId) -> bool {
         self.effect_store.cant_effects.can_attack(creature)
+    }
+
+    /// Can the creature attack this player or planeswalkers they control?
+    pub fn can_attack_defending_player(
+        &self,
+        creature: ObjectId,
+        defending_player: PlayerId,
+    ) -> bool {
+        self.effect_store
+            .cant_effects
+            .can_attack_defending_player(creature, defending_player)
     }
 
     /// Can the creature attack as the only attacker?

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -572,6 +572,10 @@ pub(crate) fn can_attack_defending_player_with_view(
         return false;
     }
 
+    if !game.can_attack_defending_player(creature.id, defending_player) {
+        return false;
+    }
+
     let abilities = view
         .calculated_characteristics(creature.id)
         .map(|c| c.static_abilities)

--- a/crates/ironsmith-runtime/src/tests/layer_system_tests.rs
+++ b/crates/ironsmith-runtime/src/tests/layer_system_tests.rs
@@ -17,7 +17,8 @@ use crate::continuous::{
     ContinuousEffect, ContinuousEffectGroupId, EffectTarget, Modification, PtSublayer,
 };
 use crate::decision::AttackerDeclaration;
-use crate::effect::{Until, Value};
+use crate::effect::{Effect, EffectId, EffectOutcome, EffectPredicate, Until, Value};
+use crate::effects::{CantEffect, EffectExecutor};
 use crate::game_loop::{GameLoopError, apply_attacker_declarations};
 use crate::game_state::{GameState, Phase};
 use crate::ids::{CardId, PlayerId};
@@ -3685,6 +3686,133 @@ fn test_same_player_goading_again_does_not_refresh_duration() {
     assert!(
         !game.is_goaded(creature_id),
         "same-player re-goad should not refresh the duration past Bob's next turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_orzhov_advokist_attack_restriction_blocks_only_accepting_players_creatures() {
+    let mut game = GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+        ],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    game.turn.active_player = bob;
+
+    let attacker_def = grizzly_bears();
+    let bob_attacker = game.create_object_from_definition(&attacker_def, bob, Zone::Battlefield);
+    let charlie_attacker =
+        game.create_object_from_definition(&attacker_def, charlie, Zone::Battlefield);
+    game.remove_summoning_sickness(bob_attacker);
+    game.remove_summoning_sickness(charlie_attacker);
+
+    let planeswalker_card = CardBuilder::new(CardId::new(), "Alice Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .build();
+    let alice_planeswalker =
+        game.create_object_from_card(&planeswalker_card, alice, Zone::Battlefield);
+
+    let orzhov_source = CardBuilder::new(CardId::new(), "Orzhov Advokist")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 4))
+        .build();
+    let source = game.create_object_from_card(&orzhov_source, alice, Zone::Battlefield);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    ctx.store_outcome(
+        EffectId(0),
+        EffectOutcome::resolved().with_player_counts(vec![(bob, 1), (charlie, 0)]),
+    );
+    let branch = crate::effects::IfEffect::new(
+        EffectId(0),
+        EffectPredicate::Happened,
+        vec![Effect::new(CantEffect::new(
+            crate::effect::Restriction::attack_player_or_planeswalkers_controlled_by(
+                crate::target::ObjectFilter::creature()
+                    .controlled_by(crate::target::PlayerFilter::IteratedPlayer),
+                crate::target::PlayerFilter::You,
+            ),
+            Until::YourNextTurn,
+        ))],
+        vec![],
+    );
+    branch
+        .execute(&mut game, &mut ctx)
+        .expect("Orzhov Advokist per-player branch should apply");
+    game.update_cant_effects();
+
+    let combat = new_combat();
+    let options = crate::decision::compute_legal_attackers(&game, &combat);
+    let bob_option = options
+        .iter()
+        .find(|option| option.creature == bob_attacker)
+        .expect("Bob's creature should still be able to attack other players");
+    assert!(
+        !bob_option.valid_targets.contains(&AttackTarget::Player(alice)),
+        "a player who accepted Orzhov Advokist's counters can't attack its controller"
+    );
+    assert!(
+        !bob_option
+            .valid_targets
+            .contains(&AttackTarget::Planeswalker(alice_planeswalker)),
+        "a player who accepted Orzhov Advokist's counters can't attack its controller's planeswalkers"
+    );
+    assert!(
+        bob_option.valid_targets.contains(&AttackTarget::Player(charlie)),
+        "Orzhov Advokist should not stop attacks against other players"
+    );
+    assert!(
+        game.can_attack_defending_player(charlie_attacker, alice),
+        "a player who did not accept counters should not receive the attack restriction"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_orzhov_advokist_attack_restriction_expires_on_controller_next_turn() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = bob;
+
+    let attacker_def = grizzly_bears();
+    let attacker = game.create_object_from_definition(&attacker_def, bob, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker);
+
+    let source_card = CardBuilder::new(CardId::new(), "Orzhov Advokist")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 4))
+        .build();
+    let source = game.create_object_from_card(&source_card, alice, Zone::Battlefield);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    ctx.iteration.iterated_player = Some(bob);
+    CantEffect::new(
+        crate::effect::Restriction::attack_player_or_planeswalkers_controlled_by(
+            crate::target::ObjectFilter::creature()
+                .controlled_by(crate::target::PlayerFilter::IteratedPlayer),
+            crate::target::PlayerFilter::You,
+        ),
+        Until::YourNextTurn,
+    )
+    .execute(&mut game, &mut ctx)
+    .expect("Orzhov Advokist attack restriction should apply");
+    assert!(
+        !game.can_attack_defending_player(attacker, alice),
+        "restriction should apply before Alice's next turn"
+    );
+
+    game.next_turn();
+    game.update_cant_effects();
+    assert!(
+        game.can_attack_defending_player(attacker, alice),
+        "restriction should expire as Alice's next turn begins"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Orzhov Advokist
Initial parse error:
```
unsupported negated restriction tail (clause: 'creatures that player controls can't attack you or planeswalkers you control'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'creatures that player controls can't attack you or planeswalkers you control')
```

Current worker: i-0602146cbce01ae0e
Branch: codex/aws-card-fix-orzhov-advokist
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0044
