### PR TITLE
Fix Ironsmith parse failure: Firkraag, Cunning Instigator

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3108,6 +3108,10 @@ pub(crate) fn parse_trigger_clause_lexed(
             let tail = &words[attacks_word_idx + 1..];
             if matches!(tail, ["a", "player"]) {
                 (&words[..=attacks_word_idx], Some(PlayerFilter::Any), true)
+            } else if matches!(tail, ["an", "opponent"] | ["opponent"])
+                || matches!(tail, ["one", "of", "your", "opponents"])
+            {
+                (&words[..=attacks_word_idx], Some(PlayerFilter::Opponent), true)
             } else if matches!(
                 tail,
                 ["the", "defending", "player"] | ["defending", "player"]

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2397,6 +2397,16 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::YouAttackedThisTurn);
     }
 
+    if matches!(
+        filtered.as_slice(),
+        ["that", "creature", "had", "to", "attack", "this", "combat"]
+            | ["it", "had", "to", "attack", "this", "combat"]
+            | ["that", "creature", "must", "attack", "this", "combat"]
+            | ["it", "must", "attack", "this", "combat"]
+    ) {
+        return Ok(PredicateAst::TriggeringObjectHadToAttackThisCombat);
+    }
+
     if filtered.len() == 9
         && filtered[0] == "you"
         && filtered[1] == "attacked"

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -535,6 +535,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::SourceIsTapped => Condition::SourceIsTapped,
         PredicateAst::SourceIsSaddled => Condition::SourceIsSaddled,
         PredicateAst::SourceMatches(filter) => Condition::SourceMatches(filter.clone()),
+        PredicateAst::TriggeringObjectHadToAttackThisCombat => {
+            Condition::TriggeringObjectHadToAttackThisCombat
+        }
         PredicateAst::SourceHasNoCounter(counter_type) => {
             Condition::SourceHasNoCounter(*counter_type)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -513,6 +513,11 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         | TriggerSpec::ThisDealsCombatDamageToPlayer
         | TriggerSpec::DealsCombatDamageToPlayer { .. } => Some(PlayerFilter::DamagedPlayer),
         TriggerSpec::ThisAttacks | TriggerSpec::ThisBecomesBlocked => Some(PlayerFilter::Defending),
+        TriggerSpec::Attacks(filter) | TriggerSpec::AttacksOneOrMore(filter)
+            if filter.attacking_player_or_planeswalker_controlled_by.is_some() =>
+        {
+            Some(PlayerFilter::Defending)
+        }
         TriggerSpec::AttacksYouOrPlaneswalkerYouControl(_)
         | TriggerSpec::AttacksYouOrPlaneswalkerYouControlOneOrMore(_) => {
             Some(PlayerFilter::IteratedPlayer)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -507,6 +507,7 @@ pub(crate) enum PredicateAst {
     SourceIsTapped,
     SourceIsSaddled,
     SourceMatches(ObjectFilter),
+    TriggeringObjectHadToAttackThisCombat,
 
     SourceHasNoCounter(CounterType),
     TriggeringObjectHadNoCounter(CounterType),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -783,6 +783,7 @@ pub enum Condition {
     MaxTimesEachTurn(u32),
     DoThisMaxTimesEachTurn(u32),
     TriggeringObjectWasEnchanted,
+    TriggeringObjectHadToAttackThisCombat,
     TriggeringObjectHadCounters {
         counter_type: CounterType,
         min_count: u32,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -512,6 +512,36 @@ fn cogwork_librarian_draft_rules_do_not_create_runtime_effects() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn firkraag_cunning_instigator_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Firkraag, Cunning Instigator");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains(
+            "Whenever one or more Dragons you control attack an opponent, goad target creature that player controls."
+        ),
+        "Firkraag should bind the attacked opponent for the goad target, got {rendered}"
+    );
+    assert!(
+        rendered.contains("if that creature had to attack this combat"),
+        "Firkraag should preserve its combat-damage intervening-if condition, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("AttacksTrigger")
+            && debug.contains("attacking_player_or_planeswalker_controlled_by: Some(\n                                    Opponent")
+            && debug.contains("controller: Some(\n                                                        Defending"),
+        "Firkraag attack trigger should structurally bind the defending opponent, got {debug}"
+    );
+    assert!(
+        debug.contains("TriggeringObjectHadToAttackThisCombat"),
+        "Firkraag combat-damage trigger should carry the had-to-attack condition, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn happily_ever_after_keeps_life_draw_and_win_gate() {
     let lines = [
         "When this enchantment enters, each player gains 5 life and draws a card.",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -528,10 +528,12 @@ fn firkraag_cunning_instigator_strict_parser_and_text_regression() {
     );
 
     let debug = format!("{:#?}", def.abilities);
+    let debug_compact = debug.split_whitespace().collect::<String>();
     assert!(
-        debug.contains("AttacksTrigger")
-            && debug.contains("attacking_player_or_planeswalker_controlled_by: Some(\n                                    Opponent")
-            && debug.contains("controller: Some(\n                                                        Defending"),
+        debug_compact.contains("AttacksTrigger")
+            && debug_compact
+                .contains("attacking_player_or_planeswalker_controlled_by:Some(Opponent,)")
+            && debug_compact.contains("controller:Some(Defending,)"),
         "Firkraag attack trigger should structurally bind the defending opponent, got {debug}"
     );
     assert!(

--- a/crates/ironsmith-runtime/src/combat_state.rs
+++ b/crates/ironsmith-runtime/src/combat_state.rs
@@ -6,7 +6,7 @@
 //! - Damage assignment order
 //! - Combat queries
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
@@ -28,6 +28,14 @@ pub struct CombatState {
     pub damage_assignment_order: HashMap<ObjectId, Vec<ObjectId>>,
     /// Attacking bands declared for the current combat.
     pub attacking_bands: Vec<Vec<ObjectId>>,
+    /// Creatures that were required to attack when they were declared this combat.
+    pub had_to_attack_this_combat: HashSet<ObjectId>,
+}
+
+impl CombatState {
+    pub fn creature_had_to_attack_this_combat(&self, creature: ObjectId) -> bool {
+        self.had_to_attack_this_combat.contains(&creature)
+    }
 }
 
 /// Information about an attacking creature.
@@ -265,6 +273,7 @@ pub fn end_combat(combat: &mut CombatState) {
     combat.attackers.clear();
     combat.blockers.clear();
     combat.damage_assignment_order.clear();
+    combat.had_to_attack_this_combat.clear();
 }
 
 fn battlefield_static_abilities(game: &GameState) -> Vec<StaticAbility> {
@@ -553,6 +562,14 @@ pub fn declare_attackers(
         }
     }
 
+    let had_to_attack: HashSet<ObjectId> = declarations
+        .iter()
+        .filter_map(|(creature_id, _)| {
+            let creature = game.object(*creature_id)?;
+            crate::rules::combat::must_attack_with_game(creature, game).then_some(*creature_id)
+        })
+        .collect();
+
     // Second pass: apply declarations and tap attackers without vigilance
     for (creature_id, target) in declarations {
         // Add to attackers list
@@ -563,6 +580,9 @@ pub fn declare_attackers(
 
         // Initialize empty blocker list
         combat.blockers.insert(creature_id, Vec::new());
+        if had_to_attack.contains(&creature_id) {
+            combat.had_to_attack_this_combat.insert(creature_id);
+        }
 
         // Tap the creature unless it has vigilance
         let creature = game.object(creature_id).unwrap();

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6672,6 +6672,17 @@ pub(super) fn describe_attach_objects_spec(spec: &ChooseSpec) -> String {
 
 pub(super) fn describe_goad_target(spec: &ChooseSpec) -> String {
     match spec {
+        ChooseSpec::Target(inner) => {
+            if let ChooseSpec::Object(filter) = inner.as_ref()
+                && filter.zone == Some(Zone::Battlefield)
+                && filter.card_types == vec![CardType::Creature]
+                && filter.controller == Some(PlayerFilter::Defending)
+                && filter.subtypes.is_empty()
+            {
+                return "target creature that player controls".to_string();
+            }
+            describe_choose_spec(spec)
+        }
         ChooseSpec::Tagged(tag) => {
             if tag.as_str().starts_with("counters_") {
                 return "each creature that had counters put on it this way".to_string();
@@ -11361,6 +11372,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             format!("this effect has been used fewer than {limit} times this turn")
         }
         Condition::TriggeringObjectWasEnchanted => "the triggering object was enchanted".to_string(),
+        Condition::TriggeringObjectHadToAttackThisCombat => {
+            "that creature had to attack this combat".to_string()
+        }
         Condition::TriggeringObjectHadCounters {
             counter_type,
             min_count,

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -990,6 +990,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::MaxTimesEachTurn(..) => {}
         Condition::DoThisMaxTimesEachTurn(..) => {}
         Condition::TriggeringObjectWasEnchanted => {}
+        Condition::TriggeringObjectHadToAttackThisCombat => {}
         Condition::TriggeringObjectHadCounters { .. } => {}
         Condition::ControlCreaturesTotalPowerAtLeast(..) => {}
         Condition::CardInYourGraveyard { .. } => {}
@@ -1353,6 +1354,11 @@ pub fn evaluate_condition_external(
             .triggering_event
             .and_then(|event| event.snapshot())
             .is_some_and(|snapshot| snapshot.was_enchanted),
+        Condition::TriggeringObjectHadToAttackThisCombat => ctx
+            .triggering_event
+            .and_then(|event| event.object_id())
+            .and_then(|object_id| game.object(object_id))
+            .is_some_and(|object| crate::rules::combat::must_attack_with_game(object, game)),
         Condition::TriggeringObjectHadCounters {
             counter_type,
             min_count,
@@ -2446,9 +2452,9 @@ fn evaluate_condition_simple(
         Condition::FirstTimeThisTurn
         | Condition::MaxTimesEachTurn(_)
         | Condition::DoThisMaxTimesEachTurn(_) => true,
-        Condition::TriggeringObjectWasEnchanted | Condition::TriggeringObjectHadCounters { .. } => {
-            false
-        }
+        Condition::TriggeringObjectWasEnchanted
+        | Condition::TriggeringObjectHadToAttackThisCombat
+        | Condition::TriggeringObjectHadCounters { .. } => false,
         Condition::ControlCreaturesTotalPowerAtLeast(_)
         | Condition::CardInYourGraveyard { .. }
         | Condition::ActivationTiming(_)
@@ -3405,6 +3411,12 @@ fn evaluate_condition(
             .as_ref()
             .and_then(|event| event.snapshot())
             .is_some_and(|snapshot| snapshot.was_enchanted)),
+        Condition::TriggeringObjectHadToAttackThisCombat => Ok(ctx
+            .triggering_event
+            .as_ref()
+            .and_then(|event| event.object_id())
+            .and_then(|object_id| game.object(object_id))
+            .is_some_and(|object| crate::rules::combat::must_attack_with_game(object, game))),
         Condition::TriggeringObjectHadCounters {
             counter_type,
             min_count,

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -698,6 +698,19 @@ fn condition_filter_context(
     ctx
 }
 
+fn triggering_object_had_to_attack_this_combat(
+    game: &GameState,
+    triggering_event: Option<&TriggerEvent>,
+) -> bool {
+    triggering_event
+        .and_then(|event| event.object_id())
+        .is_some_and(|object_id| {
+            game.combat
+                .as_ref()
+                .is_some_and(|combat| combat.creature_had_to_attack_this_combat(object_id))
+        })
+}
+
 fn evaluate_condition_shared_core(
     game: &GameState,
     condition: &Condition,
@@ -1354,11 +1367,9 @@ pub fn evaluate_condition_external(
             .triggering_event
             .and_then(|event| event.snapshot())
             .is_some_and(|snapshot| snapshot.was_enchanted),
-        Condition::TriggeringObjectHadToAttackThisCombat => ctx
-            .triggering_event
-            .and_then(|event| event.object_id())
-            .and_then(|object_id| game.object(object_id))
-            .is_some_and(|object| crate::rules::combat::must_attack_with_game(object, game)),
+        Condition::TriggeringObjectHadToAttackThisCombat => {
+            triggering_object_had_to_attack_this_combat(game, ctx.triggering_event)
+        }
         Condition::TriggeringObjectHadCounters {
             counter_type,
             min_count,
@@ -3411,12 +3422,9 @@ fn evaluate_condition(
             .as_ref()
             .and_then(|event| event.snapshot())
             .is_some_and(|snapshot| snapshot.was_enchanted)),
-        Condition::TriggeringObjectHadToAttackThisCombat => Ok(ctx
-            .triggering_event
-            .as_ref()
-            .and_then(|event| event.object_id())
-            .and_then(|object_id| game.object(object_id))
-            .is_some_and(|object| crate::rules::combat::must_attack_with_game(object, game))),
+        Condition::TriggeringObjectHadToAttackThisCombat => Ok(
+            triggering_object_had_to_attack_this_combat(game, ctx.triggering_event.as_ref()),
+        ),
         Condition::TriggeringObjectHadCounters {
             counter_type,
             min_count,

--- a/crates/ironsmith-runtime/src/effects/permanents/meld.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/meld.rs
@@ -379,6 +379,7 @@ mod tests {
             blockers: Default::default(),
             damage_assignment_order: Default::default(),
             attacking_bands: Default::default(),
+            had_to_attack_this_combat: Default::default(),
         });
 
         let mut ctx = ExecutionContext::new_default(source_battlefield, alice)

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -4787,6 +4787,7 @@ mod tests {
             blockers: std::collections::HashMap::from([(attacker.id, vec![blocker.id])]),
             damage_assignment_order: std::collections::HashMap::new(),
             attacking_bands: Vec::new(),
+            had_to_attack_this_combat: Default::default(),
         });
 
         let blocker_snapshot =

--- a/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
@@ -172,6 +172,7 @@ struct PreparedAttackerDeclaration {
     declaration: AttackerDeclaration,
     controller: PlayerId,
     abilities: Vec<crate::static_abilities::StaticAbility>,
+    had_to_attack_this_combat: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -286,6 +287,7 @@ fn prepare_attacker_declarations(
             declaration: decl.clone(),
             controller: game.controller_of(creature),
             abilities,
+            had_to_attack_this_combat: legal_option.must_attack,
         });
 
         if let AttackTarget::Player(defending_player) = &decl.target {
@@ -412,6 +414,7 @@ fn apply_prepared_attacker_declarations_with_dm(
 
     // Clear any existing attackers.
     combat.attackers.clear();
+    combat.had_to_attack_this_combat.clear();
     if !declarations.is_empty() {
         game.turn_store
             .turn_history
@@ -419,7 +422,8 @@ fn apply_prepared_attacker_declarations_with_dm(
             .insert(game.turn.active_player);
     }
 
-    for decl in &declarations {
+    for prepared_decl in &prepared.declarations {
+        let decl = &prepared_decl.declaration;
         let Some(creature) = game.object(decl.creature) else {
             return Err(
                 ResponseError::InvalidAttackers("Creature cannot attack".to_string()).into(),
@@ -430,6 +434,9 @@ fn apply_prepared_attacker_declarations_with_dm(
             creature: decl.creature,
             target: decl.target.clone(),
         });
+        if prepared_decl.had_to_attack_this_combat {
+            combat.had_to_attack_this_combat.insert(decl.creature);
+        }
 
         if !crate::rules::combat::has_vigilance_with_game(creature, game) {
             tap_permanent_with_trigger(game, trigger_queue, decl.creature);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11072,6 +11072,44 @@ fn firkraag_attack_trigger_fires_once_for_each_attacked_opponent() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn firkraag_attack_trigger_does_not_fire_for_dragon_attacking_planeswalker() {
+    let (mut game, alice, bob, _charlie, _firkraag) = create_firkraag_game();
+    let dragon = create_creature(&mut game, "Planeswalker-Bound Dragon", alice, 4, 4);
+    game.object_mut(dragon)
+        .expect("Planeswalker-Bound Dragon should exist")
+        .subtypes
+        .push(Subtype::Dragon);
+    game.remove_summoning_sickness(dragon);
+    let planeswalker = CardBuilder::new(CardId::from_raw(72_942), "Bob Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(4)
+        .build();
+    let planeswalker_id = game.create_object_from_card(&planeswalker, bob, Zone::Battlefield);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: dragon,
+            target: AttackTarget::Planeswalker(planeswalker_id),
+        }],
+    )
+    .expect("Dragon should be able to attack an opponent's planeswalker");
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Firkraag should trigger only for Dragons attacking an opponent, not a planeswalker"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn firkraag_damage_trigger_requires_creature_that_had_to_attack() {
     let (mut game, alice, bob, charlie, firkraag) = create_firkraag_game();
     let forced_attacker = create_creature(&mut game, "Forced Attacker", bob, 2, 2);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11002,12 +11002,109 @@ fn firkraag_attack_trigger_goads_only_creature_that_attacked_player_controls() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn firkraag_attack_trigger_fires_once_for_each_attacked_opponent() {
+    let (mut game, alice, bob, charlie, _firkraag) = create_firkraag_game();
+    let bob_dragon = create_creature(&mut game, "Bob-Bound Dragon", alice, 4, 4);
+    game.object_mut(bob_dragon)
+        .expect("Bob-Bound Dragon should exist")
+        .subtypes
+        .push(Subtype::Dragon);
+    let charlie_dragon = create_creature(&mut game, "Charlie-Bound Dragon", alice, 4, 4);
+    game.object_mut(charlie_dragon)
+        .expect("Charlie-Bound Dragon should exist")
+        .subtypes
+        .push(Subtype::Dragon);
+    game.remove_summoning_sickness(bob_dragon);
+    game.remove_summoning_sickness(charlie_dragon);
+    let bob_creature = create_creature(&mut game, "Bob Creature", bob, 2, 2);
+    let charlie_creature = create_creature(&mut game, "Charlie Creature", charlie, 2, 2);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[
+            AttackerDeclaration {
+                creature: bob_dragon,
+                target: AttackTarget::Player(bob),
+            },
+            AttackerDeclaration {
+                creature: charlie_dragon,
+                target: AttackTarget::Player(charlie),
+            },
+        ],
+    )
+    .expect("both Dragons should be declared as attackers");
+    game.combat = Some(combat);
+
+    assert_eq!(
+        trigger_queue.entries.len(),
+        2,
+        "Firkraag should trigger once for each opponent attacked by Dragons"
+    );
+
+    let mut dm =
+        ChooseObjectByOnlyLegalSetDecisionMaker::new(vec![bob_creature, charlie_creature]);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Firkraag attack triggers should go on the stack");
+
+    assert_eq!(dm.chosen.len(), 2);
+    assert!(dm.chosen.contains(&bob_creature));
+    assert!(dm.chosen.contains(&charlie_creature));
+    assert!(
+        dm.seen_candidate_sets.iter().any(|candidates| {
+            candidates.contains(&bob_creature) && !candidates.contains(&charlie_creature)
+        }),
+        "one trigger should target only the attacked Bob's creatures"
+    );
+    assert!(
+        dm.seen_candidate_sets.iter().any(|candidates| {
+            candidates.contains(&charlie_creature) && !candidates.contains(&bob_creature)
+        }),
+        "one trigger should target only the attacked Charlie's creatures"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn firkraag_damage_trigger_requires_creature_that_had_to_attack() {
     let (mut game, alice, bob, charlie, firkraag) = create_firkraag_game();
     let forced_attacker = create_creature(&mut game, "Forced Attacker", bob, 2, 2);
     game.add_goad_effect(forced_attacker, alice, Until::Forever, firkraag);
+    game.remove_summoning_sickness(forced_attacker);
     let library_card = CardBuilder::new(CardId::from_raw(72_941), "Drawn Card").build();
     game.create_object_from_card(&library_card, alice, Zone::Library);
+
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut declaration_triggers = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut declaration_triggers,
+        &[AttackerDeclaration {
+            creature: forced_attacker,
+            target: AttackTarget::Player(charlie),
+        }],
+    )
+    .expect("goaded creature should be declared as an attacker");
+    assert!(
+        combat.creature_had_to_attack_this_combat(forced_attacker),
+        "combat state should snapshot that the creature had to attack when declared"
+    );
+    game.combat = Some(combat);
+    game.effect_store.goad_effects.clear();
+    assert!(
+        !game.is_goaded(forced_attacker),
+        "the runtime check must not rely on current goad state at damage time"
+    );
 
     let damage_event = TriggerEvent::new_with_provenance(
         crate::events::DamageEvent::with_cause(
@@ -11419,11 +11516,29 @@ struct ChooseSpecificObjectDecisionMaker {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseObjectByOnlyLegalSetDecisionMaker {
+    allowed: Vec<ObjectId>,
+    chosen: Vec<ObjectId>,
+    seen_candidate_sets: Vec<Vec<ObjectId>>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 impl ChooseSpecificObjectDecisionMaker {
     fn new(desired: ObjectId) -> Self {
         Self {
             desired,
             seen_candidates: Vec::new(),
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl ChooseObjectByOnlyLegalSetDecisionMaker {
+    fn new(allowed: Vec<ObjectId>) -> Self {
+        Self {
+            allowed,
+            chosen: Vec::new(),
+            seen_candidate_sets: Vec::new(),
         }
     }
 }
@@ -11474,6 +11589,33 @@ impl DecisionMaker for ChooseSpecificObjectDecisionMaker {
             ctx.candidates
         );
         vec![self.desired]
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseObjectByOnlyLegalSetDecisionMaker {
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<Target> {
+        let candidates: Vec<ObjectId> = ctx
+            .requirements
+            .iter()
+            .flat_map(|requirement| requirement.legal_targets.iter())
+            .filter_map(|target| match target {
+                Target::Object(id) => Some(*id),
+                Target::Player(_) => None,
+            })
+            .collect();
+        self.seen_candidate_sets.push(candidates.clone());
+        let chosen = candidates
+            .iter()
+            .copied()
+            .find(|candidate| self.allowed.contains(candidate))
+            .expect("expected one allowed object target to be legal");
+        self.chosen.push(chosen);
+        vec![Target::Object(chosen)]
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11430,6 +11430,32 @@ impl ChooseSpecificObjectDecisionMaker {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 impl DecisionMaker for ChooseSpecificObjectDecisionMaker {
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<Target> {
+        self.seen_candidates = ctx
+            .requirements
+            .iter()
+            .flat_map(|requirement| requirement.legal_targets.iter())
+            .filter_map(|target| match target {
+                Target::Object(id) => Some(*id),
+                Target::Player(_) => None,
+            })
+            .collect();
+        assert!(
+            ctx.requirements
+                .iter()
+                .any(|requirement| requirement
+                    .legal_targets
+                    .contains(&Target::Object(self.desired))),
+            "expected desired object target to be legal, got {:?}",
+            ctx.requirements
+        );
+        vec![Target::Object(self.desired)]
+    }
+
     fn decide_objects(
         &mut self,
         _game: &GameState,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -10916,6 +10916,155 @@ fn create_creature(
     game.create_object_from_card(&card, owner, Zone::Battlefield)
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn firkraag_cunning_instigator_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_940), "Firkraag, Cunning Instigator")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Red],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dragon])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Flying, haste\n\
+             Whenever one or more Dragons you control attack an opponent, goad target creature that player controls.\n\
+             Whenever a creature deals combat damage to one of your opponents, if that creature had to attack this combat, you put a +1/+1 counter on Firkraag and you draw a card.",
+        )
+        .expect("Firkraag, Cunning Instigator should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_firkraag_game() -> (GameState, PlayerId, PlayerId, PlayerId, ObjectId) {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let firkraag = game.create_object_from_definition(
+        &firkraag_cunning_instigator_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    (game, alice, bob, charlie, firkraag)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn firkraag_attack_trigger_goads_only_creature_that_attacked_player_controls() {
+    let (mut game, alice, bob, charlie, _firkraag) = create_firkraag_game();
+    let dragon = create_creature(&mut game, "Dragon Ally", alice, 4, 4);
+    game.object_mut(dragon)
+        .expect("Dragon Ally should exist")
+        .subtypes
+        .push(Subtype::Dragon);
+    let bob_creature = create_creature(&mut game, "Bob Creature", bob, 2, 2);
+    let charlie_creature = create_creature(&mut game, "Charlie Creature", charlie, 2, 2);
+
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: dragon,
+            target: AttackTarget::Player(bob),
+        }],
+        ..Default::default()
+    });
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::with_total_attackers(
+            dragon,
+            crate::triggers::AttackEventTarget::Player(bob),
+            1,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        trigger_queue.add(trigger);
+    }
+    let mut dm = ChooseSpecificObjectDecisionMaker::new(bob_creature);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Firkraag attack trigger should go on the stack");
+
+    assert!(
+        dm.seen_candidates.contains(&bob_creature),
+        "Bob's creature should be a legal goad target"
+    );
+    assert!(
+        !dm.seen_candidates.contains(&charlie_creature),
+        "Charlie's creature should not be targetable by the trigger for attacking Bob"
+    );
+
+    let mut auto = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut auto).expect("Firkraag goad trigger should resolve");
+    assert!(game.is_goaded(bob_creature));
+    assert!(!game.is_goaded(charlie_creature));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn firkraag_damage_trigger_requires_creature_that_had_to_attack() {
+    let (mut game, alice, bob, charlie, firkraag) = create_firkraag_game();
+    let forced_attacker = create_creature(&mut game, "Forced Attacker", bob, 2, 2);
+    game.add_goad_effect(forced_attacker, alice, Until::Forever, firkraag);
+    let library_card = CardBuilder::new(CardId::from_raw(72_941), "Drawn Card").build();
+    game.create_object_from_card(&library_card, alice, Zone::Library);
+
+    let damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            forced_attacker,
+            crate::events::DamageTarget::Player(charlie),
+            2,
+            true,
+            crate::events::EventCause::from_combat_damage(forced_attacker, bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &damage_event) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Firkraag damage trigger should go on the stack for forced attacker");
+    assert_eq!(game.stack.len(), 1);
+
+    let mut auto = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut auto).expect("Firkraag damage trigger should resolve");
+    assert_eq!(
+        game.object(firkraag)
+            .expect("Firkraag should still exist")
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0),
+        1,
+        "Firkraag should get a +1/+1 counter"
+    );
+    assert_eq!(game.player(alice).expect("Alice should exist").hand.len(), 1);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn firkraag_damage_trigger_does_not_fire_when_creature_did_not_have_to_attack() {
+    let (game, _alice, bob, charlie, _firkraag) = create_firkraag_game();
+    let mut game = game;
+    let voluntary_attacker = create_creature(&mut game, "Voluntary Attacker", bob, 2, 2);
+    let damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            voluntary_attacker,
+            crate::events::DamageTarget::Player(charlie),
+            2,
+            true,
+            crate::events::EventCause::from_combat_damage(voluntary_attacker, bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert!(
+        crate::triggers::check_triggers(&game, &damage_event).is_empty(),
+        "Firkraag should not trigger for a creature that did not have to attack"
+    );
+}
+
 #[test]
 fn awaken_cast_action_is_available_even_when_normal_cast_is_legal() {
     use crate::cards::definitions::{basic_plains, basic_swamp};

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -1184,6 +1184,7 @@ mod tests {
             blockers: Default::default(),
             damage_assignment_order: Default::default(),
             attacking_bands: Default::default(),
+            had_to_attack_this_combat: Default::default(),
         });
 
         let filter = ObjectFilter::creature()
@@ -1221,6 +1222,7 @@ mod tests {
             blockers: Default::default(),
             damage_assignment_order: Default::default(),
             attacking_bands: Default::default(),
+            had_to_attack_this_combat: Default::default(),
         });
 
         let filter = ObjectFilter::creature().controlled_by(PlayerFilter::Defending);
@@ -1252,6 +1254,7 @@ mod tests {
             blockers: Default::default(),
             damage_assignment_order: Default::default(),
             attacking_bands: Default::default(),
+            had_to_attack_this_combat: Default::default(),
         });
 
         let legal_targets = compute_legal_targets(

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -4,7 +4,7 @@ use crate::events::EventKind;
 use crate::events::combat::CreatureAttackedEvent;
 use crate::filter::{ObjectFilterExt as _, PlayerFilterExt as _};
 use crate::ids::ObjectId;
-use crate::target::ObjectFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 use crate::triggers::TriggerEvent;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
 
@@ -161,29 +161,48 @@ impl TriggerMatcher for AttacksTrigger {
     }
 
     fn display(&self) -> String {
-        let mut subject = self.filter.description();
+        let mut display_filter = self.filter.clone();
+        let attacked_player = display_filter
+            .attacking_player_or_planeswalker_controlled_by
+            .take();
+        let attacked_target_must_be_player = display_filter.targets_only_player.take().is_some();
+        let mut subject = display_filter.description();
         if let Some(stripped) = subject.strip_prefix("a ") {
             subject = stripped.to_string();
         } else if let Some(stripped) = subject.strip_prefix("an ") {
             subject = stripped.to_string();
         }
+        let subject = if self.one_or_more {
+            pluralize_one_or_more_attack_subject(&subject)
+        } else {
+            subject
+        };
+        let target_tail = match (attacked_player.as_ref(), attacked_target_must_be_player) {
+            (Some(PlayerFilter::Opponent), true) => " an opponent",
+            (Some(PlayerFilter::Any), true) => " a player",
+            (Some(PlayerFilter::Opponent), false) => {
+                " an opponent or a planeswalker controlled by an opponent"
+            }
+            (Some(PlayerFilter::You), true) => " you",
+            _ => "",
+        };
 
         if self.one_or_more {
             if self.min_total_attackers > 1 {
                 return format!(
-                    "Whenever {} or more {subject} attack",
-                    self.min_total_attackers
+                    "Whenever {} or more {subject} attack{target_tail}",
+                    self.min_total_attackers,
                 );
             }
-            return format!("Whenever one or more {subject} attack");
+            return format!("Whenever one or more {subject} attack{target_tail}");
         }
         if self.min_total_attackers > 1 {
             return format!(
-                "Whenever {} or more {subject} attack",
-                self.min_total_attackers
+                "Whenever {} or more {subject} attack{target_tail}",
+                self.min_total_attackers,
             );
         }
-        format!("Whenever {} attacks", self.filter.description())
+        format!("Whenever {} attacks{target_tail}", display_filter.description())
     }
 
     fn event_value_amount(&self, event: &TriggerEvent, ctx: &TriggerContext) -> Option<i32> {
@@ -192,6 +211,35 @@ impl TriggerMatcher for AttacksTrigger {
         }
         self.matching_attacker_count_this_combat(ctx)
     }
+}
+
+fn pluralize_one_or_more_attack_subject(subject: &str) -> String {
+    if let Some((head, tail)) = subject.split_once(" creature ") {
+        if !head.contains(' ')
+            && head.chars().next().is_some_and(|ch| ch.is_ascii_uppercase())
+        {
+            return format!("{head}s {tail}");
+        }
+        return format!("{head} creatures {tail}");
+    }
+    if let Some(stripped) = subject.strip_suffix(" creature") {
+        if !stripped.contains(' ')
+            && stripped
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_uppercase())
+        {
+            return format!("{stripped}s");
+        }
+        return format!("{stripped} creatures");
+    }
+    if let Some((head, tail)) = subject.split_once(" permanent ") {
+        return format!("{head} permanents {tail}");
+    }
+    if let Some(stripped) = subject.strip_suffix(" permanent") {
+        return format!("{stripped} permanents");
+    }
+    subject.to_string()
 }
 
 #[cfg(test)]

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -61,12 +61,26 @@ impl AttacksTrigger {
     fn is_first_matching_attacker_this_combat(
         &self,
         attacker: ObjectId,
+        attack_target: &crate::combat_state::AttackTarget,
         ctx: &TriggerContext,
     ) -> bool {
         let Some(combat) = ctx.game.combat.as_ref() else {
             return true;
         };
+        let match_per_defending_player = self
+            .filter
+            .attacking_player_or_planeswalker_controlled_by
+            .is_some();
+        let current_defending_player = match_per_defending_player
+            .then(|| defending_player_for_attack_target(attack_target, ctx.game))
+            .flatten();
         for info in &combat.attackers {
+            if match_per_defending_player
+                && defending_player_for_attack_target(&info.target, ctx.game)
+                    != current_defending_player
+            {
+                continue;
+            }
             if self.matches_attacker_info(info, ctx) {
                 return info.creature == attacker;
             }
@@ -155,7 +169,7 @@ impl TriggerMatcher for AttacksTrigger {
             return false;
         }
         if self.one_or_more {
-            return self.is_first_matching_attacker_this_combat(e.attacker, ctx);
+            return self.is_first_matching_attacker_this_combat(e.attacker, &attack_target, ctx);
         }
         true
     }
@@ -210,6 +224,18 @@ impl TriggerMatcher for AttacksTrigger {
             return None;
         }
         self.matching_attacker_count_this_combat(ctx)
+    }
+}
+
+fn defending_player_for_attack_target(
+    target: &crate::combat_state::AttackTarget,
+    game: &crate::game_state::GameState,
+) -> Option<crate::ids::PlayerId> {
+    match target {
+        crate::combat_state::AttackTarget::Player(player) => Some(*player),
+        crate::combat_state::AttackTarget::Planeswalker(planeswalker) => game
+            .object(*planeswalker)
+            .map(|planeswalker| game.controller_of(planeswalker)),
     }
 }
 
@@ -335,6 +361,72 @@ mod tests {
             crate::provenance::ProvNodeId::default(),
         );
         assert!(!trigger.matches(&second_event, &ctx));
+    }
+
+    #[test]
+    fn one_or_more_attack_an_opponent_matches_first_attacker_for_each_opponent() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let charlie = PlayerId::from_index(2);
+        let source_id = ObjectId::from_raw(100);
+        let bob_attacker_one = create_creature(&mut game, "A", alice);
+        let bob_attacker_two = create_creature(&mut game, "B", alice);
+        let charlie_attacker = create_creature(&mut game, "C", alice);
+
+        let mut combat = CombatState::default();
+        combat.attackers.push(AttackerInfo {
+            creature: bob_attacker_one,
+            target: AttackTarget::Player(bob),
+        });
+        combat.attackers.push(AttackerInfo {
+            creature: bob_attacker_two,
+            target: AttackTarget::Player(bob),
+        });
+        combat.attackers.push(AttackerInfo {
+            creature: charlie_attacker,
+            target: AttackTarget::Player(charlie),
+        });
+        game.combat = Some(combat);
+
+        let mut filter = ObjectFilter::creature().you_control();
+        filter.attacking_player_or_planeswalker_controlled_by = Some(PlayerFilter::Opponent);
+        filter.targets_only_player = Some(PlayerFilter::Any);
+        let trigger = AttacksTrigger::one_or_more(filter);
+        let ctx = TriggerContext::for_source(source_id, alice, &game);
+
+        let first_bob_event = TriggerEvent::new_with_provenance(
+            CreatureAttackedEvent::with_total_attackers(
+                bob_attacker_one,
+                AttackEventTarget::Player(bob),
+                3,
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        assert!(trigger.matches(&first_bob_event, &ctx));
+
+        let second_bob_event = TriggerEvent::new_with_provenance(
+            CreatureAttackedEvent::with_total_attackers(
+                bob_attacker_two,
+                AttackEventTarget::Player(bob),
+                3,
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        assert!(!trigger.matches(&second_bob_event, &ctx));
+
+        let charlie_event = TriggerEvent::new_with_provenance(
+            CreatureAttackedEvent::with_total_attackers(
+                charlie_attacker,
+                AttackEventTarget::Player(charlie),
+                3,
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        assert!(trigger.matches(&charlie_event, &ctx));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/triggers/combat/deals_combat_damage_to_player.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/deals_combat_damage_to_player.rs
@@ -98,13 +98,41 @@ impl TriggerMatcher for DealsCombatDamageToPlayerTrigger {
             };
             return format!("Whenever one or more {subject} deal combat damage to {player}");
         }
-        let player = self.player.description();
+        let player = if matches!(self.player, PlayerFilter::Opponent) {
+            "one of your opponents".to_string()
+        } else {
+            self.player.description()
+        };
+        let subject = with_indefinite_article(self.filter.description());
         format!(
             "Whenever {} deals combat damage to {}",
-            self.filter.description(),
-            player
+            subject, player
         )
     }
+}
+
+fn with_indefinite_article(subject: String) -> String {
+    let trimmed = subject.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("a ")
+        || lower.starts_with("an ")
+        || lower.starts_with("the ")
+        || lower.starts_with("this ")
+        || lower.starts_with("that ")
+        || lower.starts_with("target ")
+    {
+        return trimmed.to_string();
+    }
+    let article = if trimmed
+        .chars()
+        .next()
+        .is_some_and(|ch| matches!(ch.to_ascii_lowercase(), 'a' | 'e' | 'i' | 'o' | 'u'))
+    {
+        "an"
+    } else {
+        "a"
+    };
+    format!("{article} {trimmed}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Firkraag, Cunning Instigator
Initial parse error:
```
triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(TargetOnlyEffect { target: Target(Object(ObjectFilter { zone: Some(Battlefield), controller: Some(IteratedPlayer), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false })) }); oracle-only fallback also failed: triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(TargetOnlyEffect { target: Target(Object(ObjectFilter { zone: Some(Battlefield), controller: Some(IteratedPlayer), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false })) })
```

Current worker: i-0ba0273d04e1f357d
Branch: codex/aws-card-fix-firkraag-cunning-instigator
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0090
