### PR TITLE
Fix Ironsmith parse failure: Cone of Flame

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/fanout_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/fanout_family.rs
@@ -1212,6 +1212,92 @@ fn compound_damage_effects(
     }
 }
 
+fn starts_with_damage_amount(tokens: &[OwnedLexToken]) -> bool {
+    let Some((_amount, used)) = parse_value(tokens) else {
+        return false;
+    };
+    tokens
+        .get(used)
+        .is_some_and(|token| token.is_word("damage"))
+}
+
+fn next_damage_amount_target_part(tokens: &[OwnedLexToken]) -> Option<(usize, usize)> {
+    for idx in 0..tokens.len() {
+        if tokens[idx].is_comma() {
+            let mut next = idx + 1;
+            if tokens.get(next).is_some_and(|token| token.is_word("and")) {
+                next += 1;
+            }
+            if starts_with_damage_amount(&tokens[next..]) {
+                return Some((idx, next));
+            }
+        } else if tokens[idx].is_word("and") {
+            let next = idx + 1;
+            if starts_with_damage_amount(&tokens[next..]) {
+                return Some((idx, next));
+            }
+        }
+    }
+    None
+}
+
+fn parse_repeated_damage_amount_target_series(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let deal_tokens = if tokens.first().is_some_and(|token| token.is_word("deal")) {
+        tokens
+    } else if let Some((Verb::Deal, verb_idx)) = find_verb(tokens) {
+        &tokens[verb_idx..]
+    } else {
+        return Ok(None);
+    };
+
+    let mut rest = deal_tokens[1..].to_vec();
+    let mut effects = Vec::new();
+    loop {
+        rest = trim_commas(&rest);
+        if rest.first().is_some_and(|token| token.is_word("and")) {
+            rest = trim_commas(&rest[1..]);
+        }
+        if rest.is_empty() {
+            break;
+        }
+
+        let Some((amount, used)) = parse_value(&rest) else {
+            return Ok(None);
+        };
+        rest = rest[used..].to_vec();
+        if !rest.first().is_some_and(|token| token.is_word("damage")) {
+            return Ok(None);
+        }
+        rest = rest[1..].to_vec();
+        if rest.first().is_some_and(|token| token.is_word("to")) {
+            rest = rest[1..].to_vec();
+        }
+
+        let (target_tokens, next_rest) = if let Some((split_idx, next_start)) =
+            next_damage_amount_target_part(&rest)
+        {
+            (&rest[..split_idx], rest[next_start..].to_vec())
+        } else {
+            (rest.as_slice(), Vec::new())
+        };
+        let target_tokens = strip_trailing_damage_noise(target_tokens);
+        if target_tokens.is_empty() {
+            return Ok(None);
+        }
+        let target = parse_target_phrase(&target_tokens)?;
+        effects.push(EffectAst::subject_verb_damage(amount, target));
+        rest = next_rest;
+    }
+
+    if effects.len() >= 2 {
+        Ok(Some(effects))
+    } else {
+        Ok(None)
+    }
+}
+
 fn equal_damage_target_tail_starts_like_destination(tokens: &[OwnedLexToken]) -> bool {
     let words = crate::runtime_backend::token_word_refs(tokens);
     matches!(
@@ -1252,6 +1338,10 @@ fn parse_equal_damage_amount_and_targets(
 pub(crate) fn parse_compound_damage_fanout_sentence(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    if let Some(effects) = parse_repeated_damage_amount_target_series(tokens)? {
+        return Ok(Some(effects));
+    }
+
     let deal_tokens = if tokens.first().is_some_and(|token| token.is_word("deal")) {
         tokens
     } else if let Some((Verb::Deal, verb_idx)) = find_verb(tokens) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37419,6 +37419,29 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn cone_of_flame_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Cone of Flame");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+
+    assert_eq!(
+        rendered,
+        "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target."
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    let compact = debug.split_whitespace().collect::<String>();
+    assert!(
+        compact.contains("DealDamageEffect")
+            && compact.contains("Fixed(1,)")
+            && compact.contains("Fixed(2,)")
+            && compact.contains("Fixed(3,)")
+            && compact.contains("AnyTarget")
+            && compact.matches("AnyOtherTarget").count() >= 2,
+        "expected Cone of Flame to lower to three distinct target damage effects, got {debug}"
+    );
+}
+
+#[test]
 fn when_we_were_young_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("When We Were Young");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5118,6 +5118,41 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         unwrap_tag_wrappers(effect)
     }
 
+    fn damage_series_target_text(target: &ChooseSpec, idx: usize, total: usize) -> Option<String> {
+        match target.base() {
+            ChooseSpec::AnyTarget if idx == 0 => Some("any target".to_string()),
+            ChooseSpec::AnyOtherTarget if idx == 1 && total >= 3 => {
+                Some("another target".to_string())
+            }
+            ChooseSpec::AnyOtherTarget if idx >= 2 && total >= 3 => {
+                let ordinal = ordinal_word((idx + 1) as u32)?;
+                Some(format!("a {ordinal} target"))
+            }
+            ChooseSpec::AnyOtherTarget => Some("any other target".to_string()),
+            _ => None,
+        }
+    }
+
+    fn describe_repeated_damage_target_series(filtered: &[&Effect]) -> Option<String> {
+        if filtered.len() < 2 {
+            return None;
+        }
+
+        let mut clauses = Vec::with_capacity(filtered.len());
+        for (idx, effect) in filtered.iter().enumerate() {
+            let damage = unwrap_tag_wrappers(effect)
+                .downcast_ref::<crate::effects::DealDamageEffect>()?;
+            let (amount, where_x) = describe_damage_amount_clause(&damage.amount);
+            if where_x.is_some() || damage.source_is_combat {
+                return None;
+            }
+            let target = damage_series_target_text(&damage.target, idx, filtered.len())?;
+            clauses.push(format!("{amount} to {target}"));
+        }
+
+        Some(format!("Deal {}", join_with_and(&clauses)))
+    }
+
     fn describe_dynamic_return_from_graveyard_bundle(
         effects: &[Effect],
         filtered: &[&Effect],
@@ -10898,6 +10933,22 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             parts.push(rendered);
             idx += 3;
             continue;
+        }
+        if idx + 1 < filtered.len() {
+            let mut series_end = idx;
+            while series_end < filtered.len()
+                && unwrap_tag_wrappers(filtered[series_end])
+                    .downcast_ref::<crate::effects::DealDamageEffect>()
+                    .is_some()
+            {
+                series_end += 1;
+            }
+            if let Some(rendered) = describe_repeated_damage_target_series(&filtered[idx..series_end])
+            {
+                parts.push(rendered);
+                idx = series_end;
+                continue;
+            }
         }
         if idx + 3 < filtered.len()
             && let Some(rendered) =

--- a/crates/ironsmith-runtime/src/decision.rs
+++ b/crates/ironsmith-runtime/src/decision.rs
@@ -698,6 +698,7 @@ mod tests {
             vec![TargetRequirementContext {
                 description: "two targets".to_string(),
                 legal_targets: vec![first, second],
+                distinct_from_previous_targets: false,
                 min_targets: 2,
                 max_targets: Some(2),
             }],

--- a/crates/ironsmith-runtime/src/decisions/context.rs
+++ b/crates/ironsmith-runtime/src/decisions/context.rs
@@ -1224,6 +1224,8 @@ pub struct TargetRequirementContext {
     pub description: String,
     /// Legal targets for this requirement.
     pub legal_targets: Vec<crate::game_state::Target>,
+    /// Whether targets for this requirement must be distinct from earlier target slots.
+    pub distinct_from_previous_targets: bool,
     /// Minimum number of targets to choose.
     pub min_targets: usize,
     /// Maximum number of targets to choose (None = unlimited).
@@ -1239,6 +1241,7 @@ impl TargetRequirementContext {
         Self {
             description: description.into(),
             legal_targets,
+            distinct_from_previous_targets: false,
             min_targets: 1,
             max_targets: Some(1),
         }

--- a/crates/ironsmith-runtime/src/decisions/specs/objects.rs
+++ b/crates/ironsmith-runtime/src/decisions/specs/objects.rs
@@ -927,6 +927,7 @@ fn runtime_requirements(
         .map(|req| crate::decisions::context::TargetRequirementContext {
             description: req.description.clone(),
             legal_targets: req.legal_targets.clone(),
+            distinct_from_previous_targets: false,
             min_targets: req.min_targets,
             max_targets: req.max_targets,
         })

--- a/crates/ironsmith-runtime/src/effects/composition/reflexive_trigger.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/reflexive_trigger.rs
@@ -82,6 +82,10 @@ fn choose_reflexive_targets(
             vec![TargetRequirementContext {
                 description: describe_choice(spec),
                 legal_targets: legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    spec.base(),
+                    crate::target::ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: count.min,
                 max_targets: count.max,
             }],

--- a/crates/ironsmith-runtime/src/effects/damage/deal_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/deal_damage.rs
@@ -8,7 +8,7 @@ use crate::effects::EffectExecutor;
 use crate::effects::helpers::{
     resolve_objects_for_effect, resolve_player_from_spec, resolve_value,
 };
-use crate::effects::{ExecutionContext, ExecutionError, ResolvedTarget};
+use crate::effects::{ExecutionContext, ExecutionError, ResolvedTarget, TargetReusePolicy};
 use crate::events::DamageEvent;
 use crate::events::DamageTarget;
 use crate::events::LifeLossEvent;
@@ -157,6 +157,14 @@ pub(crate) fn apply_processed_damage_outcome(
 }
 
 impl EffectExecutor for DealDamageEffect {
+    fn target_reuse_policy(&self) -> TargetReusePolicy {
+        if matches!(self.target, ChooseSpec::AnyOtherTarget) {
+            TargetReusePolicy::AlwaysDeclareNew
+        } else {
+            TargetReusePolicy::ReuseCompatiblePrevious
+        }
+    }
+
     fn execute(
         &self,
         game: &mut GameState,

--- a/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
@@ -27,6 +27,10 @@ fn build_target_assignments_for_cast_tagged_copy(
             |requirement| crate::decisions::context::TargetRequirementContext {
                 description: requirement.description.clone(),
                 legal_targets: requirement.legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    requirement.spec.base(),
+                    crate::target::ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: requirement.min_targets,
                 max_targets: requirement.max_targets,
             },
@@ -71,6 +75,10 @@ fn choose_targets_for_cast_tagged_spell(
             |requirement| crate::decisions::context::TargetRequirementContext {
                 description: requirement.description.clone(),
                 legal_targets: requirement.legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    requirement.spec.base(),
+                    crate::target::ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: requirement.min_targets,
                 max_targets: requirement.max_targets,
             },
@@ -417,6 +425,10 @@ impl EffectExecutor for CastTaggedEffect {
                     |requirement| crate::decisions::context::TargetRequirementContext {
                         description: requirement.description.clone(),
                         legal_targets: requirement.legal_targets.clone(),
+                        distinct_from_previous_targets: matches!(
+                            requirement.spec.base(),
+                            crate::target::ChooseSpec::AnyOtherTarget
+                        ),
                         min_targets: requirement.min_targets,
                         max_targets: requirement.max_targets,
                     },

--- a/crates/ironsmith-runtime/src/effects/player/runtime_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/player/runtime_helpers.rs
@@ -156,6 +156,10 @@ fn target_assignments_for_requirements(
             |requirement| crate::decisions::context::TargetRequirementContext {
                 description: requirement.description.clone(),
                 legal_targets: requirement.legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    requirement.spec.base(),
+                    crate::target::ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: requirement.min_targets,
                 max_targets: requirement.max_targets,
             },
@@ -200,6 +204,10 @@ fn choose_effect_driven_cast_targets(
             |requirement| crate::decisions::context::TargetRequirementContext {
                 description: requirement.description.clone(),
                 legal_targets: requirement.legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    requirement.spec.base(),
+                    crate::target::ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: requirement.min_targets,
                 max_targets: requirement.max_targets,
             },

--- a/crates/ironsmith-runtime/src/effects/stack/choose_new_targets.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/choose_new_targets.rs
@@ -73,6 +73,7 @@ fn extract_requirements(
         requirements.push(TargetRequirementContext {
             description: effect.0.target_description().to_string(),
             legal_targets,
+            distinct_from_previous_targets: matches!(spec.base(), crate::target::ChooseSpec::AnyOtherTarget),
             min_targets: count.min,
             max_targets: count.max,
         });

--- a/crates/ironsmith-runtime/src/effects/stack/copy_spell_for_each_target.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/copy_spell_for_each_target.rs
@@ -75,6 +75,7 @@ fn extract_requirements(
         requirements.push(TargetRequirementContext {
             description: effect.0.target_description().to_string(),
             legal_targets,
+            distinct_from_previous_targets: matches!(spec.base(), crate::target::ChooseSpec::AnyOtherTarget),
             min_targets: count.min,
             max_targets: count.max,
         });

--- a/crates/ironsmith-runtime/src/effects/stack/retarget_stack_object.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/retarget_stack_object.rs
@@ -79,6 +79,7 @@ fn extract_requirements(
         requirements.push(TargetRequirementContext {
             description: effect.0.target_description().to_string(),
             legal_targets,
+            distinct_from_previous_targets: matches!(spec.base(), crate::target::ChooseSpec::AnyOtherTarget),
             min_targets: count.min,
             max_targets: count.max,
         });

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -1032,6 +1032,10 @@ fn resolve_madness_discard(
                         |requirement| crate::decisions::context::TargetRequirementContext {
                             description: requirement.description.clone(),
                             legal_targets: requirement.legal_targets.clone(),
+                            distinct_from_previous_targets: matches!(
+                                requirement.spec.base(),
+                                crate::target::ChooseSpec::AnyOtherTarget
+                            ),
                             min_targets: requirement.min_targets,
                             max_targets: requirement.max_targets,
                         },

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -17,6 +17,7 @@ pub(super) fn stage_after_activation_announcements(pending: &PendingActivation) 
 
 fn build_target_assignments(
     requirements: &[TargetRequirement],
+    previous_targets: &[Target],
     targets: &[Target],
     offset: usize,
 ) -> Result<Vec<crate::game_state::TargetAssignment>, GameLoopError> {
@@ -26,14 +27,21 @@ fn build_target_assignments(
             |requirement| crate::decisions::context::TargetRequirementContext {
                 description: requirement.description.clone(),
                 legal_targets: requirement.legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    requirement.spec.base(),
+                    ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: requirement.min_targets,
                 max_targets: requirement.max_targets,
             },
         )
         .collect::<Vec<_>>();
 
-    let Some(ranges) = crate::targeting::assigned_target_ranges(&requirement_contexts, targets)
-    else {
+    let Some(ranges) = crate::targeting::assigned_target_ranges_after(
+        &requirement_contexts,
+        previous_targets,
+        targets,
+    ) else {
         return Err(GameLoopError::InvalidState(
             "targets do not satisfy the stored targeting requirements".to_string(),
         ));
@@ -1321,6 +1329,7 @@ pub(super) fn apply_targets_response(
     if let Some(mut pending) = state.pending_activation.take() {
         let assignments = build_target_assignments(
             &pending.remaining_requirements,
+            &pending.chosen_targets,
             targets,
             pending.chosen_targets.len(),
         )?;
@@ -1366,6 +1375,7 @@ pub(super) fn apply_targets_response(
 
     let assignments = build_target_assignments(
         &pending.remaining_requirements,
+        &pending.chosen_targets,
         targets,
         pending.chosen_targets.len(),
     )?;

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1289,6 +1289,7 @@ pub(super) fn continue_to_targets_or_mana_payment(
                 .map(|r| crate::decisions::context::TargetRequirementContext {
                     description: r.description,
                     legal_targets: r.legal_targets,
+                    distinct_from_previous_targets: matches!(r.spec.base(), ChooseSpec::AnyOtherTarget),
                     min_targets: r.min_targets,
                     max_targets: r.max_targets,
                 })
@@ -3237,6 +3238,10 @@ pub(super) fn continue_activation(
                         .map(|r| crate::decisions::context::TargetRequirementContext {
                             description: r.description,
                             legal_targets: r.legal_targets,
+                            distinct_from_previous_targets: matches!(
+                                r.spec.base(),
+                                ChooseSpec::AnyOtherTarget
+                            ),
                             min_targets: r.min_targets,
                             max_targets: r.max_targets,
                         })

--- a/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
+++ b/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
@@ -742,6 +742,10 @@ fn trigger_target_requirement_contexts(
             |requirement| crate::decisions::context::TargetRequirementContext {
                 description: requirement.description.clone(),
                 legal_targets: requirement.legal_targets.clone(),
+                distinct_from_previous_targets: matches!(
+                    requirement.spec.base(),
+                    ChooseSpec::AnyOtherTarget
+                ),
                 min_targets: requirement.min_targets,
                 max_targets: requirement.max_targets,
             },

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -2318,8 +2318,23 @@ pub(super) fn validate_stack_entry_targets_with_view(
             };
 
             let start = valid_targets.len();
-            for target in &entry.targets[assignment.range.clone()] {
+            if assignment.range.end > entry.targets.len()
+                || assignment.range.start > entry.targets.len()
+            {
+                invalid_count += assignment
+                    .range
+                    .end
+                    .saturating_sub(entry.targets.len())
+                    .max(1);
+            }
+            let available_start = assignment.range.start.min(entry.targets.len());
+            let available_end = assignment.range.end.min(entry.targets.len());
+            for target in &entry.targets[available_start..available_end] {
+                let repeats_prior_target =
+                    matches!(assignment.spec.base(), ChooseSpec::AnyOtherTarget)
+                        && entry.targets[..available_start].contains(target);
                 if legal_targets.contains(target)
+                    && !repeats_prior_target
                     || (contains_exchange_control
                         && exchange_control_target_still_targetable(game, entry, target, view))
                 {
@@ -2338,7 +2353,7 @@ pub(super) fn validate_stack_entry_targets_with_view(
             });
         }
 
-        let all_invalid = invalid_count == entry.targets.len();
+        let all_invalid = valid_targets.is_empty() && invalid_count > 0;
         return (valid_targets, valid_assignments, all_invalid);
     }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -10550,6 +10550,205 @@ fn stack_spell_with_granted_static_ability_still_executes_spell_effect() {
 }
 
 #[test]
+fn cone_of_flame_resolves_three_damage_amounts_to_three_targets() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let cone = CardDefinitionBuilder::new(CardId::new(), "Cone of Flame")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target.",
+        )
+        .expect("Cone of Flame should parse");
+    let first_creature = CardBuilder::new(CardId::from_raw(995_000), "First Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let second_creature = CardBuilder::new(CardId::from_raw(995_001), "Second Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let first_creature_id = game.create_object_from_card(&first_creature, bob, Zone::Battlefield);
+    let second_creature_id = game.create_object_from_card(&second_creature, bob, Zone::Battlefield);
+    let cone_id = game.create_object_from_definition(&cone, alice, Zone::Stack);
+
+    let entry = StackEntry::new(cone_id, alice)
+        .with_targets(vec![
+            Target::Player(bob),
+            Target::Object(first_creature_id),
+            Target::Object(second_creature_id),
+        ])
+        .with_target_assignments(vec![
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyTarget,
+                range: 0..1,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 1..2,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 2..3,
+            },
+        ]);
+    game.push_to_stack(entry);
+
+    resolve_stack_entry(&mut game).expect("Cone of Flame should resolve");
+
+    assert_eq!(game.player(bob).expect("Bob should exist").life, 19);
+    assert_eq!(game.damage_on(first_creature_id), 2);
+    assert_eq!(game.damage_on(second_creature_id), 3);
+}
+
+#[test]
+fn cone_of_flame_skips_only_targets_that_become_illegal_before_resolution() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let cone = CardDefinitionBuilder::new(CardId::new(), "Cone of Flame")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target.",
+        )
+        .expect("Cone of Flame should parse");
+    let first_creature = CardBuilder::new(CardId::from_raw(995_020), "First Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let second_creature = CardBuilder::new(CardId::from_raw(995_021), "Second Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let first_creature_id = game.create_object_from_card(&first_creature, bob, Zone::Battlefield);
+    let second_creature_id = game.create_object_from_card(&second_creature, bob, Zone::Battlefield);
+    let cone_id = game.create_object_from_definition(&cone, alice, Zone::Stack);
+
+    let entry = StackEntry::new(cone_id, alice)
+        .with_targets(vec![
+            Target::Player(bob),
+            Target::Object(first_creature_id),
+            Target::Object(second_creature_id),
+        ])
+        .with_target_assignments(vec![
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyTarget,
+                range: 0..1,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 1..2,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 2..3,
+            },
+        ]);
+    game.push_to_stack(entry);
+
+    game.move_object_by_effect(first_creature_id, Zone::Graveyard)
+        .expect("first creature should leave the battlefield before resolution");
+    resolve_stack_entry(&mut game).expect("Cone of Flame should resolve remaining legal targets");
+
+    assert_eq!(game.player(bob).expect("Bob should exist").life, 19);
+    assert_eq!(game.damage_on(first_creature_id), 0);
+    assert_eq!(game.damage_on(second_creature_id), 3);
+}
+
+#[test]
+fn cone_of_flame_exposes_three_target_requirements_and_ignores_missing_target_slot() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let cone = CardDefinitionBuilder::new(CardId::new(), "Cone of Flame")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target.",
+        )
+        .expect("Cone of Flame should parse");
+    let effects = cone
+        .spell_effect
+        .as_ref()
+        .expect("Cone of Flame should have spell effects")
+        .flattened_default_effects();
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(
+        requirements.len(),
+        3,
+        "Cone of Flame should require three target choices, got {requirements:?}"
+    );
+    assert!(
+        requirements
+            .iter()
+            .all(|requirement| requirement.min_targets == 1 && requirement.max_targets == Some(1)),
+        "each Cone of Flame damage clause should require exactly one target, got {requirements:?}"
+    );
+
+    let creature = CardBuilder::new(CardId::from_raw(995_010), "Only Creature Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let creature_id = game.create_object_from_card(&creature, bob, Zone::Battlefield);
+    let cone_id = game.create_object_from_definition(&cone, alice, Zone::Stack);
+
+    let entry = StackEntry::new(cone_id, alice)
+        .with_targets(vec![Target::Player(bob), Target::Object(creature_id)])
+        .with_target_assignments(vec![
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyTarget,
+                range: 0..1,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 1..2,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 2..3,
+            },
+        ]);
+    game.push_to_stack(entry);
+
+    resolve_stack_entry(&mut game)
+        .expect("Cone of Flame should handle an incomplete target assignment without panicking");
+
+    assert_eq!(game.player(bob).expect("Bob should exist").life, 19);
+    assert_eq!(game.damage_on(creature_id), 2);
+
+    let duplicate_cone_id = game.create_object_from_definition(&cone, alice, Zone::Stack);
+    let duplicate_entry = StackEntry::new(duplicate_cone_id, alice)
+        .with_targets(vec![Target::Player(bob), Target::Player(bob), Target::Player(bob)])
+        .with_target_assignments(vec![
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyTarget,
+                range: 0..1,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 1..2,
+            },
+            crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyOtherTarget,
+                range: 2..3,
+            },
+        ]);
+    game.push_to_stack(duplicate_entry);
+
+    resolve_stack_entry(&mut game)
+        .expect("Cone of Flame should ignore repeated choices for later 'other' targets");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        18,
+        "duplicate later targets should not receive the 2- and 3-damage clauses"
+    );
+}
+
+#[test]
 fn magma_mine_activated_ability_sacrifices_source_and_deals_counter_scaled_damage_to_player() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -10718,34 +10718,97 @@ fn cone_of_flame_exposes_three_target_requirements_and_ignores_missing_target_sl
 
     assert_eq!(game.player(bob).expect("Bob should exist").life, 19);
     assert_eq!(game.damage_on(creature_id), 2);
+}
 
-    let duplicate_cone_id = game.create_object_from_definition(&cone, alice, Zone::Stack);
-    let duplicate_entry = StackEntry::new(duplicate_cone_id, alice)
-        .with_targets(vec![Target::Player(bob), Target::Player(bob), Target::Player(bob)])
-        .with_target_assignments(vec![
-            crate::game_state::TargetAssignment {
-                spec: crate::target::ChooseSpec::AnyTarget,
-                range: 0..1,
-            },
-            crate::game_state::TargetAssignment {
-                spec: crate::target::ChooseSpec::AnyOtherTarget,
-                range: 1..2,
-            },
-            crate::game_state::TargetAssignment {
-                spec: crate::target::ChooseSpec::AnyOtherTarget,
-                range: 2..3,
-            },
-        ]);
-    game.push_to_stack(duplicate_entry);
+#[test]
+fn cone_of_flame_rejects_duplicate_targets_during_announcement() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
 
-    resolve_stack_entry(&mut game)
-        .expect("Cone of Flame should ignore repeated choices for later 'other' targets");
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
 
+    let cone = CardDefinitionBuilder::new(CardId::new(), "Cone of Flame")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Cone of Flame deals 1 damage to any target, 2 damage to another target, and 3 damage to a third target.",
+        )
+        .expect("Cone of Flame should parse");
+    let first_creature = CardBuilder::new(CardId::from_raw(995_030), "First Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let second_creature = CardBuilder::new(CardId::from_raw(995_031), "Second Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let first_creature_id = game.create_object_from_card(&first_creature, bob, Zone::Battlefield);
+    let second_creature_id = game.create_object_from_card(&second_creature, bob, Zone::Battlefield);
+    let cone_id = game.create_object_from_definition(&cone, alice, Zone::Hand);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id: cone_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("Cone of Flame cast should ask for targets");
+
+    let ctx = match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(ctx)) => {
+            ctx
+        }
+        other => panic!("expected Cone of Flame target selection, got {other:?}"),
+    };
+    assert_eq!(ctx.requirements.len(), 3);
     assert_eq!(
-        game.player(bob).expect("Bob should exist").life,
-        18,
-        "duplicate later targets should not receive the 2- and 3-damage clauses"
+        ctx.requirements
+            .iter()
+            .map(|requirement| requirement.distinct_from_previous_targets)
+            .collect::<Vec<_>>(),
+        vec![false, true, true],
+        "later Cone of Flame target clauses must be distinct from earlier target slots"
     );
+
+    let duplicate_result = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![
+            Target::Player(bob),
+            Target::Player(bob),
+            Target::Object(first_creature_id),
+        ]),
+    );
+    assert!(
+        duplicate_result.is_err(),
+        "Cone of Flame should reject a repeated 'another target' choice"
+    );
+    assert!(
+        game.stack.is_empty(),
+        "invalid duplicate targets should not create a stack entry"
+    );
+
+    let normalized = crate::targeting::normalize_targets_for_requirements(&ctx.requirements, vec![])
+        .expect("default target selection should find distinct Cone of Flame targets");
+    assert_eq!(normalized.len(), 3);
+    assert_ne!(normalized[0], normalized[1]);
+    assert_ne!(normalized[0], normalized[2]);
+    assert_ne!(normalized[1], normalized[2]);
+    assert!(normalized.iter().all(|target| match target {
+        Target::Player(_) => true,
+        Target::Object(object_id) => [first_creature_id, second_creature_id].contains(object_id),
+    }));
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/targeting/assignment.rs
+++ b/crates/ironsmith-runtime/src/targeting/assignment.rs
@@ -6,11 +6,13 @@ use crate::game_state::Target;
 
 fn assign_target_counts(
     requirements: &[TargetRequirementContext],
+    previous_targets: &[Target],
     targets: &[Target],
     allow_autofill: bool,
 ) -> Option<Vec<usize>> {
     fn recurse(
         requirements: &[TargetRequirementContext],
+        previous_targets: &[Target],
         targets: &[Target],
         req_idx: usize,
         cursor: usize,
@@ -30,10 +32,14 @@ fn assign_target_counts(
         } else {
             let req = &requirements[req_idx];
             let remaining = targets.len().saturating_sub(cursor);
-            let future_min: usize = requirements[req_idx + 1..]
-                .iter()
-                .map(|next| next.min_targets)
-                .sum();
+            let future_min: usize = if allow_autofill {
+                0
+            } else {
+                requirements[req_idx + 1..]
+                    .iter()
+                    .map(|next| next.min_targets)
+                    .sum()
+            };
             let min_for_req = if allow_autofill { 0 } else { req.min_targets };
             let max_for_req = req.max_targets.unwrap_or(remaining).min(remaining);
             let mut found = None;
@@ -51,9 +57,19 @@ fn assign_target_counts(
                     {
                         continue;
                     }
+                    if req.distinct_from_previous_targets
+                        && slice.iter().enumerate().any(|(idx, target)| {
+                            previous_targets.contains(target)
+                                || targets[..cursor].contains(target)
+                                || slice[..idx].contains(target)
+                        })
+                    {
+                        continue;
+                    }
 
                     if let Some(mut rest) = recurse(
                         requirements,
+                        previous_targets,
                         targets,
                         req_idx + 1,
                         cursor + count,
@@ -77,20 +93,31 @@ fn assign_target_counts(
     }
 
     let mut memo = HashMap::new();
-    recurse(requirements, targets, 0, 0, allow_autofill, &mut memo)
+    recurse(
+        requirements,
+        previous_targets,
+        targets,
+        0,
+        0,
+        allow_autofill,
+        &mut memo,
+    )
 }
 
 pub fn normalize_targets_for_requirements(
     requirements: &[TargetRequirementContext],
     proposed: Vec<Target>,
 ) -> Option<Vec<Target>> {
-    let counts = assign_target_counts(requirements, &proposed, true)?;
+    let counts = assign_target_counts(requirements, &[], &proposed, true)?;
     let mut out = Vec::new();
     let mut cursor = 0usize;
 
     for (req, count) in requirements.iter().zip(counts.into_iter()) {
         let mut selected = Vec::new();
         for target in &proposed[cursor..cursor + count] {
+            if req.distinct_from_previous_targets && out.contains(target) {
+                continue;
+            }
             if !selected.contains(target) {
                 selected.push(*target);
             }
@@ -101,6 +128,9 @@ pub fn normalize_targets_for_requirements(
             for legal in &req.legal_targets {
                 if selected.len() >= req.min_targets {
                     break;
+                }
+                if req.distinct_from_previous_targets && out.contains(legal) {
+                    continue;
                 }
                 if !selected.contains(legal) {
                     selected.push(*legal);
@@ -127,7 +157,15 @@ pub fn assigned_target_ranges(
     requirements: &[TargetRequirementContext],
     assigned: &[Target],
 ) -> Option<Vec<Range<usize>>> {
-    let counts = assign_target_counts(requirements, assigned, false)?;
+    assigned_target_ranges_after(requirements, &[], assigned)
+}
+
+pub fn assigned_target_ranges_after(
+    requirements: &[TargetRequirementContext],
+    previous_targets: &[Target],
+    assigned: &[Target],
+) -> Option<Vec<Range<usize>>> {
+    let counts = assign_target_counts(requirements, previous_targets, assigned, false)?;
     let mut cursor = 0usize;
     let mut ranges = Vec::with_capacity(counts.len());
 
@@ -144,7 +182,7 @@ pub fn validate_flat_target_assignment(
     requirements: &[TargetRequirementContext],
     targets: &[Target],
 ) -> bool {
-    assign_target_counts(requirements, targets, false).is_some()
+    assign_target_counts(requirements, &[], targets, false).is_some()
 }
 
 #[cfg(test)]
@@ -166,12 +204,14 @@ mod tests {
             TargetRequirementContext {
                 description: "any number".to_string(),
                 legal_targets: vec![a, b, c],
+                distinct_from_previous_targets: false,
                 min_targets: 0,
                 max_targets: None,
             },
             TargetRequirementContext {
                 description: "final target".to_string(),
                 legal_targets: vec![d],
+                distinct_from_previous_targets: false,
                 min_targets: 1,
                 max_targets: Some(1),
             },
@@ -193,6 +233,7 @@ mod tests {
         let requirements = vec![TargetRequirementContext {
             description: "required".to_string(),
             legal_targets: vec![a],
+            distinct_from_previous_targets: false,
             min_targets: 1,
             max_targets: Some(1),
         }];
@@ -211,17 +252,57 @@ mod tests {
             TargetRequirementContext {
                 description: "first".to_string(),
                 legal_targets: vec![a],
+                distinct_from_previous_targets: false,
                 min_targets: 1,
                 max_targets: Some(1),
             },
             TargetRequirementContext {
                 description: "second".to_string(),
                 legal_targets: vec![b],
+                distinct_from_previous_targets: false,
                 min_targets: 1,
                 max_targets: Some(1),
             },
         ];
 
         assert!(!validate_flat_target_assignment(&requirements, &[b, a]));
+    }
+
+    #[test]
+    fn any_other_target_requirements_reject_prior_target_reuse() {
+        let a = Target::Object(ObjectId::from_raw(1));
+        let b = Target::Object(ObjectId::from_raw(2));
+        let c = Target::Object(ObjectId::from_raw(3));
+        let requirements = vec![
+            TargetRequirementContext {
+                description: "first target".to_string(),
+                legal_targets: vec![a, b, c],
+                distinct_from_previous_targets: false,
+                min_targets: 1,
+                max_targets: Some(1),
+            },
+            TargetRequirementContext {
+                description: "another target".to_string(),
+                legal_targets: vec![a, b, c],
+                distinct_from_previous_targets: true,
+                min_targets: 1,
+                max_targets: Some(1),
+            },
+            TargetRequirementContext {
+                description: "a third target".to_string(),
+                legal_targets: vec![a, b, c],
+                distinct_from_previous_targets: true,
+                min_targets: 1,
+                max_targets: Some(1),
+            },
+        ];
+
+        assert!(assigned_target_ranges(&requirements, &[a, b, c]).is_some());
+        assert!(assigned_target_ranges(&requirements, &[a, a, c]).is_none());
+        assert!(assigned_target_ranges(&requirements, &[a, b, a]).is_none());
+        assert_eq!(
+            normalize_targets_for_requirements(&requirements, Vec::new()).expect("autofill"),
+            vec![a, b, c]
+        );
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cone of Flame
Initial parse error:
```
unsupported target phrase (clause: 'any target 2 damage to another target'); oracle-only fallback also failed: unsupported target phrase (clause: 'any target 2 damage to another target')
```

Current worker: i-0edcd1f2c8d1d4d3b
Branch: codex/aws-card-fix-cone-of-flame
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0258
