### PR TITLE
Fix Ironsmith parse failure: Ace's Baseball Bat

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_activated_lines.rs
@@ -760,27 +760,41 @@ fn parse_equip_target_filter_qualifier(tokens: &[OwnedLexToken]) -> Option<Objec
     }
 
     let mut parsed_subtypes = Vec::new();
-    let mut saw_subtype = false;
+    let mut parsed_supertypes = Vec::new();
+    let mut saw_qualifier = false;
     for word in subtype_words {
         if matches!(*word, "or" | "and" | "and/or") {
-            if !saw_subtype {
+            if !saw_qualifier {
                 return None;
             }
             continue;
         }
 
-        let subtype = parse_subtype_flexible(word)?;
-        push_unique(&mut parsed_subtypes, subtype);
-        saw_subtype = true;
+        if let Some(supertype) = parse_supertype_word(word) {
+            push_unique(&mut parsed_supertypes, supertype);
+            saw_qualifier = true;
+            continue;
+        }
+
+        if let Some(subtype) = parse_subtype_flexible(word) {
+            push_unique(&mut parsed_subtypes, subtype);
+            saw_qualifier = true;
+            continue;
+        }
+
+        return None;
     }
 
-    if parsed_subtypes.is_empty() {
+    if parsed_subtypes.is_empty() && parsed_supertypes.is_empty() {
         return None;
     }
 
     let mut filter = ObjectFilter::creature().you_control();
     for subtype in parsed_subtypes {
         push_unique(&mut filter.subtypes, subtype);
+    }
+    for supertype in parsed_supertypes {
+        push_unique(&mut filter.supertypes, supertype);
     }
     Some(filter)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -590,6 +590,62 @@ pub(crate) fn parse_granted_keyword_static_line(
         Ok(Some(generic))
     }
 
+    fn parse_must_be_blocked_by_if_able_tail(
+        tokens: &[OwnedLexToken],
+    ) -> Result<Option<(usize, StaticAbility)>, CardTextError> {
+        let words = crate::runtime_backend::token_word_refs(tokens);
+        let Some(and_word_idx) = word_slice_find_phrase_start_or_zero(
+            &words,
+            &["and", "must", "be", "blocked", "by"],
+        ) else {
+            return Ok(None);
+        };
+        let filter_start_word_idx = and_word_idx + 5;
+        let Some(if_able_word_idx) = word_slice_find_phrase_start_or_zero(
+            &words[filter_start_word_idx..],
+            &["if", "able"],
+        )
+        .map(|idx| idx + filter_start_word_idx)
+        else {
+            return Ok(None);
+        };
+        if if_able_word_idx + 2 != words.len() || filter_start_word_idx >= if_able_word_idx {
+            return Ok(None);
+        }
+
+        let and_token_idx = token_index_for_word_index(tokens, and_word_idx).ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "unable to map must-be-blocked conjunction (clause: '{}')",
+                words.join(" ")
+            ))
+        })?;
+        let filter_start_token_idx = token_index_for_word_index(tokens, filter_start_word_idx)
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unable to map must-be-blocked blocker filter (clause: '{}')",
+                    words.join(" ")
+                ))
+            })?;
+        let filter_end_token_idx = token_index_for_word_index(tokens, if_able_word_idx)
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unable to map must-be-blocked if-able suffix (clause: '{}')",
+                    words.join(" ")
+                ))
+            })?;
+        let blocker_tokens = trim_edge_punctuation(&tokens[filter_start_token_idx..filter_end_token_idx]);
+        if blocker_tokens.is_empty() {
+            return Ok(None);
+        }
+        let blockers = parse_object_filter(&blocker_tokens, false)?;
+        let blocker_text = render_token_slice(&blocker_tokens);
+        let ability = StaticAbility::restriction(
+            crate::effect::Restriction::must_be_blocked_by(ObjectFilter::source(), blockers),
+            format!("This creature must be blocked by {blocker_text} if able"),
+        );
+        Ok(Some((and_token_idx, ability)))
+    }
+
     fn parse_granted_alternative_cast_static(
         subject_tokens: &[OwnedLexToken],
         keyword_tokens: &[OwnedLexToken],
@@ -786,6 +842,7 @@ pub(crate) fn parse_granted_keyword_static_line(
     }
 
     let mut grants_must_attack = false;
+    let mut grants_must_be_blocked_by = None;
     let keyword_words = crate::runtime_backend::token_word_refs(&keyword_tokens);
     if let Some(and_idx) = word_slice_find_phrase_start_or_zero(
         &keyword_words,
@@ -799,6 +856,11 @@ pub(crate) fn parse_granted_keyword_static_line(
     }) {
         keyword_tokens = trim_commas(&keyword_tokens[..and_idx]);
         grants_must_attack = true;
+    }
+    if let Some((and_token_idx, ability)) = parse_must_be_blocked_by_if_able_tail(&keyword_tokens)?
+    {
+        keyword_tokens = trim_commas(&keyword_tokens[..and_token_idx]);
+        grants_must_be_blocked_by = Some(ability);
     }
     if keyword_tokens.is_empty() {
         return Ok(None);
@@ -931,7 +993,7 @@ pub(crate) fn parse_granted_keyword_static_line(
         .into_iter()
         .filter(|action| action.lowers_to_static_ability())
         .collect::<Vec<_>>();
-    if mapped.is_empty() && !grants_must_attack {
+    if mapped.is_empty() && !grants_must_attack && grants_must_be_blocked_by.is_none() {
         return Ok(None);
     }
 
@@ -952,6 +1014,27 @@ pub(crate) fn parse_granted_keyword_static_line(
                 compiled.push(StaticAbilityAst::GrantStaticAbility {
                     filter: filter.clone(),
                     ability: Box::new(StaticAbilityAst::Static(StaticAbility::must_attack())),
+                    condition: condition.clone(),
+                })
+            }
+        }
+    }
+    if let Some(ability) = grants_must_be_blocked_by {
+        match &subject {
+            AnthemSubjectAst::Source => {
+                if let Some(condition) = &condition {
+                    compiled.push(StaticAbilityAst::ConditionalStaticAbility {
+                        ability: Box::new(StaticAbilityAst::Static(ability)),
+                        condition: condition.clone(),
+                    });
+                } else {
+                    compiled.push(StaticAbilityAst::Static(ability));
+                }
+            }
+            AnthemSubjectAst::Filter(filter) => {
+                compiled.push(StaticAbilityAst::GrantStaticAbility {
+                    filter: filter.clone(),
+                    ability: Box::new(StaticAbilityAst::Static(ability)),
                     condition: condition.clone(),
                 })
             }
@@ -1523,6 +1606,45 @@ pub(crate) struct ParsedGrantedTailAst {
     pub(crate) granted_object_abilities: Vec<(ParsedAbility, String)>,
 }
 
+fn parse_must_be_blocked_by_if_able_static(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !word_slice_starts_with(&words, &["must", "be", "blocked", "by"]) {
+        return Ok(None);
+    }
+    let Some(if_able_word_idx) = word_slice_find_phrase_start_or_zero(&words, &["if", "able"])
+    else {
+        return Ok(None);
+    };
+    if if_able_word_idx + 2 != words.len() || if_able_word_idx <= 4 {
+        return Ok(None);
+    }
+
+    let filter_start_token_idx = token_index_for_word_index(tokens, 4).ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "unable to map must-be-blocked blocker filter (clause: '{}')",
+            words.join(" ")
+        ))
+    })?;
+    let filter_end_token_idx = token_index_for_word_index(tokens, if_able_word_idx).ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "unable to map must-be-blocked if-able suffix (clause: '{}')",
+            words.join(" ")
+        ))
+    })?;
+    let blocker_tokens = trim_edge_punctuation(&tokens[filter_start_token_idx..filter_end_token_idx]);
+    if blocker_tokens.is_empty() {
+        return Ok(None);
+    }
+    let blockers = parse_object_filter(&blocker_tokens, false)?;
+    let blocker_text = render_token_slice(&blocker_tokens);
+    Ok(Some(StaticAbility::restriction(
+        crate::effect::Restriction::must_be_blocked_by(ObjectFilter::source(), blockers),
+        format!("This creature must be blocked by {blocker_text} if able"),
+    )))
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct StaticAnimationBundleAst {
     pub(crate) subject: AnthemSubjectAst,
@@ -1955,6 +2077,13 @@ fn infer_attached_subject_filter_from_condition_expr(
     condition: Option<&crate::ConditionExpr>,
 ) -> Option<ObjectFilter> {
     match condition {
+        Some(crate::ConditionExpr::EquippedCreatureAttacking)
+        | Some(crate::ConditionExpr::EquippedCreatureTapped)
+        | Some(crate::ConditionExpr::EquippedCreatureUntapped) => {
+            let mut filter = ObjectFilter::tagged("equipped");
+            filter.card_types.push(CardType::Creature);
+            Some(filter)
+        }
         Some(crate::ConditionExpr::EnchantedPermanentIsCreature)
         | Some(crate::ConditionExpr::EnchantedPermanentIsLand)
         | Some(crate::ConditionExpr::EnchantedPermanentIsEquipment)
@@ -5071,6 +5200,11 @@ pub(crate) fn parse_heterogeneous_granted_tail(
             continue;
         }
 
+        if let Some(ability) = parse_must_be_blocked_by_if_able_static(&segment)? {
+            parsed.granted_static.push(ability.into());
+            continue;
+        }
+
         if let Some(actions) = parse_granted_keyword_fragment(&segment) {
             reject_unimplemented_keyword_actions(&actions, &clause_words.join(" "))?;
             if let [KeywordAction::CumulativeUpkeep { total_cost, .. }] = actions.as_slice() {
@@ -6757,23 +6891,33 @@ pub(crate) fn parse_filter_has_granted_ability_line(
                 && if_idx > 0
                 && let Some(condition_start) = token_index_for_word_index(&ability_tokens, if_idx)
             {
-                let condition_tokens = trim_commas(&ability_tokens[condition_start + 1..]);
-                if !condition_tokens.is_empty() {
-                    let parsed_condition = match parse_static_condition_clause(&condition_tokens) {
-                        Ok(condition) => condition,
-                        Err(err) => {
-                            deferred_error.get_or_insert(err);
-                            continue;
-                        }
-                    };
-                    condition = Some(match condition {
-                        Some(existing) => crate::ConditionExpr::And(
-                            Box::new(existing),
-                            Box::new(parsed_condition),
-                        ),
-                        None => parsed_condition,
-                    });
-                    ability_tokens = trim_commas(&ability_tokens[..condition_start]);
+                let is_blocking_if_able = ability_words.get(if_idx..) == Some(&["if", "able"][..])
+                    && word_slice_contains_phrase(
+                        &ability_words[..if_idx],
+                        &["must", "be", "blocked", "by"],
+                    );
+                if is_blocking_if_able {
+                    // "if able" is part of the blocking requirement, not a static condition.
+                } else {
+                    let condition_tokens = trim_commas(&ability_tokens[condition_start + 1..]);
+                    if !condition_tokens.is_empty() {
+                        let parsed_condition = match parse_static_condition_clause(&condition_tokens)
+                        {
+                            Ok(condition) => condition,
+                            Err(err) => {
+                                deferred_error.get_or_insert(err);
+                                continue;
+                            }
+                        };
+                        condition = Some(match condition {
+                            Some(existing) => crate::ConditionExpr::And(
+                                Box::new(existing),
+                                Box::new(parsed_condition),
+                            ),
+                            None => parsed_condition,
+                        });
+                        ability_tokens = trim_commas(&ability_tokens[..condition_start]);
+                    }
                 }
             }
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -1123,7 +1123,9 @@ pub(crate) fn restriction_references_tag(
             .any(|constraint| constraint.tag.as_str() == tag);
         return blockers_reference || attacker_reference;
     }
-    if let Restriction::MustBlockSpecificAttacker { blockers, attacker } = restriction {
+    if let Restriction::MustBlockSpecificAttacker { blockers, attacker }
+    | Restriction::MustBeBlockedBy { blockers, attacker } = restriction
+    {
         let blockers_reference = blockers
             .tagged_constraints
             .iter()

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -463,6 +463,10 @@ pub(crate) fn resolve_restriction_it_tag(
                 resolve_it_tag(attacker, refs)?,
             )
         }
+        Restriction::MustBeBlockedBy { attacker, blockers } => Restriction::must_be_blocked_by(
+            resolve_it_tag(attacker, refs)?,
+            resolve_it_tag(blockers, refs)?,
+        ),
         Restriction::MustBeBlocked(filter) => {
             Restriction::must_be_blocked(resolve_it_tag(filter, refs)?)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -3249,7 +3249,8 @@ fn bind_unresolved_it_in_restriction(
             bind_unresolved_it_in_filter(filter, seed_tag)
         }
         Restriction::BlockSpecificAttacker { blockers, attacker }
-        | Restriction::MustBlockSpecificAttacker { blockers, attacker } => {
+        | Restriction::MustBlockSpecificAttacker { blockers, attacker }
+        | Restriction::MustBeBlockedBy { blockers, attacker } => {
             bind_unresolved_it_in_filter(blockers, seed_tag)
                 + bind_unresolved_it_in_filter(attacker, seed_tag)
         }

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -465,6 +465,7 @@ impl Subtype {
             Subtype::Construct,
             Subtype::Crab,
             Subtype::Crocodile,
+            Subtype::Dalek,
             Subtype::Detective,
             Subtype::Doctor,
             Subtype::Demon,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -287,6 +287,10 @@ pub enum Restriction {
         blockers: ObjectFilter,
         attacker: ObjectFilter,
     },
+    MustBeBlockedBy {
+        attacker: ObjectFilter,
+        blockers: ObjectFilter,
+    },
     MustBeBlocked(ObjectFilter),
     BlockAlone(ObjectFilter),
     Untap(ObjectFilter),
@@ -515,6 +519,10 @@ impl Restriction {
 
     pub fn must_block_specific_attacker(blockers: ObjectFilter, attacker: ObjectFilter) -> Self {
         Self::MustBlockSpecificAttacker { blockers, attacker }
+    }
+
+    pub fn must_be_blocked_by(attacker: ObjectFilter, blockers: ObjectFilter) -> Self {
+        Self::MustBeBlockedBy { attacker, blockers }
     }
 
     pub fn must_be_blocked(filter: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -48436,6 +48436,67 @@ fn parse_must_be_blocked_each_combat_this_turn_if_able() {
 }
 
 #[test]
+fn parse_aces_baseball_bat_strictly_and_renders_blocked_by_dalek_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(98_775), "Ace's Baseball Bat")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Equipped creature gets +3/+0.\n\
+             As long as equipped creature is attacking, it has first strike and must be blocked by a Dalek if able.\n\
+             Equip legendary creature {1}\n\
+             Equip {3}",
+        )
+        .expect("Ace's Baseball Bat should parse strictly");
+
+    assert_eq!(def.name(), "Ace's Baseball Bat");
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        lower.contains("equipped creature gets +3/+0"),
+        "expected equipped pump surface, got {rendered}"
+    );
+    assert!(
+        lower.contains("as long as equipped creature is attacking"),
+        "expected attacking condition surface, got {rendered}"
+    );
+    assert!(
+        lower.contains("first strike") && lower.contains("must be blocked by a dalek if able"),
+        "expected first-strike and Dalek blocking surface, got {rendered}"
+    );
+    assert!(
+        lower.contains("equip legendary creature {1}"),
+        "expected legendary-creature equip surface, got {rendered}"
+    );
+
+    let legendary_equip = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.mana_cost.display() == "{1}" => {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("expected a one-mana legendary-creature equip ability");
+    assert_eq!(
+        legendary_equip.timing,
+        crate::ability::ActivationTiming::SorcerySpeed
+    );
+    let target_filter = match legendary_equip.choices.as_slice() {
+        [ChooseSpec::Target(inner)] => match inner.as_ref() {
+            ChooseSpec::Object(filter) => filter,
+            other => panic!("expected object target for legendary equip, got {other:?}"),
+        },
+        other => panic!("expected one target choice for legendary equip, got {other:?}"),
+    };
+    assert_eq!(target_filter.controller, Some(PlayerFilter::You));
+    assert!(target_filter.card_types.contains(&CardType::Creature));
+    assert!(target_filter.supertypes.contains(&Supertype::Legendary));
+}
+
+#[test]
 fn parse_suspect_designation_clauses() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Suspect Variant")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))

--- a/crates/ironsmith-runtime/src/combat_state.rs
+++ b/crates/ironsmith-runtime/src/combat_state.rs
@@ -854,6 +854,73 @@ pub fn declare_blockers(
         }
     }
 
+    // Enforce "must be blocked by [quality] if able" requirements. Unlike
+    // per-blocker requirements, only one eligible blocker in the group needs to block.
+    for (&required_attacker, blocker_groups) in &game.effect_store.cant_effects.must_be_blocked_by {
+        if !is_attacking(combat, required_attacker) {
+            continue;
+        }
+        let Some(attacker) = game.object(required_attacker) else {
+            continue;
+        };
+        let Some(attacker_info) = combat
+            .attackers
+            .iter()
+            .find(|info| info.creature == required_attacker)
+        else {
+            continue;
+        };
+        let defending_player = match attacker_info.target {
+            AttackTarget::Player(player_id) => player_id,
+            AttackTarget::Planeswalker(planeswalker_id) => game
+                .object(planeswalker_id)
+                .map(|planeswalker| game.controller_of(planeswalker))
+                .unwrap_or(game.turn.active_player),
+        };
+
+        for blocker_group in blocker_groups {
+            let legal_blockers = blocker_group
+                .iter()
+                .copied()
+                .filter(|&blocker_id| {
+                    let Some(blocker) = game.object(blocker_id) else {
+                        return false;
+                    };
+                    blocker.zone == Zone::Battlefield
+                        && game.controller_of(blocker) == defending_player
+                        && game.object_has_card_type_with_effects(
+                            blocker_id,
+                            crate::types::CardType::Creature,
+                            &all_effects,
+                        )
+                        && !game.is_tapped(blocker_id)
+                        && can_block(attacker, blocker, game)
+                        && game.can_block_attacker(blocker_id, required_attacker)
+                        && game.can_block(blocker_id)
+                        && game.can_be_blocked(required_attacker)
+                        && !game.object_has_ability_with_effects(
+                            blocker_id,
+                            &StaticAbility::cant_block(),
+                            &all_effects,
+                        )
+                })
+                .collect::<Vec<_>>();
+            if legal_blockers.is_empty() {
+                continue;
+            }
+
+            let declared_required = attackers_by_blocker.iter().any(|(&blocker_id, attackers)| {
+                legal_blockers.contains(&blocker_id) && attackers.contains(&required_attacker)
+            });
+            if !declared_required {
+                return Err(CombatError::MustBlockRequirementNotMet {
+                    blocker: legal_blockers[0],
+                    attacker: required_attacker,
+                });
+            }
+        }
+    }
+
     // Third pass: apply declarations
     for (attacker_id, blocker_list) in blockers_by_attacker {
         combat.blockers.insert(attacker_id, blocker_list);

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -256,6 +256,56 @@ fn parse_conditional_subject_predicate(line: &str) -> Option<ConditionalSubjectP
     })
 }
 
+fn parse_conditional_must_be_blocked_by(line: &str) -> Option<(String, String, String)> {
+    let trimmed = line.trim().trim_end_matches('.');
+    let (body, condition) = trimmed.rsplit_once(" as long as ")?;
+    let (subject, blocked_by) = body.split_once(" must be blocked by ")?;
+    if subject.trim().is_empty() || blocked_by.trim().is_empty() {
+        return None;
+    }
+    Some((
+        format!("As long as {}", condition.trim()),
+        subject.trim().to_string(),
+        format!("must be blocked by {}", blocked_by.trim()),
+    ))
+}
+
+fn merge_conditional_keyword_and_block_requirement(left: &str, right: &str) -> Option<String> {
+    let left_keyword = parse_conditional_subject_predicate(left);
+    let right_keyword = parse_conditional_subject_predicate(right);
+    let left_blocked = parse_conditional_must_be_blocked_by(left);
+    let right_blocked = parse_conditional_must_be_blocked_by(right);
+
+    let (keyword, blocked) = match (left_keyword, right_keyword, left_blocked, right_blocked) {
+        (Some(keyword), None, None, Some(blocked)) => (keyword, blocked),
+        (None, Some(keyword), Some(blocked), None) => (keyword, blocked),
+        _ => return None,
+    };
+    if !matches!(keyword.verb.as_str(), "has" | "have" | "gains" | "gain") {
+        return None;
+    }
+    if !conditioned_subjects_equivalent(&keyword.subject, &blocked.1)
+        || !keyword.condition.eq_ignore_ascii_case(&blocked.0)
+    {
+        return None;
+    }
+    let predicate = normalize_keyword_predicate_case(&keyword.predicate);
+    if !is_keyword_phrase(&predicate) {
+        return None;
+    }
+    let condition = keyword
+        .condition
+        .trim_start_matches("As long as ")
+        .trim_start_matches("as long as ")
+        .trim();
+    Some(format!(
+        "As long as {condition}, {} {} {predicate} and {}",
+        lowercase_first(&keyword.subject),
+        have_verb_for_subject(&keyword.subject),
+        blocked.2
+    ))
+}
+
 fn is_creature_addition_predicate(predicate: &str) -> bool {
     let lower = predicate.trim().to_ascii_lowercase();
     lower == "a creature in addition to its other types"
@@ -672,6 +722,11 @@ pub(super) fn merge_adjacent_subject_predicate_lines(lines: Vec<String>) -> Vec<
         if idx + 1 < lines.len() {
             let left = lines[idx].trim().trim_end_matches('.');
             let right = lines[idx + 1].trim().trim_end_matches('.');
+            if let Some(line) = merge_conditional_keyword_and_block_requirement(left, right) {
+                merged.push(line);
+                idx += 2;
+                continue;
+            }
             if let Some(subject) = left
                 .strip_suffix(" enters tapped")
                 .or_else(|| left.strip_suffix(" enter tapped"))

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9821,6 +9821,13 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
                 attacker.description()
             )
         }
+        crate::effect::Restriction::MustBeBlockedBy { attacker, blockers } => {
+            format!(
+                "{} must be blocked by {} if able",
+                attacker.description(),
+                blockers.description()
+            )
+        }
         crate::effect::Restriction::MustBeBlocked(filter) => {
             format!("{} must be blocked if able", filter.description())
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -35217,15 +35217,41 @@ fn equip_target_qualifier_text(spec: &ChooseSpec) -> Option<String> {
                 return None;
             }
             if filter.subtypes.len() == 1 {
-                return Some(filter.subtypes[0].to_string());
+                let mut parts = filter
+                    .supertypes
+                    .iter()
+                    .map(|supertype| supertype.to_string().to_ascii_lowercase())
+                    .collect::<Vec<_>>();
+                parts.push(filter.subtypes[0].to_string());
+                return Some(parts.join(" "));
             }
             if filter.subtypes.len() > 1 {
-                let names = filter
+                let mut names = filter
                     .subtypes
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<_>>();
+                if !filter.supertypes.is_empty() {
+                    let prefix = filter
+                        .supertypes
+                        .iter()
+                        .map(|supertype| supertype.to_string().to_ascii_lowercase())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    for name in &mut names {
+                        *name = format!("{prefix} {name}");
+                    }
+                }
                 return Some(names.join(" or "));
+            }
+            if !filter.supertypes.is_empty() {
+                let mut parts = filter
+                    .supertypes
+                    .iter()
+                    .map(|supertype| supertype.to_string().to_ascii_lowercase())
+                    .collect::<Vec<_>>();
+                parts.push("creature".to_string());
+                return Some(parts.join(" "));
             }
             None
         }

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -35,6 +35,7 @@ pub use ironsmith_core::effect::{ChoiceCount, EffectId, SearchSelectionMode};
 pub use ironsmith_core::{
     Comparison, EffectPredicate, EventValueSpec, Until, ValueComparisonOperator,
 };
+use std::collections::HashSet;
 use std::sync::Arc;
 
 // ============================================================================
@@ -1078,6 +1079,41 @@ impl RestrictionExt for Restriction {
                             .or_default();
                         required.extend(attacker_ids.iter().copied());
                     }
+                }
+            }
+            Restriction::MustBeBlockedBy { attacker, blockers } => {
+                let attacker_ids = game
+                    .battlefield
+                    .iter()
+                    .copied()
+                    .filter(|obj_id| {
+                        game.object(*obj_id)
+                            .is_some_and(|obj| attacker.matches(obj, &ctx, game))
+                    })
+                    .collect::<Vec<_>>();
+                if attacker_ids.is_empty() {
+                    return;
+                }
+
+                let blocker_ids = game
+                    .battlefield
+                    .iter()
+                    .copied()
+                    .filter(|obj_id| {
+                        game.object(*obj_id)
+                            .is_some_and(|obj| blockers.matches(obj, &ctx, game))
+                    })
+                    .collect::<HashSet<_>>();
+                if blocker_ids.is_empty() {
+                    return;
+                }
+
+                for attacker_id in attacker_ids {
+                    tracker
+                        .must_be_blocked_by
+                        .entry(attacker_id)
+                        .or_default()
+                        .push(blocker_ids.clone());
                 }
             }
             Restriction::MustBeBlocked(filter) => {

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -134,6 +134,10 @@ fn normalize_restriction_for_resolution(
         Restriction::MustBeBlocked(filter) => Restriction::must_be_blocked(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),
+        Restriction::MustBeBlockedBy { attacker, blockers } => Restriction::must_be_blocked_by(
+            collapse_filter_to_current_matching_objects(attacker, ctx, game),
+            collapse_filter_to_current_matching_objects(blockers, ctx, game),
+        ),
         Restriction::Attack(filter) => Restriction::attack(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2132,6 +2132,201 @@ fn sharpened_pitchfork_boosts_only_humans_but_always_grants_first_strike() {
     assert_eq!(game.calculated_toughness(non_human_id), Some(2));
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn aces_baseball_bat_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(98_775), "Ace's Baseball Bat")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Equipped creature gets +3/+0.\n\
+             As long as equipped creature is attacking, it has first strike and must be blocked by a Dalek if able.\n\
+             Equip legendary creature {1}\n\
+             Equip {3}",
+        )
+        .expect("Ace's Baseball Bat should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn attach_equipment_to(game: &mut GameState, equipment_id: ObjectId, creature_id: ObjectId) {
+    if let Some(equipment) = game.object_mut(equipment_id) {
+        equipment.attached_to = Some(crate::object::AttachmentTarget::Object(creature_id));
+    }
+    if let Some(creature) = game.object_mut(creature_id) {
+        creature.attachments.push(equipment_id);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aces_baseball_bat_forces_available_dalek_to_block_attacking_equipped_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let bat_id = game.create_object_from_definition(
+        &aces_baseball_bat_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let bearer = CardBuilder::new(CardId::from_raw(98_776), "Ace's Bearer")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bearer_id = game.create_object_from_card(&bearer, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(bearer_id);
+    let dalek = CardBuilder::new(CardId::from_raw(98_777), "Test Dalek")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dalek])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let dalek_id = game.create_object_from_card(&dalek, bob, Zone::Battlefield);
+    let second_dalek = CardBuilder::new(CardId::from_raw(98_781), "Second Test Dalek")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dalek])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let second_dalek_id = game.create_object_from_card(&second_dalek, bob, Zone::Battlefield);
+    let soldier = CardBuilder::new(CardId::from_raw(98_778), "Non-Dalek Blocker")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let soldier_id = game.create_object_from_card(&soldier, bob, Zone::Battlefield);
+    attach_equipment_to(&mut game, bat_id, bearer_id);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = CombatState::default();
+    crate::combat_state::declare_attackers(
+        &mut game,
+        &mut combat,
+        vec![(bearer_id, AttackTarget::Player(bob))],
+    )
+    .expect("equipped creature should attack");
+    game.combat = Some(combat.clone());
+    game.update_cant_effects();
+
+    assert!(
+        game.object_has_ability(bearer_id, &StaticAbility::first_strike()),
+        "Ace's Baseball Bat should grant first strike while the equipped creature attacks"
+    );
+
+    let missing_dalek = crate::combat_state::declare_blockers(&game, &mut combat.clone(), vec![]);
+    assert!(
+        matches!(
+            missing_dalek,
+            Err(crate::combat_state::CombatError::MustBlockRequirementNotMet { blocker, attacker })
+                if (blocker == dalek_id || blocker == second_dalek_id) && attacker == bearer_id
+        ),
+        "expected an able Dalek blocker to be required, got {missing_dalek:?}"
+    );
+
+    let non_dalek_only = crate::combat_state::declare_blockers(
+        &game,
+        &mut combat.clone(),
+        vec![(soldier_id, bearer_id)],
+    );
+    assert!(
+        matches!(
+            non_dalek_only,
+            Err(crate::combat_state::CombatError::MustBlockRequirementNotMet { blocker, attacker })
+                if (blocker == dalek_id || blocker == second_dalek_id) && attacker == bearer_id
+        ),
+        "expected a non-Dalek blocker not to satisfy Ace's Baseball Bat, got {non_dalek_only:?}"
+    );
+
+    crate::combat_state::declare_blockers(&game, &mut combat, vec![(second_dalek_id, bearer_id)])
+        .expect("one Dalek blocking the equipped creature should satisfy Ace's Baseball Bat");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aces_baseball_bat_does_not_force_tapped_dalek_to_block() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let bat_id = game.create_object_from_definition(
+        &aces_baseball_bat_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let bearer = CardBuilder::new(CardId::from_raw(98_782), "Tapping Ace's Bearer")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bearer_id = game.create_object_from_card(&bearer, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(bearer_id);
+    let dalek = CardBuilder::new(CardId::from_raw(98_783), "Tapped Test Dalek")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dalek])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let dalek_id = game.create_object_from_card(&dalek, bob, Zone::Battlefield);
+    game.tap(dalek_id);
+    attach_equipment_to(&mut game, bat_id, bearer_id);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = CombatState::default();
+    crate::combat_state::declare_attackers(
+        &mut game,
+        &mut combat,
+        vec![(bearer_id, AttackTarget::Player(bob))],
+    )
+    .expect("equipped creature should attack");
+    game.combat = Some(combat.clone());
+    game.update_cant_effects();
+
+    crate::combat_state::declare_blockers(&game, &mut combat, vec![])
+        .expect("a tapped Dalek should not be forced to block");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aces_baseball_bat_does_not_force_dalek_when_equipped_creature_is_not_attacking() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let bat_id = game.create_object_from_definition(
+        &aces_baseball_bat_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let bearer = CardBuilder::new(CardId::from_raw(98_779), "Idle Ace's Bearer")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bearer_id = game.create_object_from_card(&bearer, alice, Zone::Battlefield);
+    let dalek = CardBuilder::new(CardId::from_raw(98_780), "Idle Test Dalek")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dalek])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let dalek_id = game.create_object_from_card(&dalek, bob, Zone::Battlefield);
+    attach_equipment_to(&mut game, bat_id, bearer_id);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareBlockers);
+    game.combat = Some(CombatState::default());
+    game.update_cant_effects();
+
+    assert!(
+        !game.object_has_ability(bearer_id, &StaticAbility::first_strike()),
+        "Ace's Baseball Bat should not grant first strike while the equipped creature is idle"
+    );
+    assert!(
+        !game.must_block_attacker(dalek_id, bearer_id),
+        "Ace's Baseball Bat should not force Daleks to block an idle equipped creature"
+    );
+}
+
 #[test]
 fn proposed_granted_emerge_cast_keeps_sacrifice_cost_on_stack_spell() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -540,6 +540,10 @@ pub struct CantEffectTracker {
     /// Example: "Target creature blocks this creature this turn if able."
     pub must_block_specific_attackers: HashMap<ObjectId, HashSet<ObjectId>>,
 
+    /// Attacker -> groups of blockers that must include at least one blocker if able.
+    /// Example: "This creature must be blocked by a Dalek if able."
+    pub must_be_blocked_by: HashMap<ObjectId, Vec<HashSet<ObjectId>>>,
+
     /// Attackers that must be blocked this turn if able.
     /// Example: "Target creature must be blocked this turn if able."
     pub must_be_blocked: HashSet<ObjectId>,
@@ -839,6 +843,12 @@ impl CantEffectTracker {
                 .or_default()
                 .extend(attackers);
         }
+        for (attacker, blocker_groups) in other.must_be_blocked_by {
+            self.must_be_blocked_by
+                .entry(attacker)
+                .or_default()
+                .extend(blocker_groups);
+        }
         self.must_be_blocked.extend(other.must_be_blocked);
         self.cant_block_alone.extend(other.cant_block_alone);
         self.cant_untap.extend(other.cant_untap);
@@ -900,6 +910,7 @@ impl CantEffectTracker {
         self.cant_block.clear();
         self.cant_block_specific_attackers.clear();
         self.must_block_specific_attackers.clear();
+        self.must_be_blocked_by.clear();
         self.must_be_blocked.clear();
         self.cant_block_alone.clear();
         self.cant_untap.clear();

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -2060,6 +2060,15 @@ impl StaticAbilityKind for GrantAbility {
             StaticAbilityId::Unblockable => format!("{subject} can't be blocked"),
             StaticAbilityId::CantAttack => format!("{subject} can't attack"),
             StaticAbilityId::CantBlock => format!("{subject} can't block"),
+            StaticAbilityId::RuleRestriction => {
+                if let Some(rest) = ability_text.strip_prefix("This creature ") {
+                    format!("{subject} {rest}")
+                } else if let Some(rest) = ability_text.strip_prefix("this creature ") {
+                    format!("{subject} {rest}")
+                } else {
+                    format!("{subject} has {ability_text}")
+                }
+            }
             _ => {
                 let singular_subject = subject.starts_with("enchanted ")
                     || subject.starts_with("equipped ")
@@ -2108,6 +2117,12 @@ impl StaticAbilityKind for GrantAbility {
     }
 
     fn apply_restrictions(&self, game: &mut GameState, _source: ObjectId, controller: PlayerId) {
+        if let Some(condition) = &self.condition
+            && !static_condition_is_active(condition, game, _source, controller)
+        {
+            return;
+        }
+
         if self.source_only {
             self.ability.apply_restrictions(game, _source, controller);
             return;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ace's Baseball Bat
Initial parse error:
```
unsupported static condition clause (clause: 'able'); oracle-only fallback also failed: unsupported static condition clause (clause: 'able')
```

Current worker: i-0727b25ad1ddd5dc0
Branch: codex/aws-card-fix-ace-s-baseball-bat
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0255
