### PR TITLE
Fix Ironsmith parse failure: Aminatou's Augury

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -126,6 +126,33 @@ fn compile_effect_inner(
             choices,
         ));
     }
+    if let EffectAst::GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn {
+        tag,
+        player,
+        card_types: _,
+    } = effect
+    {
+        let source_tag = resolve_it_tag_key(tag, &current_reference_env(ctx))?;
+        let player_filter = resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
+        let compiled = vec![
+            Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+                source_tag.clone(),
+                player_filter.clone(),
+                crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn,
+                false,
+                false,
+            )),
+            Effect::new(
+                crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect::new(
+                    source_tag,
+                    player_filter.clone(),
+                )
+                .with_usage_limit(crate::grant::GrantUsageLimit::OncePerNonlandCardType),
+            ),
+        ];
+
+        return Ok((compiled, Vec::new()));
+    }
     if let EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
         player,
         filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -3173,6 +3173,11 @@ pub(crate) enum EffectAst {
         filter: ObjectFilter,
         zone: Zone,
     },
+    GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn {
+        tag: TagKey,
+        player: PlayerAst,
+        card_types: Vec<CardType>,
+    },
     RepeatThisProcess,
     RepeatThisProcessMay,
     RepeatThisProcessOnce,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
@@ -128,6 +128,7 @@ pub(crate) fn assert_effect_ast_variant_coverage(effect: &EffectAst) {
         EffectAst::ChooseObjects { .. } => {}
         EffectAst::ChooseObjectsAcrossZones { .. } => {}
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}
+        EffectAst::GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn { .. } => {}
         EffectAst::RepeatThisProcess => {}
         EffectAst::RepeatThisProcessMay => {}
         EffectAst::RepeatThisProcessOnce => {}

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1026,6 +1026,9 @@ fn advance_reference_frame_for_effect(
             frame.last_object_tag = Some(chosen_tag);
         }
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}
+        EffectAst::GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn { player, .. } => {
+            track_effect_player(*player, frame, true, true)?;
+        }
         EffectAst::May { effects }
         | EffectAst::DelayedUntilNextEndStep { effects, .. }
         | EffectAst::DelayedUntilEndOfCombat { effects }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -447,33 +447,6 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         return Ok(effect);
     }
 
-    if word_slice_starts_with(
-        &clause_words,
-        &[
-            "until", "end", "of", "turn", "for", "each", "nonland", "card", "type", "you",
-            "may", "cast", "a", "spell", "of", "that", "type", "from", "among",
-        ],
-    ) && word_slice_ends_with(
-        &clause_words,
-        &["without", "paying", "its", "mana", "cost"],
-    ) && find_word_sequence_index(&clause_words, &["exiled", "cards"]).is_some()
-    {
-        return Ok(EffectAst::GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn {
-            tag: TagKey::from(IT_TAG),
-            player: PlayerAst::You,
-            card_types: vec![
-                CardType::Artifact,
-                CardType::Battle,
-                CardType::Creature,
-                CardType::Enchantment,
-                CardType::Instant,
-                CardType::Kindred,
-                CardType::Planeswalker,
-                CardType::Sorcery,
-            ],
-        });
-    }
-
     if word_slice_starts_with(&clause_words, &["cast", "any", "number", "of", "spells"])
         && find_word_sequence_index(
             &clause_words,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -447,6 +447,33 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         return Ok(effect);
     }
 
+    if word_slice_starts_with(
+        &clause_words,
+        &[
+            "until", "end", "of", "turn", "for", "each", "nonland", "card", "type", "you",
+            "may", "cast", "a", "spell", "of", "that", "type", "from", "among",
+        ],
+    ) && word_slice_ends_with(
+        &clause_words,
+        &["without", "paying", "its", "mana", "cost"],
+    ) && find_word_sequence_index(&clause_words, &["exiled", "cards"]).is_some()
+    {
+        return Ok(EffectAst::GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn {
+            tag: TagKey::from(IT_TAG),
+            player: PlayerAst::You,
+            card_types: vec![
+                CardType::Artifact,
+                CardType::Battle,
+                CardType::Creature,
+                CardType::Enchantment,
+                CardType::Instant,
+                CardType::Kindred,
+                CardType::Planeswalker,
+                CardType::Sorcery,
+            ],
+        });
+    }
+
     if word_slice_starts_with(&clause_words, &["cast", "any", "number", "of", "spells"])
         && find_word_sequence_index(
             &clause_words,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -173,6 +173,104 @@ pub(crate) fn parse_choose_land_or_nonland_then_consult_to_hand_bottom(
     ]))
 }
 
+pub(crate) fn parse_exile_top_put_land_then_cast_each_nonland_type(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let first = trim_commas(sentences[sentence_idx].lowered());
+    let second = trim_commas(sentences[sentence_idx + 1].lowered());
+    let third = trim_commas(sentences[sentence_idx + 2].lowered());
+
+    let first_words = crate::runtime_backend::token_word_refs(&first);
+    if !slice_starts_with(&first_words, &["exile", "the", "top"])
+        || first_words.get(4..) != Some(["cards", "of", "your", "library"].as_slice())
+    {
+        return Ok(None);
+    }
+
+    let second_words = crate::runtime_backend::token_word_refs(&second);
+    if second_words.as_slice()
+        != [
+            "you",
+            "may",
+            "put",
+            "a",
+            "land",
+            "card",
+            "from",
+            "among",
+            "them",
+            "onto",
+            "the",
+            "battlefield",
+        ]
+    {
+        return Ok(None);
+    }
+
+    let third_words = crate::runtime_backend::token_word_refs(&third);
+    if !slice_starts_with(
+        &third_words,
+        &[
+            "until", "end", "of", "turn", "for", "each", "nonland", "card", "type", "you",
+            "may", "cast", "a", "spell", "of", "that", "type", "from", "among", "the",
+            "exiled", "cards",
+        ],
+    ) || !slice_ends_with(&third_words, &["without", "paying", "its", "mana", "cost"])
+    {
+        return Ok(None);
+    }
+
+    let mut effects = effect_sentences::parse_effect_sentence_lexed(&first)?;
+    let Some(EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action: SubjectVerbActionAst::ExileTopOfLibrary { tags, .. },
+        ..
+    })) = effects.first()
+    else {
+        return Ok(None);
+    };
+    let Some(exiled_tag) = tags.first().cloned() else {
+        return Ok(None);
+    };
+
+    let mut land_filter = ObjectFilter::default()
+        .in_zone(Zone::Exile)
+        .with_type(CardType::Land)
+        .match_tagged(exiled_tag.clone(), TaggedOpbjectRelation::IsTaggedObject);
+    land_filter.zone = Some(Zone::Exile);
+    let land_target = TargetAst::WithCount(
+        Box::new(TargetAst::Object(land_filter, None, None)),
+        ChoiceCount::up_to(1),
+    );
+
+    effects.push(EffectAst::May {
+        effects: vec![EffectAst::subject_verb_move_to_zone(
+            land_target,
+            Zone::Battlefield,
+            false,
+            ReturnControllerAst::Preserve,
+            false,
+            None,
+        )],
+    });
+    effects.push(EffectAst::GrantFreeCastFromTaggedForEachCardTypeUntilEndOfTurn {
+        tag: exiled_tag,
+        player: PlayerAst::You,
+        card_types: vec![
+            CardType::Artifact,
+            CardType::Battle,
+            CardType::Creature,
+            CardType::Enchantment,
+            CardType::Instant,
+            CardType::Kindred,
+            CardType::Planeswalker,
+            CardType::Sorcery,
+        ],
+    });
+
+    Ok(Some(effects))
+}
+
 pub(crate) fn parse_mill_then_may_put_from_among_into_hand_then_if_you_dont(
     sentences: &[SentenceInput],
     sentence_idx: usize,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -209,6 +209,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
             generic_subject_verb_sequences::quads::parse_look_at_top_may_reveal_match_bargain_battlefield_else_hand_then_shuffle,
     },
     SequenceRuleDef {
+        name: "exile-top-put-land-cast-each-nonland-type",
+        feature_tag: Some("exiled-cards-card-type-cast"),
+        priority: 342,
+        consumed_sentences: 3,
+        predicate: first_word_if_target_exile_or_reveal,
+        parser: generic_subject_verb_sequences::triples::parse_exile_top_put_land_then_cast_each_nonland_type,
+    },
+    SequenceRuleDef {
         name: "choose-land-or-nonland-consult-hand-bottom",
         feature_tag: Some("consult-choice-kind"),
         priority: 341,

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -2946,6 +2946,7 @@ impl<E> VoteEffect<E> {
 pub struct GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
     pub tag: crate::tag::TagKey,
     pub player: PlayerFilter,
+    pub usage_limit: Option<crate::grant_model::GrantUsageLimit>,
 }
 
 impl GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
@@ -2953,7 +2954,16 @@ impl GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
         Self {
             tag: tag.into(),
             player,
+            usage_limit: None,
         }
+    }
+
+    pub fn with_usage_limit(
+        mut self,
+        usage_limit: crate::grant_model::GrantUsageLimit,
+    ) -> Self {
+        self.usage_limit = Some(usage_limit);
+        self
     }
 }
 

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -66,6 +66,7 @@ impl<C> DerivedAlternativeCast<C> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GrantUsageLimit {
     OnceDuringEachOfYourTurns,
+    OncePerNonlandCardType,
 }
 
 impl<C: CostComponent> DerivedAlternativeCast<C> {
@@ -674,11 +675,11 @@ where
         ) = &self.grantable
             && self.zone == Zone::Hand
         {
-            let prefix = if matches!(usage_limit, Some(GrantUsageLimit::OnceDuringEachOfYourTurns))
-            {
-                "Once during each of your turns, "
-            } else {
-                ""
+            let prefix = match usage_limit {
+                Some(GrantUsageLimit::OnceDuringEachOfYourTurns) => {
+                    "Once during each of your turns, "
+                }
+                Some(GrantUsageLimit::OncePerNonlandCardType) | None => "",
             };
             let filter_desc = castable_filter_description(&self.filter);
             let singular_filter_desc = filter_desc
@@ -726,13 +727,11 @@ where
                 }
                 return line;
             }
-            let prefix = if matches!(
-                usage_limit,
-                Some(GrantUsageLimit::OnceDuringEachOfYourTurns)
-            ) {
-                "Once during each of your turns, "
-            } else {
-                ""
+            let prefix = match usage_limit {
+                Some(GrantUsageLimit::OnceDuringEachOfYourTurns) => {
+                    "Once during each of your turns, "
+                }
+                Some(GrantUsageLimit::OncePerNonlandCardType) | None => "",
             };
             return format!(
                 "{prefix}{} cast {} from your graveyard by {}",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36413,6 +36413,256 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn aminatous_augury_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Aminatou's Augury");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("exile the top 8 cards of your library")
+            || rendered_lower.contains("exile the top eight cards of your library"),
+        "expected Aminatou's Augury to strictly parse its top-eight exile, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("you may put a land card from among them onto the battlefield"),
+        "expected Aminatou's Augury land branch to render from the exiled set, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("for each nonland card type")
+            && rendered_lower.contains("you may cast a spell of that type")
+            && rendered_lower.contains("without paying its mana cost"),
+        "expected Aminatou's Augury card-type free-cast clause to render, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("ExileTopOfLibraryEffect")
+            && debug.contains("MoveToZoneEffect")
+            && debug.contains("GrantTaggedSpellFreeCastUntilEndOfTurnEffect"),
+        "expected Aminatou's Augury to lower into exile, land move, and free-cast grants, got {debug}"
+    );
+    assert!(
+        debug.contains("zone: Some(") && debug.contains("Exile,"),
+        "expected Aminatou's Augury choices to reference exiled cards structurally, got {debug}"
+    );
+}
+
+fn aminatou_augury_test_card(
+    id: u32,
+    name: &str,
+    card_types: Vec<CardType>,
+) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(id), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(card_types)
+        .build()
+}
+
+fn execute_aminatous_augury(game: &mut crate::game_state::GameState, alice: PlayerId) {
+    let def = parse_oracle_card_definition("Aminatou's Augury");
+    let source = game.new_object_id();
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    for effect in def.spell_effect.as_ref().expect("Aminatou spell effects") {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Aminatou's Augury effect should resolve");
+    }
+}
+
+fn has_aminatou_free_cast_grant(
+    game: &crate::game_state::GameState,
+    object_id: ObjectId,
+    player: PlayerId,
+) -> bool {
+    game.effect_store
+        .grant_registry
+        .card_can_play_from_zone(game, object_id, Zone::Exile, player)
+        && !game
+            .effect_store
+            .grant_registry
+            .granted_alternative_casts_for_card(game, object_id, Zone::Exile, player)
+            .is_empty()
+}
+
+fn has_aminatou_free_cast_grant_named(
+    game: &crate::game_state::GameState,
+    name: &str,
+    player: PlayerId,
+) -> bool {
+    game.exile
+        .iter()
+        .chain(game.battlefield.iter())
+        .copied()
+        .filter(|&id| game.object(id).is_some_and(|object| object.name == name))
+        .any(|id| has_aminatou_free_cast_grant(game, id, player))
+}
+
+fn aminatou_free_cast_action_named(
+    game: &crate::game_state::GameState,
+    name: &str,
+    player: PlayerId,
+) -> Option<crate::decision::LegalAction> {
+    crate::decision::compute_legal_actions(game, player)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Exile,
+                    casting_method:
+                        crate::alternative_cast::CastingMethod::PlayFrom {
+                            use_alternative: Some(_),
+                            ..
+                        },
+                } if game.object(*spell_id).is_some_and(|object| object.name == name)
+            )
+        })
+}
+
+#[test]
+fn aminatous_augury_runtime_exiles_top_eight_puts_land_and_grants_one_spell_per_type() {
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+
+    let _land = game.create_object_from_card(
+        &aminatou_augury_test_card(91_100, "Augury Island", vec![CardType::Land]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_101, "Augury Bauble", vec![CardType::Artifact]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_102, "Augury Relic", vec![CardType::Artifact]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_103, "Augury Trick", vec![CardType::Instant]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_104, "Augury Ruse", vec![CardType::Instant]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_105, "Augury Echo", vec![CardType::Sorcery]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_106, "Augury Omen", vec![CardType::Enchantment]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_107, "Augury Walker", vec![CardType::Planeswalker]),
+        alice,
+        Zone::Library,
+    );
+
+    execute_aminatous_augury(&mut game, alice);
+
+    assert!(
+        game.player(alice).expect("alice exists").library.is_empty(),
+        "Aminatou's Augury should exile the top eight cards before moving/granting"
+    );
+    assert!(
+        game.battlefield.iter().any(|&id| game
+            .object(id)
+            .is_some_and(|object| object.name == "Augury Island")),
+        "Aminatou's Augury should put a land from the exiled cards onto the battlefield"
+    );
+
+    let granted_instants = ["Augury Trick", "Augury Ruse"]
+        .into_iter()
+        .filter(|name| has_aminatou_free_cast_grant_named(&game, name, alice))
+        .count();
+    assert_eq!(
+        granted_instants, 2,
+        "Aminatou's Augury should leave duplicated type choices available until a spell of that type is cast"
+    );
+    for name in [
+        "Augury Bauble",
+        "Augury Relic",
+        "Augury Trick",
+        "Augury Ruse",
+        "Augury Echo",
+        "Augury Omen",
+        "Augury Walker",
+    ] {
+        assert!(
+            has_aminatou_free_cast_grant_named(&game, name, alice),
+            "Aminatou's Augury should grant a free cast to the selected spell for each represented nonland card type"
+        );
+    }
+
+    let cast_trick = aminatou_free_cast_action_named(&game, "Augury Trick", alice)
+        .expect("Aminatou's Augury should offer either exiled instant before one is cast");
+    let mut state = crate::game_loop::PriorityLoopState::new(game.players_in_game());
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let mut decision_maker = crate::decision::SelectFirstDecisionMaker;
+    crate::game_loop::apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &crate::game_loop::PriorityResponse::PriorityAction(cast_trick),
+        &mut decision_maker,
+    )
+    .expect("Aminatou free-cast instant should cast without paying mana");
+
+    assert!(
+        aminatou_free_cast_action_named(&game, "Augury Ruse", alice).is_none(),
+        "Aminatou's Augury should not offer a second instant after its instant permission is used"
+    );
+}
+
+#[test]
+fn aminatous_augury_runtime_no_land_branch_still_grants_nonland_card_type_casts() {
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_120, "Augury Trick", vec![CardType::Instant]),
+        alice,
+        Zone::Library,
+    );
+    for idx in 0..7 {
+        game.create_object_from_card(
+            &aminatou_augury_test_card(
+                91_121 + idx,
+                &format!("Augury Filler {idx}"),
+                vec![CardType::Creature],
+            ),
+            alice,
+            Zone::Library,
+        );
+    }
+
+    execute_aminatous_augury(&mut game, alice);
+
+    assert!(
+        !game
+            .battlefield
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|object| object.is_land())),
+        "Aminatou's Augury should not move a land when no exiled land card exists"
+    );
+    assert!(
+        has_aminatou_free_cast_grant_named(&game, "Augury Trick", alice),
+        "Aminatou's Augury should still grant the represented nonland card type when the land branch does nothing"
+    );
+}
+
+#[test]
 fn when_we_were_young_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("When We Were Young");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36663,6 +36663,47 @@ fn aminatous_augury_runtime_no_land_branch_still_grants_nonland_card_type_casts(
 }
 
 #[test]
+fn aminatous_augury_runtime_free_cast_permissions_expire_after_turn() {
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+
+    game.create_object_from_card(
+        &aminatou_augury_test_card(91_140, "Augury Trick", vec![CardType::Instant]),
+        alice,
+        Zone::Library,
+    );
+    for idx in 0..7 {
+        game.create_object_from_card(
+            &aminatou_augury_test_card(
+                91_141 + idx,
+                &format!("Augury Filler {idx}"),
+                vec![CardType::Creature],
+            ),
+            alice,
+            Zone::Library,
+        );
+    }
+
+    execute_aminatous_augury(&mut game, alice);
+
+    assert!(
+        aminatou_free_cast_action_named(&game, "Augury Trick", alice).is_some(),
+        "Aminatou's Augury should offer the exiled spell during the current turn"
+    );
+
+    game.next_turn();
+
+    assert!(
+        aminatou_free_cast_action_named(&game, "Augury Trick", alice).is_none(),
+        "Aminatou's Augury free-cast permission should expire after the turn ends"
+    );
+}
+
+#[test]
 fn when_we_were_young_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("When We Were Young");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36581,6 +36581,10 @@ fn aminatous_augury_runtime_exiles_top_eight_puts_land_and_grants_one_spell_per_
             .is_some_and(|object| object.name == "Augury Island")),
         "Aminatou's Augury should put a land from the exiled cards onto the battlefield"
     );
+    assert!(
+        !has_aminatou_free_cast_grant_named(&game, "Augury Island", alice),
+        "Aminatou's Augury should not grant the nonland free-cast permission to a land card"
+    );
 
     let granted_instants = ["Augury Trick", "Augury Ruse"]
         .into_iter()
@@ -36622,6 +36626,12 @@ fn aminatous_augury_runtime_exiles_top_eight_puts_land_and_grants_one_spell_per_
     assert!(
         aminatou_free_cast_action_named(&game, "Augury Ruse", alice).is_none(),
         "Aminatou's Augury should not offer a second instant after its instant permission is used"
+    );
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("resolve the cast instant before checking sorcery-speed permissions");
+    assert!(
+        aminatou_free_cast_action_named(&game, "Augury Bauble", alice).is_some(),
+        "Aminatou's Augury should still offer a different represented card type after its instant permission is used"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -409,6 +409,97 @@ fn choose_primary_zone(choose: &crate::effects::ChooseObjectsEffect) -> Option<Z
     choose.filter.zone.or(choose.zone)
 }
 
+fn describe_card_type_free_cast_grant_sequence(effects: &[&Effect]) -> Option<(String, usize)> {
+    let [grant_play_effect, grant_free_effect, ..] = effects else {
+        return None;
+    };
+    let grant_play = grant_play_effect.downcast_ref::<crate::effects::GrantPlayTaggedEffect>()?;
+    let grant_free = grant_free_effect
+        .downcast_ref::<crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect>()?;
+    if grant_play.tag != grant_free.tag
+        || grant_play.player != grant_free.player
+        || grant_play.duration != crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+        || grant_play.allow_land
+        || grant_free.usage_limit != Some(crate::grant::GrantUsageLimit::OncePerNonlandCardType)
+    {
+        return None;
+    }
+
+    let player_text = describe_player_filter(&grant_play.player);
+    let subject = if player_text == "you" {
+        "you may".to_string()
+    } else {
+        format!("{player_text} may")
+    };
+    Some((
+        format!(
+            "Until end of turn, for each nonland card type, {subject} cast a spell of that type from among the exiled cards without paying its mana cost"
+        ),
+        2,
+    ))
+}
+
+fn describe_exile_top_land_then_card_type_free_cast(effects: &[Effect]) -> Option<String> {
+    let [exile_effect, land_may_effect, rest @ ..] = effects else {
+        return None;
+    };
+    let exile = exile_effect.downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()?;
+    if exile.player != PlayerFilter::You || exile.moved_tags.len() != 1 {
+        return None;
+    }
+    let exiled_tag = &exile.moved_tags[0];
+
+    let land_may = land_may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let [land_move_effect] = land_may.effects.as_slice() else {
+        return None;
+    };
+    let land_move = unwrap_tag_wrapped_effect(land_move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if land_move.zone != Zone::Battlefield {
+        return None;
+    }
+    let ChooseSpec::WithCount(inner, count) = &land_move.target else {
+        return None;
+    };
+    if count.min > 1 || count.max != Some(1) {
+        return None;
+    }
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        return None;
+    };
+    if filter.zone != Some(Zone::Exile)
+        || filter.card_types != vec![CardType::Land]
+        || !filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag == *exiled_tag
+                && constraint.relation == crate::target::TaggedOpbjectRelation::IsTaggedObject
+        })
+    {
+        return None;
+    }
+
+    let rest_refs = rest.iter().collect::<Vec<_>>();
+    let grant_play = rest_refs
+        .first()
+        .and_then(|effect| effect.downcast_ref::<crate::effects::GrantPlayTaggedEffect>())?;
+    if grant_play.tag != *exiled_tag {
+        return None;
+    }
+    let (cast_text, consumed) = describe_card_type_free_cast_grant_sequence(&rest_refs)?;
+    if consumed != rest_refs.len() {
+        return None;
+    }
+
+    let count_text = describe_value(&exile.count);
+    let card_noun = if matches!(exile.count, Value::Fixed(1)) {
+        "card"
+    } else {
+        "cards"
+    };
+    Some(format!(
+        "Exile the top {count_text} {card_noun} of your library. You may put a land card from among them onto the battlefield. {cast_text}"
+    ))
+}
+
 fn describe_reveal_hand_subset_choose_then_discard(effects: &[&Effect]) -> Option<String> {
     let [reveal_effect, choose_effect, discard_effect] = effects else {
         return None;
@@ -2382,6 +2473,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
             .is_some()
     {
         return describe_structural_multisentence_effect_list(rest);
+    }
+
+    if let Some(compact) = describe_exile_top_land_then_card_type_free_cast(effects) {
+        return Some(compact);
     }
 
     describe_draw_discard_then_create_structural(effects)
@@ -8313,6 +8408,12 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     let mut parts = Vec::new();
     let mut idx = 0usize;
     while idx < filtered.len() {
+        if let Some((compact, consumed)) = describe_card_type_free_cast_grant_sequence(&filtered[idx..]) {
+            parts.push(compact);
+            idx += consumed;
+            continue;
+        }
+
         if idx + 1 < filtered.len()
             && let Some(compact) =
                 describe_exile_source_and_unless_pays_target(&[filtered[idx], filtered[idx + 1]])

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -5,6 +5,7 @@ fn grant_usage_limit_allows(
     game: &GameState,
     player: PlayerId,
     source_id: ObjectId,
+    card: &crate::object::Object,
     limit: Option<crate::grant::GrantUsageLimit>,
 ) -> bool {
     match limit {
@@ -14,6 +15,15 @@ fn grant_usage_limit_allows(
                     .turn_store
                     .grant_cast_uses_this_turn
                     .contains(&(player, source_id))
+        }
+        Some(crate::grant::GrantUsageLimit::OncePerNonlandCardType) => {
+            card.card_types.iter().any(|card_type| {
+                *card_type != crate::types::CardType::Land
+                    && !game
+                        .turn_store
+                        .grant_cast_card_type_uses_this_turn
+                        .contains(&(player, source_id, *card_type))
+            })
         }
         None => true,
     }
@@ -83,7 +93,14 @@ fn append_granted_play_from_actions_for_card(
 
         let base_alt_idx = card.alternative_casts.len();
         for (offset, granted_alt) in granted_alternatives.iter().enumerate() {
-            if can_cast_with_alternative_with_view(game, player, card, &granted_alt.method, view) {
+            if grant_usage_limit_allows(
+                game,
+                player,
+                granted_alt.source_id,
+                card,
+                granted_alt.usage_limit,
+            ) && can_cast_with_alternative_with_view(game, player, card, &granted_alt.method, view)
+            {
                 actions.push(LegalAction::CastSpell {
                     spell_id: card_id,
                     from_zone,
@@ -169,7 +186,7 @@ fn append_graveyard_granted_alternative_cast_actions_for_card(
     let base_alt_idx = card.alternative_casts.len();
     for (offset, grant) in granted_casts.into_iter().enumerate() {
         let method = &grant.method;
-        if !grant_usage_limit_allows(game, player, grant.source_id, grant.usage_limit) {
+        if !grant_usage_limit_allows(game, player, grant.source_id, card, grant.usage_limit) {
             continue;
         }
         let requirements = build_requirements_for_method(method);
@@ -247,7 +264,7 @@ fn append_graveyard_granted_adventure_alternative_cast_actions_for_card(
     for (offset, grant) in granted_casts.into_iter().enumerate() {
         let method = &grant.method;
         if method.cast_from_zone() != Zone::Graveyard
-            || !grant_usage_limit_allows(game, player, grant.source_id, grant.usage_limit)
+            || !grant_usage_limit_allows(game, player, grant.source_id, card, grant.usage_limit)
         {
             continue;
         }
@@ -298,7 +315,7 @@ fn append_hand_granted_alternative_cast_actions_for_card(
 
     for (offset, grant) in granted_casts.iter().enumerate() {
         if grant.method.cast_from_zone() != Zone::Hand
-            || !grant_usage_limit_allows(game, player, grant.source_id, grant.usage_limit)
+            || !grant_usage_limit_allows(game, player, grant.source_id, card, grant.usage_limit)
             || !can_cast_with_alternative_from_hand_with_view(
                 game,
                 player,

--- a/crates/ironsmith-runtime/src/derived_view.rs
+++ b/crates/ironsmith-runtime/src/derived_view.rs
@@ -740,7 +740,7 @@ impl<'a> DerivedGameView<'a> {
                     method: method.clone(),
                     source_id: grant.source.source_id(),
                     zone: grant.zone,
-                    usage_limit: None,
+                    usage_limit: grant.usage_limit,
                 }),
                 Grantable::DerivedAlternativeCast(spec) => {
                     materialize_derived_alternative_cast(card, spec).map(|method| {
@@ -748,7 +748,7 @@ impl<'a> DerivedGameView<'a> {
                             method,
                             source_id: grant.source.source_id(),
                             zone: grant.zone,
-                            usage_limit: spec.usage_limit(),
+                            usage_limit: grant.usage_limit.or_else(|| spec.usage_limit()),
                         }
                     })
                 }
@@ -816,7 +816,7 @@ impl<'a> DerivedGameView<'a> {
                     method: method.clone(),
                     source_id: grant.source.source_id(),
                     zone: grant.zone,
-                    usage_limit: None,
+                    usage_limit: grant.usage_limit,
                 }),
                 Grantable::DerivedAlternativeCast(spec) => {
                     materialize_derived_alternative_cast(card, spec).map(|method| {
@@ -824,7 +824,7 @@ impl<'a> DerivedGameView<'a> {
                             method,
                             source_id: grant.source.source_id(),
                             zone: grant.zone,
-                            usage_limit: spec.usage_limit(),
+                            usage_limit: grant.usage_limit.or_else(|| spec.usage_limit()),
                         }
                     })
                 }

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2833,6 +2833,9 @@ pub fn resolve_objects_from_spec(
                     .collect();
 
                 if objects.is_empty() {
+                    if count.min == 0 {
+                        return Ok(Vec::new());
+                    }
                     return Err(ExecutionError::InvalidTarget);
                 }
 

--- a/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
@@ -51,18 +51,32 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
                 None,
                 vec![],
             );
-            game.effect_store
-                .grant_registry
-                .grant_alternative_cast_to_card(
-                    object_id,
-                    Zone::Exile,
-                    player_id,
-                    method,
-                    GrantSource::Effect {
-                        source_id: ctx.source,
-                        expires_end_of_turn,
-                    },
-                );
+            let source = GrantSource::Effect {
+                source_id: ctx.source,
+                expires_end_of_turn,
+            };
+            if let Some(usage_limit) = self.usage_limit {
+                game.effect_store
+                    .grant_registry
+                    .grant_limited_alternative_cast_to_card(
+                        object_id,
+                        Zone::Exile,
+                        player_id,
+                        method,
+                        usage_limit,
+                        source,
+                    );
+            } else {
+                game.effect_store
+                    .grant_registry
+                    .grant_alternative_cast_to_card(
+                        object_id,
+                        Zone::Exile,
+                        player_id,
+                        method,
+                        source,
+                    );
+            }
             granted += 1;
         }
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3572,6 +3572,43 @@ fn alternative_cast_label(
     (!name.is_empty()).then(|| name.to_string())
 }
 
+fn play_from_granted_usage_limit(
+    game: &GameState,
+    caster: PlayerId,
+    obj_id: ObjectId,
+    casting_method: &CastingMethod,
+) -> Option<(ObjectId, crate::grant::GrantUsageLimit)> {
+    let obj = game.object(obj_id)?;
+    let CastingMethod::PlayFrom {
+        source,
+        use_alternative: Some(idx),
+        zone,
+    } = casting_method
+    else {
+        return None;
+    };
+    let granted_idx = idx.checked_sub(obj.alternative_casts.len())?;
+    let granted = game
+        .effect_store
+        .grant_registry
+        .granted_alternative_casts_for_card(game, obj.id, *zone, caster);
+    granted
+        .get(granted_idx)
+        .and_then(|grant| grant.usage_limit.map(|limit| (*source, limit)))
+        .or_else(|| {
+            game.effect_store
+                .grant_registry
+                .grants
+                .iter()
+                .find(|grant| {
+                    grant.player == caster
+                        && grant.source.source_id() == *source
+                        && grant.usage_limit.is_some()
+                })
+                .and_then(|grant| grant.usage_limit.map(|limit| (*source, limit)))
+        })
+}
+
 /// Finalize a spell cast by paying remaining costs and creating the stack entry.
 /// Returns the spell cast info for trigger checking.
 ///
@@ -3870,6 +3907,22 @@ pub(super) fn finalize_spell_cast(
             game.turn_store
                 .grant_cast_uses_this_turn
                 .insert((caster, *source));
+        }
+    }
+    if let Some((source, crate::grant::GrantUsageLimit::OncePerNonlandCardType)) =
+        play_from_granted_usage_limit(game, caster, new_id, &casting_method)
+        && let Some(spell_obj) = game.object(new_id)
+    {
+        let used_types = spell_obj
+            .card_types
+            .iter()
+            .copied()
+            .filter(|card_type| *card_type != crate::types::CardType::Land)
+            .collect::<Vec<_>>();
+        for card_type in used_types {
+            game.turn_store
+                .grant_cast_card_type_uses_this_turn
+                .insert((caster, source, card_type));
         }
     }
 

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -259,6 +259,8 @@ pub struct TurnStore {
     pub entered_battlefield_last_turn: Vec<ObjectSnapshot>,
     /// Static or temporary grant sources whose once-per-turn cast permission was used.
     pub grant_cast_uses_this_turn: HashSet<(PlayerId, ObjectId)>,
+    /// Card types already used for source-scoped "one spell of each type" cast grants.
+    pub grant_cast_card_type_uses_this_turn: HashSet<(PlayerId, ObjectId, CardType)>,
     /// Explicit combat damage assignments keyed by attacker then damage recipient.
     pub combat_damage_assignments: HashMap<ObjectId, HashMap<ObjectId, u32>>,
 }
@@ -6940,6 +6942,9 @@ impl GameState {
             self.set_daytime(false);
         }
         self.turn_store.grant_cast_uses_this_turn.clear();
+        self.turn_store
+            .grant_cast_card_type_uses_this_turn
+            .clear();
         self.saddled_until_end_of_turn.clear();
         self.ninjutsu_attack_targets.clear();
         self.combat_damage_player_batch_hits.clear();

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -182,6 +182,8 @@ pub struct Grant {
     pub player: PlayerId,
     /// What is being granted (ability or alternative casting method).
     pub grantable: Grantable,
+    /// Optional usage limit for effect-created alternative casts.
+    pub usage_limit: Option<GrantUsageLimit>,
     /// How this grant was created.
     pub source: GrantSource,
 }
@@ -220,6 +222,7 @@ impl GrantRegistry {
             zone,
             player,
             grantable,
+            usage_limit: None,
             source,
         });
     }
@@ -241,6 +244,7 @@ impl GrantRegistry {
             zone,
             player,
             grantable,
+            usage_limit: None,
             source,
         });
     }
@@ -262,6 +266,7 @@ impl GrantRegistry {
             zone,
             player,
             grantable,
+            usage_limit: None,
             source,
         });
     }
@@ -301,6 +306,28 @@ impl GrantRegistry {
             Grantable::AlternativeCast(method),
             source,
         );
+    }
+
+    /// Add a usage-limited alternative cast grant for a specific card.
+    pub fn grant_limited_alternative_cast_to_card(
+        &mut self,
+        target_id: ObjectId,
+        zone: Zone,
+        player: PlayerId,
+        method: AlternativeCastingMethod,
+        usage_limit: GrantUsageLimit,
+        source: GrantSource,
+    ) {
+        self.grants.push(Grant {
+            target_id: Some(target_id),
+            target_stable_id: None,
+            filter: None,
+            zone,
+            player,
+            grantable: Grantable::AlternativeCast(method),
+            usage_limit: Some(usage_limit),
+            source,
+        });
     }
 
     /// Add an alternative cast grant for cards matching a filter.
@@ -587,6 +614,7 @@ impl GrantRegistry {
                         zone: spec.zone,
                         player: player.id,
                         grantable: spec.grantable.clone(),
+                        usage_limit: None,
                         source: GrantSource::StaticAbility { source_id },
                     });
                 }
@@ -616,10 +644,10 @@ fn materialize_granted_alternative_cast(
     grant: Grant,
 ) -> Option<GrantedAlternativeCast> {
     let (method, usage_limit) = match grant.grantable {
-        Grantable::AlternativeCast(method) => (method, None),
+        Grantable::AlternativeCast(method) => (method, grant.usage_limit),
         Grantable::DerivedAlternativeCast(spec) => {
             let card = game.object(card_id)?;
-            let usage_limit = spec.usage_limit();
+            let usage_limit = grant.usage_limit.or_else(|| spec.usage_limit());
             (
                 materialize_derived_alternative_cast(card, spec)?,
                 usage_limit,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aminatou's Augury
Initial parse error:
```
could not find verb in effect clause (clause: 'until end of turn for each nonland card type you may cast a spell of that type from among the exiled cards without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'until end of turn for each nonland card type you may cast a spell of that type from among the exiled cards without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0957541cfc94420a7
Branch: codex/aws-card-fix-aminatou-s-augury
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0211
