### PR TITLE
Fix Ironsmith parse failure: Carnage, Crimson Chaos

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -50,6 +50,7 @@ pub(super) enum KeywordDispatchHint {
     Epic,
     Offspring,
     Madness,
+    Mayhem,
     Escape,
     MorphFamily,
     Mutate,
@@ -266,6 +267,12 @@ mod spell_keywords {
             lower: registry::lower_madness,
         },
         KeywordLineRule {
+            cst_kind: super::super::cst::KeywordLineKindCst::Mayhem,
+            hints: &[KeywordDispatchHint::Mayhem],
+            matches: registry::matches_mayhem,
+            lower: registry::lower_mayhem,
+        },
+        KeywordLineRule {
             cst_kind: super::super::cst::KeywordLineKindCst::Escape,
             hints: &[KeywordDispatchHint::Escape],
             matches: registry::matches_escape,
@@ -361,6 +368,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
             )),
             winnow::combinator::alt((
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),
+                grammar::kw("mayhem").value(KeywordDispatchHint::Mayhem),
                 grammar::kw("warp").value(KeywordDispatchHint::Warp),
                 grammar::kw("prowl").value(KeywordDispatchHint::AlternativeOrExertFamily),
                 grammar::kw("escalate").value(KeywordDispatchHint::Escalate),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -37,6 +37,7 @@ use super::util::{
     parse_flash_with_additional_cost_line_lexed, parse_flashback_line_lexed,
     parse_harmonize_line_lexed, parse_if_conditional_alternative_cost_line_lexed,
     parse_jump_start_line_lexed, parse_kicker_line_lexed, parse_madness_line_lexed,
+    parse_mayhem_line_lexed,
     parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_offspring_line_lexed,
     parse_prowl_line_lexed, parse_reinforce_line_lexed, parse_replicate_line_lexed,
     parse_retrace_line_lexed, parse_self_free_cast_alternative_cost_line_lexed,
@@ -460,6 +461,15 @@ pub(super) fn lower_madness(
     ))
 }
 
+pub(super) fn lower_mayhem(
+    line: &RewriteKeywordLine,
+    tokens: &[OwnedLexToken],
+) -> Result<LineAst, CardTextError> {
+    Ok(LineAst::AlternativeCastingMethod(
+        require_keyword_parse(line, "mayhem", parse_mayhem_line_lexed(tokens)?)?.into(),
+    ))
+}
+
 pub(super) fn lower_morph(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
@@ -865,6 +875,13 @@ pub(super) fn matches_madness(
     tokens: &[OwnedLexToken],
 ) -> Result<bool, CardTextError> {
     Ok(parse_madness_line_lexed(tokens)?.is_some())
+}
+
+pub(super) fn matches_mayhem(
+    _line: &PreprocessedLine,
+    tokens: &[OwnedLexToken],
+) -> Result<bool, CardTextError> {
+    Ok(parse_mayhem_line_lexed(tokens)?.is_some())
 }
 
 pub(super) fn matches_escape(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -53,6 +53,7 @@ pub(crate) enum KeywordLineKindCst {
     Harmonize,
     Kicker,
     Madness,
+    Mayhem,
     Morph,
     Mutate,
     Multikicker,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4789,6 +4789,51 @@ pub(crate) fn parse_jump_start_line_lexed(
     parse_jump_start_line(tokens)
 }
 
+pub(crate) fn parse_mayhem_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    if !tokens.first().is_some_and(|token| token.is_word("mayhem")) {
+        return Ok(None);
+    }
+
+    let cost_tokens = tokens
+        .get(1..)
+        .unwrap_or_default()
+        .iter()
+        .take_while(|token| token.kind != TokenKind::LParen)
+        .cloned()
+        .collect::<Vec<_>>();
+    if cost_tokens.is_empty() {
+        return Err(CardTextError::ParseError(
+            "mayhem keyword missing mana cost".to_string(),
+        ));
+    }
+    let (mana_cost, consumed) =
+        leading_mana_cost_from_tokens(cost_tokens.as_slice()).ok_or_else(|| {
+            CardTextError::ParseError("mayhem keyword has an invalid mana cost".to_string())
+        })?;
+    if consumed != cost_tokens.len() {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported mayhem keyword tail '{}'",
+            render_token_slice(&cost_tokens[consumed..])
+        )));
+    }
+
+    Ok(Some(AlternativeCastingMethod::cast_from_zone_with_total_cost(
+        "Mayhem",
+        Zone::Graveyard,
+        TotalCost::from_cost(Cost::mana(mana_cost)),
+        Some(crate::static_abilities::ThisSpellCostCondition::ThisCardWasDiscardedThisTurn),
+        false,
+    )))
+}
+
+pub(crate) fn parse_mayhem_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    parse_mayhem_line(tokens)
+}
+
 pub(crate) fn parse_harmonize_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {

--- a/crates/ironsmith-core/src/spell_cost_condition_model.rs
+++ b/crates/ironsmith-core/src/spell_cost_condition_model.rs
@@ -48,6 +48,7 @@ pub enum ThisSpellCostCondition {
     },
     NotStartingPlayer,
     CreatureCardPutIntoYourGraveyardThisTurn,
+    ThisCardWasDiscardedThisTurn,
     CreatureIsAttackingYou,
     YouDealtCombatDamageToPlayerWithSubtypeThisTurn(Subtype),
     YouDealtCombatDamageToPlayerWithSubtypeOrCommanderThisTurn(Subtype),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11,6 +11,7 @@ use crate::effects::{
     MoveToZoneEffect, ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect, TaggedEffect,
     TargetOnlyEffect, UntapEffect,
 };
+use crate::filter::ObjectFilterExt;
 use crate::object::AuraAttachmentFilter;
 use crate::static_abilities::StaticAbilityId;
 use crate::target::{ChooseSpec, ObjectRef, PlayerFilter, SourceReferenceSurface};
@@ -512,6 +513,264 @@ fn cogwork_librarian_draft_rules_do_not_create_runtime_effects() {
         );
         assert!(ability.pregame_action_kind().is_none());
     }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn carnage_crimson_chaos_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Carnage, Crimson Chaos");
+    let rendered_lines = canonical_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Trample".to_string(),
+            concat!(
+                "When this creature enters, return target creature card with mana value 3 or less ",
+                "from your graveyard to the battlefield. It gains ",
+                "\"This creature attacks each combat if able\" and ",
+                "\"Whenever this creature deals combat damage to a player, sacrifice it\""
+            )
+            .to_string(),
+            "Mayhem {B}{R}".to_string(),
+        ],
+        "Carnage should preserve its exact compiled text shape, got {rendered}"
+    );
+    assert!(
+        !format!("{def:#?}").contains("UnsupportedParserLine"),
+        "Carnage should parse strictly without unsupported placeholders"
+    );
+    let mayhem = def
+        .alternative_casts
+        .iter()
+        .find(|method| method.name() == "Mayhem")
+        .expect("Carnage should lower Mayhem as an alternative casting method");
+    assert_eq!(mayhem.cast_from_zone(), Zone::Graveyard);
+    assert_eq!(
+        mayhem.mana_cost().map(|cost| cost.to_oracle()),
+        Some("{B}{R}".to_string())
+    );
+    assert_eq!(
+        mayhem.cast_condition(),
+        Some(&crate::static_abilities::ThisSpellCostCondition::ThisCardWasDiscardedThisTurn),
+        "Mayhem should retain keyword identity and the this-card-discarded condition"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn carnage_crimson_chaos_mayhem_requires_this_card_discarded_this_turn() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let carnage = parse_oracle_card_definition("Carnage, Crimson Chaos");
+    let carnage_id = game.create_object_from_definition(&carnage, alice, Zone::Graveyard);
+
+    let without_discard = compute_legal_actions(&game, alice);
+    assert!(
+        without_discard.iter().all(|action| !matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::Alternative(_),
+            } if *spell_id == carnage_id
+        )),
+        "Carnage should not be castable with mayhem before this card was discarded this turn"
+    );
+
+    let unrelated = CardDefinitionBuilder::new(CardId::new(), "Unrelated Discard")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let unrelated_id = game.create_object_from_definition(&unrelated, alice, Zone::Graveyard);
+    let unrelated_discard_event = crate::events::RawEvent::new(
+        crate::events::CardDiscardedEvent::new(alice, unrelated_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&unrelated_discard_event);
+
+    let with_other_card_discarded = compute_legal_actions(&game, alice);
+    assert!(
+        with_other_card_discarded.iter().all(|action| !matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::Alternative(_),
+            } if *spell_id == carnage_id
+        )),
+        "Carnage mayhem should care that this card, not just any card, was discarded this turn"
+    );
+
+    let other_player_discard_event = crate::events::RawEvent::new(
+        crate::events::CardDiscardedEvent::new(bob, carnage_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&other_player_discard_event);
+
+    let with_other_player_discard = compute_legal_actions(&game, alice);
+    assert!(
+        with_other_player_discard.iter().all(|action| !matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::Alternative(_),
+            } if *spell_id == carnage_id
+        )),
+        "Carnage mayhem should require that you discarded this card this turn"
+    );
+
+    let discard_event = crate::events::RawEvent::new(
+        crate::events::CardDiscardedEvent::new(alice, carnage_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&discard_event);
+
+    let with_discard = compute_legal_actions(&game, alice);
+    assert!(
+        with_discard.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::Alternative(_),
+            } if *spell_id == carnage_id
+        )),
+        "Carnage should be castable from the graveyard for mayhem after this card was discarded this turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn carnage_crimson_chaos_etb_returns_only_small_creature_and_grants_abilities() {
+    let carnage = parse_oracle_card_definition("Carnage, Crimson Chaos");
+    let triggered = carnage
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Carnage should have an ETB trigger");
+    let ChooseSpec::Target(inner) = &triggered.choices[0] else {
+        panic!("Carnage ETB should target a creature card in your graveyard");
+    };
+    let ChooseSpec::Object(target_filter) = inner.as_ref() else {
+        panic!("Carnage ETB target should be an object filter");
+    };
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let carnage_id = game.create_object_from_definition(&carnage, alice, Zone::Battlefield);
+    let small = CardDefinitionBuilder::new(CardId::new(), "Small Graveyard Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let large = CardDefinitionBuilder::new(CardId::new(), "Large Graveyard Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let small_id = game.create_object_from_definition(&small, alice, Zone::Graveyard);
+    let small_stable_id = game
+        .object(small_id)
+        .expect("small creature exists")
+        .stable_id;
+    let large_id = game.create_object_from_definition(&large, alice, Zone::Graveyard);
+    let filter_ctx = crate::filter::FilterContext::new(alice).with_source(carnage_id);
+
+    assert!(
+        target_filter.matches(
+            game.object(small_id).expect("small creature exists"),
+            &filter_ctx,
+            &game,
+        ),
+        "Carnage should be able to target a mana-value-3 creature card in your graveyard"
+    );
+    assert!(
+        !target_filter.matches(
+            game.object(large_id).expect("large creature exists"),
+            &filter_ctx,
+            &game,
+        ),
+        "Carnage should not be able to target a mana-value-4 creature card"
+    );
+
+    let carnage_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(carnage_id).expect("Carnage exists"),
+        &game,
+    );
+    let etb_event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            carnage_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(carnage_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(carnage_id, alice)
+        .with_triggering_event(etb_event)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(small_id)]);
+    for segment in &triggered.effects.segments {
+        for effect in &segment.default_effects {
+            crate::effects::execute_effect(&mut game, effect, &mut ctx)
+                .expect("Carnage ETB effect should resolve");
+        }
+    }
+
+    let returned_small_id = game
+        .find_object_by_stable_id(small_stable_id)
+        .expect("small creature should still be tracked after moving zones");
+    assert_eq!(
+        game.object(returned_small_id)
+            .expect("small creature exists")
+            .zone,
+        Zone::Battlefield,
+        "Carnage should return the chosen small creature card to the battlefield"
+    );
+    assert!(
+        game.object_has_static_ability_id(returned_small_id, StaticAbilityId::MustAttack),
+        "Carnage should grant the returned creature attacks-each-combat-if-able"
+    );
+    let granted_combat_damage_trigger = game
+        .current_abilities(returned_small_id)
+        .expect("returned creature should have current abilities")
+        .iter()
+        .any(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered
+                .trigger
+                .downcast_ref::<crate::triggers::ThisDealsCombatDamageToPlayerTrigger>()
+                .is_some(),
+            _ => false,
+        });
+    assert!(
+        granted_combat_damage_trigger,
+        "Carnage should grant the returned creature the combat-damage sacrifice trigger"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -752,7 +752,21 @@ pub(super) fn substitute_legendary_source_reference(
         return line.to_string();
     }
 
+    let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
+    if source_name.is_empty() {
+        return line.to_string();
+    }
+
     let lower = line.to_ascii_lowercase();
+    if card.supertypes.contains(&Supertype::Legendary) {
+        if let Some(rest) = line.strip_prefix("When this creature enters,") {
+            return format!("When {source_name} enters,{rest}");
+        }
+        if let Some(rest) = line.strip_prefix("When this creature enters the battlefield,") {
+            return format!("When {source_name} enters the battlefield,{rest}");
+        }
+    }
+
     let conditional_static_self_surface = (lower.starts_with("as long as ")
         || lower.contains(": as long as "))
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
@@ -762,11 +776,6 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(": this creature gets ")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {
-        return line.to_string();
-    }
-
-    let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
-    if source_name.is_empty() {
         return line.to_string();
     }
 
@@ -1972,6 +1981,14 @@ pub(super) fn describe_alternative_cast_line(
         }
         AlternativeCastingMethod::Retrace { .. } => "Retrace".to_string(),
         AlternativeCastingMethod::JumpStart => "Jump-start".to_string(),
+        AlternativeCastingMethod::FromZone { name, .. }
+            if name.eq_ignore_ascii_case("Mayhem") =>
+        {
+            method
+                .mana_cost()
+                .map(|cost| format!("Mayhem {}", cost.to_oracle()))
+                .unwrap_or_else(|| "Mayhem".to_string())
+        }
         AlternativeCastingMethod::Escape { cost, exile_count } => {
             let count_text =
                 small_number_word(*exile_count).unwrap_or_else(|| exile_count.to_string());

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -1697,6 +1697,7 @@ pub(super) fn is_keyword_style_line(line: &str) -> bool {
         "landcycling ",
         "basic landcycling ",
         "madness ",
+        "mayhem ",
         "morph ",
         "suspend ",
         "prototype ",

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8524,6 +8524,16 @@ pub(super) fn describe_apply_continuous_clauses(
                     gains
                 };
                 clauses.push(format!("{grant_verb} \"{ability_text}\""));
+            } else if let crate::ability::AbilityKind::Static(static_ability) = &ability.kind
+                && static_ability.id() == crate::static_abilities::StaticAbilityId::MustAttack
+            {
+                clauses.push(format!(
+                    "{gains} \"{}\"",
+                    capitalize_first(&describe_inline_ability_with_self_subject(
+                        ability,
+                        self_subject
+                    ))
+                ));
             } else {
                 clauses.push(format!(
                     "{gains} {}",
@@ -9020,12 +9030,32 @@ pub(super) fn describe_apply_continuous_effect(
         return None;
     }
 
-    let mut text = format!("{target} {}", join_with_and(&clauses));
+    let joined = combine_parallel_gain_clauses(&clauses).unwrap_or_else(|| join_with_and(&clauses));
+    let mut text = format!("{target} {joined}");
     if let Some(tail) = describe_apply_continuous_tail(effect) {
         text.push(' ');
         text.push_str(&tail);
     }
     Some(text)
+}
+
+fn combine_parallel_gain_clauses(clauses: &[String]) -> Option<String> {
+    let [first, rest @ ..] = clauses else {
+        return None;
+    };
+    let prefix = if first.starts_with("gains ") {
+        "gains "
+    } else if first.starts_with("gain ") {
+        "gain "
+    } else {
+        return None;
+    };
+    let mut parts = Vec::with_capacity(clauses.len());
+    for clause in std::iter::once(first).chain(rest.iter()) {
+        let tail = clause.strip_prefix(prefix)?;
+        parts.push(tail.to_string());
+    }
+    Some(format!("{prefix}{}", join_with_and(&parts)))
 }
 
 fn describe_dies_return_counter_grant(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14109,8 +14109,8 @@ fn describe_triggered_inline_ability(
                 line.push_str(" — ");
                 line.push_str(only);
             } else {
-                line.push_str(": ");
-                line.push_str(only);
+                line.push_str(", ");
+                line.push_str(&lowercase_first(only));
             }
         } else {
             line.push_str(": ");

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -1242,6 +1242,9 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
         ThisSpellCostCondition::CreatureCardPutIntoYourGraveyardThisTurn => {
             Some("a creature card was put into your graveyard from anywhere this turn".to_string())
         }
+        ThisSpellCostCondition::ThisCardWasDiscardedThisTurn => {
+            Some("you discarded this card this turn".to_string())
+        }
         ThisSpellCostCondition::CreatureIsAttackingYou => {
             Some("a creature is attacking you".to_string())
         }
@@ -1632,9 +1635,13 @@ pub fn this_spell_cost_condition_is_active_for_cast_with_optional_costs_paid(
                             .turn_store
                             .turn_history
                             .object_was_put_into_graveyard_this_turn(object.stable_id)
-                })
+                    })
             })
         }
+        ThisSpellCostCondition::ThisCardWasDiscardedThisTurn => game
+            .turn_store
+            .turn_history
+            .object_was_discarded_by_player_this_turn(source_obj.stable_id, controller),
         ThisSpellCostCondition::CreatureIsAttackingYou => {
             game.combat.as_ref().is_some_and(|combat| {
                 combat.attackers.iter().any(|attacker| {

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -28,6 +28,19 @@ pub struct TurnEventRecord {
     pub source_snapshot: Option<ObjectSnapshot>,
 }
 
+fn discarded_record_matches_stable_id(record: &TurnEventRecord, stable_id: StableId) -> bool {
+    record
+        .event
+        .downcast::<CardDiscardedEvent>()
+        .is_some_and(|event| {
+            event
+                .snapshot
+                .as_ref()
+                .or(record.object_snapshot.as_ref())
+                .is_some_and(|snapshot| snapshot.stable_id == stable_id)
+        })
+}
+
 /// Unified owner for turn-scoped bookkeeping and history.
 #[derive(Debug, Clone, Default)]
 pub struct TurnHistory {
@@ -174,6 +187,20 @@ impl TurnHistory {
             .filter_map(|record| record.event.downcast::<CardDiscardedEvent>())
             .filter(|event| event.player == player)
             .count() as u32
+    }
+
+    pub fn object_was_discarded_by_player_this_turn(
+        &self,
+        stable_id: StableId,
+        player: PlayerId,
+    ) -> bool {
+        self.projected_records().any(|record| {
+            record
+                .event
+                .downcast::<CardDiscardedEvent>()
+                .is_some_and(|event| event.player == player)
+                && discarded_record_matches_stable_id(record, stable_id)
+        })
     }
 
     pub fn total_cards_discarded_for_players(&self, players: &[PlayerId]) -> u32 {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Carnage, Crimson Chaos
Initial parse error:
```
parser does not yet support line family: 'Mayhem {B}{R}'; oracle-only fallback also failed: parser does not yet support line family: 'Mayhem {B}{R}'
```

Current worker: i-0ac5260cee77135c2
Branch: codex/aws-card-fix-carnage-crimson-chaos
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0255
