### PR TITLE
Fix Ironsmith parse failure: Public Enemy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -7994,6 +7994,26 @@ pub(crate) fn parse_attacks_each_combat_if_able_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbilityAst>, CardTextError> {
     let words = crate::runtime_backend::token_word_refs(tokens);
+    if matches!(
+        words.as_slice(),
+        [
+            "all",
+            "creatures",
+            "attack",
+            "enchanted",
+            "creatures" | "creature" | "creature's",
+            "controller",
+            "each",
+            "combat",
+            "if",
+            "able",
+        ]
+    ) {
+        return Ok(Some(StaticAbilityAst::Static(
+            StaticAbility::all_creatures_attack_attached_controller_each_combat_if_able(),
+        )));
+    }
+
     let Some(attack_idx) = find_index(&words, |word| *word == "attack" || *word == "attacks")
     else {
         return Ok(None);

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -75,6 +75,8 @@ pub enum StaticAbilityId {
     CantBeBlockedExceptByNOrMore,
     CanAttackAsThoughNoDefender,
     MustAttack,
+    MustAttackAttachedController,
+    AllCreaturesAttackAttachedControllerEachCombatIfAble,
     ExertAttack,
     MustBlock,
     CantAttack,
@@ -326,6 +328,8 @@ impl StaticAbilityId {
             | CantBeBlockedExceptByNOrMore
             | CanAttackAsThoughNoDefender
             | MustAttack
+            | MustAttackAttachedController
+            | AllCreaturesAttackAttachedControllerEachCombatIfAble
             | ExertAttack
             | MustBlock
             | CantAttack

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1799,6 +1799,13 @@ impl<
         Self::identified(StaticAbilityId::MustAttack, "must attack")
     }
 
+    pub fn all_creatures_attack_attached_controller_each_combat_if_able() -> Self {
+        Self::identified(
+            StaticAbilityId::AllCreaturesAttackAttachedControllerEachCombatIfAble,
+            "All creatures attack enchanted creature's controller each combat if able",
+        )
+    }
+
     pub fn must_block() -> Self {
         Self::identified(StaticAbilityId::MustBlock, "must block")
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -253,6 +253,157 @@ fn day_of_the_moon_chapter_resolution_goads_only_chosen_name() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_public_enemy_oracle_and_compiled_text() {
+    let def = parse_oracle_card_definition("Public Enemy");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Enchant creature"),
+        "Public Enemy should keep its Aura restriction, got {rendered}"
+    );
+    assert!(
+        rendered
+            .contains("All creatures attack enchanted creature's controller each combat if able."),
+        "Public Enemy should render the required attack-player clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("When enchanted creature dies, draw a card.")
+            || rendered.contains("Whenever enchanted creature dies, draw a card."),
+        "Public Enemy should keep its death trigger, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn public_enemy_requires_legal_attackers_to_attack_enchanted_creatures_controller() {
+    let public_enemy = parse_oracle_card_definition("Public Enemy");
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_101), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+
+    let enchanted_creature =
+        game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let aura = game.create_object_from_definition(&public_enemy, bob, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura,
+        crate::object::AttachmentTarget::Object(enchanted_creature),
+    ));
+    let attacker = game.create_object_from_definition(&creature, charlie, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker);
+    game.turn.active_player = charlie;
+
+    let combat = crate::combat_state::CombatState::default();
+    let options = crate::decision::compute_legal_attackers(&game, &combat);
+    let attacker_option = options
+        .iter()
+        .find(|option| option.creature == attacker)
+        .expect("Charlie's creature should be attack-capable");
+    assert!(
+        attacker_option.must_attack,
+        "Public Enemy should make creatures attack the enchanted creature's controller if able"
+    );
+    assert_eq!(
+        attacker_option.valid_targets,
+        vec![crate::combat_state::AttackTarget::Player(alice)],
+        "Public Enemy should require attacking the enchanted creature's controller, not another player"
+    );
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let wrong_target = [crate::AttackerDeclaration {
+        creature: attacker,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    }];
+    assert!(
+        crate::game_loop::apply_attacker_declarations(
+            &mut game,
+            &mut combat,
+            &mut trigger_queue,
+            &wrong_target,
+        )
+        .is_err(),
+        "attacking a different player should be illegal while the enchanted creature's controller is attackable"
+    );
+
+    let correct_target = [crate::AttackerDeclaration {
+        creature: attacker,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    }];
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &correct_target,
+    )
+    .expect("attacking the enchanted creature's controller should be legal");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn public_enemy_does_not_force_attack_when_enchanted_creatures_controller_cant_be_attacked() {
+    let public_enemy = parse_oracle_card_definition("Public Enemy");
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_102), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+
+    let enchanted_creature =
+        game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let aura = game.create_object_from_definition(&public_enemy, bob, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura,
+        crate::object::AttachmentTarget::Object(enchanted_creature),
+    ));
+    let attacker = game.create_object_from_definition(&creature, charlie, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker);
+    game.effect_store
+        .cant_effects
+        .add_cant_attack_defenders(attacker, [alice]);
+    game.turn.active_player = charlie;
+
+    let combat = crate::combat_state::CombatState::default();
+    let options = crate::decision::compute_legal_attackers(&game, &combat);
+    let attacker_option = options
+        .iter()
+        .find(|option| option.creature == attacker)
+        .expect("Charlie's creature should still be able to attack someone else");
+    assert!(
+        !attacker_option.must_attack,
+        "Public Enemy should not force an attack when its required player is not attackable"
+    );
+    assert!(
+        !attacker_option
+            .valid_targets
+            .contains(&crate::combat_state::AttackTarget::Player(alice)),
+        "the restricted enchanted creature's controller should not be a legal target"
+    );
+    assert!(
+        attacker_option
+            .valid_targets
+            .contains(&crate::combat_state::AttackTarget::Player(bob)),
+        "the creature may still attack other legal players"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_lantern_of_insight_public_top_library_static() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Lantern of Insight Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/decision/attack_block.rs
+++ b/crates/ironsmith-runtime/src/decision/attack_block.rs
@@ -44,6 +44,19 @@ fn defending_player_for_attack_target(game: &GameState, target: &AttackTarget) -
     }
 }
 
+fn required_attack_players_for_attack_preview(
+    game: &GameState,
+    attacker: &crate::object::Object,
+    view: &DerivedGameView<'_>,
+) -> Vec<PlayerId> {
+    static_abilities_for_attack_preview(view, attacker)
+        .into_iter()
+        .filter_map(|ability| {
+            ability.required_attack_player(game, attacker.id, game.controller_of(attacker))
+        })
+        .collect()
+}
+
 fn generic_attack_tax_preview(
     game: &GameState,
     defending_player: PlayerId,
@@ -173,7 +186,7 @@ pub fn compute_legal_attackers(game: &GameState, _combat: &CombatState) -> Vec<A
         let goaded_by = game.active_goaders_for(perm.id);
 
         // Determine valid attack targets
-        let mut valid_targets = Vec::new();
+        let mut legal_targets = Vec::new();
 
         // Can attack each opponent
         let mut goad_targets = Vec::new();
@@ -183,6 +196,7 @@ pub fn compute_legal_attackers(game: &GameState, _combat: &CombatState) -> Vec<A
             if opponent.id != active_player && opponent.is_in_game() {
                 let target = AttackTarget::Player(opponent.id);
                 if can_declare_attack_target_preview(game, perm, &target, &view) {
+                    legal_targets.push(target.clone());
                     if goaded_by.contains(&opponent.id) {
                         goad_targets.push(target);
                     } else {
@@ -200,6 +214,7 @@ pub fn compute_legal_attackers(game: &GameState, _combat: &CombatState) -> Vec<A
             {
                 let target = AttackTarget::Planeswalker(other_perm_id);
                 if can_declare_attack_target_preview(game, perm, &target, &view) {
+                    legal_targets.push(target.clone());
                     if goaded_by.contains(&game.controller_of(other_perm)) {
                         goad_targets.push(target);
                     } else {
@@ -209,13 +224,32 @@ pub fn compute_legal_attackers(game: &GameState, _combat: &CombatState) -> Vec<A
             }
         }
 
-        if !nongoad_targets.is_empty() {
+        let required_attack_players = required_attack_players_for_attack_preview(game, perm, &view);
+        let required_player_targets = legal_targets
+            .iter()
+            .filter(|target| match target {
+                AttackTarget::Player(player) => required_attack_players.contains(player),
+                AttackTarget::Planeswalker(_) => false,
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let mut valid_targets = Vec::new();
+        if !required_player_targets.is_empty() {
+            valid_targets.extend(required_player_targets);
+        } else if !nongoad_targets.is_empty() {
             valid_targets.extend(nongoad_targets);
         } else {
             valid_targets.extend(goad_targets);
         }
 
-        let must_attack = crate::rules::combat::must_attack_with_view(perm, game, &view);
+        let has_required_attack_target = !required_attack_players.is_empty()
+            && valid_targets.iter().any(|target| match target {
+                AttackTarget::Player(player) => required_attack_players.contains(player),
+                AttackTarget::Planeswalker(_) => false,
+            });
+        let must_attack = crate::rules::combat::must_attack_with_view(perm, game, &view)
+            || has_required_attack_target;
 
         if !valid_targets.is_empty() {
             options.push(AttackerOption {

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -748,6 +748,72 @@ impl StaticAbilityKind for MustAttack {
     // by checking if creatures have this ability, rather than using a tracker.
 }
 
+/// Must attack the controller of the object enchanted/equipped by another source if able.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MustAttackAttachedController {
+    attachment_source: ObjectId,
+}
+
+impl MustAttackAttachedController {
+    pub const fn new(attachment_source: ObjectId) -> Self {
+        Self { attachment_source }
+    }
+}
+
+impl StaticAbilityKind for MustAttackAttachedController {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::MustAttackAttachedController
+    }
+
+    fn display(&self) -> String {
+        "Attacks enchanted creature's controller each combat if able".to_string()
+    }
+
+    fn required_attack_player(
+        &self,
+        game: &GameState,
+        _source: ObjectId,
+        _controller: PlayerId,
+    ) -> Option<PlayerId> {
+        let target = game.object(self.attachment_source)?.attached_to?;
+        match target {
+            crate::object::AttachmentTarget::Object(object_id) => game.controller_of_id(object_id),
+            crate::object::AttachmentTarget::Player(player) => Some(player),
+        }
+    }
+}
+
+/// All creatures attack the enchanted creature's controller each combat if able.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AllCreaturesAttackAttachedControllerEachCombatIfAble;
+
+impl StaticAbilityKind for AllCreaturesAttackAttachedControllerEachCombatIfAble {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::AllCreaturesAttackAttachedControllerEachCombatIfAble
+    }
+
+    fn display(&self) -> String {
+        "All creatures attack enchanted creature's controller each combat if able".to_string()
+    }
+
+    fn generate_effects(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+        _game: &GameState,
+    ) -> Vec<crate::continuous::ContinuousEffect> {
+        vec![crate::continuous::ContinuousEffect::new(
+            source,
+            controller,
+            crate::continuous::EffectTarget::AllCreatures,
+            crate::continuous::Modification::AddAbility(
+                crate::static_abilities::StaticAbility::must_attack_attached_controller(source),
+            ),
+        )
+        .with_source_type(crate::continuous::EffectSourceType::StaticAbility)]
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum CantAttackUnlessConditionSpec {
     /// Controller controls more permanents matching this filter than defending player.

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -83,6 +83,9 @@ impl StaticAbility {
             Some(StaticAbilityId::CanBlockFlying) => Self::can_block_flying(),
             Some(StaticAbilityId::CanBlockOnlyFlying) => Self::can_block_only_flying(),
             Some(StaticAbilityId::MustAttack) => Self::must_attack(),
+            Some(StaticAbilityId::AllCreaturesAttackAttachedControllerEachCombatIfAble) => {
+                Self::all_creatures_attack_attached_controller_each_combat_if_able()
+            }
             Some(StaticAbilityId::MustBlock) => Self::must_block(),
             Some(StaticAbilityId::Shadow) => Self::shadow(),
             Some(StaticAbilityId::Horsemanship) => Self::horsemanship(),

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -393,6 +393,16 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Player this creature is required to attack if that player is a legal attack target.
+    fn required_attack_player(
+        &self,
+        _game: &GameState,
+        _source: ObjectId,
+        _controller: PlayerId,
+    ) -> Option<PlayerId> {
+        None
+    }
+
     /// Attacking-group legality hook for "can't attack unless ... also attacks" style clauses.
     ///
     /// Return:
@@ -1197,6 +1207,15 @@ impl StaticAbility {
             .can_attack_specific_defender(game, source, controller, defending_player)
     }
 
+    pub fn required_attack_player(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<PlayerId> {
+        self.0.required_attack_player(game, source, controller)
+    }
+
     pub fn can_attack_with_attacking_group(
         &self,
         game: &GameState,
@@ -1728,6 +1747,14 @@ impl StaticAbility {
 
     pub fn must_attack() -> Self {
         Self::new(MustAttack)
+    }
+
+    pub fn must_attack_attached_controller(attachment_source: ObjectId) -> Self {
+        Self::new(MustAttackAttachedController::new(attachment_source))
+    }
+
+    pub fn all_creatures_attack_attached_controller_each_combat_if_able() -> Self {
+        Self::new(AllCreaturesAttackAttachedControllerEachCombatIfAble)
     }
 
     pub fn exert_attack(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Public Enemy
Initial parse error:
```
parser does not yet support line family: 'All creatures attack enchanted creature's controller each combat if able.'; oracle-only fallback also failed: parser does not yet support line family: 'All creatures attack enchanted creature's controller each combat if able.'
```

Current worker: i-00ef5d83735663a07
Branch: codex/aws-card-fix-public-enemy
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0254
