### PR TITLE
Fix Ironsmith parse failure: Vislor Turlough

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1482,6 +1482,12 @@ impl Effect {
         Self::new(crate::effects::GoadEffect::new(target))
     }
 
+    pub fn goad_until(target: crate::target::ChooseSpec, duration: Until) -> Self {
+        Self::new(crate::effects::GoadEffect::new_with_duration(
+            target, duration,
+        ))
+    }
+
     pub fn suspect(target: crate::target::ChooseSpec) -> Self {
         Self::new(crate::effects::SuspectEffect::new(target))
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -2409,7 +2409,7 @@ fn looks_like_ability_word_label(label: &str, preserve_as_choice_label: bool) ->
     !trimmed.is_empty()
         && !trimmed.contains('.')
         && !trimmed.contains(':')
-        && trimmed.split_whitespace().count() <= 4
+        && trimmed.split_whitespace().count() <= 5
 }
 
 fn rewrite_line_normalized(
@@ -2599,6 +2599,10 @@ fn try_parse_labeled_line_dispatch(
     };
 
     let is_named_label = is_named_ability_label(label.as_str());
+    let presentation_label = split_label_prefix(line.info.raw_line.as_str())
+        .map(|(raw_label, _)| raw_label.trim())
+        .unwrap_or(label.trim())
+        .to_string();
     let preserve_as_choice_label = labeled_choice_block_has_peer(&preprocessed.items, idx);
     if preserve_keyword_prefix_for_parse(label.as_str()) {
         return Ok(None);
@@ -2630,7 +2634,7 @@ fn try_parse_labeled_line_dispatch(
                 triggered.chosen_option_label = Some(label.to_ascii_lowercase());
             }
             if looks_like_ability_word_label(label.as_str(), preserve_as_choice_label) {
-                triggered.presentation_label = Some(label.trim().to_string());
+                triggered.presentation_label = Some(presentation_label.clone());
             }
             let (triggered, next_idx) =
                 extend_triggered_line_with_result_followups(&preprocessed.items, idx, triggered);
@@ -2644,7 +2648,7 @@ fn try_parse_labeled_line_dispatch(
                 triggered.chosen_option_label = Some(label.to_ascii_lowercase());
             }
             if looks_like_ability_word_label(label.as_str(), preserve_as_choice_label) {
-                triggered.presentation_label = Some(label.trim().to_string());
+                triggered.presentation_label = Some(presentation_label.clone());
             }
             let (triggered, next_idx) =
                 extend_triggered_line_with_result_followups(&preprocessed.items, idx, triggered);
@@ -2662,7 +2666,7 @@ fn try_parse_labeled_line_dispatch(
                 triggered.chosen_option_label = Some(label.to_ascii_lowercase());
             }
             if looks_like_ability_word_label(label.as_str(), preserve_as_choice_label) {
-                triggered.presentation_label = Some(label.trim().to_string());
+                triggered.presentation_label = Some(presentation_label.clone());
             }
             let (triggered, next_idx) =
                 extend_triggered_line_with_result_followups(&preprocessed.items, idx, triggered);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1088,8 +1088,18 @@ fn compile_subject_verb_effect(
             let (spec, mut choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
             let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
-            let controller = subject.into_player_filter();
+            let mut controller = subject.into_player_filter();
             choices.extend(subject.into_choices());
+            let mut effects = Vec::new();
+            if matches!(controller, PlayerFilter::Opponent) && choices.is_empty() {
+                let tag = ctx.next_tag("opponent");
+                effects.push(Effect::new(crate::effects::ChoosePlayerEffect::new(
+                    PlayerFilter::You,
+                    PlayerFilter::Opponent,
+                    tag.clone(),
+                )));
+                controller = PlayerFilter::TaggedPlayer(tag.into());
+            }
             let runtime_modification = if matches!(controller, PlayerFilter::You) {
                 crate::effects::continuous::RuntimeModification::ChangeControllerToEffectController
             } else {
@@ -1107,7 +1117,8 @@ fn compile_subject_verb_effect(
                 ctx,
                 "controlled",
             );
-            Ok((vec![effect], choices))
+            effects.push(effect);
+            Ok((effects, choices))
         }
         SubjectVerbActionAst::RevealTop => {
             let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
@@ -5184,7 +5195,7 @@ fn compile_subject_verb_effect(
                 tag_object_target_effect(Effect::detain(spec.clone()), &spec, ctx, "detained");
             Ok((vec![effect], choices))
         }
-        SubjectVerbActionAst::Goad { target } => {
+        SubjectVerbActionAst::Goad { target, duration } => {
             let (spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
             let spec = if choices.is_empty() {
@@ -5195,7 +5206,12 @@ fn compile_subject_verb_effect(
             } else {
                 spec
             };
-            let effect = tag_object_target_effect(Effect::goad(spec.clone()), &spec, ctx, "goaded");
+            let effect = tag_object_target_effect(
+                Effect::goad_until(spec.clone(), duration.clone()),
+                &spec,
+                ctx,
+                "goaded",
+            );
             Ok((vec![effect], choices))
         }
         SubjectVerbActionAst::Suspect { target } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -67,7 +67,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::ReturnToBattlefield { target, .. }
             | SubjectVerbActionAst::FightIterated { creature2: target }
             | SubjectVerbActionAst::Detain { target }
-            | SubjectVerbActionAst::Goad { target }
+            | SubjectVerbActionAst::Goad { target, .. }
             | SubjectVerbActionAst::Suspect { target }
             | SubjectVerbActionAst::RemoveFromCombat { target }
             | SubjectVerbActionAst::Flip { target }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -72,7 +72,7 @@ fn presentation_label_from_raw_trigger_line(raw_line: &str) -> Option<&str> {
     if label.is_empty()
         || label.contains('.')
         || label.contains(':')
-        || label.split_whitespace().count() > 4
+        || label.split_whitespace().count() > 5
     {
         return None;
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1619,6 +1619,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     Goad {
         target: TargetAst,
+        duration: Until,
     },
     Suspect {
         target: TargetAst,
@@ -3074,7 +3075,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::LoseGame => f.write_str("LoseGame"),
             Self::WinGame => f.write_str("WinGame"),
             Self::Detain { target } => f.debug_tuple("Detain").field(target).finish(),
-            Self::Goad { target } => f.debug_tuple("Goad").field(target).finish(),
+            Self::Goad { target, duration } => f
+                .debug_struct("Goad")
+                .field("target", target)
+                .field("duration", duration)
+                .finish(),
             Self::Suspect { target } => f.debug_tuple("Suspect").field(target).finish(),
             Self::ClearSuspected { target } => f
                 .debug_tuple("ClearSuspected")
@@ -6167,10 +6172,14 @@ impl EffectAst {
     }
 
     pub(crate) fn subject_verb_goad(target: TargetAst) -> Self {
+        Self::subject_verb_goad_until(target, Until::YourNextTurn)
+    }
+
+    pub(crate) fn subject_verb_goad_until(target: TargetAst, duration: Until) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::Goad { target },
+            SubjectVerbActionAst::Goad { target, duration },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -567,7 +567,7 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::Detain { target } => {
                     maybe_tag_target(target, frame, id_gen, "detained")?;
                 }
-                SubjectVerbActionAst::Goad { target } => {
+                SubjectVerbActionAst::Goad { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "goaded")?;
                 }
                 SubjectVerbActionAst::Suspect { target } => {
@@ -2495,7 +2495,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::PutSticker { target, .. }
             | SubjectVerbActionAst::SwitchPowerToughness { target, .. }
             | SubjectVerbActionAst::Detain { target }
-            | SubjectVerbActionAst::Goad { target }
+                | SubjectVerbActionAst::Goad { target, .. }
             | SubjectVerbActionAst::Suspect { target }
             | SubjectVerbActionAst::RemoveFromCombat { target }
             | SubjectVerbActionAst::Flip { target }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -1401,30 +1401,42 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     Ok(effect)
 }
 
-fn parse_passive_goad_clause(tokens: &[OwnedLexToken]) -> Result<Option<EffectAst>, CardTextError> {
+fn parse_passive_goad_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
     let words = ClauseDispatchCompatWords::new(tokens).to_word_refs();
-    let Some(is_word_idx) = find_word_index(&words, "is") else {
+    let Some(goaded_word_idx) =
+        find_word_index_by(&words, |word| matches!(word, "goaded" | "goad"))
+    else {
         return Ok(None);
     };
-    if !matches!(words.get(is_word_idx + 1).copied(), Some("goaded" | "goad")) {
-        return Ok(None);
-    }
-
-    let duration_tail = &words[is_word_idx + 2..];
-    let duration_ok = duration_tail.is_empty()
-        || matches!(
-            duration_tail,
-            ["for", "the", "rest", "of", "the", "game"]
-                | ["for", "the", "rest", "of", "this", "game"]
-        );
-    if !duration_ok {
-        return Ok(None);
-    }
-
-    let Some(is_token_idx) = token_index_for_word_index(tokens, is_word_idx) else {
+    let Some(copula_word_idx) = goaded_word_idx.checked_sub(1) else {
         return Ok(None);
     };
-    let subject_tokens = trim_commas(&tokens[..is_token_idx]);
+    let subject_end_word_idx = match words.get(copula_word_idx).copied() {
+        Some("is" | "are") => copula_word_idx,
+        Some("s") => copula_word_idx,
+        Some("its") if copula_word_idx == 0 => goaded_word_idx,
+        _ => return Ok(None),
+    };
+
+    let duration_tail = &words[goaded_word_idx + 1..];
+    let duration = match duration_tail {
+        [] => Until::YourNextTurn,
+        ["for", "the", "rest", "of", "the", "game"]
+        | ["for", "the", "rest", "of", "this", "game"] => Until::Forever,
+        ["for", "as", "long", "as", "they", "control", "it"]
+        | ["for", "as", "long", "as", "that", "player", "controls", "it"] => {
+            Until::YouStopControllingThis
+        }
+        _ => return Ok(None),
+    };
+
+    let Some(subject_end_token_idx) = token_index_for_word_index(tokens, subject_end_word_idx)
+    else {
+        return Ok(None);
+    };
+    let subject_tokens = trim_commas(&tokens[..subject_end_token_idx]);
     if subject_tokens.is_empty() {
         return Ok(None);
     }
@@ -1432,7 +1444,7 @@ fn parse_passive_goad_clause(tokens: &[OwnedLexToken]) -> Result<Option<EffectAs
     let subject_words = ClauseDispatchCompatWords::new(&subject_tokens).to_word_refs();
     let target = if matches!(
         subject_words.as_slice(),
-        ["the", "token"] | ["the", "tokens"]
+        ["it"] | ["its"] | ["the", "token"] | ["the", "tokens"]
     ) {
         TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(&subject_tokens))
     } else {
@@ -1448,7 +1460,7 @@ fn parse_passive_goad_clause(tokens: &[OwnedLexToken]) -> Result<Option<EffectAs
         )));
     }
 
-    Ok(Some(EffectAst::subject_verb_goad(target)))
+    Ok(Some(EffectAst::subject_verb_goad_until(target, duration)))
 }
 
 fn parse_hexproof_targeting_override_clause(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -1956,7 +1956,7 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::PutCounters { target, .. }
             | SubjectVerbActionAst::ReturnToHand { target, .. }
             | SubjectVerbActionAst::Detain { target }
-            | SubjectVerbActionAst::Goad { target }
+            | SubjectVerbActionAst::Goad { target, .. }
             | SubjectVerbActionAst::Suspect { target }
             | SubjectVerbActionAst::RemoveFromCombat { target }
             | SubjectVerbActionAst::Flip { target }
@@ -2664,6 +2664,7 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
             }
             | SubjectVerbActionAst::Goad {
                 target: effect_target,
+                ..
             }
             | SubjectVerbActionAst::Suspect {
                 target: effect_target,

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1996,11 +1996,16 @@ impl DetainEffect {
 #[derive(Debug, Clone, PartialEq)]
 pub struct GoadEffect {
     pub target: ChooseSpec,
+    pub duration: Until,
 }
 
 impl GoadEffect {
     pub fn new(target: ChooseSpec) -> Self {
-        Self { target }
+        Self::new_with_duration(target, Until::YourNextTurn)
+    }
+
+    pub fn new_with_duration(target: ChooseSpec, duration: Until) -> Self {
+        Self { target, duration }
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -19991,6 +19991,130 @@ fn parse_partial_reveal_from_hand_choose_one_of_them_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_vislor_turlough_black_guardian_strict_text_regression() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Vislor Turlough")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Rogue])
+        .parse_text(
+            "Deal with the Black Guardian — When Vislor Turlough enters, you may have an opponent gain control of it. If you do, it's goaded for as long as they control it.\n\
+             At the beginning of your end step, draw a card, then you lose life equal to the number of cards in your hand.\n\
+             Doctor's companion (You can have two commanders if the other is the Doctor.)",
+        )
+        .expect("Vislor Turlough should parse strictly");
+
+    let debug = format!("{def:#?}");
+    assert!(!debug.contains("UnsupportedParserLine"), "{debug}");
+    assert!(
+        debug.contains("MayEffect")
+            && debug.contains("ChoosePlayerEffect")
+            && debug.contains("TaggedPlayer")
+            && debug.contains("IfEffect")
+            && debug.contains("GoadEffect")
+            && debug.contains("YouStopControllingThis"),
+        "expected optional chosen-opponent control branch followed by duration-bound goad, got {debug}"
+    );
+
+    let lines = unprocessed_compiled_lines(&def);
+    assert_eq!(
+        lines[0],
+        "Deal with the Black Guardian — When Vislor Turlough enters, you may have an opponent gain control of it. If you do, it's goaded for as long as they control it."
+    );
+    assert_eq!(
+        lines[1],
+        "At the beginning of your end step, draw a card, then you lose life equal to the number of cards in your hand."
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn vislor_turlough_black_guardian_runtime_accept_and_decline_branches() {
+    let def = parse_oracle_card_definition("Vislor Turlough");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Vislor Turlough should have an enters trigger");
+
+    let resolve = |accept: bool| {
+        let mut game = crate::game_state::GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+        let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+            game.object(source).expect("Vislor should exist"),
+            &game,
+        );
+        let event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::zones::ZoneChangeEvent::with_cause(
+                source,
+                Zone::Hand,
+                Zone::Battlefield,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+
+        if accept {
+            let mut dm = crate::decision::SelectFirstDecisionMaker;
+            let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+                .with_triggering_event(event);
+            crate::game_loop::execute_resolution_program(
+                &mut game,
+                &mut ctx,
+                alice,
+                source,
+                &triggered.effects,
+                None,
+                &[],
+            )
+            .expect("accepted Vislor trigger should resolve");
+        } else {
+            let mut dm = crate::decision::AutoPassDecisionMaker;
+            let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+                .with_triggering_event(event);
+            crate::game_loop::execute_resolution_program(
+                &mut game,
+                &mut ctx,
+                alice,
+                source,
+                &triggered.effects,
+                None,
+                &[],
+            )
+            .expect("declined Vislor trigger should resolve");
+        }
+        (game, source)
+    };
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let (declined_game, declined_source) = resolve(false);
+    assert_eq!(declined_game.current_controller(declined_source), Some(alice));
+    assert!(!declined_game.is_goaded(declined_source));
+
+    let (mut accepted_game, accepted_source) = resolve(true);
+    assert_eq!(accepted_game.current_controller(accepted_source), Some(bob));
+    assert!(accepted_game.is_goaded(accepted_source));
+    assert!(accepted_game.active_goaders_for(accepted_source).contains(&alice));
+
+    accepted_game.set_current_controller(accepted_source, charlie);
+    assert!(
+        !accepted_game.is_goaded(accepted_source),
+        "Vislor should stop being goaded when the chosen opponent no longer controls it"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_trigger_target_opponent_gains_control_of_it_clause() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Gain Control Of It Variant")
         .parse_text("When this creature enters, target opponent gains control of it.")

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -754,8 +754,10 @@ pub(super) fn substitute_legendary_source_reference(
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
     let uses_named_source_surface = lower.starts_with("this creature gets ")
         || conditional_static_self_surface
+        || lower.starts_with("when this creature enters,")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.contains(": this creature gets ")
+        || lower.contains("— when this creature enters,")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {
         return line.to_string();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -155,6 +155,44 @@ fn may_causative_clause(inner: &str) -> Option<String> {
     })
 }
 
+fn describe_may_opponent_gain_control(may: &crate::effects::MayEffect) -> Option<String> {
+    if !matches!(may.decider, None | Some(PlayerFilter::You)) {
+        return None;
+    }
+    let [choose_effect, control_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChoosePlayerEffect>()?;
+    if choose.chooser != PlayerFilter::You
+        || choose.filter != PlayerFilter::Opponent
+        || choose.random
+        || choose.remember_as_chosen_player
+        || !choose.excluded_tags.is_empty()
+    {
+        return None;
+    }
+    let tagged = control_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let control = tagged
+        .effect
+        .downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if control.modification.is_some()
+        || !control.additional_modifications.is_empty()
+        || !matches!(control.until, Until::Forever)
+        || !matches!(
+            control.runtime_modifications.as_slice(),
+            [crate::effects::continuous::RuntimeModification::ChangeControllerToPlayer(
+                PlayerFilter::TaggedPlayer(tag)
+            )] if tag == &choose.tag
+        )
+    {
+        return None;
+    }
+
+    let control_text = describe_effect(control_effect);
+    let target = control_text.strip_prefix("that player gains control of ")?;
+    Some(format!("You may have an opponent gain control of {target}"))
+}
+
 fn prevention_put_counters_follow_up(
     follow_up_effects: &[Effect],
 ) -> Option<&crate::effects::PutCountersEffect> {
@@ -27985,6 +28023,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             );
         }
         if let Value::Count(filter) = &lose.amount {
+            if filter.zone == Some(Zone::Hand)
+                && filter.owner == Some(PlayerFilter::You)
+                && filter.card_types.is_empty()
+                && filter.subtypes.is_empty()
+            {
+                return format!(
+                    "{} {} life equal to the number of cards in your hand",
+                    player,
+                    player_verb(&player, "lose", "loses")
+                );
+            }
             return format!(
                 "{} {} 1 life for each {}",
                 player,
@@ -29315,6 +29364,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return text;
     }
     if let Some(may) = effect.downcast_ref::<crate::effects::MayEffect>() {
+        if let Some(compact) = describe_may_opponent_gain_control(may) {
+            return compact;
+        }
         if let Some(compact) = describe_may_enlist(may) {
             return compact;
         }
@@ -30416,7 +30468,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return format!("Detain {}", describe_choose_spec(&detain.target));
     }
     if let Some(goad) = effect.downcast_ref::<crate::effects::GoadEffect>() {
-        return format!("Goad {}", describe_goad_target(&goad.target));
+        let target = if matches!(goad.duration, crate::effect::Until::YouStopControllingThis)
+            && matches!(goad.target, ChooseSpec::Tagged(_))
+        {
+            "it".to_string()
+        } else {
+            describe_goad_target(&goad.target)
+        };
+        return match goad.duration {
+            crate::effect::Until::YourNextTurn => format!("Goad {target}"),
+            crate::effect::Until::Forever => format!("{target} is goaded for the rest of the game"),
+            crate::effect::Until::YouStopControllingThis => {
+                format!("{target}'s goaded for as long as they control it")
+            }
+            _ => format!("Goad {target} {}", describe_until(&goad.duration)),
+        };
     }
     if let Some(suspect) = effect.downcast_ref::<crate::effects::SuspectEffect>() {
         return format!("Suspect {}", describe_choose_spec(&suspect.target));

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -1514,6 +1514,12 @@ impl Effect {
         Self::new(GoadEffect::new(target))
     }
 
+    /// Create a "goad target creature" effect with an explicit duration.
+    pub fn goad_until(target: ChooseSpec, duration: Until) -> Self {
+        use crate::effects::GoadEffect;
+        Self::new(GoadEffect::new_with_duration(target, duration))
+    }
+
     /// Create a "detain target permanent" effect.
     pub fn detain(target: ChooseSpec) -> Self {
         use crate::effects::DetainEffect;

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1239,8 +1239,9 @@ where
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::GoadEffect>(&effect) {
-        return Ok(Effect::new(crate::effects::GoadEffect::new(
+        return Ok(Effect::new(crate::effects::GoadEffect::new_with_duration(
             payload.target.clone(),
+            payload.duration.clone(),
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::SuspectEffect>(&effect) {

--- a/crates/ironsmith-runtime/src/effects/combat/goad.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/goad.rs
@@ -15,12 +15,19 @@ use crate::zone::Zone;
 pub struct GoadEffect {
     /// Creature target specification.
     pub target: ChooseSpec,
+    /// How long the goad effect lasts.
+    pub duration: Until,
 }
 
 impl GoadEffect {
     /// Create a new goad effect.
     pub fn new(target: ChooseSpec) -> Self {
-        Self { target }
+        Self::new_with_duration(target, Until::YourNextTurn)
+    }
+
+    /// Create a new goad effect with an explicit duration.
+    pub fn new_with_duration(target: ChooseSpec, duration: Until) -> Self {
+        Self { target, duration }
     }
 }
 
@@ -40,7 +47,7 @@ impl EffectExecutor for GoadEffect {
             if object.zone != Zone::Battlefield || !game.current_is_creature(object_id) {
                 continue;
             }
-            game.add_goad_effect(object_id, ctx.controller, Until::YourNextTurn, ctx.source);
+            game.add_goad_effect(object_id, ctx.controller, self.duration.clone(), ctx.source);
             count += 1;
         }
         Ok(EffectOutcome::count(count))
@@ -110,6 +117,7 @@ mod tests {
     use super::*;
     use crate::card::{CardBuilder, PowerToughness};
     use crate::decision::AutoPassDecisionMaker;
+    use crate::effect::Effect;
     use crate::filter::{TaggedObjectConstraint, TaggedOpbjectRelation};
     use crate::ids::{CardId, ObjectId, PlayerId};
     use crate::object::Object;
@@ -208,5 +216,65 @@ mod tests {
 
         assert!(game.is_goaded(ObjectId::from_raw(1)));
         assert!(!game.is_goaded(ObjectId::from_raw(2)));
+    }
+
+    #[test]
+    fn vislor_turlough_goad_lasts_as_long_as_gained_controller_controls_it() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let charlie = PlayerId::from_index(2);
+        let vislor_id = ObjectId::from_raw(968);
+        let mut vislor = battlefield_creature(968, "Vislor Turlough", alice, 2, 5);
+        vislor.id = vislor_id;
+        game.add_object(vislor);
+
+        game.set_current_controller(vislor_id, bob);
+        let effect =
+            GoadEffect::new_with_duration(ChooseSpec::Source, Until::YouStopControllingThis);
+        let mut dm = AutoPassDecisionMaker;
+        let mut ctx = ExecutionContext::new(vislor_id, alice, &mut dm);
+
+        effect
+            .execute(&mut game, &mut ctx)
+            .expect("Vislor Turlough goad should resolve after control changes");
+
+        assert!(game.is_goaded(vislor_id));
+        let goaders = game.active_goaders_for(vislor_id);
+        assert_eq!(goaders.len(), 1);
+        assert!(goaders.contains(&alice));
+
+        game.set_current_controller(vislor_id, charlie);
+
+        assert!(
+            !game.is_goaded(vislor_id),
+            "Vislor Turlough should stop being goaded once the chosen opponent no longer controls it"
+        );
+    }
+
+    #[test]
+    fn vislor_turlough_declined_black_guardian_branch_does_not_goad() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let vislor_id = ObjectId::from_raw(968);
+        let mut vislor = battlefield_creature(968, "Vislor Turlough", alice, 2, 5);
+        vislor.id = vislor_id;
+        game.add_object(vislor);
+
+        let may_goad = crate::effects::MayEffect::new(vec![Effect::goad_until(
+            ChooseSpec::Source,
+            Until::YouStopControllingThis,
+        )]);
+        let mut dm = AutoPassDecisionMaker;
+        let mut ctx = ExecutionContext::new(vislor_id, alice, &mut dm);
+
+        may_goad
+            .execute(&mut game, &mut ctx)
+            .expect("declining Vislor Turlough's optional branch should be valid");
+
+        assert!(!game.is_goaded(vislor_id));
     }
 }

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -738,6 +738,7 @@ pub struct GoadEffectInstance {
     pub goaded_by: PlayerId,
     pub source: ObjectId,
     pub duration: crate::effect::Until,
+    pub duration_controller: Option<PlayerId>,
     pub expires_end_of_turn: u32,
 }
 
@@ -761,11 +762,9 @@ impl GoadEffectInstance {
             crate::effect::Until::ThisLeavesTheBattlefield => game
                 .object(self.source)
                 .is_some_and(|obj| obj.zone == Zone::Battlefield),
-            crate::effect::Until::YouStopControllingThis => {
-                game.object(self.source).is_some_and(|obj| {
-                    obj.zone == Zone::Battlefield && game.controller_of(obj) == self.goaded_by
-                })
-            }
+            crate::effect::Until::YouStopControllingThis => self
+                .duration_controller
+                .is_some_and(|controller| game.current_controller(self.creature) == Some(controller)),
             _ => true,
         }
     }
@@ -2709,11 +2708,16 @@ impl GameState {
             _ => self.turn.turn_number,
         };
 
+        let duration_controller = matches!(duration, crate::effect::Until::YouStopControllingThis)
+            .then(|| self.current_controller(creature))
+            .flatten();
+
         self.effect_store.goad_effects.push(GoadEffectInstance {
             creature,
             goaded_by,
             source,
             duration,
+            duration_controller,
             expires_end_of_turn,
         });
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vislor Turlough
Initial parse error:
```
parser does not yet support line family: 'Deal with the Black Guardian — When Vislor Turlough enters, you may have an opponent gain control of it. If you do, it's goaded for as long as they control it.'; oracle-only fallback also failed: parser does not yet support line family: 'Deal with the Black Guardian — When Vislor Turlough enters, you may have an opponent gain control of it. If you do, it's goaded for as long as they control it.'
```

Current worker: i-02b0089d613d34c57
Branch: codex/aws-card-fix-vislor-turlough
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0241
