### PR TITLE
Fix Ironsmith parse failure: Tadeas, Juniper Ascendant

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -796,10 +796,8 @@ pub(crate) fn parse_granted_keyword_static_line(
 
     let mut keyword_tokens = tail_tokens.clone();
     let mut suffix_condition = None;
-    if let Some(idx) = anthem_find_word_sequence_index(
-        &crate::runtime_backend::token_word_refs(&tail_tokens),
-        &["as", "long", "as"],
-    ) {
+    let tail_words = crate::runtime_backend::token_word_refs(&tail_tokens);
+    if let Some(idx) = anthem_find_word_sequence_index(&tail_words, &["as", "long", "as"]) {
         if idx + 3 >= tail_tokens.len() {
             return Err(CardTextError::ParseError(format!(
                 "missing condition after trailing 'as long as' clause (clause: '{}')",
@@ -808,6 +806,17 @@ pub(crate) fn parse_granted_keyword_static_line(
         }
         keyword_tokens = trim_commas(&tail_tokens[..idx]);
         suffix_condition = Some(parse_static_condition_clause(&tail_tokens[idx + 3..])?);
+    } else if let Some(idx) = anthem_find_word_sequence_index(&tail_words, &["unless"]) {
+        if idx + 1 >= tail_tokens.len() {
+            return Err(CardTextError::ParseError(format!(
+                "missing condition after trailing 'unless' clause (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+        keyword_tokens = trim_commas(&tail_tokens[..idx]);
+        suffix_condition = Some(crate::ConditionExpr::Not(Box::new(
+            parse_static_condition_clause(&tail_tokens[idx + 1..])?,
+        )));
     }
     if keyword_tokens.is_empty() {
         return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -3,11 +3,12 @@ use winnow::error::{ContextError, ErrMode};
 use winnow::prelude::*;
 
 use crate::cards::builders::{
-    CardTextError, ChoiceCount, EffectAst, IT_TAG, LibraryBottomOrderAst, LibraryConsultModeAst,
-    LibraryConsultStopRuleAst, PlayerAst, PredicateAst, ReturnControllerAst, SubjectAst,
-    SubjectVerbActionAst, SubjectVerbRoleAst, TagKey, TargetAst, TextSpan,
+    CardTextError, ChoiceCount, EffectAst, GrantedAbilityAst, IT_TAG, LibraryBottomOrderAst,
+    LibraryConsultModeAst, LibraryConsultStopRuleAst, PlayerAst, PredicateAst, ReturnControllerAst,
+    SubjectAst, SubjectVerbActionAst, SubjectVerbRoleAst, TagKey, TargetAst, TextSpan,
 };
 use crate::effect::SearchSelectionMode;
+use crate::static_abilities::StaticAbility;
 use crate::target::PlayerFilter;
 use crate::target::{ObjectFilter, TaggedObjectConstraint, TaggedOpbjectRelation};
 use crate::zone::Zone;
@@ -202,6 +203,55 @@ pub(crate) fn prepare_cant_sentence_restriction_clause_lexed(
         duration,
         clause_tokens,
     }))
+}
+
+fn parse_cant_be_blocked_by_greater_power_grant_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<EffectAst>> {
+    let (neg_start, neg_end) = find_cant_sentence_negation_span_lexed(tokens)?;
+    let subject_tokens = trim_lexed_commas(&tokens[..neg_start]);
+    let subject_words = token_word_refs(subject_tokens);
+    let target = match subject_words.as_slice() {
+        [] | ["it"] | ["that", "creature"] | ["they"] => {
+            TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(subject_tokens))
+        }
+        ["this", "creature"] => TargetAst::Source(span_from_tokens(subject_tokens)),
+        _ => return None,
+    };
+
+    let remainder_tokens = trim_lexed_commas(&tokens[neg_end..]);
+    let mut remainder_words = token_word_refs(remainder_tokens);
+    let duration = if remainder_words.ends_with(&["this", "combat"]) {
+        remainder_words.truncate(remainder_words.len().saturating_sub(2));
+        crate::effect::Until::EndOfCombat
+    } else if remainder_words.ends_with(&["until", "end", "of", "combat"])
+        || remainder_words.ends_with(&["until", "the", "end", "of", "combat"])
+    {
+        let suffix_len = if remainder_words.ends_with(&["until", "the", "end", "of", "combat"])
+        {
+            5
+        } else {
+            4
+        };
+        remainder_words.truncate(remainder_words.len().saturating_sub(suffix_len));
+        crate::effect::Until::EndOfCombat
+    } else {
+        return None;
+    };
+
+    if remainder_words.as_slice()
+        != ["be", "blocked", "by", "creatures", "with", "greater", "power"]
+    {
+        return None;
+    }
+
+    Some(vec![EffectAst::subject_verb_grant_abilities_to_target(
+        target,
+        vec![GrantedAbilityAst::StaticAbility(
+            StaticAbility::cant_be_blocked_by_greater_power_than_source(),
+        )],
+        duration,
+    )])
 }
 
 fn conditional_label_delimiter<'a>(input: &mut LexStream<'a>) -> Result<(), ErrMode<ContextError>> {
@@ -919,6 +969,10 @@ pub(crate) fn parse_conditional_sentence_family_lexed(
 pub(crate) fn parse_cant_effect_sentence_with_grammar_entrypoint_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    if let Some(effects) = parse_cant_be_blocked_by_greater_power_grant_lexed(tokens) {
+        return Ok(Some(effects));
+    }
+
     if let Some(prefix_tokens) = split_cant_sentence_next_turn_prefix_lexed(tokens) {
         let prefix_tokens = prefix_tokens.as_slice();
         if let Some(parsed) = parse_cant_restriction_clause(prefix_tokens)? {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -276,6 +276,23 @@ fn starts_with_player_may_clause_lexed(words: &[&str]) -> bool {
     )
 }
 
+fn starts_with_pronoun_cant_be_blocked_clause_lexed(words: &[&str]) -> bool {
+    let words = match words {
+        ["it", tail @ ..]
+        | ["this", "creature", tail @ ..]
+        | ["that", "creature", tail @ ..]
+        | ["those", "creatures", tail @ ..]
+        | ["they", tail @ ..] => tail,
+        _ => words,
+    };
+
+    matches!(
+        words,
+        ["cant" | "can't" | "cannot", "be", "blocked", ..]
+            | ["can", "not", "be", "blocked", ..]
+    )
+}
+
 pub(crate) fn is_token_creation_context(tokens: &[OwnedLexToken]) -> bool {
     tokens.first().is_some_and(|t| t.is_word("create"))
         && (grammar::contains_word(tokens, "token") || grammar::contains_word(tokens, "tokens"))
@@ -886,6 +903,7 @@ pub(crate) fn has_effect_head_without_verb_lexed(tokens: &[OwnedLexToken]) -> bo
 
     is_prevent_next_damage_clause_words_lexed(&token_words)
         || is_prevent_all_damage_clause_words_lexed(&token_words)
+        || starts_with_pronoun_cant_be_blocked_clause_lexed(&token_words)
         || is_can_attack_as_though_no_defender_clause_words_lexed(&token_words)
         || is_attack_or_block_this_turn_if_able_clause_words_lexed(&token_words)
         || is_attack_this_turn_if_able_clause_words_lexed(&token_words)

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -71,6 +71,7 @@ pub enum StaticAbilityId {
     CantBeBlockedByPowerOrLess,
     CantBeBlockedByPowerOrGreater,
     CantBeBlockedByLowerPowerThanSource,
+    CantBeBlockedByGreaterPowerThanSource,
     CantBeBlockedByMoreThan,
     CantBeBlockedExceptByNOrMore,
     CanAttackAsThoughNoDefender,
@@ -319,6 +320,7 @@ impl StaticAbilityId {
             | CantBeBlockedByPowerOrLess
             | CantBeBlockedByPowerOrGreater
             | CantBeBlockedByLowerPowerThanSource
+            | CantBeBlockedByGreaterPowerThanSource
             | CantBeBlockedByMoreThan
             | CantBeBlockedExceptByNOrMore
             | CanAttackAsThoughNoDefender
@@ -569,6 +571,7 @@ impl StaticAbilityId {
                 | CantBeBlockedByPowerOrLess
                 | CantBeBlockedByPowerOrGreater
                 | CantBeBlockedByLowerPowerThanSource
+                | CantBeBlockedByGreaterPowerThanSource
                 | CantBeBlockedByMoreThan
                 | CantBeBlockedExceptByNOrMore
                 | Landwalk
@@ -609,6 +612,7 @@ impl StaticAbilityId {
                 | CantBeBlockedByPowerOrLess
                 | CantBeBlockedByPowerOrGreater
                 | CantBeBlockedByLowerPowerThanSource
+                | CantBeBlockedByGreaterPowerThanSource
                 | CantBeBlockedByMoreThan
                 | CantBeBlockedExceptByNOrMore
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardType

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2846,6 +2846,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn cant_be_blocked_by_greater_power_than_source() -> Self {
+        Self {
+            id: Some(StaticAbilityId::CantBeBlockedByGreaterPowerThanSource),
+            label: "can't be blocked by creatures with greater power".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn doctors_companion() -> Self {
         Self {
             id: Some(StaticAbilityId::DoctorsCompanion),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35759,6 +35759,39 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn tadeas_juniper_ascendant_strict_parser_and_text_regression() {
+    let oracle = oracle_text_by_name()
+        .get("Tadeas, Juniper Ascendant")
+        .expect("missing Tadeas oracle text")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Tadeas, Juniper Ascendant")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Tadeas should parse strictly");
+
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Reach".to_string(),
+            "Tadeas has hexproof unless it's attacking.".to_string(),
+            "Whenever a creature you control with reach attacks, untap it and it can't be blocked by creatures with greater power this combat.".to_string(),
+            "Whenever one or more creatures you control deal combat damage to a player, draw a card.".to_string(),
+        ]
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("Not(SourceIsAttacking)")
+            && debug.contains("CantBeBlockedByGreaterPowerThanSource")
+            && !debug.contains("Skulk")
+            && debug.contains("EndOfCombat"),
+        "Tadeas should compile unless-attacking hexproof and this-combat greater-power blocking restriction: {debug}"
+    );
+}
+
+#[test]
 fn guardian_of_the_ages_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Guardian of the Ages");
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -753,8 +753,10 @@ fn substitute_legendary_source_reference(
 
     let lower = line.to_ascii_lowercase();
     let uses_named_source_surface = lower.starts_with("this creature gets ")
+        || lower.starts_with("this creature has ")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.contains(": this creature gets ")
+        || lower.contains(": this creature has ")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !uses_named_source_surface {
         return line.to_string();

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -83,6 +83,12 @@ fn finalize_ast_surface_line(line: String) -> String {
     {
         line = line.replace("that permanent's mana value", "that card's mana value");
     }
+    line = line
+        .replace("creature with reach you control", "creature you control with reach")
+        .replace(
+            "creatures with reach you control",
+            "creatures you control with reach",
+        );
     if lower.contains("if it's a permanent, exile it")
         && lower.contains("at the beginning of the next end step, exile it")
     {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8862,6 +8862,9 @@ pub(super) fn describe_apply_continuous_effect(
     effect: &crate::effects::ApplyContinuousEffect,
 ) -> Option<String> {
     let (target, plural_target) = describe_apply_continuous_target(effect);
+    if let Some(text) = describe_greater_power_blocking_grant_effect(effect, &target) {
+        return Some(text);
+    }
     if let Some(text) = describe_dies_return_counter_grant(effect, &target) {
         return Some(text);
     }
@@ -8965,6 +8968,39 @@ pub(super) fn describe_apply_continuous_effect(
     if let Some(tail) = describe_apply_continuous_tail(effect) {
         text.push(' ');
         text.push_str(&tail);
+    }
+    Some(text)
+}
+
+fn describe_greater_power_blocking_grant_effect(
+    effect: &crate::effects::ApplyContinuousEffect,
+    target: &str,
+) -> Option<String> {
+    if effect.condition.is_some()
+        || !effect.additional_modifications.is_empty()
+        || !effect.runtime_modifications.is_empty()
+    {
+        return None;
+    }
+
+    let crate::continuous::Modification::AddAbility(ability) = effect.modification.as_ref()? else {
+        return None;
+    };
+    if ability.id()
+        != crate::static_abilities::StaticAbilityId::CantBeBlockedByGreaterPowerThanSource
+    {
+        return None;
+    }
+
+    let mut text = format!("{target} can't be blocked by creatures with greater power");
+    match effect.until {
+        Until::Forever => {}
+        Until::EndOfCombat => text.push_str(" this combat"),
+        Until::EndOfTurn => text.push_str(" this turn"),
+        _ => {
+            text.push(' ');
+            text.push_str(&describe_until(&effect.until));
+        }
     }
     Some(text)
 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2387,6 +2387,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     describe_draw_discard_then_create_structural(effects)
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
+        .or_else(|| describe_untap_then_greater_power_blocking_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
 }
@@ -2620,6 +2621,43 @@ fn is_haste_until_eot_for_tag(
             Some(crate::continuous::Modification::AddAbility(ability))
                 if ability.id() == crate::static_abilities::StaticAbilityId::Haste
         )
+}
+
+fn is_greater_power_blocking_until_end_of_combat_for_tag(
+    apply: &crate::effects::ApplyContinuousEffect,
+    tag: &crate::TagKey,
+) -> bool {
+    apply.target == crate::continuous::EffectTarget::Source
+        && apply.until == Until::EndOfCombat
+        && apply.condition.is_none()
+        && apply.additional_modifications.is_empty()
+        && apply.runtime_modifications.is_empty()
+        && matches!(&apply.target_spec, Some(ChooseSpec::Tagged(target_tag)) if target_tag == tag)
+        && matches!(
+            &apply.modification,
+            Some(crate::continuous::Modification::AddAbility(ability))
+                if ability.id()
+                    == crate::static_abilities::StaticAbilityId::CantBeBlockedByGreaterPowerThanSource
+        )
+}
+
+fn describe_untap_then_greater_power_blocking_structural(effects: &[Effect]) -> Option<String> {
+    let [first, second] = effects else {
+        return None;
+    };
+    let (_, untap) = tagged_untap_effect_view(first)?;
+    let apply = second.downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    let ChooseSpec::Tagged(target_tag) = &untap.target else {
+        return None;
+    };
+    if !is_greater_power_blocking_until_end_of_combat_for_tag(apply, target_tag) {
+        return None;
+    }
+
+    let target = describe_choose_spec(&untap.target);
+    Some(format!(
+        "Untap {target} and {target} can't be blocked by creatures with greater power this combat"
+    ))
 }
 
 fn describe_gain_control_untap_haste_structural(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -880,6 +880,166 @@ fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup()
     );
 }
 
+fn tadeas_definition_for_tests() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(1), "Tadeas, Juniper Ascendant")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Monk])
+        .power_toughness(PowerToughness::fixed(1, 3))
+        .parse_text(
+            "Reach\n\
+             Tadeas has hexproof unless it's attacking.\n\
+             Whenever a creature you control with reach attacks, untap it and it can't be blocked by creatures with greater power this combat.\n\
+             Whenever one or more creatures you control deal combat damage to a player, draw a card.",
+        )
+        .expect("Tadeas should parse")
+}
+
+#[test]
+fn tadeas_has_hexproof_only_while_not_attacking() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let tadeas_id = game.create_object_from_definition(
+        &tadeas_definition_for_tests(),
+        alice,
+        Zone::Battlefield,
+    );
+    assert!(
+        game.object_has_static_ability_id(
+            tadeas_id,
+            crate::static_abilities::StaticAbilityId::Hexproof,
+        ),
+        "Tadeas should have hexproof while not attacking"
+    );
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: tadeas_id,
+        target: AttackTarget::Player(bob),
+    });
+    game.combat = Some(combat);
+
+    assert!(
+        !game.object_has_static_ability_id(
+            tadeas_id,
+            crate::static_abilities::StaticAbilityId::Hexproof,
+        ),
+        "Tadeas should lose hexproof while attacking"
+    );
+}
+
+#[test]
+fn tadeas_attack_trigger_untaps_reach_attacker_and_grants_greater_power_restriction() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&tadeas_definition_for_tests(), alice, Zone::Battlefield);
+    let reach_attacker_def = CardDefinitionBuilder::new(CardId::from_raw(2), "Reach Attacker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("Reach")
+        .expect("reach attacker should parse");
+    let attacker_id =
+        game.create_object_from_definition(&reach_attacker_def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker_id);
+    let greater_blocker = create_creature(&mut game, "Greater Blocker", bob, 3, 3);
+    let equal_blocker = create_creature(&mut game, "Equal Blocker", bob, 2, 2);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("reach attacker should attack");
+    assert!(game.is_tapped(attacker_id), "attacking should tap the attacker");
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("Tadeas trigger should stack");
+    resolve_stack_entry(&mut game).expect("Tadeas trigger should resolve");
+
+    assert!(!game.is_tapped(attacker_id), "Tadeas should untap the attacker");
+    assert!(
+        game.object_has_static_ability_id(
+            attacker_id,
+            crate::static_abilities::StaticAbilityId::CantBeBlockedByGreaterPowerThanSource,
+        ),
+        "Tadeas should grant the greater-power blocking restriction for this combat"
+    );
+    assert!(
+        !game.object_has_static_ability_id(
+            attacker_id,
+            crate::static_abilities::StaticAbilityId::Skulk,
+        ),
+        "Tadeas text should not grant the skulk keyword"
+    );
+    assert!(
+        !crate::rules::combat::can_block(
+            game.object(attacker_id).expect("attacker exists"),
+            game.object(greater_blocker).expect("greater blocker exists"),
+            &game,
+        ),
+        "greater-power blockers should be illegal after Tadeas resolves"
+    );
+    assert!(
+        crate::rules::combat::can_block(
+            game.object(attacker_id).expect("attacker exists"),
+            game.object(equal_blocker).expect("equal blocker exists"),
+            &game,
+        ),
+        "equal-power blockers should remain legal"
+    );
+}
+
+#[test]
+fn tadeas_attack_trigger_ignores_non_reach_attackers() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&tadeas_definition_for_tests(), alice, Zone::Battlefield);
+    let attacker_id = create_creature(&mut game, "Ground Attacker", alice, 2, 2);
+    game.remove_summoning_sickness(attacker_id);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("non-reach attacker should attack");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("trigger queue processing succeeds");
+
+    assert!(
+        game.stack.is_empty(),
+        "Tadeas should not trigger for a non-reach attacker"
+    );
+    assert!(
+        !game.object_has_static_ability_id(
+            attacker_id,
+            crate::static_abilities::StaticAbilityId::CantBeBlockedByGreaterPowerThanSource,
+        ),
+        "non-reach attacker should not gain the greater-power blocking restriction"
+    );
+}
+
 #[test]
 fn guardian_of_the_ages_loses_defender_and_stops_triggering() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -204,6 +204,23 @@ pub(crate) fn can_block_with_view(
         }
     }
 
+    // Non-keyword text: can't be blocked by creatures with greater power.
+    if attacker_has(StaticAbilityId::CantBeBlockedByGreaterPowerThanSource) {
+        let attacker_power = attacker_chars
+            .as_ref()
+            .and_then(|c| c.power)
+            .or_else(|| attacker.power());
+        let blocker_power = blocker_chars
+            .as_ref()
+            .and_then(|c| c.power)
+            .or_else(|| blocker.power());
+        if let (Some(attacker_power), Some(blocker_power)) = (attacker_power, blocker_power)
+            && blocker_power > attacker_power
+        {
+            return false;
+        }
+    }
+
     if let Some(attacker_controller) = game.current_controller(attacker.id)
         && game.ring_level(attacker_controller) >= 1
         && game.current_ring_bearer(attacker_controller) == Some(attacker.id)

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -653,6 +653,24 @@ impl StaticAbilityKind for CantBeBlockedByLowerPowerThanSource {
     }
 }
 
+/// This creature can't be blocked by creatures with greater power.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CantBeBlockedByGreaterPowerThanSource;
+
+impl StaticAbilityKind for CantBeBlockedByGreaterPowerThanSource {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::CantBeBlockedByGreaterPowerThanSource
+    }
+
+    fn display(&self) -> String {
+        "This creature can't be blocked by creatures with greater power".to_string()
+    }
+
+    fn grants_evasion(&self) -> bool {
+        true
+    }
+}
+
 /// Can't be blocked by more than N creatures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CantBeBlockedByMoreThan {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -91,6 +91,9 @@ impl StaticAbility {
             Some(StaticAbilityId::CantBeBlockedByLowerPowerThanSource) => {
                 Self::cant_be_blocked_by_lower_power_than_source()
             }
+            Some(StaticAbilityId::CantBeBlockedByGreaterPowerThanSource) => {
+                Self::cant_be_blocked_by_greater_power_than_source()
+            }
             Some(StaticAbilityId::CanAttackAsThoughNoDefender) => {
                 Self::can_attack_as_though_no_defender()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -923,6 +923,11 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::SourceIsAttacking => {
             "as long as this creature is attacking".to_string()
         }
+        crate::ConditionExpr::Not(inner)
+            if matches!(inner.as_ref(), crate::ConditionExpr::SourceIsAttacking) =>
+        {
+            "unless it's attacking".to_string()
+        }
         crate::ConditionExpr::SourceAttackedThisTurn => {
             "as long as this creature attacked this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -1862,6 +1862,10 @@ impl StaticAbility {
         Self::new(CantBeBlockedByLowerPowerThanSource)
     }
 
+    pub fn cant_be_blocked_by_greater_power_than_source() -> Self {
+        Self::new(CantBeBlockedByGreaterPowerThanSource)
+    }
+
     pub fn cant_be_blocked_by_more_than(max_blockers: usize) -> Self {
         Self::new(CantBeBlockedByMoreThan::new(max_blockers))
     }

--- a/crates/ironsmith-runtime/src/triggers/combat/deals_combat_damage_to_player.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/deals_combat_damage_to_player.rs
@@ -53,6 +53,16 @@ impl DealsCombatDamageToPlayerTrigger {
     }
 }
 
+fn pluralize_one_or_more_subject(subject: String) -> String {
+    if subject == "creature" {
+        return "creatures".to_string();
+    }
+    if let Some(rest) = subject.strip_prefix("creature ") {
+        return format!("creatures {rest}");
+    }
+    subject
+}
+
 impl TriggerMatcher for DealsCombatDamageToPlayerTrigger {
     fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
         if event.kind() != EventKind::Damage {
@@ -91,6 +101,7 @@ impl TriggerMatcher for DealsCombatDamageToPlayerTrigger {
             } else if let Some(stripped) = subject.strip_prefix("an ") {
                 subject = stripped.to_string();
             }
+            subject = pluralize_one_or_more_subject(subject);
             let player = if matches!(self.player, PlayerFilter::Opponent) {
                 "one or more of your opponents".to_string()
             } else {
@@ -153,7 +164,7 @@ mod tests {
         );
         assert_eq!(
             trigger.display(),
-            "Whenever one or more creature deal combat damage to one or more of your opponents"
+            "Whenever one or more creatures deal combat damage to one or more of your opponents"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tadeas, Juniper Ascendant
Initial parse error:
```
parser does not yet support line family: 'Tadeas has hexproof unless it's attacking.'; oracle-only fallback also failed: parser does not yet support line family: 'Tadeas has hexproof unless it's attacking.'
```

Current worker: i-025255b4f3c473db1
Branch: codex/aws-card-fix-tadeas-juniper-ascendant
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0077
