### PR TITLE
Fix Ironsmith parse failure: Reaper's Scythe

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -430,6 +430,7 @@ impl CardDefinitionBuilder {
             KeywordAction::ProtectionFromSubtype(subtype) => self.protection_from_subtype(subtype),
             KeywordAction::Devoid => self.devoid(),
             KeywordAction::Annihilator(amount) => self.annihilator(amount),
+            KeywordAction::JobSelect => self.job_select(),
             KeywordAction::ForMirrodin => self.for_mirrodin(),
             KeywordAction::LivingWeapon => self.living_weapon(),
             KeywordAction::Marker(name) if name.eq_ignore_ascii_case("fuse") => self.has_fuse(),
@@ -1794,6 +1795,18 @@ impl CardDefinitionBuilder {
         ))
     }
 
+    pub fn job_select(self) -> Self {
+        let created_tag = crate::tag::TagKey::from("job_select_created");
+        self.with_ability(crate::ability::Ability::triggered(
+            crate::triggers::Trigger::this_enters_battlefield(),
+            vec![
+                crate::effect::Effect::create_tokens(Self::job_select_hero_token(), 1)
+                    .tag(created_tag.clone()),
+                crate::effect::Effect::attach_to(crate::target::ChooseSpec::Tagged(created_tag)),
+            ],
+        ))
+    }
+
     pub fn living_weapon(self) -> Self {
         let created_tag = crate::tag::TagKey::from("living_weapon_created");
         self.with_ability(crate::ability::Ability::triggered(
@@ -2264,6 +2277,15 @@ impl CardDefinitionBuilder {
             .subtypes(vec![Subtype::Rebel])
             .color_indicator(ColorSet::RED)
             .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    }
+
+    fn job_select_hero_token() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Hero")
+            .token()
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Hero])
+            .power_toughness(PowerToughness::fixed(1, 1))
             .build()
     }
 

--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -144,6 +144,7 @@ pub enum KeywordAction {
     Unblockable,
     Devoid,
     Annihilator(u32),
+    JobSelect,
     ForMirrodin,
     LivingWeapon,
     Crew {
@@ -429,6 +430,7 @@ impl KeywordAction {
             Self::Unblockable => "This can't be blocked".to_string(),
             Self::Devoid => "Devoid".to_string(),
             Self::Annihilator(amount) => format!("Annihilator {amount}"),
+            Self::JobSelect => "Job select".to_string(),
             Self::ForMirrodin => "For Mirrodin!".to_string(),
             Self::LivingWeapon => "Living weapon".to_string(),
             Self::Crew { amount, .. } => format!("Crew {amount}"),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -1105,7 +1105,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
     ) {
         return match matched_phrase {
             ["emerge", "from"] => marker_text_from_words(&words).map(KeywordAction::MarkerText),
-            ["job", "select"] => Some(KeywordAction::MarkerText("Job select".to_string())),
+            ["job", "select"] => Some(KeywordAction::JobSelect),
             ["umbra", "armor"] => Some(KeywordAction::UmbraArmor),
             _ => None,
         };
@@ -1222,6 +1222,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
     if let Some((matched_phrase, _)) = strip_prefix_phrases(
         phrase_tokens,
         &[
+            &["job", "select"],
             &["for", "mirrodin"],
             &["living", "weapon"],
             &["battle", "cry"],
@@ -1231,6 +1232,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
         ],
     ) {
         return Some(match matched_phrase {
+            ["job", "select"] => KeywordAction::JobSelect,
             ["for", "mirrodin"] => KeywordAction::ForMirrodin,
             ["living", "weapon"] => KeywordAction::LivingWeapon,
             ["battle", "cry"] => KeywordAction::BattleCry,
@@ -1343,6 +1345,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
         ["affinity", "for", "artifacts"] => KeywordAction::AffinityForArtifacts,
         ["first", "strike"] => KeywordAction::FirstStrike,
         ["double", "strike"] => KeywordAction::DoubleStrike,
+        ["job", "select"] => KeywordAction::JobSelect,
         ["for", "mirrodin"] => KeywordAction::ForMirrodin,
         ["living", "weapon"] => KeywordAction::LivingWeapon,
         ["fading", amount] => {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -486,6 +486,7 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
                 ["battle", "cry"] => Some(KeywordAction::BattleCry),
                 ["split", "second"] => Some(KeywordAction::SplitSecond),
                 ["read", "ahead"] => Some(KeywordAction::ReadAhead),
+                ["job", "select"] => Some(KeywordAction::JobSelect),
                 ["for", "mirrodin"] => Some(KeywordAction::ForMirrodin),
                 ["living", "weapon"] => Some(KeywordAction::LivingWeapon),
                 ["umbra", "armor"] => Some(KeywordAction::UmbraArmor),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -388,11 +388,31 @@ pub(super) fn lower_equip(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
 ) -> Result<LineAst, CardTextError> {
-    Ok(LineAst::Ability(require_keyword_parse(
+    let mut parsed = require_keyword_parse(
         line,
         "equip",
         parse_equip_line_lexed(tokens)?,
-    )?))
+    )?;
+    if let Some(label) = labeled_keyword_presentation_label(line.info.raw_line.as_str(), "equip")
+        && let crate::ability::AbilityKind::Activated(activated) = parsed.kind_mut()
+    {
+        activated
+            .additional_restrictions
+            .push(format!("__presentation_label: {label}"));
+    }
+    Ok(LineAst::Ability(parsed))
+}
+
+fn labeled_keyword_presentation_label(raw: &str, keyword: &str) -> Option<String> {
+    let (label, body) = raw
+        .split_once('—')
+        .or_else(|| raw.split_once('–'))
+        .or_else(|| raw.split_once(" - "))?;
+    if !body.trim_start().to_ascii_lowercase().starts_with(keyword) {
+        return None;
+    }
+    let label = label.trim();
+    (!label.is_empty()).then(|| label.to_string())
 }
 
 pub(super) fn lower_reconfigure(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2693,11 +2693,7 @@ pub(crate) fn parse_static_condition_clause(
                 )));
             };
 
-            let counter_type = if counter_word_idx > 0 {
-                parse_counter_type_word(counter_words[counter_word_idx - 1])
-            } else {
-                None
-            };
+            let counter_type = parse_counter_type_from_tokens(counter_tokens);
 
             let tail = &counter_words[counter_word_idx + 1..];
             let on_source_tail = anthem_word_slice_starts_with(tail, &["on", "it"])
@@ -3014,7 +3010,7 @@ pub(crate) fn parse_anthem_for_each_expression(
     if let Some(counter_word_idx) =
         anthem_find_word_index(&rest_words, |word| matches!(word, "counter" | "counters"))
         && counter_word_idx > 0
-        && let Some(counter_type) = parse_counter_type_word(rest_words[counter_word_idx - 1])
+        && let Some(counter_type) = parse_counter_type_from_tokens(rest)
     {
         let tail_words = &rest_words[counter_word_idx + 1..];
         let on_source_tail = anthem_word_slice_starts_with(tail_words, &["on", "it"])

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -2718,7 +2718,7 @@ fn try_parse_labeled_line_dispatch(
         }
     }
 
-    if is_named_label && let Some(keyword_line) = parse_keyword_line_cst(&body_line)? {
+    if !preserve_as_choice_label && let Some(keyword_line) = parse_keyword_line_cst(&body_line)? {
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Keyword(keyword_line),
             idx + 1,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -461,6 +461,22 @@ pub(crate) fn parse_for_each_count_value_words(words: &[&str]) -> Option<(Value,
     }
 
     match &words[idx..filter_end] {
+        ["player" | "players", "who", "lost", "life", "this", "turn"] => {
+            return Some((
+                Value::CountPlayers(PlayerFilter::LostLifeThisTurn {
+                    base: Box::new(PlayerFilter::Any),
+                }),
+                filter_end,
+            ));
+        }
+        ["opponent" | "opponents", "who", "lost", "life", "this", "turn"] => {
+            return Some((
+                Value::CountPlayers(PlayerFilter::LostLifeThisTurn {
+                    base: Box::new(PlayerFilter::Opponent),
+                }),
+                filter_end,
+            ));
+        }
         ["time", "it", "regenerated", "this", "turn"]
         | ["times", "it", "regenerated", "this", "turn"] => {
             return Some((Value::SourceRegeneratedThisTurnCount, filter_end));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -27,8 +27,9 @@ use super::super::token_primitives::{
 };
 use super::super::util::{
     parse_counter_type_from_tokens, parse_counter_type_word, parse_number, parse_target_phrase,
-    parse_value, record_source_reference_surface, source_reference_surface_for_words,
-    span_from_tokens, this_source_surface_for_words, trim_commas,
+    parse_for_each_count_value_words, parse_value, record_source_reference_surface,
+    source_reference_surface_for_words, span_from_tokens, this_source_surface_for_words,
+    trim_commas,
 };
 use super::super::value_helpers::{
     parse_equal_to_aggregate_filter_value, parse_equal_to_number_of_filter_value,
@@ -590,6 +591,18 @@ pub(crate) fn parse_put_counters(tokens: &[OwnedLexToken]) -> Result<EffectAst, 
                     dynamic
                 } else if tokens_reference_objects_this_way(&count_filter_tokens) {
                     this_way_object_count_value()
+                } else if let Some(value) = {
+                    let count_words = ZoneCounterCompatWords::new(&count_filter_tokens)
+                        .to_word_refs();
+                    let mut prefixed_words = Vec::with_capacity(count_words.len() + 2);
+                    prefixed_words.push("for");
+                    prefixed_words.push("each");
+                    prefixed_words.extend(count_words);
+                    parse_for_each_count_value_words(&prefixed_words).and_then(|(value, used)| {
+                        (used == prefixed_words.len()).then_some(value)
+                    })
+                } {
+                    value
                 } else {
                     Value::Count(parse_object_filter(&count_filter_tokens, false)?)
                 };

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -157,6 +157,9 @@ pub enum PlayerFilter {
     HasMoreLifeThanYou {
         base: Box<PlayerFilter>,
     },
+    LostLifeThisTurn {
+        base: Box<PlayerFilter>,
+    },
     MaxSpeed {
         base: Box<PlayerFilter>,
         has_max_speed: bool,
@@ -212,6 +215,7 @@ impl PlayerFilter {
             Self::Target(inner) => inner.mentions_iterated_player(),
             Self::CardsInHandAtLeastMoreThanYou { base, .. } => base.mentions_iterated_player(),
             Self::HasMoreLifeThanYou { base } => base.mentions_iterated_player(),
+            Self::LostLifeThisTurn { base } => base.mentions_iterated_player(),
             Self::MaxSpeed { base, .. } => base.mentions_iterated_player(),
             Self::Excluding { base, excluded } => {
                 base.mentions_iterated_player() || excluded.mentions_iterated_player()
@@ -276,6 +280,9 @@ impl PlayerFilter {
                     "{} who has more life than you do as you activate this ability",
                     base.description()
                 )
+            }
+            Self::LostLifeThisTurn { base } => {
+                format!("{} who lost life this turn", base.description())
             }
             Self::MaxSpeed {
                 base,
@@ -1182,6 +1189,9 @@ impl ObjectFilter {
                 PlayerFilter::HasMoreLifeThanYou { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
+                PlayerFilter::LostLifeThisTurn { .. } => {
+                    parts.push(describe_possessive_player_filter(ctrl));
+                }
                 PlayerFilter::MaxSpeed { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
@@ -1260,6 +1270,9 @@ impl ObjectFilter {
                     format!("{} owns", describe_player_filter(owner))
                 }
                 PlayerFilter::HasMoreLifeThanYou { .. } => {
+                    format!("{} owns", describe_player_filter(owner))
+                }
+                PlayerFilter::LostLifeThisTurn { .. } => {
                     format!("{} owns", describe_player_filter(owner))
                 }
                 PlayerFilter::MaxSpeed { .. } => {
@@ -2197,6 +2210,9 @@ fn describe_possessive_player_filter(filter: &PlayerFilter) -> String {
                 describe_player_filter(base)
             )
         }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            format!("{} who lost life this turn's", describe_player_filter(base))
+        }
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,
@@ -2268,6 +2284,9 @@ pub(crate) fn describe_player_filter(filter: &PlayerFilter) -> String {
                 "{} who has more life than you do as you activate this ability",
                 describe_player_filter(base)
             )
+        }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            format!("{} who lost life this turn", describe_player_filter(base))
         }
         PlayerFilter::MaxSpeed {
             base,

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -467,6 +467,7 @@ where
                 ),
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. } => "That player may".to_string(),
                 PlayerFilter::HasMoreLifeThanYou { .. } => "That player may".to_string(),
+                PlayerFilter::LostLifeThisTurn { .. } => "That player may".to_string(),
                 PlayerFilter::MaxSpeed { .. } => "That player may".to_string(),
                 PlayerFilter::ChosenPlayer => "The chosen player may".to_string(),
                 PlayerFilter::TaggedPlayer(_)

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -598,6 +598,7 @@ pub(crate) enum KeywordAction {
     Unblockable,
     Devoid,
     Annihilator(u32),
+    JobSelect,
     ForMirrodin,
     LivingWeapon,
     Crew {
@@ -871,6 +872,7 @@ impl KeywordAction {
             Self::Unblockable => "This can't be blocked".to_string(),
             Self::Devoid => "Devoid".to_string(),
             Self::Annihilator(amount) => format!("Annihilator {amount}"),
+            Self::JobSelect => "Job select".to_string(),
             Self::ForMirrodin => "For Mirrodin!".to_string(),
             Self::LivingWeapon => "Living weapon".to_string(),
             Self::Crew { amount, .. } => format!("Crew {amount}"),
@@ -1798,6 +1800,7 @@ impl CardDefinitionBuilder {
                 }),
                 functional_zones: vec![Zone::Battlefield],
             }),
+            KeywordAction::JobSelect => self.job_select(),
             KeywordAction::ForMirrodin => self.for_mirrodin(),
             KeywordAction::LivingWeapon => self.living_weapon(),
             KeywordAction::Crew {
@@ -3670,6 +3673,20 @@ impl CardDefinitionBuilder {
         ))
     }
 
+    /// Add job select.
+    ///
+    /// "When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it."
+    pub fn job_select(self) -> Self {
+        let created_tag = TagKey::from("job_select_created");
+        self.with_ability(Ability::triggered(
+            Trigger::this_enters_battlefield(),
+            vec![
+                Effect::create_tokens(Self::job_select_hero_token(), 1).tag(created_tag.clone()),
+                Effect::attach_to(ChooseSpec::Tagged(created_tag)),
+            ],
+        ))
+    }
+
     /// Add living weapon.
     ///
     /// "When this Equipment enters, create a 0/0 black Phyrexian Germ creature token, then attach this to it."
@@ -4354,6 +4371,15 @@ impl CardDefinitionBuilder {
             .build()
     }
 
+    fn job_select_hero_token() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Hero")
+            .token()
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Hero])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build()
+    }
+
     fn living_weapon_germ_token() -> CardDefinition {
         CardDefinitionBuilder::new(CardId::new(), "Phyrexian Germ")
             .token()
@@ -4555,6 +4581,32 @@ mod keyword_behavior_tests {
                 && debug.contains("rebel")
                 && debug.contains("attachtoeffect"),
             "expected For Mirrodin trigger to create Rebel token and attach equipment, got {debug}"
+        );
+    }
+
+    #[test]
+    fn job_select_adds_etb_create_and_attach_trigger() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Job Select Variant")
+            .card_types(vec![CardType::Artifact])
+            .subtypes(vec![Subtype::Equipment])
+            .job_select()
+            .build();
+
+        let ability = def
+            .abilities
+            .iter()
+            .find(|ability| matches!(&ability.kind, AbilityKind::Triggered(_)))
+            .expect("expected job select ability");
+        let AbilityKind::Triggered(triggered) = &ability.kind else {
+            panic!("expected job select to add a triggered ability");
+        };
+
+        let debug = format!("{triggered:?}").to_ascii_lowercase();
+        assert!(
+            debug.contains("createtokeneffect")
+                && debug.contains("hero")
+                && debug.contains("attachtoeffect"),
+            "expected job select trigger to create Hero token and attach equipment, got {debug}"
         );
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1331,6 +1331,71 @@ fn test_parse_repeated_backup_keyword_line_compiles_each_instance() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_reapers_scythe_strictly_renders_lost_life_count_and_labeled_equip() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(81_087), "Reaper's Scythe")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Job select\n\
+             At the beginning of your end step, put a soul counter on this Equipment for each player who lost life this turn.\n\
+             Equipped creature gets +1/+1 for each soul counter on this Equipment and is an Assassin in addition to its other types.\n\
+             Death Sickle — Equip {2}",
+        )
+        .expect("Reaper's Scythe should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Job select"),
+        "expected Job select keyword text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("for each player who lost life this turn"),
+        "expected lost-life player count text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("for each soul counter on this Equipment"),
+        "expected source-counter scaling text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Death Sickle — Equip {2}"),
+        "expected labeled equip text, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("LostLifeThisTurn") && debug.contains("CountPlayers"),
+        "expected lost-life player count in structured definition, got {debug}"
+    );
+    assert!(
+        debug.contains("CreateTokenEffect")
+            && debug.contains("Hero")
+            && debug.contains("AttachToEffect"),
+        "expected job select to create a Hero token and attach Reaper's Scythe, got {debug}"
+    );
+    assert!(
+        !debug.contains("KeywordFallbackText") && !debug.contains("UnsupportedParserLine"),
+        "Reaper's Scythe should not lower to unsupported fallbacks, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_labeled_equip_keyword_preserves_generic_presentation_label() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(81_088), "Labeled Equip Test")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text("Limit Break — Equip {3}")
+        .expect("labeled equip keyword should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Limit Break — Equip {3}"),
+        "expected generic labeled equip rendering, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_backup_copy_trigger() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Mirror-Shield Hoplite")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1146,6 +1146,9 @@ fn describe_structural_equipment_token_keyword(ability: &Ability) -> Option<Stri
     if is_for_mirrodin_rebel_token(&create.token) {
         return Some("For Mirrodin!".to_string());
     }
+    if is_job_select_hero_token(&create.token) {
+        return Some("Job select".to_string());
+    }
     None
 }
 
@@ -1193,6 +1196,22 @@ fn is_for_mirrodin_rebel_token(token: &CardDefinition) -> bool {
             Some(crate::card::PowerToughness {
                 power: crate::card::PtValue::Fixed(2),
                 toughness: crate::card::PtValue::Fixed(2),
+            })
+        )
+        && token.abilities.is_empty()
+}
+
+fn is_job_select_hero_token(token: &CardDefinition) -> bool {
+    token.card.is_token
+        && token.card.name == "Hero"
+        && token.card.colors().is_empty()
+        && token.card.card_types == [CardType::Creature]
+        && token.card.subtypes == [Subtype::Hero]
+        && matches!(
+            token.card.power_toughness,
+            Some(crate::card::PowerToughness {
+                power: crate::card::PtValue::Fixed(1),
+                toughness: crate::card::PtValue::Fixed(1),
             })
         )
         && token.abilities.is_empty()

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -60,6 +60,12 @@ pub(super) fn describe_player_filter(filter: &PlayerFilter) -> String {
                 strip_leading_article(&describe_player_filter(base))
             )
         }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            format!(
+                "{} who lost life this turn",
+                strip_leading_article(&describe_player_filter(base))
+            )
+        }
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,
@@ -7681,6 +7687,16 @@ pub(crate) fn describe_value(value: &Value) -> String {
             PlayerFilter::Opponent => "the number of opponents".to_string(),
             PlayerFilter::NotYou => "the number of players other than you".to_string(),
             PlayerFilter::You => "the number of you".to_string(),
+            PlayerFilter::LostLifeThisTurn { base } => match base.as_ref() {
+                PlayerFilter::Any => "the number of players who lost life this turn".to_string(),
+                PlayerFilter::Opponent => {
+                    "the number of opponents who lost life this turn".to_string()
+                }
+                _ => format!(
+                    "the number of {}",
+                    pluralize_noun_phrase(&describe_player_filter(filter))
+                ),
+            },
             _ => format!("the number of {}", describe_player_filter(filter)),
         },
         Value::PlayersWhoControlMoreThanYou(filter) => {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3,6 +3,15 @@ use crate::effect::SearchSelectionMode;
 use crate::filter::StackObjectKind;
 use ironsmith_core::{LibraryBottomOrder, ValueSurfaceHint, ordinal_word};
 
+const PRESENTATION_LABEL_RESTRICTION_PREFIX: &str = "__presentation_label: ";
+
+fn activated_presentation_label(activated: &crate::ability::ActivatedAbility) -> Option<&str> {
+    activated
+        .additional_restrictions
+        .iter()
+        .find_map(|restriction| restriction.strip_prefix(PRESENTATION_LABEL_RESTRICTION_PREFIX))
+}
+
 fn value_has_surface_hint(value: &Value, hint: ValueSurfaceHint) -> bool {
     value.has_surface_hint(hint)
 }
@@ -27089,6 +27098,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         {
             target = format!("each of {target}");
         }
+        if let Value::CountPlayers(player_filter) = &put_counters.amount {
+            return format!(
+                "Put a {} counter on {target} for each {}",
+                describe_counter_type(put_counters.counter_type),
+                describe_player_filter(player_filter)
+            );
+        }
         if let Value::Count(filter) = &put_counters.amount
             && matches!(
                 put_counters.counter_type,
@@ -32247,6 +32263,9 @@ pub(super) fn collect_activation_restriction_clauses(
     }
 
     for raw in additional_restrictions {
+        if raw.starts_with(PRESENTATION_LABEL_RESTRICTION_PREFIX) {
+            continue;
+        }
         let normalized = normalize_activation_restriction_clause(raw);
         push_activation_restriction_clause(&mut clauses, normalized);
     }
@@ -32995,6 +33014,10 @@ fn describe_structural_equip_keyword(
     } else {
         format!("Equip {cost}")
     };
+
+    if let Some(label) = activated_presentation_label(activated) {
+        rendered = format!("{label} — {rendered}");
+    }
 
     let mut restriction_clauses = collect_activation_restriction_clauses(
         &activated.timing,

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -2613,6 +2613,7 @@ fn resolve_condition_player_simple(
         }
         PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
         | PlayerFilter::HasMoreLifeThanYou { .. }
+        | PlayerFilter::LostLifeThisTurn { .. }
         | PlayerFilter::MaxSpeed { .. } => {
             let filter_ctx = crate::target::FilterContext::new(controller)
                 .with_opponents(

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -854,6 +854,7 @@ fn object_matches_filter_with_chars(
             | PlayerFilter::MostCardsInHand
             | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
             | PlayerFilter::HasMoreLifeThanYou { .. }
+            | PlayerFilter::LostLifeThisTurn { .. }
             | PlayerFilter::MaxSpeed { .. }
             | PlayerFilter::CastCardTypeThisTurn(_)
             | PlayerFilter::Teammate

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -824,7 +824,7 @@ pub fn resolve_value(
                 .players
                 .iter()
                 .filter(|p| p.is_in_game())
-                .filter(|p| player_filter.matches_player(p.id, &filter_ctx))
+                .filter(|p| player_filter_matches_game(player_filter, p.id, game, &filter_ctx))
                 .count();
             Ok(count as i32)
         }
@@ -2065,6 +2065,7 @@ pub fn resolve_player_filter(
         | PlayerFilter::CastCardTypeThisTurn(_)
         | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
         | PlayerFilter::HasMoreLifeThanYou { .. }
+        | PlayerFilter::LostLifeThisTurn { .. }
         | PlayerFilter::MaxSpeed { .. } => {
             let filter_ctx = ctx.filter_context(game);
             let mut players = resolve_player_filter_to_list(game, spec, &filter_ctx, ctx)?;
@@ -3196,7 +3197,8 @@ pub(crate) fn resolve_player_filter_to_list(
             .map(|player| player.id)
             .collect()),
         PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
-        | PlayerFilter::HasMoreLifeThanYou { .. } => Ok(game
+        | PlayerFilter::HasMoreLifeThanYou { .. }
+        | PlayerFilter::LostLifeThisTurn { .. } => Ok(game
             .players
             .iter()
             .filter(|player| player.is_in_game())

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1129,6 +1129,7 @@ impl PlayerFilterExt for PlayerFilter {
                 base.matches_player(player, ctx)
             }
             PlayerFilter::HasMoreLifeThanYou { base } => base.matches_player(player, ctx),
+            PlayerFilter::LostLifeThisTurn { .. } => false,
             PlayerFilter::MaxSpeed { .. } => false,
             PlayerFilter::ChosenPlayer => ctx.chosen_player.is_some_and(|chosen| chosen == player),
             PlayerFilter::TaggedPlayer(tag) => ctx
@@ -1202,6 +1203,13 @@ pub(crate) fn player_filter_matches_game(
             let candidate_life = game.player(player).map(|p| p.life).unwrap_or(0);
             let your_life = game.player(you).map(|p| p.life).unwrap_or(0);
             candidate_life > your_life
+        }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            player_filter_matches_game(base, player, game, ctx)
+                && game
+                    .turn_store
+                    .turn_history
+                    .player_lost_life_this_turn(player)
         }
         PlayerFilter::MaxSpeed {
             base,
@@ -2990,6 +2998,9 @@ impl ObjectFilterExt for ObjectFilter {
                 PlayerFilter::HasMoreLifeThanYou { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
+                PlayerFilter::LostLifeThisTurn { .. } => {
+                    parts.push(describe_possessive_player_filter(ctrl));
+                }
                 PlayerFilter::MaxSpeed { .. } => {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
@@ -3067,6 +3078,9 @@ impl ObjectFilterExt for ObjectFilter {
                     format!("{} owns", describe_player_filter(owner))
                 }
                 PlayerFilter::HasMoreLifeThanYou { .. } => {
+                    format!("{} owns", describe_player_filter(owner))
+                }
+                PlayerFilter::LostLifeThisTurn { .. } => {
                     format!("{} owns", describe_player_filter(owner))
                 }
                 PlayerFilter::MaxSpeed { .. } => {
@@ -4118,6 +4132,7 @@ fn describe_possessive_player_filter(filter: &PlayerFilter) -> String {
             format!("{}'s", describe_player_filter(filter))
         }
         PlayerFilter::HasMoreLifeThanYou { .. } => format!("{}'s", describe_player_filter(filter)),
+        PlayerFilter::LostLifeThisTurn { .. } => format!("{}'s", describe_player_filter(filter)),
         PlayerFilter::MaxSpeed { .. } => format!("{}'s", describe_player_filter(filter)),
         PlayerFilter::ChosenPlayer => "the chosen player's".to_string(),
         PlayerFilter::TaggedPlayer(_) => "that player's".to_string(),
@@ -4179,6 +4194,9 @@ pub(crate) fn describe_player_filter(filter: &PlayerFilter) -> String {
                 "{} who has more life than you do as you activate this ability",
                 describe_player_filter(base)
             )
+        }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            format!("{} who lost life this turn", describe_player_filter(base))
         }
         PlayerFilter::MaxSpeed {
             base,

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -1928,6 +1928,13 @@ pub fn player_matches_filter_with_combat(
                     .zip(game.player(controller))
                     .is_some_and(|(candidate, you)| candidate.life > you.life)
         }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            player_matches_filter_with_combat(player_id, base, game, controller, combat)
+                && game
+                    .turn_store
+                    .turn_history
+                    .player_lost_life_this_turn(player_id)
+        }
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -57,6 +57,80 @@ fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn reapers_scythe_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(81_087), "Reaper's Scythe")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Job select\n\
+             At the beginning of your end step, put a soul counter on this Equipment for each player who lost life this turn.\n\
+             Equipped creature gets +1/+1 for each soul counter on this Equipment and is an Assassin in addition to its other types.\n\
+             Death Sickle — Equip {2}",
+        )
+        .expect("Reaper's Scythe should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn record_life_loss_this_turn(game: &mut GameState, player: PlayerId, amount: u32) {
+    let mut trigger_queue = TriggerQueue::new();
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::life::LifeLossEvent::from_effect(player, amount),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(game, &mut trigger_queue, event, false);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_reapers_scythe_end_step_trigger(game: &mut GameState) {
+    let alice = PlayerId::from_index(0);
+    let mut trigger_queue = TriggerQueue::new();
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+
+    generate_and_queue_step_triggers(game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Reaper's Scythe should trigger at its controller's end step"
+    );
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Reaper's Scythe trigger should go on the stack");
+    resolve_stack_entry(game).expect("Reaper's Scythe trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_reapers_scythe_job_select_trigger(game: &mut GameState, scythe_id: ObjectId) {
+    let alice = PlayerId::from_index(0);
+    let mut trigger_queue = TriggerQueue::new();
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            scythe_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    queue_triggers_from_event(game, &mut trigger_queue, event, false);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Reaper's Scythe should queue its job select ETB trigger"
+    );
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Reaper's Scythe job select trigger should go on the stack");
+    resolve_stack_entry(game).expect("Reaper's Scythe job select trigger should resolve");
+
+    assert!(
+        game.current_controller(scythe_id) == Some(alice),
+        "Reaper's Scythe should remain under its controller's control"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn put_test_cards_in_zone(game: &mut GameState, player: PlayerId, zone: Zone, count: u32) {
     for index in 0..count {
         let card = CardBuilder::new(
@@ -112,6 +186,104 @@ fn twenty_toed_toad_static_ability_sets_maximum_hand_size_to_twenty() {
 
     assert_eq!(game.player(alice).unwrap().max_hand_size, 20);
     assert_eq!(game.player(bob).unwrap().max_hand_size, 7);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn reapers_scythe_end_step_adds_no_soul_counters_when_no_player_lost_life() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let scythe = reapers_scythe_definition();
+    let scythe_id = game.create_object_from_definition(&scythe, alice, Zone::Battlefield);
+
+    resolve_reapers_scythe_end_step_trigger(&mut game);
+
+    assert_eq!(
+        game.counter_count(scythe_id, crate::object::CounterType::Named("soul")),
+        0,
+        "Reaper's Scythe should add no soul counters when no player lost life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn reapers_scythe_job_select_creates_hero_and_attaches_equipment() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let scythe = reapers_scythe_definition();
+    let scythe_id = game.create_object_from_definition(&scythe, alice, Zone::Battlefield);
+
+    resolve_reapers_scythe_job_select_trigger(&mut game, scythe_id);
+
+    let heroes: Vec<_> = game
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|id| game.object(*id).is_some_and(|object| object.name == "Hero"))
+        .collect();
+    assert_eq!(heroes.len(), 1, "job select should create one Hero token");
+    let hero_id = heroes[0];
+
+    assert_eq!(game.calculated_power(hero_id), Some(1));
+    assert_eq!(game.calculated_toughness(hero_id), Some(1));
+    assert!(game.current_has_subtype(hero_id, Subtype::Hero));
+    assert_eq!(
+        game.object(scythe_id).and_then(|object| object.attached_to),
+        Some(crate::object::AttachmentTarget::Object(hero_id)),
+        "Reaper's Scythe should attach itself to the Hero token"
+    );
+    assert!(
+        game.object(hero_id)
+            .is_some_and(|object| object.attachments.contains(&scythe_id)),
+        "Hero token should track Reaper's Scythe as attached"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn reapers_scythe_end_step_counts_each_player_who_lost_life_once() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let scythe = reapers_scythe_definition();
+    let scythe_id = game.create_object_from_definition(&scythe, alice, Zone::Battlefield);
+
+    record_life_loss_this_turn(&mut game, alice, 2);
+    record_life_loss_this_turn(&mut game, bob, 5);
+    record_life_loss_this_turn(&mut game, bob, 1);
+    resolve_reapers_scythe_end_step_trigger(&mut game);
+
+    assert_eq!(
+        game.counter_count(scythe_id, crate::object::CounterType::Named("soul")),
+        2,
+        "Reaper's Scythe should count players, not life-loss events or amount lost"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn reapers_scythe_soul_counters_scale_equipped_creature_and_add_assassin() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let scythe = reapers_scythe_definition();
+    let scythe_id = game.create_object_from_definition(&scythe, alice, Zone::Battlefield);
+    game.add_counters(scythe_id, crate::object::CounterType::Named("soul"), 3)
+        .expect("should add soul counters to Reaper's Scythe");
+
+    let bearer_id = create_creature(&mut game, "Bearer", alice, 2, 2);
+    if let Some(scythe_object) = game.object_mut(scythe_id) {
+        scythe_object.attached_to = Some(crate::object::AttachmentTarget::Object(bearer_id));
+    }
+    if let Some(bearer) = game.object_mut(bearer_id) {
+        bearer.attachments.push(scythe_id);
+    }
+
+    assert_eq!(game.calculated_power(bearer_id), Some(5));
+    assert_eq!(game.calculated_toughness(bearer_id), Some(5));
+    assert!(
+        game.current_has_subtype(bearer_id, Subtype::Assassin),
+        "equipped creature should be an Assassin in addition to its other types"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1158,6 +1158,9 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             crate::target::PlayerFilter::HasMoreLifeThanYou { .. } => {
                 "as long as that player is the monarch".to_string()
             }
+            crate::target::PlayerFilter::LostLifeThisTurn { .. } => {
+                "as long as that player is the monarch".to_string()
+            }
             crate::target::PlayerFilter::MaxSpeed { .. } => {
                 "as long as that player is the monarch".to_string()
             }
@@ -1675,7 +1678,7 @@ impl StaticAbilityKind for Anthem {
                 },
             ) if power_counter == toughness_counter && *power == 1 && *toughness == 1 => {
                 format!(
-                    "{subject} {verb} +X/+X, where X is the number of {} counters on this permanent",
+                    "{subject} {verb} +1/+1 for each {} counter on this permanent",
                     power_counter.description(),
                 )
             }

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -1982,6 +1982,13 @@ pub fn player_filter_matches_with_context(
                     .zip(game.player(controller))
                     .is_some_and(|(candidate, you)| candidate.life > you.life)
         }
+        PlayerFilter::LostLifeThisTurn { base } => {
+            player_filter_matches_with_context(base, player, controller, game, defending_player)
+                && game
+                    .turn_store
+                    .turn_history
+                    .player_lost_life_this_turn(player)
+        }
         PlayerFilter::MaxSpeed {
             base,
             has_max_speed,

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -105,6 +105,7 @@ pub(crate) fn describe_player_filter_subject(filter: &PlayerFilter) -> String {
         | PlayerFilter::MostCardsInHand
         | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
         | PlayerFilter::HasMoreLifeThanYou { .. }
+        | PlayerFilter::LostLifeThisTurn { .. }
         | PlayerFilter::MaxSpeed { .. }
         | PlayerFilter::CastCardTypeThisTurn(_)
         | PlayerFilter::ChosenPlayer
@@ -144,6 +145,7 @@ pub(crate) fn describe_player_filter_possessive(filter: &PlayerFilter) -> String
         | PlayerFilter::MostCardsInHand
         | PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
         | PlayerFilter::HasMoreLifeThanYou { .. }
+        | PlayerFilter::LostLifeThisTurn { .. }
         | PlayerFilter::MaxSpeed { .. }
         | PlayerFilter::CastCardTypeThisTurn(_)
         | PlayerFilter::ChosenPlayer

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
@@ -277,6 +277,7 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
                 }
                 PlayerFilter::CardsInHandAtLeastMoreThanYou { .. }
                 | PlayerFilter::HasMoreLifeThanYou { .. }
+                | PlayerFilter::LostLifeThisTurn { .. }
                 | PlayerFilter::MaxSpeed { .. } => player_filter.description(),
                 PlayerFilter::CastCardTypeThisTurn(card_type) => format!(
                     "a player who cast one or more {} spells this turn",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Reaper's Scythe
Initial parse error:
```
unsupported target phrase (clause: 'player who lost life this turn'); oracle-only fallback also failed: unsupported target phrase (clause: 'player who lost life this turn')
```

Current worker: i-0fbc8ddc53e4a01e4
Branch: codex/aws-card-fix-reaper-s-scythe
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0122
