### PR TITLE
Fix Ironsmith parse failure: Town Greeter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3255,6 +3255,25 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         });
     }
 
+    if filtered.len() >= 8
+        && filtered[0] == "you"
+        && filtered[1] == "put"
+        && slice_ends_with(&filtered, &["into", "your", "hand", "this", "way"])
+    {
+        let filter_words = &filtered[2..filtered.len() - 5];
+        let filter_tokens = filter_words
+            .iter()
+            .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+            .collect::<Vec<_>>();
+        let mut filter = parse_object_filter(&filter_tokens, false)?;
+        filter.zone = Some(Zone::Hand);
+        return Ok(PredicateAst::PlayerTaggedObjectMatches {
+            player: PlayerAst::You,
+            tag: TagKey::from(IT_TAG),
+            filter,
+        });
+    }
+
     if filtered.len() >= 7
         && filtered[1] == "is"
         && filtered[2] == "put"
@@ -3718,6 +3737,32 @@ mod tests {
                 tag: TagKey::from(IT_TAG),
                 filter: ObjectFilter::default().in_zone(Zone::Hand),
             }))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_if_you_put_filtered_card_into_your_hand_this_way()
+    -> Result<(), CardTextError> {
+        let tokens = lex_line("If you put a Town card into your hand this way", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+        let filter_tokens = lex_line("Town card", 0)?;
+        let mut filter = parse_object_filter(&filter_tokens, false)?;
+        filter.zone = Some(Zone::Hand);
+
+        assert_eq!(
+            parsed,
+            PredicateAst::PlayerTaggedObjectMatches {
+                player: PlayerAst::You,
+                tag: TagKey::from(IT_TAG),
+                filter,
+            }
         );
         Ok(())
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35570,6 +35570,159 @@ fn unprocessed_compiled_lines_normalize_remaining_tag_scaffolding_regressions() 
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_town_greeter_strict_regression() {
+    assert_oracle_card_parses_strict("Town Greeter");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn town_greeter_compiled_text_keeps_town_hand_condition() {
+    let rendered = unprocessed_compiled_lines(&parse_oracle_card_definition("Town Greeter"))
+        .join(" ");
+
+    assert!(
+        rendered.contains(
+            "When this creature enters, mill four cards. You may put a land card from among them into your hand. If you put a Town card into your hand this way, you gain 2 life."
+        ),
+        "expected Town Greeter to render the Town hand condition, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("tagged object") && !rendered.contains("__sentence_helper_chosen"),
+        "expected Town Greeter text to avoid internal tags, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct SelectTownGreeterCard {
+    name: &'static str,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for SelectTownGreeterCard {
+    fn decide_objects(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        ctx.candidates
+            .iter()
+            .find(|candidate| candidate.legal && candidate.name == self.name)
+            .map(|candidate| vec![candidate.id])
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_town_greeter_with_decision(
+    mut decision_maker: impl crate::decision::DecisionMaker,
+) -> crate::game_state::GameState {
+    let def = parse_oracle_card_definition("Town Greeter");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) if triggered.trigger.display().contains("enters") => {
+                Some(triggered.clone())
+            }
+            _ => None,
+        })
+        .expect("Town Greeter should compile to an enters trigger");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let town = CardDefinitionBuilder::new(CardId::from_raw(120_901), "Balamb Town")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Town])
+        .build();
+    let forest = CardDefinitionBuilder::new(CardId::from_raw(120_902), "Forest Glade")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Forest])
+        .build();
+    let filler = CardDefinitionBuilder::new(CardId::from_raw(120_903), "Filler Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+
+    game.create_object_from_definition(&filler, alice, Zone::Library);
+    game.create_object_from_definition(&forest, alice, Zone::Library);
+    game.create_object_from_definition(&filler, alice, Zone::Library);
+    game.create_object_from_definition(&town, alice, Zone::Library);
+
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut decision_maker);
+    for effect in triggered.effects.segments[0].default_effects.iter().skip(1) {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Town Greeter trigger effect should resolve");
+    }
+
+    game
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn alice_has_card_in_hand(game: &crate::game_state::GameState, name: &str) -> bool {
+    let alice = PlayerId::from_index(0);
+    game.player(alice)
+        .expect("Alice should exist")
+        .hand
+        .iter()
+        .any(|id| game.object(*id).is_some_and(|object| object.name == name))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn town_greeter_gains_life_when_town_card_put_into_hand() {
+    let game = resolve_town_greeter_with_decision(SelectTownGreeterCard {
+        name: "Balamb Town",
+    });
+    let alice = PlayerId::from_index(0);
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        22,
+        "Town Greeter should gain 2 life after choosing a Town land"
+    );
+    assert!(
+        alice_has_card_in_hand(&game, "Balamb Town"),
+        "chosen Town land should move to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn town_greeter_does_not_gain_life_for_non_town_land() {
+    let game = resolve_town_greeter_with_decision(SelectTownGreeterCard {
+        name: "Forest Glade",
+    });
+    let alice = PlayerId::from_index(0);
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        20,
+        "Town Greeter should not gain life after choosing a non-Town land"
+    );
+    assert!(
+        alice_has_card_in_hand(&game, "Forest Glade"),
+        "chosen non-Town land should still move to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn town_greeter_declined_hand_choice_does_not_gain_life() {
+    let game = resolve_town_greeter_with_decision(crate::decision::AutoPassDecisionMaker);
+    let alice = PlayerId::from_index(0);
+    let player = game.player(alice).expect("Alice should exist");
+
+    assert_eq!(player.life, 20, "declining the choice should not gain life");
+    assert_eq!(player.hand.len(), 0, "declining the choice should leave hand empty");
+    assert_eq!(
+        player.graveyard.len(),
+        4,
+        "declining the choice should leave all milled cards in the graveyard"
+    );
+}
+
 #[test]
 fn parse_oracle_dawnbreak_reclaimer_keeps_linked_player_choice_and_plural_return() {
     let rendered = unprocessed_compiled_lines(&parse_oracle_card_definition("Dawnbreak Reclaimer"))

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12356,6 +12356,28 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 2;
             continue;
         }
+        if idx + 3 < filtered.len()
+            && let Some(tagged_mill) = filtered[idx].downcast_ref::<crate::effects::TaggedEffect>()
+            && let Some(mill) = tagged_mill
+                .effect
+                .downcast_ref::<crate::effects::MillEffect>()
+            && let Some(choose) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some((_, move_to_hand)) = for_each_tagged_for_compaction(filtered[idx + 2])
+            && let Some(conditional) =
+                filtered[idx + 3].downcast_ref::<crate::effects::ConditionalEffect>()
+            && let Some(compact) = describe_tagged_mill_then_put_milled_card_into_hand_then_if_put_matching(
+                tagged_mill,
+                mill,
+                choose,
+                move_to_hand,
+                conditional,
+            )
+        {
+            parts.push(compact);
+            idx += 4;
+            continue;
+        }
         if idx + 2 < filtered.len()
             && let Some(tagged_mill) = filtered[idx].downcast_ref::<crate::effects::TaggedEffect>()
             && let Some(mill) = tagged_mill
@@ -22342,7 +22364,57 @@ pub(super) fn describe_tagged_mill_then_put_milled_card_into_hand(
     let hand = describe_possessive_player_filter(&choose.chooser);
     let may = if choose.count.min == 0 { " may" } else { "" };
     Some(format!(
-        "{mill_clause}. You{may} put {chosen} from among the cards milled this way into {hand} hand"
+        "{mill_clause}. You{may} put {chosen} from among them into {hand} hand"
+    ))
+}
+
+pub(super) fn describe_tagged_mill_then_put_milled_card_into_hand_then_if_put_matching(
+    tagged_mill: &crate::effects::TaggedEffect,
+    mill: &crate::effects::MillEffect,
+    choose: &crate::effects::ChooseObjectsEffect,
+    move_to_hand: &crate::effects::ForEachTaggedEffect,
+    conditional: &crate::effects::ConditionalEffect,
+) -> Option<String> {
+    if !conditional.if_false.is_empty() || conditional.if_true.is_empty() {
+        return None;
+    }
+    let crate::effect::Condition::PlayerTaggedObjectMatches {
+        player,
+        tag,
+        filter,
+    } = &conditional.condition
+    else {
+        return None;
+    };
+    if *player != choose.chooser
+        || tag.as_str() != choose.tag.as_str()
+        || filter.zone != Some(Zone::Hand)
+    {
+        return None;
+    }
+
+    let base = describe_tagged_mill_then_put_milled_card_into_hand(
+        tagged_mill,
+        mill,
+        choose,
+        move_to_hand,
+    )?;
+    let then_text = describe_effect_clause_list(&conditional.if_true)
+        .unwrap_or_else(|| describe_effect_list(&conditional.if_true));
+    if then_text.is_empty() {
+        return None;
+    }
+
+    let mut object_filter = filter.clone();
+    object_filter.zone = None;
+    let selection = describe_search_selection_with_cards(strip_leading_article(
+        &object_filter.description(),
+    ));
+    let subject = describe_player_filter(player);
+    let hand = describe_possessive_player_filter(player);
+    Some(format!(
+        "{base}. If {subject} {} {selection} into {hand} hand this way, {then_text}",
+        player_verb(&subject, "put", "puts")
     ))
 }
 
@@ -22379,7 +22451,7 @@ pub(super) fn describe_tagged_mill_then_may_put_milled_card_into_hand(
     let mill_clause = describe_tagged_mill_clause(mill);
     let hand = describe_possessive_player_filter(&choose.chooser);
     Some(format!(
-        "{mill_clause}. You may put {chosen} from among the cards milled this way into {hand} hand"
+        "{mill_clause}. You may put {chosen} from among them into {hand} hand"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -3376,6 +3376,14 @@ fn evaluate_condition(
             let mut filter_ctx = ctx.filter_context(game);
             filter_ctx.iterated_player = Some(player_id);
             for snapshot in tagged {
+                if filter.zone.is_some()
+                    && let Some(current_id) = game.find_object_by_stable_id(snapshot.stable_id)
+                    && let Some(object) = game.object(current_id)
+                    && game.controller_of(object) == player_id
+                    && filter.matches(object, &filter_ctx, game)
+                {
+                    return Ok(true);
+                }
                 if snapshot.controller != player_id {
                     continue;
                 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Town Greeter
Initial parse error:
```
unsupported predicate (predicate: 'you put town card into your hand this way'); oracle-only fallback also failed: unsupported predicate (predicate: 'you put town card into your hand this way')
```

Current worker: i-009d5e9d5c1eb30f5
Branch: codex/aws-card-fix-town-greeter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0090
