### PR TITLE
Fix Ironsmith parse failure: Dream Tides

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2531,6 +2531,18 @@ pub(crate) fn bind_implicit_player_context(effect: &mut EffectAst, player: Playe
                 *effect_player = player;
             }
         }
+        EffectAst::ChooseObjects {
+            player: effect_player,
+            ..
+        }
+        | EffectAst::ChooseObjectsAcrossZones {
+            player: effect_player,
+            ..
+        } => {
+            if matches!(*effect_player, PlayerAst::Implicit) {
+                *effect_player = player;
+            }
+        }
         _ => for_each_nested_effects_mut(effect, true, |nested| {
             for nested_effect in nested {
                 bind_implicit_player_context(nested_effect, player);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -27309,6 +27309,24 @@ fn render_wild_research_style_search_reveal_hand_discard_shuffle_hides_search_ta
     );
 }
 
+#[test]
+fn dream_tides_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Dream Tides");
+    let def = parse_oracle_card_definition("Dream Tides");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains(
+            "At the beginning of each player's upkeep, that player may choose any number of tapped nongreen creatures they control and pay {2} for each creature chosen this way. If the player does, untap those creatures."
+        ),
+        "expected Dream Tides choose/pay/untap clause to render oracle-like text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("tagged") && !rendered.contains("have you choose"),
+        "Dream Tides compiled text should not expose internal tags or mis-bound chooser text, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn render_source_surface_for_hard_triggered_and_static_clauses() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2738,6 +2738,93 @@ fn filter_references_tag(filter: &ObjectFilter, tag: &TagKey) -> bool {
     })
 }
 
+fn describe_may_choose_pay_for_each_then_untap_tagged(effects: &[&Effect]) -> Option<String> {
+    let [may_effect, if_effect] = effects else {
+        return None;
+    };
+    let with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let may = with_id.effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let decider = may.decider.as_ref()?;
+    let conditional = if_effect.downcast_ref::<crate::effects::IfEffect>()?;
+    if conditional.condition != with_id.id
+        || conditional.predicate != crate::effect::EffectPredicate::Happened
+        || !conditional.else_.is_empty()
+    {
+        return None;
+    }
+
+    let [choose_effect, for_each_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachTaggedEffect>()?;
+    let [pay_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let pay = pay_effect.downcast_ref::<crate::effects::PayManaEffect>()?;
+    let [untap_effect] = conditional.then.as_slice() else {
+        return None;
+    };
+    let untap = untap_effect.downcast_ref::<crate::effects::UntapEffect>()?;
+
+    if choose.is_search
+        || choose.top_only
+        || choose.chooser != *decider
+        || for_each.tag != choose.tag
+        || !matches!(pay.player, ChooseSpec::Player(PlayerFilter::IteratedPlayer))
+    {
+        return None;
+    }
+    let ChooseSpec::Object(untap_filter) = &untap.target else {
+        return None;
+    };
+    if !filter_references_tag(untap_filter, &choose.tag) {
+        return None;
+    }
+
+    let mut selected_filter = choose.filter.clone();
+    if selected_filter.controller != Some(decider.clone()) {
+        return None;
+    }
+    selected_filter.controller = None;
+    let mut selected = selected_filter.description();
+    if let Some(rest) = selected.strip_prefix("a ") {
+        selected = rest.to_string();
+    }
+    if let Some(rest) = selected.strip_prefix("an ") {
+        selected = rest.to_string();
+    }
+    if let Some(rest) = selected.strip_suffix(" on the battlefield") {
+        selected = rest.to_string();
+    }
+    selected = selected.replace("nongreen tapped ", "tapped nongreen ");
+
+    let selection = if choose.count.min == 0 && choose.count.max.is_none() {
+        format!("any number of {}", pluralize_noun_phrase(&selected))
+    } else {
+        describe_choose_selection(choose)
+    };
+    let chooser = describe_player_filter(decider);
+    let controlled_by = if *decider == PlayerFilter::You {
+        "you control"
+    } else {
+        "they control"
+    };
+    let if_player = if chooser == "that player" {
+        "the player"
+    } else {
+        chooser.as_str()
+    };
+    let chosen_noun = describe_iterated_object_reference_noun(&choose.filter);
+    let chosen_plural = pluralize_noun_phrase(chosen_noun);
+
+    Some(format!(
+        "{chooser} may choose {selection} {controlled_by} and pay {} for each \
+         {chosen_noun} chosen this way. If {if_player} does, untap those {chosen_plural}",
+        pay.cost.to_oracle()
+    ))
+}
+
 fn describe_each_creature_and_player_damage_cant_regenerate_structural(
     effects: &[Effect],
 ) -> Option<String> {
@@ -3780,6 +3867,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_exile_graveyard_reflexive_copy_artifact(&filtered) {
+        return compact;
+    }
+    if let Some(compact) = describe_may_choose_pay_for_each_then_untap_tagged(&filtered) {
         return compact;
     }
 

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2512,6 +2512,10 @@ pub fn resolve_objects_for_effect_with_choice_description(
             }
         }
 
+        if !filter.tagged_constraints.is_empty() {
+            return resolve_objects_from_spec(game, spec, ctx);
+        }
+
         let count = spec.count();
         let mut candidates = candidate_object_ids_for_filter(game, filter, ctx);
         if candidates.is_empty() {
@@ -2856,29 +2860,17 @@ pub fn resolve_objects_from_spec(
         // Object filter (non-targeted choice) - generally supplied via previous selection,
         // but some tags only effects resolve from tagged objects and filters.
         ChooseSpec::Object(filter) => {
-            let objects: Vec<ObjectId> = ctx
-                .targets
-                .iter()
-                .filter_map(|t| {
-                    if let ResolvedTarget::Object(id) = t {
-                        Some(*id)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            if objects.is_empty() {
-                if filter.tagged_constraints.is_empty() {
-                    return Err(ExecutionError::InvalidTarget);
-                }
-
-                let filter_ctx = ctx.filter_context(game);
-                let objects: Vec<ObjectId> = candidate_ids_for_filter(game, filter)
+            if filter.tagged_constraints.is_empty() {
+                let objects: Vec<ObjectId> = ctx
+                    .targets
                     .iter()
-                    .filter_map(|&id| game.object(id))
-                    .filter(|obj| filter.matches(obj, &filter_ctx, game))
-                    .map(|obj| obj.id)
+                    .filter_map(|t| {
+                        if let ResolvedTarget::Object(id) = t {
+                            Some(*id)
+                        } else {
+                            None
+                        }
+                    })
                     .collect();
 
                 if objects.is_empty() {
@@ -2886,6 +2878,18 @@ pub fn resolve_objects_from_spec(
                 }
 
                 return Ok(objects);
+            }
+
+            let filter_ctx = ctx.filter_context(game);
+            let objects: Vec<ObjectId> = candidate_ids_for_filter(game, filter)
+                .iter()
+                .filter_map(|&id| game.object(id))
+                .filter(|obj| filter.matches(obj, &filter_ctx, game))
+                .map(|obj| obj.id)
+                .collect();
+
+            if objects.is_empty() {
+                return Err(ExecutionError::InvalidTarget);
             }
 
             Ok(objects)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3128,6 +3128,244 @@ fn oath_of_druids_upkeep_trigger_puts_revealed_creature_onto_battlefield() {
     );
 }
 
+fn dream_tides_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(99_120), "Dream Tides")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Creatures don't untap during their controllers' untap steps.\n\
+             At the beginning of each player's upkeep, that player may choose any number of tapped nongreen creatures they control and pay {2} for each creature chosen this way. If the player does, untap those creatures.",
+        )
+        .expect("Dream Tides should parse for runtime tests")
+}
+
+fn create_colored_creature(
+    game: &mut GameState,
+    name: &str,
+    owner: PlayerId,
+    colors: Option<crate::color::ColorSet>,
+) -> ObjectId {
+    let mut builder = CardBuilder::new(CardId::from_raw(99_121), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2));
+    if let Some(colors) = colors {
+        builder = builder.color_indicator(colors);
+    }
+    let card = builder.build();
+    game.create_object_from_card(&card, owner, Zone::Battlefield)
+}
+
+fn put_dream_tides_upkeep_trigger_on_stack(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+) {
+    generate_and_queue_step_triggers(game, trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Dream Tides should create one upkeep trigger"
+    );
+    put_triggers_on_stack(game, trigger_queue)
+        .expect("Dream Tides trigger should go on the stack");
+}
+
+#[test]
+fn dream_tides_prevents_creatures_from_untapping_during_untap_step() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let dream_tides = dream_tides_definition();
+    game.create_object_from_definition(&dream_tides, alice, Zone::Battlefield);
+    let bob_creature = create_creature(&mut game, "Bob Bear", bob, 2, 2);
+    let bob_relic = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(99_122), "Bob Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.tap(bob_creature);
+    game.tap(bob_relic);
+
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Untap);
+    let mut dm = AutoPassDecisionMaker;
+    crate::turn::execute_untap_step_with(&mut game, &mut dm);
+
+    assert!(
+        game.is_tapped(bob_creature),
+        "Dream Tides should keep creatures tapped during their controller's untap step"
+    );
+    assert!(
+        !game.is_tapped(bob_relic),
+        "Dream Tides should not stop noncreature permanents from untapping"
+    );
+}
+
+struct DreamTidesChoiceDecisionMaker {
+    chooser: PlayerId,
+    selected: Vec<ObjectId>,
+    rejected: Vec<ObjectId>,
+}
+
+impl DecisionMaker for DreamTidesChoiceDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        true
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        assert_eq!(
+            ctx.player, self.chooser,
+            "active player should choose for Dream Tides"
+        );
+        assert_eq!(ctx.min, 0, "Dream Tides should allow choosing zero creatures");
+        assert_eq!(
+            ctx.max,
+            Some(ctx.candidates.len()),
+            "Dream Tides any-number choice should be capped only by available candidates"
+        );
+        for selected in &self.selected {
+            assert!(
+                ctx.candidates
+                    .iter()
+                    .any(|candidate| candidate.id == *selected && candidate.legal),
+                "selected tapped nongreen creature should be legal for Dream Tides"
+            );
+        }
+        for rejected in &self.rejected {
+            assert!(
+                !ctx.candidates
+                    .iter()
+                    .any(|candidate| candidate.id == *rejected && candidate.legal),
+                "green, untapped, and non-controlled creatures should not be legal \
+                 Dream Tides choices"
+            );
+        }
+        self.selected.clone()
+    }
+
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        ctx.options
+            .iter()
+            .find(|option| option.legal)
+            .map(|option| vec![option.index])
+            .unwrap_or_default()
+    }
+}
+
+#[test]
+fn dream_tides_upkeep_payment_untaps_only_chosen_tapped_nongreen_creature() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let dream_tides = dream_tides_definition();
+    game.create_object_from_definition(&dream_tides, alice, Zone::Battlefield);
+    let first_chosen = create_colored_creature(&mut game, "First Chosen Bob Bear", bob, None);
+    let second_chosen = create_colored_creature(&mut game, "Second Chosen Bob Bear", bob, None);
+    let unchosen = create_colored_creature(&mut game, "Unchosen Bob Bear", bob, None);
+    let green = create_colored_creature(
+        &mut game,
+        "Green Bob Bear",
+        bob,
+        Some(crate::color::ColorSet::GREEN),
+    );
+    let untapped = create_colored_creature(&mut game, "Untapped Bob Bear", bob, None);
+    let alice_creature = create_colored_creature(&mut game, "Alice Bear", alice, None);
+    game.tap(first_chosen);
+    game.tap(second_chosen);
+    game.tap(unchosen);
+    game.tap(green);
+    game.tap(alice_creature);
+    game.player_mut(bob)
+        .expect("Bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 4);
+
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    put_dream_tides_upkeep_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = DreamTidesChoiceDecisionMaker {
+        chooser: bob,
+        selected: vec![first_chosen, second_chosen],
+        rejected: vec![green, untapped, alice_creature],
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Dream Tides trigger should resolve");
+
+    assert!(
+        !game.is_tapped(first_chosen) && !game.is_tapped(second_chosen),
+        "paid-for chosen creatures should untap"
+    );
+    assert!(
+        game.is_tapped(unchosen),
+        "unchosen tapped nongreen creatures should remain tapped"
+    );
+    assert!(
+        game.is_tapped(green),
+        "green creatures should not be legal choices"
+    );
+    assert!(
+        !game.is_tapped(untapped),
+        "untapped creatures should remain unchanged"
+    );
+    assert!(
+        game.is_tapped(alice_creature),
+        "active player should not choose creatures they do not control"
+    );
+}
+
+#[test]
+fn dream_tides_upkeep_without_payment_leaves_chosen_creature_tapped() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let dream_tides = dream_tides_definition();
+    game.create_object_from_definition(&dream_tides, alice, Zone::Battlefield);
+    let chosen = create_colored_creature(&mut game, "Unpaid Bob Bear", bob, None);
+    game.tap(chosen);
+
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    put_dream_tides_upkeep_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = DreamTidesChoiceDecisionMaker {
+        chooser: bob,
+        selected: vec![chosen],
+        rejected: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Dream Tides trigger should resolve even when payment is impossible");
+
+    assert!(
+        game.is_tapped(chosen),
+        "chosen creature should remain tapped when its controller cannot pay {{2}}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn aether_rift_returns_randomly_discarded_creature_when_no_player_pays() {

--- a/crates/ironsmith-runtime/src/turn.rs
+++ b/crates/ironsmith-runtime/src/turn.rs
@@ -295,9 +295,7 @@ pub fn execute_untap_step_with(game: &mut GameState, decision_maker: &mut impl D
 
     let active_player = game.turn.active_player;
     let had_restriction_effects = !game.effect_store.restriction_effects.is_empty();
-    if had_restriction_effects {
-        game.update_cant_effects();
-    }
+    game.update_cant_effects();
 
     let phased_in: Vec<_> = game
         .phased_out
@@ -804,9 +802,13 @@ mod tests {
         );
         game.tap(doesnt_untap_artifact);
         game.tap(cant_untap_artifact);
-        game.effect_store
-            .cant_effects
-            .add_cant_untap(cant_untap_artifact);
+        game.add_restriction_effect(
+            Restriction::untap(ObjectFilter::specific(cant_untap_artifact)),
+            Until::Forever,
+            cant_untap_artifact,
+            alice,
+            None,
+        );
 
         let mut dm = AlwaysYesDecisionMaker;
         execute_untap_step_with(&mut game, &mut dm);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dream Tides
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-065e57e0bdf72e003
Branch: codex/aws-card-fix-dream-tides
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0079
