### PR TITLE
Fix Ironsmith parse failure: Shield of the Oversoul

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2271,8 +2271,8 @@ pub(crate) fn parse_static_condition_clause(
         return Ok(crate::ConditionExpr::EquippedCreatureAttacking);
     }
     if clause_words.len() >= 4
-        && clause_words[0] == "equipped"
-        && clause_words[1] == "creature"
+        && matches!(clause_words[0], "equipped" | "enchanted")
+        && matches!(clause_words[1], "artifact" | "creature" | "land" | "permanent")
         && clause_words[2] == "is"
     {
         let mut descriptor_words = &clause_words[3..];
@@ -2282,8 +2282,13 @@ pub(crate) fn parse_static_condition_clause(
 
         if descriptor_words.len() == 1 {
             let descriptor = descriptor_words[0];
-            let mut filter = ObjectFilter::creature()
-                .match_tagged(crate::TagKey::from("equipped"), crate::target::TaggedOpbjectRelation::IsTaggedObject);
+            let subject_end = token_index_for_word_index(&tokens, 2).ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unable to map attached-object static condition subject (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+            let mut filter = parse_object_filter(&tokens[..subject_end], false)?;
             if let Some(color) = parse_color(descriptor) {
                 filter.colors = Some(color);
                 return Ok(crate::ConditionExpr::CountComparison {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5412,6 +5412,41 @@ fn test_do_not_replace_keyword_named_card_reference_in_enchanted_grant_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_shield_of_the_oversoul_strict_oracle_and_compiled_text_regression() {
+    let oracle = oracle_text_by_name()
+        .get("Shield of the Oversoul")
+        .expect("Shield of the Oversoul oracle text should be present")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Shield of the Oversoul")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(oracle)
+        .expect("Shield of the Oversoul should parse strictly");
+
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Enchant creature".to_string(),
+            "Enchanted creature gets +1/+1 and has indestructible as long as enchanted creature is green."
+                .to_string(),
+            "Enchanted creature gets +1/+1 and has flying as long as enchanted creature is white."
+                .to_string(),
+        ],
+        "expected Shield of the Oversoul to preserve both attached-color branches"
+    );
+
+    let debug = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        debug.contains("countcomparison")
+            && debug.contains("enchanted creature is green")
+            && debug.contains("enchanted creature is white"),
+        "expected attached-color conditions to be structural count comparisons, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_source_deals_damage_to_target_equal_to_number_of_filter() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Ben-Ben Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1730,6 +1730,79 @@ fn sharpened_pitchfork_boosts_only_humans_but_always_grants_first_strike() {
     assert_eq!(game.calculated_toughness(non_human_id), Some(2));
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn shield_of_the_oversoul_applies_each_attached_color_branch_independently() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let shield = CardDefinitionBuilder::new(CardId::from_raw(72_114), "Shield of the Oversoul")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant creature\n\
+             As long as enchanted creature is green, it gets +1/+1 and has indestructible.\n\
+             As long as enchanted creature is white, it gets +1/+1 and has flying.",
+        )
+        .expect("Shield of the Oversoul should parse");
+
+    let green_id = create_colored_creature(
+        &mut game,
+        "Green Bearer",
+        alice,
+        Some(crate::color::ColorSet::GREEN),
+    );
+    let white_id = create_colored_creature(
+        &mut game,
+        "White Bearer",
+        alice,
+        Some(crate::color::ColorSet::WHITE),
+    );
+    let green_white_id = create_colored_creature(
+        &mut game,
+        "Green White Bearer",
+        alice,
+        Some(crate::color::ColorSet::GREEN.union(crate::color::ColorSet::WHITE)),
+    );
+    let colorless_id = create_colored_creature(&mut game, "Colorless Bearer", alice, None);
+
+    for creature_id in [green_id, white_id, green_white_id, colorless_id] {
+        let aura_id = game.create_object_from_definition(&shield, alice, Zone::Battlefield);
+        if let Some(aura) = game.object_mut(aura_id) {
+            aura.attached_to = Some(crate::object::AttachmentTarget::Object(creature_id));
+        }
+        if let Some(creature) = game.object_mut(creature_id) {
+            creature.attachments.push(aura_id);
+        }
+    }
+
+    assert_eq!(game.calculated_power(green_id), Some(3));
+    assert_eq!(game.calculated_toughness(green_id), Some(3));
+    assert!(game.object_has_ability(green_id, &StaticAbility::indestructible()));
+    assert!(!game.object_has_ability(green_id, &StaticAbility::flying()));
+
+    assert_eq!(game.calculated_power(white_id), Some(3));
+    assert_eq!(game.calculated_toughness(white_id), Some(3));
+    assert!(game.object_has_ability(white_id, &StaticAbility::flying()));
+    assert!(!game.object_has_ability(white_id, &StaticAbility::indestructible()));
+
+    assert_eq!(game.calculated_power(green_white_id), Some(4));
+    assert_eq!(game.calculated_toughness(green_white_id), Some(4));
+    assert!(game.object_has_ability(green_white_id, &StaticAbility::flying()));
+    assert!(game.object_has_ability(
+        green_white_id,
+        &StaticAbility::indestructible()
+    ));
+
+    assert_eq!(game.calculated_power(colorless_id), Some(2));
+    assert_eq!(game.calculated_toughness(colorless_id), Some(2));
+    assert!(!game.object_has_ability(colorless_id, &StaticAbility::flying()));
+    assert!(!game.object_has_ability(
+        colorless_id,
+        &StaticAbility::indestructible()
+    ));
+}
+
 #[test]
 fn proposed_granted_emerge_cast_keeps_sacrifice_cost_on_stack_spell() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Shield of the Oversoul
Initial parse error:
```
unsupported static condition clause (clause: 'enchanted creature is green'); oracle-only fallback also failed: unsupported static condition clause (clause: 'enchanted creature is green')
```

Current worker: i-07169c1f9a51c6e12
Branch: codex/aws-card-fix-shield-of-the-oversoul
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0142
