### PR TITLE
Fix Ironsmith parse failure: Semblance Anvil

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -774,6 +774,7 @@ pub(crate) fn spell_filter_has_identity(filter: &ObjectFilter) -> bool {
         || filter.target_count.is_some()
         || filter.could_be_targeted_by.is_some()
         || filter.alternative_cast.is_some()
+        || !filter.tagged_constraints.is_empty()
         || !filter.any_of.is_empty()
 }
 
@@ -839,6 +840,11 @@ pub(crate) fn merge_spell_filters(base: &mut ObjectFilter, extra: ObjectFilter) 
     }
     if base.could_be_targeted_by.is_none() {
         base.could_be_targeted_by = extra.could_be_targeted_by;
+    }
+    for constraint in extra.tagged_constraints {
+        if !base.tagged_constraints.contains(&constraint) {
+            base.tagged_constraints.push(constraint);
+        }
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
@@ -518,9 +518,33 @@ pub(super) fn parse_spell_filter_from_words(words: &[&str]) -> ObjectFilter {
 
     apply_spell_filter_word_atoms(&mut filter, words);
     apply_spell_filter_comparisons(&mut filter, words, words);
+    apply_spell_filter_tagged_relations(&mut filter, words);
     apply_spell_filter_parity_phrases(words, &mut filter);
 
     build_spell_filter_power_or_toughness_disjunction(&filter, words, words).unwrap_or(filter)
+}
+
+fn apply_spell_filter_tagged_relations(filter: &mut ObjectFilter, words: &[&str]) {
+    let shares_card_type = (contains_filter_word(words, "share")
+        || contains_filter_word(words, "shares"))
+        && contains_filter_word(words, "card")
+        && contains_filter_word(words, "type");
+    let references_exiled_card = contains_any_filter_phrase(
+        words,
+        &[
+            &["with", "exiled", "card"],
+            &["with", "exiled", "cards"],
+            &["with", "the", "exiled", "card"],
+            &["with", "the", "exiled", "cards"],
+        ],
+    );
+
+    if shares_card_type && references_exiled_card {
+        filter.tagged_constraints.push(TaggedObjectConstraint {
+            tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+            relation: TaggedOpbjectRelation::SharesCardType,
+        });
+    }
 }
 
 pub(super) fn parse_with_no_abilities_words(words: &[&str]) -> Option<usize> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -23755,6 +23755,54 @@ fn parse_spells_cost_modifier_target_clause_does_not_add_spell_type() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_semblance_anvil_keeps_shared_exiled_card_type_cost_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Semblance Anvil")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Imprint — When this artifact enters, you may exile a nonland card from your hand.\n\
+             Spells you cast that share a card type with the exiled card cost {2} less to cast.",
+        )
+        .expect("Semblance Anvil should parse strictly");
+
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.cost_reduction(),
+            _ => None,
+        })
+        .expect("Semblance Anvil should have a cost reduction static ability");
+
+    assert_eq!(reduction.filter.cast_by, Some(PlayerFilter::You));
+    assert!(
+        reduction.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+                && constraint.relation == crate::target::TaggedOpbjectRelation::SharesCardType
+        }),
+        "Semblance Anvil cost filter should require sharing a card type with the exiled card, got {:?}",
+        reduction.filter
+    );
+
+    let joined = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains(
+            "imprint — when this artifact enters, you may exile a nonland card from your hand"
+        ),
+        "expected compiled text to preserve Semblance Anvil's imprint trigger, got {joined}"
+    );
+    assert!(
+        joined.contains(
+            "spells you cast that share a card type with the exiled card cost {2} less to cast"
+        ),
+        "expected compiled text to preserve Semblance Anvil's shared-card-type cost clause, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_spells_cost_modifier_keeps_noncreature_qualifier() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Glowrider Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -35735,7 +35735,23 @@ pub(super) fn describe_imprint_from_hand_phrase(
     {
         card_text = format!("{subject} from {zone_phrase}");
     }
-    format!("imprint, you may exile {card_text}")
+    let lower = card_text.to_ascii_lowercase();
+    if !matches!(
+        lower.split_whitespace().next(),
+        Some("a" | "an" | "one" | "two" | "three" | "each" | "another")
+    ) && (lower.ends_with("card") || lower.contains(" card "))
+    {
+        let article = if matches!(
+            lower.split_whitespace().next(),
+            Some("artifact" | "enchantment" | "instant")
+        ) {
+            "an"
+        } else {
+            "a"
+        };
+        card_text = format!("{article} {card_text}");
+    }
+    format!("you may exile {card_text}")
 }
 
 pub(super) fn describe_optional_cost_line(cost: &crate::cost::OptionalCost) -> String {

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -55,7 +55,7 @@ pub use types::*;
 mod tests {
     use super::*;
     use crate::CardDefinitionBuilder;
-    use crate::ability::Ability;
+    use crate::ability::{Ability, AbilityKind};
     use crate::card::{CardBuilder, PowerToughness};
     use crate::cards::definitions::{
         basic_forest, basic_island, counterspell, force_of_will, lightning_bolt,
@@ -64,6 +64,7 @@ mod tests {
     use crate::costs::PaymentReason;
     use crate::decisions::context::{TargetRequirementContext, TargetsContext};
     use crate::effect::{Effect, Value};
+    use crate::effects::ExecutionContext;
     use crate::filter::Comparison;
     use crate::grant::Grantable;
     use crate::ids::CardId;
@@ -4840,6 +4841,158 @@ mod tests {
             ),
             "two Aura cost reducers should make bestow {{5}}{{G}} payable with four Forests"
         );
+    }
+
+    #[test]
+    fn semblance_anvil_imprint_trigger_exiles_card_and_records_source_link() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let semblance = CardDefinitionBuilder::new(CardId::from_raw(9010), "Semblance Anvil")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text(
+                "Imprint — When this artifact enters, you may exile a nonland card from your hand.\n\
+                 Spells you cast that share a card type with the exiled card cost {2} less to cast.",
+            )
+            .expect("Semblance Anvil should parse");
+        let anvil_id = game.create_object_from_definition(&semblance, alice, Zone::Battlefield);
+        let spell = CardBuilder::new(CardId::from_raw(9011), "Semblance Anvil Imprint Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+            .card_types(vec![CardType::Instant])
+            .build();
+        let original_card_id = game.create_object_from_card(&spell, alice, Zone::Hand);
+
+        let triggered = semblance
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered) => Some(triggered),
+                _ => None,
+            })
+            .expect("Semblance Anvil should have an imprint trigger");
+        let mut ctx = ExecutionContext::new_default(anvil_id, alice);
+        for effect in &triggered.effects {
+            effect.0.execute(&mut game, &mut ctx).unwrap();
+        }
+
+        assert!(
+            !game
+                .object(original_card_id)
+                .is_some_and(|obj| obj.zone == Zone::Hand)
+        );
+        let imprinted = game.get_imprinted_cards(anvil_id);
+        assert_eq!(imprinted.len(), 1, "Semblance Anvil should imprint one card");
+        assert_eq!(game.get_exiled_with_source_links(anvil_id), imprinted);
+        assert_eq!(
+            game.object(imprinted[0]).map(|obj| obj.zone),
+            Some(Zone::Exile),
+            "Semblance Anvil should move the imprinted card to exile"
+        );
+    }
+
+    #[test]
+    fn semblance_anvil_reduces_only_your_spells_sharing_imprinted_card_type() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let semblance = CardDefinitionBuilder::new(CardId::from_raw(9020), "Semblance Anvil")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text(
+                "Imprint — When this artifact enters, you may exile a nonland card from your hand.\n\
+                 Spells you cast that share a card type with the exiled card cost {2} less to cast.",
+            )
+            .expect("Semblance Anvil should parse");
+        let anvil_id = game.create_object_from_definition(&semblance, alice, Zone::Battlefield);
+        let imprinted = CardBuilder::new(CardId::from_raw(9021), "Semblance Anvil Exiled Artifact")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let imprinted_id = game.create_object_from_card(&imprinted, alice, Zone::Exile);
+        game.imprint_card(anvil_id, imprinted_id);
+        game.add_exiled_with_source_link(anvil_id, imprinted_id);
+
+        let artifact_spell = CardBuilder::new(
+            CardId::from_raw(9022),
+            "Semblance Anvil Artifact Probe",
+        )
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_spell_id = game.create_object_from_card(&artifact_spell, alice, Zone::Hand);
+        let artifact_spell = game.object(artifact_spell_id).expect("artifact spell exists");
+        let reduced = calculate_effective_mana_cost(
+            &game,
+            alice,
+            artifact_spell,
+            artifact_spell.mana_cost.as_ref().unwrap(),
+        );
+        assert_eq!(reduced.to_oracle(), "{2}");
+
+        let sorcery = CardBuilder::new(CardId::from_raw(9023), "Semblance Anvil Sorcery Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        let sorcery_id = game.create_object_from_card(&sorcery, alice, Zone::Hand);
+        let sorcery = game.object(sorcery_id).expect("sorcery exists");
+        let unreduced_sorcery = calculate_effective_mana_cost(
+            &game,
+            alice,
+            sorcery,
+            sorcery.mana_cost.as_ref().unwrap(),
+        );
+        assert_eq!(unreduced_sorcery.to_oracle(), "{4}");
+
+        let bob_artifact = CardBuilder::new(
+            CardId::from_raw(9024),
+            "Semblance Anvil Opponent Probe",
+        )
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let bob_artifact_id = game.create_object_from_card(&bob_artifact, bob, Zone::Hand);
+        let bob_artifact = game.object(bob_artifact_id).expect("opponent artifact exists");
+        let unreduced_opponent = calculate_effective_mana_cost(
+            &game,
+            bob,
+            bob_artifact,
+            bob_artifact.mana_cost.as_ref().unwrap(),
+        );
+        assert_eq!(unreduced_opponent.to_oracle(), "{4}");
+    }
+
+    #[test]
+    fn semblance_anvil_does_not_reduce_without_an_exiled_card() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let semblance = CardDefinitionBuilder::new(CardId::from_raw(9030), "Semblance Anvil")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text(
+                "Imprint — When this artifact enters, you may exile a nonland card from your hand.\n\
+                 Spells you cast that share a card type with the exiled card cost {2} less to cast.",
+            )
+            .expect("Semblance Anvil should parse");
+        game.create_object_from_definition(&semblance, alice, Zone::Battlefield);
+
+        let artifact_spell = CardBuilder::new(
+            CardId::from_raw(9031),
+            "Semblance Anvil No Imprint Probe",
+        )
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_spell_id = game.create_object_from_card(&artifact_spell, alice, Zone::Hand);
+        let artifact_spell = game.object(artifact_spell_id).expect("artifact spell exists");
+        let unreduced = calculate_effective_mana_cost(
+            &game,
+            alice,
+            artifact_spell,
+            artifact_spell.mana_cost.as_ref().unwrap(),
+        );
+
+        assert_eq!(unreduced.to_oracle(), "{4}");
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -4891,6 +4891,81 @@ mod tests {
     }
 
     #[test]
+    fn semblance_anvil_declined_imprint_leaves_card_in_hand_and_costs_unchanged() {
+        struct DeclineImprint;
+
+        impl DecisionMaker for DeclineImprint {
+            fn decide_objects(
+                &mut self,
+                _game: &GameState,
+                _ctx: &crate::decisions::context::SelectObjectsContext,
+            ) -> Vec<ObjectId> {
+                Vec::new()
+            }
+        }
+
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let semblance = CardDefinitionBuilder::new(CardId::from_raw(9012), "Semblance Anvil")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text(
+                "Imprint — When this artifact enters, you may exile a nonland card from your hand.\n\
+                 Spells you cast that share a card type with the exiled card cost {2} less to cast.",
+            )
+            .expect("Semblance Anvil should parse");
+        let anvil_id = game.create_object_from_definition(&semblance, alice, Zone::Battlefield);
+        let imprinted_candidate = CardBuilder::new(
+            CardId::from_raw(9013),
+            "Semblance Anvil Declined Imprint Probe",
+        )
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let original_card_id =
+            game.create_object_from_card(&imprinted_candidate, alice, Zone::Hand);
+
+        let triggered = semblance
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered) => Some(triggered),
+                _ => None,
+            })
+            .expect("Semblance Anvil should have an imprint trigger");
+        let mut dm = DeclineImprint;
+        let mut ctx = ExecutionContext::new_default(anvil_id, alice).with_decision_maker(&mut dm);
+        for effect in &triggered.effects {
+            effect.0.execute(&mut game, &mut ctx).unwrap();
+        }
+
+        assert_eq!(
+            game.object(original_card_id).map(|obj| obj.zone),
+            Some(Zone::Hand)
+        );
+        assert!(game.get_imprinted_cards(anvil_id).is_empty());
+        assert!(game.get_exiled_with_source_links(anvil_id).is_empty());
+
+        let artifact_spell = CardBuilder::new(
+            CardId::from_raw(9014),
+            "Semblance Anvil Declined Cost Probe",
+        )
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_spell_id = game.create_object_from_card(&artifact_spell, alice, Zone::Hand);
+        let artifact_spell = game.object(artifact_spell_id).expect("artifact spell exists");
+        let unreduced = calculate_effective_mana_cost(
+            &game,
+            alice,
+            artifact_spell,
+            artifact_spell.mana_cost.as_ref().unwrap(),
+        );
+
+        assert_eq!(unreduced.to_oracle(), "{4}");
+    }
+
+    #[test]
     fn semblance_anvil_reduces_only_your_spells_sharing_imprinted_card_type() {
         let mut game = setup_game();
         let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -2,6 +2,26 @@ use super::*;
 use crate::ability::ActivatedAbilityRuntimeExt as _;
 use crate::filter::ObjectFilterExt as _;
 
+fn with_source_exiled_tagged_objects(
+    game: &GameState,
+    mut ctx: crate::filter::FilterContext,
+    source: ObjectId,
+) -> crate::filter::FilterContext {
+    let source_exiled = game
+        .get_exiled_with_source_links(source)
+        .iter()
+        .filter_map(|id| {
+            game.object(*id)
+                .map(|obj| crate::snapshot::ObjectSnapshot::from_object(obj, game))
+        })
+        .collect::<Vec<_>>();
+    if !source_exiled.is_empty() {
+        ctx.tagged_objects
+            .insert(crate::tag::SOURCE_EXILED_TAG.into(), source_exiled);
+    }
+    ctx
+}
+
 fn count_basic_land_types_among_filter(
     game: &GameState,
     filter: &crate::target::ObjectFilter,
@@ -2862,10 +2882,14 @@ pub(crate) fn apply_spell_cost_modifiers(
     let mut total_reduction: i32 = 0;
     let mut increase_pips: Vec<Vec<ManaSymbol>> = Vec::new();
     let mut reduction_pips: Vec<Vec<ManaSymbol>> = Vec::new();
-    let ctx = FilterContext::new(player)
-        .with_source(spell.id)
-        .with_active_player(game.turn.active_player)
-        .with_opponents(opponents_of(game, player));
+    let ctx = with_source_exiled_tagged_objects(
+        game,
+        FilterContext::new(player)
+            .with_source(spell.id)
+            .with_active_player(game.turn.active_player)
+            .with_opponents(opponents_of(game, player)),
+        spell.id,
+    );
 
     for ability in &spell.abilities {
         let AbilityKind::Static(static_ability) = &ability.kind else {
@@ -3038,10 +3062,14 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
             continue;
         };
         let controller = game.controller_of(perm);
-        let ctx = FilterContext::new(controller)
-            .with_source(perm_id)
-            .with_active_player(game.turn.active_player)
-            .with_opponents(opponents_of(game, controller));
+        let ctx = with_source_exiled_tagged_objects(
+            game,
+            FilterContext::new(controller)
+                .with_source(perm_id)
+                .with_active_player(game.turn.active_player)
+                .with_opponents(opponents_of(game, controller)),
+            perm_id,
+        );
 
         if let Some(static_abilities) = view.static_abilities_rc(perm_id) {
             for static_ability in static_abilities.iter() {

--- a/crates/ironsmith-runtime/src/effects/cards/imprint.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/imprint.rs
@@ -106,6 +106,7 @@ impl EffectExecutor for ImprintFromHandEffect {
             if let Some(exiled_id) = exiled_id {
                 // Imprint it on the source permanent
                 game.imprint_card(source_id, exiled_id);
+                game.add_exiled_with_source_link(source_id, exiled_id);
                 Ok(EffectOutcome::with_objects(vec![exiled_id]))
             } else {
                 Ok(EffectOutcome::count(0))

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -8,7 +8,7 @@ use crate::effect::Value;
 use crate::filter::ObjectFilterExt as _;
 use crate::filter::{AlternativeCastKind, Comparison, PlayerFilterExt};
 use crate::mana::{ManaCost, ManaSymbol};
-use crate::target::{ObjectFilter, PlayerFilter};
+use crate::target::{ObjectFilter, PlayerFilter, TaggedOpbjectRelation};
 use crate::types::CardType;
 use crate::zone::Zone;
 
@@ -509,6 +509,28 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
         Some(PlayerFilter::You) => description.push_str(" you cast"),
         Some(PlayerFilter::Opponent) => description.push_str(" your opponents cast"),
         _ => {}
+    }
+    for constraint in &filter.tagged_constraints {
+        match constraint.relation {
+            TaggedOpbjectRelation::SharesCardType => {
+                if constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
+                    description.push_str(" that share a card type with the exiled card");
+                } else {
+                    description.push_str(" that share a card type with that object");
+                }
+            }
+            TaggedOpbjectRelation::SharesColorWithTagged => {
+                if constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
+                    description.push_str(" that share a color with the exiled card");
+                } else {
+                    description.push_str(" that share a color with that object");
+                }
+            }
+            TaggedOpbjectRelation::SharesSubtypeWithTagged => {
+                description.push_str(" that share a creature type with that object");
+            }
+            _ => {}
+        }
     }
     if let Some(zone_suffix) = match filter.zone {
         Some(Zone::Hand) => Some(match filter.owner.as_ref() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Semblance Anvil
Initial parse error:
```
compiled text dropped required semantic marker: shares-a-card-type
```

Current worker: i-0ad2ca40aaddeddd2
Branch: codex/aws-card-fix-semblance-anvil
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0075
