### PR TITLE
Fix Ironsmith parse failure: Wall of Shards

### DIFF
--- a/crates/ironsmith-compiler/src/costs/mod.rs
+++ b/crates/ironsmith-compiler/src/costs/mod.rs
@@ -58,6 +58,9 @@ fn is_payment_effect(effect: &crate::effect::Effect) -> bool {
         || effect
             .downcast_ref::<effects::ChooseCreatureTypeEffect>()
             .is_some()
+        || effect
+            .downcast_ref::<effects::GainLifeEffect>()
+            .is_some_and(gain_life_effect_is_payment)
         || effect.downcast_ref::<effects::BeholdEffect>().is_some()
         || effect
             .downcast_ref::<effects::RevealTaggedEffect>()
@@ -103,6 +106,47 @@ fn is_payment_effect(effect: &crate::effect::Effect) -> bool {
     }
 
     false
+}
+
+fn gain_life_effect_is_payment(effect: &crate::effects::GainLifeEffect) -> bool {
+    gain_life_recipient_is_non_payer(&effect.player)
+}
+
+fn gain_life_recipient_is_non_payer(spec: &crate::target::ChooseSpec) -> bool {
+    match spec {
+        crate::target::ChooseSpec::SurfaceHinted { spec, .. }
+        | crate::target::ChooseSpec::Target(spec)
+        | crate::target::ChooseSpec::WithCount(spec, _)
+        | crate::target::ChooseSpec::WithCountValue(spec, _, _) => {
+            gain_life_recipient_is_non_payer(spec)
+        }
+        crate::target::ChooseSpec::Player(filter)
+        | crate::target::ChooseSpec::EachPlayer(filter)
+        | crate::target::ChooseSpec::PlayerOrPlaneswalker(filter) => {
+            gain_life_player_filter_is_non_payer(filter)
+        }
+        crate::target::ChooseSpec::SpecificPlayer(_) | crate::target::ChooseSpec::Tagged(_) => {
+            false
+        }
+        crate::target::ChooseSpec::SourceController | crate::target::ChooseSpec::SourceOwner => {
+            false
+        }
+        _ => false,
+    }
+}
+
+fn gain_life_player_filter_is_non_payer(filter: &crate::target::PlayerFilter) -> bool {
+    match filter {
+        crate::target::PlayerFilter::Opponent | crate::target::PlayerFilter::NotYou => true,
+        crate::target::PlayerFilter::Target(inner) => {
+            gain_life_player_filter_is_non_payer(inner)
+        }
+        crate::target::PlayerFilter::Excluding { base, excluded } => {
+            matches!(excluded.as_ref(), crate::target::PlayerFilter::You)
+                || gain_life_player_filter_is_non_payer(base)
+        }
+        _ => false,
+    }
 }
 
 pub(crate) fn payment_effect_to_cost(effect: crate::effect::Effect) -> Result<Cost, String> {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5260,6 +5260,35 @@ fn flashback_keyword_accepts_non_mana_total_cost() {
 }
 
 #[test]
+fn wall_of_shards_strict_parse_accepts_opponent_life_cumulative_upkeep_cost() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(23), "Wall of Shards")
+        .mana_cost(crate::mana::ManaCost::from_pips(vec![
+            vec![crate::mana::ManaSymbol::Generic(1)],
+            vec![crate::mana::ManaSymbol::White],
+        ]))
+        .supertypes(vec![Supertype::Snow])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Wall])
+        .power_toughness(crate::card::PowerToughness::fixed(1, 8))
+        .parse_text("Defender, flying\nCumulative upkeep—An opponent gains 1 life. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)")
+        .expect("Wall of Shards should parse strictly");
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("CumulativeUpkeepEffect")
+            && debug.contains("GainLifeEffect")
+            && debug.contains("Opponent")
+            && debug.contains("Defender")
+            && debug.contains("Flying"),
+        "expected Wall of Shards to lower into defender, flying, and opponent-life cumulative upkeep, got {debug}"
+    );
+    assert!(
+        !debug.contains("KeywordFallbackText") && !debug.contains("RuleFallbackText"),
+        "Wall of Shards should not compile through fallback text: {debug}"
+    );
+}
+
+#[test]
 fn jump_start_keyword_line_is_classified_as_alternative_cast() {
     let tokens = lex_line(
         "Jump-start (You may cast this card from your graveyard by discarding a card in addition to paying its other costs. Then exile this card.)",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14048,6 +14048,32 @@ mod tests {
     }
 
     #[test]
+    fn wall_of_shards_cumulative_upkeep_renders_opponent_life_payment() {
+        let triggered = crate::ability::TriggeredAbility {
+            trigger: crate::triggers::Trigger::beginning_of_upkeep(PlayerFilter::You),
+            effects: crate::resolution::ResolutionProgram::from_effects(vec![
+                Effect::put_counters_on_source(CounterType::Age, 1),
+                Effect::cumulative_upkeep(
+                    vec![Effect::gain_life_player(
+                        1,
+                        ChooseSpec::Player(PlayerFilter::Opponent),
+                    )],
+                    PlayerFilter::You,
+                    vec![Effect::sacrifice_source()],
+                ),
+            ]),
+            choices: Vec::new(),
+            intervening_if: None,
+            presentation_label: None,
+        };
+
+        assert_eq!(
+            describe_structural_cumulative_upkeep_keyword(&triggered),
+            Some("Cumulative upkeep—An opponent gains 1 life".to_string())
+        );
+    }
+
+    #[test]
     fn describe_false_only_conditional_prefers_unless_surface() {
         assert_eq!(
             describe_false_only_conditional(
@@ -33218,6 +33244,13 @@ fn cumulative_upkeep_payment_text(payment: &[Effect]) -> Option<String> {
             {
                 parts.push(format!("Pay {} life", describe_value(&lose_life.amount)));
             }
+        } else if let Some(gain_life) = effect.downcast_ref::<crate::effects::GainLifeEffect>() {
+            if cumulative_upkeep_gain_life_recipient_is_opponent(&gain_life.player) {
+                parts.push(format!(
+                    "An opponent gains {} life",
+                    describe_value(&gain_life.amount)
+                ));
+            }
         } else if let Some(put_counters) =
             effect.downcast_ref::<crate::effects::PutCountersEffect>()
         {
@@ -33236,6 +33269,21 @@ fn cumulative_upkeep_payment_text(payment: &[Effect]) -> Option<String> {
         None
     } else {
         Some(parts.join(" and "))
+    }
+}
+
+fn cumulative_upkeep_gain_life_recipient_is_opponent(spec: &ChooseSpec) -> bool {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::Target(spec)
+        | ChooseSpec::WithCount(spec, _)
+        | ChooseSpec::WithCountValue(spec, _, _) => {
+            cumulative_upkeep_gain_life_recipient_is_opponent(spec)
+        }
+        ChooseSpec::Player(PlayerFilter::Opponent | PlayerFilter::NotYou)
+        | ChooseSpec::PlayerOrPlaneswalker(PlayerFilter::Opponent | PlayerFilter::NotYou)
+        | ChooseSpec::EachPlayer(PlayerFilter::Opponent | PlayerFilter::NotYou) => true,
+        _ => false,
     }
 }
 

--- a/crates/ironsmith-runtime/src/effects/composition/cumulative_upkeep.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/cumulative_upkeep.rs
@@ -138,6 +138,9 @@ fn payment_can_complete(
         .with_decision_maker(&mut simulated_dm);
 
     for _ in 0..count {
+        if !payment_effects_can_execute_as_cost(effects, &simulated_game, &simulated_ctx) {
+            return false;
+        }
         let Ok(outcome) = execute_sequence(&mut simulated_game, &mut simulated_ctx, effects) else {
             return false;
         };
@@ -146,6 +149,24 @@ fn payment_can_complete(
         }
     }
     true
+}
+
+fn payment_effects_can_execute_as_cost(
+    effects: &[Effect],
+    game: &GameState,
+    ctx: &ExecutionContext,
+) -> bool {
+    effects.iter().all(|effect| {
+        effect.0.as_cost_executable().is_none_or(|cost_effect| {
+            crate::effects::CostExecutableEffect::can_execute_as_cost(
+                cost_effect,
+                game,
+                ctx.source,
+                ctx.controller,
+            )
+            .is_ok()
+        })
+    })
 }
 
 fn execute_payment_atomically(
@@ -161,6 +182,10 @@ fn execute_payment_atomically(
     let mut execution_error = None;
 
     for _ in 0..count {
+        if !payment_effects_can_execute_as_cost(effects, game, ctx) {
+            failed_to_pay = true;
+            break;
+        }
         match execute_sequence(game, ctx, effects) {
             Ok(outcome) => {
                 let status = outcome.status;
@@ -377,6 +402,140 @@ mod tests {
 
         assert_eq!(game.player(alice).expect("alice").life, 18);
         assert!(game.battlefield.contains(&source));
+    }
+
+    #[test]
+    fn wall_of_shards_cumulative_upkeep_paid_gives_opponent_life_per_age_counter() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let wall = CardBuilder::new(CardId::new(), "Wall of Shards")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source = game.create_object_from_card(&wall, alice, Zone::Battlefield);
+        let payment = Effect::new(crate::effects::GainLifeEffect::new(
+            1,
+            crate::target::ChooseSpec::Player(crate::target::PlayerFilter::Opponent),
+        ));
+        let cost_effect = payment
+            .downcast_ref::<crate::effects::GainLifeEffect>()
+            .expect("Wall of Shards payment should be a gain-life effect");
+        crate::effects::CostExecutableEffect::can_execute_as_cost(
+            cost_effect,
+            &game,
+            source,
+            alice,
+        )
+        .expect("opponent life gain should be executable as a cumulative upkeep cost");
+        let effects = vec![
+            Effect::put_counters_on_source(CounterType::Age, 1),
+            Effect::cumulative_upkeep(
+                vec![payment],
+                crate::target::PlayerFilter::You,
+                vec![Effect::sacrifice_source()],
+            ),
+        ];
+        let mut dm = ScriptedBooleanDecisionMaker::new(vec![true, true]);
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+
+        for effect in &effects {
+            execute_effect(&mut game, effect, &mut ctx).expect("first upkeep should resolve");
+        }
+        for effect in &effects {
+            execute_effect(&mut game, effect, &mut ctx).expect("second upkeep should resolve");
+        }
+
+        let source_obj = game.object(source).expect("Wall of Shards should remain paid");
+        assert_eq!(
+            source_obj.counters.get(&CounterType::Age).copied().unwrap_or(0),
+            2,
+            "two upkeeps should leave two age counters"
+        );
+        assert_eq!(
+            game.player(bob).expect("bob").life,
+            23,
+            "Wall of Shards should give an opponent one life per age counter paid"
+        );
+        assert!(game.battlefield.contains(&source));
+    }
+
+    #[test]
+    fn wall_of_shards_cumulative_upkeep_declined_sacrifices_without_life_gain() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let wall = CardBuilder::new(CardId::new(), "Wall of Shards")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source = game.create_object_from_card(&wall, alice, Zone::Battlefield);
+        let effects = vec![
+            Effect::put_counters_on_source(CounterType::Age, 1),
+            Effect::cumulative_upkeep(
+                vec![Effect::new(crate::effects::GainLifeEffect::new(
+                    1,
+                    crate::target::ChooseSpec::Player(crate::target::PlayerFilter::Opponent),
+                ))],
+                crate::target::PlayerFilter::You,
+                vec![Effect::sacrifice_source()],
+            ),
+        ];
+        let mut dm = BooleanDecisionMaker { response: false };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+
+        for effect in &effects {
+            execute_effect(&mut game, effect, &mut ctx)
+                .expect("declined Wall of Shards upkeep should resolve");
+        }
+
+        assert_eq!(
+            game.player(bob).expect("bob").life,
+            20,
+            "declining the upkeep should not grant the opponent life"
+        );
+        assert!(
+            !game.battlefield.contains(&source),
+            "declining cumulative upkeep should sacrifice Wall of Shards"
+        );
+    }
+
+    #[test]
+    fn wall_of_shards_cumulative_upkeep_sacrifices_when_opponent_cant_gain_life() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.effect_store.cant_effects.add_cant_gain_life(bob);
+        let wall = CardBuilder::new(CardId::new(), "Wall of Shards")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source = game.create_object_from_card(&wall, alice, Zone::Battlefield);
+        let effects = vec![
+            Effect::put_counters_on_source(CounterType::Age, 1),
+            Effect::cumulative_upkeep(
+                vec![Effect::new(crate::effects::GainLifeEffect::new(
+                    1,
+                    crate::target::ChooseSpec::Player(crate::target::PlayerFilter::Opponent),
+                ))],
+                crate::target::PlayerFilter::You,
+                vec![Effect::sacrifice_source()],
+            ),
+        ];
+        let mut dm = BooleanDecisionMaker { response: true };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+
+        for effect in &effects {
+            execute_effect(&mut game, effect, &mut ctx)
+                .expect("unpayable Wall of Shards upkeep should resolve");
+        }
+
+        assert_eq!(
+            game.player(bob).expect("bob").life,
+            20,
+            "an opponent who can't gain life should not satisfy the upkeep cost"
+        );
+        assert!(
+            !game.battlefield.contains(&source),
+            "Wall of Shards should be sacrificed when its life-gain cost can't be paid"
+        );
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/effects/composition/cumulative_upkeep.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/cumulative_upkeep.rs
@@ -6,6 +6,7 @@ use crate::effect::{Effect, EffectOutcome};
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_player_filter, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError, execute_effect};
+use crate::events::cause::EventCause;
 use crate::game_state::GameState;
 use crate::object::CounterType;
 
@@ -135,7 +136,8 @@ fn payment_can_complete(
     let mut simulated_game = game.clone();
     let mut simulated_dm = SelectFirstDecisionMaker;
     let mut simulated_ctx = ExecutionContext::new_default(ctx.source, ctx.controller)
-        .with_decision_maker(&mut simulated_dm);
+        .with_decision_maker(&mut simulated_dm)
+        .with_cause(EventCause::from_cost(ctx.source, ctx.controller));
 
     for _ in 0..count {
         if !payment_effects_can_execute_as_cost(effects, &simulated_game, &simulated_ctx) {
@@ -177,6 +179,7 @@ fn execute_payment_atomically(
 ) -> Result<Option<EffectOutcome>, ExecutionError> {
     let game_checkpoint = game.clone();
     let ctx_checkpoint = ExecutionContextCheckpoint::from_context(ctx);
+    let original_cause = ctx.cause.clone();
     let mut outcomes = Vec::new();
     let mut failed_to_pay = false;
     let mut execution_error = None;
@@ -186,6 +189,7 @@ fn execute_payment_atomically(
             failed_to_pay = true;
             break;
         }
+        ctx.cause = EventCause::from_cost(ctx.source, ctx.controller);
         match execute_sequence(game, ctx, effects) {
             Ok(outcome) => {
                 let status = outcome.status;
@@ -211,6 +215,7 @@ fn execute_payment_atomically(
         return Ok(None);
     }
 
+    ctx.cause = original_cause;
     Ok(Some(EffectOutcome::aggregate_summing_counts(outcomes)))
 }
 
@@ -535,6 +540,61 @@ mod tests {
         assert!(
             !game.battlefield.contains(&source),
             "Wall of Shards should be sacrificed when its life-gain cost can't be paid"
+        );
+    }
+
+    #[test]
+    fn wall_of_shards_cumulative_upkeep_can_choose_legal_opponent_in_multiplayer() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let charlie = PlayerId::from_index(2);
+        game.effect_store.cant_effects.add_cant_gain_life(bob);
+        let wall = CardBuilder::new(CardId::new(), "Wall of Shards")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source = game.create_object_from_card(&wall, alice, Zone::Battlefield);
+        game.object_mut(source)
+            .expect("Wall of Shards exists")
+            .add_counters(CounterType::Age, 2);
+        let payment = Effect::new(crate::effects::GainLifeEffect::new(
+            1,
+            crate::target::ChooseSpec::Player(crate::target::PlayerFilter::Opponent),
+        ));
+        let cost_effect = payment
+            .downcast_ref::<crate::effects::GainLifeEffect>()
+            .expect("Wall of Shards payment should be a gain-life effect");
+        crate::effects::CostExecutableEffect::can_execute_as_cost(
+            cost_effect,
+            &game,
+            source,
+            alice,
+        )
+        .expect("one opponent who can gain life should make the upkeep cost payable");
+        let effect = Effect::cumulative_upkeep(
+            vec![payment],
+            crate::target::PlayerFilter::You,
+            vec![Effect::sacrifice_source()],
+        );
+        let mut dm = BooleanDecisionMaker { response: true };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+
+        execute_effect(&mut game, &effect, &mut ctx)
+            .expect("multiplayer Wall of Shards upkeep should resolve");
+
+        assert!(game.battlefield.contains(&source));
+        assert_eq!(
+            game.player(bob).expect("bob").life,
+            20,
+            "an opponent who can't gain life should not be chosen for the payment"
+        );
+        assert_eq!(
+            game.player(charlie).expect("charlie").life,
+            22,
+            "the legal opponent should gain one life for each age-counter payment"
         );
     }
 

--- a/crates/ironsmith-runtime/src/effects/life/gain_life.rs
+++ b/crates/ironsmith-runtime/src/effects/life/gain_life.rs
@@ -2,14 +2,93 @@
 
 use crate::effect::EffectOutcome;
 use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
-use crate::effects::helpers::{resolve_player_from_spec, resolve_value};
+use crate::effects::helpers::{
+    resolve_player_filter_to_list, resolve_player_from_spec, resolve_value,
+};
 use crate::effects::{ExecutionContext, ExecutionError};
+use crate::events::cause::CauseType;
 use crate::events::LifeGainEvent;
 use crate::events::processing::process_life_gain_with_event;
 use crate::game_state::GameState;
+use crate::ids::PlayerId;
 use crate::target::ChooseSpec;
 use crate::triggers::TriggerEvent;
 pub use ironsmith_core::GainLifeEffect;
+
+fn candidate_life_gain_players(
+    game: &GameState,
+    spec: &ChooseSpec,
+    ctx: &ExecutionContext,
+) -> Result<Vec<PlayerId>, ExecutionError> {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::WithCount(spec, _)
+        | ChooseSpec::WithCountValue(spec, _, _) => candidate_life_gain_players(game, spec, ctx),
+        ChooseSpec::Player(filter)
+        | ChooseSpec::EachPlayer(filter)
+        | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+            let filter_ctx = ctx.filter_context(game);
+            resolve_player_filter_to_list(game, filter, &filter_ctx, ctx)
+        }
+        _ => resolve_player_from_spec(game, spec, ctx).map(|player| vec![player]),
+    }
+}
+
+fn legal_life_gain_cost_recipients(
+    game: &GameState,
+    spec: &ChooseSpec,
+    ctx: &ExecutionContext,
+) -> Result<Vec<PlayerId>, ExecutionError> {
+    let mut players = candidate_life_gain_players(game, spec, ctx)?;
+    players.retain(|player| *player != ctx.controller && game.can_gain_life(*player));
+    players.sort_by_key(|player| player.0);
+    players.dedup();
+    Ok(players)
+}
+
+fn resolve_life_gain_cost_recipient(
+    game: &GameState,
+    spec: &ChooseSpec,
+    ctx: &mut ExecutionContext,
+) -> Result<PlayerId, ExecutionError> {
+    let candidates = legal_life_gain_cost_recipients(game, spec, ctx)?;
+    if let Some(chosen) = ctx.targets.iter().find_map(|target| match target {
+        crate::effects::ResolvedTarget::Player(player) if candidates.contains(player) => {
+            Some(*player)
+        }
+        _ => None,
+    }) {
+        return Ok(chosen);
+    }
+
+    match candidates.as_slice() {
+        [player] => Ok(*player),
+        [] => Err(ExecutionError::Impossible(
+            "no legal life-gain cost recipient".to_string(),
+        )),
+        _ => {
+            let options = candidates
+                .iter()
+                .filter_map(|player_id| {
+                    game.player(*player_id)
+                        .map(|player| (player.name.clone(), *player_id))
+                })
+                .collect::<Vec<_>>();
+            crate::decisions::ask_choose_one(
+                game,
+                &mut ctx.decision_maker,
+                ctx.controller,
+                ctx.source,
+                &options,
+            )
+            .ok_or_else(|| {
+                ExecutionError::UnresolvableValue(
+                    "life-gain cost recipient choice is pending".to_string(),
+                )
+            })
+        }
+    }
+}
 
 /// Effect that causes a player to gain life.
 ///
@@ -43,7 +122,11 @@ impl EffectExecutor for GainLifeEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        let player_id = resolve_player_from_spec(game, &self.player, ctx)?;
+        let player_id = if ctx.cause.cause_type == CauseType::Cost {
+            resolve_life_gain_cost_recipient(game, &self.player, ctx)?
+        } else {
+            resolve_player_from_spec(game, &self.player, ctx)?
+        };
         let amount = resolve_value(game, &self.amount, ctx)?.max(0) as u32;
 
         // Process through replacement effects and check "can't gain life"
@@ -90,17 +173,12 @@ impl CostExecutableEffect for GainLifeEffect {
         controller: crate::ids::PlayerId,
     ) -> Result<(), CostValidationError> {
         let ctx = ExecutionContext::new_default(source, controller);
-        let player = resolve_player_from_spec(game, &self.player, &ctx).map_err(|err| {
+        let candidates = legal_life_gain_cost_recipients(game, &self.player, &ctx).map_err(|err| {
             CostValidationError::Other(format!("unable to choose life-gain recipient: {err:?}"))
         })?;
-        if player == controller {
+        if candidates.is_empty() {
             return Err(CostValidationError::Other(
-                "life-gain costs must benefit another player".to_string(),
-            ));
-        }
-        if !game.can_gain_life(player) {
-            return Err(CostValidationError::Other(
-                "chosen player can't gain life".to_string(),
+                "no legal player can gain life for this cost".to_string(),
             ));
         }
         Ok(())

--- a/crates/ironsmith-runtime/src/effects/life/gain_life.rs
+++ b/crates/ironsmith-runtime/src/effects/life/gain_life.rs
@@ -1,7 +1,7 @@
 //! Gain life effect implementation.
 
 use crate::effect::EffectOutcome;
-use crate::effects::EffectExecutor;
+use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
 use crate::effects::helpers::{resolve_player_from_spec, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::LifeGainEvent;
@@ -34,6 +34,10 @@ pub use ironsmith_core::GainLifeEffect;
 /// };
 /// ```
 impl EffectExecutor for GainLifeEffect {
+    fn as_cost_executable(&self) -> Option<&dyn CostExecutableEffect> {
+        Some(self)
+    }
+
     fn execute(
         &self,
         game: &mut GameState,
@@ -75,6 +79,31 @@ impl EffectExecutor for GainLifeEffect {
 
     fn target_description(&self) -> &'static str {
         "player to gain life"
+    }
+}
+
+impl CostExecutableEffect for GainLifeEffect {
+    fn can_execute_as_cost(
+        &self,
+        game: &GameState,
+        source: crate::ids::ObjectId,
+        controller: crate::ids::PlayerId,
+    ) -> Result<(), CostValidationError> {
+        let ctx = ExecutionContext::new_default(source, controller);
+        let player = resolve_player_from_spec(game, &self.player, &ctx).map_err(|err| {
+            CostValidationError::Other(format!("unable to choose life-gain recipient: {err:?}"))
+        })?;
+        if player == controller {
+            return Err(CostValidationError::Other(
+                "life-gain costs must benefit another player".to_string(),
+            ));
+        }
+        if !game.can_gain_life(player) {
+            return Err(CostValidationError::Other(
+                "chosen player can't gain life".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wall of Shards
Initial parse error:
```
unsupported cumulative upkeep payment cost (clause: 'An opponent gains 1 life'): effect is not marked as cost-executable: ironsmith_core::effect::GainLifeEffect; oracle-only fallback also failed: unsupported cumulative upkeep payment cost (clause: 'An opponent gains 1 life'): effect is not marked as cost-executable: ironsmith_core::effect::GainLifeEffect
```

Current worker: i-00f17a4f52246377d
Branch: codex/aws-card-fix-wall-of-shards
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0101
