### PR TITLE
Fix Ironsmith parse failure: Skeleton Crew

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1355,6 +1355,47 @@ pub(crate) fn parse_trigger_clause_lexed(
         (words.as_slice(), None)
     };
 
+    for tail in [
+        ["leave", "your", "graveyard"].as_slice(),
+        ["leaves", "your", "graveyard"].as_slice(),
+    ] {
+        if slice_ends_with(zone_change_words, tail) {
+            let subject_word_len = zone_change_words.len().saturating_sub(tail.len());
+            let mut subject_tokens = ActivationRestrictionCompatWords::new(tokens)
+                .token_index_for_word_index(subject_word_len)
+                .map(|idx| &tokens[..idx])
+                .unwrap_or_default();
+            let one_or_more = has_leading_one_or_more(subject_tokens);
+            subject_tokens = strip_leading_one_or_more_lexed(subject_tokens);
+            let subject_view = ActivationRestrictionCompatWords::new(subject_tokens);
+            let subject_words = subject_view.to_word_refs();
+            let mut filter = if matches!(subject_words.as_slice(), ["card"] | ["cards"]) {
+                ObjectFilter::default()
+            } else {
+                parse_object_filter_lexed(subject_tokens, false).map_err(|_| {
+                    CardTextError::ParseError(format!(
+                        "unsupported filter in leave-your-graveyard trigger clause (clause: '{}')",
+                        words.join(" ")
+                    ))
+                })?
+            };
+            filter.zone = None;
+            filter.controller = None;
+            filter.owner = None;
+            if subject_words
+                .iter()
+                .any(|word| matches!(*word, "card" | "cards"))
+            {
+                filter.nontoken = true;
+            }
+            return Ok(TriggerSpec::CardsLeaveYourGraveyard {
+                filter,
+                one_or_more,
+                during_your_turn: during_turn == Some(PlayerFilter::You),
+            });
+        }
+    }
+
     for (tail, from_zones) in [
         (["is", "put", "into", "exile"].as_slice(), Vec::new()),
         (["are", "put", "into", "exile"].as_slice(), Vec::new()),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -236,6 +236,11 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             }
             Trigger::new(trigger)
         }
+        TriggerSpec::CardsLeaveYourGraveyard {
+            filter,
+            one_or_more,
+            during_your_turn,
+        } => Trigger::cards_leave_your_graveyard(filter, one_or_more, during_your_turn),
         TriggerSpec::CounterPutOn {
             filter,
             counter_type,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -247,6 +247,11 @@ pub(crate) enum TriggerSpec {
         one_or_more: bool,
         during_turn: Option<PlayerFilter>,
     },
+    CardsLeaveYourGraveyard {
+        filter: ObjectFilter,
+        one_or_more: bool,
+        during_your_turn: bool,
+    },
     CounterPutOn {
         filter: ObjectFilter,
         counter_type: Option<CounterType>,

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -215,6 +215,11 @@ pub enum TriggerKind {
     PutIntoGraveyard {
         filter: ObjectFilter,
     },
+    CardsLeaveYourGraveyard {
+        filter: ObjectFilter,
+        one_or_more: bool,
+        during_your_turn: bool,
+    },
     DiesCreatureDealtDamageByThisTurn {
         victim: ObjectFilter,
         damager: DamagedBySource,
@@ -773,6 +778,20 @@ impl Trigger {
         Self::typed(
             "put_into_graveyard",
             TriggerKind::PutIntoGraveyard { filter },
+        )
+    }
+    pub fn cards_leave_your_graveyard(
+        filter: ObjectFilter,
+        one_or_more: bool,
+        during_your_turn: bool,
+    ) -> Self {
+        Self::typed(
+            "cards_leave_your_graveyard",
+            TriggerKind::CardsLeaveYourGraveyard {
+                filter,
+                one_or_more,
+                during_your_turn,
+            },
         )
     }
     pub fn creature_dealt_damage_by_this_creature_this_turn_dies(victim: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38790,6 +38790,7 @@ strict_parse_card_test!(strict_parse_genesis_chamber, "Genesis Chamber");
 strict_parse_card_test!(strict_parse_inviolability, "Inviolability");
 strict_parse_card_test!(strict_parse_saving_grace, "Saving Grace");
 strict_parse_card_test!(strict_parse_sacrifice, "Sacrifice");
+strict_parse_card_test!(strict_parse_skeleton_crew, "Skeleton Crew");
 strict_parse_card_test!(
     strict_parse_sephiroth_fabled_soldier,
     "Sephiroth, Fabled SOLDIER"
@@ -38830,6 +38831,19 @@ fn inviolability_compiled_text_keeps_damage_prevention_clause() {
     assert!(
         rendered.contains("prevent all damage that would be dealt to enchanted creature"),
         "expected Inviolability compiled text to preserve enchanted-creature prevention semantics, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn skeleton_crew_compiled_text_keeps_graveyard_leave_trigger() {
+    let def = parse_oracle_card_definition("Skeleton Crew");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Each other creature you control that's a Skeleton or Pirate gets +1/+1")
+            && rendered.contains("Whenever one or more creature cards leave your graveyard, create a 2/2 black Skeleton Pirate creature token")
+            && rendered.contains("{5}{B}: Return this card from your graveyard to the battlefield tapped"),
+        "expected Skeleton Crew compiled text to preserve anthem, graveyard-leave trigger, and graveyard activation, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -6587,6 +6587,347 @@ fn test_bridge_from_below_token_trigger_fizzles_if_bridge_leaves_graveyard() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn skeleton_crew_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(640_045), "Skeleton Crew")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Skeleton, Subtype::Pirate])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Each other creature you control that's a Skeleton or Pirate gets +1/+1.\n\
+             Whenever one or more creature cards leave your graveyard, create a 2/2 black Skeleton Pirate creature token. (This ability triggers only from the battlefield.)\n\
+             {5}{B}: Return this card from your graveyard to the battlefield tapped.",
+        )
+        .expect("Skeleton Crew should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_skeleton_crew_test_card(
+    game: &mut GameState,
+    name: &str,
+    owner: PlayerId,
+    zone: Zone,
+    card_types: Vec<CardType>,
+    subtypes: Vec<Subtype>,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .subtypes(subtypes)
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build();
+    game.create_object_from_card(&card, owner, zone)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn skeleton_crew_anthem_buffs_other_skeletons_and_pirates_only() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let crew_id = game.create_object_from_definition(
+        &skeleton_crew_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let skeleton_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Ally Skeleton",
+        alice,
+        Zone::Battlefield,
+        vec![CardType::Creature],
+        vec![Subtype::Skeleton],
+        2,
+        2,
+    );
+    let pirate_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Ally Pirate",
+        alice,
+        Zone::Battlefield,
+        vec![CardType::Creature],
+        vec![Subtype::Pirate],
+        2,
+        2,
+    );
+    let bear_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Ally Bear",
+        alice,
+        Zone::Battlefield,
+        vec![CardType::Creature],
+        vec![Subtype::Bear],
+        2,
+        2,
+    );
+    let opponent_pirate_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Opponent Pirate",
+        bob,
+        Zone::Battlefield,
+        vec![CardType::Creature],
+        vec![Subtype::Pirate],
+        2,
+        2,
+    );
+
+    assert_eq!(game.calculated_power(skeleton_id), Some(3));
+    assert_eq!(game.calculated_toughness(skeleton_id), Some(3));
+    assert_eq!(game.calculated_power(pirate_id), Some(3));
+    assert_eq!(game.calculated_toughness(pirate_id), Some(3));
+    assert_eq!(game.calculated_power(bear_id), Some(2));
+    assert_eq!(game.calculated_toughness(bear_id), Some(2));
+    assert_eq!(game.calculated_power(opponent_pirate_id), Some(2));
+    assert_eq!(game.calculated_toughness(opponent_pirate_id), Some(2));
+    assert_eq!(game.calculated_power(crew_id), Some(3));
+    assert_eq!(game.calculated_toughness(crew_id), Some(3));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn skeleton_crew_creates_token_when_your_creature_card_leaves_graveyard() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.create_object_from_definition(&skeleton_crew_definition(), alice, Zone::Battlefield);
+    let creature_card_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Graveyard Creature",
+        alice,
+        Zone::Graveyard,
+        vec![CardType::Creature],
+        vec![Subtype::Zombie],
+        2,
+        2,
+    );
+
+    let moved = game.move_object_by_effect(creature_card_id, Zone::Battlefield);
+    assert!(moved.is_some(), "creature card should leave your graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Skeleton Crew should trigger once when a creature card leaves your graveyard"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Skeleton Crew trigger should be put on stack");
+    resolve_stack_entry(&mut game).expect("Skeleton Crew trigger should resolve");
+
+    let skeleton_pirate_tokens = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id).is_some_and(|object| {
+                object.kind == ObjectKind::Token
+                    && game.calculated_subtypes(id).contains(&Subtype::Skeleton)
+                    && game.calculated_subtypes(id).contains(&Subtype::Pirate)
+            })
+        })
+        .count();
+    assert_eq!(
+        skeleton_pirate_tokens, 1,
+        "Skeleton Crew should create one Skeleton Pirate token"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn skeleton_crew_one_or_more_graveyard_leave_batches_once() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.create_object_from_definition(&skeleton_crew_definition(), alice, Zone::Battlefield);
+    let first_id = create_skeleton_crew_test_card(
+        &mut game,
+        "First Graveyard Creature",
+        alice,
+        Zone::Graveyard,
+        vec![CardType::Creature],
+        vec![Subtype::Zombie],
+        2,
+        2,
+    );
+    let second_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Second Graveyard Creature",
+        alice,
+        Zone::Graveyard,
+        vec![CardType::Creature],
+        vec![Subtype::Zombie],
+        2,
+        2,
+    );
+    let snapshots = [first_id, second_id]
+        .into_iter()
+        .map(|id| {
+            let object = game.object(id).expect("graveyard creature should exist");
+            crate::snapshot::ObjectSnapshot::from_object(object, &game)
+        })
+        .collect();
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::batch_with_snapshots(
+            vec![first_id, second_id],
+            Zone::Graveyard,
+            Zone::Exile,
+            crate::events::cause::EventCause::effect(),
+            snapshots,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Skeleton Crew should trigger once when multiple creature cards leave your graveyard together"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn skeleton_crew_does_not_trigger_for_noncreatures_opponents_graveyard_or_off_battlefield() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let battlefield_crew_id = game.create_object_from_definition(
+        &skeleton_crew_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let noncreature_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Graveyard Artifact",
+        alice,
+        Zone::Graveyard,
+        vec![CardType::Artifact],
+        vec![],
+        0,
+        0,
+    );
+    let opponent_creature_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Opponent Graveyard Creature",
+        bob,
+        Zone::Graveyard,
+        vec![CardType::Creature],
+        vec![Subtype::Zombie],
+        2,
+        2,
+    );
+
+    assert!(game.move_object_by_effect(noncreature_id, Zone::Battlefield).is_some());
+    assert!(game.move_object_by_effect(opponent_creature_id, Zone::Battlefield).is_some());
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Skeleton Crew should ignore noncreature cards and opponents' graveyards"
+    );
+
+    assert!(game.move_object_by_effect(battlefield_crew_id, Zone::Exile).is_some());
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    trigger_queue.entries.clear();
+
+    let graveyard_crew_id = game.create_object_from_definition(
+        &skeleton_crew_definition(),
+        alice,
+        Zone::Graveyard,
+    );
+    let second_creature_id = create_skeleton_crew_test_card(
+        &mut game,
+        "Second Graveyard Creature",
+        alice,
+        Zone::Graveyard,
+        vec![CardType::Creature],
+        vec![Subtype::Zombie],
+        2,
+        2,
+    );
+
+    assert!(game.move_object_by_effect(graveyard_crew_id, Zone::Exile).is_some());
+    assert!(game.move_object_by_effect(second_creature_id, Zone::Battlefield).is_some());
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Skeleton Crew's creature-card trigger should function only from the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn skeleton_crew_graveyard_activation_returns_it_tapped() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let crew_id = game.create_object_from_definition(
+        &skeleton_crew_definition(),
+        alice,
+        Zone::Graveyard,
+    );
+    let crew_stable_id = game
+        .object(crew_id)
+        .expect("Skeleton Crew should exist")
+        .stable_id;
+    {
+        let player = game.player_mut(alice).expect("Alice should exist");
+        player.mana_pool.add(ManaSymbol::Colorless, 5);
+        player.mana_pool.add(ManaSymbol::Black, 1);
+    }
+
+    let ability_index = game
+        .object(crew_id)
+        .expect("Skeleton Crew should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Skeleton Crew should have a graveyard activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                if *source == crew_id && *idx == ability_index
+        ))
+        .expect("Skeleton Crew graveyard activation should be legal with mana available");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Skeleton Crew activation should be put on the stack");
+    resolve_stack_entry(&mut game).expect("Skeleton Crew activation should resolve");
+
+    let returned_id = game
+        .find_object_by_stable_id(crew_stable_id)
+        .expect("Skeleton Crew should still be tracked after changing zones");
+    assert!(
+        game.battlefield.contains(&returned_id),
+        "Skeleton Crew should return to the battlefield"
+    );
+    assert!(game.is_tapped(returned_id), "Skeleton Crew should return tapped");
+}
+
 #[test]
 fn test_mortuary_triggers_for_owned_creatures_even_if_control_changed() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -17,7 +17,7 @@ use crate::filter::{PlayerFilterExt, TaggedConstraintSubject, TaggedOpbjectRelat
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::object::CounterType;
-use crate::target::ObjectFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype, SubtypeFamily, Supertype};
 use crate::zone::Zone;
 
@@ -220,6 +220,33 @@ fn pluralized_subject_text(filter: &ObjectFilter) -> String {
     }
 
     subject
+}
+
+fn subtype_creature_anthem_subject(filter: &ObjectFilter) -> Option<String> {
+    if filter.zone != Some(Zone::Battlefield)
+        || filter.controller != Some(PlayerFilter::You)
+        || filter.owner.is_some()
+        || filter.card_types != [CardType::Creature]
+        || !filter.all_card_types.is_empty()
+        || filter.subtypes.len() < 2
+        || filter.type_or_subtype_union
+        || !filter.excluded_card_types.is_empty()
+        || !filter.excluded_subtypes.is_empty()
+    {
+        return None;
+    }
+
+    let subtype_text = filter
+        .subtypes
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" or ");
+    let article = indefinite_article_for(&subtype_text);
+    let other = if filter.other { "other " } else { "" };
+    Some(format!(
+        "Each {other}creature you control that's {article} {subtype_text}"
+    ))
 }
 
 fn pluralize_subject_clause(subject: &str) -> String {
@@ -1624,7 +1651,8 @@ impl StaticAbilityKind for Anthem {
         let subject = if self.source_only {
             "this creature".to_string()
         } else {
-            pluralized_subject_text(&self.filter)
+            subtype_creature_anthem_subject(&self.filter)
+                .unwrap_or_else(|| pluralized_subject_text(&self.filter))
         };
         let subject_mentions_plural = subject.contains("creatures")
             || subject.contains("tokens")
@@ -1638,6 +1666,7 @@ impl StaticAbilityKind for Anthem {
             || subject.contains("cards")
             || subject.contains("allies");
         let singular = self.source_only
+            || subject.starts_with("Each ")
             || subject.starts_with("a ")
             || subject.starts_with("an ")
             || subject.starts_with("this ")

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -303,6 +303,15 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::PutIntoGraveyard { filter } => {
             crate::triggers::Trigger::put_into_graveyard(filter)
         }
+        TriggerKind::CardsLeaveYourGraveyard {
+            filter,
+            one_or_more,
+            during_your_turn,
+        } => crate::triggers::Trigger::cards_leave_your_graveyard(
+            filter,
+            one_or_more,
+            during_your_turn,
+        ),
         TriggerKind::DiesCreatureDealtDamageByThisTurn { victim, damager } => match damager {
             DamagedBySource::ThisCreature => {
                 crate::triggers::Trigger::creature_dealt_damage_by_this_creature_this_turn_dies(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Skeleton Crew
Initial parse error:
```
unsupported triggered line: 'Whenever one or more creature cards leave your graveyard, create a 2/2 black Skeleton Pirate creature token. (This ability triggers only from the battlefield.)'; oracle-only fallback also failed: unsupported triggered line: 'Whenever one or more creature cards leave your graveyard, create a 2/2 black Skeleton Pirate creature token.'
```

Current worker: i-050fb1cc0f0827a36
Branch: codex/aws-card-fix-skeleton-crew
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0250
