### PR TITLE
Fix Ironsmith parse failure: Elvish Refueler

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activated_line_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activated_line_core.rs
@@ -35,6 +35,7 @@ pub(crate) fn parse_prefixed_activated_ability_label(
     let prefix = ActivationRestrictionCompatWords::new(&tokens[..cost_start]);
     match prefix.get(prefix.len().saturating_sub(1)) {
         Some("boast") => Some("Boast".to_string()),
+        Some("exhaust") => Some("Exhaust".to_string()),
         Some("renew") => Some("Renew".to_string()),
         _ => None,
     }
@@ -138,6 +139,16 @@ pub(crate) fn parse_activated_line_with_raw(
     let mana_activation_condition = scanned_modifiers.mana_activation_condition;
     let mut additional_activation_restrictions =
         scanned_modifiers.additional_activation_restrictions;
+    if ability_label.as_deref() == Some("Exhaust")
+        && !additional_activation_restrictions.iter().any(|restriction| {
+            restriction
+                .to_ascii_lowercase()
+                .contains("activate each exhaust ability only once")
+        })
+    {
+        additional_activation_restrictions
+            .push("Activate each exhaust ability only once.".to_string());
+    }
     let mana_usage_restrictions = scanned_modifiers.mana_usage_restrictions;
     let inline_effects_ast = scanned_modifiers.inline_effects_ast;
     effect_sentences = scanned_modifiers.kept_sentences;

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -904,6 +904,13 @@ fn parse_static_ability_ast_line_early_lexed(
             .into(),
         ]));
     }
+    if rendered
+        == "during your turn as long as you havent activated an exhaust ability this turn you may activate exhaust abilities as though they havent been activated"
+    {
+        return Ok(Some(vec![
+            StaticAbility::exhaust_abilities_as_though_unactivated_this_turn().into(),
+        ]));
+    }
     if rendered == "this creature cant attack unless youve cast a creature spell this turn"
         || rendered == "this cant attack unless youve cast a creature spell this turn"
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -529,6 +529,14 @@ fn lower_rewrite_activated_to_chunk_impl(
 
     let normalized_cost = line.cost.clone();
     let ability_text = rewrite_activated_display_text(line);
+    let additional_activation_restrictions = if ability_text
+        .as_deref()
+        .is_some_and(|text| text.trim_start().starts_with("Exhaust"))
+    {
+        vec!["Activate each exhaust ability only once.".to_string()]
+    } else {
+        Vec::new()
+    };
     let normalized_effect_text = effect_text.to_ascii_lowercase();
     let normalized_raw_line = line.info.raw_line.to_ascii_lowercase();
 
@@ -556,7 +564,7 @@ fn lower_rewrite_activated_to_chunk_impl(
                     choices: vec![],
                     timing: line.timing_hint.clone(),
                     is_loyalty_ability: line.is_loyalty_ability,
-                    additional_restrictions: vec![],
+                    additional_restrictions: additional_activation_restrictions.clone(),
                     activation_restrictions: vec![],
                     mana_output: Some(mana_output),
                     activation_condition: None,
@@ -612,7 +620,7 @@ fn lower_rewrite_activated_to_chunk_impl(
                         choices: vec![],
                         timing: line.timing_hint.clone(),
                         is_loyalty_ability: line.is_loyalty_ability,
-                        additional_restrictions: vec![],
+                        additional_restrictions: additional_activation_restrictions.clone(),
                         activation_restrictions: vec![],
                         mana_output: Some(vec![]),
                         activation_condition: None,
@@ -673,7 +681,7 @@ fn lower_rewrite_activated_to_chunk_impl(
                 choices: vec![],
                 timing: line.timing_hint.clone(),
                 is_loyalty_ability: line.is_loyalty_ability,
-                additional_restrictions: vec![],
+                additional_restrictions: additional_activation_restrictions,
                 activation_restrictions: vec![],
                 mana_output: None,
                 activation_condition: None,
@@ -723,6 +731,7 @@ fn rewrite_activated_display_text(line: &RewriteActivatedLine) -> Option<String>
 
     for display in [
         "Boast",
+        "Exhaust",
         "Renew",
         "Channel",
         "Cohort",
@@ -738,6 +747,7 @@ fn rewrite_activated_display_text(line: &RewriteActivatedLine) -> Option<String>
     if let Some(chosen) = line.chosen_option_label.as_deref() {
         for display in [
             "Boast",
+            "Exhaust",
             "Renew",
             "Channel",
             "Cohort",

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -413,6 +413,14 @@ impl<E: Clone, C: CoreCostComponent> ActivatedAbility<E, C> {
         self.mana_cost.costs().iter().find_map(|c| c.life_amount())
     }
 
+    pub fn is_exhaust_ability(&self) -> bool {
+        self.additional_restrictions.iter().any(|restriction| {
+            let lower = restriction.to_ascii_lowercase();
+            lower.contains("activate each exhaust ability only once")
+                || lower.contains("activate this exhaust ability only once")
+        })
+    }
+
     pub fn max_activations_per_turn(&self) -> Option<u32> {
         fn min_cap(current: Option<u32>, next: u32) -> Option<u32> {
             Some(current.map_or(next, |existing| existing.min(next)))

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -159,6 +159,7 @@ pub enum StaticAbilityId {
     BoastTwiceEachTurn,
     FirstEquipCostAlternative,
     EquipAbilitiesAnyTime,
+    ExhaustAbilitiesAsThoughUnactivatedThisTurn,
     VoteAdditionalTimeWhileVoting,
     VoteAdditionalVoteWhileVoting,
     EnchantedLandIsChosenType,
@@ -409,6 +410,7 @@ impl StaticAbilityId {
             | BoastTwiceEachTurn
             | FirstEquipCostAlternative
             | EquipAbilitiesAnyTime
+            | ExhaustAbilitiesAsThoughUnactivatedThisTurn
             | VoteAdditionalTimeWhileVoting
             | VoteAdditionalVoteWhileVoting
             | EnchantedLandIsChosenType

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2578,6 +2578,12 @@ impl<
             "activate equip abilities any time",
         )
     }
+    pub fn exhaust_abilities_as_though_unactivated_this_turn() -> Self {
+        Self::identified(
+            StaticAbilityId::ExhaustAbilitiesAsThoughUnactivatedThisTurn,
+            "activate exhaust abilities as though unactivated this turn",
+        )
+    }
     pub fn vote_additional_time_while_voting() -> Self {
         Self::identified(
             StaticAbilityId::VoteAdditionalTimeWhileVoting,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -23304,6 +23304,47 @@ fn parse_equip_with_once_each_turn_restriction() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn elvish_refueler_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Elvish Refueler");
+    let lines = canonical_compiled_lines(&def);
+
+    assert!(
+        lines.iter().any(|line| line
+            == "During your turn, as long as you haven't activated an exhaust ability this turn, you may activate exhaust abilities as though they haven't been activated."),
+        "expected Elvish Refueler exhaust permission line, got {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line
+            == "Exhaust — {1}{G}: Put a +1/+1 counter on this creature."),
+        "expected Elvish Refueler exhaust activated line, got {lines:?}"
+    );
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id()
+                    == StaticAbilityId::ExhaustAbilitiesAsThoughUnactivatedThisTurn
+        )),
+        "expected Elvish Refueler static exhaust permission ability, got {:#?}",
+        def.abilities
+    );
+    let exhaust = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.is_exhaust_ability() => Some(activated),
+            _ => None,
+        })
+        .expect("Elvish Refueler should have an exhaust activated ability");
+    let effects_debug = format!("{:#?}", exhaust.effects);
+    assert!(
+        effects_debug.contains("PutCountersEffect") && effects_debug.contains("PlusOnePlusOne"),
+        "expected Elvish Refueler exhaust ability to put a +1/+1 counter on itself, got {effects_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_mercenary_token_with_tap_pump_ability() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Mercenary Token Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13618,6 +13618,8 @@ pub(super) fn describe_inline_ability_with_self_subject(
             }
             if line.is_empty() {
                 "an activated ability".to_string()
+            } else if activated.is_exhaust_ability() {
+                format!("Exhaust — {}", normalize_ability_self_reference_surface(&line, self_subject))
             } else {
                 normalize_ability_self_reference_surface(&line, self_subject)
             }
@@ -32681,6 +32683,9 @@ pub(super) fn collect_activation_restriction_clauses(
     }
 
     for raw in additional_restrictions {
+        if raw.to_ascii_lowercase().contains("exhaust ability only once") {
+            continue;
+        }
         let normalized = normalize_activation_restriction_clause(raw);
         push_activation_restriction_clause(&mut clauses, normalized);
     }
@@ -35733,7 +35738,8 @@ pub(super) fn describe_ability(
                 return vec![line];
             }
             let is_grandeur = is_grandeur_activation_cost(activated);
-            let mut line = if is_grandeur {
+            let is_exhaust = activated.is_exhaust_ability();
+            let mut line = if is_grandeur || is_exhaust {
                 String::new()
             } else {
                 format!("Activated ability {index}")
@@ -35801,6 +35807,9 @@ pub(super) fn describe_ability(
             }
             if is_grandeur_activation_cost(activated) {
                 line = format!("Grandeur — {line}");
+            }
+            if is_exhaust {
+                line = format!("Exhaust — {line}");
             }
             line = normalize_ability_self_reference_surface(&line, subject);
             line = normalize_graveyard_source_return_surface(&line, ability);

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -1182,6 +1182,38 @@ fn player_may_activate_equip_abilities_any_time(
     })
 }
 
+fn player_may_activate_exhaust_abilities_as_unactivated_this_turn(
+    game: &GameState,
+    controller: PlayerId,
+    view: &DerivedGameView<'_>,
+) -> bool {
+    if game.turn.active_player != controller
+        || game.exhaust_ability_activation_count_this_turn(controller) > 0
+    {
+        return false;
+    }
+
+    game.battlefield.iter().copied().any(|object_id| {
+        let Some(object) = game.object(object_id) else {
+            return false;
+        };
+        if game.controller_of(object) != controller {
+            return false;
+        }
+        let abilities = view
+            .abilities_rc(object_id)
+            .unwrap_or_else(|| std::rc::Rc::new(object.abilities.clone()));
+        abilities.iter().any(|ability| {
+            matches!(
+                &ability.kind,
+                crate::ability::AbilityKind::Static(static_ability)
+                    if static_ability.id()
+                        == crate::static_abilities::StaticAbilityId::ExhaustAbilitiesAsThoughUnactivatedThisTurn
+            )
+        })
+    })
+}
+
 fn activation_cost_component_precheck_with_view(
     game: &GameState,
     controller: PlayerId,
@@ -1355,6 +1387,18 @@ fn activation_precheck_with_view(
     }
     if !activated.is_runtime_mana_ability(game, source, controller)
         && !source_facts.can_activate_non_mana_abilities_of_source
+    {
+        if let Some(perf_ctx) = perf_ctx {
+            perf_ctx.add_precheck_ms(started_at.elapsed_ms());
+        }
+        return None;
+    }
+
+    if activated.is_exhaust_ability()
+        && game.exhaust_ability_activated(source, ability_index)
+        && !player_may_activate_exhaust_abilities_as_unactivated_this_turn(
+            game, controller, view,
+        )
     {
         if let Some(perf_ctx) = perf_ctx {
             perf_ctx.add_precheck_ms(started_at.elapsed_ms());

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -20908,6 +20908,95 @@ fn test_once_per_turn_in_legal_actions() {
 }
 
 #[test]
+fn elvish_refueler_exhaust_permission_allows_one_used_exhaust_on_your_turn() {
+    use crate::ability::{ActivatedAbility, ActivationTiming};
+    use crate::cost::TotalCost;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let refueler_id = create_creature(&mut game, "Elvish Refueler", alice, 2, 3);
+    game.object_mut(refueler_id)
+        .expect("Elvish Refueler should exist")
+        .abilities
+        .push(Ability::static_ability(
+            StaticAbility::exhaust_abilities_as_though_unactivated_this_turn(),
+        ));
+    game.object_mut(refueler_id)
+        .expect("Elvish Refueler should exist")
+        .abilities
+        .push(Ability {
+            kind: AbilityKind::Activated(ActivatedAbility {
+                mana_cost: TotalCost::mana(ManaCost::from_pips(vec![
+                    vec![ManaSymbol::Generic(1)],
+                    vec![ManaSymbol::Green],
+                ])),
+                effects: crate::resolution::ResolutionProgram::from_effects(vec![
+                    Effect::put_counters_on_source(crate::object::CounterType::PlusOnePlusOne, 1),
+                ]),
+                choices: vec![],
+                timing: ActivationTiming::AnyTime,
+                additional_restrictions: vec![
+                    "Activate each exhaust ability only once.".to_string(),
+                ],
+                activation_restrictions: vec![],
+                mana_output: None,
+                activation_condition: None,
+                mana_usage_restrictions: vec![],
+                is_loyalty_ability: false,
+            }),
+            functional_zones: vec![Zone::Battlefield],
+        });
+
+    let ability_index = 1;
+    let ability = match &game
+        .object(refueler_id)
+        .expect("Elvish Refueler should exist")
+        .abilities[ability_index]
+        .kind
+    {
+        AbilityKind::Activated(activated) => activated.clone(),
+        _ => panic!("expected Elvish Refueler exhaust activated ability"),
+    };
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    assert!(
+        can_activate_ability_with_restrictions(&game, refueler_id, ability_index, &ability),
+        "Elvish Refueler's unused exhaust ability should be activatable"
+    );
+    game.record_ability_activation(refueler_id, ability_index);
+    assert!(
+        !can_activate_ability_with_restrictions(&game, refueler_id, ability_index, &ability),
+        "Elvish Refueler should not let the same exhaust ability be activated twice in one turn"
+    );
+
+    game.next_turn();
+    game.turn.active_player = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    assert!(
+        !can_activate_ability_with_restrictions(&game, refueler_id, ability_index, &ability),
+        "Elvish Refueler's static permission should not refresh exhaust abilities outside its controller's turn"
+    );
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    assert!(
+        can_activate_ability_with_restrictions(&game, refueler_id, ability_index, &ability),
+        "Elvish Refueler should refresh one previously activated exhaust ability during its controller's turn before any exhaust activation that turn"
+    );
+    game.record_ability_activation(refueler_id, ability_index);
+    assert!(
+        !can_activate_ability_with_restrictions(&game, refueler_id, ability_index, &ability),
+        "after activating an exhaust ability this turn, Elvish Refueler's condition should stop refreshing it"
+    );
+}
+
+#[test]
 fn test_nonactive_player_keeps_priority_after_activating_ability() {
     use crate::ability::{AbilityKind, ActivatedAbility, ActivationTiming};
     use crate::cost::TotalCost;

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -259,6 +259,8 @@ pub struct TurnStore {
     pub entered_battlefield_last_turn: Vec<ObjectSnapshot>,
     /// Static or temporary grant sources whose once-per-turn cast permission was used.
     pub grant_cast_uses_this_turn: HashSet<(PlayerId, ObjectId)>,
+    /// Exhaust activated abilities that have been activated by this object instance.
+    pub exhaust_abilities_activated: HashSet<(ObjectId, usize)>,
     /// Explicit combat damage assignments keyed by attacker then damage recipient.
     pub combat_damage_assignments: HashMap<ObjectId, HashMap<ObjectId, u32>>,
 }
@@ -430,6 +432,10 @@ pub struct TurnCounterTracker {
 
 fn activated_ability_turn_counter_name(source: ObjectId, ability_index: usize) -> String {
     format!("activated_ability:{}:{}", source.0, ability_index)
+}
+
+fn exhaust_ability_turn_counter_name(player: PlayerId) -> String {
+    format!("exhaust_ability:{}", player.0)
 }
 
 fn activated_ability_resolution_turn_counter_name(
@@ -7397,6 +7403,13 @@ impl GameState {
     /// Records that an activated ability was used.
     /// Used for OncePerTurn timing restrictions.
     pub fn record_ability_activation(&mut self, source: ObjectId, ability_index: usize) {
+        let exhaust_controller = self.object(source).and_then(|object| {
+            object.abilities.get(ability_index).and_then(|ability| match &ability.kind {
+                crate::ability::AbilityKind::Activated(activated)
+                    if activated.is_exhaust_ability() => Some(self.controller_of(object)),
+                _ => None,
+            })
+        });
         self.turn_store
             .turn_history
             .activated_abilities_this_turn
@@ -7405,6 +7418,15 @@ impl GameState {
             .turn_history
             .turn_counters
             .increment_named(activated_ability_turn_counter_name(source, ability_index));
+        if let Some(controller) = exhaust_controller {
+            self.turn_store
+                .exhaust_abilities_activated
+                .insert((source, ability_index));
+            self.turn_store
+                .turn_history
+                .turn_counters
+                .increment_named(exhaust_ability_turn_counter_name(controller));
+        }
     }
 
     /// Check if an activated ability has been used this turn.
@@ -7422,6 +7444,18 @@ impl GameState {
         ability_index: usize,
     ) -> u32 {
         self.named_turn_counter(&activated_ability_turn_counter_name(source, ability_index))
+    }
+
+    /// Check if an exhaust ability has already been activated by this object instance.
+    pub fn exhaust_ability_activated(&self, source: ObjectId, ability_index: usize) -> bool {
+        self.turn_store
+            .exhaust_abilities_activated
+            .contains(&(source, ability_index))
+    }
+
+    /// Count exhaust activations by this player during the current turn.
+    pub fn exhaust_ability_activation_count_this_turn(&self, player: PlayerId) -> u32 {
+        self.named_turn_counter(&exhaust_ability_turn_counter_name(player))
     }
 
     /// Record that a specific activated ability resolved this turn.

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -100,6 +100,9 @@ impl StaticAbility {
             Some(StaticAbilityId::DoesntUntap) => Self::doesnt_untap(),
             Some(StaticAbilityId::BoastTwiceEachTurn) => Self::boast_twice_each_turn(),
             Some(StaticAbilityId::EquipAbilitiesAnyTime) => Self::equip_abilities_any_time(),
+            Some(StaticAbilityId::ExhaustAbilitiesAsThoughUnactivatedThisTurn) => {
+                Self::exhaust_abilities_as_though_unactivated_this_turn()
+            }
             Some(StaticAbilityId::VoteAdditionalTimeWhileVoting) => {
                 Self::vote_additional_time_while_voting()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -385,6 +385,21 @@ impl StaticAbilityKind for EquipAbilitiesAnyTime {
     }
 }
 
+/// "During your turn, as long as you haven't activated an exhaust ability this turn,
+/// you may activate exhaust abilities as though they haven't been activated."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ExhaustAbilitiesAsThoughUnactivatedThisTurn;
+
+impl StaticAbilityKind for ExhaustAbilitiesAsThoughUnactivatedThisTurn {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::ExhaustAbilitiesAsThoughUnactivatedThisTurn
+    }
+
+    fn display(&self) -> String {
+        "During your turn, as long as you haven't activated an exhaust ability this turn, you may activate exhaust abilities as though they haven't been activated".to_string()
+    }
+}
+
 /// "While voting, you may vote an additional time."
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct VoteAdditionalTimeWhileVoting;

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -1927,6 +1927,10 @@ impl StaticAbility {
         Self::new(EquipAbilitiesAnyTime)
     }
 
+    pub fn exhaust_abilities_as_though_unactivated_this_turn() -> Self {
+        Self::new(ExhaustAbilitiesAsThoughUnactivatedThisTurn)
+    }
+
     pub fn vote_additional_time_while_voting() -> Self {
         Self::new(VoteAdditionalTimeWhileVoting)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Elvish Refueler
Initial parse error:
```
unsupported static condition clause (clause: 'as long as you haven't activated an exhaust ability this turn you may activate exhaust abilities as though they haven't been activated'); oracle-only fallback also failed: unsupported static condition clause (clause: 'as long as you haven't activated an exhaust ability this turn you may activate exhaust abilities as though they haven't been activated')
```

Current worker: i-07f85d99dd6f8cadd
Branch: codex/aws-card-fix-elvish-refueler
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0250
