### PR TITLE
Fix Ironsmith parse failure: Goblin Kites

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -86,6 +86,22 @@ fn compile_delayed_trigger_spec(
     }
 }
 
+fn compile_delayed_effects_preserving_outer_context(
+    effects: &[EffectAst],
+    ctx: &mut EffectLoweringContext,
+) -> Result<(Vec<Effect>, Vec<ChooseSpec>), CardTextError> {
+    let saved_frame = ctx.lowering_frame();
+    let mut delayed_frame = saved_frame.clone();
+    delayed_frame.last_effect_id = None;
+    let mut id_gen = ctx.id_gen_context();
+    let (compiled, choices, mut frame_out) =
+        compile_effects_with_explicit_frame(effects, &mut id_gen, delayed_frame)?;
+    frame_out.last_effect_id = saved_frame.last_effect_id;
+    ctx.apply_id_gen_context(id_gen);
+    ctx.apply_lowering_frame(frame_out);
+    Ok((compiled, choices))
+}
+
 fn rewrite_filter_tag_relation(
     filter: &mut ObjectFilter,
     tag: &str,
@@ -172,7 +188,8 @@ pub(super) fn try_compile_timing_and_control_effect(
 ) -> Result<Option<(Vec<Effect>, Vec<ChooseSpec>)>, CardTextError> {
     let compiled = match effect {
         EffectAst::DelayedUntilNextEndStep { player, effects } => {
-            let (delayed_effects, choices) = compile_effects_preserving_last_effect(effects, ctx)?;
+            let (delayed_effects, choices) =
+                compile_delayed_effects_preserving_outer_context(effects, ctx)?;
             let effect = Effect::new(crate::effects::ScheduleDelayedTriggerEffect::new(
                 ironsmith_core::DelayedTriggerSpec::BeginningOfEndStep(player.clone()),
                 delayed_effects,
@@ -187,7 +204,7 @@ pub(super) fn try_compile_timing_and_control_effect(
             let player_filter = subject.into_player_filter();
             let mut choices = subject.into_choices();
             let (delayed_effects, nested_choices) =
-                compile_effects_preserving_last_effect(effects, ctx)?;
+                compile_delayed_effects_preserving_outer_context(effects, ctx)?;
             choices.extend(nested_choices);
             let effect = Effect::new(
                 crate::effects::ScheduleDelayedTriggerEffect::new(
@@ -206,7 +223,7 @@ pub(super) fn try_compile_timing_and_control_effect(
             let player_filter = subject.into_player_filter();
             let mut choices = subject.into_choices();
             let (delayed_effects, nested_choices) =
-                compile_effects_preserving_last_effect(effects, ctx)?;
+                compile_delayed_effects_preserving_outer_context(effects, ctx)?;
             choices.extend(nested_choices);
             let effect = Effect::new(
                 crate::effects::ScheduleDelayedTriggerEffect::new(
@@ -225,7 +242,7 @@ pub(super) fn try_compile_timing_and_control_effect(
             let player_filter = subject.into_player_filter();
             let mut choices = subject.into_choices();
             let (delayed_effects, nested_choices) =
-                compile_effects_preserving_last_effect(effects, ctx)?;
+                compile_delayed_effects_preserving_outer_context(effects, ctx)?;
             choices.extend(nested_choices);
             let effect = Effect::new(
                 crate::effects::ScheduleDelayedTriggerEffect::new(
@@ -240,7 +257,8 @@ pub(super) fn try_compile_timing_and_control_effect(
             (vec![effect], choices)
         }
         EffectAst::DelayedUntilEndOfCombat { effects } => {
-            let (delayed_effects, choices) = compile_effects_preserving_last_effect(effects, ctx)?;
+            let (delayed_effects, choices) =
+                compile_delayed_effects_preserving_outer_context(effects, ctx)?;
             let effect = Effect::new(crate::effects::ScheduleDelayedTriggerEffect::new(
                 ironsmith_core::DelayedTriggerSpec::EndOfCombat,
                 delayed_effects,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1268,7 +1268,10 @@ fn maybe_assign_effect_result_id(
     let next_is_result_gate = idx + 1 < effects.len()
         && matches!(
             effects[idx + 1],
-            EffectAst::IfResult { .. } | EffectAst::WhenResult { .. }
+            EffectAst::IfResult { .. }
+                | EffectAst::WhenResult { .. }
+                | EffectAst::ResolvedIfResult { .. }
+                | EffectAst::ResolvedWhenResult { .. }
         );
     let next_is_if_result_with_opponent_doesnt = next_is_result_gate
         && idx + 2 < effects.len()

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -951,7 +951,13 @@ fn post_rule_delayed_trigger_result_followup(
     else {
         return Ok(None);
     };
-    let Some(EffectAst::DelayedTriggerThisTurn { effects, .. }) = state.effects.last_mut() else {
+    let Some(
+        EffectAst::DelayedTriggerThisTurn { effects, .. }
+        | EffectAst::DelayedUntilNextEndStep { effects, .. }
+        | EffectAst::DelayedUntilNextUpkeep { effects, .. }
+        | EffectAst::DelayedUntilNextDrawStep { effects, .. },
+    ) = state.effects.last_mut()
+    else {
         return Ok(None);
     };
     effects.extend(sentence_effects.drain(..));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -204,6 +204,14 @@ pub(crate) fn parse_flip(
         return Ok(EffectAst::subject_verb_flip(TargetAst::Source(None)));
     }
 
+    if let Some(timed_tokens) = split_trailing_next_end_step_timing(tokens) {
+        let timed_effect = parse_flip(timed_tokens, subject)?;
+        return Ok(EffectAst::DelayedUntilNextEndStep {
+            player: PlayerFilter::Any,
+            effects: vec![timed_effect],
+        });
+    }
+
     let target_words = crate::runtime_backend::token_word_refs(tokens);
     if matches!(target_words.as_slice(), ["a", "coin"] | ["coin"]) {
         return Ok(EffectAst::subject_verb_flip_coin(player));
@@ -220,6 +228,42 @@ pub(crate) fn parse_flip(
 
     let target = parse_target_phrase(tokens)?;
     Ok(EffectAst::subject_verb_flip(target))
+}
+
+fn split_trailing_next_end_step_timing(tokens: &[OwnedLexToken]) -> Option<&[OwnedLexToken]> {
+    let words = TokenWordView::new(tokens);
+    let timing_phrases: &[&[&str]] = &[
+        &[
+            "at",
+            "the",
+            "beginning",
+            "of",
+            "the",
+            "next",
+            "end",
+            "step",
+        ],
+        &["at", "the", "beginning", "of", "next", "end", "step"],
+        &["at", "beginning", "of", "the", "next", "end", "step"],
+        &["at", "beginning", "of", "next", "end", "step"],
+    ];
+
+    for phrase in timing_phrases {
+        if words.len() < phrase.len() {
+            continue;
+        }
+        let phrase_start = words.len() - phrase.len();
+        if !words.slice_eq(phrase_start, phrase) {
+            continue;
+        }
+        let token_start = words.token_index_for_word_index(phrase_start)?;
+        let action_tokens = &tokens[..token_start];
+        if !trim_commas(action_tokens).is_empty() {
+            return Some(action_tokens);
+        }
+    }
+
+    None
 }
 
 pub(crate) fn parse_roll(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -26495,6 +26495,27 @@ fn parse_delayed_next_end_step_sentence_with_this_creature_keeps_source_referenc
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_goblin_kites_strictly_and_renders_delayed_coin_flip_clause() {
+    let def = parse_oracle_card_definition("Goblin Kites");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Flip a coin at the beginning of the next end step"),
+        "expected delayed coin-flip timing in rendered text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("If you lose the flip, sacrifice that creature"),
+        "expected lose-the-flip sacrifice branch in rendered text, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(debug.contains("ScheduleDelayedTriggerEffect"), "{debug}");
+    assert!(debug.contains("FlipCoinEffect"), "{debug}");
+    assert!(debug.contains("DidNotHappen"), "{debug}");
+    assert!(debug.contains("LessThanOrEqual") && debug.contains("2"), "{debug}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_object_filter_with_entered_since_last_turn_ended_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Premature Burial Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13966,6 +13966,71 @@ fn source_return_from_graveyard_subject_in_effect(effect: &Effect) -> Option<Str
     None
 }
 
+fn describe_delayed_coin_flip_result(
+    schedule: &crate::effects::ScheduleDelayedTriggerEffect,
+) -> Option<String> {
+    if !schedule.one_shot || schedule.start_next_turn || schedule.until_end_of_turn {
+        return None;
+    }
+    let trigger_text = schedule.trigger.display().to_ascii_lowercase();
+    if !trigger_text.contains("beginning of") || !trigger_text.contains("end step") {
+        return None;
+    }
+
+    let effects: &[Effect] = &schedule.effects;
+    let [flip_effect, branch_effect] = effects else {
+        return None;
+    };
+    let flip_with_id = flip_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let flip_coin = flip_with_id
+        .effect
+        .downcast_ref::<crate::effects::FlipCoinEffect>()?;
+    if flip_coin.player != PlayerFilter::You {
+        return None;
+    }
+
+    let if_effect = branch_effect.downcast_ref::<crate::effects::IfEffect>()?;
+    if if_effect.condition != flip_with_id.id
+        || !matches!(if_effect.predicate, EffectPredicate::DidNotHappen)
+        || !if_effect.else_.is_empty()
+    {
+        return None;
+    }
+    let [choose_effect, sacrifice_effect] = if_effect.then.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let sacrifice = sacrifice_view(sacrifice_effect)?;
+    let sacrifice_text = describe_choose_then_sacrifice(choose, sacrifice)?;
+    if !sacrifice_text.starts_with("you sacrifice ") {
+        return None;
+    }
+    if !choose.filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag.as_str().starts_with("targeted_")
+    }) {
+        return None;
+    }
+
+    let object = if choose.filter.card_types.contains(&CardType::Creature) {
+        "creature"
+    } else if choose.filter.card_types.contains(&CardType::Artifact) {
+        "artifact"
+    } else if choose.filter.card_types.contains(&CardType::Enchantment) {
+        "enchantment"
+    } else if choose.filter.card_types.contains(&CardType::Planeswalker) {
+        "planeswalker"
+    } else if choose.filter.card_types.contains(&CardType::Land) {
+        "land"
+    } else {
+        "permanent"
+    };
+
+    Some(format!(
+        "Flip a coin at the beginning of the next end step. If you lose the flip, sacrifice that {object}"
+    ))
+}
+
 fn normalize_modal_named_source_etb_surface(
     line: String,
     triggered: &crate::ability::TriggeredAbility,
@@ -30955,6 +31020,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(schedule) = effect.downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>() {
+        if let Some(text) = describe_delayed_coin_flip_result(schedule) {
+            return text;
+        }
         let trigger_display = schedule.trigger.display();
         let mut trigger_text = trigger_display.trim().trim_end_matches('.').to_string();
         if schedule.until_end_of_turn {

--- a/crates/ironsmith-runtime/src/effects/delayed/schedule_delayed_trigger.rs
+++ b/crates/ironsmith-runtime/src/effects/delayed/schedule_delayed_trigger.rs
@@ -99,9 +99,31 @@ impl EffectExecutor for ScheduleDelayedTriggerEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let controller_id = resolve_player_filter(game, &self.controller, ctx)?;
+        let mut tagged_objects = ctx.tagged_objects.clone();
+        if !ctx.targets_are_cost_choices {
+            for (idx, target) in ctx.targets.iter().enumerate() {
+                let crate::effects::ResolvedTarget::Object(object_id) = target else {
+                    continue;
+                };
+                let Some(object) = game.object(*object_id) else {
+                    continue;
+                };
+                let tag = TagKey::from(format!("targeted_{idx}"));
+                if !tagged_objects.contains_key(&tag) {
+                    tagged_objects.insert(
+                        tag,
+                        vec![
+                            crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+                                object, game,
+                            ),
+                        ],
+                    );
+                }
+            }
+        }
 
         if let Some(tag) = &self.target_tag {
-            let Some(tagged) = ctx.get_tagged_all(tag) else {
+            let Some(tagged) = tagged_objects.get(tag) else {
                 return Ok(EffectOutcome::count(0));
             };
             let filter_ctx = ctx.filter_context(game);
@@ -112,8 +134,8 @@ impl EffectExecutor for ScheduleDelayedTriggerEffect {
                 {
                     continue;
                 }
-                let mut tagged_objects = ctx.tagged_objects.clone();
-                tagged_objects.insert(tag.clone(), vec![snapshot.clone()]);
+                let mut delayed_tagged_objects = tagged_objects.clone();
+                delayed_tagged_objects.insert(tag.clone(), vec![snapshot.clone()]);
                 let delayed = DelayedTriggerTemplate::new(
                     self.trigger.clone(),
                     self.effects.clone(),
@@ -132,7 +154,7 @@ impl EffectExecutor for ScheduleDelayedTriggerEffect {
                 } else {
                     None
                 })
-                .with_tagged_objects(tagged_objects);
+                .with_tagged_objects(delayed_tagged_objects);
                 queue_delayed_from_template(
                     game,
                     DelayedWatcherIdentity::combined(vec![snapshot.object_id]),
@@ -161,7 +183,7 @@ impl EffectExecutor for ScheduleDelayedTriggerEffect {
         } else {
             None
         })
-        .with_tagged_objects(ctx.tagged_objects.clone());
+        .with_tagged_objects(tagged_objects);
         queue_delayed_from_template(
             game,
             DelayedWatcherIdentity::combined(self.target_objects.clone()),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -408,6 +408,217 @@ fn keeper_of_the_flame_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn goblin_kites_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_955), "Goblin Kites")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "{R}: Target creature you control with toughness 2 or less gains flying until end of turn. Flip a coin at the beginning of the next end step. If you lose the flip, sacrifice that creature.",
+        )
+        .expect("Goblin Kites should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_vanilla_creature(
+    game: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_goblin_kites_targeting(
+    game: &mut GameState,
+    controller: PlayerId,
+    kites_id: ObjectId,
+    target_id: ObjectId,
+) {
+    let ability_index = game
+        .object(kites_id)
+        .expect("Goblin Kites should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Goblin Kites should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(game, controller)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                if *source == kites_id && *idx == ability_index
+        ))
+        .expect("Goblin Kites activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Goblin Kites activation should start");
+    apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("choosing Goblin Kites target should complete activation");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_goblin_kites_delayed_trigger(game: &mut GameState) {
+    let mut trigger_queue = TriggerQueue::new();
+    let end_step_event = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(game.turn.active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(game, &end_step_event) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Goblin Kites delayed trigger should go on stack");
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(game, &mut dm).expect("Goblin Kites delayed trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn goblin_kites_activation_requires_creature_you_control_with_toughness_two_or_less() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let kites_id = game.create_object_from_definition(
+        &goblin_kites_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    create_vanilla_creature(&mut game, "Too Tough", alice, 2, 3);
+    create_vanilla_creature(&mut game, "Opponent's 1/1", bob, 1, 1);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. } if source == kites_id
+            )),
+        "Goblin Kites should not be activatable without a legal controlled low-toughness target"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn goblin_kites_grants_flying_and_sacrifices_target_after_losing_delayed_flip() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.set_random_seed(7);
+
+    let kites_id = game.create_object_from_definition(
+        &goblin_kites_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let target_id = create_vanilla_creature(&mut game, "Kited Goblin", alice, 1, 1);
+    let target_stable = game.object(target_id).expect("target should exist").stable_id;
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    activate_goblin_kites_targeting(&mut game, alice, kites_id, target_id);
+    resolve_stack_entry(&mut game).expect("Goblin Kites ability should resolve");
+    game.refresh_continuous_state();
+    assert!(
+        game.object_has_static_ability_id(
+            target_id,
+            crate::static_abilities::StaticAbilityId::Flying
+        ),
+        "Goblin Kites should grant flying to the targeted creature until end of turn"
+    );
+    assert_eq!(
+        game.effect_store.delayed_triggers.len(),
+        1,
+        "Goblin Kites should schedule exactly one delayed end-step coin flip"
+    );
+
+    resolve_goblin_kites_delayed_trigger(&mut game);
+    let moved_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("sacrificed target should still be tracked");
+    assert!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .graveyard
+            .contains(&moved_id),
+        "losing the delayed Goblin Kites flip should sacrifice the targeted creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn goblin_kites_winning_delayed_flip_leaves_target_on_battlefield() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.set_random_seed(2);
+
+    let kites_id = game.create_object_from_definition(
+        &goblin_kites_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let target_id = create_vanilla_creature(&mut game, "Lucky Goblin", alice, 1, 1);
+    let target_stable = game.object(target_id).expect("target should exist").stable_id;
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    activate_goblin_kites_targeting(&mut game, alice, kites_id, target_id);
+    resolve_stack_entry(&mut game).expect("Goblin Kites ability should resolve");
+    resolve_goblin_kites_delayed_trigger(&mut game);
+
+    let current_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("target should still be tracked");
+    assert!(
+        game.battlefield.contains(&current_id),
+        "winning the delayed Goblin Kites flip should leave the targeted creature on the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn tsabos_assassin_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_960), "Tsabo's Assassin")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Goblin Kites
Initial parse error:
```
unsupported target phrase (clause: 'coin at beginning of next end step'); oracle-only fallback also failed: unsupported target phrase (clause: 'coin at beginning of next end step')
```

Current worker: i-0624e2567e3a7f5be
Branch: codex/aws-card-fix-goblin-kites
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0211
