### PR TITLE
Fix Ironsmith parse failure: Abuelo's Awakening

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -1397,6 +1397,42 @@ pub(super) fn parse_object_filter_inner(
         }
     }
 
+    let artifact_or_non_aura_enchantment = all_words.windows(4).any(|window| {
+        matches!(
+            window,
+            ["artifact", "or", "non-aura", "enchantment"]
+                | ["artifact", "or", "nonaura", "enchantment"]
+        )
+    }) || all_words.windows(5).any(|window| {
+        matches!(
+            window,
+            ["artifact", "or", "non", "aura", "enchantment"]
+        )
+    });
+    if artifact_or_non_aura_enchantment
+        && filter.any_of.is_empty()
+        && slice_has(&filter.card_types, &CardType::Artifact)
+        && slice_has(&filter.card_types, &CardType::Enchantment)
+        && slice_has(&filter.excluded_subtypes, &Subtype::Aura)
+    {
+        let mut artifact_branch = filter.clone();
+        artifact_branch.any_of.clear();
+        artifact_branch.card_types.retain(|card_type| *card_type == CardType::Artifact);
+        artifact_branch
+            .excluded_subtypes
+            .retain(|subtype| *subtype != Subtype::Aura);
+
+        let mut enchantment_branch = filter.clone();
+        enchantment_branch.any_of.clear();
+        enchantment_branch
+            .card_types
+            .retain(|card_type| *card_type == CardType::Enchantment);
+
+        let mut disjunction = ObjectFilter::default();
+        disjunction.any_of = vec![artifact_branch, enchantment_branch];
+        filter = disjunction;
+    }
+
     if let Some(or_subtype) = legendary_or_subtype
         && filter.any_of.is_empty()
         && slice_has(&filter.supertypes, &Supertype::Legendary)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sentence_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sentence_helpers.rs
@@ -90,7 +90,7 @@ pub(crate) use super::subject_verb_primitives::{
 };
 pub(crate) use super::zone_counter_helpers::{
     apply_exile_subject_hand_owner_context, apply_shuffle_subject_graveyard_owner_context,
-    parse_counter_descriptor, parse_counter_target_count_prefix,
+    parse_counter_descriptor, parse_counter_descriptor_value, parse_counter_target_count_prefix,
     parse_half_starting_life_total_value, parse_put_counters,
     parse_sentence_put_multiple_counters_on_target, parse_transform,
     split_until_source_leaves_tail, target_object_filter_mut,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -536,10 +536,10 @@ pub(crate) fn parse_return_with_counters_on_it_sentence(
     )];
     let tagged_target = TargetAst::Tagged(TagKey::from(IT_TAG), clause.span());
     for descriptor in descriptors {
-        let (count, counter_type) = parse_counter_descriptor(descriptor.tokens())?;
+        let (count, counter_type) = parse_counter_descriptor_value(descriptor.tokens())?;
         effects.push(EffectAst::subject_verb_put_counters(
             counter_type,
-            Value::Fixed(count as i32),
+            count,
             tagged_target.clone(),
             None,
             false,
@@ -689,10 +689,10 @@ pub(crate) fn parse_put_onto_battlefield_with_counters_on_it_sentence(
     )];
     let tagged_target = TargetAst::Tagged(TagKey::from(IT_TAG), clause.span());
     for descriptor in descriptors {
-        let (count, counter_type) = parse_counter_descriptor(descriptor.tokens())?;
+        let (count, counter_type) = parse_counter_descriptor_value(descriptor.tokens())?;
         effects.push(EffectAst::subject_verb_put_counters(
             counter_type,
-            Value::Fixed(count as i32),
+            count,
             tagged_target.clone(),
             None,
             false,
@@ -824,7 +824,7 @@ pub(crate) fn parse_sentence_draw_then_connive(
 fn parse_additional_counter_descriptor_on_target(
     counter_clause: SubjectVerbPrimitiveClause<'_>,
     accepted_targets: &[&[&str]],
-) -> Result<Option<(u32, crate::object::CounterType)>, CardTextError> {
+) -> Result<Option<(Value, crate::object::CounterType)>, CardTextError> {
     let counter_clause = counter_clause.trimmed();
     let Some((descriptor_clause, on_target_clause)) =
         counter_clause.rsplit_once_on_word_trimmed("on")
@@ -840,7 +840,7 @@ fn parse_additional_counter_descriptor_on_target(
         return Ok(None);
     }
 
-    parse_counter_descriptor(descriptor_clause.tokens()).map(Some)
+    parse_counter_descriptor_value(descriptor_clause.tokens()).map(Some)
 }
 
 pub(crate) fn parse_if_enters_with_additional_counter_sentence(
@@ -884,7 +884,7 @@ pub(crate) fn parse_if_enters_with_additional_counter_sentence(
     };
     let put_counter = EffectAst::subject_verb_put_counters(
         counter_type,
-        Value::Fixed(count as i32),
+        count,
         TargetAst::Tagged(TagKey::from(IT_TAG), clause.span()),
         None,
         false,
@@ -944,7 +944,7 @@ pub(crate) fn parse_put_onto_battlefield_with_additional_counters_sentence(
 
     effects.push(EffectAst::subject_verb_put_counters(
         counter_type,
-        Value::Fixed(count as i32),
+        count,
         TargetAst::Tagged(TagKey::from(IT_TAG), clause.span()),
         None,
         false,
@@ -1080,7 +1080,7 @@ pub(crate) fn parse_each_player_return_with_additional_counter_sentence(
 
     per_player_effects.push(EffectAst::subject_verb_put_counters(
         counter_type,
-        Value::Fixed(count as i32),
+        count,
         TargetAst::Tagged(TagKey::from(IT_TAG), clause.span()),
         None,
         false,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/delayed_step_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/delayed_step_family.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::static_abilities::StaticAbility;
 
 pub(super) fn wrap_delayed_next_step_unless_pays(
     step: DelayedNextStepKind,
@@ -877,18 +878,56 @@ pub(crate) fn parse_sentence_implicit_become_clause(
         && let Some(tail_len) = addition_tail_len
         && body_words.len() > 1 + tail_len
     {
-        let subtype_words = &body_words[1..body_words.len().saturating_sub(tail_len)];
-        let mut subtypes = Vec::new();
-        for word in subtype_words {
-            let Some(subtype) = parse_pluralized_subtype_word(word) else {
-                return Ok(None);
+        let descriptor_words = &body_words[1..body_words.len().saturating_sub(tail_len)];
+        let (descriptor_words, abilities) = if let Some(with_idx) = descriptor_words
+            .iter()
+            .position(|word| *word == "with")
+        {
+            let ability_words = &descriptor_words[with_idx + 1..];
+            let abilities = match ability_words {
+                ["flying"] => vec![StaticAbility::flying()],
+                _ => return Ok(None),
             };
-            if !iter_contains(subtypes.iter(), &subtype) {
-                subtypes.push(subtype);
+            (&descriptor_words[..with_idx], abilities)
+        } else {
+            (descriptor_words, Vec::new())
+        };
+
+        let mut card_types = Vec::new();
+        let mut subtypes = Vec::new();
+        for word in descriptor_words {
+            if *word == "and" {
+                continue;
             }
-        }
-        if subtypes.is_empty() {
+            if let Some(card_type) = parse_card_type(word) {
+                if !iter_contains(card_types.iter(), &card_type) {
+                    card_types.push(card_type);
+                }
+                continue;
+            }
+            if let Some(subtype) = parse_pluralized_subtype_word(word) {
+                if !iter_contains(subtypes.iter(), &subtype) {
+                    subtypes.push(subtype);
+                }
+                continue;
+            }
             return Ok(None);
+        }
+        if card_types.is_empty() && subtypes.is_empty() {
+            return Ok(None);
+        }
+        if !card_types.is_empty() || !abilities.is_empty() {
+            return Ok(Some(vec![EffectAst::subject_verb_become_base_pt_creature(
+                power,
+                toughness,
+                target,
+                card_types,
+                subtypes,
+                None,
+                abilities,
+                Vec::new(),
+                duration,
+            )]));
         }
         return Ok(Some(vec![
             EffectAst::subject_verb_set_base_power_toughness(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -28,8 +28,9 @@ use super::super::token_primitives::{
 };
 use super::super::util::{
     parse_counter_type_from_tokens, parse_counter_type_word, parse_number, parse_target_phrase,
-    parse_value, record_source_reference_surface, source_reference_surface_for_words,
-    span_from_tokens, this_source_surface_for_words, trim_commas,
+    parse_number_or_x_value, parse_value, record_source_reference_surface,
+    source_reference_surface_for_words, span_from_tokens, this_source_surface_for_words,
+    trim_commas,
 };
 use super::super::value_helpers::{
     parse_equal_to_aggregate_filter_value, parse_equal_to_number_of_filter_value,
@@ -196,15 +197,38 @@ pub(crate) fn sentence_case_mode_text(text: &str) -> String {
 pub(crate) fn parse_counter_descriptor(
     tokens: &[OwnedLexToken],
 ) -> Result<(u32, CounterType), CardTextError> {
+    let descriptor_text = render_clause_words(&trim_commas(tokens));
+    let (count, counter_type) = parse_counter_descriptor_value(tokens)?;
+    let Value::Fixed(count) = count else {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported dynamic counter amount (clause: '{}')",
+            descriptor_text
+        )));
+    };
+    let count = u32::try_from(count).map_err(|_| {
+        CardTextError::ParseError(format!(
+            "unsupported negative counter amount (clause: '{}')",
+            descriptor_text
+        ))
+    })?;
+    Ok((count, counter_type))
+}
+
+pub(crate) fn parse_counter_descriptor_value(
+    tokens: &[OwnedLexToken],
+) -> Result<(Value, CounterType), CardTextError> {
     let descriptor = trim_commas(tokens);
     let descriptor_text = render_clause_words(&descriptor);
-    let (count, used) = parse_number(&descriptor).ok_or_else(|| {
+    let (count, used) = parse_number_or_x_value(&descriptor).ok_or_else(|| {
         CardTextError::ParseError(format!(
             "missing counter amount (clause: '{}')",
             descriptor_text
         ))
     })?;
-    let rest = &descriptor[used..];
+    let mut rest = &descriptor[used..];
+    if rest.first().is_some_and(|token| token.is_word("additional")) {
+        rest = &rest[1..];
+    }
     if !rest
         .iter()
         .any(|token| token.is_word("counter") || token.is_word("counters"))

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42812,6 +42812,36 @@ fn parse_ghost_vacuum_base_pt_and_subtype_followup_sentence() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn abuelo_awakening_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Abuelo's Awakening");
+
+    let def = parse_oracle_card_definition("Abuelo's Awakening");
+    let compiled = crate::compiled_text::compiled_text_lines(&def).join(" ");
+    assert!(
+        compiled.contains("Return target artifact or non-Aura enchantment card from your graveyard to the battlefield with X additional +1/+1 counters on it"),
+        "expected X additional counters return wording, got {compiled}"
+    );
+    assert!(
+        compiled.contains("It's a 1/1 Spirit creature with flying in addition to its other types"),
+        "expected Spirit creature with flying animation wording, got {compiled}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("ReturnFromGraveyardToBattlefieldEffect")
+            && debug.contains("PutCountersEffect")
+            && debug.contains("amount: X")
+            && debug.contains("AddCardTypes")
+            && debug.contains("Creature")
+            && debug.contains("AddSubtypes")
+            && debug.contains("Spirit")
+            && debug.contains("Flying"),
+        "expected return, X counters, and Spirit/flying animation effects, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_sothera_supervoid_end_step_trigger() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Sothera, the Supervoid")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2477,11 +2477,210 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     describe_roll_choose_destroy_create_structural(effects)
+        .or_else(|| describe_return_with_counters_and_animation_structural(effects))
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_return_with_counters_and_animation_structural(effects: &[Effect]) -> Option<String> {
+    let [return_effect, counters_effect, animation_effect] = effects else {
+        return None;
+    };
+
+    let (returned_tag, return_to_battlefield) =
+        structural_tagged_return_from_graveyard_to_battlefield(return_effect)?;
+    if return_to_battlefield.tapped || return_to_battlefield.as_aura.is_some() {
+        return None;
+    }
+
+    let counters = structural_unwrap_render_wrappers(counters_effect)
+        .downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if counters.distributed
+        || counters.target_count.is_some()
+        || !matches!(&counters.target, ChooseSpec::Tagged(tag) if tag == returned_tag)
+    {
+        return None;
+    }
+
+    let animation = structural_unwrap_render_wrappers(animation_effect)
+        .downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if !matches!(animation.target, crate::continuous::EffectTarget::Source)
+        || animation.until != Until::Forever
+        || animation.condition.is_some()
+        || !animation.runtime_modifications.is_empty()
+        || !matches!(&animation.target_spec, Some(ChooseSpec::Tagged(tag)) if tag == returned_tag)
+    {
+        return None;
+    }
+
+    let (target_text, graveyard_owner) =
+        describe_graveyard_return_target(&return_to_battlefield.target)?;
+    let from_graveyard = match graveyard_owner {
+        Some(owner) => describe_possessive_player_filter(&owner),
+        None => "a".to_string(),
+    };
+    let counter_text = describe_additional_counter_phrase(counters);
+    let animation_text = describe_animation_clause(animation)?;
+
+    Some(format!(
+        "Return {target_text} from {from_graveyard} graveyard to the battlefield with {counter_text} on it. It's {animation_text} in addition to its other types."
+    ))
+}
+
+fn structural_tagged_return_from_graveyard_to_battlefield(
+    effect: &Effect,
+) -> Option<(
+    &TagKey,
+    &crate::effects::ReturnFromGraveyardToBattlefieldEffect,
+)> {
+    let tagged = effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let return_to_battlefield = tagged
+        .effect
+        .downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()?;
+    Some((&tagged.tag, return_to_battlefield))
+}
+
+fn describe_graveyard_return_target(spec: &ChooseSpec) -> Option<(String, Option<PlayerFilter>)> {
+    match spec {
+        ChooseSpec::Target(inner) => {
+            let (inner_text, owner) = describe_graveyard_return_target(inner)?;
+            if inner_text.starts_with("target ") {
+                Some((inner_text, owner))
+            } else {
+                Some((format!("target {inner_text}"), owner))
+            }
+        }
+        ChooseSpec::Object(filter) => {
+            let (text, owner) = describe_graveyard_object_filter_without_zone(filter)?;
+            Some((text, owner))
+        }
+        _ => graveyard_owner_from_spec(spec)
+            .map(|owner| (describe_choose_spec_without_graveyard_zone(spec), owner)),
+    }
+}
+
+fn describe_graveyard_object_filter_without_zone(
+    filter: &ObjectFilter,
+) -> Option<(String, Option<PlayerFilter>)> {
+    if !filter.any_of.is_empty() {
+        let mut owner: Option<PlayerFilter> = None;
+        let mut owner_seen = false;
+        let mut parts = Vec::new();
+        for branch in &filter.any_of {
+            if branch.zone != Some(Zone::Graveyard) {
+                return None;
+            }
+            if owner_seen {
+                if branch.owner != owner {
+                    return None;
+                }
+            } else {
+                owner = branch.owner.clone();
+                owner_seen = true;
+            }
+            parts.push(describe_graveyard_branch_without_zone(branch));
+        }
+        let text = if parts.iter().all(|part| part.ends_with(" card")) {
+            let card_parts = parts
+                .iter()
+                .map(|part| part.trim_end_matches(" card").to_string())
+                .collect::<Vec<_>>();
+            format!("{} card", join_with_or(&card_parts))
+        } else {
+            join_with_or(&parts)
+        };
+        return Some((text, owner));
+    }
+
+    if filter.zone != Some(Zone::Graveyard) {
+        return None;
+    }
+    Some((describe_graveyard_branch_without_zone(filter), filter.owner.clone()))
+}
+
+fn describe_graveyard_branch_without_zone(filter: &ObjectFilter) -> String {
+    let mut display_filter = filter.clone();
+    display_filter.zone = None;
+    display_filter.owner = None;
+    display_filter.single_graveyard = false;
+
+    let mut text = strip_leading_article(&display_filter.description()).to_string();
+    if !text.contains(" card") && !text.ends_with(" cards") {
+        text.push_str(" card");
+    }
+    text
+}
+
+fn describe_additional_counter_phrase(put: &crate::effects::PutCountersEffect) -> String {
+    let counter_text = describe_put_counter_phrase(&put.amount, put.counter_type);
+    if let Some(rest) = counter_text.strip_prefix("a ") {
+        return format!("an additional {rest}");
+    }
+    if let Some((amount, rest)) = counter_text.split_once(' ') {
+        return format!("{amount} additional {rest}");
+    }
+    format!("additional {counter_text}")
+}
+
+fn describe_animation_clause(apply: &crate::effects::ApplyContinuousEffect) -> Option<String> {
+    let mut card_types = Vec::new();
+    let mut subtypes = Vec::new();
+    let mut abilities = Vec::new();
+    let mut power_toughness: Option<(&Value, &Value)> = None;
+
+    let modifications = apply
+        .modification
+        .iter()
+        .chain(apply.additional_modifications.iter());
+    for modification in modifications {
+        match modification {
+            crate::continuous::Modification::AddCardTypes(types) => {
+                card_types.extend(types.iter().copied());
+            }
+            crate::continuous::Modification::AddSubtypes(types) => {
+                subtypes.extend(types.iter().copied());
+            }
+            crate::continuous::Modification::AddAbility(ability) => {
+                abilities.push(lowercase_first(&ability.display()));
+            }
+            crate::continuous::Modification::SetPowerToughness {
+                power,
+                toughness,
+                sublayer: crate::continuous::PtSublayer::Setting,
+            } => {
+                power_toughness = Some((power, toughness));
+            }
+            _ => return None,
+        }
+    }
+
+    let (power, toughness) = power_toughness?;
+    if card_types.is_empty() && subtypes.is_empty() {
+        return None;
+    }
+
+    let mut descriptor = Vec::new();
+    descriptor.extend(subtypes.iter().map(ToString::to_string));
+    descriptor.extend(
+        card_types
+            .iter()
+            .map(|card_type| describe_card_type_word_local(*card_type).to_string()),
+    );
+
+    let mut text = format!(
+        "a {}/{} {}",
+        describe_value(power),
+        describe_value(toughness),
+        descriptor.join(" ")
+    );
+    if !abilities.is_empty() {
+        text.push_str(" with ");
+        text.push_str(&join_with_and(&abilities));
+    }
+    Some(text)
 }
 
 fn describe_roll_choose_destroy_create_structural(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1786,6 +1786,109 @@ fn rise_from_the_grave_targets_only_creature_cards_in_graveyards() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn abuelo_awakening_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(73_951), "Abuelo's Awakening")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Return target artifact or non-Aura enchantment card from your graveyard to the battlefield with X additional +1/+1 counters on it. It's a 1/1 Spirit creature with flying in addition to its other types.",
+        )
+        .expect("Abuelo's Awakening should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn abuelo_awakening_targets_artifacts_and_non_aura_enchantments_in_your_graveyard() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell = abuelo_awakening_definition();
+    let effects = spell.spell_effect.as_ref().expect("expected spell effects");
+
+    let artifact = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(73_952), "Buried Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let non_aura_enchantment = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(73_953), "Buried Shrine")
+            .card_types(vec![CardType::Enchantment])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let aura = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(73_954), "Buried Aura")
+            .card_types(vec![CardType::Enchantment])
+            .subtypes(vec![Subtype::Aura])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let opponent_artifact = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(73_955), "Opponent Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Graveyard,
+    );
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(requirements.len(), 1, "Abuelo should have one target");
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(legal_targets.contains(&Target::Object(artifact)));
+    assert!(legal_targets.contains(&Target::Object(non_aura_enchantment)));
+    assert!(!legal_targets.contains(&Target::Object(aura)));
+    assert!(!legal_targets.contains(&Target::Object(opponent_artifact)));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn abuelo_awakening_returns_with_x_counters_and_animates_target() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let spell = abuelo_awakening_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    game.object_mut(spell_id).unwrap().x_value = Some(3);
+
+    let target_card = CardBuilder::new(CardId::from_raw(73_956), "Sleeping Idol")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let target_id = game.create_object_from_card(&target_card, alice, Zone::Graveyard);
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
+
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice)
+            .with_x(3)
+            .with_targets(vec![Target::Object(target_id)]),
+    );
+    resolve_stack_entry(&mut game).expect("Abuelo's Awakening should resolve");
+
+    let returned_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("returned object should still exist");
+    assert!(game.battlefield.contains(&returned_id));
+    assert_eq!(
+        game.counter_count(returned_id, crate::object::CounterType::PlusOnePlusOne),
+        3
+    );
+
+    let card_types = game.calculated_card_types(returned_id);
+    assert!(card_types.contains(&CardType::Artifact));
+    assert!(card_types.contains(&CardType::Creature));
+    assert!(game.calculated_subtypes(returned_id).contains(&Subtype::Spirit));
+    assert!(game.object_has_ability(returned_id, &StaticAbility::flying()));
+    assert_eq!(game.current_power(returned_id), Some(4));
+    assert_eq!(game.current_toughness(returned_id), Some(4));
+}
+
 #[test]
 fn regeneration_count_tracks_used_shields_until_cleanup() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Abuelo's Awakening
Initial parse error:
```
missing counter amount (clause: 'x additional +1/+1 counters'); oracle-only fallback also failed: missing counter amount (clause: 'x additional +1/+1 counters')
```

Current worker: i-0cad0d3da200466dd
Branch: codex/aws-card-fix-abuelo-s-awakening
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0260
