### PR TITLE
Fix Ironsmith parse failure: When We Were Young

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3148,6 +3148,37 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         && filtered[0] == "you"
         && (filtered[1] == "control" || filtered[1] == "controls")
     {
+        if let Some(and_idx) = find_index(&filtered[2..], |word| *word == "and") {
+            let and_idx = 2 + and_idx;
+            if and_idx > 2 && and_idx + 1 < filtered.len() {
+                let left_tokens = filtered[2..and_idx]
+                    .iter()
+                    .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                    .collect::<Vec<_>>();
+                let right_tokens = filtered[and_idx + 1..]
+                    .iter()
+                    .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                    .collect::<Vec<_>>();
+                if let (Ok(mut left_filter), Ok(mut right_filter)) = (
+                    parse_object_filter(&left_tokens, false),
+                    parse_object_filter(&right_tokens, false),
+                ) {
+                    left_filter.controller = Some(PlayerFilter::You);
+                    right_filter.controller = Some(PlayerFilter::You);
+                    return Ok(PredicateAst::And(
+                        Box::new(PredicateAst::PlayerControls {
+                            player: PlayerAst::You,
+                            filter: left_filter,
+                        }),
+                        Box::new(PredicateAst::PlayerControls {
+                            player: PlayerAst::You,
+                            filter: right_filter,
+                        }),
+                    ));
+                }
+            }
+        }
+
         let mut filter_start = 2usize;
         let mut min_count: Option<u32> = None;
         let mut exact_count: Option<u32> = None;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -361,7 +361,13 @@ fn statement_group_should_parse_as_effects_first(tokens: &[OwnedLexToken]) -> bo
     let contains_sequence = |needle: &[&str]| -> bool {
         !needle.is_empty() && words.windows(needle.len()).any(|window| window == needle)
     };
+    let targeted_temporary_modifier = words.contains(&"target")
+        && contains_sequence(&["until", "end", "of", "turn"])
+        && words
+            .iter()
+            .any(|word| matches!(*word, "get" | "gets" | "gain" | "gains"));
     contains_sequence(&["if"]) && contains_sequence(&["instead"])
+        || targeted_temporary_modifier
         || ((contains_sequence(&["cant", "cast"]) || contains_sequence(&["can't", "cast"]))
             && contains_sequence(&["next", "turn"]))
         || (contains_sequence(&["until", "end", "of", "turn"])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36149,13 +36149,131 @@ fn when_we_were_young_strict_parser_and_text_regression() {
     let debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
     let compact_debug = debug.split_whitespace().collect::<String>();
     assert!(
-        compact_debug.contains("choicecount{min:0,max:some(2)")
+        compact_debug.contains("choicecount{min:0,max:some(2")
             && debug.contains("and(")
             && debug.contains("artifact")
             && debug.contains("enchantment")
             && debug.contains("lifelink"),
         "expected structural up-to-two targets plus artifact/enchantment lifelink condition, got {debug}"
     );
+}
+
+fn vanilla_creature_for_when_we_were_young(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build()
+}
+
+fn resolve_when_we_were_young_with_condition(
+    controls_enchantment: bool,
+) -> (crate::game_state::GameState, ObjectId, ObjectId, ObjectId) {
+    struct NoopDecisionMaker;
+    impl crate::decision::DecisionMaker for NoopDecisionMaker {}
+
+    let def = parse_oracle_card_definition("When We Were Young");
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("When We Were Young should compile to spell effects");
+    let target_spec = (*program.segments[0].default_effects[0]
+        .target_selection_profile()
+        .expect("When We Were Young should require targets")
+        .spec)
+        .clone();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let first = game.create_object_from_definition(
+        &vanilla_creature_for_when_we_were_young(91_500, "First Target"),
+        alice,
+        Zone::Battlefield,
+    );
+    let second = game.create_object_from_definition(
+        &vanilla_creature_for_when_we_were_young(91_501, "Second Target"),
+        bob,
+        Zone::Battlefield,
+    );
+    let unselected = game.create_object_from_definition(
+        &vanilla_creature_for_when_we_were_young(91_502, "Unselected Creature"),
+        bob,
+        Zone::Battlefield,
+    );
+
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_503), "Condition Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    if controls_enchantment {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(91_504), "Condition Enchantment")
+                .card_types(vec![CardType::Enchantment])
+                .build(),
+            alice,
+            Zone::Battlefield,
+        );
+    }
+
+    let mut dm = NoopDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    ctx.targets = vec![
+        crate::effects::ResolvedTarget::Object(first),
+        crate::effects::ResolvedTarget::Object(second),
+    ];
+    let assignments = vec![crate::game_state::TargetAssignment {
+        spec: target_spec,
+        range: 0..2,
+    }];
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        program,
+        None,
+        &assignments,
+    )
+    .expect("When We Were Young should resolve");
+
+    (game, first, second, unselected)
+}
+
+#[test]
+fn when_we_were_young_pumps_two_targets_and_conditionally_grants_lifelink() {
+    let (game, first, second, unselected) = resolve_when_we_were_young_with_condition(true);
+
+    assert_eq!(game.current_power(first), Some(3));
+    assert_eq!(game.current_toughness(first), Some(3));
+    assert_eq!(game.current_power(second), Some(3));
+    assert_eq!(game.current_toughness(second), Some(3));
+    assert!(game.current_has_static_ability_id(first, StaticAbilityId::Lifelink));
+    assert!(game.current_has_static_ability_id(second, StaticAbilityId::Lifelink));
+
+    assert_eq!(game.current_power(unselected), Some(1));
+    assert_eq!(game.current_toughness(unselected), Some(1));
+    assert!(!game.current_has_static_ability_id(unselected, StaticAbilityId::Lifelink));
+}
+
+#[test]
+fn when_we_were_young_without_artifact_enchantment_condition_only_pumps_targets() {
+    let (game, first, second, unselected) = resolve_when_we_were_young_with_condition(false);
+
+    assert_eq!(game.current_power(first), Some(3));
+    assert_eq!(game.current_toughness(first), Some(3));
+    assert_eq!(game.current_power(second), Some(3));
+    assert_eq!(game.current_toughness(second), Some(3));
+    assert!(!game.current_has_static_ability_id(first, StaticAbilityId::Lifelink));
+    assert!(!game.current_has_static_ability_id(second, StaticAbilityId::Lifelink));
+
+    assert_eq!(game.current_power(unselected), Some(1));
+    assert_eq!(game.current_toughness(unselected), Some(1));
+    assert!(!game.current_has_static_ability_id(unselected, StaticAbilityId::Lifelink));
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36131,6 +36131,34 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn when_we_were_young_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("When We Were Young");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains("Up to two target creatures each get +2/+2 until end of turn"),
+        "expected up-to-two pump clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "If you control an artifact and an enchantment, those creatures also gain lifelink until end of turn"
+        ),
+        "expected conditional lifelink clause to render, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    let compact_debug = debug.split_whitespace().collect::<String>();
+    assert!(
+        compact_debug.contains("choicecount{min:0,max:some(2)")
+            && debug.contains("and(")
+            && debug.contains("artifact")
+            && debug.contains("enchantment")
+            && debug.contains("lifelink"),
+        "expected structural up-to-two targets plus artifact/enchantment lifelink condition, got {debug}"
+    );
+}
+
+#[test]
 fn guardian_of_the_ages_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Guardian of the Ages");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2913,6 +2913,115 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         matches!(apply.target_spec.as_ref(), Some(ChooseSpec::Tagged(candidate)) if candidate == tag)
     }
 
+    fn filter_is_tagged_object(filter: &ObjectFilter, tag: &crate::TagKey) -> bool {
+        filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag == *tag
+                && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+        })
+    }
+
+    fn describe_artifact_enchantment_condition(condition: &Condition) -> Option<String> {
+        fn controlled_type(condition: &Condition) -> Option<CardType> {
+            let Condition::PlayerControls {
+                player: PlayerFilter::You,
+                filter,
+            } = condition
+            else {
+                return None;
+            };
+            if filter.controller == Some(PlayerFilter::You)
+                && filter.zone == Some(Zone::Battlefield)
+                && filter.card_types.len() == 1
+                && filter.subtypes.is_empty()
+            {
+                return filter.card_types.first().copied();
+            }
+            None
+        }
+
+        let Condition::And(left, right) = condition else {
+            return None;
+        };
+        let left_type = controlled_type(left)?;
+        let right_type = controlled_type(right)?;
+        if matches!(
+            (left_type, right_type),
+            (CardType::Artifact, CardType::Enchantment)
+                | (CardType::Enchantment, CardType::Artifact)
+        ) {
+            return Some("you control an artifact and an enchantment".to_string());
+        }
+        None
+    }
+
+    fn describe_tagged_pump_then_conditional_keyword(effects: &[&Effect]) -> Option<String> {
+        let [pump_effect, conditional_effect] = effects else {
+            return None;
+        };
+        let pumped_tag = effect_tag(pump_effect)?;
+        let pump = unwrap_wrapped_effect(pump_effect).downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+        if pump.until != Until::EndOfTurn
+            || pump.condition.is_some()
+            || pump.modification.is_some()
+            || !pump.additional_modifications.is_empty()
+        {
+            return None;
+        }
+        let [crate::effects::continuous::RuntimeModification::ModifyPowerToughness {
+            power,
+            toughness,
+        }] = pump.runtime_modifications.as_slice()
+        else {
+            return None;
+        };
+        let target_spec = pump.target_spec.as_ref()?;
+        let target_text = describe_choose_spec(target_spec);
+        if !target_text.contains("target") || !target_text.ends_with("creatures") {
+            return None;
+        }
+
+        let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        let [grant_effect] = conditional.if_true.as_slice() else {
+            return None;
+        };
+        if !conditional.if_false.is_empty() {
+            return None;
+        }
+        let grant = unwrap_wrapped_effect(grant_effect).downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+        if grant.until != Until::EndOfTurn
+            || grant.condition.is_some()
+            || !grant.runtime_modifications.is_empty()
+            || !grant.additional_modifications.is_empty()
+        {
+            return None;
+        }
+        let Some(crate::continuous::Modification::AddAbility(ability)) = &grant.modification else {
+            return None;
+        };
+        if ability.id() != crate::static_abilities::StaticAbilityId::Lifelink {
+            return None;
+        }
+        let Some(ChooseSpec::Object(filter)) = grant.target_spec.as_ref() else {
+            return None;
+        };
+        if !filter_is_tagged_object(filter, pumped_tag) {
+            return None;
+        }
+
+        let condition = describe_artifact_enchantment_condition(&conditional.condition)
+            .unwrap_or_else(|| describe_condition(&conditional.condition));
+        Some(format!(
+            "{} each get {}/{} until end of turn. If {condition}, those creatures also gain lifelink until end of turn",
+            capitalize_first(&target_text),
+            describe_signed_value(power),
+            describe_toughness_delta_with_power_context(power, toughness),
+        ))
+    }
+
+    if let Some(compact) = describe_tagged_pump_then_conditional_keyword(&raw_effects) {
+        return compact;
+    }
+
     fn describe_move_then_color_subtype_addition(effects: &[&Effect]) -> Option<String> {
         let [move_effect, color_effect, subtype_effect] = effects else {
             return None;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: When We Were Young
Initial parse error:
```
unsupported trailing anthem clause (clause: 'up to two target creatures each get +2/+2 until end of turn if you control an artifact and an enchantment those creatures also gain lifelink until end of turn'); oracle-only fallback also failed: unsupported trailing anthem clause (clause: 'up to two target creatures each get +2/+2 until end of turn if you control an artifact and an enchantment those creatures also gain lifelink until end of turn')
```

Current worker: i-082aa3b8fb159e623
Branch: codex/aws-card-fix-when-we-were-young
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0187
