### PR TITLE
Fix Ironsmith parse failure: Leyline of Transformation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6291,6 +6291,20 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
         return Ok(None);
     }
 
+    let subject_tokens = &tokens[..be_idx];
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let added_words = &tail[..addition_idx];
+    if matches!(added_words, ["the", "chosen", "type"] | ["chosen", "type"]) {
+        let filter = parse_object_filter(subject_tokens, false)?;
+        return Ok(Some(vec![StaticAbility::add_chosen_creature_type(
+            filter,
+            render_token_slice(tokens),
+        )]));
+    }
+
     let mut card_types = Vec::new();
     let mut subtypes = Vec::new();
     for descriptor in &tail[..addition_idx] {
@@ -6317,10 +6331,6 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
         return Ok(None);
     }
 
-    let subject_tokens = &tokens[..be_idx];
-    if subject_tokens.is_empty() {
-        return Ok(None);
-    }
     let filter = parse_object_filter(subject_tokens, false)?;
 
     let mut abilities = Vec::new();

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33846,9 +33846,22 @@ fn parse_oracle_leyline_of_transformation_regression() {
         "expected Leyline to lower chosen-type additions structurally, got {raw}"
     );
 
-    let rendered = unprocessed_compiled_lines(&def)
-        .join(" ")
-        .to_ascii_lowercase();
+    let compiled_lines = unprocessed_compiled_lines(&def);
+    assert_eq!(
+        compiled_lines,
+        vec![
+            "If this card is in your opening hand, you may begin the game with it on the battlefield.".to_string(),
+            "As this enchantment enters, choose a creature type.".to_string(),
+            "Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.".to_string(),
+        ],
+        "expected Leyline compiled text to match oracle wording"
+    );
+
+    let rendered = compiled_lines.join(" ").to_ascii_lowercase();
+    assert!(
+        rendered.contains("as this enchantment enters, choose a creature type"),
+        "expected Leyline choose-as-enters wording to keep the enchantment self-reference, got {rendered}"
+    );
     assert!(
         rendered.contains(
             "creatures you control are the chosen type in addition to their other types"
@@ -33857,15 +33870,9 @@ fn parse_oracle_leyline_of_transformation_regression() {
     );
     assert!(
         rendered.contains(
-            "creature spells you control are the chosen type in addition to their other types"
+            "the same is true for creature spells you control and creature cards you own that aren't on the battlefield"
         ),
-        "expected Leyline stack chosen-type clause to render, got {rendered}"
-    );
-    assert!(
-        rendered.contains(
-            "creature cards you own that aren't on the battlefield are the chosen type in addition to their other types"
-        ),
-        "expected Leyline off-battlefield chosen-type clause to render, got {rendered}"
+        "expected Leyline chosen-type clauses to merge through same-is-true wording, got {rendered}"
     );
     assert!(
         !rendered.contains("unsupported"),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33813,6 +33813,67 @@ fn parse_oracle_roshan_hidden_magister_regression() {
 }
 
 #[test]
+fn parse_oracle_leyline_of_transformation_regression() {
+    let def = parse_oracle_card_definition("Leyline of Transformation");
+
+    let ids: Vec<StaticAbilityId> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        ids.contains(&StaticAbilityId::PregameAction),
+        "expected Leyline opening-hand pregame ability, got {ids:?}"
+    );
+    assert!(
+        ids.contains(&StaticAbilityId::ChooseCreatureTypeAsEnters),
+        "expected Leyline to choose a creature type as it enters, got {ids:?}"
+    );
+    assert_eq!(
+        ids.iter()
+            .filter(|id| **id == StaticAbilityId::AddChosenCreatureType)
+            .count(),
+        3,
+        "expected battlefield, stack, and off-battlefield chosen-type static abilities, got {ids:?}"
+    );
+
+    let raw = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        raw.matches("addchosencreaturetype").count() >= 3,
+        "expected Leyline to lower chosen-type additions structurally, got {raw}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains(
+            "creatures you control are the chosen type in addition to their other types"
+        ),
+        "expected Leyline battlefield chosen-type clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "creature spells you control are the chosen type in addition to their other types"
+        ),
+        "expected Leyline stack chosen-type clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "creature cards you own that aren't on the battlefield are the chosen type in addition to their other types"
+        ),
+        "expected Leyline off-battlefield chosen-type clause to render, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported"),
+        "expected Leyline to avoid unsupported markers, got {rendered}"
+    );
+}
+
+#[test]
 fn parse_oracle_leyline_of_the_guildpact_static_characteristics_regression() {
     let def = parse_oracle_card_definition("Leyline of the Guildpact");
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -734,6 +734,10 @@ fn substitute_pregame_card_self_reference(line: &str, subject: &str, card_name: 
     if subject.is_empty() || subject.eq_ignore_ascii_case("this source") {
         return line.to_string();
     }
+    let lower = line.to_ascii_lowercase();
+    if !lower.contains("begin the game") {
+        return line.to_string();
+    }
     let capitalized = capitalize_first_ascii(subject);
     line.replace(subject, card_name)
         .replace(&capitalized, card_name)

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -281,6 +281,70 @@ fn subtype_addition_predicate(predicate: &str) -> Option<String> {
     None
 }
 
+#[derive(Debug, Clone)]
+struct TypeAdditionLine {
+    subject: String,
+    verb: String,
+    type_phrase: String,
+}
+
+fn parse_type_addition_line(line: &str) -> Option<TypeAdditionLine> {
+    let trimmed = line.trim().trim_end_matches('.');
+    let (subject, verb, predicate) = split_subject_predicate_clause(trimmed)?;
+    if !matches!(verb, "is" | "are") {
+        return None;
+    }
+    let type_phrase = subtype_addition_predicate(predicate)?;
+    Some(TypeAdditionLine {
+        subject: subject.trim().to_string(),
+        verb: verb.trim().to_string(),
+        type_phrase,
+    })
+}
+
+pub(super) fn merge_same_true_type_addition_lines(lines: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::with_capacity(lines.len());
+    let mut idx = 0usize;
+
+    while idx < lines.len() {
+        let Some(first) = parse_type_addition_line(&lines[idx]) else {
+            merged.push(lines[idx].clone());
+            idx += 1;
+            continue;
+        };
+
+        let mut same_true_subjects = Vec::new();
+        let mut consumed = 1usize;
+        while idx + consumed < lines.len() {
+            let Some(next) = parse_type_addition_line(&lines[idx + consumed]) else {
+                break;
+            };
+            if !first.type_phrase.eq_ignore_ascii_case(&next.type_phrase)
+                || !first.verb.eq_ignore_ascii_case(&next.verb)
+            {
+                break;
+            }
+            same_true_subjects.push(lowercase_first(&next.subject));
+            consumed += 1;
+        }
+
+        if same_true_subjects.len() < 2 {
+            merged.push(lines[idx].clone());
+            idx += 1;
+            continue;
+        }
+
+        merged.push(format!(
+            "{} The same is true for {}.",
+            lines[idx].trim(),
+            join_with_and(&same_true_subjects)
+        ));
+        idx += consumed;
+    }
+
+    merged
+}
+
 fn indefinite_article_for_phrase(phrase: &str) -> &'static str {
     match phrase.chars().next().map(|ch| ch.to_ascii_lowercase()) {
         Some('a' | 'e' | 'i' | 'o' | 'u') => "an",

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -455,8 +455,10 @@ fn merge_ast_surface_lines(mut lines: Vec<String>) -> Vec<String> {
             merge_conditioned_spell_and_activation_tax_lines(merge_adjacent_simple_mana_add_lines(
                 drop_redundant_spell_cost_lines(merge_specific_adjacent_surface_lines(
                     merge_lose_all_transform_lines(merge_blockability_lines(
-                        annotate_color_choice_exclusions(merge_same_true_keyword_grant_lines(
-                            merge_subject_predicate_surface_lines(previous.clone()),
+                        annotate_color_choice_exclusions(merge_same_true_type_addition_lines(
+                            merge_same_true_keyword_grant_lines(
+                                merge_subject_predicate_surface_lines(previous.clone()),
+                            ),
                         )),
                     )),
                 )),
@@ -894,6 +896,26 @@ mod tests {
             lines,
             vec![
                 "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying and vigilance."
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn repeated_type_additions_use_same_is_true_surface() {
+        let lines = merge_ast_surface_lines(vec![
+            "Creatures you control are the chosen type in addition to their other types."
+                .to_string(),
+            "Creature spells you control are the chosen type in addition to their other types."
+                .to_string(),
+            "Creature cards you own that aren't on the battlefield are the chosen type in addition to their other types."
+                .to_string(),
+        ]);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield."
                     .to_string()
             ]
         );

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7020,6 +7020,93 @@ fn roshan_hidden_magister_applies_assassin_subtype_across_zones_for_you_only() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn leyline_of_transformation_applies_chosen_type_across_its_three_scopes() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let leyline = CardDefinitionBuilder::new(CardId::new(), "Leyline of Transformation")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "If this card is in your opening hand, you may begin the game with it on the battlefield.\nAs this enchantment enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
+        )
+        .expect("Leyline of Transformation text should parse");
+    let leyline_in_hand = game.create_object_from_definition(&leyline, alice, Zone::Hand);
+    let mut dm = SelectFirstDecisionMaker;
+    let leyline_id = game
+        .move_object_with_etb_processing_with_dm(leyline_in_hand, Zone::Battlefield, &mut dm)
+        .expect("Leyline should enter and record its creature-type choice")
+        .new_id;
+    let chosen_type = game
+        .chosen_creature_type(leyline_id)
+        .expect("Leyline should choose a creature type as it enters");
+
+    let ally = CardBuilder::new(CardId::new(), "Leyline Ally")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let ally_id = game.create_object_from_card(&ally, alice, Zone::Battlefield);
+
+    let opponent = CardBuilder::new(CardId::new(), "Leyline Opponent")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let opponent_id = game.create_object_from_card(&opponent, bob, Zone::Battlefield);
+
+    let creature_spell = CardBuilder::new(CardId::new(), "Leyline Stack Creature")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let creature_spell_id = game.create_object_from_card(&creature_spell, alice, Zone::Stack);
+
+    let noncreature_spell = CardBuilder::new(CardId::new(), "Leyline Stack Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let noncreature_spell_id = game.create_object_from_card(&noncreature_spell, alice, Zone::Stack);
+
+    let graveyard_creature = CardBuilder::new(CardId::new(), "Leyline Graveyard Creature")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let graveyard_creature_id = game.create_object_from_card(&graveyard_creature, alice, Zone::Graveyard);
+
+    assert!(
+        game.current_has_subtype(ally_id, chosen_type),
+        "creatures you control should gain Leyline's chosen type"
+    );
+    assert!(
+        game.current_has_subtype(ally_id, Subtype::Bear),
+        "Leyline should add to, not replace, existing creature types"
+    );
+    assert!(
+        game.current_has_subtype(creature_spell_id, chosen_type),
+        "creature spells you control should gain Leyline's chosen type"
+    );
+    assert!(
+        game.current_has_subtype(graveyard_creature_id, chosen_type),
+        "creature cards you own off the battlefield should gain Leyline's chosen type"
+    );
+    assert!(
+        !game.current_has_subtype(opponent_id, chosen_type),
+        "opposing creatures should not gain Leyline's chosen type"
+    );
+    assert!(
+        !game.current_has_subtype(noncreature_spell_id, chosen_type),
+        "noncreature spells should not gain Leyline's chosen type"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn roshan_hidden_magister_face_up_trigger_only_for_your_permanents() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::decision::{LegalAction, SelectFirstDecisionMaker};

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7061,23 +7061,52 @@ fn leyline_of_transformation_applies_chosen_type_across_its_three_scopes() {
     let opponent_id = game.create_object_from_card(&opponent, bob, Zone::Battlefield);
 
     let creature_spell = CardBuilder::new(CardId::new(), "Leyline Stack Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
         .card_types(vec![CardType::Creature])
         .subtypes(vec![Subtype::Elf])
         .power_toughness(PowerToughness::fixed(1, 1))
         .build();
     let creature_spell_id = game.create_object_from_card(&creature_spell, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(creature_spell_id, alice));
 
     let noncreature_spell = CardBuilder::new(CardId::new(), "Leyline Stack Instant")
         .card_types(vec![CardType::Instant])
         .build();
     let noncreature_spell_id = game.create_object_from_card(&noncreature_spell, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(noncreature_spell_id, alice));
+
+    let opponent_creature_spell = CardBuilder::new(CardId::new(), "Leyline Opposing Stack Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let opponent_creature_spell_id =
+        game.create_object_from_card(&opponent_creature_spell, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(opponent_creature_spell_id, bob));
 
     let graveyard_creature = CardBuilder::new(CardId::new(), "Leyline Graveyard Creature")
         .card_types(vec![CardType::Creature])
         .subtypes(vec![Subtype::Wizard])
         .power_toughness(PowerToughness::fixed(1, 1))
         .build();
-    let graveyard_creature_id = game.create_object_from_card(&graveyard_creature, alice, Zone::Graveyard);
+    let graveyard_creature_id =
+        game.create_object_from_card(&graveyard_creature, alice, Zone::Graveyard);
+
+    let opponent_graveyard_creature =
+        CardBuilder::new(CardId::new(), "Leyline Opposing Graveyard Creature")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Wizard])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+    let opponent_graveyard_creature_id =
+        game.create_object_from_card(&opponent_graveyard_creature, bob, Zone::Graveyard);
+
+    let graveyard_noncreature = CardBuilder::new(CardId::new(), "Leyline Graveyard Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let graveyard_noncreature_id =
+        game.create_object_from_card(&graveyard_noncreature, alice, Zone::Graveyard);
 
     assert!(
         game.current_has_subtype(ally_id, chosen_type),
@@ -7102,6 +7131,18 @@ fn leyline_of_transformation_applies_chosen_type_across_its_three_scopes() {
     assert!(
         !game.current_has_subtype(noncreature_spell_id, chosen_type),
         "noncreature spells should not gain Leyline's chosen type"
+    );
+    assert!(
+        !game.current_has_subtype(opponent_creature_spell_id, chosen_type),
+        "creature spells controlled by opponents should not gain Leyline's chosen type"
+    );
+    assert!(
+        !game.current_has_subtype(opponent_graveyard_creature_id, chosen_type),
+        "creature cards opponents own off the battlefield should not gain Leyline's chosen type"
+    );
+    assert!(
+        !game.current_has_subtype(graveyard_noncreature_id, chosen_type),
+        "noncreature cards off the battlefield should not gain Leyline's chosen type"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Leyline of Transformation
Initial parse error:
```
parser does not yet support line family: 'Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.'; oracle-only fallback also failed: parser does not yet support line family: 'Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.'
```

Current worker: i-0c505606fa335e580
Branch: codex/aws-card-fix-leyline-of-transformation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0241
