### PR TITLE
Fix Ironsmith parse failure: Cabaretti Ascendancy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -402,6 +402,55 @@ fn parse_repeated_if_or_predicate(
     Ok(Some(PredicateAst::Or(Box::new(left), Box::new(right))))
 }
 
+fn predicate_reference_prefix<'a>(words: &'a [&'a str]) -> Option<&'a [&'a str]> {
+    if words.first().copied() == Some("it") {
+        return Some(&words[..1]);
+    }
+    if words.len() >= 2
+        && words[0] == "that"
+        && matches!(
+            words[1],
+            "artifact"
+                | "card"
+                | "creature"
+                | "creatures"
+                | "enchantment"
+                | "land"
+                | "object"
+                | "permanent"
+                | "source"
+                | "spell"
+                | "token"
+        )
+    {
+        return Some(&words[..2]);
+    }
+    None
+}
+
+fn predicate_words_start_with_reference(words: &[&str]) -> bool {
+    matches!(
+        words.first().copied(),
+        Some(
+            "it" | "its" | "this" | "that" | "you" | "your" | "opponent" | "player"
+                | "target" | "source"
+        )
+    )
+}
+
+fn parse_single_card_type_card_descriptor(words: &[&str]) -> Option<ObjectFilter> {
+    if words.len() == 2
+        && matches!(words[1], "card" | "cards")
+        && let Some(card_type) = parse_card_type(words[0])
+    {
+        return Some(ObjectFilter {
+            card_types: vec![card_type],
+            ..Default::default()
+        });
+    }
+    None
+}
+
 fn parse_or_predicate(filtered: &[&str]) -> Result<Option<PredicateAst>, CardTextError> {
     let Some(or_idx) = filtered.iter().enumerate().rev().find_map(|(idx, word)| {
         if *word != "or" || idx == 0 || idx + 1 >= filtered.len() {
@@ -418,10 +467,29 @@ fn parse_or_predicate(filtered: &[&str]) -> Result<Option<PredicateAst>, CardTex
         return Ok(None);
     };
 
-    let left_tokens = predicate_tokens_from_words(&filtered[..or_idx]);
-    let right_tokens = predicate_tokens_from_words(&filtered[or_idx + 1..]);
+    let left_words = &filtered[..or_idx];
+    let right_words = &filtered[or_idx + 1..];
+    let left_tokens = predicate_tokens_from_words(left_words);
+    let right_tokens = predicate_tokens_from_words(right_words);
     let left = parse_predicate(&left_tokens)?;
-    let right = parse_predicate(&right_tokens)?;
+    let right = match parse_predicate(&right_tokens) {
+        Ok(predicate) => predicate,
+        Err(original_err) => {
+            let Some(reference_prefix) = predicate_reference_prefix(left_words) else {
+                return Err(original_err);
+            };
+            if predicate_words_start_with_reference(right_words) {
+                return Err(original_err);
+            }
+            let prefixed_words = reference_prefix
+                .iter()
+                .copied()
+                .chain(right_words.iter().copied())
+                .collect::<Vec<_>>();
+            let prefixed_tokens = predicate_tokens_from_words(&prefixed_words);
+            parse_predicate(&prefixed_tokens).map_err(|_| original_err)?
+        }
+    };
     Ok(Some(PredicateAst::Or(Box::new(left), Box::new(right))))
 }
 
@@ -695,7 +763,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
             "empty predicate in if clause".to_string(),
         ));
     }
-    if filtered[0] == "it's" {
+    if filtered[0] == "its" || filtered[0] == "it's" {
         filtered[0] = "it";
     }
     if filtered.len() >= 2 && filtered[0] == "it" && filtered[1] == "s" {
@@ -3003,6 +3071,9 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
             descriptor_words.insert(0, "nontoken");
         }
         if !descriptor_words.is_empty() {
+            if let Some(filter) = parse_single_card_type_card_descriptor(&descriptor_words) {
+                return Ok(PredicateAst::ItMatches(filter));
+            }
             let descriptor_tokens = descriptor_words
                 .iter()
                 .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
@@ -3735,6 +3806,33 @@ mod tests {
         let parsed = parse_predicate(&predicate_tokens)?;
 
         assert_eq!(parsed, PredicateAst::ItIsNight);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_inherits_it_for_bare_or_descriptor_tail() -> Result<(), CardTextError> {
+        let tokens = lex_line("If it's a creature or planeswalker card", 0)?;
+        let predicate_tokens = tokens
+            .iter()
+            .filter(|token| !token.is_word("if"))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        match parsed {
+            PredicateAst::Or(left, right) => {
+                assert!(
+                    matches!(*left, PredicateAst::ItMatches(ref filter) if filter.card_types == vec![CardType::Creature]),
+                    "expected creature left predicate, got {left:?}"
+                );
+                assert!(
+                    matches!(*right, PredicateAst::ItMatches(ref filter) if filter.card_types == vec![CardType::Planeswalker]),
+                    "expected planeswalker right predicate, got {right:?}"
+                );
+            }
+            other => panic!("expected inherited-reference or predicate, got {other:?}"),
+        }
         Ok(())
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38160,20 +38160,18 @@ fn parse_cabaretti_ascendancy_strict_regression() {
 #[test]
 fn cabaretti_ascendancy_compiled_text_keeps_hand_or_bottom_branch() {
     let def = parse_oracle_card_definition("Cabaretti Ascendancy");
-    let rendered = canonical_compiled_lines(&def)
-        .join(" ")
-        .to_ascii_lowercase();
+    let rendered = canonical_compiled_lines(&def);
 
-    assert!(
-        rendered.contains("if you don't put the card into your hand")
-            || rendered.contains("if you dont put the card into your hand")
-            || rendered.contains("if not"),
-        "expected hand-branch predicate in compiled text, got {rendered}"
-    );
-    assert!(
-        rendered.contains("you may put it on the bottom of your library")
-            || rendered.contains("you may put it on the bottom of its owner's library"),
-        "expected optional bottom-of-library branch in compiled text, got {rendered}"
+    assert_eq!(
+        rendered,
+        vec![concat!(
+            "At the beginning of your upkeep, look at the top card of your library. ",
+            "If it's a creature or a planeswalker card, you may reveal it and put it ",
+            "into your hand. If you don't put the card into your hand, you may put ",
+            "it on the bottom of your library."
+        )
+        .to_string()],
+        "expected Cabaretti Ascendancy compiled text to preserve both matching card types, the reveal-to-hand branch, and the conditional bottom branch"
     );
 }
 
@@ -38207,6 +38205,176 @@ fn cabaretti_ascendancy_trigger_keeps_conditional_bottom_branch_runtime_shape() 
             && debug.contains("to_top: false")
             && debug.contains("mayeffect"),
         "expected optional move-to-bottom effect gated by the condition, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[derive(Default)]
+struct CabarettiSequenceDecisionMaker {
+    decisions: Vec<bool>,
+    index: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for CabarettiSequenceDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        let choice = self.decisions.get(self.index).copied().unwrap_or(false);
+        self.index += 1;
+        choice
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_cabaretti_ascendancy_top_card(
+    top_name: &str,
+    top_card_types: Vec<CardType>,
+    decisions: Vec<bool>,
+) -> (crate::game_state::GameState, PlayerId, ObjectId, ObjectId, usize) {
+    let def = parse_oracle_card_definition("Cabaretti Ascendancy");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Cabaretti Ascendancy should compile to a triggered upkeep ability");
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let bottom_id = game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(93_001), "Bottom Filler")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Library,
+    );
+    let top_id = game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(93_002), top_name)
+            .card_types(top_card_types)
+            .build(),
+        alice,
+        Zone::Library,
+    );
+
+    let mut dm = CabarettiSequenceDecisionMaker {
+        decisions,
+        index: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source_id, alice, &mut dm);
+    for effect in &triggered.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Cabaretti Ascendancy trigger should resolve");
+    }
+    drop(ctx);
+    let decision_count = dm.index;
+
+    (game, alice, top_id, bottom_id, decision_count)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn cabaretti_player_zone_names(
+    game: &crate::game_state::GameState,
+    player: PlayerId,
+    zone: Zone,
+) -> Vec<String> {
+    let player = game.player(player).expect("player exists");
+    let ids = match zone {
+        Zone::Hand => &player.hand,
+        Zone::Library => &player.library,
+        _ => panic!("unsupported Cabaretti test zone {zone:?}"),
+    };
+    ids.iter()
+        .map(|id| game.object(*id).expect("zone object exists").name.clone())
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cabaretti_ascendancy_planeswalker_top_card_can_go_to_hand() {
+    let (game, alice, _top_id, _bottom_id, decision_count) =
+        execute_cabaretti_ascendancy_top_card(
+            "Top Planeswalker",
+            vec![CardType::Planeswalker],
+            vec![true],
+        );
+
+    assert_eq!(decision_count, 1, "matching top card should ask the hand decision once");
+    assert_eq!(
+        cabaretti_player_zone_names(&game, alice, Zone::Hand),
+        vec!["Top Planeswalker".to_string()],
+        "accepted planeswalker branch should put exactly the top card into hand"
+    );
+    assert_eq!(
+        cabaretti_player_zone_names(&game, alice, Zone::Library),
+        vec!["Bottom Filler".to_string()],
+        "only the filler card should remain in library after the top card moves to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cabaretti_ascendancy_creature_top_card_can_decline_hand_and_move_bottom() {
+    let (game, alice, _top_id, _bottom_id, decision_count) = execute_cabaretti_ascendancy_top_card(
+        "Top Creature",
+        vec![CardType::Creature],
+        vec![false, true],
+    );
+
+    assert_eq!(
+        decision_count, 2,
+        "matching top card should ask hand decision and then bottom decision when hand is declined"
+    );
+    assert_eq!(game.player(alice).expect("alice exists").hand.len(), 0);
+    assert_eq!(
+        cabaretti_player_zone_names(&game, alice, Zone::Library),
+        vec!["Top Creature".to_string(), "Bottom Filler".to_string()],
+        "declined creature card should move from top to bottom when the bottom branch is accepted"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cabaretti_ascendancy_matching_top_card_can_decline_both_optional_actions() {
+    let (game, alice, _top_id, _bottom_id, decision_count) = execute_cabaretti_ascendancy_top_card(
+        "Top Creature",
+        vec![CardType::Creature],
+        vec![false, false],
+    );
+
+    assert_eq!(decision_count, 2, "both optional decisions should be offered");
+    assert_eq!(game.player(alice).expect("alice exists").hand.len(), 0);
+    assert_eq!(
+        cabaretti_player_zone_names(&game, alice, Zone::Library),
+        vec!["Bottom Filler".to_string(), "Top Creature".to_string()],
+        "declining the bottom branch should leave the matching card on top"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cabaretti_ascendancy_nonmatching_top_card_skips_hand_branch_and_can_move_bottom() {
+    let (game, alice, _top_id, _bottom_id, decision_count) = execute_cabaretti_ascendancy_top_card(
+        "Top Artifact",
+        vec![CardType::Artifact],
+        vec![true],
+    );
+
+    assert_eq!(
+        decision_count, 1,
+        "nonmatching top card should skip the hand decision and only ask the bottom decision"
+    );
+    assert_eq!(game.player(alice).expect("alice exists").hand.len(), 0);
+    assert_eq!(
+        cabaretti_player_zone_names(&game, alice, Zone::Library),
+        vec!["Top Artifact".to_string(), "Bottom Filler".to_string()],
+        "nonmatching card should move to bottom when the fallback branch is accepted"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1162,15 +1162,26 @@ fn is_nonland_permanent_filter_in_zone(filter: &ObjectFilter, zone: Zone) -> boo
         })
 }
 
-fn is_noncreature_nonland_card_filter(filter: &ObjectFilter) -> bool {
-    filter.zone.is_none()
-        && filter.card_types.is_empty()
-        && filter.all_card_types.is_empty()
-        && filter.excluded_card_types.len() == 2
-        && filter.excluded_card_types.contains(&CardType::Creature)
-        && filter.excluded_card_types.contains(&CardType::Land)
-        && filter.subtypes.is_empty()
-        && filter.name.is_none()
+fn describe_tagged_condition_card_selection(
+    condition: &Condition,
+    tag: &str,
+) -> Option<String> {
+    match condition {
+        Condition::TaggedObjectMatches(condition_tag, filter) if condition_tag.as_str() == tag => {
+            Some(describe_search_selection_with_cards(&filter.description()))
+        }
+        Condition::Or(left, right) => {
+            let left = describe_tagged_condition_card_selection(left, tag)?;
+            let right = describe_tagged_condition_card_selection(right, tag)?;
+            if let (Some(left_type), true) = (left.strip_suffix(" card"), right.ends_with(" card"))
+            {
+                Some(format!("{left_type} or {right}"))
+            } else {
+                Some(format!("{left} or {right}"))
+            }
+        }
+        _ => None,
+    }
 }
 
 fn describe_look_top_card_if_matching_may_reveal_put_hand(
@@ -1180,13 +1191,11 @@ fn describe_look_top_card_if_matching_may_reveal_put_hand(
     if look_at_top.player != PlayerFilter::You || look_at_top.count != Value::Fixed(1) {
         return None;
     }
-    let Condition::TaggedObjectMatches(tag, filter) = &conditional.condition else {
-        return None;
-    };
-    if tag != &look_at_top.tag
-        || !is_noncreature_nonland_card_filter(filter)
-        || !conditional.if_false.is_empty()
-    {
+    let selection = describe_tagged_condition_card_selection(
+        &conditional.condition,
+        look_at_top.tag.as_str(),
+    )?;
+    if !conditional.if_false.is_empty() {
         return None;
     }
     let [may_effect] = conditional.if_true.as_slice() else {
@@ -1208,10 +1217,58 @@ fn describe_look_top_card_if_matching_may_reveal_put_hand(
         return None;
     }
 
-    Some(
-        "Look at the top card of your library. If it's a noncreature, nonland card, you may reveal it and put it into your hand"
-            .to_string(),
-    )
+    Some(format!(
+        "Look at the top card of your library. If it's {}, you may reveal it and put it into your hand",
+        with_indefinite_article(&selection)
+    ))
+}
+
+fn describe_look_top_card_if_matching_may_reveal_put_hand_else_bottom(
+    look_at_top: &crate::effects::LookAtTopCardsEffect,
+    conditional: &crate::effects::ConditionalEffect,
+    bottom_conditional: &crate::effects::ConditionalEffect,
+) -> Option<String> {
+    let first = describe_look_top_card_if_matching_may_reveal_put_hand(look_at_top, conditional)?;
+    let Condition::Not(inner) = &bottom_conditional.condition else {
+        return None;
+    };
+    let Condition::PlayerTaggedObjectMatches {
+        player,
+        tag,
+        filter,
+    } = inner.as_ref()
+    else {
+        return None;
+    };
+    let hand_filter = ObjectFilter {
+        zone: Some(Zone::Hand),
+        ..Default::default()
+    };
+    if player != &PlayerFilter::You
+        || tag.as_str() != look_at_top.tag.as_str()
+        || filter != &hand_filter
+        || !bottom_conditional.if_false.is_empty()
+    {
+        return None;
+    }
+    let [may_effect] = bottom_conditional.if_true.as_slice() else {
+        return None;
+    };
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may.decider != Some(PlayerFilter::You) || may.effects.len() != 1 {
+        return None;
+    }
+    let move_to_bottom = may.effects[0].downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_bottom.zone != Zone::Library
+        || move_to_bottom.to_top
+        || !matches!(move_to_bottom.target.base(), ChooseSpec::Tagged(tag) if tag.as_str() == look_at_top.tag.as_str())
+    {
+        return None;
+    }
+
+    Some(format!(
+        "{first}. If you don't put the card into your hand, you may put it on the bottom of your library"
+    ))
 }
 
 fn describe_counter_constraint(counter: crate::filter::CounterConstraint) -> String {
@@ -11750,6 +11807,23 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         {
             parts.push(compact);
             idx += 2;
+            continue;
+        }
+        if idx + 2 < filtered.len()
+            && let Some(look_at_top) =
+                filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
+            && let Some(conditional) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ConditionalEffect>()
+            && let Some(bottom_conditional) =
+                filtered[idx + 2].downcast_ref::<crate::effects::ConditionalEffect>()
+            && let Some(compact) = describe_look_top_card_if_matching_may_reveal_put_hand_else_bottom(
+                look_at_top,
+                conditional,
+                bottom_conditional,
+            )
+        {
+            parts.push(compact);
+            idx += 3;
             continue;
         }
         if idx + 1 < filtered.len()

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -3406,6 +3406,20 @@ fn evaluate_condition(
             let mut filter_ctx = ctx.filter_context(game);
             filter_ctx.iterated_player = Some(player_id);
             for snapshot in tagged {
+                let current_id = game
+                    .object(snapshot.object_id)
+                    .map(|object| object.id)
+                    .or_else(|| game.find_object_by_stable_id(snapshot.stable_id));
+                if let Some(current_id) = current_id
+                    && let Some(object) = game.object(current_id)
+                {
+                    if game.controller_of(object) == player_id
+                        && filter.matches(object, &filter_ctx, game)
+                    {
+                        return Ok(true);
+                    }
+                    continue;
+                }
                 if snapshot.controller != player_id {
                     continue;
                 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cabaretti Ascendancy
Initial parse error:
```
unsupported predicate (predicate: 'planeswalker card'); oracle-only fallback also failed: unsupported predicate (predicate: 'planeswalker card')
```

Current worker: i-0323b33f89d72ba70
Branch: codex/aws-card-fix-cabaretti-ascendancy
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0211
