### PR TITLE
Fix Ironsmith parse failure: Twenty-Toed Toad

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -8378,16 +8378,7 @@ pub(crate) fn parse_reduced_maximum_hand_size_line(
             return Ok(None);
         }
 
-        if amount <= 7 {
-            return Ok(Some(StaticAbility::reduce_maximum_hand_size(
-                player,
-                7 - amount,
-            )));
-        }
-        return Err(CardTextError::ParseError(format!(
-            "unsupported maximum-hand-size increase clause (clause: '{}')",
-            line_words.join(" ")
-        )));
+        return Ok(Some(StaticAbility::set_maximum_hand_size(player, amount)));
     }
     Ok(None)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -402,6 +402,29 @@ fn parse_repeated_if_or_predicate(
     Ok(Some(PredicateAst::Or(Box::new(left), Box::new(right))))
 }
 
+fn parse_or_predicate(filtered: &[&str]) -> Result<Option<PredicateAst>, CardTextError> {
+    let Some(or_idx) = filtered.iter().enumerate().rev().find_map(|(idx, word)| {
+        if *word != "or" || idx == 0 || idx + 1 >= filtered.len() {
+            return None;
+        }
+        if matches!(
+            filtered.get(idx + 1).copied(),
+            Some("more" | "fewer" | "less" | "greater" | "equal")
+        ) {
+            return None;
+        }
+        Some(idx)
+    }) else {
+        return Ok(None);
+    };
+
+    let left_tokens = predicate_tokens_from_words(&filtered[..or_idx]);
+    let right_tokens = predicate_tokens_from_words(&filtered[or_idx + 1..]);
+    let left = parse_predicate(&left_tokens)?;
+    let right = parse_predicate(&right_tokens)?;
+    Ok(Some(PredicateAst::Or(Box::new(left), Box::new(right))))
+}
+
 fn player_filter_for_turn_value(player: PlayerAst) -> Option<PlayerFilter> {
     match player {
         PlayerAst::You | PlayerAst::Implicit => Some(PlayerFilter::You),
@@ -693,6 +716,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_repeated_if_or_predicate(&filtered)? {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_or_predicate(&filtered)? {
         return Ok(predicate);
     }
 
@@ -1431,13 +1458,19 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
             }) && rest_words.len() >= 4
                 && rest_words[0] == "or"
                 && rest_words[1] == "more"
-                && counter_idx > 2
-                && let Some(counter_type) = parse_counter_type_from_tokens(&rest[2..=counter_idx])
             {
-                return Ok(PredicateAst::SourceHasCounterAtLeast {
-                    counter_type,
-                    count,
-                });
+                if counter_idx == 2 {
+                    return Ok(PredicateAst::SourceHasCountersAtLeast(count));
+                }
+                if counter_idx > 2
+                    && let Some(counter_type) =
+                        parse_counter_type_from_tokens(&rest[2..=counter_idx])
+                {
+                    return Ok(PredicateAst::SourceHasCounterAtLeast {
+                        counter_type,
+                        count,
+                    });
+                }
             }
         }
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -558,6 +558,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
             counter_type: *counter_type,
             count: *count,
         },
+        PredicateAst::SourceHasCountersAtLeast(count) => {
+            Condition::SourceHasCountersAtLeast(*count)
+        }
         PredicateAst::SourceHasAttachmentsMatching {
             filter,
             comparison,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -337,6 +337,14 @@ pub(crate) fn rewrite_prepare_triggered_effects_for_lowering(
         }
     }
 
+    fn is_win_the_game_effect(effects: &[EffectAst]) -> bool {
+        matches!(
+            effects,
+            [EffectAst::SubjectVerb(subject_verb)]
+                if matches!(subject_verb.action, SubjectVerbActionAst::WinGame)
+        )
+    }
+
     fn extract_exact_other_attack_predicate(
         predicate: PredicateAst,
     ) -> (Option<u32>, Option<PredicateAst>) {
@@ -379,6 +387,9 @@ pub(crate) fn rewrite_prepare_triggered_effects_for_lowering(
         && if_false.is_empty()
         && !if_true.is_empty()
         && predicate_can_promote_to_intervening_if(predicate)
+        // "Whenever this attacks, you win the game if ..." checks on resolution;
+        // it is not an intervening-if trigger gate.
+        && !(matches!(trigger, TriggerSpec::ThisAttacks) && is_win_the_game_effect(if_true))
     {
         body_effects = if_true.clone();
         intervening_if = merge_intervening_predicates(intervening_if, Some(predicate.clone()));

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -518,6 +518,7 @@ pub(crate) enum PredicateAst {
         counter_type: CounterType,
         count: u32,
     },
+    SourceHasCountersAtLeast(u32),
     SourceHasAttachmentsMatching {
         filter: ObjectFilter,
         comparison: crate::effect::Comparison,
@@ -585,6 +586,7 @@ impl PredicateAst {
             | PredicateAst::SourceMatches(_)
             | PredicateAst::SourceHasNoCounter(_)
             | PredicateAst::SourceHasCounterAtLeast { .. }
+            | PredicateAst::SourceHasCountersAtLeast(_)
             | PredicateAst::SourceHasAttachmentsMatching { .. }
             | PredicateAst::SourcePowerAtLeast(_)
             | PredicateAst::SourceAttackedThisTurn

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1631,6 +1631,17 @@ pub(crate) fn parse_win_the_game_clause(
         return Ok(Some(EffectAst::subject_verb_win_game(PlayerAst::You)));
     }
 
+    if let Some(trailing_if) = split_trailing_if_clause_lexed(tokens) {
+        let leading_words = ClausePatternCompatWords::new(trailing_if.leading_tokens).to_word_refs();
+        if leading_words.as_slice() == ["you", "win", "the", "game"] {
+            return Ok(Some(EffectAst::Conditional {
+                predicate: trailing_if.predicate,
+                if_true: vec![EffectAst::subject_verb_win_game(PlayerAst::You)],
+                if_false: Vec::new(),
+            }));
+        }
+    }
+
     if clause_words.get(4).copied() != Some("if") {
         return Ok(None);
     }

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -201,6 +201,7 @@ pub enum StaticAbilityId {
     CanBeCommander,
     LevelAbilities,
     NoMaximumHandSize,
+    SetMaximumHandSize,
     ReduceMaximumHandSize,
     MaximumHandSizeSevenMinusYourGraveyardCardTypes,
     RevealFirstCardYouDrawEachTurn,
@@ -449,6 +450,7 @@ impl StaticAbilityId {
             | CanBeCommander
             | LevelAbilities
             | NoMaximumHandSize
+            | SetMaximumHandSize
             | ReduceMaximumHandSize
             | MaximumHandSizeSevenMinusYourGraveyardCardTypes
             | RevealFirstCardYouDrawEachTurn

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -254,6 +254,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         filter: ObjectFilter,
         display: String,
     },
+    SetMaximumHandSize {
+        player: PlayerFilter,
+        amount: u32,
+    },
     ReduceMaximumHandSize {
         player: PlayerFilter,
         by: u32,
@@ -950,6 +954,9 @@ where
             }
             StaticAbilityPayload::SetChosenColor { filter, display } => {
                 StaticAbilityPayload::SetChosenColor { filter, display }
+            }
+            StaticAbilityPayload::SetMaximumHandSize { player, amount } => {
+                StaticAbilityPayload::SetMaximumHandSize { player, amount }
             }
             StaticAbilityPayload::ReduceMaximumHandSize { player, by } => {
                 StaticAbilityPayload::ReduceMaximumHandSize { player, by }
@@ -2502,6 +2509,13 @@ impl<
             id: Some(StaticAbilityId::ReduceMaximumHandSize),
             label: "reduce maximum hand size".into(),
             payload: StaticAbilityPayload::ReduceMaximumHandSize { player, by },
+        }
+    }
+    pub fn set_maximum_hand_size(player: PlayerFilter, amount: u32) -> Self {
+        Self {
+            id: Some(StaticAbilityId::SetMaximumHandSize),
+            label: "set maximum hand size".into(),
+            payload: StaticAbilityPayload::SetMaximumHandSize { player, amount },
         }
     }
     pub fn equipment_grant(abilities: Vec<StaticAbility<T, E, C, Cond>>) -> Self {

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -738,6 +738,7 @@ pub enum Condition {
         counter_type: CounterType,
         count: u32,
     },
+    SourceHasCountersAtLeast(u32),
     SourcePowerAtLeast(u32),
     SourceDealtCombatDamageToPlayerThisTurn,
     ManaSpentToCastThisSpellAtLeast {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31962,6 +31962,26 @@ fn twenty_toed_toad_strict_parser_and_compiled_text_regression() {
         "Twenty-Toed Toad should compile its exact maximum hand size as a static ability"
     );
 
+    let win_trigger = def.abilities.iter().find_map(|ability| match &ability.kind {
+        AbilityKind::Triggered(triggered) => {
+            format!("{:?}", triggered.trigger)
+                .contains("ThisAttacksTrigger")
+                .then_some(triggered)
+        }
+        _ => None,
+    });
+    let win_trigger = win_trigger.expect("Twenty-Toed Toad should have a this-attacks win trigger");
+    assert!(
+        win_trigger.intervening_if.is_none(),
+        "Twenty-Toed Toad's trailing win condition should be checked on resolution, not as an intervening-if trigger gate"
+    );
+    let win_effects_debug = format!("{:?}", win_trigger.effects);
+    assert!(
+        win_effects_debug.contains("ConditionalEffect")
+            && win_effects_debug.contains("WinTheGameEffect"),
+        "Twenty-Toed Toad's win trigger should compile to a conditional win effect, got {win_effects_debug}"
+    );
+
     let rendered = unprocessed_compiled_lines(&def).join(" ");
     assert!(
         rendered.contains("Your maximum hand size is twenty."),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31947,6 +31947,41 @@ fn parse_each_opponents_maximum_hand_size_reduced_static_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn twenty_toed_toad_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Twenty-Toed Toad");
+
+    let has_set_max_hand_size = def.abilities.iter().any(|ability| {
+        matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::SetMaximumHandSize
+        )
+    });
+    assert!(
+        has_set_max_hand_size,
+        "Twenty-Toed Toad should compile its exact maximum hand size as a static ability"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Your maximum hand size is twenty."),
+        "expected Twenty-Toed Toad compiled text to include exact maximum hand size, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever you attack with 2 or more creatures")
+            || rendered.contains("Whenever you attack with two or more creatures"),
+        "expected Twenty-Toed Toad compiled text to include the attack threshold trigger, got {rendered}"
+    );
+    assert!(
+        rendered.contains("twenty or more counters")
+            || rendered.contains("20 or more counters")
+            || rendered.contains("20 or more cards in hand"),
+        "expected Twenty-Toed Toad compiled text to include its alternate-win condition, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_exile_top_x_until_end_of_your_next_turn_may_play_those_cards() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Commune with Lava Variant")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10649,23 +10649,28 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         },
         Condition::LifeTotalOrLess(n) => format!("your life total is {n} or less"),
         Condition::LifeTotalOrGreater(n) => format!("your life total is {n} or greater"),
-        Condition::CardsInHandOrMore(n) => format!("you have {n} or more cards in hand"),
+        Condition::CardsInHandOrMore(n) => {
+            let count = number_word(*n).unwrap_or_else(|| n.to_string());
+            format!("you have {count} or more cards in hand")
+        }
         Condition::PlayerCardsInHandOrMore { player, count } => {
             let subject = describe_player_filter(player);
+            let count_text = number_word(*count).unwrap_or_else(|| count.to_string());
             format!(
                 "{} {} {} or more cards in hand",
                 subject,
                 player_verb(&subject, "have", "has"),
-                count
+                count_text
             )
         }
         Condition::PlayerCardsInHandOrFewer { player, count } => {
             let subject = describe_player_filter(player);
+            let count_text = number_word(*count).unwrap_or_else(|| count.to_string());
             format!(
                 "{} {} {} or fewer cards in hand",
                 subject,
                 player_verb(&subject, "have", "has"),
-                count
+                count_text
             )
         }
         Condition::PlayerHasMoreCardsInHandThanYou { player } => {
@@ -10889,6 +10894,10 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                     counter_type.description()
                 )
             }
+        }
+        Condition::SourceHasCountersAtLeast(count) => {
+            let count_text = small_number_word(*count).unwrap_or_else(|| count.to_string());
+            format!("there are {count_text} or more counters on it")
         }
         Condition::SourcePowerAtLeast(min_power) => {
             format!("this has power {min_power} or greater")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28705,6 +28705,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return describe_false_only_conditional(&conditional.condition, &false_branch);
         }
         if false_branch.is_empty() {
+            if true_branch.eq_ignore_ascii_case("you win the game") {
+                return format!(
+                    "You win the game if {}",
+                    describe_condition(&conditional.condition)
+                );
+            }
             return format!(
                 "If {}, {}",
                 describe_condition(&conditional.condition),

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -847,6 +847,11 @@ fn evaluate_condition_shared_core(
                 .map(|obj| obj.counters.get(counter_type).copied().unwrap_or(0) >= *count)
                 .unwrap_or(false),
         ),
+        Condition::SourceHasCountersAtLeast(count) => Some(
+            game.object(ctx.source)
+                .map(|obj| obj.counters.values().copied().sum::<u32>() >= *count)
+                .unwrap_or(false),
+        ),
         Condition::SourcePowerAtLeast(min_power) => Some(
             game.calculated_power(ctx.source)
                 .or_else(|| game.object(ctx.source).and_then(|obj| obj.power()))
@@ -968,6 +973,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::SourceMatches(..) => {}
         Condition::SourceHasNoCounter(..) => {}
         Condition::SourceHasCounterAtLeast { .. } => {}
+        Condition::SourceHasCountersAtLeast(..) => {}
         Condition::SourcePowerAtLeast(..) => {}
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {}
         Condition::SourceAttackedOrBlockedThisTurn => {}
@@ -1764,6 +1770,9 @@ pub fn evaluate_condition_external(
             .calculated_power(ctx.source)
             .or_else(|| game.object(ctx.source).and_then(|obj| obj.power()))
             .is_some_and(|power| power >= *min_power as i32),
+        Condition::SourceHasCountersAtLeast(count) => game
+            .object(ctx.source)
+            .is_some_and(|obj| obj.counters.values().copied().sum::<u32>() >= *count),
         Condition::SourceIsUntapped => !game.is_tapped(ctx.source),
         Condition::SourceIsAttacking => game
             .combat
@@ -2522,6 +2531,7 @@ fn evaluate_condition_simple(
         | Condition::SpellsWereCastLastTurnOrMore(_)
         | Condition::SourceHasNoCounter(_)
         | Condition::SourceHasCounterAtLeast { .. }
+        | Condition::SourceHasCountersAtLeast(_)
         | Condition::SourceIsInZone(_)
         | Condition::ManaSpentToCastThisSpellAtLeast { .. }
         | Condition::SameColorManaSpentToCastThisSpellAtLeast(_)
@@ -3268,6 +3278,9 @@ fn evaluate_condition(
             .calculated_power(ctx.source)
             .or_else(|| game.object(ctx.source).and_then(|obj| obj.power()))
             .is_some_and(|power| power >= *min_power as i32)),
+        Condition::SourceHasCountersAtLeast(count) => Ok(game
+            .object(ctx.source)
+            .is_some_and(|obj| obj.counters.values().copied().sum::<u32>() >= *count)),
         Condition::SourceAttackedOrBlockedThisTurn => Ok(game
             .creature_attacked_this_turn(ctx.source)
             || game.creature_blocked_this_turn(ctx.source)),

--- a/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
@@ -430,8 +430,10 @@ fn apply_prepared_attacker_declarations_with_dm(
             creature: decl.creature,
             target: decl.target.clone(),
         });
+        let has_vigilance = crate::rules::combat::has_vigilance_with_game(creature, game);
+        game.combat = Some(combat.clone());
 
-        if !crate::rules::combat::has_vigilance_with_game(creature, game) {
+        if !has_vigilance {
             tap_permanent_with_trigger(game, trigger_queue, decl.creature);
         }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -137,8 +137,8 @@ fn twenty_toed_toad_two_creature_attack_puts_counter_and_draws() {
         .expect("Twenty-Toed Toad attack triggers should go on stack");
     assert_eq!(
         game.stack.len(),
-        1,
-        "toad attacking with another creature below the win threshold should create the counter/draw trigger"
+        2,
+        "toad attacking with another creature below the win threshold should still create both attack triggers"
     );
 
     while !game.stack.is_empty() {
@@ -175,6 +175,11 @@ fn twenty_toed_toad_win_trigger_checks_cards_in_hand_and_counters() {
     let mut trigger_queue = attack_with_toad(&mut below_threshold, toad_id, None);
     put_triggers_on_stack(&mut below_threshold, &mut trigger_queue)
         .expect("Twenty-Toed Toad attack trigger should go on stack");
+    assert_eq!(
+        below_threshold.stack.len(),
+        1,
+        "Twenty-Toed Toad's win trigger should still go on stack below the resolution threshold"
+    );
     while !below_threshold.stack.is_empty() {
         resolve_stack_entry(&mut below_threshold).expect("below-threshold trigger should resolve");
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14,7 +14,7 @@ use crate::events::zones::EnterBattlefieldEvent;
 use crate::execute_cleanup_step;
 use crate::filter::ObjectFilterExt as _;
 use crate::game_state::Phase;
-use crate::ids::CardId;
+use crate::ids::{CardId, ObjectId};
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::ObjectKind;
 use crate::static_abilities::StaticAbility;
@@ -36,6 +36,190 @@ fn setup_three_player_game() -> GameState {
         ],
         20,
     )
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_950), "Twenty-Toed Toad")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Frog, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Your maximum hand size is twenty.\n\
+             Whenever you attack with two or more creatures, put a +1/+1 counter on this creature and draw a card.\n\
+             Whenever this creature attacks, you win the game if there are twenty or more counters on it or you have twenty or more cards in hand.",
+        )
+        .expect("Twenty-Toed Toad should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_test_cards_in_zone(game: &mut GameState, player: PlayerId, zone: Zone, count: u32) {
+    for index in 0..count {
+        let card = CardBuilder::new(
+            CardId::from_raw(73_000 + index),
+            &format!("Test Card {index}"),
+        )
+        .card_types(vec![CardType::Sorcery])
+        .build();
+        game.create_object_from_card(&card, player, zone);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn attack_with_toad(
+    game: &mut GameState,
+    toad_id: ObjectId,
+    extra_attacker: Option<ObjectId>,
+) -> TriggerQueue {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut declarations = vec![AttackerDeclaration {
+        creature: toad_id,
+        target: AttackTarget::Player(bob),
+    }];
+    if let Some(creature) = extra_attacker {
+        declarations.push(AttackerDeclaration {
+            creature,
+            target: AttackTarget::Player(bob),
+        });
+    }
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(&mut *game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("Twenty-Toed Toad attack declaration should be legal");
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn twenty_toed_toad_static_ability_sets_maximum_hand_size_to_twenty() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let toad = twenty_toed_toad_definition();
+    game.create_object_from_definition(&toad, alice, Zone::Battlefield);
+
+    game.update_cant_effects();
+
+    assert_eq!(game.player(alice).unwrap().max_hand_size, 20);
+    assert_eq!(game.player(bob).unwrap().max_hand_size, 7);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn twenty_toed_toad_two_creature_attack_puts_counter_and_draws() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let toad = twenty_toed_toad_definition();
+    let toad_id = game.create_object_from_definition(&toad, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(toad_id);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 1);
+
+    let helper = CardBuilder::new(CardId::from_raw(73_100), "Helper Attacker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let helper_id = game.create_object_from_card(&helper, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(helper_id);
+
+    let mut trigger_queue = attack_with_toad(&mut game, toad_id, Some(helper_id));
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Twenty-Toed Toad attack triggers should go on stack");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "toad attacking with another creature below the win threshold should create the counter/draw trigger"
+    );
+
+    while !game.stack.is_empty() {
+        resolve_stack_entry(&mut game).expect("Twenty-Toed Toad trigger should resolve");
+    }
+
+    assert_eq!(
+        game.counter_count(toad_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "two-creature attack trigger should put a +1/+1 counter on Twenty-Toed Toad"
+    );
+    assert_eq!(
+        game.player(alice).unwrap().hand.len(),
+        1,
+        "two-creature attack trigger should draw one card"
+    );
+    assert!(
+        !game.player(bob).unwrap().has_lost,
+        "Twenty-Toed Toad should not win below both twenty-card and twenty-counter thresholds"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn twenty_toed_toad_win_trigger_checks_cards_in_hand_and_counters() {
+    let mut below_threshold = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let toad = twenty_toed_toad_definition();
+    let toad_id = below_threshold.create_object_from_definition(&toad, alice, Zone::Battlefield);
+    below_threshold.remove_summoning_sickness(toad_id);
+    put_test_cards_in_zone(&mut below_threshold, alice, Zone::Hand, 19);
+
+    let mut trigger_queue = attack_with_toad(&mut below_threshold, toad_id, None);
+    put_triggers_on_stack(&mut below_threshold, &mut trigger_queue)
+        .expect("Twenty-Toed Toad attack trigger should go on stack");
+    while !below_threshold.stack.is_empty() {
+        resolve_stack_entry(&mut below_threshold).expect("below-threshold trigger should resolve");
+    }
+    assert!(
+        !below_threshold.player(bob).unwrap().has_lost,
+        "nineteen cards and fewer than twenty counters should not satisfy Twenty-Toed Toad"
+    );
+
+    let mut cards_threshold = setup_game();
+    let toad = twenty_toed_toad_definition();
+    let toad_id = cards_threshold.create_object_from_definition(&toad, alice, Zone::Battlefield);
+    cards_threshold.remove_summoning_sickness(toad_id);
+    put_test_cards_in_zone(&mut cards_threshold, alice, Zone::Hand, 20);
+
+    let mut trigger_queue = attack_with_toad(&mut cards_threshold, toad_id, None);
+    put_triggers_on_stack(&mut cards_threshold, &mut trigger_queue)
+        .expect("Twenty-Toed Toad card-threshold trigger should go on stack");
+    while !cards_threshold.stack.is_empty() {
+        resolve_stack_entry(&mut cards_threshold).expect("card-threshold trigger should resolve");
+    }
+    assert!(
+        cards_threshold.player(bob).unwrap().has_lost,
+        "twenty cards in hand should satisfy Twenty-Toed Toad's win trigger"
+    );
+
+    let mut counters_threshold = setup_game();
+    let toad = twenty_toed_toad_definition();
+    let toad_id =
+        counters_threshold.create_object_from_definition(&toad, alice, Zone::Battlefield);
+    counters_threshold.remove_summoning_sickness(toad_id);
+    counters_threshold
+        .add_counters(toad_id, crate::object::CounterType::PlusOnePlusOne, 20)
+        .expect("test should add counters to Twenty-Toed Toad");
+
+    let mut trigger_queue = attack_with_toad(&mut counters_threshold, toad_id, None);
+    put_triggers_on_stack(&mut counters_threshold, &mut trigger_queue)
+        .expect("Twenty-Toed Toad counter-threshold trigger should go on stack");
+    while !counters_threshold.stack.is_empty() {
+        resolve_stack_entry(&mut counters_threshold)
+            .expect("counter-threshold trigger should resolve");
+    }
+    assert!(
+        counters_threshold.player(bob).unwrap().has_lost,
+        "twenty counters should satisfy Twenty-Toed Toad's win trigger"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3541,6 +3541,45 @@ impl StaticAbilityKind for NoMaximumHandSize {
     }
 }
 
+/// "Your/Each opponent's maximum hand size is N."
+#[derive(Debug, Clone, PartialEq)]
+pub struct SetMaximumHandSize {
+    pub player: PlayerFilter,
+    pub amount: u32,
+}
+
+impl SetMaximumHandSize {
+    pub fn new(player: PlayerFilter, amount: u32) -> Self {
+        Self { player, amount }
+    }
+}
+
+impl StaticAbilityKind for SetMaximumHandSize {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::SetMaximumHandSize
+    }
+
+    fn display(&self) -> String {
+        let amount = number_word_u32(self.amount).unwrap_or_else(|| self.amount.to_string());
+        match self.player {
+            PlayerFilter::You => format!("Your maximum hand size is {amount}."),
+            PlayerFilter::Opponent => {
+                format!("Each opponent's maximum hand size is {amount}.")
+            }
+            PlayerFilter::Any => format!("Each player's maximum hand size is {amount}."),
+            _ => format!("Maximum hand size is {amount}."),
+        }
+    }
+
+    fn apply_restrictions(&self, game: &mut GameState, _source: ObjectId, controller: PlayerId) {
+        for player_id in player_ids_for_filter(game, self.player.clone(), controller) {
+            if let Some(player) = game.player_mut(player_id) {
+                player.max_hand_size = self.amount as i32;
+            }
+        }
+    }
+}
+
 /// "Your/Each opponent's maximum hand size is reduced by N."
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReduceMaximumHandSize {
@@ -5047,6 +5086,27 @@ mod tests {
                 .max_hand_size,
             i32::MAX
         );
+    }
+
+    #[test]
+    fn test_set_maximum_hand_size_for_you() {
+        let ability = SetMaximumHandSize::new(PlayerFilter::You, 20);
+        assert_eq!(ability.id(), StaticAbilityId::SetMaximumHandSize);
+        assert_eq!(ability.display(), "Your maximum hand size is twenty.");
+
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = ObjectId::from_raw(43);
+        ability.apply_restrictions(&mut game, source, alice);
+
+        assert_eq!(
+            game.player(alice)
+                .expect("alice should exist")
+                .max_hand_size,
+            20
+        );
+        assert_eq!(game.player(bob).expect("bob should exist").max_hand_size, 7);
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2474,6 +2474,10 @@ impl StaticAbility {
         Self::new(NoMaximumHandSize)
     }
 
+    pub fn set_maximum_hand_size(player: crate::target::PlayerFilter, amount: u32) -> Self {
+        Self::new(SetMaximumHandSize::new(player, amount))
+    }
+
     pub fn reduce_maximum_hand_size(player: crate::target::PlayerFilter, amount: u32) -> Self {
         Self::new(ReduceMaximumHandSize::new(player, amount))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1023,6 +1023,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::SetChosenColor { filter, display } => {
                 StaticAbility::set_chosen_color(filter.clone(), display.clone())
             }
+            ironsmith_core::StaticAbilityPayload::SetMaximumHandSize { player, amount } => {
+                StaticAbility::set_maximum_hand_size(player.clone(), *amount)
+            }
             ironsmith_core::StaticAbilityPayload::ReduceMaximumHandSize { player, by } => {
                 StaticAbility::reduce_maximum_hand_size(player.clone(), *by)
             }

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -129,6 +129,16 @@ impl AttacksTrigger {
     }
 }
 
+fn pluralize_attack_subject(subject: &str) -> String {
+    if subject == "creature" {
+        return "creatures".to_string();
+    }
+    if let Some(rest) = subject.strip_prefix("creature ") {
+        return format!("creatures {rest}");
+    }
+    subject.to_string()
+}
+
 impl TriggerMatcher for AttacksTrigger {
     fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
         if event.kind() != EventKind::CreatureAttacked {
@@ -170,9 +180,16 @@ impl TriggerMatcher for AttacksTrigger {
 
         if self.one_or_more {
             if self.min_total_attackers > 1 {
+                let min_total = ironsmith_core::cardinal_word(self.min_total_attackers as u32)
+                    .unwrap_or_else(|| self.min_total_attackers.to_string());
+                if let Some(controlled_subject) = subject.strip_suffix(" you control") {
+                    return format!(
+                        "Whenever you attack with {min_total} or more {}",
+                        pluralize_attack_subject(controlled_subject)
+                    );
+                }
                 return format!(
-                    "Whenever {} or more {subject} attack",
-                    self.min_total_attackers
+                    "Whenever {min_total} or more {subject} attack",
                 );
             }
             return format!("Whenever one or more {subject} attack");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Twenty-Toed Toad
Initial parse error:
```
unsupported maximum-hand-size increase clause (clause: 'your maximum hand size is twenty'); oracle-only fallback also failed: unsupported maximum-hand-size increase clause (clause: 'your maximum hand size is twenty')
```

Current worker: i-0a60ebc8273cef636
Branch: codex/aws-card-fix-twenty-toed-toad
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0044
