### PR TITLE
Fix Ironsmith parse failure: Tattered Ratter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3101,6 +3101,23 @@ pub(crate) fn parse_trigger_clause_lexed(
         }
     }
 
+    if let Some(becomes_blocked_idx) = find_word_sequence_start(&words, &["becomes", "blocked"])
+        && becomes_blocked_idx + 2 == words.len()
+    {
+        let subject_end = ActivationRestrictionCompatWords::new(tokens)
+            .token_index_for_word_index(becomes_blocked_idx)
+            .unwrap_or(tokens.len());
+        let subject_tokens = trim_commas(&tokens[..subject_end]);
+        let subject_words = ActivationRestrictionCompatWords::new(&subject_tokens).to_word_refs();
+        if subject_tokens.is_empty() || is_source_reference_words(&subject_words) {
+            return Ok(TriggerSpec::ThisBecomesBlocked);
+        }
+        return Ok(match parse_trigger_subject_filter_lexed(&subject_tokens)? {
+            Some(filter) => TriggerSpec::BecomesBlocked(filter),
+            None => TriggerSpec::ThisBecomesBlocked,
+        });
+    }
+
     let (words, attacked_player_filter, attacked_target_must_be_player) =
         if let Some(attacks_word_idx) =
             find_index(&words, |word| matches!(*word, "attack" | "attacks"))

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -37,6 +37,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::ThisBecomesBlockedByObject(filter) => {
             Trigger::this_becomes_blocked_by_object(filter)
         }
+        TriggerSpec::BecomesBlocked(filter) => Trigger::becomes_blocked(filter),
         TriggerSpec::ThisDies => Trigger::this_dies(),
         TriggerSpec::ThisDiesOrIsExiled => Trigger::this_dies_or_is_exiled(),
         TriggerSpec::ThisExiledFromBattlefieldDuringCostOfAbilityWithMarker { marker } => {
@@ -512,7 +513,9 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
         | TriggerSpec::ThisDealsCombatDamageToPlayer
         | TriggerSpec::DealsCombatDamageToPlayer { .. } => Some(PlayerFilter::DamagedPlayer),
-        TriggerSpec::ThisAttacks | TriggerSpec::ThisBecomesBlocked => Some(PlayerFilter::Defending),
+        TriggerSpec::ThisAttacks
+        | TriggerSpec::ThisBecomesBlocked
+        | TriggerSpec::BecomesBlocked(_) => Some(PlayerFilter::Defending),
         TriggerSpec::AttacksYouOrPlaneswalkerYouControl(_)
         | TriggerSpec::AttacksYouOrPlaneswalkerYouControlOneOrMore(_) => {
             Some(PlayerFilter::IteratedPlayer)
@@ -602,7 +605,7 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             _ => false,
         },
         EventValueSpec::BlockersBeyondFirst { .. } => match trigger {
-            TriggerSpec::ThisBecomesBlocked => true,
+            TriggerSpec::ThisBecomesBlocked | TriggerSpec::BecomesBlocked(_) => true,
             TriggerSpec::Either(left, right) => {
                 trigger_supports_event_value(left, spec)
                     && trigger_supports_event_value(right, spec)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -121,6 +121,7 @@ pub(crate) enum TriggerSpec {
     Blocks(ObjectFilter),
     ThisBecomesBlocked,
     ThisBecomesBlockedByObject(ObjectFilter),
+    BecomesBlocked(ObjectFilter),
     ThisDies,
     ThisDiesOrIsExiled,
     ThisExiledFromBattlefieldDuringCostOfAbilityWithMarker {

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -65,6 +65,9 @@ pub enum TriggerKind {
     ThisBecomesBlockedByObject {
         filter: ObjectFilter,
     },
+    BecomesBlocked {
+        filter: ObjectFilter,
+    },
     ThisDies,
     ThisDiesOrIsExiled,
     ThisLeavesBattlefield,
@@ -428,6 +431,9 @@ impl Trigger {
             "this_becomes_blocked_by_object",
             TriggerKind::ThisBecomesBlockedByObject { filter },
         )
+    }
+    pub fn becomes_blocked(filter: ObjectFilter) -> Self {
+        Self::typed("becomes_blocked", TriggerKind::BecomesBlocked { filter })
     }
     pub fn this_dies() -> Self {
         Self::typed("this_dies", TriggerKind::ThisDies)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -4599,6 +4599,44 @@ fn test_parse_trigger_attacks_with_subject_filter() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn tattered_ratter_parses_filtered_becomes_blocked_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Tattered Ratter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Peasant])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.",
+        )
+        .expect("Tattered Ratter should parse");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("BecomesBlockedTrigger")
+            && debug.contains("Rat")
+            && debug.contains("You")
+            && !debug.contains("UnsupportedParserLine")
+            && !debug.contains("RuleFallbackText"),
+        "expected filtered becomes-blocked trigger without unsupported fallback, got {debug}"
+    );
+
+    let joined = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains("whenever")
+            && joined.contains("rat you control")
+            && joined.contains("becomes blocked")
+            && joined.contains("gets +2/+0 until end of turn"),
+        "expected Tattered Ratter compiled text to preserve filtered trigger and pump, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_deals_combat_damage_with_subject_filter() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Combat Damage Filter Probe")
             .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39,6 +39,184 @@ fn setup_three_player_game() -> GameState {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn tattered_ratter_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_980), "Tattered Ratter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Peasant])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.",
+        )
+        .expect("Tattered Ratter should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn declare_blocked_attacker(
+    game: &mut GameState,
+    attacker: ObjectId,
+    blocker: ObjectId,
+    attacking_player: PlayerId,
+    defending_player: PlayerId,
+) -> TriggerQueue {
+    game.turn.active_player = attacking_player;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker,
+            target: AttackTarget::Player(defending_player),
+        }],
+    )
+    .expect("attacker declaration should be legal");
+
+    game.turn.step = Some(crate::game_state::Step::DeclareBlockers);
+    apply_blocker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[BlockerDeclaration {
+            blocker,
+            blocking: attacker,
+        }],
+        defending_player,
+    )
+    .expect("blocker declaration should be legal");
+
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn creature_definition(
+    name: &str,
+    subtypes: Vec<Subtype>,
+    power: i32,
+    toughness: i32,
+) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .subtypes(subtypes)
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tattered_ratter_pumps_rat_you_control_when_it_becomes_blocked() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let ratter_id = game.create_object_from_definition(
+        &tattered_ratter_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let rat_id = game.create_object_from_definition(
+        &creature_definition("Warehouse Rat", vec![Subtype::Rat], 1, 1),
+        alice,
+        Zone::Battlefield,
+    );
+    let blocker_id = game.create_object_from_definition(
+        &creature_definition("Blocking Bear", vec![Subtype::Bear], 2, 2),
+        bob,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(rat_id);
+
+    let mut trigger_queue = declare_blocked_attacker(&mut game, rat_id, blocker_id, alice, bob);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Tattered Ratter trigger should go on stack");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "blocked Rat should trigger Tattered Ratter"
+    );
+
+    resolve_stack_entry(&mut game).expect("Tattered Ratter trigger should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(game.calculated_power(rat_id), Some(3));
+    assert_eq!(game.calculated_toughness(rat_id), Some(1));
+    assert_eq!(game.calculated_power(ratter_id), Some(2));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tattered_ratter_does_not_pump_blocked_non_rat() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&tattered_ratter_definition(), alice, Zone::Battlefield);
+    let attacker_id = game.create_object_from_definition(
+        &creature_definition("Peasant Attacker", vec![Subtype::Human], 1, 1),
+        alice,
+        Zone::Battlefield,
+    );
+    let blocker_id = game.create_object_from_definition(
+        &creature_definition("Blocking Bear", vec![Subtype::Bear], 2, 2),
+        bob,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(attacker_id);
+
+    let mut trigger_queue =
+        declare_blocked_attacker(&mut game, attacker_id, blocker_id, alice, bob);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("non-Rat block should not produce an invalid trigger");
+
+    assert!(
+        game.stack.is_empty(),
+        "blocked non-Rat should not trigger Tattered Ratter"
+    );
+    game.refresh_continuous_state();
+    assert_eq!(game.calculated_power(attacker_id), Some(1));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tattered_ratter_does_not_trigger_for_rat_an_opponent_controls() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&tattered_ratter_definition(), alice, Zone::Battlefield);
+    let attacker_id = game.create_object_from_definition(
+        &creature_definition("Opponent Rat", vec![Subtype::Rat], 1, 1),
+        bob,
+        Zone::Battlefield,
+    );
+    let blocker_id = game.create_object_from_definition(
+        &creature_definition("Blocking Bear", vec![Subtype::Bear], 2, 2),
+        alice,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(attacker_id);
+
+    let mut trigger_queue =
+        declare_blocked_attacker(&mut game, attacker_id, blocker_id, bob, alice);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("opponent-controlled Rat block should not produce an invalid trigger");
+
+    assert!(
+        game.stack.is_empty(),
+        "Rat controlled by an opponent should not trigger Tattered Ratter"
+    );
+    game.refresh_continuous_state();
+    assert_eq!(game.calculated_power(attacker_id), Some(1));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_950), "Twenty-Toed Toad")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -142,6 +142,7 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::ThisBecomesBlockedByObject { filter } => {
             crate::triggers::Trigger::this_becomes_blocked_by_object(filter)
         }
+        TriggerKind::BecomesBlocked { filter } => crate::triggers::Trigger::becomes_blocked(filter),
         TriggerKind::ThisDies => crate::triggers::Trigger::this_dies(),
         TriggerKind::ThisDiesOrIsExiled => crate::triggers::Trigger::this_dies_or_is_exiled(),
         TriggerKind::ThisLeavesBattlefield => crate::triggers::Trigger::this_leaves_battlefield(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tattered Ratter
Initial parse error:
```
unsupported triggered line: 'Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.'
```

Current worker: i-05220a2decd284122
Branch: codex/aws-card-fix-tattered-ratter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0133
