### PR TITLE
Fix Ironsmith parse failure: Yue, the Moon Spirit

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activated_line_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activated_line_core.rs
@@ -44,6 +44,7 @@ pub(crate) fn parse_prefixed_activated_ability_label(
         Some("boast") => Some("Boast".to_string()),
         Some("exhaust") => Some("Exhaust".to_string()),
         Some("renew") => Some("Renew".to_string()),
+        Some("waterbend") => Some("Waterbend".to_string()),
         _ => None,
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1303,8 +1303,24 @@ fn grant_spec_is_free_cast_from_hand(spec: &crate::grant::GrantSpec) -> bool {
 }
 
 fn clause_is_singular_free_cast_from_hand(clause_words: &[&str]) -> bool {
-    word_slice_contains_phrase(clause_words, &["cast", "a", "spell"])
-        || word_slice_contains_phrase(clause_words, &["cast", "one", "spell"])
+    let Some(cast_idx) = clause_words.iter().position(|word| *word == "cast") else {
+        return false;
+    };
+    let Some(article_idx) = cast_idx.checked_add(1) else {
+        return false;
+    };
+    if !matches!(clause_words.get(article_idx).copied(), Some("a" | "an" | "one")) {
+        return false;
+    }
+    let Some(from_idx) = clause_words[article_idx + 1..]
+        .iter()
+        .position(|word| *word == "from")
+        .map(|idx| article_idx + 1 + idx)
+    else {
+        return false;
+    };
+    clause_words[article_idx + 1..from_idx].contains(&"spell")
+        && clause_words.get(from_idx..from_idx + 3) == Some(["from", "your", "hand"].as_slice())
 }
 
 fn parse_cast_with_tagged_mana_value_limit_clause(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -515,7 +515,7 @@ fn lower_rewrite_activated_to_chunk_impl(
 
     let normalized_cost = line.cost.clone();
     let ability_text = rewrite_activated_display_text(line);
-    let additional_activation_restrictions = if ability_text
+    let mut additional_activation_restrictions = if ability_text
         .as_deref()
         .is_some_and(|text| text.trim_start().starts_with("Exhaust"))
     {
@@ -523,6 +523,12 @@ fn lower_rewrite_activated_to_chunk_impl(
     } else {
         Vec::new()
     };
+    if ability_text
+        .as_deref()
+        .is_some_and(|text| text.trim_start().starts_with("Waterbend"))
+    {
+        additional_activation_restrictions.push("Display label: Waterbend.".to_string());
+    }
     let normalized_effect_text = effect_text.to_ascii_lowercase();
     let normalized_raw_line = line.info.raw_line.to_ascii_lowercase();
 
@@ -719,6 +725,7 @@ fn rewrite_activated_display_text(line: &RewriteActivatedLine) -> Option<String>
         "Boast",
         "Exhaust",
         "Renew",
+        "Waterbend",
         "Channel",
         "Cohort",
         "Teleport",
@@ -728,6 +735,10 @@ fn rewrite_activated_display_text(line: &RewriteActivatedLine) -> Option<String>
         if let Some(idx) = str_find(raw_lower.as_str(), needle.as_str()) {
             return Some(raw[idx..].trim().to_string());
         }
+        let keyword_prefix = format!("{} ", display.to_ascii_lowercase());
+        if raw_lower.starts_with(keyword_prefix.as_str()) {
+            return Some(raw.to_string());
+        }
     }
 
     if let Some(chosen) = line.chosen_option_label.as_deref() {
@@ -735,6 +746,7 @@ fn rewrite_activated_display_text(line: &RewriteActivatedLine) -> Option<String>
             "Boast",
             "Exhaust",
             "Renew",
+            "Waterbend",
             "Channel",
             "Cohort",
             "Teleport",

--- a/crates/ironsmith-core/src/event_model.rs
+++ b/crates/ironsmith-core/src/event_model.rs
@@ -41,6 +41,7 @@ pub enum KeywordActionKind {
     Surveil,
     Train,
     UnlockDoor,
+    Waterbend,
     Vote,
 }
 
@@ -82,6 +83,7 @@ impl KeywordActionKind {
             "surveil" | "surveils" => Some(Self::Surveil),
             "train" | "trains" | "trained" | "training" => Some(Self::Train),
             "unlock" | "unlocks" | "unlocked" | "unlocking" => Some(Self::UnlockDoor),
+            "waterbend" | "waterbends" => Some(Self::Waterbend),
             "vote" | "votes" | "voting" => Some(Self::Vote),
             _ => None,
         }
@@ -130,6 +132,7 @@ impl KeywordActionKind {
             Self::Surveil => "surveil",
             Self::Train => "train",
             Self::UnlockDoor => "unlock this door",
+            Self::Waterbend => "waterbend",
             Self::Vote => "vote",
         }
     }
@@ -177,6 +180,7 @@ impl KeywordActionKind {
             Self::Surveil => "surveils",
             Self::Train => "trains",
             Self::UnlockDoor => "unlocks this door",
+            Self::Waterbend => "waterbends",
             Self::Vote => "votes",
         }
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18854,6 +18854,74 @@ fn parse_omniscience_static_free_cast_permission() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_yue_the_moon_spirit_strictly_compiles_waterbend_free_cast() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(83_001), "Yue, the Moon Spirit")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit, Subtype::Ally])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Flying, vigilance\n\
+             Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost.",
+        )
+        .expect("Yue, the Moon Spirit should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Flying, vigilance")
+            && rendered.contains(
+                "Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost"
+            ),
+        "expected Yue's compiled text to preserve waterbend and noncreature free-cast wording, got {rendered}"
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Yue should have a waterbend activated ability");
+    assert!(
+        activated.mana_cost.costs().iter().any(|cost| cost.requires_tap()),
+        "Yue's waterbend activation should keep the tap cost"
+    );
+    assert!(
+        activated
+            .additional_restrictions
+            .iter()
+            .any(|restriction| restriction.eq_ignore_ascii_case("Display label: Waterbend.")),
+        "Yue's waterbend activation should retain a structural display label"
+    );
+
+    let [may_effect] = activated.effects.flattened_default_effects() else {
+        panic!(
+            "expected Yue's activation to lower to one optional free-cast effect, got {:#?}",
+            activated.effects.flattened_default_effects()
+        );
+    };
+    let may = may_effect
+        .downcast_ref::<crate::effects::MayEffect>()
+        .expect("Yue's free-cast effect should be optional");
+    let [free_cast] = may.effects.as_slice() else {
+        panic!("expected one nested free-cast effect, got {:#?}", may.effects);
+    };
+    let free_cast = free_cast
+        .downcast_ref::<crate::effects::MayCastMatchingSpellWithoutPayingManaCostEffect>()
+        .expect("Yue should lower to the reusable one-shot free-cast effect");
+    assert_eq!(free_cast.zone, Zone::Hand);
+    assert_eq!(free_cast.player, PlayerFilter::You);
+    assert!(free_cast.filter.excluded_card_types.contains(&CardType::Creature));
+    assert!(free_cast.filter.excluded_card_types.contains(&CardType::Land));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_kentaro_static_mana_value_permission() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Kentaro Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -135,6 +135,9 @@ pub(super) fn describe_cast_limit_spell_filter(filter: &ObjectFilter) -> String 
     if filter == &ObjectFilter::default() {
         return "spell".to_string();
     }
+    if is_noncreature_spell_filter(filter) {
+        return "noncreature spell".to_string();
+    }
     if filter == &ObjectFilter::default().without_type(CardType::Creature) {
         return "noncreature spell".to_string();
     }
@@ -153,6 +156,16 @@ pub(super) fn describe_cast_limit_spell_filter(filter: &ObjectFilter) -> String 
     } else {
         format!("spell matching {}", strip_leading_article(&fallback))
     }
+}
+
+fn is_noncreature_spell_filter(filter: &ObjectFilter) -> bool {
+    let mut base = filter.clone();
+    let excluded = base.excluded_card_types.clone();
+    base.excluded_card_types.clear();
+    base == ObjectFilter::default()
+        && excluded.len() == 2
+        && excluded.contains(&CardType::Creature)
+        && excluded.contains(&CardType::Land)
 }
 
 pub(super) fn describe_cast_ban_spell_filter(filter: &ObjectFilter) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32822,6 +32822,9 @@ pub(super) fn collect_activation_restriction_clauses(
     }
 
     for raw in additional_restrictions {
+        if raw.to_ascii_lowercase().starts_with("display label:") {
+            continue;
+        }
         if raw
             .to_ascii_lowercase()
             .contains("exhaust ability only once")
@@ -35961,11 +35964,27 @@ pub(super) fn describe_ability(
             if is_exhaust {
                 line = format!("Exhaust — {line}");
             }
+            if activated_has_display_label(activated, "Waterbend") {
+                if let Some((_, tail)) = line.split_once(": ") {
+                    line = format!("Waterbend {tail}");
+                }
+            }
             line = normalize_ability_self_reference_surface(&line, subject);
             line = normalize_graveyard_source_return_surface(&line, ability);
             vec![line]
         }
     }
+}
+
+fn activated_has_display_label(
+    activated: &crate::ability::ActivatedAbility,
+    label: &str,
+) -> bool {
+    let needle = format!("display label: {}", label.to_ascii_lowercase());
+    activated
+        .additional_restrictions
+        .iter()
+        .any(|restriction| restriction.to_ascii_lowercase().starts_with(&needle))
 }
 
 fn normalize_granted_triggered_ability_surface(surface: String) -> String {

--- a/crates/ironsmith-runtime/src/decision/types.rs
+++ b/crates/ironsmith-runtime/src/decision/types.rs
@@ -302,6 +302,7 @@ pub enum ManaPipPaymentAction {
 pub enum AlternativePaymentEffect {
     Convoke,
     Improvise,
+    Waterbend,
 }
 
 /// Tracks a keyword ability payment contribution made while casting a spell.

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -3286,7 +3286,7 @@ pub(super) fn continue_activation(
             );
             let display_pip =
                 current_display_pip(&pending.display_mana_pips, &pending.remaining_mana_pips);
-            let options = build_pip_payment_options(
+            let mut options = build_pip_payment_options(
                 game,
                 player_id,
                 &pip,
@@ -3295,6 +3295,14 @@ pub(super) fn continue_activation(
                 allow_black_life,
                 Some(source),
                 &mut *decision_maker,
+            );
+            add_activation_waterbend_pip_payment_options(
+                game,
+                player_id,
+                source,
+                pending.ability_index,
+                &pip,
+                &mut options,
             );
 
             // If no options available (shouldn't happen if we validated correctly), error

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -567,6 +567,73 @@ pub(super) fn add_pip_alternative_payment_options(
     }
 }
 
+pub(super) fn add_activation_waterbend_pip_payment_options(
+    game: &GameState,
+    player: PlayerId,
+    source: ObjectId,
+    ability_index: usize,
+    pip: &[crate::mana::ManaSymbol],
+    options: &mut Vec<ManaPipPaymentOption>,
+) {
+    if !activation_has_display_label(game, source, ability_index, "Waterbend")
+        || !waterbend_can_pay_pip(pip)
+    {
+        return;
+    }
+
+    for permanent_id in get_waterbend_permanents(game, player) {
+        options.push(ManaPipPaymentOption {
+            index: options.len(),
+            description: format!(
+                "Tap {} to pay this pip (Waterbend)",
+                describe_permanent(game, permanent_id)
+            ),
+            action: ManaPipPaymentAction::PayViaAlternative {
+                permanent_id,
+                effect: AlternativePaymentEffect::Waterbend,
+            },
+        });
+    }
+}
+
+fn activation_has_display_label(
+    game: &GameState,
+    source: ObjectId,
+    ability_index: usize,
+    label: &str,
+) -> bool {
+    let Some(ability) = game
+        .object(source)
+        .and_then(|object| object.abilities.get(ability_index))
+    else {
+        return false;
+    };
+    let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+        return false;
+    };
+
+    let needle = format!("display label: {}", label.to_ascii_lowercase());
+    activated
+        .additional_restrictions
+        .iter()
+        .any(|restriction| restriction.to_ascii_lowercase().starts_with(&needle))
+}
+
+fn get_waterbend_permanents(game: &GameState, player: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .filter_map(|&id| {
+            let obj = game.object(id)?;
+            if game.controller_of(obj) != player || game.is_tapped(id) {
+                return None;
+            }
+            (game.current_is_creature(id)
+                || game.current_has_card_type(id, crate::types::CardType::Artifact))
+            .then_some(id)
+        })
+        .collect()
+}
+
 pub(super) fn convoke_can_pay_pip(
     colors: crate::color::ColorSet,
     pip: &[crate::mana::ManaSymbol],
@@ -586,6 +653,11 @@ pub(super) fn convoke_can_pay_pip(
 }
 
 pub(super) fn improvise_can_pay_pip(pip: &[crate::mana::ManaSymbol]) -> bool {
+    pip.iter()
+        .any(|symbol| matches!(symbol, crate::mana::ManaSymbol::Generic(_)))
+}
+
+fn waterbend_can_pay_pip(pip: &[crate::mana::ManaSymbol]) -> bool {
     pip.iter()
         .any(|symbol| matches!(symbol, crate::mana::ManaSymbol::Generic(_)))
 }
@@ -2253,7 +2325,7 @@ pub(super) fn apply_pip_payment_response_activation(
         Some(pending.source),
         crate::costs::PaymentReason::ActivateAbility,
     );
-    let options = build_pip_payment_options(
+    let mut options = build_pip_payment_options(
         game,
         pending.activator,
         &pip,
@@ -2262,6 +2334,14 @@ pub(super) fn apply_pip_payment_response_activation(
         allow_black_life,
         Some(pending.source),
         &mut *decision_maker,
+    );
+    add_activation_waterbend_pip_payment_options(
+        game,
+        pending.activator,
+        pending.source,
+        pending.ability_index,
+        &pip,
+        &mut options,
     );
 
     if choice >= options.len() {

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -273,6 +273,7 @@ pub(super) fn keyword_action_from_alternative_effect(
     match effect {
         AlternativePaymentEffect::Convoke => KeywordActionKind::Convoke,
         AlternativePaymentEffect::Improvise => KeywordActionKind::Improvise,
+        AlternativePaymentEffect::Waterbend => KeywordActionKind::Waterbend,
     }
 }
 
@@ -280,6 +281,7 @@ pub(super) fn payment_contribution_tag(effect: AlternativePaymentEffect) -> &'st
     match effect {
         AlternativePaymentEffect::Convoke => "convoked_this_spell",
         AlternativePaymentEffect::Improvise => "improvised_this_spell",
+        AlternativePaymentEffect::Waterbend => "waterbent_this_spell",
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -28218,6 +28218,182 @@ impl DecisionMaker for ChooseFreeCastOptionByLabel {
     }
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn yue_the_moon_spirit_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(83_001), "Yue, the Moon Spirit")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit, Subtype::Ally])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Flying, vigilance\n\
+             Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost.",
+        )
+        .expect("Yue, the Moon Spirit should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn yue_waterbend_resolution_effect(def: &crate::cards::CardDefinition) -> Effect {
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Yue should have a waterbend activated ability");
+    let [effect] = activated.effects.flattened_default_effects() else {
+        panic!(
+            "expected Yue's waterbend ability to have one resolution effect, got {:#?}",
+            activated.effects.flattened_default_effects()
+        );
+    };
+    effect.clone()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_yue_waterbend_casts_noncreature_spell_from_hand_without_mana() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let yue = yue_the_moon_spirit_definition();
+    let yue_id = game.create_object_from_definition(&yue, alice, Zone::Battlefield);
+    let free_spell = CardBuilder::new(CardId::from_raw(83_002), "Yue Free Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(9)]]))
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let free_spell_id = game.create_object_from_card(&free_spell, alice, Zone::Hand);
+
+    let effect = yue_waterbend_resolution_effect(&yue);
+    let mut dm = ChooseFreeCastOptionByLabel {
+        needle: "Yue Free Spell",
+    };
+    let mut ctx = ExecutionContext::new(yue_id, alice, &mut dm);
+    execute_effect(&mut game, &effect, &mut ctx)
+        .expect("Yue's waterbend free-cast effect should resolve");
+
+    let stack_entry = game
+        .stack
+        .last()
+        .expect("Yue's waterbend should put the chosen noncreature spell on the stack");
+    assert_eq!(stack_entry.casting_method, CastingMethod::Normal);
+    assert_eq!(stack_entry.controller, alice);
+    let stack_obj = game
+        .object(stack_entry.object_id)
+        .expect("free-cast spell should exist on stack");
+    assert_eq!(stack_obj.name, "Yue Free Spell");
+    assert!(
+        game.object(free_spell_id)
+            .is_none_or(|object| object.zone != Zone::Hand),
+        "Yue's chosen noncreature spell should leave hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_yue_waterbend_does_not_cast_creature_or_wrong_zone_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let yue = yue_the_moon_spirit_definition();
+    let yue_id = game.create_object_from_definition(&yue, alice, Zone::Battlefield);
+    let creature = CardBuilder::new(CardId::from_raw(83_003), "Yue Creature Decoy")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let creature_id = game.create_object_from_card(&creature, alice, Zone::Hand);
+    let graveyard_spell = CardBuilder::new(CardId::from_raw(83_004), "Yue Graveyard Decoy")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let graveyard_spell_id = game.create_object_from_card(&graveyard_spell, alice, Zone::Graveyard);
+
+    let effect = yue_waterbend_resolution_effect(&yue);
+    let mut dm = ChooseFreeCastOptionByLabel {
+        needle: "Yue Creature Decoy",
+    };
+    let mut ctx = ExecutionContext::new(yue_id, alice, &mut dm);
+    execute_effect(&mut game, &effect, &mut ctx)
+        .expect("Yue's waterbend should resolve even with no legal spell to cast");
+
+    assert!(game.stack.is_empty(), "Yue should not cast an ineligible card");
+    assert_eq!(game.object(creature_id).map(|object| object.zone), Some(Zone::Hand));
+    assert_eq!(
+        game.object(graveyard_spell_id).map(|object| object.zone),
+        Some(Zone::Graveyard),
+        "Yue should only look for noncreature spells in hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_yue_waterbend_activation_taps_artifacts_and_creatures_for_generic_cost() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let yue = yue_the_moon_spirit_definition();
+    let yue_id = game.create_object_from_definition(&yue, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(yue_id);
+
+    let mut helper_ids = Vec::new();
+    for idx in 0..3 {
+        let artifact = CardBuilder::new(CardId::from_raw(83_010 + idx), "Waterbend Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        helper_ids.push(game.create_object_from_card(&artifact, alice, Zone::Battlefield));
+    }
+    for idx in 0..2 {
+        let creature = CardBuilder::new(CardId::from_raw(83_020 + idx), "Waterbend Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        helper_ids.push(game.create_object_from_card(&creature, alice, Zone::Battlefield));
+    }
+
+    let ability_index = game
+        .object(yue_id)
+        .expect("Yue should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Yue should have a waterbend activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                if *source == yue_id && *idx == ability_index
+        ))
+        .expect("Yue's waterbend activation should be legal with five helpers and no mana");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = AutoPassDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Yue's waterbend activation should pay costs and go on the stack");
+
+    assert!(game.is_tapped(yue_id), "Yue should tap for its {{T}} cost");
+    assert!(
+        helper_ids.iter().all(|&id| game.is_tapped(id)),
+        "waterbend should tap artifacts and creatures to pay the five generic mana"
+    );
+    assert_eq!(game.stack.len(), 1, "Yue's activated ability should be on the stack");
+}
+
 #[test]
 fn test_effect_driven_free_cast_can_choose_adventure_half_from_hand() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Yue, the Moon Spirit
Initial parse error:
```
could not find verb in effect clause (clause: 'cast a noncreature spell from your hand without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast a noncreature spell from your hand without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-03485e95837f95d6c
Branch: codex/aws-card-fix-yue-the-moon-spirit
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0256
