### PR TITLE
Fix Ironsmith parse failure: Sauron's Ransom

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -884,6 +884,17 @@ impl Effect {
         ))
     }
 
+    pub fn look_at_top_cards_viewed_by(
+        player: crate::target::PlayerFilter,
+        viewer: crate::target::PlayerFilter,
+        count: Value,
+        tag: impl Into<crate::tag::TagKey>,
+    ) -> Self {
+        Self::new(crate::effects::LookAtTopCardsEffect::viewed_by(
+            player, viewer, count, tag,
+        ))
+    }
+
     pub fn reveal_top_cards(
         player: crate::target::PlayerFilter,
         count: Value,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1196,7 +1196,15 @@ fn compile_subject_verb_effect(
             ctx.last_player_filter = Some(player_filter);
             Ok((vec![Effect::new(choose)], subject.into_choices()))
         }
-        SubjectVerbActionAst::LookAtTopCards { count, tag, reveal } => {
+        SubjectVerbActionAst::LookAtTopCards {
+            count,
+            tag,
+            reveal,
+            viewer,
+        } => {
+            let viewer_filter = viewer
+                .map(|player| resolve_non_target_player_filter(player, &current_reference_env(ctx)))
+                .transpose()?;
             let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
             let player_filter = subject.clone_player_filter();
             let resolved_tag = if tag.as_str() == IT_TAG {
@@ -1210,6 +1218,13 @@ fn compile_subject_verb_effect(
             }
             let effect = if *reveal {
                 Effect::reveal_top_cards(player_filter, count.clone(), resolved_tag)
+            } else if let Some(viewer_filter) = viewer_filter {
+                Effect::look_at_top_cards_viewed_by(
+                    player_filter,
+                    viewer_filter,
+                    count.clone(),
+                    resolved_tag,
+                )
             } else {
                 Effect::look_at_top_cards(player_filter, count.clone(), resolved_tag)
             };

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -911,6 +911,7 @@ pub(crate) enum SubjectVerbActionAst {
         count: Value,
         tag: TagKey,
         reveal: bool,
+        viewer: Option<PlayerAst>,
     },
     PutIntoHand {
         object: ObjectRefAst,
@@ -2008,11 +2009,17 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("count_value", count_value)
                 .field("tag", tag)
                 .finish(),
-            Self::LookAtTopCards { count, tag, reveal } => f
+            Self::LookAtTopCards {
+                count,
+                tag,
+                reveal,
+                viewer,
+            } => f
                 .debug_struct("LookAtTopCards")
                 .field("count", count)
                 .field("tag", tag)
                 .field("reveal", reveal)
+                .field("viewer", viewer)
                 .finish(),
             Self::PutIntoHand { object } => f.debug_tuple("PutIntoHand").field(object).finish(),
             Self::MayMoveToZone { target, zone } => f
@@ -5310,7 +5317,16 @@ impl EffectAst {
         count: Value,
         tag: TagKey,
     ) -> Self {
-        Self::subject_verb_top_library_cards(player, count, tag, false)
+        Self::subject_verb_top_library_cards(player, None, count, tag, false)
+    }
+
+    pub(crate) fn subject_verb_look_at_top_cards_viewed_by(
+        player: PlayerAst,
+        viewer: PlayerAst,
+        count: Value,
+        tag: TagKey,
+    ) -> Self {
+        Self::subject_verb_top_library_cards(player, Some(viewer), count, tag, false)
     }
 
     pub(crate) fn subject_verb_reveal_top_cards(
@@ -5318,11 +5334,12 @@ impl EffectAst {
         count: Value,
         tag: TagKey,
     ) -> Self {
-        Self::subject_verb_top_library_cards(player, count, tag, true)
+        Self::subject_verb_top_library_cards(player, None, count, tag, true)
     }
 
     fn subject_verb_top_library_cards(
         player: PlayerAst,
+        viewer: Option<PlayerAst>,
         count: Value,
         tag: TagKey,
         reveal: bool,
@@ -5330,7 +5347,12 @@ impl EffectAst {
         Self::subject_verb(
             SubjectVerbRoleAst::LibraryOwner,
             player,
-            SubjectVerbActionAst::LookAtTopCards { count, tag, reveal },
+            SubjectVerbActionAst::LookAtTopCards {
+                count,
+                tag,
+                reveal,
+                viewer,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
@@ -128,7 +128,12 @@ pub(super) fn try_parse_divvy_sentence_sequence(
                 false,
                 0,
             ),
-            EffectAst::subject_verb_look_at_top_cards(PlayerAst::You, count, source_tag.clone()),
+            EffectAst::subject_verb_look_at_top_cards_viewed_by(
+                PlayerAst::You,
+                PlayerAst::That,
+                count,
+                source_tag.clone(),
+            ),
             EffectAst::ChooseObjectsAcrossZones {
                 filter: ObjectFilter::tagged(source_tag.clone()),
                 count: ChoiceCount::any_number(),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
@@ -1,5 +1,6 @@
 use super::super::grammar::primitives::TokenWordView;
 use super::super::lexer::{OwnedLexToken, split_lexed_sentences};
+use super::super::util::parse_value;
 use super::dispatch_entry::SentenceInput;
 use super::dispatch_inner::parse_effect_sentence_lexed;
 use crate::cards::builders::{
@@ -61,6 +62,27 @@ fn sentence_has_phrase(sentence_words: &[TokenWordView<'_>], phrase: &[&str]) ->
     sentence_words.iter().any(|words| words.has_phrase(phrase))
 }
 
+fn parse_top_library_count(tokens: &[OwnedLexToken]) -> Result<Value, CardTextError> {
+    let Some(top_idx) = tokens.iter().position(|token| token.is_word("top")) else {
+        return Err(CardTextError::ParseError(
+            "missing top-library pile count".to_string(),
+        ));
+    };
+    let (count, used) = parse_value(&tokens[top_idx + 1..]).ok_or_else(|| {
+        CardTextError::ParseError("missing top-library pile count".to_string())
+    })?;
+    let card_idx = top_idx + 1 + used;
+    if !tokens
+        .get(card_idx)
+        .is_some_and(|token| token.is_word("card") || token.is_word("cards"))
+    {
+        return Err(CardTextError::ParseError(
+            "missing top-library pile card noun".to_string(),
+        ));
+    }
+    Ok(count)
+}
+
 pub(super) fn try_parse_divvy_sentence_sequence(
     sentences: &[SentenceInput],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
@@ -68,6 +90,113 @@ pub(super) fn try_parse_divvy_sentence_sequence(
         .iter()
         .map(|sentence| TokenWordView::new(sentence.lowered()))
         .collect::<Vec<_>>();
+
+    if sentences.len() >= 3
+        && matches_sentence(&sentence_words[0], &["choose", "an", "opponent"])
+        && sentence_words[1].starts_with(&["they", "look", "at", "the", "top"])
+        && sentence_words[1].has_phrase(&["of", "your", "library"])
+        && sentence_words[1].has_phrase(&[
+            "separate", "them", "into", "a", "face", "down", "pile", "and", "a", "face",
+            "up", "pile",
+        ])
+        && matches_sentence(
+            &sentence_words[2],
+            &[
+                "put",
+                "one",
+                "pile",
+                "into",
+                "your",
+                "hand",
+                "and",
+                "the",
+                "other",
+                "into",
+                "your",
+                "graveyard",
+            ],
+        )
+    {
+        let source_tag = TagKey::from("divvy_source");
+        let pile_tag = TagKey::from("divvy_pile");
+        let count = parse_top_library_count(sentences[1].lowered())?;
+        let mut effects = vec![
+            EffectAst::subject_verb_choose_player(
+                PlayerAst::Implicit,
+                PlayerFilter::Opponent,
+                TagKey::from("divvy_opponent"),
+                false,
+                0,
+            ),
+            EffectAst::subject_verb_look_at_top_cards(PlayerAst::You, count, source_tag.clone()),
+            EffectAst::ChooseObjectsAcrossZones {
+                filter: ObjectFilter::tagged(source_tag.clone()),
+                count: ChoiceCount::any_number(),
+                count_value: None,
+                player: PlayerAst::That,
+                tag: pile_tag.clone(),
+                zones: vec![Zone::Library],
+                search_mode: None,
+            },
+            EffectAst::UnlessAction {
+                player: PlayerAst::You,
+                effects: vec![
+                    EffectAst::subject_verb_move_to_zone(
+                        TargetAst::Tagged(pile_tag.clone(), None),
+                        Zone::Graveyard,
+                        false,
+                        ReturnControllerAst::Preserve,
+                        false,
+                        None,
+                    ),
+                    EffectAst::ForEachTagged {
+                        tag: source_tag.clone(),
+                        effects: vec![EffectAst::Conditional {
+                            predicate: membership_predicate_for_iterated_object(pile_tag.as_str()),
+                            if_true: Vec::new(),
+                            if_false: vec![EffectAst::subject_verb_move_to_zone(
+                                TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                                Zone::Hand,
+                                false,
+                                ReturnControllerAst::Preserve,
+                                false,
+                                None,
+                            )],
+                        }],
+                    },
+                ],
+                alternative: vec![
+                    EffectAst::subject_verb_move_to_zone(
+                        TargetAst::Tagged(pile_tag.clone(), None),
+                        Zone::Hand,
+                        false,
+                        ReturnControllerAst::Preserve,
+                        false,
+                        None,
+                    ),
+                    EffectAst::ForEachTagged {
+                        tag: source_tag.clone(),
+                        effects: vec![EffectAst::Conditional {
+                            predicate: membership_predicate_for_iterated_object(pile_tag.as_str()),
+                            if_true: Vec::new(),
+                            if_false: vec![EffectAst::subject_verb_move_to_zone(
+                                TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                                Zone::Graveyard,
+                                false,
+                                ReturnControllerAst::Preserve,
+                                false,
+                                None,
+                            )],
+                        }],
+                    },
+                ],
+            },
+        ];
+        for sentence in sentences.iter().skip(3) {
+            effects.extend(parse_effect_sentence_lexed(sentence.lowered())?);
+        }
+        return Ok(Some(effects));
+    }
 
     if sentences.len() == 1 {
         let words = TokenWordView::new(sentences[0].lowered());

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -5414,6 +5414,7 @@ impl MayMoveToZoneEffect {
 #[derive(Debug, Clone, PartialEq)]
 pub struct LookAtTopCardsEffect {
     pub player: PlayerFilter,
+    pub viewer: PlayerFilter,
     pub count: Value,
     pub tag: TagKey,
     pub reveal: bool,
@@ -5421,8 +5422,18 @@ pub struct LookAtTopCardsEffect {
 
 impl LookAtTopCardsEffect {
     pub fn new(player: PlayerFilter, count: impl Into<Value>, tag: impl Into<TagKey>) -> Self {
+        Self::viewed_by(player.clone(), player, count, tag)
+    }
+
+    pub fn viewed_by(
+        player: PlayerFilter,
+        viewer: PlayerFilter,
+        count: impl Into<Value>,
+        tag: impl Into<TagKey>,
+    ) -> Self {
         Self {
             player,
+            viewer,
             count: count.into(),
             tag: tag.into(),
             reveal: false,
@@ -5435,7 +5446,8 @@ impl LookAtTopCardsEffect {
         tag: impl Into<TagKey>,
     ) -> Self {
         Self {
-            player,
+            player: player.clone(),
+            viewer: player,
             count: count.into(),
             tag: tag.into(),
             reveal: true,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32135,6 +32135,33 @@ fn parse_split_the_spoils_divvy_uses_splitter_then_opponent_choice() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_saurons_ransom_face_pile_regression() {
+    let def = parse_oracle_card_definition("Sauron's Ransom");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains(
+            "Choose an opponent. They look at the top four cards of your library and separate \
+             them into a face-down pile and a face-up pile. Put one pile into your hand and the \
+             other into your graveyard."
+        ),
+        "expected Sauron's Ransom to render the opponent face-pile clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("The Ring tempts you"),
+        "expected Sauron's Ransom to keep the Ring temptation tail, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(debug.contains("ChoosePlayerEffect"), "{debug}");
+    assert!(debug.contains("LookAtTopCardsEffect"), "{debug}");
+    assert!(debug.contains("ChooseObjectsEffect"), "{debug}");
+    assert!(debug.contains("UnlessActionEffect"), "{debug}");
+    assert!(debug.contains("RingTemptsYouEffect"), "{debug}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn render_make_an_example_preserves_choose_then_sacrifice_surface() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Make an Example")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32155,6 +32155,10 @@ fn parse_oracle_saurons_ransom_face_pile_regression() {
     let debug = format!("{:#?}", def.spell_effect);
     assert!(debug.contains("ChoosePlayerEffect"), "{debug}");
     assert!(debug.contains("LookAtTopCardsEffect"), "{debug}");
+    assert!(
+        debug.contains("viewer: TaggedPlayer(") && debug.contains("divvy_opponent"),
+        "expected the chosen opponent to view the hidden library cards, got {debug}"
+    );
     assert!(debug.contains("ChooseObjectsEffect"), "{debug}");
     assert!(debug.contains("UnlessActionEffect"), "{debug}");
     assert!(debug.contains("RingTemptsYouEffect"), "{debug}");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -6260,6 +6260,7 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             || choose_player.filter != PlayerFilter::Opponent
             || choose_player.random
             || look.player != PlayerFilter::You
+            || look.viewer != chosen_opponent
             || look.tag.as_str() != "divvy_source"
             || choose.tag.as_str() != "divvy_pile"
             || choose.chooser != chosen_opponent

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -6244,6 +6244,70 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         ))
     }
 
+    fn describe_library_face_pile_choice_bundle(filtered: &[&Effect]) -> Option<String> {
+        let [choose_player_effect, look_effect, choose_effect, unless_effect] = filtered else {
+            return None;
+        };
+
+        let choose_player = choose_player_effect
+            .downcast_ref::<crate::effects::ChoosePlayerEffect>()?;
+        let look = look_effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+        let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+        let unless_action = unless_effect.downcast_ref::<crate::effects::UnlessActionEffect>()?;
+        let chosen_opponent = PlayerFilter::TaggedPlayer(choose_player.tag.clone());
+
+        if choose_player.chooser != PlayerFilter::You
+            || choose_player.filter != PlayerFilter::Opponent
+            || choose_player.random
+            || look.player != PlayerFilter::You
+            || look.tag.as_str() != "divvy_source"
+            || choose.tag.as_str() != "divvy_pile"
+            || choose.chooser != chosen_opponent
+            || choose_primary_zone(choose) != Some(Zone::Library)
+            || choose.is_search
+            || !choose.count.is_any_number()
+            || !filter_is_tagged_as(&choose.filter, look.tag.as_str())
+            || unless_action.player != PlayerFilter::You
+        {
+            return None;
+        }
+
+        let [main_selected, main_rest] = unless_action.effects.as_slice() else {
+            return None;
+        };
+        let [alt_selected, alt_rest] = unless_action.alternative.as_slice() else {
+            return None;
+        };
+        let main_selected = downcast_move_to_zone(main_selected)?;
+        let alt_selected = downcast_move_to_zone(alt_selected)?;
+        let (_, main_rest) = for_each_tagged_for_compaction(main_rest)?;
+        let (_, alt_rest) = for_each_tagged_for_compaction(alt_rest)?;
+
+        if !move_to_zone_uses_tag(main_selected, choose.tag.as_str(), Zone::Graveyard)
+            || !move_to_zone_uses_tag(alt_selected, choose.tag.as_str(), Zone::Hand)
+            || !for_each_moves_unselected_to_zone(
+                main_rest,
+                look.tag.as_str(),
+                choose.tag.as_str(),
+                Zone::Hand,
+            )
+            || !for_each_moves_unselected_to_zone(
+                alt_rest,
+                look.tag.as_str(),
+                choose.tag.as_str(),
+                Zone::Graveyard,
+            )
+        {
+            return None;
+        }
+
+        let (count_text, noun, count_where_clause) =
+            describe_top_count_noun_and_where_clause(&look.count);
+        Some(format!(
+            "Choose an opponent. They look at the top {count_text} {noun} of your library{count_where_clause} and separate them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard"
+        ))
+    }
+
     fn filter_has_not_tagged_constraint(filter: &ObjectFilter, tag: &str) -> bool {
         filter.tagged_constraints.iter().any(|constraint| {
             constraint.relation == crate::filter::TaggedOpbjectRelation::IsNotTaggedObject
@@ -10777,6 +10841,14 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         if idx + 3 < filtered.len()
             && let Some(rendered) =
                 describe_exile_split_pile_opponent_choice_bundle(&filtered[idx..idx + 4])
+        {
+            parts.push(rendered);
+            idx += 4;
+            continue;
+        }
+        if idx + 3 < filtered.len()
+            && let Some(rendered) =
+                describe_library_face_pile_choice_bundle(&filtered[idx..idx + 4])
         {
             parts.push(rendered);
             idx += 4;

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -3809,6 +3809,17 @@ impl Effect {
         Self::new(LookAtTopCardsEffect::new(player, count, tag))
     }
 
+    /// Create a "look at the top N cards" effect with separate library owner and viewer.
+    pub fn look_at_top_cards_viewed_by(
+        player: PlayerFilter,
+        viewer: PlayerFilter,
+        count: impl Into<Value>,
+        tag: impl Into<TagKey>,
+    ) -> Self {
+        use crate::effects::LookAtTopCardsEffect;
+        Self::new(LookAtTopCardsEffect::viewed_by(player, viewer, count, tag))
+    }
+
     /// Create a "reveal the top N cards" effect, tagging the revealed cards.
     pub fn reveal_top_cards(
         player: PlayerFilter,

--- a/crates/ironsmith-runtime/src/effects/cards/look_at_top.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/look_at_top.rs
@@ -58,16 +58,17 @@ impl EffectExecutor for LookAtTopCardsEffect {
                     .view_cards(game, viewer, &top_cards, &view_ctx);
             }
         } else {
+            let viewer_id = resolve_player_filter(game, &self.viewer, ctx)?;
             let view_ctx = ViewCardsContext::new(
-                ctx.controller,
+                viewer_id,
                 player_id,
                 Some(ctx.source),
                 crate::zone::Zone::Library,
                 "Look at cards from the top of a library",
             );
             ctx.decision_maker
-                .view_cards(game, ctx.controller, &top_cards, &view_ctx);
-            ctx.remember_face_down_exile_viewers(&top_cards, ctx.controller);
+                .view_cards(game, viewer_id, &top_cards, &view_ctx);
+            ctx.remember_face_down_exile_viewers(&top_cards, viewer_id);
             ctx.set_tagged_objects(self.tag.clone(), snapshots.clone());
         }
 
@@ -300,5 +301,41 @@ mod tests {
         assert_eq!(call.zone, Zone::Library);
         assert!(!call.public);
         assert_eq!(call.cards.len(), 2);
+    }
+
+    #[test]
+    fn look_at_top_can_view_another_players_library() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = game.new_object_id();
+        add_cards_to_library(&mut game, alice, 4);
+
+        let mut dm = CaptureViewDm::default();
+        let mut ctx = ExecutionContext::new(source, alice, &mut dm);
+        let effect = LookAtTopCardsEffect::viewed_by(
+            PlayerFilter::You,
+            PlayerFilter::Opponent,
+            2,
+            "looked",
+        );
+        effect
+            .execute(&mut game, &mut ctx)
+            .expect("execute look-at-top");
+
+        let tagged_count = ctx
+            .tagged_objects
+            .get(&TagKey::from("looked"))
+            .map(|snapshots| snapshots.len());
+        drop(ctx);
+
+        assert_eq!(dm.calls.len(), 1);
+        let call = &dm.calls[0];
+        assert_eq!(call.viewer, bob);
+        assert_eq!(call.subject, alice);
+        assert_eq!(call.zone, Zone::Library);
+        assert!(!call.public);
+        assert_eq!(call.cards.len(), 2);
+        assert_eq!(tagged_count, Some(2));
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -24354,13 +24354,15 @@ fn run_saurons_ransom_face_pile_resolution(
     expected_graveyard_names: &[&str],
 ) {
     use crate::decision::DecisionMaker;
-    use crate::decisions::context::SelectObjectsContext;
+    use crate::decisions::context::{SelectObjectsContext, ViewCardsContext};
     use crate::effects::{ExecutionContext, execute_effect};
 
     struct SauronsRansomDecisionMaker {
+        library_owner: PlayerId,
         opponent: PlayerId,
         split_names: &'static [&'static str],
         keep_opponent_pile: bool,
+        saw_opponent_view: bool,
     }
 
     impl DecisionMaker for SauronsRansomDecisionMaker {
@@ -24408,6 +24410,27 @@ fn run_saurons_ransom_face_pile_resolution(
                 .map(|candidate| vec![candidate.id])
                 .unwrap_or_default()
         }
+
+        fn view_cards(
+            &mut self,
+            _game: &GameState,
+            viewer: PlayerId,
+            cards: &[ObjectId],
+            ctx: &ViewCardsContext,
+        ) {
+            assert_eq!(
+                viewer, self.opponent,
+                "the chosen opponent should view the hidden library cards"
+            );
+            assert_eq!(
+                ctx.subject, self.library_owner,
+                "the viewed cards should come from the caster's library"
+            );
+            assert_eq!(ctx.zone, Zone::Library);
+            assert!(!ctx.public);
+            assert_eq!(cards.len(), 4);
+            self.saw_opponent_view = true;
+        }
     }
 
     let mut game = setup_game();
@@ -24449,9 +24472,11 @@ fn run_saurons_ransom_face_pile_resolution(
         .as_ref()
         .expect("Sauron's Ransom should have spell effects");
     let mut dm = SauronsRansomDecisionMaker {
+        library_owner: alice,
         opponent: bob,
         split_names: &["Ransom Alpha", "Ransom Beta"],
         keep_opponent_pile,
+        saw_opponent_view: false,
     };
     let mut ctx = ExecutionContext::new_default(source_id, alice).with_decision_maker(&mut dm);
 
@@ -24459,6 +24484,11 @@ fn run_saurons_ransom_face_pile_resolution(
         execute_effect(&mut game, effect, &mut ctx)
             .expect("Sauron's Ransom effect should resolve");
     }
+    drop(ctx);
+    assert!(
+        dm.saw_opponent_view,
+        "Sauron's Ransom should let the chosen opponent privately view the caster's top cards"
+    );
 
     let alice_hand = game.player(alice).expect("alice exists").hand.clone();
     let alice_graveyard = game.player(alice).expect("alice exists").graveyard.clone();

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -24347,6 +24347,171 @@ fn test_split_the_spoils_opponent_can_take_the_other_pile_into_hand() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn run_saurons_ransom_face_pile_resolution(
+    keep_opponent_pile: bool,
+    expected_hand_names: &[&str],
+    expected_graveyard_names: &[&str],
+) {
+    use crate::decision::DecisionMaker;
+    use crate::decisions::context::SelectObjectsContext;
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    struct SauronsRansomDecisionMaker {
+        opponent: PlayerId,
+        split_names: &'static [&'static str],
+        keep_opponent_pile: bool,
+    }
+
+    impl DecisionMaker for SauronsRansomDecisionMaker {
+        fn decide_boolean(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            self.keep_opponent_pile
+        }
+
+        fn decide_objects(
+            &mut self,
+            game: &GameState,
+            ctx: &SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            let legal = ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .collect::<Vec<_>>();
+            let split_selection = self
+                .split_names
+                .iter()
+                .filter_map(|wanted_name| {
+                    legal
+                        .iter()
+                        .find(|candidate| {
+                            game.object(candidate.id)
+                                .is_some_and(|object| object.name == *wanted_name)
+                        })
+                        .map(|candidate| candidate.id)
+                })
+                .collect::<Vec<_>>();
+
+            if split_selection.len() == self.split_names.len() {
+                assert_eq!(
+                    ctx.player, self.opponent,
+                    "the chosen opponent should separate the library cards into piles"
+                );
+                return split_selection;
+            }
+
+            legal.first()
+                .map(|candidate| vec![candidate.id])
+                .unwrap_or_default()
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let saurons_ransom = CardDefinitionBuilder::new(CardId::from_raw(91_130), "Sauron's Ransom")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Choose an opponent. They look at the top four cards of your library and separate them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard. The Ring tempts you.",
+        )
+        .expect("Sauron's Ransom should parse");
+
+    let source_id = game.create_object_from_definition(&saurons_ransom, alice, Zone::Stack);
+    let bearer = CardBuilder::new(CardId::from_raw(91_131), "Ransom Ring-bearer")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let bearer_id = game.create_object_from_card(&bearer, alice, Zone::Battlefield);
+    for (idx, name) in [
+        "Ransom Bottom",
+        "Ransom Alpha",
+        "Ransom Beta",
+        "Ransom Gamma",
+        "Ransom Delta",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let card = CardBuilder::new(CardId::from_raw(91_140 + idx as u32), *name).build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+
+    let spell_effects = saurons_ransom
+        .spell_effect
+        .as_ref()
+        .expect("Sauron's Ransom should have spell effects");
+    let mut dm = SauronsRansomDecisionMaker {
+        opponent: bob,
+        split_names: &["Ransom Alpha", "Ransom Beta"],
+        keep_opponent_pile,
+    };
+    let mut ctx = ExecutionContext::new_default(source_id, alice).with_decision_maker(&mut dm);
+
+    for effect in spell_effects {
+        execute_effect(&mut game, effect, &mut ctx)
+            .expect("Sauron's Ransom effect should resolve");
+    }
+
+    let alice_hand = game.player(alice).expect("alice exists").hand.clone();
+    let alice_graveyard = game.player(alice).expect("alice exists").graveyard.clone();
+    for expected in expected_hand_names {
+        assert!(
+            alice_hand.iter().any(|&id| game
+                .object(id)
+                .is_some_and(|object| object.name == *expected)),
+            "expected {expected} in Alice's hand"
+        );
+    }
+    for expected in expected_graveyard_names {
+        assert!(
+            alice_graveyard.iter().any(|&id| game
+                .object(id)
+                .is_some_and(|object| object.name == *expected)),
+            "expected {expected} in Alice's graveyard"
+        );
+    }
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .library
+            .iter()
+            .any(|&id| game
+                .object(id)
+                .is_some_and(|object| object.name == "Ransom Bottom")),
+        "the fifth library card should stay in the library"
+    );
+    assert_eq!(game.ring_temptations(alice), 1);
+    assert_eq!(game.current_ring_bearer(alice), Some(bearer_id));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_saurons_ransom_can_put_opponents_face_pile_into_hand() {
+    run_saurons_ransom_face_pile_resolution(
+        true,
+        &["Ransom Alpha", "Ransom Beta"],
+        &["Ransom Gamma", "Ransom Delta"],
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_saurons_ransom_can_put_the_other_face_pile_into_hand() {
+    run_saurons_ransom_face_pile_resolution(
+        false,
+        &["Ransom Gamma", "Ransom Delta"],
+        &["Ransom Alpha", "Ransom Beta"],
+    );
+}
+
 #[test]
 fn test_dash_grants_haste_and_returns_to_hand_at_next_end_step() {
     use crate::cards::CardDefinitionBuilder;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sauron's Ransom
Initial parse error:
```
unsupported trailing look clause (clause: 'the top four cards of your library and separate them into a face down pile and a face up pile'); oracle-only fallback also failed: unsupported trailing look clause (clause: 'the top four cards of your library and separate them into a face down pile and a face up pile')
```

Current worker: i-093d95496870b1824
Branch: codex/aws-card-fix-sauron-s-ransom
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0252
