### PR TITLE
Fix Ironsmith parse failure: Cho-Arrim Alchemist

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1456,6 +1456,7 @@ fn compile_subject_verb_effect(
             source,
             target,
             reflect_damage_to_source_controller,
+            follow_up_effects,
         } => {
             let source_spec = match source {
                 PreventNextTimeDamageSourceAst::Choice => {
@@ -1480,10 +1481,25 @@ fn compile_subject_verb_effect(
                 source_spec,
                 target_spec,
             );
+            let (follow_up_effects, follow_up_choices) = if follow_up_effects.is_empty() {
+                (Vec::new(), Vec::new())
+            } else {
+                let mut follow_up_ctx = EffectLoweringContext::from_parts(
+                    ctx.id_gen_context(),
+                    ctx.lowering_frame(),
+                );
+                follow_up_ctx.allow_life_event_value = true;
+                let compiled = compile_effects(follow_up_effects, &mut follow_up_ctx)?;
+                ctx.apply_id_gen_context(follow_up_ctx.id_gen_context());
+                compiled
+            };
+            if !follow_up_effects.is_empty() {
+                effect = effect.with_follow_up_effects(follow_up_effects);
+            }
             if *reflect_damage_to_source_controller {
                 effect = effect.reflecting_to_source_controller();
             }
-            Ok((vec![Effect::new(effect)], Vec::new()))
+            Ok((vec![Effect::new(effect)], follow_up_choices))
         }
         SubjectVerbActionAst::PreventDamage {
             amount,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -972,6 +972,7 @@ pub(crate) enum SubjectVerbActionAst {
         source: PreventNextTimeDamageSourceAst,
         target: PreventNextTimeDamageTargetAst,
         reflect_damage_to_source_controller: bool,
+        follow_up_effects: Vec<EffectAst>,
     },
     PreventDamage {
         amount: Value,
@@ -2094,6 +2095,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 source,
                 target,
                 reflect_damage_to_source_controller,
+                follow_up_effects,
             } => f
                 .debug_struct("PreventNextTimeDamage")
                 .field("source", source)
@@ -2102,6 +2104,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                     "reflect_damage_to_source_controller",
                     reflect_damage_to_source_controller,
                 )
+                .field("follow_up_effects", follow_up_effects)
                 .finish(),
             Self::PreventDamage {
                 amount,
@@ -3475,6 +3478,7 @@ impl EffectAst {
                 source,
                 target,
                 reflect_damage_to_source_controller,
+                follow_up_effects: Vec::new(),
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
@@ -8,7 +8,7 @@ use crate::cards::builders::{
     PredicateAst, ReturnControllerAst, SubjectVerbActionAst, SubjectVerbEffectAst,
     SubjectVerbRoleAst, SubjectVerbSubjectAst, TagKey, TargetAst,
 };
-use crate::effect::Value;
+use crate::effect::{EventValueSpec, Value};
 use crate::mana::ManaSymbol;
 use crate::object::CounterType;
 use crate::runtime_backend::effect_sentences;
@@ -455,6 +455,60 @@ pub(crate) fn parse_damage_prevention_counter_sequence(
             CounterType::PlusOnePlusOne,
         ),
     ]))
+}
+
+pub(crate) fn parse_next_damage_prevention_gain_life_sequence(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Ok(mut first_effects) =
+        effect_sentences::parse_effect_sentence_lexed(sentences[sentence_idx].lowered())
+    else {
+        return Ok(None);
+    };
+    let [first_effect] = first_effects.as_mut_slice() else {
+        return Ok(None);
+    };
+
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action:
+            SubjectVerbActionAst::PreventNextTimeDamage {
+                follow_up_effects,
+                ..
+            },
+        ..
+    }) = first_effect
+    else {
+        return Ok(None);
+    };
+    if !follow_up_effects.is_empty() {
+        return Ok(None);
+    }
+
+    let Ok(second_effects) =
+        effect_sentences::parse_effect_sentence_lexed(sentences[sentence_idx + 1].lowered())
+    else {
+        return Ok(None);
+    };
+    let [second_effect] = second_effects.as_slice() else {
+        return Ok(None);
+    };
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        subject: SubjectVerbSubjectAst {
+            player: PlayerAst::You,
+            ..
+        },
+        action: SubjectVerbActionAst::GainLife { amount },
+    }) = second_effect
+    else {
+        return Ok(None);
+    };
+    if !matches!(amount, Value::EventValue(EventValueSpec::Amount)) {
+        return Ok(None);
+    }
+
+    follow_up_effects.push(second_effect.clone());
+    Ok(Some(first_effects))
 }
 
 const THEY_DONT_UNTAP_DURING_PREFIXES: &[&[&str]] = &[

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -113,6 +113,10 @@ fn first_word_prevent(sentences: &[SentenceInput], sentence_idx: usize) -> bool 
     sentence_head_word_is(sentences, sentence_idx, "prevent")
 }
 
+fn first_word_the(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
+    sentence_head_word_is(sentences, sentence_idx, "the")
+}
+
 fn first_word_tap(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
     sentence_head_word_is(sentences, sentence_idx, "tap")
 }
@@ -458,6 +462,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         consumed_sentences: 2,
         predicate: first_word_prevent,
         parser: generic_subject_verb_sequences::parse_damage_prevention_counter_sequence,
+    },
+    SequenceRuleDef {
+        name: "next-damage-prevention-then-gain-prevented-life",
+        feature_tag: Some("damage-prevention-followup"),
+        priority: 240,
+        consumed_sentences: 2,
+        predicate: first_word_the,
+        parser: generic_subject_verb_sequences::parse_next_damage_prevention_gain_life_sequence,
     },
     SequenceRuleDef {
         name: "tap-all-then-they-dont-untap-while-source-tapped",

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -763,6 +763,17 @@ pub(crate) fn parse_life_equal_to_value(
     }
     if matches!(
         amount_words.as_slice(),
+        ["equal", "to", "the", "damage", "prevented", "this", "way"]
+            | ["equal", "to", "damage", "prevented", "this", "way"]
+            | [
+                "equal", "to", "the", "amount", "of", "damage", "prevented", "this", "way"
+            ]
+            | ["equal", "to", "amount", "of", "damage", "prevented", "this", "way"]
+    ) {
+        return Ok(Some(Value::EventValue(EventValueSpec::Amount)));
+    }
+    if matches!(
+        amount_words.as_slice(),
         [
             "equal", "to", "the", "total", "life", "lost", "by", "all", "players", "this",
             "turn"

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3379,19 +3379,26 @@ impl<E> PreventAllDamageToTargetEffect<E> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct PreventNextTimeDamageEffect {
+pub struct PreventNextTimeDamageEffect<E = ()> {
     pub source: PreventNextTimeDamageSource,
     pub target: PreventNextTimeDamageTarget,
     pub reflect_damage_to_source_controller: bool,
+    pub follow_up_effects: Vec<E>,
 }
 
-impl PreventNextTimeDamageEffect {
+impl<E> PreventNextTimeDamageEffect<E> {
     pub fn new(source: PreventNextTimeDamageSource, target: PreventNextTimeDamageTarget) -> Self {
         Self {
             source,
             target,
             reflect_damage_to_source_controller: false,
+            follow_up_effects: Vec::new(),
         }
+    }
+
+    pub fn with_follow_up_effects(mut self, effects: Vec<E>) -> Self {
+        self.follow_up_effects = effects;
+        self
     }
 
     pub fn reflecting_to_source_controller(mut self) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -15429,6 +15429,167 @@ fn healing_grace_runtime_only_protects_chosen_target() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_cho_arrim_alchemist_strict_text_and_activation_shape() {
+    assert_oracle_card_parses_strict("Cho-Arrim Alchemist");
+    let def = parse_oracle_card_definition("Cho-Arrim Alchemist");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Cho-Arrim Alchemist should have an activated ability");
+    let debug = format!("{activated:#?}");
+    assert!(
+        debug.contains("PreventNextTimeDamageEffect")
+            && debug.contains("GainLifeEffect")
+            && debug.contains("EventValue")
+            && debug.contains("Amount"),
+        "expected activated ability to prevent next damage and gain prevented amount as life, got {debug}"
+    );
+    assert!(
+        debug.contains("Tap") && debug.contains("Discard") && debug.contains("White"),
+        "expected activation costs to include white mana, tap, and discard, got {debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("The next time a source of your choice would deal damage to you this turn, prevent that damage")
+            && rendered.contains("You gain life equal to the damage prevented this way"),
+        "expected Cho-Arrim Alchemist prevention/life text to compile, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported"),
+        "Cho-Arrim Alchemist should parse strictly without unsupported markers, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cho_arrim_alchemist_runtime_prevents_chosen_source_to_you_and_gains_that_life() {
+    struct ChooseNamedSourceDecisionMaker {
+        source_name: &'static str,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseNamedSourceDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            if let Some(chosen) = ctx.candidates.iter().find_map(|candidate| {
+                if !candidate.legal {
+                    return None;
+                }
+                game.object(candidate.id)
+                    .is_some_and(|object| object.name == self.source_name)
+                    .then_some(candidate.id)
+            }) {
+                vec![chosen]
+            } else {
+                crate::decision::AutoPassDecisionMaker.decide_objects(game, ctx)
+            }
+        }
+    }
+
+    let def = parse_oracle_card_definition("Cho-Arrim Alchemist");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Cho-Arrim Alchemist should have an activated ability");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let alchemist_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let chosen_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_103), "Chosen Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let other_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_104), "Other Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let mut dm = ChooseNamedSourceDecisionMaker {
+        source_name: "Chosen Damage Source",
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(alchemist_id, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        alchemist_id,
+        &activated.effects,
+        None,
+        &[],
+    )
+    .expect("Cho-Arrim Alchemist ability should resolve");
+
+    let (wrong_player_damage, wrong_player_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            chosen_source,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(wrong_player_damage, 3, "damage to Bob should not be prevented");
+    assert!(!wrong_player_prevented, "the shield only protects Alice");
+    assert_eq!(game.life_total(alice), 20, "nonmatching damage should not gain life");
+
+    let (other_source_damage, other_source_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            other_source,
+            crate::events::DamageTarget::Player(alice),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        other_source_damage, 3,
+        "damage from an unchosen source should not be prevented"
+    );
+    assert!(!other_source_prevented, "unchosen source should not consume the shield");
+    assert_eq!(game.life_total(alice), 20, "unchosen source should not gain life");
+
+    let (prevented_damage, prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        chosen_source,
+        crate::events::DamageTarget::Player(alice),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        prevented_damage, 0,
+        "chosen source damage to Alice should be prevented"
+    );
+    assert!(prevented, "the matching damage event should be replaced");
+    assert_eq!(
+        game.life_total(alice),
+        24,
+        "Alice should gain life equal to the damage prevented this way"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_target_opponent_chooses_creature_then_other_cant_block() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Eunuchs Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -174,6 +174,22 @@ fn prevention_put_counters_follow_up(
     Some(put)
 }
 
+fn prevention_gain_life_follow_up(
+    follow_up_effects: &[Effect],
+) -> Option<&crate::effects::GainLifeEffect> {
+    let [effect] = follow_up_effects else {
+        return None;
+    };
+    let gain = effect.downcast_ref::<crate::effects::GainLifeEffect>()?;
+    if !matches!(gain.player, ChooseSpec::Player(crate::target::PlayerFilter::You)) {
+        return None;
+    }
+    if !matches!(gain.amount.unhinted(), Value::EventValue(EventValueSpec::Amount)) {
+        return None;
+    }
+    Some(gain)
+}
+
 fn describe_assigns_no_combat_damage(source: &ChooseSpec, until: &Until) -> Option<String> {
     if !matches!(until, Until::EndOfTurn) {
         return None;
@@ -31083,6 +31099,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             rendered.push_str(
                 ". If damage is prevented this way, this spell deals that much damage to that source's controller",
             );
+        }
+        if prevention_gain_life_follow_up(&prevent_next_time.follow_up_effects).is_some() {
+            rendered.push_str(". You gain life equal to the damage prevented this way");
         }
         return rendered;
     }

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -939,7 +939,9 @@ where
             ),
         ));
     }
-    if let Some(payload) = M::downcast_ref::<ironsmith_core::PreventNextTimeDamageEffect>(&effect) {
+    if let Some(payload) =
+        M::downcast_ref::<ironsmith_core::PreventNextTimeDamageEffect<M::Effect>>(&effect)
+    {
         let source = match &payload.source {
             ironsmith_core::PreventNextTimeDamageSource::Choice => {
                 crate::effects::PreventNextTimeDamageSource::Choice
@@ -957,6 +959,10 @@ where
             }
         };
         let mut effect = crate::effects::PreventNextTimeDamageEffect::new(source, target);
+        effect = effect.with_follow_up_effects(convert_effects(
+            payload.follow_up_effects.iter().cloned(),
+            hooks,
+        )?);
         if payload.reflect_damage_to_source_controller {
             effect = effect.reflecting_to_source_controller();
         }

--- a/crates/ironsmith-runtime/src/effects/cards/draw_cards.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/draw_cards.rs
@@ -319,7 +319,7 @@ impl EffectExecutor for DrawCardsEffect {
                 &applied_effect_keys,
             ) {
                 TraitEventResult::Prevented => continue,
-                TraitEventResult::Replaced { effects, effect_id } => {
+                TraitEventResult::Replaced { effects, effect_id, .. } => {
                     let replacement_outcome =
                         execute_draw_replacement_effects(game, ctx, effects, effect_id, player_id)?;
                     replacement_count += replacement_outcome.count_or_zero();

--- a/crates/ironsmith-runtime/src/effects/composition/mechanic_actions.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/mechanic_actions.rs
@@ -385,7 +385,7 @@ impl EffectExecutor for ExploreEffect {
                     &applied_effects,
                     &applied_effect_keys,
                 ) {
-                    TraitEventResult::Replaced { effects, effect_id } => {
+                    TraitEventResult::Replaced { effects, effect_id, .. } => {
                         let replacement_outcome = execute_keyword_action_replacement_effects(
                             game,
                             ctx,

--- a/crates/ironsmith-runtime/src/effects/counters/proliferate.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/proliferate.rs
@@ -131,7 +131,7 @@ impl EffectExecutor for ProliferateEffect {
                 &applied_effects,
                 &applied_effect_keys,
             ) {
-                TraitEventResult::Replaced { effects, effect_id } => {
+                TraitEventResult::Replaced { effects, effect_id, .. } => {
                     let snapshot = game
                         .object(ctx.source)
                         .map(|object| ObjectSnapshot::from_object(object, game));

--- a/crates/ironsmith-runtime/src/effects/damage/prevent_next_time_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/prevent_next_time_damage.rs
@@ -42,6 +42,7 @@ pub struct PreventNextTimeDamageEffect {
     pub source: PreventNextTimeDamageSource,
     pub target: PreventNextTimeDamageTarget,
     pub reflect_damage_to_source_controller: bool,
+    pub follow_up_effects: Vec<Effect>,
 }
 
 impl PreventNextTimeDamageEffect {
@@ -50,7 +51,13 @@ impl PreventNextTimeDamageEffect {
             source,
             target,
             reflect_damage_to_source_controller: false,
+            follow_up_effects: Vec::new(),
         }
+    }
+
+    pub fn with_follow_up_effects(mut self, effects: Vec<Effect>) -> Self {
+        self.follow_up_effects = effects;
+        self
     }
 
     pub fn reflecting_to_source_controller(mut self) -> Self {
@@ -130,10 +137,14 @@ impl EffectExecutor for PreventNextTimeDamageEffect {
         let replacement_action = if self.reflect_damage_to_source_controller
             && let Some(source) = chosen_source
         {
-            ReplacementAction::Instead(vec![Effect::new(DealDamageEffect::new(
+            let mut effects = vec![Effect::new(DealDamageEffect::new(
                 Value::EventValue(EventValueSpec::Amount),
                 ChooseSpec::Player(PlayerFilter::ControllerOf(ObjectRef::Specific(source))),
-            ))])
+            ))];
+            effects.extend(self.follow_up_effects.clone());
+            ReplacementAction::Instead(effects)
+        } else if !self.follow_up_effects.is_empty() {
+            ReplacementAction::Instead(self.follow_up_effects.clone())
         } else {
             ReplacementAction::Prevent
         };

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -372,7 +372,12 @@ fn process_event_direct(
             ),
             TraitApplyResult::Prevented => TraitEventResult::Prevented,
             TraitApplyResult::Replaced(effects) => {
-                TraitEventResult::Replaced { effects, effect_id }
+                TraitEventResult::Replaced {
+                    effects,
+                    effect_id,
+                    source: chosen_effect.source,
+                    controller: chosen_effect.controller,
+                }
             }
             TraitApplyResult::Unchanged(event) => TraitEventResult::Proceed(event),
             TraitApplyResult::NeedsInteraction {
@@ -439,7 +444,12 @@ fn process_event_direct(
             event_source_snapshot,
         ),
         TraitApplyResult::Prevented => TraitEventResult::Prevented,
-        TraitApplyResult::Replaced(effects) => TraitEventResult::Replaced { effects, effect_id },
+        TraitApplyResult::Replaced(effects) => TraitEventResult::Replaced {
+            effects,
+            effect_id,
+            source: chosen_effect.source,
+            controller: chosen_effect.controller,
+        },
         TraitApplyResult::Unchanged(event) => TraitEventResult::Proceed(event),
         TraitApplyResult::NeedsInteraction {
             decision_ctx,
@@ -1210,6 +1220,8 @@ pub enum TraitEventResult {
         /// The ID of the replacement effect that was applied.
         /// Used to consume one-shot effects after application.
         effect_id: crate::replacement::ReplacementEffectId,
+        source: crate::ids::ObjectId,
+        controller: PlayerId,
     },
     /// Multiple replacement effects apply - player must choose.
     NeedsChoice {
@@ -1537,7 +1549,12 @@ fn process_destroy_inner(
             }
         }
 
-        TraitEventResult::Replaced { effects, effect_id } => {
+        TraitEventResult::Replaced {
+            effects,
+            effect_id,
+            source: replacement_source,
+            controller: replacement_controller,
+        } => {
             // Destruction was replaced with other effects.
             // Execute the replacement effects with a minimal context.
             // The effects typically use ChooseSpec::SpecificObject, so they're self-contained.
@@ -1547,8 +1564,8 @@ fn process_destroy_inner(
                 .replacement_effects
                 .mark_effect_used(effect_id);
 
-            let effect_source = source.unwrap_or(permanent);
-            let mut ctx = ExecutionContext::new(effect_source, controller, dm);
+            let effect_source = source.unwrap_or(replacement_source);
+            let mut ctx = ExecutionContext::new(effect_source, replacement_controller, dm);
 
             for effect in effects {
                 // Ignore errors from effect execution - the replacement still happened
@@ -1665,7 +1682,12 @@ fn process_zone_change_inner(
                 EventOutcome::Proceed(requested_to)
             }
         }
-        TraitEventResult::Replaced { effects, effect_id } => {
+        TraitEventResult::Replaced {
+            effects,
+            effect_id,
+            source: replacement_source,
+            controller: replacement_controller,
+        } => {
             let replacement_effect = game
                 .effect_store
                 .replacement_effects
@@ -1718,12 +1740,11 @@ fn process_zone_change_inner(
                 }
                 return EventOutcome::Replaced;
             }
-            let controller = game
-                .object(object)
-                .map(|obj| game.controller_of(obj))
-                .or_else(|| snapshot.as_ref().map(|snap| snap.controller))
-                .unwrap_or(PlayerId::from_index(0));
-            let mut ctx = crate::effects::ExecutionContext::new(object, controller, dm);
+            let mut ctx = crate::effects::ExecutionContext::new(
+                replacement_source,
+                replacement_controller,
+                dm,
+            );
             for effect in effects {
                 let _ = crate::effects::execute_effect(game, &effect, &mut ctx);
             }
@@ -1946,7 +1967,12 @@ fn process_with_dm_and_additional_effects_and_applied(
                     }
                     TraitApplyResult::Prevented => return TraitEventResult::Prevented,
                     TraitApplyResult::Replaced(effects) => {
-                        return TraitEventResult::Replaced { effects, effect_id };
+                        return TraitEventResult::Replaced {
+                            effects,
+                            effect_id,
+                            source: chosen_effect.source,
+                            controller: chosen_effect.controller,
+                        };
                     }
                     TraitApplyResult::Unchanged(unchanged_event) => {
                         current_event = unchanged_event;
@@ -2184,7 +2210,12 @@ pub fn process_damage_assignments_with_event_with_source_snapshot(
                 replacement_prevented: true,
             };
         }
-        TraitEventResult::Replaced { effects, effect_id } => {
+        TraitEventResult::Replaced {
+            effects,
+            source: replacement_source,
+            controller: replacement_controller,
+            ..
+        } => {
             let triggering_event = crate::events::RawEvent::new(
                 crate::events::DamageEvent::with_cause(
                     source,
@@ -2195,19 +2226,6 @@ pub fn process_damage_assignments_with_event_with_source_snapshot(
                 ),
                 event_provenance,
             );
-            let (replacement_source, replacement_controller) = game
-                .effect_store
-                .replacement_effects
-                .get_effect(effect_id)
-                .map(|effect| (effect.source, effect.controller))
-                .unwrap_or_else(|| {
-                    let controller = game
-                        .object(source)
-                        .map(|object| game.controller_of(object))
-                        .unwrap_or(game.turn.active_player);
-                    (source, controller)
-                });
-
             let mut dm = crate::decision::AutoPassDecisionMaker;
             let mut exec_ctx = crate::effects::ExecutionContext::new(
                 replacement_source,
@@ -2897,13 +2915,19 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                 }
                 return EtbEventResult::default();
             }
-            TraitEventResult::Replaced { effects, effect_id } => {
+            TraitEventResult::Replaced {
+                effects,
+                effect_id,
+                source: replacement_source,
+                controller: replacement_controller,
+            } => {
                 use crate::effects::{ExecutionContext, execute_effect};
-                if let Some(controller) = game.object(object).map(|o| game.controller_of(o)) {
+                if game.object(object).is_some() {
                     game.effect_store
                         .replacement_effects
                         .mark_effect_used(effect_id);
-                    let mut ctx = ExecutionContext::new(object, controller, dm);
+                    let mut ctx =
+                        ExecutionContext::new(replacement_source, replacement_controller, dm);
                     for effect in effects {
                         let _ = execute_effect(game, &effect, &mut ctx);
                     }
@@ -2970,12 +2994,15 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                     }
                     TraitApplyResult::Replaced(effects) => {
                         use crate::effects::{ExecutionContext, execute_effect};
-                        if let Some(controller) = game.object(object).map(|o| game.controller_of(o))
-                        {
+                        if game.object(object).is_some() {
                             game.effect_store
                                 .replacement_effects
                                 .mark_effect_used(chosen_id);
-                            let mut ctx = ExecutionContext::new(object, controller, dm);
+                            let mut ctx = ExecutionContext::new(
+                                chosen_effect.source,
+                                chosen_effect.controller,
+                                dm,
+                            );
                             for effect in effects {
                                 let _ = execute_effect(game, &effect, &mut ctx);
                             }
@@ -3390,6 +3417,8 @@ pub fn process_event_with_chosen_replacement_trait(
         TraitApplyResult::Replaced(effects) => TraitEventResult::Replaced {
             effects,
             effect_id: chosen_effect_id,
+            source: effect.source,
+            controller: effect.controller,
         },
         TraitApplyResult::Unchanged(unchanged) => {
             // Effect didn't change anything - continue with original event

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -1226,20 +1226,17 @@ pub(super) fn apply_replacement_choice_response(
             // (e.g., damage application, zone change, etc.)
             // The result is now stored and will be picked up by the caller
         }
-        TraitEventResult::Replaced { effects, effect_id } => {
+        TraitEventResult::Replaced {
+            effects,
+            effect_id,
+            source,
+            controller,
+        } => {
             // Event was replaced with different effects - execute them
             // Consume one-shot effects
             game.effect_store
                 .replacement_effects
                 .mark_effect_used(effect_id);
-
-            // Get the source/controller from the chosen replacement effect
-            let (source, controller) = game
-                .effect_store
-                .replacement_effects
-                .get_effect(chosen_id)
-                .map(|e| (e.source, e.controller))
-                .unwrap_or((ObjectId::from_raw(0), PlayerId::from_index(0)));
 
             let mut dm = crate::decision::SelectFirstDecisionMaker;
             let mut ctx = ExecutionContext::new(source, controller, &mut dm)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -622,6 +622,195 @@ fn create_vanilla_creature(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn cho_arrim_alchemist_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(19647), "Cho-Arrim Alchemist")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{1}{W}{W}, {T}, Discard a card: The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way.",
+        )
+        .expect("Cho-Arrim Alchemist should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseNamedSourceDecisionMaker {
+    source_name: &'static str,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseNamedSourceDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if let Some(chosen) = ctx.candidates.iter().find_map(|candidate| {
+            if !candidate.legal {
+                return None;
+            }
+            game.object(candidate.id)
+                .is_some_and(|object| object.name == self.source_name)
+                .then_some(candidate.id)
+        }) {
+            vec![chosen]
+        } else {
+            AutoPassDecisionMaker.decide_objects(game, ctx)
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cho_arrim_alchemist_activation_pays_costs_and_registers_prevention_life_followup() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let alchemist = cho_arrim_alchemist_definition();
+    let alchemist_id = game.create_object_from_definition(&alchemist, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(alchemist_id);
+    let discard_fuel = CardBuilder::new(CardId::new(), "Discard Fuel")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let discard_id = game.create_object_from_card(&discard_fuel, alice, Zone::Hand);
+    let discard_stable = game.object(discard_id).expect("discard card exists").stable_id;
+    let chosen_source = create_vanilla_creature(&mut game, "Chosen Damage Source", bob, 2, 2);
+
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 3);
+
+    let ability_index = game
+        .object(alchemist_id)
+        .expect("Cho-Arrim Alchemist should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Cho-Arrim Alchemist should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                if *source == alchemist_id && *idx == ability_index
+        ))
+        .expect("Cho-Arrim Alchemist activation should be legal with mana and discard fuel");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = ChooseNamedSourceDecisionMaker {
+        source_name: "Chosen Damage Source",
+    };
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Cho-Arrim Alchemist activation should pay costs and go on the stack");
+
+    let mut progress = progress;
+    let mut paid_discard = false;
+    let mut cost_steps = 0;
+    while cost_steps < 6 {
+        cost_steps += 1;
+        let next_progress = match progress {
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectObjects(_),
+            ) => {
+                paid_discard = true;
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::CardCostChoice(discard_id),
+                    &mut dm,
+                )
+                .expect("discarding a card should continue paying Cho-Arrim Alchemist's cost")
+            }
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(cost_ctx),
+            ) if cost_ctx.description.to_ascii_lowercase().contains("choose the next cost") => {
+                let option = cost_ctx
+                    .options
+                    .iter()
+                    .find(|option| {
+                        option.legal
+                            && !paid_discard
+                            && option.description.to_ascii_lowercase().contains("discard")
+                    })
+                    .or_else(|| cost_ctx.options.iter().find(|option| option.legal))
+                    .expect("Cho-Arrim Alchemist should have a payable remaining cost");
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(option.index),
+                    &mut dm,
+                )
+                .expect("choosing next Cho-Arrim Alchemist cost should continue activation")
+            }
+            other => {
+                progress = other;
+                break;
+            }
+        };
+        progress = next_progress;
+    }
+
+    assert!(
+        matches!(
+            progress,
+            crate::decision::GameProgress::Continue
+                | crate::decision::GameProgress::NeedsDecisionCtx(
+                    crate::decisions::context::DecisionContext::Priority(_)
+                )
+        ),
+        "expected Cho-Arrim Alchemist activation to finish after discard cost, got {progress:?}"
+    );
+
+    assert!(game.is_tapped(alchemist_id), "activation should tap Cho-Arrim Alchemist");
+    let discarded_id = game
+        .find_object_by_stable_id(discard_stable)
+        .expect("discarded card should remain tracked");
+    assert!(
+        !game
+            .player(alice)
+            .expect("Alice exists")
+            .hand
+            .contains(&discarded_id),
+        "activation should remove a discarded card from hand as an activation cost"
+    );
+
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Cho-Arrim Alchemist ability should resolve");
+    let (damage, prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        chosen_source,
+        crate::events::DamageTarget::Player(alice),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(damage, 0, "chosen source damage to Alice should be prevented");
+    assert!(prevented, "the next matching damage event should be replaced");
+    assert_eq!(
+        game.life_total(alice),
+        22,
+        "Cho-Arrim Alchemist should gain life equal to the prevented damage"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn activate_goblin_kites_targeting(
     game: &mut GameState,
     controller: PlayerId,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cho-Arrim Alchemist
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to the damage prevented this way'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to the damage prevented this way')
```

Current worker: i-00df0e5f968676d9e
Branch: codex/aws-card-fix-cho-arrim-alchemist
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0253
