### PR TITLE
Fix Ironsmith parse failure: Villainous Wealth

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -415,6 +415,70 @@ fn parse_for_each_prevent_damage_clause(
     Ok(Some(EffectAst::ForEachObject { filter, effects }))
 }
 
+fn parse_cast_any_number_from_among_tagged_clause(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    let clause_word_view = ClauseDispatchCompatWords::new(tokens);
+    let clause_words = clause_word_view.to_word_refs();
+    let (words, word_offset) = if word_slice_starts_with(&clause_words, &["you", "may"]) {
+        (&clause_words[2..], 2)
+    } else {
+        (clause_words.as_slice(), 0)
+    };
+
+    if !word_slice_starts_with(words, &["cast", "any", "number", "of", "spells"])
+        || !word_slice_ends_with(words, &["without", "paying", "their", "mana", "costs"])
+    {
+        return None;
+    }
+
+    let from_idx = word_slice_find_phrase_start(words, &["from", "among", "them"])
+        .or_else(|| word_slice_find_phrase_start(words, &["from", "among", "those", "cards"]))?;
+
+    let mut filter = ObjectFilter::nonland()
+        .in_zone(Zone::Exile)
+        .match_tagged(
+            TagKey::from(IT_TAG),
+            crate::target::TaggedOpbjectRelation::IsTaggedObject,
+        );
+
+    if let Some(mana_idx) = word_slice_find_phrase_start(words, &["with", "mana", "value"]) {
+        if mana_idx + 5 > from_idx
+            || words.get(mana_idx + 4) != Some(&"or")
+            || words.get(mana_idx + 5) != Some(&"less")
+        {
+            return None;
+        }
+        let value_word_idx = mana_idx + 3;
+        filter.mana_value = Some(if words.get(value_word_idx) == Some(&"x") {
+            crate::filter::Comparison::LessThanOrEqualExpr(Box::new(Value::X))
+        } else {
+            let value_token_idx = token_index_for_word_index(tokens, word_offset + value_word_idx)?;
+            let (value, used) = parse_number(&tokens[value_token_idx..])?;
+            if used == 0 {
+                return None;
+            }
+            crate::filter::Comparison::LessThanOrEqual(value as i32)
+        });
+    } else if from_idx != 5 {
+        return None;
+    }
+
+    Some(EffectAst::ForEachObject {
+        filter,
+        effects: vec![EffectAst::May {
+            effects: vec![EffectAst::subject_verb_cast_tagged(
+                TagKey::from(IT_TAG),
+                PlayerAst::You,
+                false,
+                false,
+                true,
+                None,
+            )],
+        }],
+    })
+}
+
 pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
     if tokens.is_empty() {
         return Err(CardTextError::ParseError("empty effect clause".to_string()));
@@ -429,6 +493,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         }
 
         if let Some(effect) = parse_cast_or_play_tagged_clause(tokens)? {
+            return Ok(effect);
+        }
+
+        if let Some(effect) = parse_cast_any_number_from_among_tagged_clause(tokens) {
             return Ok(effect);
         }
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46915,6 +46915,211 @@ fn parse_etali_attack_exiles_each_players_top_card_and_casts_any_number() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn villainous_wealth_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Villainous Wealth");
+
+    let spell_debug = format!("{:?}", def.spell_effect);
+    assert!(
+        spell_debug.contains("ExileTopOfLibraryEffect")
+            && spell_debug.contains("ForEachObject")
+            && spell_debug.contains("CastTaggedEffect")
+            && spell_debug.contains("LessThanOrEqualExpr")
+            && spell_debug.contains("X"),
+        "expected Villainous Wealth to lower to exile-top plus mana-value-capped free casts, got {spell_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("target opponent exiles the top x cards of their library")
+            && rendered.contains("you may cast any number of spells with mana value x or less from among them without paying their mana costs"),
+        "expected Villainous Wealth compiled text to preserve the capped any-number free-cast clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn villainous_wealth_runtime_casts_only_exiled_nonland_spells_with_mana_value_at_most_x() {
+    let def = parse_oracle_card_definition("Villainous Wealth");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Villainous Wealth should produce spell effects")
+        .clone();
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    game.object_mut(source)
+        .expect("Villainous Wealth source should exist")
+        .x_value = Some(3);
+
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(80_001), "Bottom Filler")
+            .card_types(vec![CardType::Artifact])
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(80_002), "Cheap Sorcery")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(80_003), "Expensive Sorcery")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(80_004), "Forest")
+            .card_types(vec![CardType::Land])
+            .subtypes(vec![Subtype::Forest])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let target_assignment = crate::game_state::TargetAssignment {
+        spec: ChooseSpec::Player(PlayerFilter::Opponent),
+        range: 0..1,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_x(3)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![target_assignment.clone()]);
+
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &spell,
+        None,
+        &[target_assignment],
+    )
+    .expect("Villainous Wealth should resolve");
+
+    let stack_names: Vec<_> = game
+        .stack
+        .iter()
+        .filter_map(|entry| game.object(entry.object_id).map(|obj| obj.name.clone()))
+        .collect();
+    assert!(
+        stack_names.iter().any(|name| name == "Cheap Sorcery"),
+        "the exiled spell with mana value at most X should be cast without paying mana, got stack {stack_names:?}"
+    );
+    assert!(
+        !stack_names.iter().any(|name| name == "Expensive Sorcery")
+            && !stack_names.iter().any(|name| name == "Forest"),
+        "expensive spells and lands should not be cast by Villainous Wealth, got stack {stack_names:?}"
+    );
+
+    let exile_names: Vec<_> = game
+        .exile
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    assert!(
+        exile_names.iter().any(|name| name == "Expensive Sorcery")
+            && exile_names.iter().any(|name| name == "Forest"),
+        "nonmatching exiled cards should remain in exile, got {exile_names:?}"
+    );
+
+    let library_names: Vec<_> = game
+        .player(bob)
+        .expect("bob exists")
+        .library
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    assert_eq!(
+        library_names,
+        vec!["Bottom Filler".to_string()],
+        "only the top X cards should be exiled from the target opponent, got library {library_names:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn villainous_wealth_runtime_may_decline_casting_exiled_spells() {
+    let def = parse_oracle_card_definition("Villainous Wealth");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Villainous Wealth should produce spell effects")
+        .clone();
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(80_011), "Declined Sorcery")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .build(),
+        bob,
+        Zone::Library,
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let target_assignment = crate::game_state::TargetAssignment {
+        spec: ChooseSpec::Player(PlayerFilter::Opponent),
+        range: 0..1,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_x(1)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![target_assignment.clone()]);
+
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &spell,
+        None,
+        &[target_assignment],
+    )
+    .expect("Villainous Wealth should resolve when its may choice is declined");
+
+    let stack_names: Vec<_> = game
+        .stack
+        .iter()
+        .filter_map(|entry| game.object(entry.object_id).map(|obj| obj.name.clone()))
+        .collect();
+    assert!(
+        !stack_names.iter().any(|name| name == "Declined Sorcery"),
+        "declining Villainous Wealth's may choice should not cast the exiled spell, got stack {stack_names:?}"
+    );
+    assert!(
+        game.exile.iter().any(|&id| game
+            .object(id)
+            .is_some_and(|obj| obj.name == "Declined Sorcery")),
+        "declined spell should remain exiled"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_day_of_black_sun_destroy_those_creatures_reuses_ability_loss_filter() {
     let def = parse_oracle_card_definition("Day of Black Sun");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -9508,6 +9508,72 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             )
         }
 
+        fn render_exile_top_then_cast_any_number_with_mana_value_cap(
+            effects: &[&Effect],
+        ) -> Option<String> {
+            let [exile_effect, may_effect] = effects else {
+                return None;
+            };
+            let exile_top = exile_effect.downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()?;
+            if !matches!(
+                exile_top.player,
+                PlayerFilter::Target(ref target) if **target == PlayerFilter::Opponent
+            ) || exile_top.moved_tags.len() != 1
+            {
+                return None;
+            }
+            let exiled_tag = &exile_top.moved_tags[0];
+
+            let outer_may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+            if outer_may.decider != Some(PlayerFilter::You) || outer_may.effects.len() != 1 {
+                return None;
+            }
+            let for_each = outer_may.effects[0].downcast_ref::<crate::effects::ForEachObject>()?;
+            if for_each.filter.zone != Some(Zone::Exile)
+                || !for_each
+                    .filter
+                    .excluded_card_types
+                    .contains(&crate::types::CardType::Land)
+                || !for_each.filter.tagged_constraints.iter().any(|constraint| {
+                    constraint.tag == *exiled_tag
+                        && constraint.relation
+                            == crate::target::TaggedOpbjectRelation::IsTaggedObject
+                })
+            {
+                return None;
+            }
+            let mana_value = match &for_each.filter.mana_value {
+                Some(crate::filter::Comparison::LessThanOrEqual(value)) => value.to_string(),
+                Some(crate::filter::Comparison::LessThanOrEqualExpr(value)) => {
+                    describe_value(value)
+                }
+                _ => return None,
+            };
+
+            let [inner_may_effect] = for_each.effects.as_slice() else {
+                return None;
+            };
+            let inner_may = inner_may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+            let [cast_effect] = inner_may.effects.as_slice() else {
+                return None;
+            };
+            let cast = cast_effect.downcast_ref::<crate::effects::CastTaggedEffect>()?;
+            if cast.tag.as_str() != "__it__"
+                || cast.player != PlayerFilter::You
+                || cast.allow_land
+                || cast.as_copy
+                || !cast.without_paying_mana_cost
+                || cast.cost_reduction.is_some()
+            {
+                return None;
+            }
+
+            let count_text = describe_value(&exile_top.count);
+            Some(format!(
+                "Target opponent exiles the top {count_text} cards of their library. You may cast any number of spells with mana value {mana_value} or less from among them without paying their mana costs"
+            ))
+        }
+
         fn render_sacrifice_then_consult_reveal_put_battlefield_rest_bottom(
             effects: &[&Effect],
         ) -> Option<String> {
@@ -11094,6 +11160,17 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         }
         if idx + 1 < filtered.len()
             && let Some(rendered) = describe_reveal_top_to_hand_bundle(&filtered[idx..idx + 2])
+        {
+            parts.push(rendered);
+            idx += 2;
+            continue;
+        }
+
+        if idx + 1 < filtered.len()
+            && let Some(rendered) = render_exile_top_then_cast_any_number_with_mana_value_cap(&[
+                filtered[idx],
+                filtered[idx + 1],
+            ])
         {
             parts.push(rendered);
             idx += 2;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Villainous Wealth
Initial parse error:
```
could not find verb in effect clause (clause: 'cast any number of spells with mana value x or less from among them without paying their mana costs'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast any number of spells with mana value x or less from among them without paying their mana costs'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0741bf5d86dbc7e5e
Branch: codex/aws-card-fix-villainous-wealth
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0261
