### PR TITLE
Fix Ironsmith parse failure: Rabble Rousing

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5631,6 +5631,70 @@ fn test_parse_hideaway_keyword_line() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn rabble_rousing_definition_for_tests() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(55_824), "Rabble Rousing")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Hideaway 5 (When this enchantment enters, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\n\
+             Whenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens. Then if you control ten or more creatures, you may play the exiled card without paying its mana cost.",
+        )
+        .expect("Rabble Rousing should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rabble_rousing_strict_parser_and_compiled_text_regression() {
+    let def = rabble_rousing_definition_for_tests();
+
+    assert_eq!(def.name(), "Rabble Rousing");
+    assert_eq!(
+        def.abilities.len(),
+        2,
+        "Rabble Rousing should have hideaway and attack triggers"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        !debug.contains("KeywordFallbackText") && !debug.contains("unsupported"),
+        "Rabble Rousing should lower without unsupported placeholders, got {debug}"
+    );
+    assert!(
+        debug.contains("LookAtTopCardsEffect")
+            && debug.contains("ExileEffect")
+            && debug.contains("PutTaggedRemainderOnLibraryBottomEffect"),
+        "Rabble Rousing hideaway should lower to look/choose/exile/bottom effects, got {debug}"
+    );
+    assert!(
+        debug.contains("AttacksTrigger")
+            && debug.contains("CreateTokenEffect")
+            && debug.contains("CastTaggedEffect"),
+        "Rabble Rousing attack trigger should lower to token creation plus conditional play permission, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Hideaway 5"),
+        "Rabble Rousing should render hideaway without tagged-object internals, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens"
+        ),
+        "Rabble Rousing should render the attack token clause, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("tagged object")
+            && !rendered.to_ascii_lowercase().contains("tagged '")
+            && !rendered.contains("tagged-object-reference"),
+        "Rabble Rousing compiled text should not leak tagged-object internals, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_partner_with_keyword_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Partner Probe")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -649,10 +649,10 @@ fn describe_hideaway_effects(effects: &[&Effect]) -> Option<String> {
         return None;
     }
 
-    let (count_text, noun, _) = describe_look_count_and_noun(&look.count);
-    Some(format!(
-        "Look at the top {count_text} {noun} of your library, then exile one of them face down. Put the rest on the bottom of your library in a random order"
-    ))
+    let Value::Fixed(count) = &look.count else {
+        return None;
+    };
+    Some(format!("Hideaway {count}"))
 }
 
 fn describe_exile_targets_opponent_piles_return_chosen(effects: &[&Effect]) -> Option<String> {
@@ -2388,6 +2388,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
+        .or_else(|| {
+            let effect_refs = effects.iter().collect::<Vec<_>>();
+            describe_hideaway_effects(&effect_refs)
+        })
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
 }
 
@@ -13545,6 +13549,30 @@ fn describe_triggered_resolution_text(
     ))
 }
 
+fn describe_triggered_hideaway_keyword(
+    triggered: &crate::ability::TriggeredAbility,
+) -> Option<String> {
+    let zone_change = triggered
+        .trigger
+        .downcast_ref::<crate::triggers::ZoneChangeTrigger>()?;
+    if !zone_change.this_object
+        || zone_change.from != crate::triggers::ZonePattern::Any
+        || zone_change.to != crate::triggers::ZonePattern::Specific(Zone::Battlefield)
+        || zone_change.player != crate::triggers::zone_changes::PlayerRelation::Any
+        || zone_change.count_mode != crate::triggers::zone_changes::CountMode::Each
+        || triggered.effects.segments.len() != 1
+        || !triggered.effects.segments[0].self_replacements.is_empty()
+    {
+        return None;
+    }
+
+    let effects = triggered.effects.segments[0]
+        .default_effects
+        .iter()
+        .collect::<Vec<_>>();
+    describe_hideaway_effects(&effects)
+}
+
 fn rewrite_damaged_player_reference_for_combat_damage_trigger(
     triggered: &crate::ability::TriggeredAbility,
     effects: String,
@@ -13568,6 +13596,9 @@ fn describe_triggered_inline_ability(
     self_subject: &str,
 ) -> String {
     if let Some(rendered) = describe_backup_keyword(triggered) {
+        return rendered;
+    }
+    if let Some(rendered) = describe_triggered_hideaway_keyword(triggered) {
         return rendered;
     }
 
@@ -28803,6 +28834,8 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             } else {
                 format!("a copy of {}", describe_choose_spec(&spec))
             }
+        } else if tag == "__source_exiled__" {
+            "the exiled card".to_string()
         } else if helper_tag {
             "that card".to_string()
         } else {
@@ -34833,6 +34866,9 @@ pub(super) fn describe_ability(
         AbilityKind::Triggered(triggered) => {
             if let Some(rendered) = describe_backup_keyword(triggered) {
                 return vec![format!("Triggered ability {index}: {rendered}")];
+            }
+            if let Some(rendered) = describe_triggered_hideaway_keyword(triggered) {
+                return vec![format!("Keyword ability {index}: {rendered}")];
             }
             if let Some(rendered) = describe_annihilator_keyword(triggered) {
                 return vec![format!("Triggered ability {index}: {rendered}")];

--- a/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
@@ -419,6 +419,7 @@ fn apply_prepared_attacker_declarations_with_dm(
             .insert(game.turn.active_player);
     }
 
+    let mut attack_events = Vec::with_capacity(declarations.len());
     for decl in &declarations {
         let Some(creature) = game.object(decl.creature) else {
             return Err(
@@ -453,6 +454,11 @@ fn apply_prepared_attacker_declarations_with_dm(
             ),
             event_provenance,
         );
+        attack_events.push(event);
+    }
+
+    game.combat = Some(combat.clone());
+    for event in attack_events {
         queue_triggers_from_event(game, trigger_queue, event, false);
     }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -5463,6 +5463,237 @@ fn cloud_ex_soldier_attack_trigger_skips_treasures_below_power_7() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn rabble_rousing_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(55_824), "Rabble Rousing")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Hideaway 5 (When this enchantment enters, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\n\
+             Whenever you attack with one or more creatures, create that many 1/1 green and white Citizen creature tokens. Then if you control ten or more creatures, you may play the exiled card without paying its mana cost.",
+        )
+        .expect("Rabble Rousing should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn controlled_citizen_count(game: &GameState, controller: PlayerId) -> usize {
+    game.battlefield
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .filter(|obj| game.controller_of(obj) == controller && obj.name == "Citizen")
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct CountingBooleanDecisionMaker {
+    boolean_prompts: usize,
+    response: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for CountingBooleanDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.boolean_prompts += 1;
+        self.response
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rabble_rousing_hideaway_exiles_one_card_face_down_and_bottoms_the_rest() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    for idx in 0..6 {
+        let card = CardBuilder::new(CardId::from_raw(55_900 + idx), &format!("Library Card {idx}"))
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    let rabble_id =
+        game.create_object_from_definition(&rabble_rousing_definition(), alice, Zone::Hand);
+    let rabble_id = game
+        .move_object_by_effect(rabble_id, Zone::Battlefield)
+        .expect("Rabble Rousing should enter the battlefield");
+
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Rabble Rousing hideaway trigger should go on stack");
+    assert_eq!(game.stack.len(), 1, "hideaway should create one ETB trigger");
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("hideaway trigger should resolve");
+
+    assert!(
+        game.battlefield.contains(&rabble_id),
+        "Rabble Rousing should remain on the battlefield"
+    );
+    assert_eq!(game.exile.len(), 1, "hideaway should exile exactly one chosen card");
+    let exiled = game.exile[0];
+    assert!(
+        game.is_face_down(exiled),
+        "hideaway should exile the chosen card face down"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").library.len(),
+        5,
+        "hideaway should leave the unchosen cards plus the unlooked card in the library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rabble_rousing_attack_trigger_creates_tokens_and_skips_play_permission_below_ten_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&rabble_rousing_definition(), alice, Zone::Battlefield);
+    let attackers = (0..2)
+        .map(|idx| {
+            let id = create_creature(&mut game, &format!("Attacker {idx}"), alice, 2, 2);
+            game.remove_summoning_sickness(id);
+            id
+        })
+        .collect::<Vec<_>>();
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    let declarations = attackers
+        .iter()
+        .copied()
+        .map(|creature| AttackerDeclaration {
+            creature,
+            target: AttackTarget::Player(bob),
+        })
+        .collect::<Vec<_>>();
+    apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("attackers should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Rabble Rousing attack trigger should go on stack");
+
+    let mut dm = CountingBooleanDecisionMaker {
+        boolean_prompts: 0,
+        response: false,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Rabble Rousing attack trigger should resolve");
+
+    assert_eq!(
+        controlled_citizen_count(&game, alice),
+        2,
+        "Rabble Rousing should create one Citizen per attacking creature"
+    );
+    assert_eq!(
+        dm.boolean_prompts, 0,
+        "Rabble Rousing should not offer the exiled-card play permission below ten creatures"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rabble_rousing_attack_trigger_offers_play_permission_after_tokens_reach_ten_creatures() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let exiled_card = CardBuilder::new(CardId::from_raw(55_950), "Hidden Sorcery")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    game.create_object_from_card(&exiled_card, alice, Zone::Library);
+    for idx in 0..4 {
+        let card = CardBuilder::new(CardId::from_raw(55_951 + idx), &format!("Library Card {idx}"))
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    let rabble_id =
+        game.create_object_from_definition(&rabble_rousing_definition(), alice, Zone::Hand);
+    game.move_object_by_effect(rabble_id, Zone::Battlefield)
+        .expect("Rabble Rousing should enter the battlefield");
+
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Rabble Rousing hideaway trigger should go on stack");
+    let mut hideaway_dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut hideaway_dm).expect("hideaway trigger should resolve");
+    assert_eq!(game.exile.len(), 1, "hideaway should exile one card");
+    let exiled_name = game
+        .object(game.exile[0])
+        .expect("exiled card should exist")
+        .name
+        .clone();
+
+    let attackers = (0..5)
+        .map(|idx| {
+            let id = create_creature(&mut game, &format!("Attacker {idx}"), alice, 2, 2);
+            game.remove_summoning_sickness(id);
+            id
+        })
+        .collect::<Vec<_>>();
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let declarations = attackers
+        .iter()
+        .copied()
+        .map(|creature| AttackerDeclaration {
+            creature,
+            target: AttackTarget::Player(bob),
+        })
+        .collect::<Vec<_>>();
+    apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("attackers should be legal");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Rabble Rousing attack trigger should go on stack");
+
+    let mut dm = CountingBooleanDecisionMaker {
+        boolean_prompts: 0,
+        response: true,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Rabble Rousing attack trigger should resolve");
+
+    assert_eq!(
+        controlled_citizen_count(&game, alice),
+        5,
+        "Rabble Rousing should create five Citizens for five attacking creatures"
+    );
+    assert_eq!(
+        dm.boolean_prompts, 1,
+        "Rabble Rousing should offer the exiled-card play permission after tokens bring you to ten creatures"
+    );
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "accepting the permission should cast the exiled card"
+    );
+    let cast_object = game
+        .object(game.stack[0].object_id)
+        .expect("cast exiled card should be on the stack");
+    assert_eq!(cast_object.name, exiled_name);
+    assert_eq!(cast_object.zone, Zone::Stack);
+}
+
 fn bridge_from_below_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(472), "Bridge from Below")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -175,6 +175,9 @@ impl TriggerMatcher for AttacksTrigger {
                     self.min_total_attackers
                 );
             }
+            if subject.eq_ignore_ascii_case("creature you control") {
+                return "Whenever you attack with one or more creatures".to_string();
+            }
             return format!("Whenever one or more {subject} attack");
         }
         if self.min_total_attackers > 1 {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rabble Rousing
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-0bba48b20c31152b7
Branch: codex/aws-card-fix-rabble-rousing
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0080
