### PR TITLE
Fix Ironsmith parse failure: Loyal Unicorn

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1184,6 +1184,17 @@ impl Effect {
         ))
     }
 
+    pub fn prevent_all_combat_damage_to(
+        target: crate::target::ObjectFilter,
+        until: Until,
+    ) -> Self {
+        Self::new(crate::effects::PreventAllDamageEffect::matching_with_filter(
+            target,
+            ironsmith_core::DamageFilter::combat(),
+            until,
+        ))
+    }
+
     pub fn prevent_all_damage_to(target: crate::target::ObjectFilter, until: Until) -> Self {
         Self::new(crate::effects::PreventAllDamageEffect::matching(
             target, until,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -847,6 +847,14 @@ pub(crate) fn parse_prevent_damage_target_scope_lexed(
             ),
         ));
     }
+    if let Ok(filter) = parse_object_filter(tokens, false) {
+        return Ok(Some(
+            EffectAst::subject_verb_prevent_all_combat_damage_to_target(
+                TargetAst::Object(filter, None, None),
+                crate::effect::Until::EndOfTurn,
+            ),
+        ));
+    }
 
     Err(CardTextError::ParseError(format!(
         "unsupported prevent-all target scope '{}'",

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1537,6 +1537,24 @@ fn compile_subject_verb_effect(
                 })
             }
         }
+        SubjectVerbActionAst::PreventAllCombatDamageToTarget { target, duration } => {
+            if let TargetAst::Object(filter, explicit_target_span, _) = target
+                && explicit_target_span.is_none()
+            {
+                let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+                Ok((
+                    vec![Effect::prevent_all_combat_damage_to(
+                        resolved_filter,
+                        duration.clone(),
+                    )],
+                    Vec::new(),
+                ))
+            } else {
+                Err(CardTextError::ParseError(
+                    "unsupported targeted prevent-all combat damage target scope".to_string(),
+                ))
+            }
+        }
         SubjectVerbActionAst::PreventAllDamageFromSourceFilter {
             duration,
             source_filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -669,6 +669,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::PreventAllCombatDamage { .. }
         | SubjectVerbActionAst::PreventAllCombatDamageFromSource { .. }
         | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
+        | SubjectVerbActionAst::PreventAllCombatDamageToTarget { .. }
         | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
         | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
         | SubjectVerbActionAst::PreventNextTimeDamage { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -967,6 +967,10 @@ pub(crate) enum SubjectVerbActionAst {
         duration: Until,
         source_filter: ObjectFilter,
     },
+    PreventAllCombatDamageToTarget {
+        target: TargetAst,
+        duration: Until,
+    },
     PreventAllCombatDamageToPlayers {
         duration: Until,
     },
@@ -2086,6 +2090,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("PreventAllCombatDamageFromSourceFilter")
                 .field("duration", duration)
                 .field("source_filter", source_filter)
+                .finish(),
+            Self::PreventAllCombatDamageToTarget { target, duration } => f
+                .debug_struct("PreventAllCombatDamageToTarget")
+                .field("target", target)
+                .field("duration", duration)
                 .finish(),
             Self::PreventAllCombatDamageToPlayers { duration } => f
                 .debug_struct("PreventAllCombatDamageToPlayers")
@@ -3442,6 +3451,17 @@ impl EffectAst {
                 duration,
                 source_filter,
             },
+        )
+    }
+
+    pub(crate) fn subject_verb_prevent_all_combat_damage_to_target(
+        target: TargetAst,
+        duration: Until,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::PreventAllCombatDamageToTarget { target, duration },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -414,6 +414,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::PreventAllCombatDamage { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSource { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToTarget { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -713,6 +713,7 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::RedirectNextDamageFromSourceToTarget { target, .. }
                 | SubjectVerbActionAst::RedirectNextTimeDamageToSource { target, .. }
                 | SubjectVerbActionAst::PreventDamage { target, .. }
+                | SubjectVerbActionAst::PreventAllCombatDamageToTarget { target, .. }
                 | SubjectVerbActionAst::PreventAllDamageToTarget { target, .. }
                 | SubjectVerbActionAst::PreventDamageToTargetPutCounters { target, .. }
                 | SubjectVerbActionAst::PutOrRemoveCounters { target, .. } => {
@@ -1966,6 +1967,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::PreventAllCombatDamage { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSource { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToTarget { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
@@ -2765,6 +2767,9 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                     + bind_unresolved_it_in_target(target, seed_tag)
             }
             SubjectVerbActionAst::PreventAllDamageToTarget { target, .. } => {
+                bind_unresolved_it_in_target(target, seed_tag)
+            }
+            SubjectVerbActionAst::PreventAllCombatDamageToTarget { target, .. } => {
                 bind_unresolved_it_in_target(target, seed_tag)
             }
             SubjectVerbActionAst::PreventAllDamageFromSourceFilter { source_filter, .. } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -1987,6 +1987,7 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::SwitchPowerToughness { target, .. }
             | SubjectVerbActionAst::GrantProtectionChoice { target, .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSource { source: target, .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToTarget { target, .. }
             | SubjectVerbActionAst::ExileWhenSourceLeaves { target }
             | SubjectVerbActionAst::SacrificeSourceWhenLeaves { target }
             | SubjectVerbActionAst::RedirectNextDamageFromSourceToTarget { target, .. }
@@ -2445,6 +2446,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::PreventAllCombatDamage { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSource { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageFromSourceFilter { .. }
+            | SubjectVerbActionAst::PreventAllCombatDamageToTarget { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToPlayers { .. }
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
@@ -2724,6 +2726,10 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
                 ..
             }
             | SubjectVerbActionAst::PreventAllDamageToTarget {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::PreventAllCombatDamageToTarget {
                 target: effect_target,
                 ..
             }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -15205,6 +15205,191 @@ fn parse_oracle_winds_of_qal_sisma_ferocious_prevents_only_opponents_creature_da
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_loyal_unicorn_strictly_compiles() {
+    assert_oracle_card_parses_strict("Loyal Unicorn");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_loyal_unicorn_renders_prevention_and_vigilance_clauses() {
+    let def = parse_oracle_card_definition("Loyal Unicorn");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Vigilance"),
+        "Loyal Unicorn should retain its printed vigilance keyword, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Lieutenant — At the beginning of combat on your turn, if you control your commander, prevent all combat damage that would be dealt to creatures you control this turn. Other creatures you control gain vigilance until end of turn."
+        ),
+        "Loyal Unicorn should render the commander condition, scoped combat prevention, and separate vigilance grant, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_loyal_unicorn_test_creature(
+    game: &mut crate::game_state::GameState,
+    name: &str,
+    controller: PlayerId,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card = crate::card::CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_loyal_unicorn_begin_combat_trigger(
+    game: &mut crate::game_state::GameState,
+    active_player: PlayerId,
+) {
+    let event = crate::events::RawEvent::new(
+        crate::events::BeginningOfCombatEvent::new(active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(game, &event) {
+        trigger_queue.add(entry);
+    }
+    crate::game_loop::put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Loyal Unicorn beginning-of-combat trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(game)
+        .expect("Loyal Unicorn beginning-of-combat trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loyal_unicorn_with_your_commander_prevents_combat_damage_to_your_creatures() {
+    let loyal_unicorn = parse_oracle_card_definition("Loyal Unicorn");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let loyal_unicorn_id =
+        game.create_object_from_definition(&loyal_unicorn, alice, Zone::Battlefield);
+    let commander_id =
+        create_loyal_unicorn_test_creature(&mut game, "Alice Commander", alice, 2, 2);
+    game.set_as_commander(commander_id, alice);
+    let protected_blocker =
+        create_loyal_unicorn_test_creature(&mut game, "Protected Blocker", alice, 2, 2);
+    let bob_attacker =
+        create_loyal_unicorn_test_creature(&mut game, "Bob Attacker", bob, 3, 3);
+
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::BeginCombat);
+    resolve_loyal_unicorn_begin_combat_trigger(&mut game, alice);
+
+    assert_eq!(
+        game.effect_store.prevention_effects.shields().len(),
+        1,
+        "Loyal Unicorn should create one combat-damage prevention shield"
+    );
+    let shield = &game.effect_store.prevention_effects.shields()[0];
+    assert!(
+        shield.damage_filter.combat_only
+            && matches!(
+                shield.protected,
+                crate::prevention::PreventionTarget::PermanentsMatching(_)
+            ),
+        "Loyal Unicorn shield should protect matching permanents from combat damage, got {shield:?}"
+    );
+
+    assert!(
+        game.object_has_static_ability_id(protected_blocker, StaticAbilityId::Vigilance),
+        "Loyal Unicorn should grant vigilance to other creatures you control"
+    );
+    assert!(
+        game.object_has_static_ability_id(loyal_unicorn_id, StaticAbilityId::Vigilance),
+        "Loyal Unicorn should keep its own printed vigilance"
+    );
+    assert!(
+        !game.object_has_static_ability_id(bob_attacker, StaticAbilityId::Vigilance),
+        "Loyal Unicorn should not grant vigilance to opponents' creatures"
+    );
+
+    let noncombat = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        bob_attacker,
+        crate::events::DamageTarget::Object(protected_blocker),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        noncombat.assignments,
+        vec![crate::events::processing::ProcessedDamageAssignment {
+            target: crate::events::DamageTarget::Object(protected_blocker),
+            amount: 3,
+        }],
+        "Loyal Unicorn should not prevent noncombat damage to creatures you control"
+    );
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: bob_attacker,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    });
+    combat.blockers.insert(bob_attacker, vec![protected_blocker]);
+
+    game.turn.step = Some(crate::game_state::Step::CombatDamage);
+    let events = crate::game_loop::execute_combat_damage_step(&mut game, &combat, false);
+    assert!(
+        events.len() >= 2,
+        "blocked combat should assign damage in both directions, got {events:?}"
+    );
+    assert_eq!(
+        game.damage_on(protected_blocker),
+        0,
+        "Loyal Unicorn should prevent combat damage to creatures you control"
+    );
+    assert_eq!(
+        game.damage_on(bob_attacker),
+        2,
+        "Loyal Unicorn should not prevent combat damage dealt to opponents' creatures"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loyal_unicorn_without_your_commander_does_not_trigger() {
+    let loyal_unicorn = parse_oracle_card_definition("Loyal Unicorn");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+
+    game.create_object_from_definition(&loyal_unicorn, alice, Zone::Battlefield);
+    let ally = create_loyal_unicorn_test_creature(&mut game, "Uninspired Ally", alice, 2, 2);
+
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::BeginCombat);
+    let event = crate::events::RawEvent::new(
+        crate::events::BeginningOfCombatEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    assert!(
+        triggered.is_empty(),
+        "Loyal Unicorn should not trigger when you do not control your commander, got {triggered:#?}"
+    );
+    assert!(
+        game.effect_store.prevention_effects.shields().is_empty(),
+        "Loyal Unicorn should not create a prevention shield without its commander condition"
+    );
+    assert!(
+        !game.object_has_static_ability_id(ally, StaticAbilityId::Vigilance),
+        "Loyal Unicorn should not grant vigilance without its commander condition"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_prevent_next_damage_to_any_target_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Amulet of Kroog Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8292,6 +8292,20 @@ pub(super) fn describe_put_counter_phrase(count: &Value, counter_type: CounterTy
 pub(super) fn describe_apply_continuous_target(
     effect: &crate::effects::ApplyContinuousEffect,
 ) -> (String, bool) {
+    if effect.target_spec.is_none()
+        && let crate::continuous::EffectTarget::Filter(filter) = &effect.target
+        && filter.other
+    {
+        let description = filter.description();
+        let rest = description
+            .strip_prefix("another ")
+            .unwrap_or(description.as_str())
+            .trim();
+        let rest = strip_indefinite_article(rest).trim();
+        if !rest.is_empty() {
+            return (format!("other {}", pluralize_noun_phrase(rest)), true);
+        }
+    }
     effect_text_shared::describe_apply_continuous_target(effect, describe_choose_spec, |filter| {
         pluralize_noun_phrase(&filter.description())
     })
@@ -9611,17 +9625,19 @@ pub(super) fn describe_damage_filter(filter: &crate::prevention::DamageFilter) -
 
 pub(super) fn describe_prevention_target(
     target: &crate::prevention::PreventionTarget,
-) -> &'static str {
+) -> String {
     match target {
-        crate::prevention::PreventionTarget::Player(_) => "that player",
-        crate::prevention::PreventionTarget::Permanent(_) => "that permanent",
-        crate::prevention::PreventionTarget::PermanentsMatching(_) => "matching permanents",
-        crate::prevention::PreventionTarget::Players => "players",
-        crate::prevention::PreventionTarget::You => "you",
-        crate::prevention::PreventionTarget::YouAndPermanentsYouControl => {
-            "you and permanents you control"
+        crate::prevention::PreventionTarget::Player(_) => "that player".to_string(),
+        crate::prevention::PreventionTarget::Permanent(_) => "that permanent".to_string(),
+        crate::prevention::PreventionTarget::PermanentsMatching(filter) => {
+            pluralize_noun_phrase(strip_indefinite_article(&filter.description()))
         }
-        crate::prevention::PreventionTarget::All => "all players and permanents",
+        crate::prevention::PreventionTarget::Players => "players".to_string(),
+        crate::prevention::PreventionTarget::You => "you".to_string(),
+        crate::prevention::PreventionTarget::YouAndPermanentsYouControl => {
+            "you and permanents you control".to_string()
+        }
+        crate::prevention::PreventionTarget::All => "all players and permanents".to_string(),
     }
 }
 
@@ -10394,6 +10410,19 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::PlayerControls { player, filter } => {
             let subject = describe_player_filter(player);
+            if subject == "you"
+                && filter.is_commander
+                && filter
+                    .controller
+                    .as_ref()
+                    .is_none_or(|controller| matches!(controller, PlayerFilter::You))
+                && filter
+                    .owner
+                    .as_ref()
+                    .is_none_or(|owner| matches!(owner, PlayerFilter::You))
+            {
+                return "you control your commander".to_string();
+            }
             if matches!(
                 filter.zone,
                 Some(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12932,6 +12932,14 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
         return Some(compact);
     }
 
+    if matches!(effects, [first, _]
+        if first.downcast_ref::<crate::effects::PreventAllDamageEffect>().is_some()
+            || first.downcast_ref::<crate::effects::PreventAllCombatDamageEffect>().is_some()
+            || first.downcast_ref::<crate::effects::PreventAllCombatDamageFromEffect>().is_some())
+    {
+        return None;
+    }
+
     let compact = describe_effect_list(effects);
     let compact_trimmed = compact.trim();
     if !compact_trimmed.is_empty()

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -2405,6 +2405,17 @@ impl Effect {
         ))
     }
 
+    /// Create a "prevent all combat damage to matching permanents" effect.
+    pub fn prevent_all_combat_damage_to(filter: ObjectFilter, until: Until) -> Self {
+        use crate::effects::PreventAllDamageEffect;
+        use crate::prevention::DamageFilter;
+        Self::new(PreventAllDamageEffect::matching_with_filter(
+            filter,
+            DamageFilter::combat(),
+            until,
+        ))
+    }
+
     /// Create a "prevent all damage to matching permanents" effect.
     pub fn prevent_all_damage_to(filter: ObjectFilter, until: Until) -> Self {
         use crate::effects::PreventAllDamageEffect;

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2368,6 +2368,28 @@ fn apply_prevention_for_damage_assignment(
         })
         .collect();
 
+    let target_filter_matches: std::collections::HashMap<_, _> = match &target {
+        DamageTarget::Object(object_id) => game
+            .effect_store
+            .prevention_effects
+            .shields()
+            .iter()
+            .filter_map(|shield| {
+                let crate::prevention::PreventionTarget::PermanentsMatching(filter) =
+                    &shield.protected
+                else {
+                    return None;
+                };
+                let filter_ctx = game.filter_context_for(shield.controller, Some(shield.source));
+                let matches = game
+                    .object(*object_id)
+                    .is_some_and(|object| filter.matches(object, &filter_ctx, game));
+                Some((shield.id, matches))
+            })
+            .collect(),
+        DamageTarget::Player(_) => std::collections::HashMap::new(),
+    };
+
     let result = match target {
         DamageTarget::Player(player_id) => game
             .effect_store
@@ -2399,6 +2421,7 @@ fn apply_prevention_for_damage_assignment(
                     &source_card_types,
                     can_prevent,
                     &source_filter_matches,
+                    &target_filter_matches,
                 )
         }
     };

--- a/crates/ironsmith-runtime/src/prevention.rs
+++ b/crates/ironsmith-runtime/src/prevention.rs
@@ -255,6 +255,7 @@ impl PreventionEffectManager {
         &self,
         permanent: ObjectId,
         controller: PlayerId,
+        target_filter_matches: &HashMap<PreventionShieldId, bool>,
     ) -> Vec<&PreventionShield> {
         self.shields
             .iter()
@@ -262,11 +263,10 @@ impl PreventionEffectManager {
             .filter(|s| match &s.protected {
                 PreventionTarget::Permanent(p) => *p == permanent,
                 PreventionTarget::YouAndPermanentsYouControl => s.controller == controller,
-                PreventionTarget::PermanentsMatching(_filter) => {
-                    // Would need object context to evaluate filter
-                    // For now, include all filter-based shields
-                    true
-                }
+                PreventionTarget::PermanentsMatching(_) => target_filter_matches
+                    .get(&s.id)
+                    .copied()
+                    .unwrap_or(false),
                 PreventionTarget::All => true,
                 _ => false,
             })
@@ -393,6 +393,7 @@ impl PreventionEffectManager {
         can_be_prevented: bool,
     ) -> u32 {
         let source_filter_matches = HashMap::new();
+        let target_filter_matches = HashMap::new();
         self.apply_prevention_to_permanent_with_follow_ups(
             permanent,
             controller,
@@ -403,6 +404,7 @@ impl PreventionEffectManager {
             source_card_types,
             can_be_prevented,
             &source_filter_matches,
+            &target_filter_matches,
         )
         .remaining
     }
@@ -419,6 +421,7 @@ impl PreventionEffectManager {
         source_card_types: &[CardType],
         can_be_prevented: bool,
         source_filter_matches: &HashMap<PreventionShieldId, bool>,
+        target_filter_matches: &HashMap<PreventionShieldId, bool>,
     ) -> PreventionApplicationResult {
         if damage == 0 {
             return PreventionApplicationResult::default();
@@ -429,7 +432,7 @@ impl PreventionEffectManager {
 
         // Find applicable shields
         let shield_ids: Vec<PreventionShieldId> = self
-            .get_shields_for_permanent(permanent, controller)
+            .get_shields_for_permanent(permanent, controller, target_filter_matches)
             .iter()
             .filter(|s| {
                 let source_filter_ok = s.damage_filter.from_source.is_none()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Loyal Unicorn
Initial parse error:
```
unsupported prevent-all target scope 'creatures you control'; oracle-only fallback also failed: unsupported prevent-all target scope 'creatures you control'
```

Current worker: i-0171ef5dbc827bedc
Branch: codex/aws-card-fix-loyal-unicorn
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0255
