### PR TITLE
Fix Ironsmith parse failure: Herald of Leshrac

### DIFF
--- a/crates/ironsmith-compiler/src/costs/mod.rs
+++ b/crates/ironsmith-compiler/src/costs/mod.rs
@@ -5,6 +5,23 @@ use ironsmith_core::CostComponent as _;
 fn is_payment_effect(effect: &crate::effect::Effect) -> bool {
     use crate::effects;
 
+    fn is_controller_change_continuous_cost(effect: &effects::ApplyContinuousEffect) -> bool {
+        let base_is_controller_change = effect.modification.is_none();
+        let additional_are_controller_changes = effect.additional_modifications.is_empty();
+        let runtime_are_controller_changes = !effect.runtime_modifications.is_empty()
+            && effect.runtime_modifications.iter().all(|modification| {
+                matches!(
+                    modification,
+                    effects::continuous::RuntimeModification::ChangeControllerToEffectController
+                        | effects::continuous::RuntimeModification::ChangeControllerToPlayer(_)
+                )
+            });
+
+        base_is_controller_change
+            && additional_are_controller_changes
+            && runtime_are_controller_changes
+    }
+
     if effect.payload_type_name().ends_with("MoveToZoneEffect") {
         return true;
     }
@@ -62,6 +79,9 @@ fn is_payment_effect(effect: &crate::effect::Effect) -> bool {
         || effect
             .downcast_ref::<effects::RevealTaggedEffect>()
             .is_some()
+        || effect
+            .downcast_ref::<effects::ApplyContinuousEffect>()
+            .is_some_and(is_controller_change_continuous_cost)
         || effect.downcast_ref::<effects::CrewCostEffect>().is_some()
         || effect
             .downcast_ref::<effects::ConspireCostEffect>()

--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -130,6 +130,7 @@ fn contains_any_word_slice_phrase(words: &[&str], phrases: &[&[&str]]) -> bool {
 enum SimpleObjectFilterSuffix {
     Controller(PlayerFilter),
     Owner(PlayerFilter),
+    ControllerOwner(PlayerFilter, PlayerFilter),
     OwnerZone(PlayerFilter, Zone),
     Zone(Zone),
 }
@@ -174,6 +175,29 @@ fn parse_simple_object_filter_suffix_inner<'a>(
 ) -> Result<SimpleObjectFilterSuffix, ErrMode<ContextError>> {
     alt((
         alt((
+            (
+                word_slice_eq("you"),
+                word_slice_eq("control"),
+                word_slice_eq("but"),
+                alt((word_slice_eq("dont"), word_slice_eq("don't"))),
+                word_slice_eq("own"),
+            )
+                .value(SimpleObjectFilterSuffix::ControllerOwner(
+                    PlayerFilter::You,
+                    PlayerFilter::NotYou,
+                )),
+            (
+                word_slice_eq("you"),
+                word_slice_eq("control"),
+                word_slice_eq("but"),
+                word_slice_eq("do"),
+                word_slice_eq("not"),
+                word_slice_eq("own"),
+            )
+                .value(SimpleObjectFilterSuffix::ControllerOwner(
+                    PlayerFilter::You,
+                    PlayerFilter::NotYou,
+                )),
             (word_slice_eq("you"), word_slice_eq("control"))
                 .value(SimpleObjectFilterSuffix::Controller(PlayerFilter::You)),
             (
@@ -253,7 +277,7 @@ fn parse_simple_object_filter_suffix_inner<'a>(
 }
 
 fn parse_simple_object_filter_suffix(words: &[&str]) -> Option<(SimpleObjectFilterSuffix, usize)> {
-    for suffix_len in [4usize, 3, 2] {
+    for suffix_len in [6usize, 5, 4, 3, 2] {
         let tail = words.get(words.len().checked_sub(suffix_len)?..)?;
         if let Some(parsed) = parse_full_word_slice(tail, parse_simple_object_filter_suffix_inner) {
             return Some((parsed, suffix_len));
@@ -475,6 +499,11 @@ fn parse_simple_object_filter_lexed(tokens: &[OwnedLexToken], other: bool) -> Op
             }
             SimpleObjectFilterSuffix::Owner(owner) => {
                 filter.owner = Some(owner);
+            }
+            SimpleObjectFilterSuffix::ControllerOwner(controller, owner) => {
+                filter.controller = Some(controller);
+                filter.owner = Some(owner);
+                filter.zone = Some(Zone::Battlefield);
             }
             SimpleObjectFilterSuffix::OwnerZone(owner, zone) => {
                 filter.owner = Some(owner);
@@ -909,6 +938,18 @@ mod tests {
         assert_eq!(filter.owner, Some(PlayerFilter::You));
         assert_eq!(filter.zone, Some(Zone::Graveyard));
         assert_eq!(filter.card_types, vec![CardType::Artifact]);
+    }
+
+    #[test]
+    fn parse_object_filter_lexed_parses_controller_without_owner_suffix() {
+        let tokens = tokenize_line("land you control but don't own", 0);
+
+        let filter = parse_object_filter_lexed(&tokens, false).expect("object filter should parse");
+
+        assert_eq!(filter.controller, Some(PlayerFilter::You));
+        assert_eq!(filter.owner, Some(PlayerFilter::NotYou));
+        assert_eq!(filter.zone, Some(Zone::Battlefield));
+        assert_eq!(filter.card_types, vec![CardType::Land]);
     }
 
     #[test]

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/player_relations.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/player_relations.rs
@@ -252,6 +252,66 @@ pub(super) fn try_apply_negated_you_relation_clause(
     if let Some((_, consumed)) = parse_filter_prefix_words(
         words,
         (
+            alt((
+                primitives::word_slice_eq("dont"),
+                primitives::word_slice_eq("don't"),
+            )),
+            alt((
+                primitives::word_slice_eq("control"),
+                primitives::word_slice_eq("controls"),
+            )),
+        ),
+    ) {
+        filter.controller = Some(PlayerFilter::NotYou);
+        return Some(consumed);
+    }
+    if let Some((_, consumed)) = parse_filter_prefix_words(
+        words,
+        (
+            alt((
+                primitives::word_slice_eq("dont"),
+                primitives::word_slice_eq("don't"),
+            )),
+            alt((
+                primitives::word_slice_eq("own"),
+                primitives::word_slice_eq("owns"),
+            )),
+        ),
+    ) {
+        filter.owner = Some(PlayerFilter::NotYou);
+        return Some(consumed);
+    }
+    if let Some((_, consumed)) = parse_filter_prefix_words(
+        words,
+        (
+            primitives::word_slice_eq("do"),
+            primitives::word_slice_eq("not"),
+            alt((
+                primitives::word_slice_eq("control"),
+                primitives::word_slice_eq("controls"),
+            )),
+        ),
+    ) {
+        filter.controller = Some(PlayerFilter::NotYou);
+        return Some(consumed);
+    }
+    if let Some((_, consumed)) = parse_filter_prefix_words(
+        words,
+        (
+            primitives::word_slice_eq("do"),
+            primitives::word_slice_eq("not"),
+            alt((
+                primitives::word_slice_eq("own"),
+                primitives::word_slice_eq("owns"),
+            )),
+        ),
+    ) {
+        filter.owner = Some(PlayerFilter::NotYou);
+        return Some(consumed);
+    }
+    if let Some((_, consumed)) = parse_filter_prefix_words(
+        words,
+        (
             primitives::word_slice_eq("you"),
             alt((
                 primitives::word_slice_eq("dont"),

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1994,6 +1994,11 @@ impl ObjectFilter {
                 parts.push("you both own and control".to_string());
             }
             (Some(controller), Some(owner))
+                if controller == "you control" && owner == "you don't own" =>
+            {
+                parts.push("you control but don't own".to_string());
+            }
+            (Some(controller), Some(owner))
                 if controller == "that player controls" && owner == "that player owns" =>
             {
                 parts.push("that player both owns and controls".to_string());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31109,6 +31109,231 @@ fn goddric_cloaked_reveler_keeps_conditional_dragon_animation() {
     );
 }
 
+fn herald_of_leshrac_definition() -> CardDefinition {
+    let oracle = oracle_text_by_name()
+        .get("Herald of Leshrac")
+        .expect("missing Herald of Leshrac oracle text")
+        .clone();
+    CardDefinitionBuilder::new(CardId::new(), "Herald of Leshrac")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(6)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Avatar])
+        .power_toughness(PowerToughness::fixed(2, 4))
+        .parse_text(oracle)
+        .expect("Herald of Leshrac should parse strictly")
+}
+
+struct PayCumulativeUpkeep;
+
+impl crate::decision::DecisionMaker for PayCumulativeUpkeep {
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        true
+    }
+}
+
+fn herald_upkeep_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if format!("{triggered:?}").contains("CumulativeUpkeepEffect") =>
+            {
+                Some(triggered)
+            }
+            _ => None,
+        })
+        .expect("Herald of Leshrac should have a cumulative upkeep trigger")
+}
+
+fn herald_leaves_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if format!("{:?}", triggered.effects)
+                    .contains("ChangeControllerToPlayer(IteratedPlayer)") =>
+            {
+                Some(triggered)
+            }
+            _ => None,
+        })
+        .expect("Herald of Leshrac should have a leaves-the-battlefield trigger")
+}
+
+fn test_land_definition(name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Land])
+        .build()
+}
+
+#[test]
+fn herald_of_leshrac_strict_parser_and_compiled_text_regression() {
+    let def = herald_of_leshrac_definition();
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("CumulativeUpkeepEffect")
+            && abilities_debug.contains("ChangeControllerToEffectController")
+            && abilities_debug.contains("ChangeControllerToPlayer(IteratedPlayer)"),
+        "expected Herald control-changing cumulative upkeep and leaves trigger, got {abilities_debug}"
+    );
+    assert!(
+        !crate::cards::generated_definition_has_unimplemented_content(&def),
+        "Herald of Leshrac should not contain unsupported markers: {abilities_debug}"
+    );
+
+    let rendered_lines = unprocessed_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+    assert!(
+        rendered.contains("Cumulative upkeep—Gain control of a land you don't control."),
+        "expected cumulative upkeep control cost in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("This creature gets +1/+1 for each land you control but don't own."),
+        "expected unowned-land scaling text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("When this creature leaves the battlefield, each player gains control of each land they own that you control."),
+        "expected owner-restoration leaves trigger text, got {rendered}"
+    );
+
+    let oracle = oracle_text_by_name()
+        .get("Herald of Leshrac")
+        .expect("missing Herald oracle text");
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_card_semantics_scored(
+            "Herald of Leshrac",
+            oracle,
+            &rendered_lines,
+            crate::semantic_compare::report_embedding_config(),
+        );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Herald compiled text to match oracle, got similarity={similarity}, mismatch={mismatch}, text={rendered}"
+    );
+}
+
+#[test]
+fn herald_of_leshrac_cumulative_upkeep_gains_land_and_scales_power() {
+    let def = herald_of_leshrac_definition();
+    let upkeep = herald_upkeep_trigger(&def);
+    let land_def = test_land_definition("Stolen Land");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let bob_land = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+
+    let mut dm = PayCumulativeUpkeep;
+    let mut ctx = crate::effects::ExecutionContext::new(herald, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        herald,
+        &upkeep.effects,
+        None,
+        &[],
+    )
+    .expect("Herald cumulative upkeep should resolve");
+
+    assert_eq!(
+        game.counter_count(herald, crate::object::CounterType::Age),
+        1,
+        "cumulative upkeep should add one age counter"
+    );
+    assert_eq!(
+        game.current_controller(bob_land),
+        Some(alice),
+        "paying Herald's upkeep should gain control of a land you don't control"
+    );
+    assert_eq!(
+        game.calculated_power(herald),
+        Some(3),
+        "Herald should get +1/+1 for the land Alice controls but doesn't own"
+    );
+    assert_eq!(game.calculated_toughness(herald), Some(5));
+}
+
+#[test]
+fn herald_of_leshrac_cumulative_upkeep_sacrifices_when_no_land_can_be_gained() {
+    let def = herald_of_leshrac_definition();
+    let upkeep = herald_upkeep_trigger(&def);
+
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let mut dm = PayCumulativeUpkeep;
+    let mut ctx = crate::effects::ExecutionContext::new(herald, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        herald,
+        &upkeep.effects,
+        None,
+        &[],
+    )
+    .expect("Herald cumulative upkeep failure branch should resolve");
+
+    assert_eq!(
+        game.object(herald).map(|object| object.zone),
+        Some(Zone::Graveyard),
+        "Herald should be sacrificed when its cumulative upkeep cost cannot be paid"
+    );
+}
+
+#[test]
+fn herald_of_leshrac_leaves_trigger_returns_lands_to_their_owners() {
+    let def = herald_of_leshrac_definition();
+    let leaves = herald_leaves_trigger(&def);
+    let land_def = test_land_definition("Recovered Land");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let alice_land = game.create_object_from_definition(&land_def, alice, Zone::Battlefield);
+    let bob_land = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+    game.set_current_controller(bob_land, alice);
+    assert_eq!(game.current_controller(bob_land), Some(alice));
+
+    let mut dm = PayCumulativeUpkeep;
+    let mut ctx = crate::effects::ExecutionContext::new(herald, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        herald,
+        &leaves.effects,
+        None,
+        &[],
+    )
+    .expect("Herald leaves trigger should resolve");
+
+    assert_eq!(
+        game.current_controller(bob_land),
+        Some(bob),
+        "Bob should regain each land they own that Alice controls"
+    );
+    assert_eq!(
+        game.current_controller(alice_land),
+        Some(alice),
+        "Alice should retain lands they already own and control"
+    );
+}
+
 #[test]
 fn bello_bard_of_the_brambles_compacts_conditional_animation_bundle() {
     let def = parse_oracle_card_definition("Bello, Bard of the Brambles");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31173,6 +31173,26 @@ fn test_land_definition(name: &str) -> CardDefinition {
         .build()
 }
 
+fn execute_herald_upkeep(
+    game: &mut crate::game_state::GameState,
+    herald: crate::ids::ObjectId,
+    upkeep: &crate::ability::TriggeredAbility,
+    controller: PlayerId,
+) {
+    let mut dm = PayCumulativeUpkeep;
+    let mut ctx = crate::effects::ExecutionContext::new(herald, controller, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        game,
+        &mut ctx,
+        controller,
+        herald,
+        &upkeep.effects,
+        None,
+        &[],
+    )
+    .expect("Herald cumulative upkeep should resolve");
+}
+
 #[test]
 fn herald_of_leshrac_strict_parser_and_compiled_text_regression() {
     let def = herald_of_leshrac_definition();
@@ -31232,18 +31252,7 @@ fn herald_of_leshrac_cumulative_upkeep_gains_land_and_scales_power() {
     let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
     let bob_land = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
 
-    let mut dm = PayCumulativeUpkeep;
-    let mut ctx = crate::effects::ExecutionContext::new(herald, alice, &mut dm);
-    crate::game_loop::execute_resolution_program(
-        &mut game,
-        &mut ctx,
-        alice,
-        herald,
-        &upkeep.effects,
-        None,
-        &[],
-    )
-    .expect("Herald cumulative upkeep should resolve");
+    execute_herald_upkeep(&mut game, herald, upkeep, alice);
 
     assert_eq!(
         game.counter_count(herald, crate::object::CounterType::Age),
@@ -31264,6 +31273,75 @@ fn herald_of_leshrac_cumulative_upkeep_gains_land_and_scales_power() {
 }
 
 #[test]
+fn herald_of_leshrac_repeated_cumulative_upkeep_pays_once_per_age_counter() {
+    let def = herald_of_leshrac_definition();
+    let upkeep = herald_upkeep_trigger(&def);
+    let land_def = test_land_definition("Stolen Land");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let bob_land_one = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+    let bob_land_two = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+    let bob_land_three = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+
+    execute_herald_upkeep(&mut game, herald, upkeep, alice);
+    execute_herald_upkeep(&mut game, herald, upkeep, alice);
+
+    assert_eq!(
+        game.counter_count(herald, crate::object::CounterType::Age),
+        2,
+        "second cumulative upkeep should leave two age counters"
+    );
+    for land in [bob_land_one, bob_land_two, bob_land_three] {
+        assert_eq!(
+            game.current_controller(land),
+            Some(alice),
+            "two age counters should require gaining control of two additional lands"
+        );
+    }
+    assert_eq!(
+        game.calculated_power(herald),
+        Some(5),
+        "Herald should count every land Alice controls but doesn't own"
+    );
+    assert_eq!(game.calculated_toughness(herald), Some(7));
+}
+
+#[test]
+fn herald_of_leshrac_repeated_cumulative_upkeep_fails_atomically_when_short_on_lands() {
+    let def = herald_of_leshrac_definition();
+    let upkeep = herald_upkeep_trigger(&def);
+    let land_def = test_land_definition("Stolen Land");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let first_land = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+    let only_remaining_land =
+        game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+
+    execute_herald_upkeep(&mut game, herald, upkeep, alice);
+    assert_eq!(game.current_controller(first_land), Some(alice));
+
+    execute_herald_upkeep(&mut game, herald, upkeep, alice);
+
+    assert!(
+        !game.battlefield.contains(&herald),
+        "Herald should be sacrificed when the full repeated upkeep cost cannot be paid"
+    );
+    assert_eq!(
+        game.current_controller(only_remaining_land),
+        Some(bob),
+        "failed repeated upkeep should not keep a partial controller-change payment"
+    );
+}
+
+#[test]
 fn herald_of_leshrac_cumulative_upkeep_sacrifices_when_no_land_can_be_gained() {
     let def = herald_of_leshrac_definition();
     let upkeep = herald_upkeep_trigger(&def);
@@ -31273,23 +31351,20 @@ fn herald_of_leshrac_cumulative_upkeep_sacrifices_when_no_land_can_be_gained() {
         crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
     let herald = game.create_object_from_definition(&def, alice, Zone::Battlefield);
 
-    let mut dm = PayCumulativeUpkeep;
-    let mut ctx = crate::effects::ExecutionContext::new(herald, alice, &mut dm);
-    crate::game_loop::execute_resolution_program(
-        &mut game,
-        &mut ctx,
-        alice,
-        herald,
-        &upkeep.effects,
-        None,
-        &[],
-    )
-    .expect("Herald cumulative upkeep failure branch should resolve");
+    execute_herald_upkeep(&mut game, herald, upkeep, alice);
 
+    assert!(
+        !game.battlefield.contains(&herald),
+        "Herald should leave the battlefield when its cumulative upkeep cost cannot be paid"
+    );
+    let graveyard_object = game
+        .player(alice)
+        .and_then(|player| player.graveyard.first().copied())
+        .and_then(|id| game.object(id));
     assert_eq!(
-        game.object(herald).map(|object| object.zone),
-        Some(Zone::Graveyard),
-        "Herald should be sacrificed when its cumulative upkeep cost cannot be paid"
+        graveyard_object.map(|object| object.name.as_str()),
+        Some("Herald of Leshrac"),
+        "Herald should be sacrificed to its owner's graveyard when its cumulative upkeep cost cannot be paid"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1699,6 +1699,30 @@ fn describe_for_players_simple_iterated_action(
             if subject == "You" { "your" } else { "their" }
         ));
     }
+    if let Some(apply) = effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()
+        && apply.modification.is_none()
+        && apply.additional_modifications.is_empty()
+        && matches!(
+            apply.runtime_modifications.as_slice(),
+            [crate::effects::continuous::RuntimeModification::ChangeControllerToPlayer(
+                PlayerFilter::IteratedPlayer
+            )]
+        )
+    {
+        if let crate::continuous::EffectTarget::Filter(filter) = &apply.target
+            && filter.owner == Some(PlayerFilter::IteratedPlayer)
+            && filter.controller == Some(PlayerFilter::You)
+        {
+            let mut object_filter = filter.clone();
+            object_filter.owner = None;
+            object_filter.controller = None;
+            let object = strip_indefinite_article(&object_filter.description()).to_string();
+            return Some(format!(
+                "{subject} {} control of each {object} they own that you control",
+                verb("gain", "gains")
+            ));
+        }
+    }
 
     let inner = describe_effect_list(&for_players.effects);
     let rest = inner
@@ -33675,6 +33699,9 @@ fn cumulative_upkeep_payment_text(payment: &[Effect]) -> Option<String> {
         } else if let Some(move_to_zone) = effect.downcast_ref::<crate::effects::MoveToZoneEffect>()
         {
             parts.push(cumulative_upkeep_move_to_zone_text(move_to_zone)?);
+        } else if let Some(apply_continuous) = effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()
+        {
+            parts.push(describe_apply_continuous_effect(apply_continuous)?);
         }
     }
     if parts.is_empty() {

--- a/crates/ironsmith-runtime/src/effects/continuous/apply_continuous.rs
+++ b/crates/ironsmith-runtime/src/effects/continuous/apply_continuous.rs
@@ -1,8 +1,9 @@
 //! Apply continuous effect implementation.
 
 use crate::continuous::{ContinuousEffect, EffectSourceType, EffectTarget, Modification};
+use crate::decision::SelectFirstDecisionMaker;
 use crate::effect::{ChoiceCount, EffectOutcome, Until, Value};
-use crate::effects::EffectExecutor;
+use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
 use crate::effects::helpers::{
     resolve_objects_for_effect, resolve_objects_from_spec, resolve_player_filter, resolve_value,
     validate_target,
@@ -345,7 +346,49 @@ fn control_change_target_object_ids(
     }
 }
 
+fn is_controller_change_cost(effect: &ApplyContinuousEffect) -> bool {
+    let base_is_controller_change = effect
+        .modification
+        .as_ref()
+        .is_none_or(|modification| matches!(modification, Modification::ChangeController(_)));
+    let additional_are_controller_changes = effect
+        .additional_modifications
+        .iter()
+        .all(|modification| matches!(modification, Modification::ChangeController(_)));
+    let runtime_are_controller_changes = effect.runtime_modifications.iter().all(|modification| {
+        matches!(
+            modification,
+            RuntimeModification::ChangeControllerToEffectController
+                | RuntimeModification::ChangeControllerToPlayer(_)
+        )
+    });
+    let has_controller_change = effect
+        .modification
+        .as_ref()
+        .is_some_and(|modification| matches!(modification, Modification::ChangeController(_)))
+        || effect
+            .additional_modifications
+            .iter()
+            .any(|modification| matches!(modification, Modification::ChangeController(_)))
+        || effect.runtime_modifications.iter().any(|modification| {
+            matches!(
+                modification,
+                RuntimeModification::ChangeControllerToEffectController
+                    | RuntimeModification::ChangeControllerToPlayer(_)
+            )
+        });
+
+    has_controller_change
+        && base_is_controller_change
+        && additional_are_controller_changes
+        && runtime_are_controller_changes
+}
+
 impl EffectExecutor for ApplyContinuousEffect {
+    fn as_cost_executable(&self) -> Option<&dyn CostExecutableEffect> {
+        is_controller_change_cost(self).then_some(self)
+    }
+
     fn decision_related_object_specs(&self) -> Vec<ChooseSpec> {
         if let Some(spec) = &self.target_spec {
             return vec![spec.clone()];
@@ -469,6 +512,35 @@ impl EffectExecutor for ApplyContinuousEffect {
 
     fn target_description(&self) -> &'static str {
         "target"
+    }
+}
+
+impl CostExecutableEffect for ApplyContinuousEffect {
+    fn can_execute_as_cost(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Result<(), CostValidationError> {
+        if !is_controller_change_cost(self) {
+            return Err(CostValidationError::Other(
+                "only controller-change continuous effects can be paid as costs".to_string(),
+            ));
+        }
+
+        let mut simulated_game = game.clone();
+        let mut simulated_decision_maker = SelectFirstDecisionMaker;
+        let mut simulated_ctx = ExecutionContext::new(source, controller, &mut simulated_decision_maker);
+        match self.execute(&mut simulated_game, &mut simulated_ctx) {
+            Ok(outcome) if !outcome.status.is_failure() => Ok(()),
+            Ok(outcome) => Err(CostValidationError::Other(format!(
+                "controller-change cost could not resolve: {:?}",
+                outcome.status
+            ))),
+            Err(err) => Err(CostValidationError::Other(format!(
+                "controller-change cost could not resolve: {err:?}"
+            ))),
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3850,6 +3850,11 @@ impl ObjectFilterExt for ObjectFilter {
                 parts.push("you both own and control".to_string());
             }
             (Some(controller), Some(owner))
+                if controller == "you control" && owner == "you don't own" =>
+            {
+                parts.push("you control but don't own".to_string());
+            }
+            (Some(controller), Some(owner))
                 if controller == "that player controls" && owner == "that player owns" =>
             {
                 parts.push("that player both owns and controls".to_string());


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Herald of Leshrac
Initial parse error:
```
unsupported cumulative upkeep payment cost (clause: 'Gain control of a land you don't control'): effect is not marked as cost-executable: ironsmith_core::effect::ApplyContinuousEffect<ironsmith_core::continuous_model::CompiledContinuousEffectTarget, ironsmith_core::continuous_model::CompiledContinuousModification<ironsmith_core::static_ability_model::StaticAbility<ironsmith_core::trigger_model::Trigger, ironsmith_compiler::effect::Effect, ironsmith_core::cost_model::Cost<ironsmith_compiler::effect::Effect>, ironsmith_core::spell_cost_condition_model::ThisSpellCostCondition>, ironsmith_core::ability_model::Ability<ironsmith_core::static_ability_model::StaticAbility<ironsmith_core::trigger_model::Trigger, ironsmith_compiler::effect::Effect, ironsmith_core::cost_model::Cost<ironsmith_compiler::effect::Effect>, ironsmith_core::spell_cost_condition_model::ThisSpellCostCondition>, ironsmith_core::trigger_model::Trigger, ironsmith_compiler::effect::Effect, ironsmith_core::cost_model::Cost<ironsmith_compiler::effect::Effect>>>, ironsmith_compiler::effects::continuous::RuntimeModification, ironsmith_core::value_model::Condition>; oracle-only fallback also failed: unsupported cumulative upkeep payment cost (clause: 'Gain control of a land you don't control'): effect is not marked as cost-executable: ironsmith_core::effect::ApplyContinuousEffect<ironsmith_core::continuous_model::CompiledContinuousEffectTarget, ironsmith_core::continuous_model::CompiledContinuousModification<ironsmith_core::static_ability_model::StaticAbility<ironsmith_core::trigger_model::Trigger, ironsmith_compiler::effect::Effect, ironsmith_core::cost_model::Cost<ironsmith_compiler::effect::Effect>, ironsmith_core::spell_cost_condition_model::ThisSpellCostCondition>, ironsmith_core::ability_model::Ability<ironsmith_core::static_ability_model::StaticAbility<ironsmith_core::trigger_model::Trigger, ironsmith_compiler::effect::Effect, ironsmith_core::cost_model::Cost<ironsmith_compiler::effect::Effect>, ironsmith_core::spell_cost_condition_model::ThisSpellCostCondition>, ironsmith_core::trigger_model::Trigger, ironsmith_compiler::effect::Effect, ironsmith_core::cost_model::Cost<ironsmith_compiler::effect::Effect>>>, ironsmith_compiler::effects::continuous::RuntimeModification, ironsmith_core::value_model::Condition>
```

Current worker: i-07cdb33c1819a3aa0
Branch: codex/aws-card-fix-herald-of-leshrac
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0250
