### PR TITLE
Fix Ironsmith parse failure: Season of the Burrow

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -110,6 +110,9 @@ fn is_bullet_line(line: &str) -> bool {
     if str_starts_with_char(trimmed, '•') || str_starts_with_char(trimmed, '*') {
         return true;
     }
+    if starts_with_pawprint_modal_label(trimmed) {
+        return true;
+    }
     if let Some(rest) = str_strip_prefix(trimmed, "-") {
         let next = rest.chars().next();
         if next.is_some_and(|ch| ch.is_ascii_digit()) {
@@ -118,6 +121,19 @@ fn is_bullet_line(line: &str) -> bool {
         return true;
     }
     false
+}
+
+fn starts_with_pawprint_modal_label(mut text: &str) -> bool {
+    let mut seen_pawprint = false;
+    loop {
+        text = text.trim_start();
+        if !text.get(..3).is_some_and(|prefix| prefix.eq_ignore_ascii_case("{p}")) {
+            break;
+        }
+        seen_pawprint = true;
+        text = &text[3..];
+    }
+    seen_pawprint && text.trim_start().starts_with('—')
 }
 
 fn parse_trigger_intro_tokens(tokens: &[OwnedLexToken]) -> Option<TriggerIntroCst> {
@@ -2260,6 +2276,28 @@ mod tests {
                 assert!(!modal.modes[1].effects_ast.is_empty());
             }
             other => panic!("expected one modal block, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn modal_mode_cst_groups_season_of_the_burrow_pawprint_modes() -> Result<(), CardTextError> {
+        let preprocessed = preprocess_document(
+            CardDefinitionBuilder::new(CardId::new(), "Season of the Burrow")
+                .card_types(vec![CardType::Sorcery]),
+            "Choose up to five {P} worth of modes. You may choose the same mode more than once.\n{P} — Create a 1/1 white Rabbit creature token.\n{P}{P} — Exile target nonland permanent. Its controller draws a card.\n{P}{P}{P} — Return target permanent card with mana value 3 or less from your graveyard to the battlefield with an indestructible counter on it.",
+        )?;
+        let cst = super::parse_document_cst(&preprocessed, false)?;
+
+        match cst.lines.as_slice() {
+            [super::RewriteLineCst::Modal(modal)] => {
+                assert_eq!(modal.modes.len(), 3);
+                assert_eq!(modal.modes[0].text, "Create a 1/1 white Rabbit creature token.");
+                assert!(modal.modes[1].text.starts_with("Exile target nonland permanent"));
+                assert!(modal.modes[2].text.starts_with("Return target permanent card"));
+            }
+            other => panic!("expected Season of the Burrow pawprint modes to form one modal block, got {other:?}"),
         }
 
         Ok(())

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/modal_and_level_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/modal_and_level_lowering.rs
@@ -52,6 +52,7 @@ pub(crate) fn try_merge_modal_into_remove_mode(
             choose_count: choose_mode.choose_count.clone(),
             min_choose_count: choose_mode.min_choose_count.clone(),
             allow_repeated_modes: choose_mode.allow_repeated_modes,
+            mode_point_costs: choose_mode.mode_point_costs.clone(),
             disallow_previously_chosen_modes: choose_mode.disallow_previously_chosen_modes,
             disallow_previously_chosen_modes_this_turn: choose_mode
                 .disallow_previously_chosen_modes_this_turn,
@@ -64,12 +65,37 @@ pub(crate) fn try_merge_modal_into_remove_mode(
             choose_count: choose_mode.choose_count.clone(),
             min_choose_count: choose_mode.min_choose_count.clone(),
             allow_repeated_modes: choose_mode.allow_repeated_modes,
+            mode_point_costs: choose_mode.mode_point_costs.clone(),
             disallow_previously_chosen_modes: choose_mode.disallow_previously_chosen_modes,
             disallow_previously_chosen_modes_this_turn: choose_mode
                 .disallow_previously_chosen_modes_this_turn,
         },
     ));
     true
+}
+
+fn header_mentions_modal_point_cost(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("worth of modes") && lower.contains("{p}")
+}
+
+fn parse_leading_modal_point_cost(text: &str) -> Option<u32> {
+    let mut rest = text.trim_start();
+    let mut count = 0u32;
+    loop {
+        let trimmed = rest.trim_start();
+        if !trimmed.get(..3).is_some_and(|prefix| prefix.eq_ignore_ascii_case("{p}")) {
+            rest = trimmed;
+            break;
+        }
+        count += 1;
+        rest = &trimmed[3..];
+    }
+    if count == 0 {
+        return None;
+    }
+    let rest = rest.trim_start();
+    rest.starts_with('—').then_some(count)
 }
 
 pub(crate) fn rewrite_lower_parsed_modal(
@@ -128,8 +154,11 @@ pub(crate) fn rewrite_lower_parsed_modal(
         }
     };
 
+    let weighted_mode_points = header_mentions_modal_point_cost(line_text.as_str());
     let mut compiled_modes = Vec::new();
+    let mut mode_point_costs = Vec::new();
     for mode in modes {
+        let point_cost = parse_leading_modal_point_cost(mode.info.raw_line.as_str()).unwrap_or(1);
         let effects = match rewrite_lower_prepared_statement_effects(&mode.prepared) {
             Ok(lowered) => lowered.effects,
             Err(err) if allow_unsupported => {
@@ -146,6 +175,7 @@ pub(crate) fn rewrite_lower_parsed_modal(
             description: mode.description,
             effects: effects.to_vec(),
         });
+        mode_point_costs.push(point_cost);
     }
 
     if compiled_modes.is_empty() {
@@ -158,20 +188,25 @@ pub(crate) fn rewrite_lower_parsed_modal(
     let min = header_min;
     let is_fixed_one =
         |value: &crate::effect::Value| matches!(value, crate::effect::Value::Fixed(1));
-    let with_unchosen_requirement = |effect: crate::effect::Effect| {
-        if !mode_must_be_unchosen {
+    let apply_modal_metadata = |effect: crate::effect::Effect| {
+        let Some(choose_mode) = effect.downcast_ref::<crate::effects::ChooseModeEffect>() else {
             return effect;
+        };
+        let mut choose_mode = choose_mode.clone();
+        if same_mode_more_than_once {
+            choose_mode = choose_mode.with_repeated_modes();
         }
-        if let Some(choose_mode) = effect.downcast_ref::<crate::effects::ChooseModeEffect>() {
-            let choose_mode = choose_mode.clone();
-            let choose_mode = if mode_must_be_unchosen_this_turn {
+        if weighted_mode_points {
+            choose_mode = choose_mode.with_mode_point_costs(mode_point_costs.clone());
+        }
+        if mode_must_be_unchosen {
+            choose_mode = if mode_must_be_unchosen_this_turn {
                 choose_mode.with_previously_unchosen_modes_only_this_turn()
             } else {
                 choose_mode.with_previously_unchosen_modes_only()
             };
-            return crate::effect::Effect::new(choose_mode);
         }
-        effect
+        crate::effect::Effect::new(choose_mode)
     };
 
     let choose_both_condition = if commander_allows_both {
@@ -199,7 +234,7 @@ pub(crate) fn rewrite_lower_parsed_modal(
     let modal_effect = if let Some(choose_both_condition) = choose_both_condition {
         let max_both = (mode_count.min(2)).max(1);
         let choose_both = if max_both == 1 {
-            with_unchosen_requirement(crate::effect::Effect::choose_one(compiled_modes.clone()))
+            apply_modal_metadata(crate::effect::Effect::choose_one(compiled_modes.clone()))
         } else {
             #[cfg(not(feature = "serialization"))]
             let choose_up_to = crate::effect::Effect::choose_up_to_with_min(
@@ -213,24 +248,23 @@ pub(crate) fn rewrite_lower_parsed_modal(
                 crate::effect::Value::Fixed(1),
                 compiled_modes.clone(),
             );
-            with_unchosen_requirement(choose_up_to)
+            apply_modal_metadata(choose_up_to)
         };
-        let choose_one =
-            with_unchosen_requirement(crate::effect::Effect::choose_one(compiled_modes.clone()));
+        let choose_one = apply_modal_metadata(crate::effect::Effect::choose_one(compiled_modes.clone()));
         crate::effect::Effect::conditional(
             choose_both_condition,
             vec![choose_both],
             vec![choose_one],
         )
     } else if same_mode_more_than_once && min == max {
-        with_unchosen_requirement(crate::effect::Effect::choose_exactly_allow_repeated_modes(
+        apply_modal_metadata(crate::effect::Effect::choose_exactly_allow_repeated_modes(
             max.clone(),
             compiled_modes,
         ))
     } else if is_fixed_one(&min) && is_fixed_one(&max) {
-        with_unchosen_requirement(crate::effect::Effect::choose_one(compiled_modes))
+        apply_modal_metadata(crate::effect::Effect::choose_one(compiled_modes))
     } else if min == max {
-        with_unchosen_requirement(crate::effect::Effect::choose_exactly(
+        apply_modal_metadata(crate::effect::Effect::choose_exactly(
             max.clone(),
             compiled_modes,
         ))
@@ -241,7 +275,7 @@ pub(crate) fn rewrite_lower_parsed_modal(
         #[cfg(feature = "serialization")]
         let choose_up_to =
             crate::effect::Effect::choose_up_to(max.clone(), min.clone(), compiled_modes);
-        with_unchosen_requirement(choose_up_to)
+        apply_modal_metadata(choose_up_to)
     };
 
     let mut combined_effects = prefix_effects;

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1571,6 +1571,18 @@ fn rewrite_modal_header_parser_supports_activated_choose_header_directly() {
 }
 
 #[test]
+fn rewrite_modal_header_parser_accepts_pawprint_worth_clause() {
+    let text = "Choose up to five {P} worth of modes. You may choose the same mode more than once.";
+    let header = super::modal_support::parse_modal_header(&rewrite_line_info(text))
+        .expect("Season of the Burrow modal header should parse")
+        .expect("Season of the Burrow modal header should be recognized");
+
+    assert_eq!(header.min, crate::effect::Value::Fixed(0));
+    assert_eq!(header.max, Some(crate::effect::Value::Fixed(5)));
+    assert!(header.same_mode_more_than_once, "{header:?}");
+}
+
+#[test]
 fn rewrite_modal_header_parser_keeps_choose_one_when_later_choose_both_is_present() {
     let text = "Choose one. If you control a commander as you cast this spell, you may choose both instead.";
     let header = super::modal_support::parse_modal_header(&rewrite_line_info(text))

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -810,6 +810,7 @@ pub struct ChooseModeEffect<E> {
     pub choose_count: Value,
     pub min_choose_count: Value,
     pub allow_repeated_modes: bool,
+    pub mode_point_costs: Vec<u32>,
     pub disallow_previously_chosen_modes: bool,
     pub disallow_previously_chosen_modes_this_turn: bool,
 }
@@ -818,6 +819,7 @@ impl<E> ChooseModeEffect<E> {
     pub fn new(modes: Vec<EffectMode<E>>, min: Value, max: Value, allow_repeat: bool) -> Self {
         let choose_count = max.clone();
         let min_choose_count = min.clone();
+        let mode_point_costs = vec![1; modes.len()];
         Self {
             modes,
             min,
@@ -826,6 +828,7 @@ impl<E> ChooseModeEffect<E> {
             choose_count,
             min_choose_count,
             allow_repeated_modes: allow_repeat,
+            mode_point_costs,
             disallow_previously_chosen_modes: false,
             disallow_previously_chosen_modes_this_turn: false,
         }
@@ -851,6 +854,11 @@ impl<E> ChooseModeEffect<E> {
     pub fn with_repeated_modes(mut self) -> Self {
         self.allow_repeat = true;
         self.allow_repeated_modes = true;
+        self
+    }
+
+    pub fn with_mode_point_costs(mut self, costs: Vec<u32>) -> Self {
+        self.mode_point_costs = costs;
         self
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36479,6 +36479,225 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+fn season_of_the_burrow_modal_effect(def: &CardDefinition) -> &ChooseModeEffect {
+    def.spell_effect
+        .as_ref()
+        .expect("Season of the Burrow should compile to spell effects")
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        .expect("Season of the Burrow should compile to one modal choice effect")
+}
+
+fn target_assignment_for_first_targeted_effect(
+    mode: &crate::effect::EffectMode,
+) -> crate::game_state::TargetAssignment {
+    let profile = mode
+        .effects
+        .iter()
+        .find_map(|effect| effect.target_selection_profile())
+        .expect("mode should require one target");
+    crate::game_state::TargetAssignment {
+        spec: profile.spec.clone(),
+        range: 0..1,
+    }
+}
+
+#[test]
+fn season_of_the_burrow_strict_parser_and_weighted_modal_text_regression() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let modal = season_of_the_burrow_modal_effect(&def);
+
+    assert_eq!(modal.choose_count, Value::Fixed(5));
+    assert_eq!(modal.min_choose_count, Value::Fixed(0));
+    assert!(modal.allow_repeated_modes);
+    assert_eq!(modal.mode_point_costs, vec![1, 2, 3]);
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Choose up to five {P} worth of modes")
+            && rendered.contains("You may choose the same mode more than once")
+            && rendered.contains("{P}{P} — Exile target nonland permanent")
+            && rendered.contains("{P}{P}{P} — Return target permanent card with mana value 3 or less"),
+        "expected Season of the Burrow weighted modal text, got {rendered}"
+    );
+}
+
+#[test]
+fn season_of_the_burrow_weighted_mode_boundary_rejects_more_than_five_points() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Season of the Burrow should compile to spell effects")
+        .segments[0]
+        .default_effects
+        .clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let target = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_700), "Bob's Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let graveyard_card = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_701), "Alice's Keepsake")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    assert!(game.object(graveyard_card).is_some());
+    assert!(game.object(target).is_some());
+
+    let legal_five_points = [2usize, 1usize];
+    assert!(
+        crate::game_loop::spell_has_legal_targets_with_modes(
+            &game,
+            &effects,
+            alice,
+            Some(source),
+            Some(&legal_five_points),
+        ),
+        "3-point plus 2-point Season modes should be legal"
+    );
+
+    let illegal_six_points = [2usize, 2usize];
+    assert!(
+        !crate::game_loop::spell_has_legal_targets_with_modes(
+            &game,
+            &effects,
+            alice,
+            Some(source),
+            Some(&illegal_six_points),
+        ),
+        "two 3-point Season modes should be rejected as more than five {{P}}"
+    );
+}
+
+#[test]
+fn season_of_the_burrow_rabbit_mode_creates_token() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let modal = season_of_the_burrow_modal_effect(&def).clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(vec![0]));
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Season of the Burrow Rabbit mode should resolve");
+
+    let rabbit_count = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter(|id| game.object(*id).is_some_and(|object| object.name == "Rabbit"))
+        .count();
+    assert_eq!(rabbit_count, 1, "Rabbit mode should create one Rabbit token");
+}
+
+#[test]
+fn season_of_the_burrow_exile_mode_exiles_nonland_permanent_and_draws_for_controller() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let modal = season_of_the_burrow_modal_effect(&def).clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_710), "Bob's Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_711), "Bob's Draw")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(vec![1]))
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)])
+        .with_target_assignments(vec![target_assignment_for_first_targeted_effect(
+            &modal.modes[1],
+        )]);
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Season of the Burrow exile mode should resolve");
+
+    assert!(
+        game.objects_in_zone(Zone::Exile).into_iter().any(|id| game
+            .object(id)
+            .is_some_and(|object| object.name == "Bob's Relic")),
+        "target nonland permanent should move to exile"
+    );
+    assert_eq!(game.player(bob).expect("Bob should exist").hand.len(), 1);
+}
+
+#[test]
+fn season_of_the_burrow_return_mode_returns_small_permanent_with_indestructible_counter() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let modal = season_of_the_burrow_modal_effect(&def).clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_720), "Alice's Keepsake")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(vec![2]))
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)])
+        .with_target_assignments(vec![target_assignment_for_first_targeted_effect(
+            &modal.modes[2],
+        )]);
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Season of the Burrow return mode should resolve");
+
+    let returned_id = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Alice's Keepsake")
+        })
+        .expect("returned permanent should be on the battlefield");
+    let returned = game.object(returned_id).expect("returned permanent should exist");
+    assert_eq!(
+        returned
+            .counters
+            .get(&crate::object::CounterType::Indestructible)
+            .copied(),
+        Some(1)
+    );
+}
+
 #[test]
 fn when_we_were_young_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("When We Were Young");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36504,6 +36504,31 @@ fn target_assignment_for_first_targeted_effect(
     }
 }
 
+fn target_assignments_for_requirements(
+    requirements: &[crate::decision::TargetRequirement],
+    targets: &[crate::game_state::Target],
+) -> Vec<crate::game_state::TargetAssignment> {
+    let requirement_contexts = requirements
+        .iter()
+        .map(|requirement| crate::decisions::context::TargetRequirementContext {
+            description: requirement.description.clone(),
+            legal_targets: requirement.legal_targets.clone(),
+            min_targets: requirement.min_targets,
+            max_targets: requirement.max_targets,
+        })
+        .collect::<Vec<_>>();
+    let ranges = crate::targeting::assigned_target_ranges(&requirement_contexts, targets)
+        .expect("selected targets should satisfy requirements");
+    requirements
+        .iter()
+        .zip(ranges)
+        .map(|(requirement, range)| crate::game_state::TargetAssignment {
+            spec: requirement.spec.clone(),
+            range,
+        })
+        .collect()
+}
+
 #[test]
 fn season_of_the_burrow_strict_parser_and_weighted_modal_text_regression() {
     let def = parse_oracle_card_definition("Season of the Burrow");
@@ -36653,6 +36678,114 @@ fn season_of_the_burrow_exile_mode_exiles_nonland_permanent_and_draws_for_contro
 }
 
 #[test]
+fn season_of_the_burrow_repeated_exile_modes_use_separate_target_slots() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let modal = season_of_the_burrow_modal_effect(&def).clone();
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Season of the Burrow should compile to spell effects")
+        .clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let first = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_712), "Bob's First Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let second = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_713), "Bob's Second Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    for idx in 0..2 {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(91_714 + idx), "Bob's Draw")
+                .card_types(vec![CardType::Creature])
+                .power_toughness(PowerToughness::fixed(1, 1))
+                .build(),
+            bob,
+            Zone::Library,
+        );
+    }
+
+    let chosen_modes = [1usize, 1usize];
+    assert!(
+        crate::game_loop::spell_program_has_legal_targets_with_modes(
+            &game,
+            &effects,
+            alice,
+            Some(source),
+            Some(&chosen_modes),
+        ),
+        "choosing Season's exile mode twice should be legal within the five {{P}} budget"
+    );
+    let requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        &effects,
+        alice,
+        Some(source),
+        Some(&chosen_modes),
+    );
+    assert_eq!(
+        requirements.len(),
+        2,
+        "repeated targeted modes should expose one target slot per selected mode instance"
+    );
+    for requirement in &requirements {
+        assert_eq!(requirement.min_targets, 1);
+        assert_eq!(requirement.max_targets, Some(1));
+        assert!(
+            requirement
+                .legal_targets
+                .contains(&crate::game_state::Target::Object(first))
+        );
+        assert!(
+            requirement
+                .legal_targets
+                .contains(&crate::game_state::Target::Object(second))
+        );
+    }
+
+    let selected_targets = vec![
+        crate::game_state::Target::Object(first),
+        crate::game_state::Target::Object(second),
+    ];
+    let assignments = target_assignments_for_requirements(&requirements, &selected_targets);
+    assert_eq!(assignments[0].range, 0..1);
+    assert_eq!(assignments[1].range, 1..2);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(chosen_modes.to_vec()))
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(first),
+            crate::effects::ResolvedTarget::Object(second),
+        ])
+        .with_target_assignments(assignments);
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Season of the Burrow repeated exile modes should resolve");
+
+    let exiled_names = game
+        .objects_in_zone(Zone::Exile)
+        .into_iter()
+        .filter_map(|id| game.object(id).map(|object| object.name.clone()))
+        .collect::<Vec<_>>();
+    assert!(exiled_names.contains(&"Bob's First Relic".to_string()));
+    assert!(exiled_names.contains(&"Bob's Second Relic".to_string()));
+    assert_eq!(game.player(bob).expect("Bob should exist").hand.len(), 2);
+}
+
+#[test]
 fn season_of_the_burrow_return_mode_returns_small_permanent_with_indestructible_counter() {
     let def = parse_oracle_card_definition("Season of the Burrow");
     let modal = season_of_the_burrow_modal_effect(&def).clone();
@@ -36696,6 +36829,115 @@ fn season_of_the_burrow_return_mode_returns_small_permanent_with_indestructible_
             .copied(),
         Some(1)
     );
+}
+
+#[test]
+fn season_of_the_burrow_return_and_exile_modes_keep_target_assignments_ordered() {
+    let def = parse_oracle_card_definition("Season of the Burrow");
+    let modal = season_of_the_burrow_modal_effect(&def).clone();
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Season of the Burrow should compile to spell effects")
+        .clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let graveyard_card = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_721), "Alice's Buried Keepsake")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let battlefield_card = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_722), "Bob's Exiled Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_723), "Bob's Draw")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        bob,
+        Zone::Library,
+    );
+
+    let chosen_modes = [2usize, 1usize];
+    assert!(
+        crate::game_loop::spell_program_has_legal_targets_with_modes(
+            &game,
+            &effects,
+            alice,
+            Some(source),
+            Some(&chosen_modes),
+        ),
+        "Season's return plus exile modes should be legal at exactly five {{P}}"
+    );
+    let requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        &effects,
+        alice,
+        Some(source),
+        Some(&chosen_modes),
+    );
+    assert_eq!(
+        requirements.len(),
+        2,
+        "return and exile modes should keep separate target slots in selected-mode order"
+    );
+
+    let selected_targets = vec![
+        crate::game_state::Target::Object(graveyard_card),
+        crate::game_state::Target::Object(battlefield_card),
+    ];
+    let assignments = target_assignments_for_requirements(&requirements, &selected_targets);
+    assert_eq!(assignments[0].range, 0..1);
+    assert_eq!(assignments[1].range, 1..2);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(chosen_modes.to_vec()))
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(graveyard_card),
+            crate::effects::ResolvedTarget::Object(battlefield_card),
+        ])
+        .with_target_assignments(assignments);
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Season of the Burrow return plus exile modes should resolve");
+
+    let returned_id = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Alice's Buried Keepsake")
+        })
+        .expect("returned permanent should be on the battlefield");
+    let returned = game.object(returned_id).expect("returned permanent should exist");
+    assert_eq!(returned.zone, Zone::Battlefield);
+    assert_eq!(
+        returned
+            .counters
+            .get(&crate::object::CounterType::Indestructible)
+            .copied(),
+        Some(1)
+    );
+    assert!(
+        game.objects_in_zone(Zone::Exile).into_iter().any(|id| game
+            .object(id)
+            .is_some_and(|object| object.name == "Bob's Exiled Relic")),
+        "exile mode should use the second selected target"
+    );
+    assert_eq!(game.player(bob).expect("Bob should exist").hand.len(), 1);
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29457,6 +29457,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             Some(&choose_mode.min_choose_count),
             Some(choose_mode.modes.len()),
         );
+        let has_weighted_modes = choose_mode
+            .mode_point_costs
+            .iter()
+            .any(|cost| *cost != 1);
+        if has_weighted_modes {
+            if let crate::effect::Value::Fixed(max) = &choose_mode.choose_count {
+                if choose_mode.min_choose_count == crate::effect::Value::Fixed(0) {
+                    let max_word = number_word(*max).unwrap_or_else(|| max.to_string());
+                    header = format!("Choose up to {max_word} {{P}} worth of modes —");
+                }
+            }
+        }
         if choose_mode.disallow_previously_chosen_modes {
             header = if choose_mode.disallow_previously_chosen_modes_this_turn {
                 "Choose one that hasn't been chosen this turn —".to_string()
@@ -29467,14 +29479,26 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         let modes = choose_mode
             .modes
             .iter()
-            .map(|mode| {
+            .enumerate()
+            .map(|(mode_idx, mode)| {
                 let description_raw = mode.description.trim();
+                let point_label = if has_weighted_modes {
+                    let cost = choose_mode
+                        .mode_point_costs
+                        .get(mode_idx)
+                        .copied()
+                        .unwrap_or(1)
+                        .max(1);
+                    Some(format!("{} — ", "{P}".repeat(cost as usize)))
+                } else {
+                    None
+                };
                 let description = ensure_trailing_period(description_raw);
                 let mode_effects = describe_effect_list(&mode.effects);
                 if !description.trim().is_empty() {
                     let mode_effects_trimmed = mode_effects.trim();
                     if mode_effects_trimmed.is_empty() {
-                        return description;
+                        return format!("{}{}", point_label.as_deref().unwrap_or(""), description);
                     }
 
                     let effects_lower = mode_effects_trimmed.to_ascii_lowercase();
@@ -29488,7 +29512,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                         && !description_lower.contains("choose one");
 
                     if !has_followup {
-                        return description;
+                        return format!("{}{}", point_label.as_deref().unwrap_or(""), description);
                     }
 
                     let mut followup = mode_effects_trimmed.to_string();
@@ -29507,16 +29531,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                         }
                     }
                     if followup.is_empty() {
-                        description
+                        format!("{}{}", point_label.as_deref().unwrap_or(""), description)
                     } else {
                         format!(
-                            "{} {}",
+                            "{}{} {}",
+                            point_label.as_deref().unwrap_or(""),
                             description_head,
                             ensure_trailing_period(followup.trim())
                         )
                     }
                 } else {
-                    ensure_trailing_period(mode_effects.trim())
+                    format!(
+                        "{}{}",
+                        point_label.as_deref().unwrap_or(""),
+                        ensure_trailing_period(mode_effects.trim())
+                    )
                 }
             })
             .collect::<Vec<_>>()

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -213,6 +213,7 @@ where
         converted.choose_count = payload.choose_count.clone();
         converted.min_choose_count = payload.min_choose_count.clone();
         converted.allow_repeated_modes = payload.allow_repeated_modes;
+        converted.mode_point_costs = payload.mode_point_costs.clone();
         converted.disallow_previously_chosen_modes = payload.disallow_previously_chosen_modes;
         converted.disallow_previously_chosen_modes_this_turn =
             payload.disallow_previously_chosen_modes_this_turn;

--- a/crates/ironsmith-runtime/src/effects/composition/choose_mode.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_mode.rs
@@ -38,6 +38,7 @@ impl EffectExecutor for ChooseModeEffect {
             max_modes: self.choose_count.clone(),
             min_modes: self.min_choose_count.clone(),
             allow_repeated_modes: self.allow_repeated_modes,
+            mode_point_costs: self.mode_point_costs.clone(),
         })
     }
 
@@ -47,6 +48,7 @@ impl EffectExecutor for ChooseModeEffect {
             max_modes: &self.choose_count,
             min_modes: &self.min_choose_count,
             allow_repeated_modes: self.allow_repeated_modes,
+            mode_point_costs: &self.mode_point_costs,
             disallow_previously_chosen_modes: self.disallow_previously_chosen_modes,
             disallow_previously_chosen_modes_this_turn: self
                 .disallow_previously_chosen_modes_this_turn,

--- a/crates/ironsmith-runtime/src/effects/composition/choose_mode_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_mode_runtime.rs
@@ -102,6 +102,22 @@ fn find_source_activated_ability_index(
     None
 }
 
+fn mode_point_cost(effect: &ChooseModeEffect, mode_idx: usize) -> usize {
+    effect
+        .mode_point_costs
+        .get(mode_idx)
+        .copied()
+        .unwrap_or(1)
+        .max(1) as usize
+}
+
+fn selected_mode_point_total(effect: &ChooseModeEffect, mode_indices: &[usize]) -> usize {
+    mode_indices
+        .iter()
+        .map(|idx| mode_point_cost(effect, *idx))
+        .sum()
+}
+
 fn active_target_assignments_for_inner_effect(
     game: &GameState,
     effect: &crate::effect::Effect,
@@ -213,6 +229,7 @@ pub(crate) fn run_choose_mode(
 
     // Filter to valid/legal indices while preserving selection order.
     let mut valid_chosen_indices: Vec<usize> = Vec::new();
+    let mut chosen_point_total = 0usize;
     for idx in chosen_indices {
         if !is_mode_legal(idx) {
             continue;
@@ -220,13 +237,18 @@ pub(crate) fn run_choose_mode(
         if !effect.allow_repeated_modes && valid_chosen_indices.contains(&idx) {
             continue;
         }
+        let point_cost = mode_point_cost(effect, idx);
+        if chosen_point_total.saturating_add(point_cost) > max_modes {
+            continue;
+        }
         valid_chosen_indices.push(idx);
-        if valid_chosen_indices.len() >= max_modes {
+        chosen_point_total += point_cost;
+        if chosen_point_total >= max_modes {
             break;
         }
     }
 
-    if valid_chosen_indices.len() < min_modes {
+    if selected_mode_point_total(effect, &valid_chosen_indices) < min_modes {
         return Err(ExecutionError::Impossible(
             "Not enough legal modes available".to_string(),
         ));

--- a/crates/ironsmith-runtime/src/effects/executor_trait.rs
+++ b/crates/ironsmith-runtime/src/effects/executor_trait.rs
@@ -28,6 +28,8 @@ pub struct ModalSpec {
     pub min_modes: Value,
     /// Whether the same mode can be chosen more than once.
     pub allow_repeated_modes: bool,
+    /// Point costs for weighted modal choices. Unweighted modes use one point each.
+    pub mode_point_costs: Vec<u32>,
 }
 
 /// The supported runtime extension categories for effects.
@@ -74,6 +76,7 @@ pub struct ModalEffectSpec<'a> {
     pub max_modes: &'a Value,
     pub min_modes: &'a Value,
     pub allow_repeated_modes: bool,
+    pub mode_point_costs: &'a [u32],
     pub disallow_previously_chosen_modes: bool,
     pub disallow_previously_chosen_modes_this_turn: bool,
 }

--- a/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
+++ b/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
@@ -713,6 +713,7 @@ fn choose_trigger_modes(
     }
 
     let mut valid = Vec::new();
+    let mut selected_point_total = 0usize;
     for idx in chosen {
         if !mode_is_legal_for_trigger(game, trigger, &effects, idx) {
             continue;
@@ -720,13 +721,23 @@ fn choose_trigger_modes(
         if !modal_spec.allow_repeated_modes && valid.contains(&idx) {
             continue;
         }
+        let point_cost = modal_spec
+            .mode_point_costs
+            .get(idx)
+            .copied()
+            .unwrap_or(1)
+            .max(1) as usize;
+        if selected_point_total.saturating_add(point_cost) > max_modes {
+            continue;
+        }
         valid.push(idx);
-        if valid.len() >= max_modes {
+        selected_point_total += point_cost;
+        if selected_point_total >= max_modes {
             break;
         }
     }
 
-    if valid.len() < min_modes {
+    if selected_point_total < min_modes {
         return None;
     }
 

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -769,6 +769,13 @@ fn modal_effect_has_legal_targets_internal_with_view(
                 return false;
             }
 
+            let point_cost = modal
+                .mode_point_costs
+                .get(*mode_idx)
+                .copied()
+                .unwrap_or(1)
+                .max(1) as usize;
+
             let mut mode_consumed_modal_selection = false;
             if !mode.effects.iter().all(|effect| {
                 spell_effect_has_legal_targets_internal_with_preview_mode_selection(
@@ -785,7 +792,7 @@ fn modal_effect_has_legal_targets_internal_with_view(
             }) {
                 return false;
             };
-            selected_count += 1;
+            selected_count += point_cost;
         }
 
         return if require_full_selection {

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -610,6 +610,14 @@ fn declare_target(profile: &ExtractedTarget<'_>, declared: &mut Vec<DeclaredTarg
     }
 }
 
+fn append_declared_targets_added_after(
+    base_len: usize,
+    declared: Vec<DeclaredTarget>,
+    added: &mut Vec<DeclaredTarget>,
+) {
+    added.extend(declared.into_iter().skip(base_len));
+}
+
 fn resolved_target_bounds(
     game: &GameState,
     profile: &ExtractedTarget<'_>,
@@ -759,6 +767,9 @@ fn modal_effect_has_legal_targets_internal_with_view(
     if let Some(chosen_modes) = chosen_modes {
         let mut selected_count = 0usize;
         let mut seen_modes = std::collections::HashSet::new();
+        let base_declared_targets = declared_targets.clone();
+        let base_declared_len = base_declared_targets.len();
+        let mut declared_targets_from_modes = Vec::new();
 
         for mode_idx in chosen_modes {
             let Some(mode) = modal.modes.get(*mode_idx) else {
@@ -777,6 +788,7 @@ fn modal_effect_has_legal_targets_internal_with_view(
                 .max(1) as usize;
 
             let mut mode_consumed_modal_selection = false;
+            let mut mode_declared_targets = base_declared_targets.clone();
             if !mode.effects.iter().all(|effect| {
                 spell_effect_has_legal_targets_internal_with_preview_mode_selection(
                     game,
@@ -785,21 +797,30 @@ fn modal_effect_has_legal_targets_internal_with_view(
                     source_id,
                     None,
                     &mut mode_consumed_modal_selection,
-                    declared_targets,
+                    &mut mode_declared_targets,
                     require_full_selection,
                     view,
                 )
             }) {
                 return false;
             };
+            append_declared_targets_added_after(
+                base_declared_len,
+                mode_declared_targets,
+                &mut declared_targets_from_modes,
+            );
             selected_count += point_cost;
         }
 
-        return if require_full_selection {
+        let valid_selection = if require_full_selection {
             selected_count >= min_modes && selected_count <= max_modes
         } else {
             selected_count <= max_modes
         };
+        if valid_selection {
+            declared_targets.extend(declared_targets_from_modes);
+        }
+        return valid_selection;
     }
 
     let legal_mode_count = modal
@@ -969,8 +990,12 @@ pub(super) fn extract_target_requirements_from_effect_internal(
             None
         };
         if let Some(chosen_modes) = modes_for_this_modal {
+            let base_declared_targets = declared_targets.clone();
+            let base_declared_len = base_declared_targets.len();
+            let mut declared_targets_from_modes = Vec::new();
             for mode_idx in chosen_modes {
                 if let Some(mode) = modal.modes.get(*mode_idx) {
+                    let mut mode_declared_targets = base_declared_targets.clone();
                     for inner in &mode.effects {
                         extract_target_requirements_from_effect_internal(
                             game,
@@ -979,12 +1004,18 @@ pub(super) fn extract_target_requirements_from_effect_internal(
                             source_id,
                             None,
                             consumed_modal_selection,
-                            declared_targets,
+                            &mut mode_declared_targets,
                             requirements,
                         );
                     }
+                    append_declared_targets_added_after(
+                        base_declared_len,
+                        mode_declared_targets,
+                        &mut declared_targets_from_modes,
+                    );
                 }
             }
+            declared_targets.extend(declared_targets_from_modes);
         }
         return;
     }
@@ -1279,24 +1310,35 @@ fn count_target_selection_slots_from_effect_internal(
             None
         };
 
-        return modes_for_this_modal
-            .into_iter()
-            .flatten()
-            .filter_map(|mode_idx| modal.modes.get(*mode_idx))
-            .map(|mode| {
-                mode.effects
-                    .iter()
-                    .map(|inner| {
-                        count_target_selection_slots_from_effect_internal(
-                            inner,
-                            None,
-                            consumed_modal_selection,
-                            declared_targets,
-                        )
-                    })
-                    .sum::<usize>()
-            })
-            .sum();
+        let base_declared_targets = declared_targets.clone();
+        let base_declared_len = base_declared_targets.len();
+        let mut declared_targets_from_modes = Vec::new();
+        let mut count = 0usize;
+        for mode_idx in modes_for_this_modal.into_iter().flatten() {
+            let Some(mode) = modal.modes.get(*mode_idx) else {
+                continue;
+            };
+            let mut mode_declared_targets = base_declared_targets.clone();
+            count += mode
+                .effects
+                .iter()
+                .map(|inner| {
+                    count_target_selection_slots_from_effect_internal(
+                        inner,
+                        None,
+                        consumed_modal_selection,
+                        &mut mode_declared_targets,
+                    )
+                })
+                .sum::<usize>();
+            append_declared_targets_added_after(
+                base_declared_len,
+                mode_declared_targets,
+                &mut declared_targets_from_modes,
+            );
+        }
+        declared_targets.extend(declared_targets_from_modes);
+        return count;
     }
 
     if let Some((first, second)) = exchange_control_target_specs(effect) {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Season of the Burrow
Initial parse error:
```
unsupported chosen object filter in choose clause (clause: 'choose up to five worth of modes'); oracle-only fallback also failed: unsupported chosen object filter in choose clause (clause: 'choose up to five worth of modes')
```

Current worker: i-0bae09cb67a4e76f4
Branch: codex/aws-card-fix-season-of-the-burrow
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0251
