### PR TITLE
Fix Ironsmith parse failure: Thunderwave

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1089,7 +1089,9 @@ pub(super) fn run_statement_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     Ok(parse_statement_line_cst(ctx.line)?.map(|statement_line| {
-        LineDispatchResult::single(RewriteLineCst::Statement(statement_line), ctx.idx + 1)
+        let (statement_line, next_idx) =
+            extend_statement_line_with_result_followups(&ctx.preprocessed.items, ctx.idx, statement_line);
+        LineDispatchResult::single(RewriteLineCst::Statement(statement_line), next_idx)
     }))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -76,9 +76,9 @@ use line_dispatch::{LineDispatchResult, dispatch_standard_line_cst};
 #[cfg(test)]
 use statement_cst_support::looks_like_statement_line;
 use statement_cst_support::{
-    extend_triggered_line_with_result_followups, looks_like_statement_line_lexed,
-    normalize_statement_parse_groups_lexed, parse_colon_nonactivation_statement_fallback,
-    parse_statement_line_cst,
+    extend_statement_line_with_result_followups, extend_triggered_line_with_result_followups,
+    looks_like_statement_line_lexed, normalize_statement_parse_groups_lexed,
+    parse_colon_nonactivation_statement_fallback, parse_statement_line_cst,
 };
 use unsupported::diagnose_known_unsupported_rewrite_line;
 
@@ -530,19 +530,24 @@ fn tokens_after_non_keyword_label_prefix(line: &PreprocessedLine) -> Option<&[Ow
 }
 
 fn looks_like_numeric_result_prefix_lexed(tokens: &[OwnedLexToken]) -> bool {
-    matches!(
+    if !matches!(
         tokens.first().map(|token| token.kind),
         Some(TokenKind::Number)
-    ) && matches!(
+    ) {
+        return false;
+    }
+
+    if matches!(tokens.get(1).map(|token| token.kind), Some(TokenKind::Pipe)) {
+        return true;
+    }
+
+    matches!(
         tokens.get(1).map(|token| token.kind),
         Some(TokenKind::Dash | TokenKind::EmDash)
     ) && matches!(
         tokens.get(2).map(|token| token.kind),
         Some(TokenKind::Number)
-    ) && tokens
-        .iter()
-        .skip(3)
-        .any(|token| token.kind == TokenKind::Pipe)
+    ) && tokens.iter().skip(3).any(|token| token.kind == TokenKind::Pipe)
 }
 
 fn should_skip_keyword_action_static_probe(tokens: &[OwnedLexToken]) -> bool {
@@ -1318,6 +1323,12 @@ fn strip_non_keyword_label_prefix(text: &str) -> &str {
 
 fn looks_like_numeric_result_prefix_text(text: &str) -> bool {
     let trimmed = text.trim_start();
+    let Some((head, _)) = trimmed.split_once('|') else {
+        return false;
+    };
+    if head.trim().chars().all(|ch| ch.is_ascii_digit()) {
+        return true;
+    }
     let Some((head, rest)) = trimmed.split_once('—').or_else(|| trimmed.split_once('-')) else {
         return false;
     };
@@ -3161,9 +3172,17 @@ pub(crate) fn parse_document_cst(
                             if let Some(statement_line) =
                                 parse_statement_line_cst(&rewritten_prefix_line)?
                             {
+                                let (statement_line, next_idx) =
+                                    extend_statement_line_with_result_followups(
+                                        &preprocessed.items,
+                                        idx,
+                                        statement_line,
+                                    );
                                 let cst = RewriteLineCst::Statement(statement_line);
                                 trace_cst_line(&cst);
                                 lines.push(cst);
+                                idx = next_idx;
+                                continue;
                             } else if let Some(static_line) =
                                 parse_static_line_cst(&rewritten_prefix_line)?
                             {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -200,6 +200,32 @@ pub(super) fn extend_triggered_line_with_result_followups(
     (triggered, next_idx)
 }
 
+pub(super) fn extend_statement_line_with_result_followups(
+    items: &[PreprocessedItem],
+    idx: usize,
+    mut statement: StatementLineCst,
+) -> (StatementLineCst, usize) {
+    let mut next_idx = idx + 1;
+
+    while let Some(PreprocessedItem::Line(line)) = items.get(next_idx) {
+        if !is_trigger_result_followup_line(line) {
+            break;
+        }
+
+        let followup_text = render_token_slice(&line.tokens).trim().to_string();
+        if !statement.text.is_empty() {
+            statement.text.push('\n');
+        }
+        statement.text.push_str(followup_text.as_str());
+        append_joined_line_tokens(&mut statement.parse_tokens, &line.tokens);
+        statement.parse_groups = normalize_statement_parse_groups_lexed(&statement.parse_tokens);
+
+        next_idx += 1;
+    }
+
+    (statement, next_idx)
+}
+
 fn looks_like_statement_line_tokens(tokens: &[OwnedLexToken]) -> bool {
     if matches!(
         structure::classify_static_line_family_lexed(tokens),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -473,6 +473,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_object_filter_lexed_handles_not_chosen_this_way_phrase() {
+        let tokens = lex_line("creature not chosen this way", 0).unwrap();
+
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.card_types, vec![CardType::Creature]);
+        assert!(filter.tagged_constraints.iter().any(|constraint| {
+            *constraint
+                == TaggedObjectConstraint {
+                    tag: TagKey::from(IT_TAG),
+                    relation: TaggedOpbjectRelation::IsNotTaggedObject,
+                }
+        }));
+    }
+
+    #[test]
     fn parse_object_filter_lexed_handles_different_one_of_prefix() {
         let tokens = lex_line("different one of those creatures", 0).unwrap();
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -408,6 +408,7 @@ pub(super) fn parse_object_filter_inner(
     );
 
     try_apply_attached_exclusion_phrases(&mut filter, &mut all_words);
+    try_apply_chosen_this_way_clause(&mut filter, &mut all_words);
     let exclude_basic_land_cards =
         strip_other_than_basic_land_cards_clause(&mut all_words, &mut segment_tokens);
 
@@ -1841,4 +1842,33 @@ fn try_apply_distinct_creature_types_clause(
         return true;
     }
     false
+}
+
+fn try_apply_chosen_this_way_clause(filter: &mut ObjectFilter, all_words: &mut Vec<&str>) -> bool {
+    let Some((idx, negated, consumed)) = find_word_slice_phrase_start(
+        all_words.as_slice(),
+        &["not", "chosen", "this", "way"],
+    )
+    .map(|idx| (idx, true, 4usize))
+    .or_else(|| {
+        find_word_slice_phrase_start(all_words.as_slice(), &["nonchosen", "this", "way"])
+            .map(|idx| (idx, true, 3usize))
+    })
+    .or_else(|| {
+        find_word_slice_phrase_start(all_words.as_slice(), &["chosen", "this", "way"])
+            .map(|idx| (idx, false, 3usize))
+    }) else {
+        return false;
+    };
+
+    filter.tagged_constraints.push(TaggedObjectConstraint {
+        tag: TagKey::from(IT_TAG),
+        relation: if negated {
+            TaggedOpbjectRelation::IsNotTaggedObject
+        } else {
+            TaggedOpbjectRelation::IsTaggedObject
+        },
+    });
+    all_words.drain(idx..idx + consumed);
+    true
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1228,10 +1228,12 @@ fn split_leading_numeric_result_prefix_lexed<'a>(
         return None;
     }
 
-    Some((
-        IfResultPredicate::Value(Comparison::BetweenInclusive(min, max)),
-        trailing_tokens,
-    ))
+    let comparison = if min == max {
+        Comparison::Equal(min)
+    } else {
+        Comparison::BetweenInclusive(min, max)
+    };
+    Some((IfResultPredicate::Value(comparison), trailing_tokens))
 }
 
 pub(crate) fn split_trailing_if_clause_lexed<'a>(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1195,12 +1195,10 @@ fn split_leading_numeric_result_prefix_lexed<'a>(
     tokens: &'a [OwnedLexToken],
 ) -> Option<(IfResultPredicate, &'a [OwnedLexToken])> {
     let first = tokens.first()?;
-    let second = tokens.get(1)?;
-    let third = tokens.get(2)?;
     let pipe_idx = tokens
         .iter()
         .position(|token| token.kind == TokenKind::Pipe)?;
-    if pipe_idx < 3 {
+    if pipe_idx < 1 {
         return None;
     }
 
@@ -1208,12 +1206,18 @@ fn split_leading_numeric_result_prefix_lexed<'a>(
         TokenKind::Number => first.parser_text().parse::<i32>().ok()?,
         _ => return None,
     };
-    if !matches!(second.kind, TokenKind::Dash | TokenKind::EmDash) {
-        return None;
-    }
-    let max = match third.kind {
-        TokenKind::Number => third.parser_text().parse::<i32>().ok()?,
-        _ => return None,
+    let max = if pipe_idx == 1 {
+        min
+    } else {
+        let second = tokens.get(1)?;
+        let third = tokens.get(2)?;
+        if pipe_idx < 3 || !matches!(second.kind, TokenKind::Dash | TokenKind::EmDash) {
+            return None;
+        }
+        match third.kind {
+            TokenKind::Number => third.parser_text().parse::<i32>().ok()?,
+            _ => return None,
+        }
     };
     if min > max {
         return None;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -674,6 +674,21 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         ));
     }
 
+    if matches!(
+        choice_words,
+        ["choose", "a" | "an", "artifact" | "battle" | "creature" | "enchantment" | "land" | "permanent" | "planeswalker"]
+    ) && let Some((_chooser, mut choose_filter, choose_count)) = parse_you_choose_objects_clause(tokens)?
+    {
+        choose_filter.controller = Some(PlayerFilter::Any);
+        return Ok(EffectAst::ChooseObjects {
+            filter: choose_filter,
+            count: choose_count,
+            count_value: None,
+            player: PlayerAst::Implicit,
+            tag: TagKey::from(IT_TAG),
+        });
+    }
+
     if let Some((consumed, options)) = parse_choose_card_type_phrase_words(choice_words)?
         && consumed == choice_words.len()
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -924,6 +924,40 @@ fn parse_effect_sentences_from_sentence_inputs(
         let sentence_text = crate::runtime_backend::token_word_refs(sentence).join(" ");
         let _sentence_scope = parse_trace::scope(format!("effect sentence: \"{}\"", sentence_text));
 
+        if sentence
+            .first()
+            .is_some_and(|token| token.kind == TokenKind::Number)
+            && let Some(prefix) =
+                super::super::grammar::structure::split_leading_result_prefix_lexed(sentence)
+        {
+            let mut branch_sentences = vec![SentenceInput::from_lexed(prefix.trailing_tokens)];
+            let mut next_idx = sentence_idx + 1;
+            while next_idx < sentences.len() {
+                let next_sentence = sentences[next_idx].lowered();
+                if next_sentence
+                    .first()
+                    .is_some_and(|token| token.kind == TokenKind::Number)
+                    && super::super::grammar::structure::split_leading_result_prefix_lexed(
+                        next_sentence,
+                    )
+                    .is_some()
+                {
+                    break;
+                }
+                branch_sentences.push(SentenceInput::from_lexed(next_sentence));
+                next_idx += 1;
+            }
+
+            let branch_effects = parse_effect_sentences_from_sentence_inputs(branch_sentences)?;
+            effects.push(EffectAst::IfResult {
+                predicate: prefix.predicate,
+                effects: branch_effects,
+            });
+            carried_context = None;
+            sentence_idx = next_idx;
+            continue;
+        }
+
         if let Some(mut matched) = try_parse_subject_verb_sequence_rule(&sentences, sentence_idx)? {
             let stage = if let Some(feature_tag) = matched.feature_tag {
                 format!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36032,12 +36032,12 @@ fn thunderwave_compiled_text_preserves_choice_and_exact_twenty_branch() {
 
     assert_eq!(
         rendered,
-        vec![
-            "Roll a d20.",
-            "1—9 | Thunderwave deals 3 damage to each creature.",
-            "10—19 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.",
+        vec![concat!(
+            "Roll a d20.\n",
+            "1—9 | Thunderwave deals 3 damage to each creature.\n",
+            "10—19 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.\n",
             "20 | Thunderwave deals 6 damage to each creature your opponents control.",
-        ]
+        )]
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36005,6 +36005,181 @@ fn parse_oracle_card_definition(name: &str) -> CardDefinition {
         .unwrap_or_else(|err| panic!("strict parser regression failed for '{name}': {err:?}"))
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn thunderwave_definition() -> CardDefinition {
+    parse_oracle_card_definition("Thunderwave")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunderwave_parses_strictly_with_d20_choice_and_not_chosen_filter() {
+    let def = thunderwave_definition();
+    let debug = format!("{:?}", def.spell_effect);
+
+    assert!(debug.contains("RollDieEffect"), "{debug}");
+    assert!(debug.contains("BetweenInclusive(1, 9)"), "{debug}");
+    assert!(debug.contains("BetweenInclusive(10, 19)"), "{debug}");
+    assert!(debug.contains("Equal(20)"), "{debug}");
+    assert!(debug.contains("ChooseObjectsEffect"), "{debug}");
+    assert!(debug.contains("IsNotTaggedObject"), "{debug}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunderwave_compiled_text_preserves_choice_and_exact_twenty_branch() {
+    let def = thunderwave_definition();
+    let rendered = unprocessed_compiled_lines(&def);
+
+    assert_eq!(
+        rendered,
+        vec![
+            "Roll a d20.",
+            "1—9 | Thunderwave deals 3 damage to each creature.",
+            "10—19 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.",
+            "20 | Thunderwave deals 6 damage to each creature your opponents control.",
+        ]
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn thunderwave_test_creature(
+    game: &mut crate::game_state::GameState,
+    name: &str,
+    controller: PlayerId,
+) -> ObjectId {
+    let creature = CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(10, 10))
+        .build();
+    game.create_object_from_definition(&creature, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ThunderwaveDecisionMaker {
+    accept_choice: bool,
+    chosen: Option<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for ThunderwaveDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept_choice
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        self.chosen
+            .filter(|chosen| {
+                ctx.candidates
+                    .iter()
+                    .any(|candidate| candidate.legal && candidate.id == *chosen)
+            })
+            .into_iter()
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_thunderwave_with_roll(
+    game: &mut crate::game_state::GameState,
+    roll: u32,
+    accept_choice: bool,
+    chosen: Option<ObjectId>,
+) {
+    let alice = PlayerId::from_index(0);
+    let def = thunderwave_definition();
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = ThunderwaveDecisionMaker {
+        accept_choice,
+        chosen,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    game.force_next_die_roll(roll);
+    crate::game_loop::execute_resolution_program(
+        game,
+        &mut ctx,
+        alice,
+        source,
+        def.spell_effect.as_ref().expect("Thunderwave spell effect"),
+        None,
+        &[],
+    )
+    .expect("Thunderwave should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunderwave_roll_one_to_nine_damages_each_creature() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let first = thunderwave_test_creature(&mut game, "Alice Creature", alice);
+    let second = thunderwave_test_creature(&mut game, "Second Alice Creature", alice);
+    let opponent = thunderwave_test_creature(&mut game, "Bob Creature", bob);
+
+    resolve_thunderwave_with_roll(&mut game, 7, false, None);
+
+    assert_eq!(game.damage_on(first), 3);
+    assert_eq!(game.damage_on(second), 3);
+    assert_eq!(game.damage_on(opponent), 3);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunderwave_roll_ten_to_nineteen_spares_chosen_creature_only() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let chosen = thunderwave_test_creature(&mut game, "Chosen Creature", alice);
+    let other = thunderwave_test_creature(&mut game, "Other Creature", alice);
+    let opponent = thunderwave_test_creature(&mut game, "Opponent Creature", bob);
+
+    resolve_thunderwave_with_roll(&mut game, 12, true, Some(chosen));
+
+    assert_eq!(game.damage_on(chosen), 0);
+    assert_eq!(game.damage_on(other), 3);
+    assert_eq!(game.damage_on(opponent), 3);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunderwave_roll_ten_to_nineteen_declined_choice_damages_all_creatures() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let first = thunderwave_test_creature(&mut game, "Alice Creature", alice);
+    let second = thunderwave_test_creature(&mut game, "Second Alice Creature", alice);
+    let opponent = thunderwave_test_creature(&mut game, "Bob Creature", bob);
+
+    resolve_thunderwave_with_roll(&mut game, 15, false, Some(first));
+
+    assert_eq!(game.damage_on(first), 3);
+    assert_eq!(game.damage_on(second), 3);
+    assert_eq!(game.damage_on(opponent), 3);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunderwave_roll_twenty_damages_only_opponent_creatures_for_six() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let yours = thunderwave_test_creature(&mut game, "Alice Creature", alice);
+    let opponent = thunderwave_test_creature(&mut game, "Bob Creature", bob);
+
+    resolve_thunderwave_with_roll(&mut game, 20, false, None);
+
+    assert_eq!(game.damage_on(yours), 0);
+    assert_eq!(game.damage_on(opponent), 6);
+}
+
 fn assert_oracle_card_parses_strict(name: &str) {
     let oracle = oracle_text_by_name()
         .get(name)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36150,6 +36150,23 @@ fn thunderwave_roll_ten_to_nineteen_spares_chosen_creature_only() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn thunderwave_roll_ten_to_nineteen_can_spare_opponent_creature() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let yours = thunderwave_test_creature(&mut game, "Alice Creature", alice);
+    let opponent = thunderwave_test_creature(&mut game, "Opponent Creature", bob);
+    let other_opponent = thunderwave_test_creature(&mut game, "Other Opponent Creature", bob);
+
+    resolve_thunderwave_with_roll(&mut game, 19, true, Some(opponent));
+
+    assert_eq!(game.damage_on(yours), 3);
+    assert_eq!(game.damage_on(opponent), 0);
+    assert_eq!(game.damage_on(other_opponent), 3);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn thunderwave_roll_ten_to_nineteen_declined_choice_damages_all_creatures() {
     let mut game = crate::tests::test_helpers::setup_two_player_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2380,7 +2380,7 @@ fn describe_may_choose_then_affect_not_chosen_this_way(effects: &[Effect]) -> Op
         return None;
     };
     let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
-    if may.decider.is_some() {
+    if !matches!(may.decider, None | Some(PlayerFilter::You)) {
         return None;
     }
     let [choose_effect] = may.effects.as_slice() else {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2375,6 +2375,55 @@ fn describe_choose_then_put_counter_on_each(effects: &[&Effect]) -> Option<Strin
     }
 }
 
+fn describe_may_choose_then_affect_not_chosen_this_way(effects: &[Effect]) -> Option<String> {
+    let [may_effect, for_each_effect] = effects else {
+        return None;
+    };
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may.decider.is_some() {
+        return None;
+    }
+    let [choose_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if choose.chooser != PlayerFilter::You
+        || choose.is_search
+        || choose_primary_zone(choose) != Some(Zone::Battlefield)
+    {
+        return None;
+    }
+    let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachObject>()?;
+    let not_chosen_idx = for_each.filter.tagged_constraints.iter().position(|constraint| {
+        constraint.tag == choose.tag
+            && constraint.relation == crate::filter::TaggedOpbjectRelation::IsNotTaggedObject
+    })?;
+
+    let mut affected_filter = for_each.filter.clone();
+    affected_filter.tagged_constraints.remove(not_chosen_idx);
+    let affected_text = strip_indefinite_article(&affected_filter.description()).to_string();
+    let effect_text = describe_effect_list(&for_each.effects);
+    let replacements = [
+        " to that object",
+        " to that creature",
+        " to that permanent",
+        " to that artifact",
+        " to that enchantment",
+        " to that land",
+        " to that spell",
+        " to that card",
+    ];
+    let suffix = replacements
+        .iter()
+        .find(|suffix| effect_text.ends_with(**suffix))?;
+    let subject_text = effect_text.trim_end_matches(*suffix);
+
+    Some(format!(
+        "You may choose {}. {subject_text} to each {affected_text} not chosen this way",
+        describe_choose_selection(choose)
+    ))
+}
+
 fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<String> {
     if let [first, rest @ ..] = effects
         && first
@@ -2384,7 +2433,8 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return describe_structural_multisentence_effect_list(rest);
     }
 
-    describe_draw_discard_then_create_structural(effects)
+    describe_may_choose_then_affect_not_chosen_this_way(effects)
+        .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
@@ -11191,6 +11241,36 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             parts.push(rendered);
             idx += 2;
             continue;
+        }
+        if idx + 1 < filtered.len()
+            && let Some(with_id) = filtered[idx].downcast_ref::<crate::effects::WithIdEffect>()
+        {
+            let mut roll_branches = Vec::new();
+            let mut lookahead = idx + 1;
+            while lookahead < filtered.len() {
+                let Some(if_effect) = filtered[lookahead]
+                    .downcast_ref::<crate::effects::IfEffect>()
+                    .or_else(|| {
+                        filtered[lookahead]
+                            .downcast_ref::<crate::effects::WithIdEffect>()
+                            .and_then(|nested| {
+                                nested.effect.downcast_ref::<crate::effects::IfEffect>()
+                            })
+                    })
+                else {
+                    break;
+                };
+                if if_effect.condition != with_id.id {
+                    break;
+                }
+                roll_branches.push(if_effect);
+                lookahead += 1;
+            }
+            if let Some(table) = describe_roll_result_table(with_id, &roll_branches) {
+                parts.push(table);
+                idx = lookahead;
+                continue;
+            }
         }
         if idx + 1 < filtered.len()
             && let Some(with_id) = filtered[idx].downcast_ref::<crate::effects::WithIdEffect>()
@@ -23712,6 +23792,7 @@ fn describe_optional_setup_effect_for_if_happened(
 fn describe_roll_result_comparison(cmp: &Comparison) -> Option<String> {
     match cmp {
         Comparison::Equal(n) => Some(n.to_string()),
+        Comparison::BetweenInclusive(min, max) if min == max => Some(min.to_string()),
         Comparison::BetweenInclusive(min, max) => Some(format!("{min}-{max}")),
         Comparison::OneOf(values) if !values.is_empty() => {
             let nums = values.iter().map(i32::to_string).collect::<Vec<_>>();
@@ -23729,6 +23810,56 @@ fn describe_roll_result_comparison(cmp: &Comparison) -> Option<String> {
         }
         _ => None,
     }
+}
+
+fn describe_roll_result_table_prefix(cmp: &Comparison) -> Option<String> {
+    match cmp {
+        Comparison::Equal(n) => Some(n.to_string()),
+        Comparison::BetweenInclusive(min, max) if min == max => Some(min.to_string()),
+        Comparison::BetweenInclusive(min, max) => Some(format!("{min}—{max}")),
+        _ => None,
+    }
+}
+
+fn normalize_roll_result_table_branch_text(text: String) -> String {
+    text.replace(
+        "to each opponent's creature",
+        "to each creature your opponents control",
+    )
+}
+
+fn describe_roll_result_table(
+    with_id: &crate::effects::WithIdEffect,
+    branches: &[&crate::effects::IfEffect],
+) -> Option<String> {
+    with_id
+        .effect
+        .downcast_ref::<crate::effects::RollDieEffect>()?;
+    if branches.len() < 2 {
+        return None;
+    }
+
+    let mut rows = Vec::new();
+    for branch in branches {
+        if !branch.else_.is_empty() {
+            return None;
+        }
+        let EffectPredicate::Value(cmp) = &branch.predicate else {
+            return None;
+        };
+        let prefix = describe_roll_result_table_prefix(cmp)?;
+        let body = describe_effect_clause_list(&branch.then)
+            .unwrap_or_else(|| describe_effect_list(&branch.then));
+        let body = normalize_roll_result_table_branch_text(body);
+        let body = body.trim().trim_end_matches('.');
+        if body.is_empty() {
+            return None;
+        }
+        rows.push(format!("{prefix} | {}.", capitalize_first(body)));
+    }
+
+    let setup = describe_effect(&with_id.effect);
+    Some(format!("{setup}.\n{}", rows.join("\n")))
 }
 
 fn describe_for_players_may_clause(
@@ -35458,7 +35589,9 @@ pub(super) fn rewrite_damage_phrases_for_permanent_abilities(
         .replace(". Deal ", &format!(". {capitalized_subject} deals "))
         .replace(". deal ", &format!(". {subject} deals "))
         .replace(", Deal ", &format!(", {subject} deals "))
-        .replace(", deal ", &format!(", {subject} deals "));
+        .replace(", deal ", &format!(", {subject} deals "))
+        .replace("| Deal ", &format!("| {capitalized_subject} deals "))
+        .replace("| deal ", &format!("| {subject} deals "));
     if rewrite_it_deals {
         if let Some(rest) = effect_text.strip_prefix("It deals ") {
             return format!("{subject} deals {rest}");


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thunderwave
Initial parse error:
```
missing prior effect for if clause; oracle-only fallback also failed: missing prior effect for if clause
```

Current worker: i-013176ec8ec5297cd
Branch: codex/aws-card-fix-thunderwave
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0147
