### PR TITLE
Fix Ironsmith parse failure: Rampaging Aetherhood

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4986,20 +4986,22 @@ fn compile_subject_verb_effect(
                 },
             )
         }
-        SubjectVerbActionAst::PayAnyEnergy => {
+        SubjectVerbActionAst::PayAnyEnergy { min_amount } => {
             let subject = resolve_subject_verb_subject(role, player, ctx, false, false, true)?;
             compile_player_effect_from_resolved_filter(
                 subject.into_player_filter(),
                 subject.into_choices(),
                 || {
-                    Effect::new(crate::effects::PayAnyEnergyEffect::new(ChooseSpec::Player(
-                        PlayerFilter::You,
-                    )))
+                    Effect::new(crate::effects::PayAnyEnergyEffect::new(
+                        ChooseSpec::Player(PlayerFilter::You),
+                        *min_amount,
+                    ))
                 },
                 |filter| {
-                    Effect::new(crate::effects::PayAnyEnergyEffect::new(ChooseSpec::Player(
-                        filter,
-                    )))
+                    Effect::new(crate::effects::PayAnyEnergyEffect::new(
+                        ChooseSpec::Player(filter),
+                        *min_amount,
+                    ))
                 },
             )
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -620,7 +620,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::CreateEmblem { .. }
         | SubjectVerbActionAst::LoseGame
         | SubjectVerbActionAst::WinGame
-        | SubjectVerbActionAst::PayAnyEnergy
+        | SubjectVerbActionAst::PayAnyEnergy { .. }
         | SubjectVerbActionAst::PayMana { .. }
         | SubjectVerbActionAst::DiscardHand
         | SubjectVerbActionAst::Detain { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1589,7 +1589,9 @@ pub(crate) enum SubjectVerbActionAst {
     PayEnergy {
         amount: Value,
     },
-    PayAnyEnergy,
+    PayAnyEnergy {
+        min_amount: u32,
+    },
     PayMana {
         cost: ManaCost,
     },
@@ -3053,7 +3055,10 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::EnergyCounters { count } => f.debug_tuple("EnergyCounters").field(count).finish(),
             Self::TicketCounters { count } => f.debug_tuple("TicketCounters").field(count).finish(),
             Self::PayEnergy { amount } => f.debug_tuple("PayEnergy").field(amount).finish(),
-            Self::PayAnyEnergy => f.write_str("PayAnyEnergy"),
+            Self::PayAnyEnergy { min_amount } => f
+                .debug_struct("PayAnyEnergy")
+                .field("min_amount", min_amount)
+                .finish(),
             Self::PayMana { cost } => f.debug_tuple("PayMana").field(cost).finish(),
             Self::DoubleManaPool => f.write_str("DoubleManaPool"),
             Self::EmptyManaPool => f.write_str("EmptyManaPool"),
@@ -6033,11 +6038,11 @@ impl EffectAst {
         )
     }
 
-    pub(crate) fn subject_verb_pay_any_energy(player: PlayerAst) -> Self {
+    pub(crate) fn subject_verb_pay_any_energy(player: PlayerAst, min_amount: u32) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::AffectedPlayer,
             player,
-            SubjectVerbActionAst::PayAnyEnergy,
+            SubjectVerbActionAst::PayAnyEnergy { min_amount },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -364,7 +364,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::CreateEmblem { .. }
             | SubjectVerbActionAst::LoseGame
             | SubjectVerbActionAst::WinGame
-            | SubjectVerbActionAst::PayAnyEnergy
+            | SubjectVerbActionAst::PayAnyEnergy { .. }
             | SubjectVerbActionAst::PayMana { .. }
             | SubjectVerbActionAst::DiscardHand
             | SubjectVerbActionAst::Detain { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1917,7 +1917,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::CreateEmblem { .. }
             | SubjectVerbActionAst::LoseGame
             | SubjectVerbActionAst::WinGame
-            | SubjectVerbActionAst::PayAnyEnergy
+            | SubjectVerbActionAst::PayAnyEnergy { .. }
             | SubjectVerbActionAst::PayMana { .. }
             | SubjectVerbActionAst::DiscardHand
             | SubjectVerbActionAst::Detain { .. }
@@ -2394,7 +2394,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::CreateEmblem { .. }
             | SubjectVerbActionAst::LoseGame
             | SubjectVerbActionAst::WinGame
-            | SubjectVerbActionAst::PayAnyEnergy
+            | SubjectVerbActionAst::PayAnyEnergy { .. }
             | SubjectVerbActionAst::PayMana { .. }
             | SubjectVerbActionAst::DiscardHand => 0,
             SubjectVerbActionAst::LoseLife { amount }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2214,7 +2214,7 @@ fn subject_verb_player_action_player_mut(effect: &mut EffectAst) -> Option<&mut 
                 | SubjectVerbActionAst::EnergyCounters { .. }
                 | SubjectVerbActionAst::TicketCounters { .. }
                 | SubjectVerbActionAst::PayEnergy { .. }
-                | SubjectVerbActionAst::PayAnyEnergy
+                | SubjectVerbActionAst::PayAnyEnergy { .. }
                 | SubjectVerbActionAst::PayMana { .. }
                 | SubjectVerbActionAst::DoubleManaPool
                 | SubjectVerbActionAst::EmptyManaPool
@@ -2286,7 +2286,7 @@ fn subject_verb_player_action_player(effect: &EffectAst) -> Option<PlayerAst> {
                 | SubjectVerbActionAst::EnergyCounters { .. }
                 | SubjectVerbActionAst::TicketCounters { .. }
                 | SubjectVerbActionAst::PayEnergy { .. }
-                | SubjectVerbActionAst::PayAnyEnergy
+                | SubjectVerbActionAst::PayAnyEnergy { .. }
                 | SubjectVerbActionAst::PayMana { .. }
                 | SubjectVerbActionAst::DoubleManaPool
                 | SubjectVerbActionAst::EmptyManaPool

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2393,7 +2393,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::CreateEmblem { .. }
             | SubjectVerbActionAst::LoseGame
             | SubjectVerbActionAst::WinGame
-            | SubjectVerbActionAst::PayAnyEnergy
+            | SubjectVerbActionAst::PayAnyEnergy { .. }
             | SubjectVerbActionAst::PayMana { .. }
             | SubjectVerbActionAst::DiscardHand
             | SubjectVerbActionAst::Detain { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -826,12 +826,12 @@ pub(crate) fn parse_pay(
     if grammar::words_match_any_prefix(tokens, ANY_AMOUNT_OF_PREFIXES).is_some()
         && (grammar::contains_word(tokens, "e") || energy_symbol_count > 0)
     {
-        return Ok(EffectAst::subject_verb_pay_any_energy(player));
+        return Ok(EffectAst::subject_verb_pay_any_energy(player, 0));
     }
     if grammar::words_match_any_prefix(tokens, &[&["one", "or", "more"]]).is_some()
         && (grammar::contains_word(tokens, "e") || energy_symbol_count > 0)
     {
-        return Ok(EffectAst::subject_verb_pay_any_energy(player));
+        return Ok(EffectAst::subject_verb_pay_any_energy(player, 1));
     }
     let has_for_each = word_slice_contains_phrase(&clause_words, &["for", "each"]);
     let references_tagged_choice = clause_words

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3101,11 +3101,12 @@ impl PayEnergyEffect {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PayAnyEnergyEffect {
     pub player: ChooseSpec,
+    pub min_amount: u32,
 }
 
 impl PayAnyEnergyEffect {
-    pub fn new(player: ChooseSpec) -> Self {
-        Self { player }
+    pub fn new(player: ChooseSpec, min_amount: u32) -> Self {
+        Self { player, min_amount }
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -113,6 +113,34 @@ fn parse_clash_repeat_process_spell_effect() {
     );
 }
 
+#[test]
+fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Rampaging Aetherhood");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Rampaging Aetherhood should parse its upkeep trigger strictly"
+    );
+    assert!(
+        ability_debug.contains("EnergyCountersEffect")
+            && ability_debug.contains("PayAnyEnergyEffect")
+            && ability_debug.contains("min_amount: 1")
+            && ability_debug.contains("IfEffect")
+            && ability_debug.contains("PutCountersEffect"),
+        "expected energy payment and paid-amount counter effects, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "Then you may pay one or more {E}. If you do, put that many +1/+1 counters on this creature"
+        ),
+        "expected one-or-more energy payment text to be preserved, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -15,6 +15,16 @@ fn value_prefers_equal_to(value: &Value) -> bool {
     value_has_surface_hint(value, ValueSurfaceHint::EqualTo)
 }
 
+fn describe_pay_any_energy_amount(
+    pay_any_energy: &crate::effects::PayAnyEnergyEffect,
+) -> Option<&'static str> {
+    match pay_any_energy.min_amount {
+        0 => Some("any amount of {E}"),
+        1 => Some("one or more {E}"),
+        _ => None,
+    }
+}
+
 fn library_position_from_top_text(position: &Value, one_as_on_top: bool) -> String {
     if let Value::Fixed(value) = position
         && let Ok(value) = u32::try_from(*value)
@@ -3557,6 +3567,58 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     if let Some(compact) = describe_energy_then_pay_any_then_destroy(&raw_effects) {
+        return compact;
+    }
+
+    fn describe_energy_then_pay_any_then_put_paid_counters(
+        effects: &[&Effect],
+    ) -> Option<String> {
+        let [energy_effect, may_effect, if_effect] = effects else {
+            return None;
+        };
+        let energy = unwrap_wrapped_effect(energy_effect)
+            .downcast_ref::<crate::effects::EnergyCountersEffect>()?;
+        if energy.player != PlayerFilter::You {
+            return None;
+        }
+        let may_with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+        let may = may_with_id
+            .effect
+            .downcast_ref::<crate::effects::MayEffect>()?;
+        if !matches!(may.decider, None | Some(PlayerFilter::You)) || may.effects.len() != 1 {
+            return None;
+        }
+        let pay_any = unwrap_wrapped_effect(&may.effects[0])
+            .downcast_ref::<crate::effects::PayAnyEnergyEffect>()?;
+        if !matches!(pay_any.player, ChooseSpec::Player(PlayerFilter::You)) {
+            return None;
+        }
+        let if_effect = if_effect.downcast_ref::<crate::effects::IfEffect>()?;
+        if if_effect.condition != may_with_id.id
+            || if_effect.predicate != crate::effect::EffectPredicate::Happened
+            || !if_effect.else_.is_empty()
+            || if_effect.then.len() != 1
+        {
+            return None;
+        }
+        let put = if_effect.then[0].downcast_ref::<crate::effects::PutCountersEffect>()?;
+        if put.distributed
+            || put.target_count.is_some()
+            || !is_effect_count_reference(&put.amount, Some(may_with_id.id))
+        {
+            return None;
+        }
+
+        let target = describe_choose_spec(&put.target);
+        let counter = describe_counter_type(put.counter_type);
+        let payment = describe_pay_any_energy_amount(pay_any)?;
+        Some(format!(
+            "{}. Then you may pay {payment}. If you do, put that many {counter} counters on {target}",
+            describe_effect(energy_effect)
+        ))
+    }
+
+    if let Some(compact) = describe_energy_then_pay_any_then_put_paid_counters(&raw_effects) {
         return compact;
     }
 
@@ -15603,6 +15665,7 @@ mod tests {
                 Effect::new(crate::effects::MayEffect::new_for_player(
                     vec![Effect::new(crate::effects::PayAnyEnergyEffect::new(
                         ChooseSpec::Player(PlayerFilter::You),
+                        0,
                     ))],
                     PlayerFilter::You,
                 )),
@@ -30503,11 +30566,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(pay_any_energy) = effect.downcast_ref::<crate::effects::PayAnyEnergyEffect>() {
         let payer = describe_choose_spec(&pay_any_energy.player);
+        let payment = describe_pay_any_energy_amount(pay_any_energy)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("{} or more {{E}}", pay_any_energy.min_amount));
         if payer == "you" {
-            return "Pay any amount of {E}".to_string();
+            return format!("Pay {payment}");
         }
         return format!(
-            "{payer} {} any amount of {{E}}",
+            "{payer} {} {payment}",
             player_verb(&payer, "pay", "pays")
         );
     }

--- a/crates/ironsmith-runtime/src/effects/player/pay_energy.rs
+++ b/crates/ironsmith-runtime/src/effects/player/pay_energy.rs
@@ -108,22 +108,33 @@ impl EffectExecutor for PayAnyEnergyEffect {
             .map(|player| player.energy_counters)
             .unwrap_or(0);
 
-        if available == 0 {
+        if available < self.min_amount {
             return Ok(EffectOutcome::count(0));
         }
+
+        let number_spec = if self.min_amount == 0 {
+            NumberSpec::up_to(ctx.source, available, "Choose how much {E} to pay")
+        } else {
+            NumberSpec::range(
+                ctx.source,
+                self.min_amount,
+                available,
+                "Choose how much {E} to pay",
+            )
+        };
 
         let chosen = make_decision_with_fallback(
             game,
             &mut ctx.decision_maker,
             player_id,
             Some(ctx.source),
-            NumberSpec::up_to(ctx.source, available, "Choose how much {E} to pay"),
+            number_spec,
             FallbackStrategy::Maximum,
         );
         if ctx.decision_maker.awaiting_choice() {
             return Ok(EffectOutcome::count(0));
         }
-        let chosen = chosen.min(available);
+        let chosen = chosen.clamp(self.min_amount, available);
 
         if chosen == 0 {
             return Ok(EffectOutcome::count(0).with_execution_fact(ExecutionFact::ChosenNumber(0)));

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39,6 +39,159 @@ fn setup_three_player_game() -> GameState {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn rampaging_aetherhood_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_200), "Rampaging Aetherhood")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Snake, Subtype::Hydra])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Trample, ward {2}\n\
+             At the beginning of your upkeep, you get an amount of {E} (energy counters) equal to this creature's power. Then you may pay one or more {E}. If you do, put that many +1/+1 counters on this creature.",
+        )
+        .expect("Rampaging Aetherhood should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct RampagingAetherhoodDecisionMaker {
+    accept_payment: bool,
+    energy_to_pay: u32,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for RampagingAetherhoodDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept_payment
+    }
+
+    fn decide_number(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::NumberContext,
+    ) -> u32 {
+        self.energy_to_pay.clamp(ctx.min, ctx.max)
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_rampaging_aetherhood_upkeep_trigger_on_stack(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+) {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(game, trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Rampaging Aetherhood should trigger at the beginning of your upkeep"
+    );
+    put_triggers_on_stack(game, trigger_queue)
+        .expect("Rampaging Aetherhood upkeep trigger should go on the stack");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rampaging_aetherhood_upkeep_pays_energy_and_adds_that_many_counters() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let aetherhood = rampaging_aetherhood_definition();
+    let aetherhood_id = game.create_object_from_definition(&aetherhood, alice, Zone::Battlefield);
+
+    put_rampaging_aetherhood_upkeep_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = RampagingAetherhoodDecisionMaker {
+        accept_payment: true,
+        energy_to_pay: 3,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Rampaging Aetherhood upkeep trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        1,
+        "the trigger should get four energy from power 4, then spend the chosen three"
+    );
+    assert_eq!(
+        game.counter_count(aetherhood_id, crate::object::CounterType::PlusOnePlusOne),
+        3,
+        "Rampaging Aetherhood should get counters equal to the amount of energy paid"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rampaging_aetherhood_payment_choice_cannot_pay_zero() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let aetherhood = rampaging_aetherhood_definition();
+    let aetherhood_id = game.create_object_from_definition(&aetherhood, alice, Zone::Battlefield);
+
+    put_rampaging_aetherhood_upkeep_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = RampagingAetherhoodDecisionMaker {
+        accept_payment: true,
+        energy_to_pay: 0,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Rampaging Aetherhood upkeep trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        3,
+        "one-or-more energy payment should force at least one energy to be paid"
+    );
+    assert_eq!(
+        game.counter_count(aetherhood_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "the if-you-do branch should use the minimum paid amount"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rampaging_aetherhood_declining_payment_gets_energy_without_counters() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let aetherhood = rampaging_aetherhood_definition();
+    let aetherhood_id = game.create_object_from_definition(&aetherhood, alice, Zone::Battlefield);
+
+    put_rampaging_aetherhood_upkeep_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = RampagingAetherhoodDecisionMaker {
+        accept_payment: false,
+        energy_to_pay: 4,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Rampaging Aetherhood upkeep trigger should resolve when payment is declined");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        4,
+        "declining payment should leave the energy gained from the trigger"
+    );
+    assert_eq!(
+        game.counter_count(aetherhood_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "declining the optional energy payment should not add +1/+1 counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_950), "Twenty-Toed Toad")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rampaging Aetherhood
Initial parse error:
```
compiled text dropped required semantic marker: one-or-more-energy
```

Current worker: i-0c9264bd226cfcf10
Branch: codex/aws-card-fix-rampaging-aetherhood
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0259
