### PR TITLE
Fix Ironsmith parse failure: Aquamorph Entity

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -2771,3 +2771,67 @@ pub(crate) fn parse_as_enters_becomes_characteristics_for_filter_line(
         filter, card_types, subtypes, power, toughness,
     )))
 }
+
+pub(crate) fn parse_as_enters_or_turns_face_up_pt_choice_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if clause_words.first().copied() != Some("as") {
+        return Ok(None);
+    }
+
+    let Some(enter_word_idx) =
+        etb_word_offset(&clause_words, |word| matches!(word, "enter" | "enters"))
+    else {
+        return Ok(None);
+    };
+    if enter_word_idx <= 1 {
+        return Ok(None);
+    }
+
+    let subject_words = &clause_words[1..enter_word_idx];
+    if !matches!(subject_words, ["this", "creature" | "permanent" | "object"]) {
+        return Ok(None);
+    }
+
+    let after_enter = clause_words.get(enter_word_idx + 1..).unwrap_or_default();
+    if after_enter.len() != 13
+        || !etb_word_slice_starts_with(
+            after_enter,
+            &[
+                "or", "is", "turned", "face", "up", "it", "becomes", "your", "choice",
+                "of",
+            ],
+        )
+        || after_enter.get(11).copied() != Some("or")
+    {
+        return Ok(None);
+    }
+
+    let first = parse_pt_modifier(after_enter[10]).map_err(|_| {
+        CardTextError::ParseError(format!(
+            "unsupported power/toughness choice '{}' (clause: '{}')",
+            after_enter[10],
+            clause_words.join(" ")
+        ))
+    })?;
+    let second = parse_pt_modifier(after_enter[12]).map_err(|_| {
+        CardTextError::ParseError(format!(
+            "unsupported power/toughness choice '{}' (clause: '{}')",
+            after_enter[12],
+            clause_words.join(" ")
+        ))
+    })?;
+
+    let subject = subject_words.join(" ");
+    let display = format!(
+        "As {subject} enters or is turned face up, it becomes your choice of {}/{} or {}/{}",
+        first.0, first.1, second.0, second.1
+    );
+    Ok(Some(
+        StaticAbility::choose_power_toughness_as_enters_or_turns_face_up(
+            vec![first, second],
+            display,
+        ),
+    ))
+}

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -779,6 +779,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_fixed_mana_cost_instead_of_mana_cost_grant_line),
         single_static_ability_ast_rule!(parse_mana_value_instead_of_mana_cost_grant_line),
         single_static_ability_ast_rule!(parse_life_mana_value_instead_of_mana_cost_grant_line),
+        single_static_ability_ast_rule!(parse_as_enters_or_turns_face_up_pt_choice_line),
         single_static_ability_ast_rule!(parse_as_enters_becomes_characteristics_for_filter_line),
         single_static_ability_ast_rule!(parse_enter_as_copy_as_enters_line),
         multi_static_ability_ast_rule!(

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -155,6 +155,7 @@ pub enum StaticAbilityId {
     ChooseBasicLandTypeAsEnters,
     ChooseLandTypeAsEnters,
     ChooseNamedOptionAsEnters,
+    ChoosePowerToughnessAsEntersOrTurnsFaceUp,
     BoastTwiceEachTurn,
     FirstEquipCostAlternative,
     EquipAbilitiesAnyTime,
@@ -403,6 +404,7 @@ impl StaticAbilityId {
             | ChooseBasicLandTypeAsEnters
             | ChooseLandTypeAsEnters
             | ChooseNamedOptionAsEnters
+            | ChoosePowerToughnessAsEntersOrTurnsFaceUp
             | BoastTwiceEachTurn
             | FirstEquipCostAlternative
             | EquipAbilitiesAnyTime

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -353,6 +353,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         options: Vec<String>,
         display: String,
     },
+    ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+        options: Vec<(i32, i32)>,
+        display: String,
+    },
     EnterAsCopyAsEnters {
         spec: EnterAsCopyAsEntersSpec<T, E, C, Cond>,
         display: String,
@@ -1133,6 +1137,13 @@ where
             StaticAbilityPayload::ChooseNamedOptionAsEnters { options, display } => {
                 StaticAbilityPayload::ChooseNamedOptionAsEnters { options, display }
             }
+            StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+                options,
+                display,
+            } => StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+                options,
+                display,
+            },
             StaticAbilityPayload::EnterAsCopyAsEnters { spec, display } => {
                 let mut added_abilities = Vec::with_capacity(spec.added_abilities.len());
                 for ability in spec.added_abilities {
@@ -2933,6 +2944,22 @@ impl<
             payload: StaticAbilityPayload::ChooseNamedOptionAsEnters { options, display },
         }
     }
+
+    pub fn choose_power_toughness_as_enters_or_turns_face_up(
+        options: Vec<(i32, i32)>,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::ChoosePowerToughnessAsEntersOrTurnsFaceUp),
+            label: display.clone(),
+            payload: StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+                options,
+                display,
+            },
+        }
+    }
+
     pub fn duplicate_matching_triggered_abilities(
         source_filter: Option<ObjectFilter>,
         event_matcher: Option<T>,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -12186,6 +12186,33 @@ fn test_experiment_twelve_strict_parse_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn aquamorph_entity_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Aquamorph Entity");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("ChoosePowerToughnessAsEntersOrTurnsFaceUp"),
+        "expected structured P/T choice static ability, got {debug}"
+    );
+    assert!(debug.contains("Morph"), "expected morph ability, got {debug}");
+
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains(
+            "as this creature enters or is turned face up, it becomes your choice of 5/1 or 1/5"
+        ),
+        "expected Aquamorph Entity P/T-choice clause in compiled output, got {compiled}"
+    );
+    assert!(
+        compiled.contains("morph {2}{u}"),
+        "expected Aquamorph Entity morph clause in compiled output, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_this_creature_enters_from_your_graveyard() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Phyrexian Dragon Engine")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -23609,6 +23609,146 @@ fn test_face_down_cast_matches_panoptic_filter_and_enters_battlefield_face_down(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn aquamorph_entity_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(386300), "Aquamorph Entity")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Shapeshifter])
+        .power_toughness(PowerToughness::new(PtValue::Star, PtValue::Star))
+        .parse_text(
+            "As this creature enters or is turned face up, it becomes your choice of 5/1 or 1/5.\nMorph {2}{U}",
+        )
+        .expect("Aquamorph Entity should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseAquamorphPowerToughness {
+    option_index: usize,
+    choices_seen: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseAquamorphPowerToughness {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if ctx.options.iter().any(|option| option.description == "5/1")
+            && ctx.options.iter().any(|option| option.description == "1/5")
+        {
+            self.choices_seen += 1;
+            return vec![self.option_index];
+        }
+        ctx.options
+            .iter()
+            .filter(|option| option.legal)
+            .map(|option| option.index)
+            .take(ctx.min)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aquamorph_entity_enters_with_chosen_power_toughness() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let aquamorph = aquamorph_entity_definition();
+    let hand_id = game.create_object_from_definition(&aquamorph, alice, Zone::Hand);
+
+    let mut dm = ChooseAquamorphPowerToughness {
+        option_index: 1,
+        choices_seen: 0,
+    };
+    let result = game
+        .move_object_with_etb_processing_with_dm(hand_id, Zone::Battlefield, &mut dm)
+        .expect("Aquamorph Entity should enter the battlefield");
+    let object = game
+        .object(result.new_id)
+        .expect("Aquamorph Entity should exist on the battlefield");
+    assert_eq!(object.power(), Some(1));
+    assert_eq!(object.toughness(), Some(5));
+    assert_eq!(dm.choices_seen, 1);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aquamorph_entity_turns_face_up_with_chosen_power_toughness() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let aquamorph = aquamorph_entity_definition();
+    let hand_id = game.create_object_from_definition(&aquamorph, alice, Zone::Hand);
+    let stack_id = super::priority_mana::propose_spell_cast(
+        &mut game,
+        hand_id,
+        Zone::Hand,
+        alice,
+        &CastingMethod::FaceDown,
+    )
+    .expect("Aquamorph Entity should be castable face down");
+    let battlefield_id = game
+        .move_object_by_effect(stack_id, Zone::Battlefield)
+        .expect("face-down Aquamorph Entity should resolve");
+    let face_down = game
+        .object(battlefield_id)
+        .expect("face-down Aquamorph Entity should exist");
+    assert!(game.is_face_down(battlefield_id));
+    assert_eq!(face_down.power(), Some(2));
+    assert_eq!(face_down.toughness(), Some(2));
+
+    game.player_mut(alice)
+        .expect("alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    game.player_mut(alice)
+        .expect("alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+    let action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::TurnFaceUp { creature_id, .. }
+                if *creature_id == battlefield_id
+        ))
+        .expect("Aquamorph Entity should be turnable face up for its morph cost");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = ChooseAquamorphPowerToughness {
+        option_index: 0,
+        choices_seen: 0,
+    };
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(action),
+        &mut dm,
+    )
+    .expect("turning Aquamorph Entity face up should succeed");
+
+    let face_up = game
+        .object(battlefield_id)
+        .expect("Aquamorph Entity should remain on the battlefield");
+    assert!(!game.is_face_down(battlefield_id));
+    assert_eq!(face_up.power(), Some(5));
+    assert_eq!(face_up.toughness(), Some(1));
+    assert_eq!(dm.choices_seen, 1);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_bestow_cast_enters_as_aura_and_reverts_when_unattached() {
     use crate::cards::CardDefinitionBuilder;

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -4540,6 +4540,11 @@ impl GameState {
                     }
                 }
             }
+            self.apply_power_toughness_choice_as_enters_or_turns_face_up(
+                new_id,
+                controller,
+                decision_maker,
+            );
         }
 
         // If this is an Aura entering from a non-stack zone, choose what to attach to
@@ -8568,6 +8573,58 @@ impl GameState {
         self.choice_store
             .chosen_named_options
             .insert(permanent_id, option);
+    }
+
+    pub(crate) fn apply_power_toughness_choice_as_enters_or_turns_face_up(
+        &mut self,
+        permanent_id: ObjectId,
+        controller: PlayerId,
+        decision_maker: &mut dyn crate::decision::DecisionMaker,
+    ) {
+        let abilities = self
+            .object(permanent_id)
+            .map(|object| object.abilities.clone())
+            .unwrap_or_default();
+        for ability in abilities {
+            let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
+                continue;
+            };
+            let Some(spec) = static_ability.power_toughness_choice_as_enters_or_turns_face_up()
+            else {
+                continue;
+            };
+            if spec.options.is_empty() {
+                continue;
+            }
+            let display_options = spec
+                .options
+                .iter()
+                .enumerate()
+                .map(|(idx, (power, toughness))| {
+                    crate::decisions::spec::DisplayOption::new(
+                        idx,
+                        format!("{power}/{toughness}"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let choice_spec =
+                crate::decisions::specs::ChoiceSpec::single(permanent_id, display_options);
+            let mut chosen = crate::decisions::make_decision(
+                self,
+                decision_maker,
+                controller,
+                Some(permanent_id),
+                choice_spec,
+            );
+            if let Some(chosen_idx) = chosen.pop().filter(|idx| *idx < spec.options.len()) {
+                let (power, toughness) = spec.options[chosen_idx];
+                if let Some(object) = self.object_mut(permanent_id) {
+                    object.base_power = Some(crate::card::PtValue::Fixed(power));
+                    object.base_toughness = Some(crate::card::PtValue::Fixed(toughness));
+                    self.mark_continuous_state_dirty();
+                }
+            }
+        }
     }
 
     /// Get a chosen named option for a permanent, if any.

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -796,6 +796,12 @@ fn perform_turn_face_up(
     }
     game.set_face_up(permanent_id);
 
+    game.apply_power_toughness_choice_as_enters_or_turns_face_up(
+        permanent_id,
+        player,
+        decision_maker,
+    );
+
     if spec.megamorph
         && let Some(object) = game.object_mut(permanent_id)
     {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -190,6 +190,9 @@ impl StaticAbility {
             Some(StaticAbilityId::ChooseColorAsBecomesAttached) => {
                 Self::choose_color_as_becomes_attached(label)
             }
+            Some(StaticAbilityId::ChoosePowerToughnessAsEntersOrTurnsFaceUp) => {
+                Self::rule_fallback_text(label)
+            }
             Some(StaticAbilityId::NoMaximumHandSize) => Self::no_maximum_hand_size(),
             Some(StaticAbilityId::CreaturesEnteringDontCauseAbilitiesToTrigger) => {
                 Self::creatures_entering_dont_cause_abilities_to_trigger()

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -5,7 +5,8 @@
 use super::{
     ChooseBasicLandTypeAsEntersSpec, ChooseCardNameAsEntersSpec, ChooseColorAsBecomesAttachedSpec,
     ChooseColorAsEntersSpec, ChooseCreatureTypeAsEntersSpec, ChooseLandTypeAsEntersSpec,
-    ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec, ConditionalSpellKeywordKind,
+    ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
+    ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
     ConditionalSpellKeywordSpec, EnterAsCopyAsEntersSpec, GraveyardCountMetric, StaticAbilityId,
     StaticAbilityKind, ThisSpellCastRestrictionKind, TriggerDuplicationSpec,
     TriggerSuppressionSpec,
@@ -1593,6 +1594,37 @@ impl StaticAbilityKind for ChooseNamedOptionAsEnters {
 
     fn named_option_choice_as_enters(&self) -> Option<ChooseNamedOptionAsEntersSpec> {
         Some(ChooseNamedOptionAsEntersSpec {
+            options: self.options.clone(),
+        })
+    }
+}
+
+/// "As this enters or is turned face up, choose a power/toughness."
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+    pub options: Vec<(i32, i32)>,
+    pub display: String,
+}
+
+impl ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+    pub fn new(options: Vec<(i32, i32)>, display: String) -> Self {
+        Self { options, display }
+    }
+}
+
+impl StaticAbilityKind for ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::ChoosePowerToughnessAsEntersOrTurnsFaceUp
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn power_toughness_choice_as_enters_or_turns_face_up(
+        &self,
+    ) -> Option<ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec> {
+        Some(ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec {
             options: self.options.clone(),
         })
     }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -632,6 +632,13 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Returns info for "as this enters or is turned face up, choose a P/T" abilities.
+    fn power_toughness_choice_as_enters_or_turns_face_up(
+        &self,
+    ) -> Option<ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec> {
+        None
+    }
+
     /// Returns info for "you may have this enter as a copy ..." abilities.
     fn enter_as_copy_as_enters(&self) -> Option<&EnterAsCopyAsEntersSpec> {
         None
@@ -948,6 +955,12 @@ pub struct ChooseNamedOptionAsEntersSpec {
     pub options: Vec<String>,
 }
 
+/// Spec for "as this enters or is turned face up, choose a P/T" abilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec {
+    pub options: Vec<(i32, i32)>,
+}
+
 /// Spec for "you may have this enter as a copy ..." abilities.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EnterAsCopyAsEntersSpec {
@@ -1061,6 +1074,12 @@ impl StaticAbility {
 
     pub fn named_option_choice_as_enters(&self) -> Option<ChooseNamedOptionAsEntersSpec> {
         self.0.named_option_choice_as_enters()
+    }
+
+    pub fn power_toughness_choice_as_enters_or_turns_face_up(
+        &self,
+    ) -> Option<ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec> {
+        self.0.power_toughness_choice_as_enters_or_turns_face_up()
     }
 
     pub fn enter_as_copy_as_enters(&self) -> Option<&EnterAsCopyAsEntersSpec> {
@@ -2540,6 +2559,15 @@ impl StaticAbility {
 
     pub fn choose_named_option_as_enters(options: Vec<String>, display: String) -> Self {
         Self::new(ChooseNamedOptionAsEnters::new(options, display))
+    }
+
+    pub fn choose_power_toughness_as_enters_or_turns_face_up(
+        options: Vec<(i32, i32)>,
+        display: String,
+    ) -> Self {
+        Self::new(ChoosePowerToughnessAsEntersOrTurnsFaceUp::new(
+            options, display,
+        ))
     }
 
     pub fn with_enter_as_copy_as_enters(spec: EnterAsCopyAsEntersSpec, display: String) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1161,6 +1161,13 @@ impl StaticAbilityModelInterpreter {
                 options,
                 display,
             } => StaticAbility::choose_named_option_as_enters(options.clone(), display.clone()),
+            ironsmith_core::StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+                options,
+                display,
+            } => StaticAbility::choose_power_toughness_as_enters_or_turns_face_up(
+                options.clone(),
+                display.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::EnterAsCopyAsEnters { spec, display } => {
                 StaticAbility::with_enter_as_copy_as_enters(
                     super::EnterAsCopyAsEntersSpec {
@@ -1839,6 +1846,23 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ChooseCreatureTypeAsEnters(_)
         )
         .then_some(super::ChooseCreatureTypeAsEntersSpec)
+    }
+
+    fn power_toughness_choice_as_enters_or_turns_face_up(
+        &self,
+    ) -> Option<super::ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec> {
+        if let Some(ability) = self.leaf_static_ability() {
+            return ability.power_toughness_choice_as_enters_or_turns_face_up();
+        }
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
+                options,
+                ..
+            } => Some(super::ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec {
+                options: options.clone(),
+            }),
+            _ => None,
+        }
     }
 
     fn pregame_action_kind(&self) -> Option<super::PregameActionKind> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aquamorph Entity
Initial parse error:
```
parser does not yet support line family: 'As this creature enters or is turned face up, it becomes your choice of 5/1 or 1/5.'; oracle-only fallback also failed: parser does not yet support line family: 'As this creature enters or is turned face up, it becomes your choice of 5/1 or 1/5.'
```

Current worker: i-0e89ac7b4e1a58504
Branch: codex/aws-card-fix-aquamorph-entity
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0078
