### PR TITLE
Fix Ironsmith parse failure: Tsabo's Assassin

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
@@ -142,6 +142,33 @@ pub(crate) fn has_different_mana_value_constraint_sentence_lexed(tokens: &[Owned
 }
 
 pub(crate) fn has_most_common_color_constraint_sentence_lexed(tokens: &[OwnedLexToken]) -> bool {
+    if primitives::words_find_phrase(
+        tokens,
+        &[
+            "shares",
+            "a",
+            "color",
+            "with",
+            "the",
+            "most",
+            "common",
+            "color",
+            "among",
+            "all",
+            "permanents",
+            "or",
+            "a",
+            "color",
+            "tied",
+            "for",
+            "most",
+            "common",
+        ],
+    )
+    .is_some()
+    {
+        return false;
+    }
     primitives::words_find_phrase(tokens, &["most", "common", "color", "among", "all"]).is_some()
         && primitives::contains_word(tokens, "permanents")
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2931,6 +2931,30 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
                 ObjectFilter::default().shares_card_type_with_tagged("triggering"),
             ));
         }
+        if matches!(
+            descriptor_words.as_slice(),
+            [
+                "shares",
+                "color",
+                "with",
+                "most",
+                "common",
+                "color",
+                "among",
+                "all",
+                "permanents",
+                "or",
+                "color",
+                "tied",
+                "for",
+                "most",
+                "common"
+            ]
+        ) {
+            return Ok(PredicateAst::ItMatches(
+                ObjectFilter::default().shares_most_common_permanent_color(),
+            ));
+        }
         if slice_starts_with(&descriptor_words, &["not", "token"]) {
             descriptor_words.drain(0..2);
             descriptor_words.insert(0, "nontoken");

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -50,6 +50,7 @@ pub enum TaggedOpbjectRelation {
     SharesCardType,
     SharesSubtypeWithTagged,
     SharesColorWithTagged,
+    SharesMostCommonPermanentColor,
     SameStableId,
     SameNameAsTagged,
     DifferentNameFromTagged,
@@ -1075,6 +1076,13 @@ impl ObjectFilter {
         self.match_tagged(tag, TaggedOpbjectRelation::SharesColorWithTagged)
     }
 
+    pub fn shares_most_common_permanent_color(self) -> Self {
+        self.match_tagged(
+            TagKey::from("most_common_permanent_color"),
+            TaggedOpbjectRelation::SharesMostCommonPermanentColor,
+        )
+    }
+
     pub fn shares_subtype_with_tagged(self, tag: impl Into<TagKey>) -> Self {
         self.match_tagged(tag, TaggedOpbjectRelation::SharesSubtypeWithTagged)
     }
@@ -1396,6 +1404,12 @@ impl ObjectFilter {
                 }
                 TaggedOpbjectRelation::SharesColorWithTagged => {
                     post_noun_qualifiers.push("that shares a color with that object".to_string());
+                }
+                TaggedOpbjectRelation::SharesMostCommonPermanentColor => {
+                    post_noun_qualifiers.push(
+                        "that shares a color with the most common color among all permanents or a color tied for most common"
+                            .to_string(),
+                    );
                 }
                 TaggedOpbjectRelation::SharesSubtypeWithTagged => {
                     post_noun_qualifiers

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -9430,14 +9430,16 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
-    fn parse_rejects_most_common_color_constraint_clause() {
-        let result = CardDefinitionBuilder::new(CardId::new(), "Barrin Unmaking Variant")
+    fn parse_supports_most_common_color_constraint_clause() {
+        let definition = CardDefinitionBuilder::new(CardId::new(), "Barrin Unmaking Variant")
             .parse_text(
                 "Return target permanent to its owner's hand if that permanent shares a color with the most common color among all permanents or a color tied for most common.",
-            );
+            )
+            .expect("most-common-color conditional should parse structurally");
+        let debug = format!("{:#?}", definition.spell_effect);
         assert!(
-            result.is_err(),
-            "unsupported most-common-color conditional should fail parse instead of dropping the condition"
+            debug.contains("ConditionalEffect") && debug.contains("SharesMostCommonPermanentColor"),
+            "expected most-common-color target condition in lowered effects, got {debug}"
         );
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11509,6 +11509,41 @@ fn test_guard_dogs_keeps_color_sharing_prevention_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn tsabos_assassin_parses_and_renders_most_common_color_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(44_300), "Tsabo's Assassin")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Phyrexian, Subtype::Zombie, Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{T}: Destroy target creature if it shares a color with the most common color among all permanents or a color tied for most common. A creature destroyed this way can't be regenerated.",
+        )
+        .expect("Tsabo's Assassin should parse strictly");
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("ConditionalEffect")
+            && ability_debug.contains("SharesMostCommonPermanentColor")
+            && ability_debug.contains("DestroyNoRegenerationEffect"),
+        "expected conditional most-common-color destroy in Tsabo's Assassin, got {ability_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("destroy target creature if it shares a color with the most common color among all permanents or a color tied for most common")
+            && (rendered.contains("can't be regenerated") || rendered.contains("cant be regenerated")),
+        "expected Tsabo's Assassin compiled text to keep the most-common-color and regeneration clauses, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_heroism_parses_for_each_attacking_red_prevention_unless_pays() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Heroism")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3872,6 +3872,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_may_choose_pay_for_each_then_untap_tagged(&filtered) {
         return compact;
     }
+    if let Some(compact) = describe_targeted_most_common_color_conditional_destroy(&filtered) {
+        return compact;
+    }
 
     fn describe_search_two_split_hand_graveyard(effects: &[&Effect]) -> Option<String> {
         let [
@@ -5739,6 +5742,51 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             .downcast_ref::<crate::effects::WithIdEffect>()?
             .effect
             .downcast_ref::<crate::effects::DestroyNoRegenerationEffect>()
+    }
+
+    fn filter_has_most_common_permanent_color_constraint(
+        filter: &crate::target::ObjectFilter,
+    ) -> bool {
+        filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation
+                == crate::target::TaggedOpbjectRelation::SharesMostCommonPermanentColor
+        })
+    }
+
+    fn describe_targeted_most_common_color_conditional_destroy(
+        effects: &[&Effect],
+    ) -> Option<String> {
+        let [target_effect, conditional_effect] = effects else {
+            return None;
+        };
+        let target_tag = effect_tag(target_effect)?;
+        let target_only = downcast_target_only(target_effect)?;
+        let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+            return None;
+        }
+        let crate::effect::Condition::TaggedObjectMatches(condition_tag, filter) =
+            &conditional.condition
+        else {
+            return None;
+        };
+        if condition_tag != target_tag || !filter_has_most_common_permanent_color_constraint(filter)
+        {
+            return None;
+        }
+
+        let target_text = describe_choose_spec(&target_only.target);
+        let condition_text = "it shares a color with the most common color among all permanents or a color tied for most common";
+        let true_effect = conditional.if_true.first()?;
+        if downcast_destroy_no_regeneration(true_effect).is_some() {
+            return Some(format!(
+                "Destroy {target_text} if {condition_text}. A creature destroyed this way can't be regenerated"
+            ));
+        }
+        if downcast_destroy(true_effect).is_some() {
+            return Some(format!("Destroy {target_text} if {condition_text}"));
+        }
+        None
     }
 
     fn downcast_return_all_to_battlefield<'a>(

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -9,7 +9,7 @@
 //! - Cost requirements (for sacrifice costs, etc.)
 //! - Triggered ability conditions (for triggers that watch for specific events)
 
-use crate::color::ColorSet;
+use crate::color::{Color, ColorSet};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId, StableId};
 use crate::object::{CounterType, Object, ObjectKind};
@@ -389,6 +389,9 @@ fn tagged_constraint_matches_subject(
                 .intersection(snapshot.colors)
                 .is_empty()
         }),
+        TaggedOpbjectRelation::SharesMostCommonPermanentColor => {
+            subject_shares_most_common_permanent_color(subject, game)
+        }
         TaggedOpbjectRelation::SameStableId => tagged_snapshots
             .iter()
             .any(|snapshot| snapshot.stable_id == subject.subject_stable_id()),
@@ -432,6 +435,44 @@ fn tagged_constraint_matches_subject(
             .iter()
             .all(|snapshot| snapshot.object_id != subject.subject_object_id()),
     }
+}
+
+fn most_common_permanent_colors(game: &GameState) -> ColorSet {
+    let mut counts = [0u32; 5];
+    for object_id in game.objects_in_zone(Zone::Battlefield) {
+        let Some(object) = game.object(object_id) else {
+            continue;
+        };
+        let colors = game.current_colors(object_id).unwrap_or_else(|| object.colors());
+        for (idx, color) in Color::ALL.into_iter().enumerate() {
+            if colors.contains(color) {
+                counts[idx] += 1;
+            }
+        }
+    }
+
+    let max_count = counts.into_iter().max().unwrap_or(0);
+    if max_count == 0 {
+        return ColorSet::new();
+    }
+
+    Color::ALL
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, color)| (counts[idx] == max_count).then_some(color))
+        .collect()
+}
+
+fn subject_shares_most_common_permanent_color(
+    subject: &impl TaggedConstraintSubject,
+    game: &GameState,
+) -> bool {
+    let most_common_colors = most_common_permanent_colors(game);
+    let subject_colors = game
+        .current_colors(subject.subject_object_id())
+        .unwrap_or_else(|| subject.subject_colors());
+    !most_common_colors.is_empty()
+        && !subject_colors.intersection(most_common_colors).is_empty()
 }
 
 // ============================================================================
@@ -1445,6 +1486,12 @@ impl ObjectFilterExt for ObjectFilter {
         }
 
         for constraint in &self.tagged_constraints {
+            if constraint.relation == TaggedOpbjectRelation::SharesMostCommonPermanentColor {
+                if !subject_shares_most_common_permanent_color(subject, game) {
+                    return false;
+                }
+                continue;
+            }
             let Some(tagged_snapshots) = ctx.tagged_objects.get(constraint.tag.as_str()) else {
                 if let Some(matches) = intrinsic_attachment_tag_constraint_matches_subject(
                     subject,
@@ -2408,6 +2455,7 @@ impl ObjectFilterExt for ObjectFilter {
             relation,
             TaggedOpbjectRelation::IsNotTaggedObject
                 | TaggedOpbjectRelation::DifferentNameFromTagged
+                | TaggedOpbjectRelation::SharesMostCommonPermanentColor
         )
     }
 
@@ -3212,6 +3260,12 @@ impl ObjectFilterExt for ObjectFilter {
                 }
                 TaggedOpbjectRelation::SharesColorWithTagged => {
                     post_noun_qualifiers.push("that shares a color with that object".to_string());
+                }
+                TaggedOpbjectRelation::SharesMostCommonPermanentColor => {
+                    post_noun_qualifiers.push(
+                        "that shares a color with the most common color among all permanents or a color tied for most common"
+                            .to_string(),
+                    );
                 }
                 TaggedOpbjectRelation::SharesSubtypeWithTagged => {
                     post_noun_qualifiers

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -198,6 +198,330 @@ fn keeper_of_the_flame_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn tsabos_assassin_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_960), "Tsabo's Assassin")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Phyrexian, Subtype::Zombie, Subtype::Assassin])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{T}: Destroy target creature if it shares a color with the most common color among all permanents or a color tied for most common. A creature destroyed this way can't be regenerated.",
+        )
+        .expect("Tsabo's Assassin should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_tsabos_assassin_conditional_effect_targeting(
+    game: &mut GameState,
+    assassin_id: ObjectId,
+    target_id: ObjectId,
+    controller: PlayerId,
+) {
+    let ability_index = game
+        .object(assassin_id)
+        .expect("Tsabo's Assassin should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Tsabo's Assassin should have an activated ability");
+    let conditional_effect = match &game
+        .object(assassin_id)
+        .expect("Tsabo's Assassin should exist")
+        .abilities[ability_index]
+        .kind
+    {
+        AbilityKind::Activated(activated) => activated.effects.segments[0]
+            .default_effects
+            .iter()
+            .find(|effect| {
+                effect
+                    .downcast_ref::<crate::effects::ConditionalEffect>()
+                    .is_some()
+            })
+            .expect("Tsabo's Assassin should have a conditional destroy effect")
+            .clone(),
+        _ => panic!("Tsabo's Assassin ability should be activated"),
+    };
+    let target_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(target_id)
+            .expect("Tsabo's Assassin target should exist"),
+        game,
+    );
+    let tagged = std::collections::HashMap::from([(
+        crate::tag::TagKey::from("targeted_0"),
+        vec![target_snapshot],
+    )]);
+    let mut ctx = ExecutionContext::new_default(assassin_id, controller)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target_id)])
+        .with_tagged_objects(tagged);
+    crate::effects::execute_effect(game, &conditional_effect, &mut ctx)
+        .expect("Tsabo's Assassin conditional destroy should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tsabos_assassin_activation_is_legal_and_taps_source() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let assassin_id = game.create_object_from_definition(
+        &tsabos_assassin_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(assassin_id);
+    let target_id = create_colored_creature(
+        &mut game,
+        "Green Target",
+        bob,
+        Some(crate::color::ColorSet::GREEN),
+    );
+    let ability_index = game
+        .object(assassin_id)
+        .expect("Tsabo's Assassin should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Tsabo's Assassin should have an activated ability");
+
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                if *source == assassin_id && *idx == ability_index
+        ))
+        .expect("Tsabo's Assassin activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Tsabo's Assassin activation should start");
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("choosing Tsabo's Assassin target should complete activation");
+
+    assert!(
+        game.is_tapped(assassin_id),
+        "paying Tsabo's Assassin's activation cost should tap it"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tsabos_assassin_destroys_creature_sharing_most_common_permanent_color() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let assassin_id = game.create_object_from_definition(
+        &tsabos_assassin_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(assassin_id);
+    create_colored_creature(
+        &mut game,
+        "Blue Permanent A",
+        alice,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    create_colored_creature(
+        &mut game,
+        "Blue Permanent B",
+        bob,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    let target_id = create_colored_creature(
+        &mut game,
+        "Blue Target With Green Base Color",
+        bob,
+        Some(crate::color::ColorSet::GREEN),
+    );
+    game.object_mut(target_id)
+        .expect("target exists")
+        .color_override = Some(crate::color::ColorSet::BLUE);
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
+    game.add_regeneration_shield(target_id, 1);
+    let filter = crate::target::ObjectFilter::default().shares_most_common_permanent_color();
+    assert_eq!(
+        game.current_colors(target_id),
+        Some(crate::color::ColorSet::BLUE),
+        "test setup should make the target currently blue despite its printed green color"
+    );
+    assert!(
+        filter.matches(
+            game.object(target_id).expect("target exists"),
+            &game.filter_context_for(alice, Some(assassin_id)),
+            &game,
+        ),
+        "blue target should match the most-common permanent color predicate"
+    );
+
+    resolve_tsabos_assassin_conditional_effect_targeting(&mut game, assassin_id, target_id, alice);
+    let graveyard_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("destroyed target should still be tracked by stable id");
+
+    assert!(
+        game.player(bob)
+            .expect("Bob exists")
+            .graveyard
+            .contains(&graveyard_id),
+        "target sharing the most common permanent color should be destroyed"
+    );
+    assert_eq!(
+        game.regenerated_this_turn_count(target_id),
+        0,
+        "Tsabo's Assassin should prevent regeneration for the destroyed creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tsabos_assassin_destroys_creature_sharing_tied_most_common_color() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let assassin_id = game.create_object_from_definition(
+        &tsabos_assassin_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(assassin_id);
+    create_colored_creature(
+        &mut game,
+        "Blue Permanent A",
+        alice,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    create_colored_creature(
+        &mut game,
+        "Blue Permanent B",
+        bob,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    create_colored_creature(
+        &mut game,
+        "Red Permanent",
+        alice,
+        Some(crate::color::ColorSet::RED),
+    );
+    let target_id = create_colored_creature(
+        &mut game,
+        "Red Target",
+        bob,
+        Some(crate::color::ColorSet::RED),
+    );
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
+    let filter = crate::target::ObjectFilter::default().shares_most_common_permanent_color();
+    assert!(
+        filter.matches(
+            game.object(target_id).expect("target exists"),
+            &game.filter_context_for(alice, Some(assassin_id)),
+            &game,
+        ),
+        "red target should match the tied most-common permanent color predicate"
+    );
+
+    resolve_tsabos_assassin_conditional_effect_targeting(&mut game, assassin_id, target_id, alice);
+    let graveyard_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("destroyed target should still be tracked by stable id");
+
+    assert!(
+        game.player(bob)
+            .expect("Bob exists")
+            .graveyard
+            .contains(&graveyard_id),
+        "target sharing a tied most-common permanent color should be destroyed"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tsabos_assassin_does_not_destroy_nonmatching_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let assassin_id = game.create_object_from_definition(
+        &tsabos_assassin_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(assassin_id);
+    create_colored_creature(
+        &mut game,
+        "Blue Permanent A",
+        alice,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    create_colored_creature(
+        &mut game,
+        "Blue Permanent B",
+        bob,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    let target_id = create_colored_creature(
+        &mut game,
+        "Green Target",
+        bob,
+        Some(crate::color::ColorSet::GREEN),
+    );
+    let filter = crate::target::ObjectFilter::default().shares_most_common_permanent_color();
+    assert!(
+        !filter.matches(
+            game.object(target_id).expect("target exists"),
+            &game.filter_context_for(alice, Some(assassin_id)),
+            &game,
+        ),
+        "green target should not match the most-common permanent color predicate"
+    );
+
+    resolve_tsabos_assassin_conditional_effect_targeting(&mut game, assassin_id, target_id, alice);
+
+    assert!(
+        game.battlefield.contains(&target_id),
+        "target that does not share a most-common or tied color should remain on the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn explore_event_for(game: &GameState, controller: PlayerId, source: ObjectId) -> TriggerEvent {
     let snapshot = game
         .object(source)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -264,7 +264,7 @@ fn resolve_tsabos_assassin_conditional_effect_targeting(
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn tsabos_assassin_activation_is_legal_and_taps_source() {
+fn tsabos_assassin_activation_is_legal_taps_source_and_resolves_from_stack() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
@@ -285,6 +285,7 @@ fn tsabos_assassin_activation_is_legal_and_taps_source() {
         bob,
         Some(crate::color::ColorSet::GREEN),
     );
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
     let ability_index = game
         .object(assassin_id)
         .expect("Tsabo's Assassin should exist")
@@ -325,6 +326,18 @@ fn tsabos_assassin_activation_is_legal_and_taps_source() {
     assert!(
         game.is_tapped(assassin_id),
         "paying Tsabo's Assassin's activation cost should tap it"
+    );
+
+    resolve_stack_entry(&mut game).expect("Tsabo's Assassin ability should resolve");
+    let graveyard_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("destroyed target should still be tracked by stable id");
+    assert!(
+        game.player(bob)
+            .expect("Bob exists")
+            .graveyard
+            .contains(&graveyard_id),
+        "resolving Tsabo's Assassin from the stack should destroy a target sharing a tied most-common color"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tsabo's Assassin
Initial parse error:
```
unsupported most-common-color constraint clause (clause: 'destroy target creature if it shares a color with the most common color among all permanents or a color tied for most common') [rule=most-common-color-constraint]; oracle-only fallback also failed: unsupported most-common-color constraint clause (clause: 'destroy target creature if it shares a color with the most common color among all permanents or a color tied for most common') [rule=most-common-color-constraint]
```

Current worker: i-09b0a8f13ddc9bf3f
Branch: codex/aws-card-fix-tsabo-s-assassin
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0091
