### PR TITLE
Fix Ironsmith parse failure: The Mimeoplasm

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3165,6 +3165,48 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
     }
 
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if slice_starts_with(&clause_words, &["as"])
+        && let Some(enter_idx) = find_index(&clause_words, |word| {
+            *word == "enter" || *word == "enters"
+        })
+        && clause_words.get(enter_idx + 1..enter_idx + 8)
+            == Some(&["you", "may", "exile", "two", "creature", "cards", "from"])
+        && clause_words.get(enter_idx + 8).copied() == Some("graveyards")
+        && find_word_slice_phrase_start(
+            &clause_words,
+            &[
+                "if", "you", "do", "it", "enters", "as", "a", "copy", "of", "one", "of",
+                "those", "cards",
+            ],
+        )
+        .is_some()
+        && slice_contains(&clause_words, &"additional")
+        && slice_contains(&clause_words, &"counters")
+        && slice_contains(&clause_words, &"power")
+        && slice_contains(&clause_words, &"other")
+    {
+        return Ok(Some(StaticAbility::with_enter_as_copy_as_enters(
+            crate::static_abilities::EnterAsCopyAsEntersSpec {
+                filter: ObjectFilter::creature().in_zone(Zone::Graveyard),
+                affected_filter: None,
+                may: true,
+                enters_tapped_if_chosen: false,
+                linked_exile_pair: Some(crate::static_abilities::EnterAsCopyLinkedExilePairSpec {
+                    counter_type: CounterType::PlusOnePlusOne,
+                }),
+                copy_source_self: false,
+                copy_source_enchanted: false,
+                name_override: None,
+                added_card_types: Vec::new(),
+                removed_supertypes: Vec::new(),
+                added_subtypes: Vec::new(),
+                added_abilities: Vec::new(),
+                set_base_power_toughness: None,
+                set_base_power_toughness_from_self: false,
+            },
+            render_token_slice(tokens).trim().to_string(),
+        )));
+    }
     if !slice_starts_with(&clause_words, &["you", "may", "have"])
         && let Some(enter_idx) =
             find_index(&clause_words, |word| *word == "enter" || *word == "enters")
@@ -3202,6 +3244,7 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
                     affected_filter: Some(affected_filter),
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self,
                     copy_source_enchanted,
                     name_override: None,
@@ -3465,6 +3508,7 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
             affected_filter: None,
             may: true,
             enters_tapped_if_chosen,
+            linked_exile_pair: None,
             copy_source_self: false,
             copy_source_enchanted: false,
             name_override,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3181,13 +3181,14 @@ pub(crate) fn parse_enter_as_copy_as_enters_line(
         )
         .is_some()
         && slice_contains(&clause_words, &"additional")
+        && slice_contains(&clause_words, &"+1/+1")
         && slice_contains(&clause_words, &"counters")
         && slice_contains(&clause_words, &"power")
         && slice_contains(&clause_words, &"other")
     {
         return Ok(Some(StaticAbility::with_enter_as_copy_as_enters(
             crate::static_abilities::EnterAsCopyAsEntersSpec {
-                filter: ObjectFilter::creature().in_zone(Zone::Graveyard),
+                filter: ObjectFilter::creature().in_zone(Zone::Graveyard).nontoken(),
                 affected_filter: None,
                 may: true,
                 enters_tapped_if_chosen: false,

--- a/crates/ironsmith-compiler/src/static_abilities.rs
+++ b/crates/ironsmith-compiler/src/static_abilities.rs
@@ -3,10 +3,10 @@ pub use ironsmith_core::{
     AttachedChosenLandwalkGrant, AttackCostCondition, AttackingGroupAttackCondition,
     CantAttackUnlessConditionSpec, ConditionalSpellKeywordKind, ConditionalSpellKeywordSpec,
     CopyActivatedAbilities, CopyTriggeredAbilities, CostIncrease, CostIncreaseManaCost,
-    CostReduction, CostReductionManaCost, DefendingPlayerAttackCondition, GraveyardCountMetric,
-    LandwalkKind, ManaSpendPermission, PregameActionKind, PregameBeginOnBattlefieldSpec,
-    RemoveCardTypesForFilter, SetColorsForFilter, StaticAbilityId, ThisSpellCastRestrictionKind,
-    ThisSpellCastTiming,
+    CostReduction, CostReductionManaCost, DefendingPlayerAttackCondition,
+    EnterAsCopyLinkedExilePairSpec, GraveyardCountMetric, LandwalkKind, ManaSpendPermission,
+    PregameActionKind, PregameBeginOnBattlefieldSpec, RemoveCardTypesForFilter, SetColorsForFilter,
+    StaticAbilityId, ThisSpellCastRestrictionKind, ThisSpellCastTiming,
 };
 
 pub const PREVENT_ALL_DAMAGE_DEALT_BY_THIS_PERMANENT: StaticAbilityId =

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -164,11 +164,11 @@ pub use static_ability_model::{
     AttachedChosenLandwalkGrant, AttackCostCondition, AttackingGroupAttackCondition,
     CantAttackUnlessConditionSpec, ConditionalSpellKeywordKind, ConditionalSpellKeywordSpec,
     CopyActivatedAbilities, CopyTriggeredAbilities, CostIncrease, CostIncreaseManaCost, CostReduction,
-    CostReductionManaCost, DefendingPlayerAttackCondition, EnterAsCopyAsEntersSpec, GrantAbility,
-    GrantObjectAbilityForFilter, GraveyardCountMetric, LandwalkKind, PregameActionKind,
-    PregameBeginOnBattlefieldSpec, RemoveCardTypesForFilter, SetColorsForFilter, StaticAbility,
-    StaticAbilityPayload, ThisSpellCastRestrictionKind, ThisSpellCostReduction,
-    ThisSpellCostReductionManaCost,
+    CostReductionManaCost, DefendingPlayerAttackCondition, EnterAsCopyAsEntersSpec,
+    EnterAsCopyLinkedExilePairSpec, GrantAbility, GrantObjectAbilityForFilter,
+    GraveyardCountMetric, LandwalkKind, PregameActionKind, PregameBeginOnBattlefieldSpec,
+    RemoveCardTypesForFilter, SetColorsForFilter, StaticAbility, StaticAbilityPayload,
+    ThisSpellCastRestrictionKind, ThisSpellCostReduction, ThisSpellCostReductionManaCost,
 };
 pub use tag::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, TagKey};
 pub use target_model::{ChooseSpec, ChooseSpecSurfaceHint, SourceReferenceSurface};

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1167,6 +1167,7 @@ where
                         affected_filter: spec.affected_filter,
                         may: spec.may,
                         enters_tapped_if_chosen: spec.enters_tapped_if_chosen,
+                        linked_exile_pair: spec.linked_exile_pair,
                         copy_source_self: spec.copy_source_self,
                         copy_source_enchanted: spec.copy_source_enchanted,
                         name_override: spec.name_override,
@@ -4219,6 +4220,7 @@ pub struct EnterAsCopyAsEntersSpec<T, E, C, Cond> {
     pub affected_filter: Option<ObjectFilter>,
     pub may: bool,
     pub enters_tapped_if_chosen: bool,
+    pub linked_exile_pair: Option<EnterAsCopyLinkedExilePairSpec>,
     pub copy_source_self: bool,
     pub copy_source_enchanted: bool,
     pub name_override: Option<String>,
@@ -4228,6 +4230,11 @@ pub struct EnterAsCopyAsEntersSpec<T, E, C, Cond> {
     pub added_abilities: Vec<AbilityModel<T, E, C, Cond>>,
     pub set_base_power_toughness: Option<(i32, i32)>,
     pub set_base_power_toughness_from_self: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnterAsCopyLinkedExilePairSpec {
+    pub counter_type: CounterType,
 }
 
 impl<T, E, C, Cond> crate::GrantStaticAbility for StaticAbility<T, E, C, Cond>

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17342,6 +17342,36 @@ fn parse_phyrexian_metamorph_style_enter_as_copy_with_added_card_type() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_the_mimeoplasm_linked_graveyard_copy_replacement() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "The Mimeoplasm")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Ooze])
+        .power_toughness(crate::card::PowerToughness::fixed(0, 0))
+        .parse_text(
+            "As The Mimeoplasm enters, you may exile two creature cards from graveyards. If you do, it enters as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
+        )
+        .expect("The Mimeoplasm linked graveyard copy replacement should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("you may exile two creature cards from graveyards")
+            && rendered.contains("it enters as a copy of one of those cards")
+            && rendered.contains("additional +1/+1 counters"),
+        "expected The Mimeoplasm compiled text to preserve linked exile/copy/counter clause, got {rendered}"
+    );
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("linked_exile_pair") && debug.contains("PlusOnePlusOne"),
+        "expected The Mimeoplasm lowering to record linked exile pair with +1/+1 counters, got {debug}"
+    );
+    assert!(
+        !debug.to_ascii_lowercase().contains("unsupported"),
+        "expected The Mimeoplasm parse to avoid unsupported placeholders, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_omni_changeling_copy_exception_stays_localized() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Omni-Changeling")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17361,8 +17361,10 @@ fn parse_the_mimeoplasm_linked_graveyard_copy_replacement() {
     );
     let debug = format!("{def:#?}");
     assert!(
-        debug.contains("linked_exile_pair") && debug.contains("PlusOnePlusOne"),
-        "expected The Mimeoplasm lowering to record linked exile pair with +1/+1 counters, got {debug}"
+        debug.contains("linked_exile_pair")
+            && debug.contains("PlusOnePlusOne")
+            && debug.contains("nontoken: true"),
+        "expected The Mimeoplasm lowering to record linked exile pair with +1/+1 counters for nontoken creature cards, got {debug}"
     );
     assert!(
         !debug.to_ascii_lowercase().contains("unsupported"),

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -2220,8 +2220,17 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                     continue;
                 }
             }
-            let mut ability_lines =
-                describe_ability(ability_idx + 1, ability, subject, rewrite_it_deals);
+            let ability_subject = if ability_prefers_card_name_subject(ability) {
+                def.card.name.as_str()
+            } else {
+                subject
+            };
+            let mut ability_lines = describe_ability(
+                ability_idx + 1,
+                ability,
+                ability_subject,
+                rewrite_it_deals,
+            );
             if ability_has_begin_on_battlefield_pregame(ability) {
                 for line in &mut ability_lines {
                     *line = substitute_pregame_self_reference(line, &def.card.name);
@@ -2284,6 +2293,15 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
         .into_iter()
         .map(|line| substitute_legendary_source_reference(&line, &def.card, subject))
         .collect()
+}
+
+fn ability_prefers_card_name_subject(ability: &Ability) -> bool {
+    let AbilityKind::Static(static_ability) = &ability.kind else {
+        return false;
+    };
+    static_ability
+        .enter_as_copy_as_enters()
+        .is_some_and(|spec| spec.linked_exile_pair.is_some())
 }
 
 fn rewrite_additional_sacrifice_reference_surface(def: &CardDefinition, text: &str) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13450,6 +13450,14 @@ fn describe_static_ability_with_subject(
     if trimmed.starts_with("This card ") || trimmed.starts_with("this card ") {
         return capitalize_first(trimmed);
     }
+    if !subject.starts_with("this ") {
+        if let Some(rest) = trimmed.strip_prefix("As this enters") {
+            return format!("As {subject} enters{rest}");
+        }
+        if let Some(rest) = trimmed.strip_prefix("as this enters") {
+            return format!("As {subject} enters{rest}");
+        }
+    }
     if trimmed.starts_with("Cards in ") || trimmed.starts_with("Each ") {
         if let Some(body) = trimmed.strip_suffix(" as long as it's your turn") {
             return format!("During your turn, {}", lowercase_first(body));

--- a/crates/ironsmith-runtime/src/events/mod.rs
+++ b/crates/ironsmith-runtime/src/events/mod.rs
@@ -317,6 +317,7 @@ impl Event {
                 from,
                 enters_tapped,
                 enters_with_counters,
+                linked_exile_with_entering: Vec::new(),
                 enters_as_copy_of: None,
                 copy_name_override: None,
                 added_card_types: Vec::new(),

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -172,6 +172,8 @@ pub(super) fn apply_trait_replacement(
         ReplacementAction::EnterAsCopy {
             source,
             enters_tapped,
+            linked_exile_objects,
+            additional_counters,
             name_override,
             added_card_types,
             removed_supertypes,
@@ -183,6 +185,8 @@ pub(super) fn apply_trait_replacement(
                 &event,
                 *source,
                 *enters_tapped,
+                linked_exile_objects,
+                additional_counters,
                 name_override.clone(),
                 added_card_types,
                 removed_supertypes,
@@ -757,6 +761,8 @@ fn apply_trait_enter_as_copy(
     event: &Event,
     source_id: crate::ids::ObjectId,
     enters_tapped: bool,
+    linked_exile_objects: &[crate::ids::ObjectId],
+    additional_counters: &[(CounterType, u32)],
     name_override: Option<String>,
     added_card_types: &[crate::types::CardType],
     removed_supertypes: &[crate::types::Supertype],
@@ -769,6 +775,7 @@ fn apply_trait_enter_as_copy(
     let apply_copy_modifiers = |mut etb: EnterBattlefieldEvent| {
         etb = etb
             .with_copy_of(source_id)
+            .with_linked_exile_objects(linked_exile_objects)
             .with_copy_name_override(name_override.clone())
             .with_added_card_types(added_card_types)
             .with_removed_supertypes(removed_supertypes)
@@ -776,6 +783,9 @@ fn apply_trait_enter_as_copy(
             .with_added_abilities(added_abilities);
         if let Some((power, toughness)) = set_base_power_toughness {
             etb = etb.with_base_power_toughness(power, toughness);
+        }
+        for (counter_type, count) in additional_counters {
+            etb = etb.with_counters(*counter_type, *count);
         }
         if enters_tapped {
             etb = etb.with_tapped();

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -51,7 +51,13 @@ fn replacement_effect_choice_description(game: &GameState, effect: &ReplacementE
 
 fn replacement_effect_related_objects(effect: &ReplacementEffect) -> Vec<crate::ids::ObjectId> {
     match &effect.replacement {
-        ReplacementAction::EnterAsCopy { source, .. } => vec![*source],
+        ReplacementAction::EnterAsCopy {
+            source,
+            linked_exile_objects,
+            ..
+        } => std::iter::once(*source)
+            .chain(linked_exile_objects.iter().copied())
+            .collect(),
         _ => Vec::new(),
     }
 }
@@ -120,6 +126,45 @@ fn push_enter_as_copy_effects_for_spec(
             .flatten()
     });
 
+    if let Some(linked_pair) = spec.linked_exile_pair {
+        if candidates.len() < 2 {
+            return;
+        }
+        for &copy_candidate in &candidates {
+            for &counter_candidate in &candidates {
+                if copy_candidate == counter_candidate {
+                    continue;
+                }
+                let counter_count = game
+                    .object(counter_candidate)
+                    .and_then(|object| object.power())
+                    .unwrap_or(0)
+                    .max(0) as u32;
+                copy_choice_effects.push(
+                    ReplacementEffect::with_matcher(
+                        entering_object,
+                        controller,
+                        crate::events::zones::matchers::ThisWouldEnterBattlefieldMatcher,
+                        ReplacementAction::EnterAsCopy {
+                            source: copy_candidate,
+                            enters_tapped: spec.enters_tapped_if_chosen,
+                            linked_exile_objects: vec![copy_candidate, counter_candidate],
+                            additional_counters: vec![(linked_pair.counter_type, counter_count)],
+                            name_override: spec.name_override.clone(),
+                            added_card_types: spec.added_card_types.clone(),
+                            removed_supertypes: spec.removed_supertypes.clone(),
+                            added_subtypes: spec.added_subtypes.clone(),
+                            added_abilities: spec.added_abilities.clone(),
+                            set_base_power_toughness,
+                        },
+                    )
+                    .with_priority_override(crate::events::ReplacementPriority::CopyEffect),
+                );
+            }
+        }
+        return;
+    }
+
     for candidate in candidates {
         copy_choice_effects.push(
             ReplacementEffect::with_matcher(
@@ -129,6 +174,8 @@ fn push_enter_as_copy_effects_for_spec(
                 ReplacementAction::EnterAsCopy {
                     source: candidate,
                     enters_tapped: spec.enters_tapped_if_chosen,
+                    linked_exile_objects: Vec::new(),
+                    additional_counters: Vec::new(),
                     name_override: spec.name_override.clone(),
                     added_card_types: spec.added_card_types.clone(),
                     removed_supertypes: spec.removed_supertypes.clone(),
@@ -1985,6 +2032,8 @@ pub struct EtbEventResult {
     pub enters_tapped: bool,
     /// Counters the permanent enters with (counter_type, count)
     pub enters_with_counters: Vec<(CounterType, u32)>,
+    /// Objects exiled and linked to the entering permanent by an as-enters choice.
+    pub linked_exile_with_entering: Vec<crate::ids::ObjectId>,
     /// Whether the ETB was prevented (e.g., creature entering from graveyard replaced with exile)
     pub prevented: bool,
     /// If zone was changed, the new destination
@@ -2734,6 +2783,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
             from,
             enters_tapped,
             enters_with_counters,
+            linked_exile_with_entering: Vec::new(),
             enters_as_copy_of: None,
             copy_name_override: None,
             added_card_types: Vec::new(),
@@ -2808,6 +2858,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                     return EtbEventResult {
                         enters_tapped: etb.enters_tapped,
                         enters_with_counters: etb.enters_with_counters.clone(),
+                        linked_exile_with_entering: etb.linked_exile_with_entering.clone(),
                         prevented: false,
                         new_destination: None,
                         enters_as_copy_of: etb.enters_as_copy_of,

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -105,18 +105,6 @@ fn push_enter_as_copy_effects_for_spec(
         return;
     }
 
-    if spec.may {
-        copy_choice_effects.push(
-            ReplacementEffect::with_matcher(
-                entering_object,
-                controller,
-                crate::events::zones::matchers::ThisWouldEnterBattlefieldMatcher,
-                ReplacementAction::Additionally(Vec::new()),
-            )
-            .with_priority_override(crate::events::ReplacementPriority::CopyEffect),
-        );
-    }
-
     let set_base_power_toughness = spec.set_base_power_toughness.or_else(|| {
         spec.set_base_power_toughness_from_self
             .then(|| {
@@ -129,6 +117,17 @@ fn push_enter_as_copy_effects_for_spec(
     if let Some(linked_pair) = spec.linked_exile_pair {
         if candidates.len() < 2 {
             return;
+        }
+        if spec.may {
+            copy_choice_effects.push(
+                ReplacementEffect::with_matcher(
+                    entering_object,
+                    controller,
+                    crate::events::zones::matchers::ThisWouldEnterBattlefieldMatcher,
+                    ReplacementAction::Additionally(Vec::new()),
+                )
+                .with_priority_override(crate::events::ReplacementPriority::CopyEffect),
+            );
         }
         for &copy_candidate in &candidates {
             for &counter_candidate in &candidates {
@@ -163,6 +162,18 @@ fn push_enter_as_copy_effects_for_spec(
             }
         }
         return;
+    }
+
+    if spec.may {
+        copy_choice_effects.push(
+            ReplacementEffect::with_matcher(
+                entering_object,
+                controller,
+                crate::events::zones::matchers::ThisWouldEnterBattlefieldMatcher,
+                ReplacementAction::Additionally(Vec::new()),
+            )
+            .with_priority_override(crate::events::ReplacementPriority::CopyEffect),
+        );
     }
 
     for candidate in candidates {

--- a/crates/ironsmith-runtime/src/events/zones/enter_battlefield.rs
+++ b/crates/ironsmith-runtime/src/events/zones/enter_battlefield.rs
@@ -25,6 +25,8 @@ pub struct EnterBattlefieldEvent {
     pub enters_tapped: bool,
     /// Counters it enters with (may be modified by replacement effects)
     pub enters_with_counters: Vec<(CounterType, u32)>,
+    /// Objects exiled and linked to this permanent as part of an as-enters choice.
+    pub linked_exile_with_entering: Vec<ObjectId>,
     /// If set, the object enters as a copy of this source object.
     pub enters_as_copy_of: Option<ObjectId>,
     /// If set, overrides the copied object's name as it enters.
@@ -51,6 +53,7 @@ impl EnterBattlefieldEvent {
             from,
             enters_tapped: false,
             enters_with_counters: Vec::new(),
+            linked_exile_with_entering: Vec::new(),
             enters_as_copy_of: None,
             copy_name_override: None,
             added_card_types: Vec::new(),
@@ -69,6 +72,7 @@ impl EnterBattlefieldEvent {
             from,
             enters_tapped: true,
             enters_with_counters: Vec::new(),
+            linked_exile_with_entering: Vec::new(),
             enters_as_copy_of: None,
             copy_name_override: None,
             added_card_types: Vec::new(),
@@ -101,6 +105,19 @@ impl EnterBattlefieldEvent {
 
         Self {
             enters_with_counters: counters,
+            ..self.clone()
+        }
+    }
+
+    pub fn with_linked_exile_objects(&self, object_ids: &[ObjectId]) -> Self {
+        let mut linked_exile_with_entering = self.linked_exile_with_entering.clone();
+        for object_id in object_ids {
+            if !linked_exile_with_entering.contains(object_id) {
+                linked_exile_with_entering.push(*object_id);
+            }
+        }
+        Self {
+            linked_exile_with_entering,
             ..self.clone()
         }
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14013,6 +14013,21 @@ impl DecisionMaker for ChooseMimeoplasmPairDecisionMaker {
     }
 }
 
+struct PanicOnMimeoplasmReplacementPrompt;
+
+impl DecisionMaker for PanicOnMimeoplasmReplacementPrompt {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        panic!(
+            "The Mimeoplasm should not offer replacement choices without two graveyard creatures: {:?}",
+            ctx.options
+        );
+    }
+}
+
 #[test]
 fn the_mimeoplasm_exiles_two_graveyard_creatures_copies_one_and_gets_other_power_counters() {
     let mut game = setup_game();
@@ -14120,8 +14135,9 @@ fn the_mimeoplasm_needs_two_graveyard_creature_cards_to_apply_copy_replacement()
 
     let mimeoplasm = the_mimeoplasm_test_definition();
     let mimeoplasm_id = game.create_object_from_definition(&mimeoplasm, alice, Zone::Hand);
+    let mut dm = PanicOnMimeoplasmReplacementPrompt;
     let result = game
-        .move_object_with_etb_processing(mimeoplasm_id, Zone::Battlefield)
+        .move_object_with_etb_processing_with_dm(mimeoplasm_id, Zone::Battlefield, &mut dm)
         .expect("The Mimeoplasm should enter without enough graveyard creature cards");
 
     let entered = game

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -13624,6 +13624,7 @@ fn test_enter_as_copy_applies_copied_enters_with_echo_counter() {
                     affected_filter: None,
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self: false,
                     copy_source_enchanted: false,
                     name_override: None,
@@ -13683,6 +13684,7 @@ fn test_enter_as_copy_can_set_base_power_toughness_from_entering_object() {
                     affected_filter: None,
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self: false,
                     copy_source_enchanted: false,
                     name_override: None,
@@ -13735,6 +13737,7 @@ fn test_enter_as_copy_can_set_base_power_toughness_from_entering_stack_object() 
                     affected_filter: None,
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self: false,
                     copy_source_enchanted: false,
                     name_override: None,
@@ -13781,6 +13784,7 @@ fn test_static_source_can_make_matching_creatures_enter_as_copy_of_itself() {
                     affected_filter: Some(crate::target::ObjectFilter::creature().you_control()),
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self: true,
                     copy_source_enchanted: false,
                     name_override: None,
@@ -13840,6 +13844,7 @@ fn test_enter_as_copy_can_remove_legendary_add_artifact_and_add_myriad() {
                     affected_filter: None,
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self: false,
                     copy_source_enchanted: false,
                     name_override: None,
@@ -13921,6 +13926,7 @@ fn test_enter_as_copy_with_no_candidates_keeps_original_characteristics() {
                     affected_filter: None,
                     may: false,
                     enters_tapped_if_chosen: false,
+                    linked_exile_pair: None,
                     copy_source_self: false,
                     copy_source_enchanted: false,
                     name_override: None,
@@ -13968,6 +13974,156 @@ fn test_enter_as_copy_with_no_candidates_keeps_original_characteristics() {
     assert_eq!(entered.name, "Auton Soldier");
     assert_eq!(entered.base_power, Some(crate::card::PtValue::Fixed(4)));
     assert_eq!(entered.base_toughness, Some(crate::card::PtValue::Fixed(4)));
+}
+
+fn the_mimeoplasm_test_definition() -> crate::card::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "The Mimeoplasm")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Ooze])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(
+            "As The Mimeoplasm enters, you may exile two creature cards from graveyards. If you do, it enters as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.",
+        )
+        .expect("The Mimeoplasm should parse for runtime tests")
+}
+
+struct ChooseMimeoplasmPairDecisionMaker {
+    copy_name: &'static str,
+    counter_id: ObjectId,
+}
+
+impl DecisionMaker for ChooseMimeoplasmPairDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        ctx.options
+            .iter()
+            .find(|option| {
+                option.legal
+                    && option.description.contains(self.copy_name)
+                    && option
+                        .related_object_ids
+                        .as_ref()
+                        .is_some_and(|ids| ids.contains(&self.counter_id))
+            })
+            .map(|option| vec![option.index])
+            .unwrap_or_else(|| vec![0])
+    }
+}
+
+#[test]
+fn the_mimeoplasm_exiles_two_graveyard_creatures_copies_one_and_gets_other_power_counters() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let copy_source = CardDefinitionBuilder::new(CardId::new(), "Copy Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let counter_source = CardDefinitionBuilder::new(CardId::new(), "Counter Wurm")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .build();
+    game.create_object_from_definition(&copy_source, alice, Zone::Graveyard);
+    let counter_id = game.create_object_from_definition(&counter_source, bob, Zone::Graveyard);
+
+    let mimeoplasm = the_mimeoplasm_test_definition();
+    let mimeoplasm_id = game.create_object_from_definition(&mimeoplasm, alice, Zone::Hand);
+    let mut dm = ChooseMimeoplasmPairDecisionMaker {
+        copy_name: "Copy Bear",
+        counter_id,
+    };
+    let result = game
+        .move_object_with_etb_processing_with_dm(mimeoplasm_id, Zone::Battlefield, &mut dm)
+        .expect("The Mimeoplasm should enter");
+
+    let entered = game
+        .object(result.new_id)
+        .expect("The Mimeoplasm permanent should exist");
+    assert_eq!(entered.name, "Copy Bear");
+    assert_eq!(entered.base_power, Some(PtValue::Fixed(2)));
+    assert_eq!(entered.base_toughness, Some(PtValue::Fixed(2)));
+    assert_eq!(
+        entered
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0),
+        6,
+        "The Mimeoplasm should get +1/+1 counters equal to the other exiled card's power"
+    );
+
+    let linked_names = game
+        .get_exiled_with_source_links(result.new_id)
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    assert!(
+        linked_names.contains(&"Copy Bear") && linked_names.contains(&"Counter Wurm"),
+        "The Mimeoplasm should exile and link both chosen graveyard cards, got {linked_names:?}"
+    );
+}
+
+#[test]
+fn the_mimeoplasm_declined_optional_exile_enters_as_itself_and_leaves_graveyards_unchanged() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let first = CardDefinitionBuilder::new(CardId::new(), "First Graveyard Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let second = CardDefinitionBuilder::new(CardId::new(), "Second Graveyard Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let first_id = game.create_object_from_definition(&first, alice, Zone::Graveyard);
+    let second_id = game.create_object_from_definition(&second, alice, Zone::Graveyard);
+
+    let mimeoplasm = the_mimeoplasm_test_definition();
+    let mimeoplasm_id = game.create_object_from_definition(&mimeoplasm, alice, Zone::Hand);
+    let mut dm = AutoPassDecisionMaker;
+    let result = game
+        .move_object_with_etb_processing_with_dm(mimeoplasm_id, Zone::Battlefield, &mut dm)
+        .expect("The Mimeoplasm should enter even when declined");
+
+    let entered = game
+        .object(result.new_id)
+        .expect("The Mimeoplasm permanent should exist");
+    assert_eq!(entered.name, "The Mimeoplasm");
+    assert!(entered.counters.is_empty());
+    assert!(game.object(first_id).is_some_and(|object| object.zone == Zone::Graveyard));
+    assert!(game.object(second_id).is_some_and(|object| object.zone == Zone::Graveyard));
+    assert!(game.get_exiled_with_source_links(result.new_id).is_empty());
+}
+
+#[test]
+fn the_mimeoplasm_needs_two_graveyard_creature_cards_to_apply_copy_replacement() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let lone = CardDefinitionBuilder::new(CardId::new(), "Lone Graveyard Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .build();
+    let lone_id = game.create_object_from_definition(&lone, alice, Zone::Graveyard);
+
+    let mimeoplasm = the_mimeoplasm_test_definition();
+    let mimeoplasm_id = game.create_object_from_definition(&mimeoplasm, alice, Zone::Hand);
+    let result = game
+        .move_object_with_etb_processing(mimeoplasm_id, Zone::Battlefield)
+        .expect("The Mimeoplasm should enter without enough graveyard creature cards");
+
+    let entered = game
+        .object(result.new_id)
+        .expect("The Mimeoplasm permanent should exist");
+    assert_eq!(entered.name, "The Mimeoplasm");
+    assert!(entered.counters.is_empty());
+    assert!(game.object(lone_id).is_some_and(|object| object.zone == Zone::Graveyard));
+    assert!(game.get_exiled_with_source_links(result.new_id).is_empty());
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -13976,7 +13976,7 @@ fn test_enter_as_copy_with_no_candidates_keeps_original_characteristics() {
     assert_eq!(entered.base_toughness, Some(crate::card::PtValue::Fixed(4)));
 }
 
-fn the_mimeoplasm_test_definition() -> crate::card::CardDefinition {
+fn the_mimeoplasm_test_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), "The Mimeoplasm")
         .card_types(vec![CardType::Creature])
         .subtypes(vec![Subtype::Ooze])
@@ -14056,8 +14056,15 @@ fn the_mimeoplasm_exiles_two_graveyard_creatures_copies_one_and_gets_other_power
         "The Mimeoplasm should get +1/+1 counters equal to the other exiled card's power"
     );
 
-    let linked_names = game
-        .get_exiled_with_source_links(result.new_id)
+    let linked_ids = game.get_exiled_with_source_links(result.new_id);
+    assert!(
+        linked_ids
+            .iter()
+            .all(|id| game.object(*id).is_some_and(|object| object.zone == Zone::Exile)),
+        "The Mimeoplasm should link only exiled objects, got {linked_ids:?}"
+    );
+
+    let linked_names = linked_ids
         .iter()
         .filter_map(|id| game.object(*id).map(|object| object.name.as_str()))
         .collect::<Vec<_>>();

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14150,6 +14150,47 @@ fn the_mimeoplasm_needs_two_graveyard_creature_cards_to_apply_copy_replacement()
 }
 
 #[test]
+fn the_mimeoplasm_does_not_count_noncreature_or_token_graveyard_objects_for_its_pair() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Only Graveyard Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .build();
+    let noncreature = CardDefinitionBuilder::new(CardId::new(), "Graveyard Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let token_creature = CardDefinitionBuilder::new(CardId::new(), "Graveyard Token Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(9, 9))
+        .build();
+    let creature_id = game.create_object_from_definition(&creature, alice, Zone::Graveyard);
+    let noncreature_id = game.create_object_from_definition(&noncreature, alice, Zone::Graveyard);
+    let token_id = game.create_object_from_definition(&token_creature, alice, Zone::Graveyard);
+    game.object_mut(token_id)
+        .expect("test token object should exist")
+        .kind = ObjectKind::Token;
+
+    let mimeoplasm = the_mimeoplasm_test_definition();
+    let mimeoplasm_id = game.create_object_from_definition(&mimeoplasm, alice, Zone::Hand);
+    let mut dm = PanicOnMimeoplasmReplacementPrompt;
+    let result = game
+        .move_object_with_etb_processing_with_dm(mimeoplasm_id, Zone::Battlefield, &mut dm)
+        .expect("The Mimeoplasm should enter without counting noncreature or token graveyard objects");
+
+    let entered = game
+        .object(result.new_id)
+        .expect("The Mimeoplasm permanent should exist");
+    assert_eq!(entered.name, "The Mimeoplasm");
+    assert!(entered.counters.is_empty());
+    assert!(game.object(creature_id).is_some_and(|object| object.zone == Zone::Graveyard));
+    assert!(game.object(noncreature_id).is_some_and(|object| object.zone == Zone::Graveyard));
+    assert!(game.object(token_id).is_some_and(|object| object.zone == Zone::Graveyard));
+    assert!(game.get_exiled_with_source_links(result.new_id).is_empty());
+}
+
+#[test]
 fn resolving_ability_from_spell_on_stack_does_not_move_source_spell() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -4271,7 +4271,7 @@ impl GameState {
         }
 
         // Proceed with normal battlefield entry
-        let new_id = self.move_object(old_id, Zone::Battlefield, cause)?;
+        let new_id = self.move_object(old_id, Zone::Battlefield, cause.clone())?;
         if let Some(controller) = result.controller_override {
             self.set_current_controller(new_id, controller);
         }
@@ -4337,6 +4337,18 @@ impl GameState {
             if let Some(obj) = self.object_mut(new_id) {
                 *obj.counters.entry(*counter_type).or_insert(0) += count;
             }
+        }
+
+        for linked_old_id in &result.linked_exile_with_entering {
+            if self.object(*linked_old_id).is_none() {
+                continue;
+            }
+            let Some(exiled_id) = self.move_object(*linked_old_id, Zone::Exile, cause.clone())
+            else {
+                continue;
+            };
+            self.add_exiled_with_source_link(new_id, exiled_id);
+            self.record_zone_change_results(*linked_old_id, vec![exiled_id]);
         }
 
         // Apply "as this enters, choose a color" selections.

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -152,6 +152,8 @@ pub enum ReplacementAction {
     EnterAsCopy {
         source: ObjectId,
         enters_tapped: bool,
+        linked_exile_objects: Vec<ObjectId>,
+        additional_counters: Vec<(CounterType, u32)>,
         name_override: Option<String>,
         added_card_types: Vec<CardType>,
         removed_supertypes: Vec<Supertype>,

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -968,6 +968,7 @@ pub struct EnterAsCopyAsEntersSpec {
     pub affected_filter: Option<crate::target::ObjectFilter>,
     pub may: bool,
     pub enters_tapped_if_chosen: bool,
+    pub linked_exile_pair: Option<EnterAsCopyLinkedExilePairSpec>,
     pub copy_source_self: bool,
     pub copy_source_enchanted: bool,
     pub name_override: Option<String>,
@@ -977,6 +978,11 @@ pub struct EnterAsCopyAsEntersSpec {
     pub added_abilities: Vec<crate::ability::Ability>,
     pub set_base_power_toughness: Option<(i32, i32)>,
     pub set_base_power_toughness_from_self: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnterAsCopyLinkedExilePairSpec {
+    pub counter_type: crate::object::CounterType,
 }
 
 /// Spec for static abilities that duplicate matching triggered abilities.

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -437,6 +437,11 @@ impl StaticAbilityModelInterpreter {
                     affected_filter: spec.affected_filter.clone(),
                     may: spec.may,
                     enters_tapped_if_chosen: spec.enters_tapped_if_chosen,
+                    linked_exile_pair: spec.linked_exile_pair.map(|pair| {
+                        super::EnterAsCopyLinkedExilePairSpec {
+                            counter_type: pair.counter_type,
+                        }
+                    }),
                     copy_source_self: spec.copy_source_self,
                     copy_source_enchanted: spec.copy_source_enchanted,
                     name_override: spec.name_override.clone(),
@@ -1178,6 +1183,11 @@ impl StaticAbilityModelInterpreter {
                         affected_filter: spec.affected_filter.clone(),
                         may: spec.may,
                         enters_tapped_if_chosen: spec.enters_tapped_if_chosen,
+                        linked_exile_pair: spec.linked_exile_pair.map(|pair| {
+                            super::EnterAsCopyLinkedExilePairSpec {
+                                counter_type: pair.counter_type,
+                            }
+                        }),
                         copy_source_self: spec.copy_source_self,
                         copy_source_enchanted: spec.copy_source_enchanted,
                         name_override: spec.name_override.clone(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The Mimeoplasm
Initial parse error:
```
parser does not yet support line family: 'As The Mimeoplasm enters, you may exile two creature cards from graveyards. If you do, it enters as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.'; oracle-only fallback also failed: parser does not yet support line family: 'As The Mimeoplasm enters, you may exile two creature cards from graveyards. If you do, it enters as a copy of one of those cards with a number of additional +1/+1 counters on it equal to the power of the other card.'
```

Current worker: i-0d7c26cd0812cbdd5
Branch: codex/aws-card-fix-the-mimeoplasm
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0143
