### PR TITLE
Fix Ironsmith parse failure: Pyretic Hunter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -798,6 +798,10 @@ pub(crate) fn parse_value_binding_clause(tokens: &[OwnedLexToken]) -> Option<Val
         return Some(value);
     }
 
+    if let Some(value) = parse_where_x_draft_noted_highest_number_value(&words) {
+        return Some(value);
+    }
+
     match words.get(3..) {
         Some(
             [
@@ -1128,6 +1132,43 @@ pub(crate) fn parse_value_binding_clause_lexed(
     tokens: &[crate::runtime_backend::lexer::OwnedLexToken],
 ) -> Option<Value> {
     parse_value_binding_clause(tokens)
+}
+
+fn parse_where_x_draft_noted_highest_number_value(words: &[&str]) -> Option<Value> {
+    let tail = words.get(3..)?;
+    let name_words = match tail {
+        [
+            "the",
+            "highest",
+            "number",
+            "you",
+            "noted",
+            "for",
+            "cards",
+            "named",
+            name @ ..,
+        ]
+        | [
+            "highest",
+            "number",
+            "you",
+            "noted",
+            "for",
+            "cards",
+            "named",
+            name @ ..,
+        ] => name,
+        _ => return None,
+    };
+    if name_words.is_empty() {
+        return None;
+    }
+    Some(
+        Value::DraftNotedHighestNumber {
+            card_name: name_words.join(" "),
+        }
+        .with_surface_hint(ValueSurfaceHint::WhereXIs),
+    )
 }
 
 pub(crate) fn parse_where_x_source_stat_value(tokens: &[OwnedLexToken]) -> Option<Value> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -107,7 +107,7 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 30] = [
     LineFamilyRuleDef {
         id: "draft-rule-line",
         priority: 37,
-        heads: &["draft", "as", "during", "immediately", "each"],
+        heads: &["draft", "reveal", "as", "during", "immediately", "each"],
         run: run_draft_rule_line_family,
     },
     LineFamilyRuleDef {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -235,6 +235,7 @@ fn is_draft_rule_line(raw_line: &str) -> bool {
     }
 
     lower.trim_end_matches('.') == "draft this card face up"
+        || lower.starts_with("reveal this card as you draft it")
         || lower.starts_with("as you draft ")
         || lower.starts_with("during the draft, ")
         || lower.starts_with("immediately after the draft, ")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1459,6 +1459,7 @@ fn looks_like_ability_word_marker_text(text: &str, parse_tokens: &[OwnedLexToken
 fn is_draft_rule_static_line(raw: &str) -> bool {
     let lower = raw.trim().to_ascii_lowercase();
     lower.trim_end_matches('.') == "draft this card face up"
+        || lower.starts_with("reveal this card as you draft it")
         || lower.starts_with("as you draft ")
         || lower.starts_with("during the draft, ")
         || lower.starts_with("immediately after the draft, ")

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -154,6 +154,7 @@ pub enum Value {
     TimesPaidLabel(String),
     KickCount,
     MagicGamesLostToOpponentsSinceLastWin,
+    DraftNotedHighestNumber { card_name: String },
     CountersOnSource(CounterType),
     CountersOn(Box<ChooseSpec>, Option<CounterType>),
     TaggedCount,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -516,6 +516,118 @@ fn cogwork_librarian_draft_rules_do_not_create_runtime_effects() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn pyretic_hunter_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Pyretic Hunter");
+
+    assert_eq!(
+        canonical_compiled_lines(&def),
+        vec![
+            "Reveal this card as you draft it and note how many cards you've drafted this draft round, including this card."
+                .to_string(),
+            "Menace".to_string(),
+            "This creature enters with X +1/+1 counters on it, where X is the highest number you noted for cards named Pyretic Hunter."
+                .to_string(),
+        ],
+        "Pyretic Hunter should preserve its draft note and noted-number counter clause"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pyretic_hunter_draft_note_and_counter_value_are_structural() {
+    let def = parse_oracle_card_definition("Pyretic Hunter");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        def.abilities.iter().any(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => {
+                static_ability.id() == StaticAbilityId::DraftRuleText
+            }
+            _ => false,
+        }),
+        "Pyretic Hunter should compile the reveal-as-you-draft line as draft-only rule text, got {debug}"
+    );
+    assert!(
+        debug.contains("DraftNotedHighestNumber") && debug.contains("pyretic hunter"),
+        "Pyretic Hunter should model the highest noted number as a structured counter value, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pyretic_hunter_without_tracked_draft_notes_enters_with_zero_counters() {
+    let oracle = oracle_text_by_name()
+        .get("Pyretic Hunter")
+        .expect("Pyretic Hunter oracle text should be available")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Pyretic Hunter")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elemental, Subtype::Cat])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(oracle)
+        .expect("Pyretic Hunter should parse strictly");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let hunter_in_hand = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let hunter = game
+        .move_object_with_etb_processing(hunter_in_hand, Zone::Battlefield)
+        .expect("Pyretic Hunter should enter")
+        .new_id;
+    let hunter_obj = game.object(hunter).expect("Pyretic Hunter should exist");
+
+    assert_eq!(
+        hunter_obj
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "without tracked draft-note state, Pyretic Hunter should enter with zero +1/+1 counters"
+    );
+    assert_eq!(game.current_power(hunter), Some(0));
+    assert_eq!(game.current_toughness(hunter), Some(0));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pyretic_hunter_uses_tracked_highest_draft_note_for_entering_counters() {
+    let oracle = oracle_text_by_name()
+        .get("Pyretic Hunter")
+        .expect("Pyretic Hunter oracle text should be available")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Pyretic Hunter")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elemental, Subtype::Cat])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(oracle)
+        .expect("Pyretic Hunter should parse strictly");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    game.set_draft_noted_highest_number(alice, "Pyretic Hunter", 4);
+    let hunter_in_hand = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let hunter = game
+        .move_object_with_etb_processing(hunter_in_hand, Zone::Battlefield)
+        .expect("Pyretic Hunter should enter")
+        .new_id;
+    let hunter_obj = game.object(hunter).expect("Pyretic Hunter should exist");
+
+    assert_eq!(
+        hunter_obj
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0),
+        4,
+        "Pyretic Hunter should enter with the highest noted number of +1/+1 counters"
+    );
+    assert_eq!(game.current_power(hunter), Some(4));
+    assert_eq!(game.current_toughness(hunter), Some(4));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn firkraag_cunning_instigator_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Firkraag, Cunning Instigator");
     let rendered = canonical_compiled_lines(&def).join("\n");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8003,6 +8003,10 @@ pub(crate) fn describe_value(value: &Value) -> String {
         Value::MagicGamesLostToOpponentsSinceLastWin => {
             "the number of Magic games you've lost to one of your opponents since you last won a game against them".to_string()
         }
+        Value::DraftNotedHighestNumber { card_name } => format!(
+            "the highest number you noted for cards named {}",
+            title_case_card_name_fragment(card_name)
+        ),
         Value::EffectValue(_) => "X".to_string(),
         Value::EffectValueOffset(_, offset) => {
             if *offset == 0 {
@@ -8080,6 +8084,32 @@ pub(crate) fn describe_value(value: &Value) -> String {
         }
         Value::TaggedCount => "the tagged object count".to_string(),
     }
+}
+
+fn title_case_card_name_fragment(name: &str) -> String {
+    let small_words = [
+        "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "of", "or", "the",
+        "to", "with",
+    ];
+    name.split_whitespace()
+        .enumerate()
+        .map(|(idx, word)| {
+            if idx > 0 && small_words.contains(&word) {
+                word.to_string()
+            } else {
+                let mut chars = word.chars();
+                match chars.next() {
+                    Some(first) => {
+                        let mut out = first.to_ascii_uppercase().to_string();
+                        out.push_str(chars.as_str());
+                        out
+                    }
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 pub(super) fn party_size_multiplier(value: &Value) -> Option<(PlayerFilter, i32)> {

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4389,6 +4389,11 @@ fn resolve_value_with_context(
         | Value::TaggedCount
         | Value::EventValue(_)
         | Value::EventValueOffset(_, _) => 0,
+        Value::DraftNotedHighestNumber { card_name } => ctx
+            .game
+            .draft_noted_highest_number(controller, card_name)
+            .try_into()
+            .unwrap_or(i32::MAX),
     }
 }
 

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1382,6 +1382,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::WasPaidLabel(_)
         | Value::TimesPaid(_)
         | Value::MagicGamesLostToOpponentsSinceLastWin
+        | Value::DraftNotedHighestNumber { .. }
         | Value::TaggedCount
         | Value::EventValue(_)
         | Value::EventValueOffset(_, _) => false,

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1406,6 +1406,11 @@ pub fn resolve_value(
         // The core engine does not currently track cross-game match history.
         Value::MagicGamesLostToOpponentsSinceLastWin => Ok(0),
 
+        Value::DraftNotedHighestNumber { card_name } => Ok(game
+            .draft_noted_highest_number(ctx.controller, card_name)
+            .try_into()
+            .unwrap_or(i32::MAX)),
+
         Value::EffectValue(effect_id) => {
             let outcome = ctx
                 .get_outcome(*effect_id)

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -1995,6 +1995,9 @@ pub struct GameState {
     /// Players whose inherent speed trigger has already fired this turn.
     pub speed_increase_triggered_this_turn: HashSet<PlayerId>,
 
+    /// Highest pregame draft-note number recorded by a player for a named card.
+    pub draft_noted_highest_numbers: HashMap<(PlayerId, String), u32>,
+
     // =========================================================================
     // Battlefield State Extension Maps
     // =========================================================================
@@ -2126,6 +2129,13 @@ impl DerefMut for GameState {
     }
 }
 
+fn normalize_draft_note_card_name(name: &str) -> String {
+    name.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
 impl GameState {
     /// Creates a new game state with the given players.
     pub fn new(player_names: Vec<String>, starting_life: i32) -> Self {
@@ -2176,6 +2186,7 @@ impl GameState {
             ninjutsu_attack_targets: HashMap::new(),
             combat_damage_player_batch_hits: Vec::new(),
             speed_increase_triggered_this_turn: HashSet::new(),
+            draft_noted_highest_numbers: HashMap::new(),
             // Battlefield state extension maps
             tapped_permanents: HashSet::new(),
             summoning_sick: HashSet::new(),
@@ -2221,6 +2232,27 @@ impl GameState {
 
     pub fn set_auto_choose_single_object_decisions(&mut self, enabled: bool) {
         self.auto_choose_single_object_decisions = enabled;
+    }
+
+    pub fn set_draft_noted_highest_number(
+        &mut self,
+        player: PlayerId,
+        card_name: impl AsRef<str>,
+        count: u32,
+    ) {
+        self.draft_noted_highest_numbers
+            .insert((player, normalize_draft_note_card_name(card_name.as_ref())), count);
+    }
+
+    pub fn draft_noted_highest_number(
+        &self,
+        player: PlayerId,
+        card_name: impl AsRef<str>,
+    ) -> u32 {
+        self.draft_noted_highest_numbers
+            .get(&(player, normalize_draft_note_card_name(card_name.as_ref())))
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Creates a new game state after explicitly resetting runtime player/object IDs.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pyretic Hunter
Initial parse error:
```
unsupported reveal clause (clause: 'this card as you draft it and note how many cards you've drafted this draft round including this card'); oracle-only fallback also failed: unsupported reveal clause (clause: 'this card as you draft it and note how many cards you've drafted this draft round including this card')
```

Current worker: i-07a17f63c30e3beec
Branch: codex/aws-card-fix-pyretic-hunter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0257
