### PR TITLE
Fix Ironsmith parse failure: Alena, Kessig Trapper

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
@@ -24,7 +24,9 @@ pub(crate) use super::util::{
     parse_mana_symbol, parse_next_end_step_token_delay_flags, parse_subtype_flexible, parse_value,
     split_cost_segments, token_index_for_word_index, trim_commas, value_contains_unbound_x,
 };
-pub(crate) use super::value_helpers::parse_filter_comparison_tokens;
+pub(crate) use super::value_helpers::{
+    parse_equal_to_aggregate_filter_value, parse_filter_comparison_tokens,
+};
 
 fn push_unique_color(colors: &mut Vec<crate::color::Color>, color: crate::color::Color) {
     crate::slice_primitives::push_unique(colors, color);
@@ -373,7 +375,9 @@ pub(crate) fn parse_add_mana(
                 player, mana, amount,
             ));
         }
-        if let Some(amount) = parse_add_mana_equal_amount_value(tokens) {
+        if let Some(amount) = parse_equal_to_aggregate_filter_value(tokens)
+            .or_else(|| parse_add_mana_equal_amount_value(tokens))
+        {
             return Ok(EffectAst::subject_verb_add_mana_scaled(
                 player, mana, amount,
             ));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
@@ -345,7 +345,9 @@ pub(crate) fn parse_add_mana(
                 player, mana, amount,
             ));
         }
-        if let Some(amount) = parse_add_mana_equal_amount_value(tokens) {
+        if let Some(amount) = parse_equal_to_aggregate_filter_value(tokens)
+            .or_else(|| parse_add_mana_equal_amount_value(tokens))
+        {
             parser_trace_stack("parse_add_mana:scaled-equal", tokens);
             return Ok(EffectAst::subject_verb_add_mana_scaled(
                 player, mana, amount,

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -3774,6 +3774,37 @@ fn rewrite_activation_helpers_parse_add_mana_preserves_chosen_color_tail() {
 }
 
 #[test]
+fn rewrite_activation_helpers_parse_add_mana_scales_by_greatest_power_entered_this_turn() {
+    let tokens = lex_line(
+        "{R} equal to the greatest power among creatures you control that entered this turn",
+        0,
+    )
+    .expect("rewrite lexer should classify aggregate red mana clause");
+
+    match super::activation_helpers::parse_add_mana(&tokens, None)
+        .expect("aggregate red mana clause should parse")
+    {
+        crate::cards::builders::EffectAst::SubjectVerb(
+            crate::cards::builders::SubjectVerbEffectAst {
+                action:
+                    crate::cards::builders::SubjectVerbActionAst::AddManaScaled { mana, amount },
+                ..
+            },
+        ) => {
+            assert_eq!(mana, vec![crate::mana::ManaSymbol::Red]);
+            assert!(matches!(
+                amount,
+                crate::effect::Value::GreatestPower(filter)
+                    if filter.card_types == vec![CardType::Creature]
+                        && filter.controller == Some(crate::target::PlayerFilter::You)
+                        && filter.entered_battlefield_this_turn
+            ));
+        }
+        other => panic!("expected scaled red mana from greatest power, got {other:?}"),
+    }
+}
+
+#[test]
 fn rewrite_activation_helpers_parse_add_mana_wraps_instead_if_tail() {
     let tokens = lex_line(
         "{B}{B}{B}{B}{B} instead if there are seven or more cards in your graveyard",
@@ -3894,6 +3925,37 @@ fn rewrite_effect_sentence_parse_add_mana_wraps_instead_if_tail() {
             }
         }
         other => panic!("expected single conditional add-mana effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn rewrite_effect_sentence_parse_add_mana_scales_by_greatest_power_entered_this_turn() {
+    let tokens = lex_line(
+        "Add {R} equal to the greatest power among creatures you control that entered this turn",
+        0,
+    )
+    .expect("rewrite lexer should classify aggregate red mana sentence");
+
+    let effects = parse_effect_sentence_lexed(&tokens).expect("mana sentence should parse");
+
+    match effects.as_slice() {
+        [crate::cards::builders::EffectAst::SubjectVerb(
+            crate::cards::builders::SubjectVerbEffectAst {
+                action:
+                    crate::cards::builders::SubjectVerbActionAst::AddManaScaled { mana, amount },
+                ..
+            },
+        )] => {
+            assert_eq!(mana.as_slice(), &[crate::mana::ManaSymbol::Red]);
+            assert!(matches!(
+                amount,
+                crate::effect::Value::GreatestPower(filter)
+                    if filter.card_types == vec![CardType::Creature]
+                        && filter.controller == Some(crate::target::PlayerFilter::You)
+                        && filter.entered_battlefield_this_turn
+            ));
+        }
+        other => panic!("expected scaled red mana sentence, got {other:?}"),
     }
 }
 

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1950,9 +1950,18 @@ impl ObjectFilter {
             }
         }
 
-        if (self.entered_battlefield_this_turn || self.entered_battlefield_controller.is_some())
-            && self.zone == Some(Zone::Battlefield)
+        let has_entered_battlefield_this_turn_clause =
+            (self.entered_battlefield_this_turn || self.entered_battlefield_controller.is_some())
+                && self.zone == Some(Zone::Battlefield);
+        if has_entered_battlefield_this_turn_clause
+            && self.entered_battlefield_controller.is_none()
+            && owner_suffix.is_none()
+            && let Some(controller) = controller_suffix.take()
         {
+            parts.push(controller);
+        }
+
+        if has_entered_battlefield_this_turn_clause {
             let clause = if let Some(controller) = &self.entered_battlefield_controller {
                 match controller {
                     PlayerFilter::You => {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37682,6 +37682,127 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn alena_kessig_trapper_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Alena, Kessig Trapper");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("first strike") && rendered_lower.contains("partner"),
+        "expected Alena's keywords to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Add an amount of {R} equal to the greatest power among creatures you control that entered this turn"
+        ),
+        "expected Alena's aggregate red mana clause to render, got {rendered}"
+    );
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("AddScaledManaEffect")
+            && ability_debug.contains("GreatestPower")
+            && ability_debug.contains("entered_battlefield_this_turn: true"),
+        "expected Alena to lower to scaled red mana from entered-this-turn greatest power, got {ability_debug}"
+    );
+}
+
+#[test]
+fn alena_kessig_trapper_mana_runtime_uses_only_your_creatures_that_entered_this_turn() {
+    fn record_entered_this_turn(game: &mut crate::game_state::GameState, id: ObjectId) {
+        let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+            game.object(id)
+                .expect("entered object should exist on the battlefield"),
+            game,
+        );
+        let entry_event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::zones::ZoneChangeEvent::with_cause(
+                id,
+                Zone::Hand,
+                Zone::Battlefield,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        game.record_turn_history_event(&entry_event);
+    }
+
+    fn create_creature(
+        game: &mut crate::game_state::GameState,
+        controller: PlayerId,
+        name: &str,
+        power: i32,
+        entered_this_turn: bool,
+    ) -> ObjectId {
+        let def = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(power, 1))
+            .build();
+        let id = game.create_object_from_definition(&def, controller, Zone::Battlefield);
+        if entered_this_turn {
+            record_entered_this_turn(game, id);
+        }
+        id
+    }
+
+    let def = parse_oracle_card_definition("Alena, Kessig Trapper");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Alena should have an activated mana ability");
+    let add_scaled = activated
+        .effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::AddScaledManaEffect>())
+        .expect("Alena should produce scaled red mana");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let alena_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    create_creature(&mut game, alice, "Old Behemoth", 7, false);
+    create_creature(&mut game, bob, "Bob's New Behemoth", 6, true);
+    create_creature(&mut game, alice, "Alice's New Scout", 3, true);
+    create_creature(&mut game, alice, "Alice's New Giant", 5, true);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(alena_id, alice, &mut dm);
+    let result = add_scaled
+        .execute(&mut game, &mut ctx)
+        .expect("Alena's mana ability should resolve");
+
+    assert_eq!(
+        result.value,
+        crate::effect::OutcomeValue::ManaAdded(vec![
+            ManaSymbol::Red,
+            ManaSymbol::Red,
+            ManaSymbol::Red,
+            ManaSymbol::Red,
+            ManaSymbol::Red,
+        ])
+    );
+    assert_eq!(game.player(alice).expect("alice").mana_pool.red, 5);
+
+    game.player_mut(alice).expect("alice").mana_pool.red = 0;
+    game.turn_store.turn_history.clear_for_new_turn();
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(alena_id, alice, &mut dm);
+    let result = add_scaled
+        .execute(&mut game, &mut ctx)
+        .expect("Alena's mana ability should resolve with no entered creatures");
+
+    assert_eq!(result.value, crate::effect::OutcomeValue::ManaAdded(vec![]));
+    assert_eq!(game.player(alice).expect("alice").mana_pool.red, 0);
+}
+
+#[test]
 fn when_we_were_young_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("When We Were Young");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3807,9 +3807,18 @@ impl ObjectFilterExt for ObjectFilter {
             }
         }
 
-        if (self.entered_battlefield_this_turn || self.entered_battlefield_controller.is_some())
-            && self.zone == Some(Zone::Battlefield)
+        let has_entered_battlefield_this_turn_clause =
+            (self.entered_battlefield_this_turn || self.entered_battlefield_controller.is_some())
+                && self.zone == Some(Zone::Battlefield);
+        if has_entered_battlefield_this_turn_clause
+            && self.entered_battlefield_controller.is_none()
+            && owner_suffix.is_none()
+            && let Some(controller) = controller_suffix.take()
         {
+            parts.push(controller);
+        }
+
+        if has_entered_battlefield_this_turn_clause {
             let clause = if let Some(controller) = &self.entered_battlefield_controller {
                 match controller {
                     PlayerFilter::You => {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Alena, Kessig Trapper
Initial parse error:
```
unsupported trailing mana clause (clause: 'an amount of r equal to the greatest power among creatures you control that entered this turn'); oracle-only fallback also failed: unsupported trailing mana clause (clause: 'an amount of r equal to the greatest power among creatures you control that entered this turn')
```

Current worker: i-01baaa2b237cc8a1d
Branch: codex/aws-card-fix-alena-kessig-trapper
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0261
