### PR TITLE
Fix Ironsmith parse failure: Excavation Technique

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -344,6 +344,7 @@ impl CardDefinitionBuilder {
             KeywordAction::VariableCasualtyPlaneswalkerCopy => {
                 self.variable_casualty_planeswalker_copy()
             }
+            KeywordAction::Demonstrate => self.demonstrate(),
             KeywordAction::Conspire => self.conspire(),
             KeywordAction::Amplify(amount) => self.amplify(amount),
             KeywordAction::Devour(multiplier) => self.devour(multiplier),
@@ -1459,6 +1460,46 @@ impl CardDefinitionBuilder {
                 vec![crate::effect::Effect::new(
                     crate::effects::VariableCasualtyPlaneswalkerCopyEffect::new(),
                 )],
+            )
+            .in_zones(vec![crate::zone::Zone::Stack]),
+        )
+    }
+
+    pub fn demonstrate(self) -> Self {
+        let opponent_tag = crate::tag::TagKey::from("demonstrate_opponent");
+        let opponent = crate::target::PlayerFilter::TaggedPlayer(opponent_tag.clone());
+        self.with_ability(
+            crate::ability::Ability::triggered(
+                crate::triggers::Trigger::you_cast_this_spell(),
+                vec![crate::effect::Effect::may(vec![
+                    crate::effect::Effect::with_id(
+                        0,
+                        crate::effect::Effect::new(crate::effects::CopySpellEffect::single(
+                            crate::target::ChooseSpec::Source,
+                        )),
+                    ),
+                    crate::effect::Effect::new(crate::effects::ChoosePlayerEffect::new(
+                        crate::target::PlayerFilter::You,
+                        crate::target::PlayerFilter::Opponent,
+                        opponent_tag.clone(),
+                    )),
+                    crate::effect::Effect::with_id(
+                        1,
+                        crate::effect::Effect::new(crate::effects::CopySpellEffect::new_for_player(
+                            crate::target::ChooseSpec::Source,
+                            1,
+                            opponent.clone(),
+                        )),
+                    ),
+                    crate::effect::Effect::may_choose_new_targets_player(
+                        crate::effect::EffectId(0),
+                        crate::target::PlayerFilter::You,
+                    ),
+                    crate::effect::Effect::may_choose_new_targets_player(
+                        crate::effect::EffectId(1),
+                        opponent,
+                    ),
+                ])],
             )
             .in_zones(vec![crate::zone::Zone::Stack]),
         )

--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -97,6 +97,7 @@ pub enum KeywordAction {
     },
     Casualty(u32),
     VariableCasualtyPlaneswalkerCopy,
+    Demonstrate,
     Conspire,
     Amplify(u32),
     AuraSwap(ManaCost),
@@ -358,6 +359,7 @@ impl KeywordAction {
             Self::VariableCasualtyPlaneswalkerCopy => {
                 "Casualty X. The copy isn't legendary and has starting loyalty X.".to_string()
             }
+            Self::Demonstrate => "Demonstrate".to_string(),
             Self::Conspire => "Conspire".to_string(),
             Self::Amplify(amount) => format!("Amplify {amount}"),
             Self::AuraSwap(cost) => format!("Aura swap {}", cost.to_oracle()),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -641,6 +641,7 @@ pub(crate) fn parse_single_word_keyword_action(word: &str) -> Option<KeywordActi
         "exalted" => Some(KeywordAction::Exalted),
         "cascade" => Some(KeywordAction::Cascade),
         "storm" => Some(KeywordAction::Storm),
+        "demonstrate" => Some(KeywordAction::Demonstrate),
         "rebound" => Some(KeywordAction::Rebound),
         "ascend" => Some(KeywordAction::Ascend),
         "compleated" => Some(KeywordAction::Marker("compleated")),
@@ -1242,6 +1243,9 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
     }
     if head == "cascade" {
         return Some(KeywordAction::Cascade);
+    }
+    if head == "demonstrate" {
+        return Some(KeywordAction::Demonstrate);
     }
 
     // Casualty N - "as you cast this spell, you may sacrifice a creature with power N or greater"

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -551,6 +551,7 @@ pub(crate) enum KeywordAction {
     },
     Casualty(u32),
     VariableCasualtyPlaneswalkerCopy,
+    Demonstrate,
     Conspire,
     Amplify(u32),
     AuraSwap(ManaCost),
@@ -810,6 +811,7 @@ impl KeywordAction {
             Self::VariableCasualtyPlaneswalkerCopy => {
                 "Casualty X. The copy isn't legendary and has starting loyalty X.".to_string()
             }
+            Self::Demonstrate => "Demonstrate".to_string(),
             Self::Conspire => "Conspire".to_string(),
             Self::Amplify(amount) => format!("Amplify {amount}"),
             Self::AuraSwap(cost) => format!("Aura swap {}", cost.to_oracle()),
@@ -1678,6 +1680,7 @@ impl CardDefinitionBuilder {
             KeywordAction::VariableCasualtyPlaneswalkerCopy => {
                 self.variable_casualty_planeswalker_copy()
             }
+            KeywordAction::Demonstrate => self.demonstrate(),
             KeywordAction::Conspire => self.conspire(),
             KeywordAction::Amplify(amount) => self.amplify(amount),
             KeywordAction::AuraSwap(cost) => self.aura_swap(cost),
@@ -2961,6 +2964,47 @@ impl CardDefinitionBuilder {
                 trigger: Trigger::you_cast_this_spell(),
                 effects: crate::resolution::ResolutionProgram::from_effects(vec![Effect::new(
                     crate::effects::VariableCasualtyPlaneswalkerCopyEffect::new(),
+                )]),
+                choices: vec![],
+                intervening_if: None,
+                presentation_label: None,
+            }),
+            functional_zones: vec![Zone::Stack],
+        })
+    }
+
+    /// Add demonstrate.
+    ///
+    /// Demonstrate means "When you cast this spell, you may copy it. If you do,
+    /// choose an opponent to also copy it. Players may choose new targets for
+    /// their copies."
+    pub fn demonstrate(self) -> Self {
+        use crate::effect::EffectId;
+
+        let opponent_tag = TagKey::from("demonstrate_opponent");
+        let opponent = PlayerFilter::TaggedPlayer(opponent_tag.clone());
+        self.with_ability(Ability {
+            kind: AbilityKind::Triggered(TriggeredAbility {
+                trigger: Trigger::you_cast_this_spell(),
+                effects: crate::resolution::ResolutionProgram::from_effects(vec![Effect::may(
+                    vec![
+                        Effect::with_id(0, Effect::copy_spell(ChooseSpec::Source)),
+                        Effect::new(crate::effects::ChoosePlayerEffect::new(
+                            PlayerFilter::You,
+                            PlayerFilter::Opponent,
+                            opponent_tag.clone(),
+                        )),
+                        Effect::with_id(
+                            1,
+                            Effect::new(crate::effects::CopySpellEffect::new_for_player(
+                                ChooseSpec::Source,
+                                1,
+                                opponent.clone(),
+                            )),
+                        ),
+                        Effect::may_choose_new_targets_player(EffectId(0), PlayerFilter::You),
+                        Effect::may_choose_new_targets_player(EffectId(1), opponent),
+                    ],
                 )]),
                 choices: vec![],
                 intervening_if: None,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6813,15 +6813,19 @@ fn test_parse_conspire_keyword_line_compiles_to_optional_cost() {
 fn excavation_technique_parses_demonstrate_and_renders_keyword_text() {
     let def = parse_oracle_card_definition("Excavation Technique");
 
-    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let lines = unprocessed_compiled_lines(&def);
+    let rendered = lines.join("\n");
     assert!(
         rendered.contains("Demonstrate"),
         "expected Excavation Technique to render the demonstrate keyword, got {rendered}"
     );
-    assert!(
-        rendered.contains("Destroy target nonland permanent")
-            && rendered.contains("creates two Treasure tokens"),
-        "expected Excavation Technique spell text to remain intact, got {rendered}"
+    assert_eq!(
+        lines,
+        vec![
+            "Destroy target nonland permanent, then that object's controller creates 2 Treasure tokens.",
+            "Demonstrate.",
+        ],
+        "expected Excavation Technique compiled text to preserve spell text and keyword identity"
     );
     assert!(
         !rendered.to_ascii_lowercase().contains("unsupported"),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6810,6 +6810,252 @@ fn test_parse_conspire_keyword_line_compiles_to_optional_cost() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn excavation_technique_parses_demonstrate_and_renders_keyword_text() {
+    let def = parse_oracle_card_definition("Excavation Technique");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Demonstrate"),
+        "expected Excavation Technique to render the demonstrate keyword, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Destroy target nonland permanent")
+            && rendered.contains("creates two Treasure tokens"),
+        "expected Excavation Technique spell text to remain intact, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported"),
+        "strict parser should not emit unsupported fallback text, got {rendered}"
+    );
+
+    let demonstrate = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if ability.functional_zones == [Zone::Stack]
+                    && triggered.trigger.display() == "When you cast this spell" =>
+            {
+                Some(triggered)
+            }
+            _ => None,
+        })
+        .expect("Excavation Technique should compile demonstrate as a stack trigger");
+    let debug = format!("{:#?}", demonstrate.effects);
+    assert!(
+        debug.contains("MayEffect")
+            && debug.contains("CopySpellEffect")
+            && debug.contains("ChoosePlayerEffect")
+            && debug.contains("ChooseNewTargetsEffect")
+            && debug.contains("Opponent"),
+        "expected demonstrate trigger to copy for you and a chosen opponent with retarget choices, got {debug}"
+    );
+}
+
+#[test]
+fn excavation_technique_demonstrate_decline_creates_no_spell_copies() {
+    use crate::decision::DecisionMaker;
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::game_state::Target;
+
+    #[derive(Default)]
+    struct DeclineDemonstrate;
+    impl DecisionMaker for DeclineDemonstrate {}
+
+    let (mut game, source, triggered) = setup_excavation_technique_demonstrate_runtime();
+    let mut dm = DeclineDemonstrate;
+    let mut ctx = ExecutionContext::new_default(source, PlayerId::from_index(0))
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(
+            game.stack
+                .iter()
+                .find(|entry| entry.object_id == source)
+                .and_then(|entry| entry.targets.first())
+                .and_then(|target| match target {
+                    Target::Object(id) => Some(*id),
+                    Target::Player(_) => None,
+                })
+                .expect("original spell should have a target"),
+        )])
+        .with_decision_maker(&mut dm);
+
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("declining demonstrate should resolve");
+    }
+
+    assert_eq!(
+        stack_entries_named(&game, "Excavation Technique").len(),
+        1,
+        "declining demonstrate should leave only the original spell on the stack"
+    );
+    assert!(
+        game.stack.iter().all(|entry| entry.object_id == source),
+        "no copy stack entries should be created when demonstrate is declined"
+    );
+}
+
+fn setup_excavation_technique_demonstrate_runtime() -> (
+    crate::game_state::GameState,
+    ObjectId,
+    crate::ability::TriggeredAbility,
+) {
+    use crate::game_state::{StackEntry, Target};
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let original_target = crate::card::CardBuilder::new(CardId::from_raw(60_001), "Alice Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let replacement_target =
+        crate::card::CardBuilder::new(CardId::from_raw(60_002), "Bob Replacement Relic")
+            .card_types(vec![CardType::Artifact])
+            .build();
+    let original_target = game.create_object_from_card(&original_target, alice, Zone::Battlefield);
+    game.create_object_from_card(&replacement_target, bob, Zone::Battlefield);
+
+    let def = CardDefinitionBuilder::new(CardId::from_raw(60_003), "Excavation Technique")
+        .card_types(vec![CardType::Sorcery])
+        .demonstrate()
+        .with_spell_effect(vec![Effect::destroy(ChooseSpec::target(ChooseSpec::Object(
+            ObjectFilter::nonland_permanent(),
+        )))])
+        .build();
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("demonstrate trigger should exist");
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut entry = StackEntry::new(source, alice);
+    entry.targets = vec![Target::Object(original_target)];
+    game.push_to_stack(entry);
+
+    (game, source, triggered)
+}
+
+fn stack_entries_named(
+    game: &crate::game_state::GameState,
+    name: &str,
+) -> Vec<crate::game_state::StackEntry> {
+    game.stack
+        .iter()
+        .filter(|entry| {
+            game.object(entry.object_id)
+                .is_some_and(|object| object.name == name)
+        })
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn excavation_technique_demonstrate_creates_player_and_opponent_copies_with_retargets() {
+    use crate::decision::DecisionMaker;
+    use crate::decisions::context::{BooleanContext, SelectOptionsContext, TargetsContext};
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::game_state::{GameState, Target};
+
+    struct AcceptDemonstrateAndRetarget {
+        replacement_target: ObjectId,
+        boolean_calls: usize,
+    }
+
+    impl DecisionMaker for AcceptDemonstrateAndRetarget {
+        fn decide_boolean(&mut self, _game: &GameState, _ctx: &BooleanContext) -> bool {
+            self.boolean_calls += 1;
+            true
+        }
+
+        fn decide_options(&mut self, _game: &GameState, ctx: &SelectOptionsContext) -> Vec<usize> {
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect()
+        }
+
+        fn decide_targets(&mut self, _game: &GameState, ctx: &TargetsContext) -> Vec<Target> {
+            assert_eq!(ctx.requirements.len(), 1, "expected one copied spell target choice");
+            assert!(
+                ctx.requirements[0]
+                    .legal_targets
+                    .contains(&Target::Object(self.replacement_target)),
+                "replacement target should be legal for the copied Excavation Technique"
+            );
+            vec![Target::Object(self.replacement_target)]
+        }
+    }
+
+    let (mut game, source, triggered) = setup_excavation_technique_demonstrate_runtime();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let replacement_target = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Bob Replacement Relic")
+        })
+        .expect("replacement target should exist");
+    let original_target = game
+        .stack
+        .iter()
+        .find(|entry| entry.object_id == source)
+        .and_then(|entry| entry.targets.first().copied())
+        .expect("original spell should have a target");
+
+    let mut dm = AcceptDemonstrateAndRetarget {
+        replacement_target,
+        boolean_calls: 0,
+    };
+    let mut ctx = ExecutionContext::new_default(source, alice)
+        .with_targets(vec![match original_target {
+            Target::Object(id) => crate::effects::ResolvedTarget::Object(id),
+            Target::Player(id) => crate::effects::ResolvedTarget::Player(id),
+        }])
+        .with_decision_maker(&mut dm);
+
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("demonstrate should resolve");
+    }
+
+    let entries = stack_entries_named(&game, "Excavation Technique");
+    assert_eq!(
+        entries.len(),
+        3,
+        "accepting demonstrate should leave the original plus two spell copies on the stack"
+    );
+
+    let alice_copies = entries
+        .iter()
+        .filter(|entry| entry.object_id != source && entry.controller == alice)
+        .collect::<Vec<_>>();
+    let bob_copies = entries
+        .iter()
+        .filter(|entry| entry.object_id != source && entry.controller == bob)
+        .collect::<Vec<_>>();
+    assert_eq!(alice_copies.len(), 1, "Alice should control one demonstrate copy");
+    assert_eq!(bob_copies.len(), 1, "chosen opponent should control one demonstrate copy");
+    assert_eq!(
+        alice_copies[0].targets,
+        vec![Target::Object(replacement_target)],
+        "Alice should be able to choose new targets for her demonstrate copy"
+    );
+    assert_eq!(
+        bob_copies[0].targets,
+        vec![Target::Object(replacement_target)],
+        "the chosen opponent should be able to choose new targets for their demonstrate copy"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_offspring_trigger_creates_one_one_copy_when_paid() {
     use crate::ability::AbilityKind;
     use crate::cost::OptionalCostsPaid;

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32508,6 +32508,11 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
         return Some(storm);
     }
     if let AbilityKind::Triggered(triggered) = &ability.kind
+        && let Some(demonstrate) = describe_structural_demonstrate_keyword(triggered)
+    {
+        return Some(demonstrate);
+    }
+    if let AbilityKind::Triggered(triggered) = &ability.kind
         && let Some(soulbond) = describe_structural_soulbond_keyword(triggered)
     {
         return Some(soulbond);
@@ -34274,6 +34279,81 @@ fn describe_structural_storm_keyword(
         return None;
     }
     Some("Storm".to_string())
+}
+
+fn describe_structural_demonstrate_keyword(
+    triggered: &crate::ability::TriggeredAbility,
+) -> Option<String> {
+    if triggered.intervening_if.is_some()
+        || !triggered.choices.is_empty()
+        || triggered
+            .trigger
+            .downcast_ref::<crate::triggers::YouCastThisSpellTrigger>()
+            .is_none()
+    {
+        return None;
+    }
+
+    let [effect] = triggered.effects.flattened_default_effects() else {
+        return None;
+    };
+    let may = effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let [copy_you, choose_opponent, copy_opponent, retarget_you, retarget_opponent] =
+        may.effects.as_slice()
+    else {
+        return None;
+    };
+
+    let copy_you = copy_you.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let copy_you_spell = copy_you
+        .effect
+        .downcast_ref::<crate::effects::CopySpellEffect>()?;
+    if copy_you.id != crate::effect::EffectId(0)
+        || !matches!(copy_you_spell.target, ChooseSpec::Source)
+        || copy_you_spell.count != Value::Fixed(1)
+        || copy_you_spell.copier != PlayerFilter::You
+        || !copy_you_spell.removed_supertypes.is_empty()
+    {
+        return None;
+    }
+
+    let choose_opponent = choose_opponent.downcast_ref::<crate::effects::ChoosePlayerEffect>()?;
+    if choose_opponent.chooser != PlayerFilter::You || choose_opponent.filter != PlayerFilter::Opponent
+    {
+        return None;
+    }
+    let opponent = PlayerFilter::TaggedPlayer(choose_opponent.tag.clone());
+
+    let copy_opponent = copy_opponent.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let copy_opponent_spell = copy_opponent
+        .effect
+        .downcast_ref::<crate::effects::CopySpellEffect>()?;
+    if copy_opponent.id != crate::effect::EffectId(1)
+        || !matches!(copy_opponent_spell.target, ChooseSpec::Source)
+        || copy_opponent_spell.count != Value::Fixed(1)
+        || copy_opponent_spell.copier != opponent
+        || !copy_opponent_spell.removed_supertypes.is_empty()
+    {
+        return None;
+    }
+
+    let retarget_you = retarget_you.downcast_ref::<crate::effects::ChooseNewTargetsEffect>()?;
+    if retarget_you.from_effect != copy_you.id
+        || !retarget_you.may
+        || retarget_you.chooser.as_ref() != Some(&PlayerFilter::You)
+    {
+        return None;
+    }
+    let retarget_opponent =
+        retarget_opponent.downcast_ref::<crate::effects::ChooseNewTargetsEffect>()?;
+    if retarget_opponent.from_effect != copy_opponent.id
+        || !retarget_opponent.may
+        || retarget_opponent.chooser.as_ref() != Some(&opponent)
+    {
+        return None;
+    }
+
+    Some("Demonstrate".to_string())
 }
 
 fn describe_structural_soulbond_keyword(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Excavation Technique
Initial parse error:
```
parser does not yet support line family: 'Demonstrate (When you cast this spell, you may copy it. If you do, choose an opponent to also copy it. Players may choose new targets for their copies.)'; oracle-only fallback also failed: parser does not yet support line family: 'Demonstrate'
```

Current worker: i-004442e575e408b86
Branch: codex/aws-card-fix-excavation-technique
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0188
