### PR TITLE
Fix Ironsmith parse failure: Path of the Pyromancer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6141,6 +6141,14 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
             metric: EffectMetric::Count,
         }));
     }
+    if word_slice_contains_word(&filter_words, "discarded")
+        && word_slice_contains_phrase(&filter_words, &["this", "way"])
+    {
+        return Ok(Some(Value::PendingEffectMetric {
+            source: EffectMetricSource::Outcome,
+            metric: EffectMetric::Count,
+        }));
+    }
     if word_slice_contains_word(&filter_words, "revealed")
         && word_slice_contains_phrase(&filter_words, &["this", "way"])
         && let Some((value, used_words)) = parse_for_each_count_value_words(&words_all)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -846,6 +846,18 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(predicate);
     }
 
+    if let Some(gets_idx) = find_index(&filtered, |word| *word == "gets")
+        && gets_idx > 0
+        && word_slice_eq(
+            &filtered[gets_idx + 1..],
+            &["more", "votes", "or", "vote", "is", "tied"],
+        )
+    {
+        return Ok(PredicateAst::VoteOptionGetsMoreVotesOrTied {
+            option: filtered[..gets_idx].join(" "),
+        });
+    }
+
     if let Some(predicate) = parse_or_predicate(&filtered)? {
         return Ok(predicate);
     }
@@ -1125,18 +1137,6 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         && word_slice_eq(&filtered[gets_idx + 1..], &["more", "votes"])
     {
         return Ok(PredicateAst::VoteOptionGetsMoreVotes {
-            option: filtered[..gets_idx].join(" "),
-        });
-    }
-
-    if let Some(gets_idx) = find_index(&filtered, |word| *word == "gets")
-        && gets_idx > 0
-        && word_slice_eq(
-            &filtered[gets_idx + 1..],
-            &["more", "votes", "or", "vote", "is", "tied"],
-        )
-    {
-        return Ok(PredicateAst::VoteOptionGetsMoreVotesOrTied {
             option: filtered[..gets_idx].join(" "),
         });
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -969,6 +969,20 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         ));
     }
 
+    if crate::runtime_backend::lexer::word_slice_eq(&clause_words, &["planeswalk"]) {
+        return Ok(EffectAst::subject_verb_emit_keyword_action(
+            crate::events::KeywordActionKind::Planeswalk,
+            1,
+        ));
+    }
+
+    if crate::runtime_backend::lexer::word_slice_eq(&clause_words, &["chaos", "ensues"]) {
+        return Ok(EffectAst::subject_verb_emit_keyword_action(
+            crate::events::KeywordActionKind::ChaosEnsues,
+            1,
+        ));
+    }
+
     let (verb, verb_idx) = find_verb(tokens).ok_or_else(|| {
         let clause = render_lower_words(tokens);
         let known_verbs = [

--- a/crates/ironsmith-core/src/event_model.rs
+++ b/crates/ironsmith-core/src/event_model.rs
@@ -34,6 +34,8 @@ pub enum KeywordActionKind {
     Plot,
     RingTemptsYou,
     Renown,
+    Planeswalk,
+    ChaosEnsues,
     Connive,
     Proliferate,
     Support,
@@ -73,6 +75,10 @@ impl KeywordActionKind {
             "investigate" | "investigates" => Some(Self::Investigate),
             "manifest" | "manifests" | "manifested" | "manifesting" => Some(Self::Manifest),
             "populate" | "populates" | "populated" | "populating" => Some(Self::Populate),
+            "planeswalk" | "planeswalks" | "planeswalked" | "planeswalking" => {
+                Some(Self::Planeswalk)
+            }
+            "chaos" => Some(Self::ChaosEnsues),
             "plot" | "plots" | "plotted" | "plotting" => Some(Self::Plot),
             "renown" | "renowned" => Some(Self::Renown),
             "connive" | "connives" | "connived" => Some(Self::Connive),
@@ -119,6 +125,8 @@ impl KeywordActionKind {
             Self::Manifest => "manifest",
             Self::OpenAttraction => "open an Attraction",
             Self::Populate => "populate",
+            Self::Planeswalk => "planeswalk",
+            Self::ChaosEnsues => "chaos ensues",
             Self::Plot => "plot",
             Self::NameSticker => "put a name sticker",
             Self::RingTemptsYou => "have the Ring tempt you",
@@ -166,6 +174,8 @@ impl KeywordActionKind {
             Self::Manifest => "manifests",
             Self::OpenAttraction => "opens an Attraction",
             Self::Populate => "populates",
+            Self::Planeswalk => "planeswalks",
+            Self::ChaosEnsues => "chaos ensues",
             Self::Plot => "plots",
             Self::NameSticker => "puts a name sticker",
             Self::RingTemptsYou => "has the Ring tempt them",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37709,6 +37709,178 @@ fn when_we_were_young_strict_parser_and_text_regression() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn path_of_the_pyromancer_strict_parser_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Path of the Pyromancer");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains(
+            "Discard all the cards in your hand. Add {R} for each card discarded this way, then draw that many cards plus one"
+        ),
+        "expected discarded-this-way mana and draw clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Will of the Planeswalkers — Starting with you, each player votes for planeswalk or chaos"
+        ),
+        "expected planeswalker vote clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains("If chaos gets more votes or the vote is tied, chaos ensues"),
+        "expected tied chaos branch to render, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("DiscardEffect")
+            && debug.contains("AddScaledManaEffect")
+            && debug.contains("EffectMetric")
+            && debug.contains("VoteEffect")
+            && debug.contains("Planeswalk")
+            && debug.contains("ChaosEnsues"),
+        "expected discard-count mana, vote, and planar keyword actions structurally, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct PathVoteDecisionMaker {
+    votes: Vec<usize>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for PathVoteDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if !self.votes.is_empty() {
+            vec![self.votes.remove(0)]
+        } else {
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn vanilla_sorcery_for_path_test(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Sorcery])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_path_of_the_pyromancer_with_votes(
+    votes: Vec<usize>,
+) -> (crate::game_state::GameState, Vec<crate::triggers::TriggerEvent>) {
+    let def = parse_oracle_card_definition("Path of the Pyromancer");
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Path of the Pyromancer should compile to spell effects");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let filler = vanilla_sorcery_for_path_test(91_101, "Path Filler");
+    for _ in 0..3 {
+        game.create_object_from_definition(&filler, alice, Zone::Hand);
+    }
+    for _ in 0..4 {
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = PathVoteDecisionMaker { votes };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    let events = crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        program,
+        None,
+        &[],
+    )
+    .expect("Path of the Pyromancer should resolve");
+    (game, events)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn keyword_action_count(
+    events: &[crate::triggers::TriggerEvent],
+    action: crate::events::KeywordActionKind,
+) -> usize {
+    events
+        .iter()
+        .filter_map(|event| event.downcast::<crate::events::KeywordActionEvent>())
+        .filter(|event| event.action == action)
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn path_of_the_pyromancer_runtime_discards_adds_mana_draws_and_planeswalks() {
+    let (game, events) = resolve_path_of_the_pyromancer_with_votes(vec![0, 0]);
+    let alice = PlayerId::from_index(0);
+    let player = game.player(alice).expect("Alice should exist");
+
+    assert_eq!(player.hand.len(), 4, "discard 3, then draw 4 cards");
+    assert_eq!(player.library.len(), 0, "four cards should be drawn");
+    assert_eq!(player.mana_pool.red, 3, "three discarded cards should add {{R}}{{R}}{{R}}");
+    assert_eq!(
+        keyword_action_count(&events, crate::events::KeywordActionKind::Planeswalk),
+        1,
+        "planeswalk should happen when planeswalk gets more votes"
+    );
+    assert_eq!(
+        keyword_action_count(&events, crate::events::KeywordActionKind::ChaosEnsues),
+        0,
+        "chaos should not happen when planeswalk gets more votes"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn path_of_the_pyromancer_runtime_tied_vote_chaos_branch() {
+    let (_game, events) = resolve_path_of_the_pyromancer_with_votes(vec![0, 1]);
+
+    assert_eq!(
+        keyword_action_count(&events, crate::events::KeywordActionKind::Planeswalk),
+        0,
+        "planeswalk should not happen when its vote is tied"
+    );
+    assert_eq!(
+        keyword_action_count(&events, crate::events::KeywordActionKind::ChaosEnsues),
+        1,
+        "chaos should happen when the vote is tied"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn path_of_the_pyromancer_runtime_chaos_more_votes_branch() {
+    let (_game, events) = resolve_path_of_the_pyromancer_with_votes(vec![1, 1]);
+
+    assert_eq!(
+        keyword_action_count(&events, crate::events::KeywordActionKind::Planeswalk),
+        0,
+        "planeswalk should not happen when chaos gets more votes"
+    );
+    assert_eq!(
+        keyword_action_count(&events, crate::events::KeywordActionKind::ChaosEnsues),
+        1,
+        "chaos should happen when chaos gets more votes"
+    );
+}
+
 fn vanilla_creature_for_when_we_were_young(id: u32, name: &str) -> CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(id), name)
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -15,6 +15,152 @@ fn value_prefers_equal_to(value: &Value) -> bool {
     value_has_surface_hint(value, ValueSurfaceHint::EqualTo)
 }
 
+fn single_mana_symbol_oracle(symbol: crate::mana::ManaSymbol) -> Option<&'static str> {
+    match symbol {
+        crate::mana::ManaSymbol::White => Some("{W}"),
+        crate::mana::ManaSymbol::Blue => Some("{U}"),
+        crate::mana::ManaSymbol::Black => Some("{B}"),
+        crate::mana::ManaSymbol::Red => Some("{R}"),
+        crate::mana::ManaSymbol::Green => Some("{G}"),
+        crate::mana::ManaSymbol::Colorless => Some("{C}"),
+        crate::mana::ManaSymbol::Snow => Some("{S}"),
+        crate::mana::ManaSymbol::X => Some("{X}"),
+        crate::mana::ManaSymbol::Generic(_) | crate::mana::ManaSymbol::Life(_) => None,
+    }
+}
+
+fn describe_discard_hand_add_mana_draw_sequence(effects: &[&Effect]) -> Option<String> {
+    let [discard_effect, mana_effect, draw_effect] = effects else {
+        return None;
+    };
+    let discard_with_id = discard_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let discard = discard_with_id
+        .effect
+        .downcast_ref::<crate::effects::DiscardEffect>()?;
+    let mana_with_id = mana_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let mana = mana_with_id
+        .effect
+        .downcast_ref::<crate::effects::AddScaledManaEffect>()?;
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+
+    let Value::Count(count_filter) = &discard.count else {
+        return None;
+    };
+    let hand_filter = |filter: &ObjectFilter| {
+        filter.zone == Some(Zone::Hand)
+            && filter.owner == Some(PlayerFilter::You)
+            && filter.controller.is_none()
+            && filter.card_types.is_empty()
+            && filter.subtypes.is_empty()
+    };
+    if discard.player != PlayerFilter::You
+        || discard.random
+        || discard.any_number
+        || !hand_filter(count_filter)
+        || !discard.card_filter.as_ref().is_some_and(hand_filter)
+        || mana.player != PlayerFilter::You
+        || draw.player != PlayerFilter::You
+    {
+        return None;
+    }
+
+    if !matches!(
+        &mana.amount,
+        Value::EffectMetric {
+            effect_id,
+            source: crate::effect::EffectMetricSource::Outcome,
+            metric: crate::effect::EffectMetric::Count,
+        } if *effect_id == discard_with_id.id
+    ) {
+        return None;
+    }
+    let Value::EffectValueOffset(draw_effect_id, draw_offset) = &draw.count else {
+        return None;
+    };
+    if *draw_effect_id != mana_with_id.id || *draw_offset < 0 {
+        return None;
+    }
+
+    let mana_text = mana
+        .mana
+        .iter()
+        .copied()
+        .map(single_mana_symbol_oracle)
+        .collect::<Option<Vec<_>>>()?
+        .join("");
+    if mana_text.is_empty() {
+        return None;
+    }
+
+    let draw_text = match *draw_offset {
+        0 => "that many cards".to_string(),
+        1 => "that many cards plus one".to_string(),
+        offset => format!("that many cards plus {offset}"),
+    };
+
+    Some(format!(
+        "Discard all the cards in your hand. Add {mana_text} for each card discarded this way, then draw {draw_text}"
+    ))
+}
+
+fn describe_planeswalk_chaos_vote_sequence(effects: &[&Effect]) -> Option<String> {
+    let [vote_effect, planeswalk_effect, chaos_effect] = effects else {
+        return None;
+    };
+    let vote = vote_effect.downcast_ref::<crate::effects::VoteEffect>()?;
+    let ironsmith_core::VoteChoice::NamedOptions(options) = &vote.choice else {
+        return None;
+    };
+    if vote.secret
+        || vote.controller_extra_votes != 0
+        || vote.controller_optional_extra_votes != 0
+        || options.len() != 2
+        || options[0].name != "planeswalk"
+        || options[1].name != "chaos"
+        || !options.iter().all(|option| option.effects_per_vote.is_empty())
+    {
+        return None;
+    }
+
+    let planeswalk = planeswalk_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let chaos = chaos_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !planeswalk.if_false.is_empty()
+        || !chaos.if_false.is_empty()
+        || !matches!(
+            &planeswalk.condition,
+            Condition::VoteOptionGetsMoreVotes(option) if option == "planeswalk"
+        )
+        || !matches!(
+            &chaos.condition,
+            Condition::VoteOptionGetsMoreVotesOrTied(option) if option == "chaos"
+        )
+    {
+        return None;
+    }
+
+    let [planeswalk_action] = planeswalk.if_true.as_slice() else {
+        return None;
+    };
+    let [chaos_action] = chaos.if_true.as_slice() else {
+        return None;
+    };
+    let planeswalk_emit = planeswalk_action
+        .downcast_ref::<crate::effects::EmitKeywordActionEffect>()?;
+    let chaos_emit = chaos_action.downcast_ref::<crate::effects::EmitKeywordActionEffect>()?;
+    if planeswalk_emit.action != crate::events::KeywordActionKind::Planeswalk
+        || planeswalk_emit.amount != 1
+        || chaos_emit.action != crate::events::KeywordActionKind::ChaosEnsues
+        || chaos_emit.amount != 1
+    {
+        return None;
+    }
+
+    Some(
+        "Will of the Planeswalkers — Starting with you, each player votes for planeswalk or chaos. If planeswalk gets more votes, planeswalk. If chaos gets more votes or the vote is tied, chaos ensues"
+            .to_string(),
+    )
+}
+
 fn library_position_from_top_text(position: &Value, one_as_on_top: bool) -> String {
     if let Value::Fixed(value) = position
         && let Ok(value) = u32::try_from(*value)
@@ -2474,6 +2620,16 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
             .is_some()
     {
         return describe_structural_multisentence_effect_list(rest);
+    }
+
+    if effects.len() == 3 {
+        let refs = effects.iter().collect::<Vec<_>>();
+        if let Some(compact) = describe_discard_hand_add_mana_draw_sequence(&refs) {
+            return Some(compact);
+        }
+        if let Some(compact) = describe_planeswalk_chaos_vote_sequence(&refs) {
+            return Some(compact);
+        }
     }
 
     describe_roll_choose_destroy_create_structural(effects)
@@ -12629,6 +12785,14 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         {
             parts.push(compact);
             idx += 2;
+            continue;
+        }
+        if idx + 2 < filtered.len()
+            && let Some(compact) =
+                describe_discard_hand_add_mana_draw_sequence(&filtered[idx..idx + 3])
+        {
+            parts.push(compact);
+            idx += 3;
             continue;
         }
         if idx + 1 < filtered.len()
@@ -32415,6 +32579,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(keyword) = effect.downcast_ref::<crate::effects::EmitKeywordActionEffect>() {
         if keyword.action == crate::events::KeywordActionKind::Forage && keyword.amount == 1 {
             return "forage".to_string();
+        }
+        if keyword.action == crate::events::KeywordActionKind::Planeswalk && keyword.amount == 1 {
+            return "planeswalk".to_string();
+        }
+        if keyword.action == crate::events::KeywordActionKind::ChaosEnsues && keyword.amount == 1 {
+            return "chaos ensues".to_string();
         }
         // Runtime keyword-action events are instrumentation; they should not leak
         // into oracle-like rendered rules text.

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -96,6 +96,7 @@ impl OutcomeValue {
     pub fn as_count(&self) -> Option<i32> {
         match self {
             Self::Count(n) => Some(*n),
+            Self::ManaAdded(mana) => Some(mana.len() as i32),
             _ => None,
         }
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Path of the Pyromancer
Initial parse error:
```
unsupported this-way dynamic value (clause: 'for each card discarded this way'); oracle-only fallback also failed: unsupported this-way dynamic value (clause: 'for each card discarded this way')
```

Current worker: i-06299be1cfc4336b5
Branch: codex/aws-card-fix-path-of-the-pyromancer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0261
