### PR TITLE
Fix Ironsmith parse failure: Pearl-Ear, Imperial Advisor

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -640,6 +640,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_equip_cost_modifier_line),
         single_static_ability_ast_rule!(parse_flashback_cost_modifier_line),
         multi_static_ability_ast_rule!(parse_spell_and_player_activated_ability_cost_modifier_line),
+        single_static_ability_ast_rule!(parse_spells_have_affinity_for_line),
         single_static_ability_ast_rule!(parse_spells_cost_modifier_line),
         single_static_ability_ast_passthrough_rule!(parse_trigger_duplication_line_ast),
         single_static_ability_ast_rule!(
@@ -5007,6 +5008,136 @@ pub(crate) fn parse_cost_modifier_prefix_condition(
     }
 
     Ok((None, 0))
+}
+
+fn uppercase_first_ascii(text: &str) -> String {
+    let mut chars = text.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    let mut out = first.to_ascii_uppercase().to_string();
+    out.push_str(chars.as_str());
+    out
+}
+
+fn affinity_spell_subject_display(filter: &ObjectFilter) -> String {
+    let mut subject_filter = filter.clone();
+    let cast_by = subject_filter.cast_by.take();
+    subject_filter.zone = None;
+    subject_filter.stack_kind = None;
+    let description = subject_filter.description();
+    let mut subject = if description == "object" {
+        "spells".to_string()
+    } else {
+        format!("{description} spells")
+    };
+    match cast_by {
+        Some(PlayerFilter::You) => subject.push_str(" you cast"),
+        Some(PlayerFilter::Opponent) => subject.push_str(" your opponents cast"),
+        _ => {}
+    }
+    uppercase_first_ascii(&subject)
+}
+
+fn affinity_object_display(filter: &ObjectFilter) -> String {
+    let description = filter.description();
+    let mut subject = description
+        .strip_suffix(" you control")
+        .or_else(|| description.strip_suffix(" controlled by you"))
+        .unwrap_or(description.as_str())
+        .to_string();
+    subject = subject
+        .strip_prefix("a ")
+        .or_else(|| subject.strip_prefix("an "))
+        .unwrap_or(subject.as_str())
+        .to_string();
+    if !subject.ends_with('s') {
+        subject.push('s');
+    }
+    uppercase_first_ascii(&subject)
+}
+
+pub(crate) fn parse_spells_have_affinity_for_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if clause_words.len() < 7 {
+        return Ok(None);
+    }
+
+    let Some(spells_token_idx) = find_index(tokens, |token| {
+        token.is_word("spell") || token.is_word("spells")
+    }) else {
+        return Ok(None);
+    };
+    let Some(have_token_idx) = find_index(&tokens[spells_token_idx + 1..], |token| {
+        token.is_word("have") || token.is_word("has")
+    })
+    .map(|idx| idx + spells_token_idx + 1) else {
+        return Ok(None);
+    };
+
+    if !tokens
+        .get(have_token_idx + 1)
+        .is_some_and(|token| token.is_word("affinity"))
+        || !tokens
+            .get(have_token_idx + 2)
+            .is_some_and(|token| token.is_word("for"))
+    {
+        return Ok(None);
+    }
+
+    let subject_tokens = trim_commas(&tokens[..spells_token_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+    let mut spell_filter = parse_spell_filter_with_grammar_entrypoint(&subject_tokens);
+
+    let between_tokens = &tokens[spells_token_idx + 1..have_token_idx];
+    let between_words = crate::runtime_backend::token_word_refs(between_tokens);
+    if word_slice_contains_phrase(&between_words, &["you", "cast"]) {
+        spell_filter.cast_by = Some(PlayerFilter::You);
+    }
+    if between_words
+        .iter()
+        .any(|word| *word == "opponent" || *word == "opponents")
+        && between_words
+            .iter()
+            .any(|word| *word == "cast" || *word == "casts")
+    {
+        spell_filter.cast_by = Some(PlayerFilter::Opponent);
+    }
+
+    let affinity_start = have_token_idx + 3;
+    let affinity_end = tokens[affinity_start..]
+        .iter()
+        .position(|token| {
+            token.is_period() || token.kind == TokenKind::LParen || token.kind == TokenKind::RParen
+        })
+        .map(|idx| affinity_start + idx)
+        .unwrap_or(tokens.len());
+    let affinity_tokens = trim_commas(&tokens[affinity_start..affinity_end]);
+    if affinity_tokens.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing affinity object in spells-have-affinity clause (clause: '{}')",
+            clause_words.join(" ")
+        )));
+    }
+
+    let affinity_filter =
+        parse_object_filter(&affinity_tokens, false)?.controlled_by(PlayerFilter::You);
+    let subject = affinity_spell_subject_display(&spell_filter);
+    let display = format!(
+        "{subject} have affinity for {}",
+        affinity_object_display(&affinity_filter)
+    );
+    let ability = crate::static_abilities::CostReduction::new(
+        spell_filter,
+        Value::Count(affinity_filter),
+    )
+    .with_display(display);
+
+    Ok(Some(StaticAbility::new(ability)))
 }
 
 pub(crate) fn parse_spells_cost_modifier_line(

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -4049,13 +4049,22 @@ impl CopyTriggeredAbilities {
 pub struct CostReduction {
     pub filter: ObjectFilter,
     pub amount: Value,
+    pub display: Option<String>,
 }
 
 impl CostReduction {
     pub fn new(filter: ObjectFilter, amount: Value) -> Self {
-        Self { filter, amount }
+        Self {
+            filter,
+            amount,
+            display: None,
+        }
     }
     pub fn with_condition(self, _condition: Condition) -> Self {
+        self
+    }
+    pub fn with_display(mut self, display: impl Into<String>) -> Self {
+        self.display = Some(display.into());
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31810,6 +31810,215 @@ fn execute_herald_upkeep(
 }
 
 #[test]
+fn pearl_ear_imperial_advisor_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Pearl-Ear, Imperial Advisor");
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        !crate::cards::generated_definition_has_unimplemented_content(&def),
+        "Pearl-Ear should not contain unsupported markers: {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("CostReduction")
+            && abilities_debug.contains("Count")
+            && abilities_debug.contains("Aura"),
+        "expected Pearl-Ear to compile affinity for Auras as a dynamic cost reduction, got {abilities_debug}"
+    );
+
+    let rendered_lines = unprocessed_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+    assert!(
+        rendered.contains("Enchantment spells you cast have affinity for Auras"),
+        "expected affinity wording in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever you cast an Aura spell that targets a modified permanent you control, draw a card."),
+        "expected modified-permanent Aura trigger text, got {rendered}"
+    );
+
+    let oracle = oracle_text_by_name()
+        .get("Pearl-Ear, Imperial Advisor")
+        .expect("missing Pearl-Ear oracle text");
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_card_semantics_scored(
+            "Pearl-Ear, Imperial Advisor",
+            oracle,
+            &rendered_lines,
+            crate::semantic_compare::report_embedding_config(),
+        );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Pearl-Ear compiled text to match oracle, got similarity={similarity}, mismatch={mismatch}, text={rendered}"
+    );
+}
+
+#[test]
+fn pearl_ear_affinity_reduces_only_enchantment_spells_for_auras_you_control() {
+    let pearl_ear = parse_oracle_card_definition("Pearl-Ear, Imperial Advisor");
+    let aura = CardDefinitionBuilder::new(CardId::from_raw(91_100), "Test Aura")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .build();
+    let enchantment_spell = CardDefinitionBuilder::new(CardId::from_raw(91_101), "Test Shrine")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let instant_spell = CardDefinitionBuilder::new(CardId::from_raw(91_102), "Test Instant")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let non_aura_enchantment = CardDefinitionBuilder::new(CardId::from_raw(91_103), "Test Seal")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    game.create_object_from_definition(&pearl_ear, alice, Zone::Battlefield);
+    game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+    game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+    game.create_object_from_definition(&aura, bob, Zone::Battlefield);
+    game.create_object_from_definition(&non_aura_enchantment, alice, Zone::Battlefield);
+
+    let enchantment_spell_id =
+        game.create_object_from_definition(&enchantment_spell, alice, Zone::Hand);
+    let enchantment_spell_obj = game
+        .object(enchantment_spell_id)
+        .expect("enchantment spell in hand");
+    let enchantment_base_cost = enchantment_spell_obj
+        .mana_cost
+        .as_ref()
+        .expect("enchantment spell has mana cost");
+    let enchantment_cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        alice,
+        enchantment_spell_obj,
+        enchantment_base_cost,
+    );
+    assert_eq!(
+        enchantment_cost.mana_value(),
+        2,
+        "Pearl-Ear should reduce enchantment spells by only Alice's two Auras"
+    );
+
+    let instant_spell_id = game.create_object_from_definition(&instant_spell, alice, Zone::Hand);
+    let instant_spell_obj = game.object(instant_spell_id).expect("instant spell in hand");
+    let instant_base_cost = instant_spell_obj
+        .mana_cost
+        .as_ref()
+        .expect("instant spell has mana cost");
+    let instant_cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        alice,
+        instant_spell_obj,
+        instant_base_cost,
+    );
+    assert_eq!(
+        instant_cost.mana_value(),
+        4,
+        "Pearl-Ear affinity should not reduce non-enchantment spells"
+    );
+
+    let opponents_enchantment_spell_id =
+        game.create_object_from_definition(&enchantment_spell, bob, Zone::Hand);
+    let opponents_enchantment_spell_obj = game
+        .object(opponents_enchantment_spell_id)
+        .expect("opponent enchantment spell in hand");
+    let opponents_enchantment_base_cost = opponents_enchantment_spell_obj
+        .mana_cost
+        .as_ref()
+        .expect("opponent enchantment spell has mana cost");
+    let opponents_enchantment_cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        bob,
+        opponents_enchantment_spell_obj,
+        opponents_enchantment_base_cost,
+    );
+    assert_eq!(
+        opponents_enchantment_cost.mana_value(),
+        4,
+        "Pearl-Ear affinity should reduce only enchantment spells its controller casts"
+    );
+}
+
+#[test]
+fn pearl_ear_draw_trigger_requires_aura_targeting_modified_permanent_you_control() {
+    let pearl_ear = parse_oracle_card_definition("Pearl-Ear, Imperial Advisor");
+    let aura_spell = CardDefinitionBuilder::new(CardId::from_raw(91_110), "Test Aura Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .build();
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_111), "Test Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let draw_card = CardDefinitionBuilder::new(CardId::from_raw(91_112), "Drawn Card").build();
+
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    game.create_object_from_definition(&pearl_ear, alice, Zone::Battlefield);
+    let modified_creature =
+        game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let unmodified_creature =
+        game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    game.add_counters(
+        modified_creature,
+        crate::object::CounterType::PlusOnePlusOne,
+        1,
+    );
+    game.create_object_from_definition(&draw_card, alice, Zone::Library);
+
+    let unmodified_aura = game.create_object_from_definition(&aura_spell, alice, Zone::Stack);
+    game.push_to_stack(
+        crate::game_state::StackEntry::new(unmodified_aura, alice)
+            .with_targets(vec![crate::game_state::Target::Object(
+                unmodified_creature,
+            )]),
+    );
+    let unmodified_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::spells::SpellCastEvent::new(unmodified_aura, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        crate::triggers::check_triggers(&game, &unmodified_event).is_empty(),
+        "Pearl-Ear should not trigger for an Aura targeting an unmodified permanent"
+    );
+
+    let aura = game.create_object_from_definition(&aura_spell, alice, Zone::Stack);
+    game.push_to_stack(
+        crate::game_state::StackEntry::new(aura, alice)
+            .with_targets(vec![crate::game_state::Target::Object(modified_creature)]),
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::spells::SpellCastEvent::new(aura, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Pearl-Ear should trigger for an Aura targeting a modified permanent you control"
+    );
+
+    let hand_before = game.player(alice).expect("Alice exists").hand.len();
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Pearl-Ear trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Pearl-Ear draw trigger should resolve");
+    let hand_after = game.player(alice).expect("Alice exists").hand.len();
+    assert_eq!(
+        hand_after,
+        hand_before + 1,
+        "resolving Pearl-Ear's trigger should draw a card"
+    );
+}
+
+#[test]
 fn herald_of_leshrac_strict_parser_and_compiled_text_regression() {
     let def = herald_of_leshrac_definition();
     let abilities_debug = format!("{:?}", def.abilities);

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -723,6 +723,7 @@ pub struct CostReduction {
     pub filter: ObjectFilter,
     pub reduction: Value,
     pub condition: Option<crate::ConditionExpr>,
+    pub display: Option<String>,
 }
 
 impl CostReduction {
@@ -731,11 +732,17 @@ impl CostReduction {
             filter,
             reduction,
             condition: None,
+            display: None,
         }
     }
 
     pub fn with_condition(mut self, condition: crate::ConditionExpr) -> Self {
         self.condition = Some(condition);
+        self
+    }
+
+    pub fn with_display(mut self, display: impl Into<String>) -> Self {
+        self.display = Some(display.into());
         self
     }
 }
@@ -746,6 +753,10 @@ impl StaticAbilityKind for CostReduction {
     }
 
     fn display(&self) -> String {
+        if let Some(display) = &self.display {
+            return describe_cost_modifier_with_condition(display.clone(), &self.condition);
+        }
+
         let (amount_text, tail) = describe_cost_modifier_amount(&self.reduction);
         if let Some(subject) = describe_alternative_cost_subject(&self.filter) {
             let mut line = format!("{subject} cost {amount_text} less");

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -518,9 +518,14 @@ impl StaticAbilityModelInterpreter {
 
     fn cached_cost_reduction(model: &CompiledStaticAbility) -> Option<super::CostReduction> {
         match &model.payload {
-            ironsmith_core::StaticAbilityPayload::CostReduction(reduction) => Some(
-                super::CostReduction::new(reduction.filter.clone(), reduction.amount.clone()),
-            ),
+            ironsmith_core::StaticAbilityPayload::CostReduction(reduction) => {
+                let mut converted =
+                    super::CostReduction::new(reduction.filter.clone(), reduction.amount.clone());
+                if let Some(display) = &reduction.display {
+                    converted = converted.with_display(display.clone());
+                }
+                Some(converted)
+            }
             ironsmith_core::StaticAbilityPayload::Conditional { ability, condition } => {
                 Self::cached_cost_reduction(ability)
                     .map(|reduction| reduction.with_condition(condition.clone()))

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
@@ -358,6 +358,15 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
     {
         return "a noncreature spell".to_string();
     }
+    if !filter.subtypes.is_empty() {
+        let subtypes = filter
+            .subtypes
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" ");
+        return format!("{} {subtypes} spell", indefinite_article_for(&subtypes));
+    }
 
     let fallback = filter.description();
     if filter.zone == Some(Zone::Stack) {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pearl-Ear, Imperial Advisor
Initial parse error:
```
parser does not yet support line family: 'Enchantment spells you cast have affinity for Auras. (They cost {1} less to cast for each Aura you control.)'; oracle-only fallback also failed: parser does not yet support line family: 'Enchantment spells you cast have affinity for Auras.'
```

Current worker: i-0baf88adcceb43c2e
Branch: codex/aws-card-fix-pearl-ear-imperial-advisor
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0257
