### PR TITLE
Fix Ironsmith parse failure: Runes of the Deus

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2271,9 +2271,16 @@ pub(crate) fn parse_static_condition_clause(
         return Ok(crate::ConditionExpr::EquippedCreatureAttacking);
     }
     if clause_words.len() >= 4
-        && clause_words[0] == "equipped"
-        && clause_words[1] == "creature"
         && clause_words[2] == "is"
+        && matches!(
+            &clause_words[..2],
+            ["equipped", "creature"]
+                | ["equipped", "permanent"]
+                | ["enchanted", "artifact"]
+                | ["enchanted", "creature"]
+                | ["enchanted", "land"]
+                | ["enchanted", "permanent"]
+        )
     {
         let mut descriptor_words = &clause_words[3..];
         if descriptor_words.first().is_some_and(|word| is_article(word)) {
@@ -2282,8 +2289,13 @@ pub(crate) fn parse_static_condition_clause(
 
         if descriptor_words.len() == 1 {
             let descriptor = descriptor_words[0];
-            let mut filter = ObjectFilter::creature()
-                .match_tagged(crate::TagKey::from("equipped"), crate::target::TaggedOpbjectRelation::IsTaggedObject);
+            let subject_end = token_index_for_word_index(&tokens, 2).ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unable to map attached-object condition subject (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+            let mut filter = parse_object_filter(&tokens[..subject_end], false)?;
             if let Some(color) = parse_color(descriptor) {
                 filter.colors = Some(color);
                 return Ok(crate::ConditionExpr::CountComparison {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8277,6 +8277,37 @@ fn test_rageform_parses_and_renders_aura_become_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn runes_of_the_deus_strict_parse_and_compiled_text_conditions() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Runes of the Deus")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant creature\nAs long as enchanted creature is red, it gets +1/+1 and has double strike.\nAs long as enchanted creature is green, it gets +1/+1 and has trample.",
+        )
+        .expect("Runes of the Deus should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("enchanted creature gets +1/+1 and has double strike")
+            && rendered.contains("as long as enchanted creature is red"),
+        "expected red conditional double-strike grant in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("enchanted creature gets +1/+1 and has trample")
+            && rendered.contains("as long as enchanted creature is green"),
+        "expected green conditional trample grant in compiled text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported parser line fallback"),
+        "Runes of the Deus should not rely on parser fallback markers: {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_manifest_dread_trigger_without_fallback_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Manifest Dread Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8293,6 +8293,10 @@ fn runes_of_the_deus_strict_parse_and_compiled_text_conditions() {
         .to_ascii_lowercase();
 
     assert!(
+        rendered.contains("enchant creature"),
+        "expected Aura enchant restriction in compiled text, got {rendered}"
+    );
+    assert!(
         rendered.contains("enchanted creature gets +1/+1 and has double strike")
             && rendered.contains("as long as enchanted creature is red"),
         "expected red conditional double-strike grant in compiled text, got {rendered}"

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8278,12 +8278,14 @@ fn test_rageform_parses_and_renders_aura_become_clause() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn runes_of_the_deus_strict_parse_and_compiled_text_conditions() {
+    let oracle = oracle_text_by_name()
+        .get("Runes of the Deus")
+        .expect("missing oracle text for Runes of the Deus")
+        .clone();
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Runes of the Deus")
         .card_types(vec![CardType::Enchantment])
         .subtypes(vec![Subtype::Aura])
-        .parse_text(
-            "Enchant creature\nAs long as enchanted creature is red, it gets +1/+1 and has double strike.\nAs long as enchanted creature is green, it gets +1/+1 and has trample.",
-        )
+        .parse_text(oracle)
         .expect("Runes of the Deus should parse strictly");
 
     let rendered = unprocessed_compiled_lines(&def)
@@ -8304,6 +8306,67 @@ fn runes_of_the_deus_strict_parse_and_compiled_text_conditions() {
         !rendered.contains("unsupported parser line fallback"),
         "Runes of the Deus should not rely on parser fallback markers: {rendered}"
     );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn runes_of_the_deus_runtime_applies_color_condition_branches() {
+    fn assert_runes_branch(
+        target_colors: crate::color::ColorSet,
+        expected_power: i32,
+        expected_toughness: i32,
+        has_double_strike: bool,
+        has_trample: bool,
+    ) {
+        let oracle = oracle_text_by_name()
+            .get("Runes of the Deus")
+            .expect("missing oracle text for Runes of the Deus")
+            .clone();
+        let runes = CardDefinitionBuilder::new(CardId::new(), "Runes of the Deus")
+            .card_types(vec![CardType::Enchantment])
+            .subtypes(vec![Subtype::Aura])
+            .parse_text(oracle)
+            .expect("Runes of the Deus should parse strictly");
+        let enchanted = CardDefinitionBuilder::new(CardId::new(), "Enchanted Test Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .color_indicator(target_colors)
+            .build();
+
+        let alice = PlayerId::from_index(0);
+        let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+        let creature_id = game.create_object_from_definition(&enchanted, alice, Zone::Battlefield);
+        let runes_id = game.create_object_from_definition(&runes, alice, Zone::Battlefield);
+        game.object_mut(runes_id)
+            .expect("Runes of the Deus object should exist")
+            .attached_to = Some(crate::object::AttachmentTarget::Object(creature_id));
+        game.object_mut(creature_id)
+            .expect("enchanted creature should exist")
+            .attachments
+            .push(runes_id);
+
+        assert_eq!(game.calculated_power(creature_id), Some(expected_power));
+        assert_eq!(game.calculated_toughness(creature_id), Some(expected_toughness));
+        assert_eq!(
+            game.object_has_static_ability_id(creature_id, StaticAbilityId::DoubleStrike),
+            has_double_strike
+        );
+        assert_eq!(
+            game.object_has_static_ability_id(creature_id, StaticAbilityId::Trample),
+            has_trample
+        );
+    }
+
+    assert_runes_branch(crate::color::ColorSet::RED, 3, 3, true, false);
+    assert_runes_branch(crate::color::ColorSet::GREEN, 3, 3, false, true);
+    assert_runes_branch(
+        crate::color::ColorSet::RED.union(crate::color::ColorSet::GREEN),
+        4,
+        4,
+        true,
+        true,
+    );
+    assert_runes_branch(crate::color::ColorSet::BLUE, 2, 2, false, false);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Runes of the Deus
Initial parse error:
```
unsupported static condition clause (clause: 'enchanted creature is red'); oracle-only fallback also failed: unsupported static condition clause (clause: 'enchanted creature is red')
```

Current worker: i-0b40102ff5e967c66
Branch: codex/aws-card-fix-runes-of-the-deus
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0147
