### PR TITLE
Fix Ironsmith parse failure: Kheru Lich Lord

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2030,6 +2030,7 @@ fn compile_subject_verb_effect(
             controller,
             count_value,
             as_aura,
+            random,
         } => {
             let (spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
@@ -2045,12 +2046,17 @@ fn compile_subject_verb_effect(
                     {
                         let tag = ctx.next_tag("chosen_return");
                         ctx.last_object_tag = Some(tag.clone());
-                        effects.push(Effect::choose_objects(
+                        let count = if *random {
+                            ChoiceCount::exactly(1).at_random()
+                        } else {
+                            ChoiceCount::exactly(1)
+                        };
+                        effects.push(Effect::new(crate::effects::ChooseObjectsEffect::new(
                             filter.clone(),
-                            1usize,
+                            count,
                             PlayerFilter::You,
                             tag.clone(),
-                        ));
+                        )));
                         ChooseSpec::tagged(tag)
                     }
                     ChooseSpec::WithCount(inner, count)
@@ -2062,10 +2068,11 @@ fn compile_subject_verb_effect(
                         };
                         let tag = ctx.next_tag("chosen_return");
                         ctx.last_object_tag = Some(tag.clone());
+                        let count = if *random { count.at_random() } else { *count };
                         effects.push(Effect::new(
                             crate::effects::ChooseObjectsEffect::new(
                                 filter.clone(),
-                                *count,
+                                count,
                                 PlayerFilter::You,
                                 tag.clone(),
                             )
@@ -2134,6 +2141,9 @@ fn compile_subject_verb_effect(
                 let tag = ctx.next_tag("returned");
                 ctx.last_object_tag = Some(tag.clone());
                 effect = effect.tag(tag);
+            }
+            if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+                ctx.last_object_tag = Some(tagged.tag.as_str().to_string());
             }
             effects.push(effect);
             if *transformed {
@@ -2704,12 +2714,37 @@ fn compile_subject_verb_effect(
             }
 
             let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
-            let mut apply = crate::effects::ApplyContinuousEffect::new(
-                crate::continuous::EffectTarget::Filter(resolved_filter),
-                modifications[0].clone(),
-                duration.clone(),
-            )
-            .lock_filter_at_resolution();
+            let pronoun_fallback_hand_filter = resolved_filter.zone == Some(Zone::Hand)
+                && resolved_filter.owner == Some(PlayerFilter::IteratedPlayer)
+                && {
+                    let mut bare = resolved_filter.clone();
+                    bare.zone = None;
+                    bare.owner = None;
+                    bare == ObjectFilter::default()
+                };
+            let mut apply = if pronoun_fallback_hand_filter {
+                if let Some(tag) = ctx.last_object_tag.clone() {
+                    crate::effects::ApplyContinuousEffect::with_spec(
+                        ChooseSpec::Tagged(TagKey::from(tag.as_str())),
+                        modifications[0].clone(),
+                        duration.clone(),
+                    )
+                } else {
+                    crate::effects::ApplyContinuousEffect::new(
+                        crate::continuous::EffectTarget::Filter(resolved_filter),
+                        modifications[0].clone(),
+                        duration.clone(),
+                    )
+                    .lock_filter_at_resolution()
+                }
+            } else {
+                crate::effects::ApplyContinuousEffect::new(
+                    crate::continuous::EffectTarget::Filter(resolved_filter),
+                    modifications[0].clone(),
+                    duration.clone(),
+                )
+                .lock_filter_at_resolution()
+            };
 
             for modification in modifications.iter().skip(1) {
                 apply = apply.with_additional_modification(modification.clone());

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
@@ -279,14 +279,22 @@ pub(super) fn try_compile_flow_and_iteration_effect(
             let condition = ctx.last_effect_id.ok_or_else(|| {
                 CardTextError::ParseError("missing prior effect for if clause".to_string())
             })?;
+            let mut inner_last_object_tag = None;
             let (inner_effects, inner_choices) = with_preserved_lowering_context(
                 ctx,
                 |ctx| {
                     ctx.last_effect_id = Some(condition);
                     ctx.bind_unbound_x_to_last_effect = true;
                 },
-                |ctx| compile_effects(effects, ctx),
+                |ctx| {
+                    let result = compile_effects(effects, ctx);
+                    inner_last_object_tag = ctx.last_object_tag.clone();
+                    result
+                },
             )?;
+            if inner_last_object_tag.is_some() {
+                ctx.last_object_tag = inner_last_object_tag;
+            }
             let predicate = effect_predicate_from_if_result(*predicate);
             let effect = Effect::if_then(condition, predicate, inner_effects);
             (vec![effect], inner_choices)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -188,15 +188,35 @@ pub(super) fn try_compile_timing_and_control_effect(
 ) -> Result<Option<(Vec<Effect>, Vec<ChooseSpec>)>, CardTextError> {
     let compiled = match effect {
         EffectAst::DelayedUntilNextEndStep { player, effects } => {
+            let outer_last_object_tag = ctx.last_object_tag.clone();
             let (delayed_effects, choices) =
                 compile_delayed_effects_preserving_outer_context(effects, ctx)?;
-            let effect = Effect::new(crate::effects::ScheduleDelayedTriggerEffect::new(
-                ironsmith_core::DelayedTriggerSpec::BeginningOfEndStep(player.clone()),
-                delayed_effects,
-                true,
-                Vec::new(),
-                PlayerFilter::You,
-            ));
+            let references_outer_tag = outer_last_object_tag.as_deref().is_some_and(|tag| {
+                delayed_effects.iter().any(|effect| {
+                    effect
+                        .target_spec()
+                        .is_some_and(|spec| choose_spec_references_tag(spec, tag))
+                })
+            });
+            let delayed = if references_outer_tag {
+                crate::effects::ScheduleDelayedTriggerEffect::from_tag(
+                    TagKey::from(outer_last_object_tag.expect("checked tag presence")),
+                    ironsmith_core::DelayedTriggerSpec::BeginningOfEndStep(player.clone()),
+                    delayed_effects,
+                    true,
+                    Vec::new(),
+                    PlayerFilter::You,
+                )
+            } else {
+                crate::effects::ScheduleDelayedTriggerEffect::new(
+                    ironsmith_core::DelayedTriggerSpec::BeginningOfEndStep(player.clone()),
+                    delayed_effects,
+                    true,
+                    Vec::new(),
+                    PlayerFilter::You,
+                )
+            };
+            let effect = Effect::new(delayed);
             (vec![effect], choices)
         }
         EffectAst::DelayedUntilNextUpkeep { player, effects } => {
@@ -526,8 +546,19 @@ pub(super) fn try_compile_stack_and_condition_effect(
             predicate,
             effects,
         } => {
-            let (inner_effects, inner_choices) =
-                with_preserved_lowering_context(ctx, |_| {}, |ctx| compile_effects(effects, ctx))?;
+            let mut inner_last_object_tag = None;
+            let (inner_effects, inner_choices) = with_preserved_lowering_context(
+                ctx,
+                |_| {},
+                |ctx| {
+                    let result = compile_effects(effects, ctx);
+                    inner_last_object_tag = ctx.last_object_tag.clone();
+                    result
+                },
+            )?;
+            if inner_last_object_tag.is_some() {
+                ctx.last_object_tag = inner_last_object_tag;
+            }
             let predicate = effect_predicate_from_if_result(*predicate);
             let effect = Effect::if_then(*condition, predicate, inner_effects);
             (vec![effect], inner_choices)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1157,6 +1157,7 @@ pub(crate) fn lower_special_rewrite_triggered_chunk(
                         false,
                         ReturnControllerAst::Preserve,
                         None,
+                        false,
                     )],
                     player: PlayerAst::Any,
                     cost: TotalCost::from_cost(Cost::life(5)),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1070,6 +1070,7 @@ pub(crate) enum SubjectVerbActionAst {
         controller: ReturnControllerAst,
         count_value: Option<Value>,
         as_aura: Option<ReturnAsAuraAst>,
+        random: bool,
     },
     ReturnAllToBattlefield {
         filter: ObjectFilter,
@@ -2281,6 +2282,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 controller,
                 count_value,
                 as_aura,
+                random,
             } => f
                 .debug_struct("ReturnToBattlefield")
                 .field("target", target)
@@ -2290,6 +2292,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("controller", controller)
                 .field("count_value", count_value)
                 .field("as_aura", as_aura)
+                .field("random", random)
                 .finish(),
             Self::ReturnAllToBattlefield {
                 filter,
@@ -3762,6 +3765,7 @@ impl EffectAst {
         converted: bool,
         controller: ReturnControllerAst,
         count_value: Option<Value>,
+        random: bool,
     ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
@@ -3774,6 +3778,7 @@ impl EffectAst {
                 controller,
                 count_value,
                 as_aura: None,
+                random,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -7,10 +7,8 @@ use crate::filter::{Comparison, TaggedOpbjectRelation};
 use crate::target::ChooseSpec;
 use crate::target::ObjectRef;
 use crate::{ObjectFilter, PlayerFilter, Value};
-use ironsmith_core::{EffectMetric, EffectMetricSource};
+use ironsmith_core::{EffectMetric, EffectMetricSource, TagKey};
 
-#[cfg(test)]
-use crate::TagKey;
 #[cfg(test)]
 use crate::cards::builders::{ObjectRefAst, PreventNextTimeDamageSourceAst, RetargetModeAst};
 #[cfg(test)]
@@ -51,9 +49,10 @@ pub(crate) struct EffectReferenceResolutionConfig {
     pub(crate) force_auto_tag_object_targets: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct EffectReferenceResolutionState {
     last_effect_id: Option<EffectId>,
+    last_object_tag: Option<TagKey>,
     allow_life_event_value: bool,
     bind_unbound_x_to_last_effect: bool,
 }
@@ -304,6 +303,44 @@ fn propagated_or_generated_object_tag(
     }
 }
 
+fn generated_return_to_battlefield_result_tag(
+    spec: &ChooseSpec,
+    count_value: &Option<Value>,
+    id_gen: &mut IdGenContext,
+) -> Option<String> {
+    let mut lowered_spec = spec.clone();
+    if !spec.is_target() {
+        match spec {
+            ChooseSpec::Object(filter)
+                if filter.tagged_constraints.is_empty()
+                    && filter.zone == Some(crate::zone::Zone::Graveyard) =>
+            {
+                let chosen = next_reference_tag(id_gen, "chosen_return");
+                lowered_spec = ChooseSpec::tagged(chosen);
+            }
+            ChooseSpec::WithCount(inner, count)
+                if (count.is_single() || count_value.is_some())
+                    && matches!(inner.base(), ChooseSpec::Object(filter) if filter.tagged_constraints.is_empty() && filter.zone == Some(crate::zone::Zone::Graveyard)) =>
+            {
+                let chosen = next_reference_tag(id_gen, "chosen_return");
+                lowered_spec = ChooseSpec::tagged(chosen);
+            }
+            _ => {}
+        }
+    }
+
+    if !choose_spec_targets_object(&lowered_spec) {
+        return None;
+    }
+
+    let inner_tag = next_reference_tag(id_gen, "returned");
+    if !lowered_spec.is_target() {
+        Some(next_reference_tag(id_gen, "returned"))
+    } else {
+        Some(inner_tag)
+    }
+}
+
 fn advance_effects_preserving_last_effect(
     effects: &[EffectAst],
     id_gen: &mut IdGenContext,
@@ -479,12 +516,8 @@ fn advance_reference_frame_for_effect(
                         frame.source_object_antecedent = true;
                     }
                     if frame.auto_tag_object_targets {
-                        if spec.is_target() {
-                            if let Some(tag) =
-                                propagated_or_generated_object_tag(&spec, id_gen, "exiled")
-                            {
-                                frame.last_object_tag = Some(tag);
-                            }
+                        if let Some(tag) = propagated_or_generated_object_tag(&spec, id_gen, "exiled") {
+                            frame.last_object_tag = Some(tag);
                         } else if choose_spec_targets_object(&spec) {
                             frame.last_object_tag = Some(crate::tag::SOURCE_EXILED_TAG.to_string());
                         }
@@ -721,14 +754,19 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::ExileUntilSourceLeaves { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "exiled")?;
                 }
-                SubjectVerbActionAst::ReturnToBattlefield { target, .. } => {
+                SubjectVerbActionAst::ReturnToBattlefield {
+                    target,
+                    count_value,
+                    ..
+                } => {
                     let refs = lowering_reference_frame(frame);
                     let (spec, _) = resolve_target_spec_with_choices(target, &refs)?;
-                    if frame.auto_tag_object_targets
-                        && let Some(tag) =
-                            propagated_or_generated_object_tag(&spec, id_gen, "returned")
-                    {
-                        frame.last_object_tag = Some(tag);
+                    if frame.auto_tag_object_targets {
+                        if let Some(tag) =
+                            generated_return_to_battlefield_result_tag(&spec, count_value, id_gen)
+                        {
+                            frame.last_object_tag = Some(tag);
+                        }
                     }
                     track_target_player(target, frame);
                 }
@@ -1158,9 +1196,30 @@ fn advance_reference_frame_for_effect(
 fn effect_reference_resolution_state(env: &ReferenceEnv) -> EffectReferenceResolutionState {
     EffectReferenceResolutionState {
         last_effect_id: env.last_effect_id.clone().into_option(),
+        last_object_tag: env.last_object_tag.clone().into_option(),
         allow_life_event_value: env.allow_life_event_value,
         bind_unbound_x_to_last_effect: env.bind_unbound_x_to_last_effect,
     }
+}
+
+fn effects_reference_pronoun_fallback_hand_filter(effects: &[EffectAst]) -> bool {
+    effects.iter().any(|effect| {
+        let EffectAst::SubjectVerb(subject_verb) = effect else {
+            return false;
+        };
+        let SubjectVerbActionAst::GrantAbilitiesAll { filter, .. } = &subject_verb.action else {
+            return false;
+        };
+        if filter.zone != Some(crate::zone::Zone::Hand)
+            || filter.owner != Some(PlayerFilter::IteratedPlayer)
+        {
+            return false;
+        }
+        let mut bare = filter.clone();
+        bare.zone = None;
+        bare.owner = None;
+        bare == ObjectFilter::default()
+    })
 }
 
 fn annotate_effect_sequence_with_env_internal(
@@ -1190,6 +1249,7 @@ fn annotate_effect_sequence_with_env_internal(
         } else {
             effects_reference_it_tag(remaining)
                 || effects_reference_its_controller(remaining)
+                || effects_reference_pronoun_fallback_hand_filter(remaining)
                 || effects_reference_tag(remaining, "damaged_0")
         };
         let assigned_effect_id =
@@ -1584,6 +1644,7 @@ fn resolve_effect_references_in_effect(
             id_gen,
             EffectReferenceResolutionState {
                 last_effect_id: Some(condition),
+                last_object_tag: state.last_object_tag.clone(),
                 allow_life_event_value: state.allow_life_event_value,
                 bind_unbound_x_to_last_effect: true,
             },
@@ -1595,6 +1656,29 @@ fn resolve_effect_references_in_effect(
         });
     }
 
+    if let EffectAst::SubjectVerb(subject_verb) = &mut effect
+        && let SubjectVerbActionAst::GrantAbilitiesAll {
+            filter,
+            abilities,
+            duration,
+        } = &subject_verb.action
+        && filter.zone == Some(crate::zone::Zone::Hand)
+        && filter.owner == Some(PlayerFilter::IteratedPlayer)
+    {
+        let mut bare = filter.clone();
+        bare.zone = None;
+        bare.owner = None;
+        if bare == ObjectFilter::default()
+            && let Some(tag) = state.last_object_tag.clone()
+        {
+            subject_verb.action = SubjectVerbActionAst::GrantAbilitiesToTarget {
+                target: TargetAst::Tagged(tag, None),
+                abilities: abilities.clone(),
+                duration: duration.clone(),
+            };
+        }
+    }
+
     if let EffectAst::WhenResult { predicate, effects } = effect {
         let condition = state.last_effect_id.ok_or_else(|| {
             CardTextError::ParseError("missing prior effect for when clause".to_string())
@@ -1604,6 +1688,7 @@ fn resolve_effect_references_in_effect(
             id_gen,
             EffectReferenceResolutionState {
                 last_effect_id: Some(condition),
+                last_object_tag: state.last_object_tag.clone(),
                 allow_life_event_value: state.allow_life_event_value,
                 bind_unbound_x_to_last_effect: true,
             },
@@ -1640,6 +1725,7 @@ fn resolve_effect_references_in_effect(
     if let EffectAst::DelayedTriggerThisTurn { trigger, effects } = &mut effect {
         let nested_state = EffectReferenceResolutionState {
             last_effect_id: state.last_effect_id,
+            last_object_tag: state.last_object_tag.clone(),
             allow_life_event_value: trigger_supports_event_amount(trigger),
             bind_unbound_x_to_last_effect: state.bind_unbound_x_to_last_effect,
         };
@@ -1647,9 +1733,9 @@ fn resolve_effect_references_in_effect(
         return Ok(effect);
     }
 
-    resolve_effect_result_values_in_fields(&mut effect, state)?;
+    resolve_effect_result_values_in_fields(&mut effect, &state)?;
     try_for_each_nested_effects_mut(&mut effect, true, |nested| {
-        let resolved = resolve_effect_sequence_references_with_state(nested, id_gen, state)?;
+        let resolved = resolve_effect_sequence_references_with_state(nested, id_gen, state.clone())?;
         nested.clone_from_slice(&resolved);
         Ok::<_, CardTextError>(())
     })?;
@@ -1665,7 +1751,7 @@ fn resolve_effect_sequence_references_with_state(
 
     for (idx, effect) in effects.iter().enumerate() {
         let saved_last_effect_id = state.last_effect_id;
-        let effect = resolve_effect_references_in_effect(effect.clone(), id_gen, state)?;
+        let effect = resolve_effect_references_in_effect(effect.clone(), id_gen, state.clone())?;
         let remaining = if idx + 1 < effects.len() {
             &effects[idx + 1..]
         } else {
@@ -1753,8 +1839,14 @@ fn advance_reference_env_for_effect(
             let mut nested_env = env.clone();
             nested_env.last_effect_id = RefState::Known(*condition);
             nested_env.bind_unbound_x_to_last_effect = true;
-            let nested =
-                annotate_effect_sequence_with_env_internal(effects, nested_env, config, id_gen)?;
+            let mut nested_config = config;
+            nested_config.force_auto_tag_object_targets |= auto_tag_object_targets;
+            let nested = annotate_effect_sequence_with_env_internal(
+                effects,
+                nested_env,
+                nested_config,
+                id_gen,
+            )?;
             let mut out_env = nested.final_env;
             out_env.last_effect_id = env.last_effect_id.clone();
             out_env.bind_unbound_x_to_last_effect = env.bind_unbound_x_to_last_effect;
@@ -1786,7 +1878,7 @@ fn advance_reference_env_for_effect(
 
 fn resolve_effect_result_values_in_fields(
     effect: &mut EffectAst,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match effect {
         EffectAst::SubjectVerb(subject_verb) => match &mut subject_verb.action {
@@ -2131,7 +2223,7 @@ fn resolve_effect_result_values_in_fields(
 
 fn resolve_effect_result_values_in_total_cost(
     cost: &mut crate::cost::TotalCost,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match cost.kind() {
         ironsmith_core::TotalCostKind::All(_) => {
@@ -2154,7 +2246,7 @@ fn resolve_effect_result_values_in_total_cost(
 
 fn resolve_effect_result_values_in_cost_component(
     component: &mut crate::costs::Cost,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match component {
         crate::costs::Cost::DynamicMana(dynamic) => {
@@ -2178,7 +2270,7 @@ fn resolve_effect_result_values_in_cost_component(
 
 fn resolve_effect_result_value(
     value: &mut Value,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match value {
         Value::X if state.bind_unbound_x_to_last_effect => {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -601,6 +601,19 @@ fn future_zone_replacement_from_sentence_text(sentence_text: &str) -> Option<Eff
         ));
     }
 
+    if str_contains(&normalized, "would leave the battlefield")
+        && str_contains(&normalized, "exile")
+        && str_contains(&normalized, "instead")
+    {
+        return Some(EffectAst::subject_verb_register_zone_replacement(
+            target(),
+            Some(Zone::Battlefield),
+            None,
+            Zone::Exile,
+            ZoneReplacementDurationAst::OneShot,
+        ));
+    }
+
     if str_contains(&normalized, "would be put into")
         && str_contains(&normalized, "graveyard")
         && str_contains(&normalized, "this turn")

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -1,6 +1,53 @@
 use super::*;
 use crate::runtime_backend::lexer::word_slice_starts_with;
 
+fn split_delayed_exile_timing_tail(
+    tokens: &[OwnedLexToken],
+) -> Result<(Vec<OwnedLexToken>, Option<DelayedReturnTimingAst>), CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    for word_idx in 0..words.len() {
+        if words[word_idx] != "at" {
+            continue;
+        }
+        if let Some(timing) = parse_delayed_return_timing_words(&words[word_idx..]) {
+            let token_cutoff = token_index_for_word_index(tokens, word_idx).unwrap_or(tokens.len());
+            return Ok((tokens[..token_cutoff].to_vec(), Some(timing)));
+        }
+    }
+    let has_delayed_timing_words = grammar::contains_word(tokens, "beginning")
+        || grammar::contains_word(tokens, "upkeep")
+        || grammar::words_find_phrase(tokens, &["end", "of", "combat"]).is_some()
+        || grammar::contains_word(tokens, "end")
+            && (grammar::contains_word(tokens, "next") || grammar::contains_word(tokens, "step"));
+    if has_delayed_timing_words {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported delayed exile timing clause (clause: '{}')",
+            words.join(" ")
+        )));
+    }
+    Ok((tokens.to_vec(), None))
+}
+
+fn wrap_exile_with_delayed_timing(
+    effect: EffectAst,
+    timing: Option<DelayedReturnTimingAst>,
+) -> EffectAst {
+    match timing {
+        Some(DelayedReturnTimingAst::NextEndStep(player)) => EffectAst::DelayedUntilNextEndStep {
+            player,
+            effects: vec![effect],
+        },
+        Some(DelayedReturnTimingAst::NextUpkeep(player)) => EffectAst::DelayedUntilNextUpkeep {
+            player,
+            effects: vec![effect],
+        },
+        Some(DelayedReturnTimingAst::EndOfCombat) => {
+            EffectAst::DelayedUntilEndOfCombat { effects: vec![effect] }
+        }
+        None => effect,
+    }
+}
+
 pub(crate) fn parse_exile(
     tokens: &[OwnedLexToken],
     subject: Option<SubjectAst>,
@@ -8,6 +55,8 @@ pub(crate) fn parse_exile(
     let (tokens, until_source_leaves) = split_until_source_leaves_tail(tokens);
     let (tokens, face_down) = split_exile_face_down_suffix(tokens);
     let tokens = split_exile_graveyard_replacement_suffix(tokens);
+    let (tokens_vec, delayed_timing) = split_delayed_exile_timing_tail(tokens)?;
+    let tokens = tokens_vec.as_slice();
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     if grammar::contains_word(tokens, "unless") {
         return Err(CardTextError::ParseError(format!(
@@ -38,24 +87,26 @@ pub(crate) fn parse_exile(
         let filter_tokens = &tokens[1..];
         let mut filter = parse_object_filter_lexed(filter_tokens, false)?;
         apply_exile_subject_owner_context(&mut filter, subject);
-        return Ok(if until_source_leaves {
+        let effect = if until_source_leaves {
             EffectAst::subject_verb_exile_until_source_leaves(
                 TargetAst::Object(filter, None, None),
                 face_down,
             )
         } else {
             EffectAst::subject_verb_exile_all(filter, face_down)
-        });
+        };
+        return Ok(wrap_exile_with_delayed_timing(effect, delayed_timing));
     }
     if let Some(filter) = parse_target_player_graveyard_filter(tokens) {
-        return Ok(if until_source_leaves {
+        let effect = if until_source_leaves {
             EffectAst::subject_verb_exile_until_source_leaves(
                 TargetAst::Object(filter, None, None),
                 face_down,
             )
         } else {
             EffectAst::subject_verb_exile_all(filter, face_down)
-        });
+        };
+        return Ok(wrap_exile_with_delayed_timing(effect, delayed_timing));
     }
     if !face_down
         && !until_source_leaves
@@ -129,15 +180,16 @@ pub(crate) fn parse_exile(
     if let Some(spec) = split_trailing_if_clause_lexed(tokens) {
         let mut target = parse_target_phrase(spec.leading_tokens)?;
         apply_exile_subject_hand_owner_context(&mut target, subject);
-        return Ok(EffectAst::Conditional {
-            predicate: spec.predicate,
-            if_true: vec![if until_source_leaves {
-                EffectAst::subject_verb_exile_until_source_leaves(target, face_down)
-            } else {
-                EffectAst::subject_verb_exile(target, face_down)
-            }],
-            if_false: Vec::new(),
-        });
+            let effect = EffectAst::Conditional {
+                predicate: spec.predicate,
+                if_true: vec![if until_source_leaves {
+                    EffectAst::subject_verb_exile_until_source_leaves(target, face_down)
+                } else {
+                    EffectAst::subject_verb_exile(target, face_down)
+                }],
+                if_false: Vec::new(),
+            };
+            return Ok(wrap_exile_with_delayed_timing(effect, delayed_timing));
     } else if grammar::contains_word(tokens, "if") {
         return Err(CardTextError::ParseError(format!(
             "unsupported conditional exile clause (clause: '{}')",
@@ -145,13 +197,31 @@ pub(crate) fn parse_exile(
         )));
     }
 
-    let mut target = parse_target_phrase(tokens)?;
+    let target_words = crate::runtime_backend::token_word_refs(tokens);
+    let mut target = if matches!(
+        target_words.as_slice(),
+        ["it"]
+            | ["them"]
+            | ["that", "card"]
+            | ["that", "creature"]
+            | ["that", "object"]
+            | ["that", "permanent"]
+            | ["those", "cards"]
+            | ["those", "creatures"]
+            | ["those", "objects"]
+            | ["those", "permanents"]
+    ) {
+        TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(tokens))
+    } else {
+        parse_target_phrase(tokens)?
+    };
     apply_exile_subject_hand_owner_context(&mut target, subject);
-    Ok(if until_source_leaves {
+    let effect = if until_source_leaves {
         EffectAst::subject_verb_exile_until_source_leaves(target, face_down)
     } else {
         EffectAst::subject_verb_exile(target, face_down)
-    })
+    };
+    Ok(wrap_exile_with_delayed_timing(effect, delayed_timing))
 }
 
 pub(crate) fn parse_same_name_exile_hand_and_graveyard_clause(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
@@ -599,6 +599,7 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
             converted,
             return_controller,
             count_value,
+            random,
         )
     } else if is_graveyard {
         EffectAst::subject_verb_move_to_zone(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -1307,6 +1307,7 @@ pub(crate) fn parse_choose_then_do_same_for_filter_then_return_to_battlefield(
         false,
         ReturnControllerAst::Preserve,
         None,
+        false,
     ));
     Ok(Some(effects))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/combat_and_damage_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/combat_and_damage_family.rs
@@ -672,6 +672,7 @@ pub(crate) fn parse_sentence_return_multiple_targets(
                     false,
                     ReturnControllerAst::Preserve,
                     None,
+                    false,
                 ));
             } else {
                 effects.push(EffectAst::subject_verb_return_to_hand(target, false));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -533,6 +533,7 @@ pub(crate) fn parse_return_with_counters_on_it_sentence(
         false,
         battlefield_controller,
         None,
+        false,
     )];
     let tagged_target = TargetAst::Tagged(TagKey::from(IT_TAG), clause.span());
     for descriptor in descriptors {
@@ -750,6 +751,7 @@ pub(crate) fn clone_return_effect_with_subtype(
                 controller,
                 count_value,
                 as_aura,
+                random,
             } => {
                 let mut cloned_target = target.clone();
                 replace_target_subtype(&mut cloned_target, subtype).then(|| {
@@ -760,6 +762,7 @@ pub(crate) fn clone_return_effect_with_subtype(
                         *converted,
                         *controller,
                         count_value.clone(),
+                        *random,
                     );
                     if let EffectAst::SubjectVerb(subject_verb) = &mut effect
                         && let SubjectVerbActionAst::ReturnToBattlefield { as_aura: dst, .. } =

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -275,6 +275,249 @@ fn parse_public_enemy_oracle_and_compiled_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_kheru_lich_lord_oracle_and_compiled_text() {
+    let def = parse_oracle_card_definition("Kheru Lich Lord");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("At the beginning of your upkeep, you may pay {2}{B}. If you do, return a creature card at random from your graveyard to the battlefield. It gains flying, trample, and haste. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else."),
+        "Kheru Lich Lord should render its random return, grants, delayed exile, and replacement, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("random: true")
+            && debug.contains("ReturnFromGraveyardToBattlefieldEffect")
+            && debug.contains("ScheduleDelayedTriggerEffect")
+            && debug.contains("RegisterZoneReplacementEffect"),
+        "expected Kheru to lower random return, delayed exile, and replacement structurally, got {debug}"
+    );
+    assert!(
+        !debug.contains("__source_exiled__"),
+        "Kheru follow-up references should stay bound to the returned card, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kheru_lich_lord_paid_upkeep_returns_grants_and_exiles_next_end_step() {
+    struct KheruDecisionMaker {
+        pay: bool,
+    }
+
+    impl crate::decision::DecisionMaker for KheruDecisionMaker {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            self.pay
+        }
+    }
+
+    fn kheru_upkeep_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
+        def.abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered) => Some(triggered),
+                _ => None,
+            })
+            .expect("Kheru Lich Lord should have an upkeep trigger")
+    }
+
+    fn execute_kheru_upkeep(
+        game: &mut crate::game_state::GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        triggered: &crate::ability::TriggeredAbility,
+        pay: bool,
+    ) {
+        let mut dm = KheruDecisionMaker { pay };
+        let mut ctx = crate::effects::ExecutionContext::new(source, controller, &mut dm);
+        crate::game_loop::execute_resolution_program(
+            game,
+            &mut ctx,
+            controller,
+            source,
+            &triggered.effects,
+            None,
+            &[],
+        )
+        .expect("Kheru upkeep trigger should resolve");
+    }
+
+    fn create_graveyard_creature(
+        game: &mut crate::game_state::GameState,
+        owner: PlayerId,
+    ) -> (ObjectId, ironsmith_core::StableId) {
+        let creature = CardDefinitionBuilder::new(CardId::new(), "Returned Probe")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let object_id = game.create_object_from_definition(&creature, owner, Zone::Graveyard);
+        let stable_id = game.object(object_id).expect("creature exists").stable_id;
+        (object_id, stable_id)
+    }
+
+    fn add_kheru_payment_mana(game: &mut crate::game_state::GameState, player: PlayerId) {
+        game.player_mut(player)
+            .expect("player exists")
+            .mana_pool
+            .add(ManaSymbol::Colorless, 2);
+        game.player_mut(player)
+            .expect("player exists")
+            .mana_pool
+            .add(ManaSymbol::Black, 1);
+    }
+
+    let alice = PlayerId::from_index(0);
+    let kheru = parse_oracle_card_definition("Kheru Lich Lord");
+    let triggered = kheru_upkeep_trigger(&kheru);
+
+    let mut declined_game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let declined_source =
+        declined_game.create_object_from_definition(&kheru, alice, Zone::Battlefield);
+    let (declined_card, declined_stable) = create_graveyard_creature(&mut declined_game, alice);
+    execute_kheru_upkeep(&mut declined_game, declined_source, alice, triggered, false);
+    assert_eq!(
+        declined_game
+            .find_object_by_stable_id(declined_stable)
+            .expect("declined card should remain tracked"),
+        declined_card,
+        "declining the optional payment should not move the graveyard creature"
+    );
+    assert_eq!(
+        declined_game
+            .object(declined_card)
+            .expect("declined card exists")
+            .zone,
+        Zone::Graveyard,
+        "declining the optional payment should leave the creature in the graveyard"
+    );
+    assert!(
+        declined_game.effect_store.delayed_triggers.is_empty(),
+        "declining payment should not schedule delayed exile"
+    );
+    assert_eq!(
+        declined_game
+            .effect_store
+            .replacement_effects
+            .count_one_shot_effects_from_source(declined_source),
+        0,
+        "declining payment should not register the leave-battlefield replacement"
+    );
+
+    let mut paid_game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let paid_source = paid_game.create_object_from_definition(&kheru, alice, Zone::Battlefield);
+    let (_graveyard_card, returned_stable) = create_graveyard_creature(&mut paid_game, alice);
+    add_kheru_payment_mana(&mut paid_game, alice);
+    execute_kheru_upkeep(&mut paid_game, paid_source, alice, triggered, true);
+
+    let returned_id = paid_game
+        .find_object_by_stable_id(returned_stable)
+        .expect("returned creature should remain tracked");
+    assert_eq!(
+        paid_game
+            .object(returned_id)
+            .expect("returned card exists")
+            .zone,
+        Zone::Battlefield,
+        "paid branch should return the random graveyard creature to the battlefield"
+    );
+    for ability in [
+        StaticAbilityId::Flying,
+        StaticAbilityId::Trample,
+        StaticAbilityId::Haste,
+    ] {
+        assert!(
+            paid_game.object_has_static_ability_id(returned_id, ability),
+            "returned creature should gain {ability:?}"
+        );
+    }
+    assert_eq!(
+        paid_game.effect_store.delayed_triggers.len(),
+        1,
+        "paid branch should schedule next-end-step exile"
+    );
+    assert_eq!(
+        paid_game
+            .effect_store
+            .replacement_effects
+            .count_one_shot_effects_from_source(paid_source),
+        1,
+        "paid branch should register one leave-battlefield exile replacement"
+    );
+
+    let mut replacement_game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let replacement_source =
+        replacement_game.create_object_from_definition(&kheru, alice, Zone::Battlefield);
+    let (_replacement_graveyard_card, replacement_stable) =
+        create_graveyard_creature(&mut replacement_game, alice);
+    add_kheru_payment_mana(&mut replacement_game, alice);
+    execute_kheru_upkeep(
+        &mut replacement_game,
+        replacement_source,
+        alice,
+        triggered,
+        true,
+    );
+    let replacement_returned_id = replacement_game
+        .find_object_by_stable_id(replacement_stable)
+        .expect("replacement returned creature should remain tracked");
+    let mut replacement_ctx =
+        crate::effects::ExecutionContext::new_default(replacement_source, alice);
+    MoveToZoneEffect::to_graveyard(ChooseSpec::SpecificObject(
+        replacement_returned_id,
+    ))
+    .execute(&mut replacement_game, &mut replacement_ctx)
+    .expect("Kheru leave-battlefield replacement should resolve");
+    let replacement_exiled_id = replacement_game
+        .find_object_by_stable_id(replacement_stable)
+        .expect("replacement exiled creature should remain tracked");
+    assert_eq!(
+        replacement_game
+            .object(replacement_exiled_id)
+            .expect("replacement exiled card exists")
+            .zone,
+        Zone::Exile,
+        "the leave-battlefield replacement should exile the returned creature instead of putting it into the graveyard"
+    );
+    assert_eq!(
+        replacement_game
+            .effect_store
+            .replacement_effects
+            .count_one_shot_effects_from_source(replacement_source),
+        0,
+        "the one-shot leave-battlefield replacement should be consumed after it applies"
+    );
+
+    let end_step_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let delayed_entries = crate::triggers::check_delayed_triggers(&mut paid_game, &end_step_event);
+    assert_eq!(delayed_entries.len(), 1, "expected Kheru delayed trigger to fire");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in delayed_entries {
+        trigger_queue.add(entry);
+    }
+    crate::game_loop::put_triggers_on_stack(&mut paid_game, &mut trigger_queue)
+        .expect("Kheru delayed trigger should go on stack");
+    crate::game_loop::resolve_stack_entry(&mut paid_game)
+        .expect("Kheru delayed exile trigger should resolve");
+
+    let exiled_id = paid_game
+        .find_object_by_stable_id(returned_stable)
+        .expect("exiled creature should remain tracked");
+    assert_eq!(
+        paid_game.object(exiled_id).expect("exiled card exists").zone,
+        Zone::Exile,
+        "next-end-step delayed trigger should exile the returned creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn public_enemy_requires_legal_attackers_to_attack_enchanted_creatures_controller() {
     let public_enemy = parse_oracle_card_definition("Public Enemy");
     let creature = CardDefinitionBuilder::new(CardId::from_raw(91_101), "Grizzly Bears")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2477,11 +2477,133 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     describe_roll_choose_destroy_create_structural(effects)
+        .or_else(|| describe_may_pay_random_graveyard_return_exile_structural(effects))
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_may_pay_random_graveyard_return_exile_structural(effects: &[Effect]) -> Option<String> {
+    let [may_effect, if_effect, grant_effect, delayed_effect, replacement_effect] = effects else {
+        return None;
+    };
+
+    let with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let may = with_id.effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may.decider != Some(PlayerFilter::You) || may.effects.len() != 1 {
+        return None;
+    }
+    may.effects[0].downcast_ref::<crate::effects::PayManaEffect>()?;
+
+    let conditional = if_effect.downcast_ref::<crate::effects::IfEffect>()?;
+    if conditional.condition != with_id.id
+        || conditional.predicate != crate::effect::EffectPredicate::Happened
+        || !conditional.else_.is_empty()
+        || conditional.then.len() != 2
+    {
+        return None;
+    }
+    let choose = conditional.then[0].downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if choose.chooser != PlayerFilter::You
+        || choose_primary_zone(choose) != Some(Zone::Graveyard)
+        || !choose.count.random
+        || choose.count.min != 1
+        || choose.count.max != Some(1)
+    {
+        return None;
+    }
+
+    fn outer_tagged_return(effect: &Effect) -> Option<(&TagKey, &crate::effects::ReturnFromGraveyardToBattlefieldEffect)> {
+        let tagged = effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+        let mut inner = tagged.effect.as_ref();
+        while let Some(nested) = inner.downcast_ref::<crate::effects::TaggedEffect>() {
+            inner = nested.effect.as_ref();
+        }
+        Some((
+            &tagged.tag,
+            inner.downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()?,
+        ))
+    }
+
+    let (returned_tag, return_to_battlefield) = outer_tagged_return(&conditional.then[1])?;
+    if !matches!(&return_to_battlefield.target, ChooseSpec::Tagged(tag) if tag == &choose.tag) {
+        return None;
+    }
+
+    let grant = grant_effect
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .map(|tagged| tagged.effect.as_ref())
+        .unwrap_or(grant_effect)
+        .downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if grant.until != Until::Forever
+        || grant.condition.is_some()
+        || !grant.runtime_modifications.is_empty()
+        || !matches!(grant.target_spec.as_ref(), Some(ChooseSpec::Tagged(tag)) if tag == returned_tag)
+    {
+        return None;
+    }
+
+    let mut ability_words = Vec::new();
+    let mut collect_ability = |modification: &crate::continuous::Modification| -> Option<()> {
+        let crate::continuous::Modification::AddAbility(ability) = modification else {
+            return None;
+        };
+        ability_words.push(lowercase_first(&ability.display()));
+        Some(())
+    };
+    collect_ability(grant.modification.as_ref()?)?;
+    for modification in &grant.additional_modifications {
+        collect_ability(modification)?;
+    }
+
+    let schedule = delayed_effect.downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()?;
+    let end_step_trigger = schedule
+        .trigger
+        .downcast_ref::<crate::triggers::BeginningOfEndStepTrigger>()?;
+    if !schedule.one_shot
+        || schedule.start_next_turn
+        || end_step_trigger.player != PlayerFilter::You
+        || schedule.target_tag.as_ref() != Some(returned_tag)
+        || schedule.effects.segments.len() != 1
+    {
+        return None;
+    }
+    let delayed_effects = &schedule.effects.segments[0].default_effects;
+    let [move_to_exile] = delayed_effects.as_slice() else {
+        return None;
+    };
+    let move_to_exile = move_to_exile.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_exile.zone != Zone::Exile
+        || !matches!(&move_to_exile.target, ChooseSpec::Tagged(tag) if tag == returned_tag)
+    {
+        return None;
+    }
+
+    let replacement =
+        replacement_effect.downcast_ref::<crate::effects::RegisterZoneReplacementEffect>()?;
+    if !matches!(&replacement.target, ChooseSpec::Tagged(tag) if tag == returned_tag)
+        || replacement.from_zone != Some(Zone::Battlefield)
+        || replacement.to_zone.is_some()
+        || replacement.replacement_zone != Zone::Exile
+        || replacement.mode != crate::effects::ReplacementApplyMode::OneShot
+        || replacement.optional
+    {
+        return None;
+    }
+
+    let from_text = match &choose.filter.owner {
+        Some(owner) => format!("from {} graveyard", describe_possessive_player_filter(owner)),
+        None => "from a graveyard".to_string(),
+    };
+    let tapped = if return_to_battlefield.tapped { " tapped" } else { "" };
+    let may_text = describe_effect(may_effect).trim_end_matches('.').to_string();
+    Some(format!(
+        "{may_text}. If you do, return {} {from_text} to the battlefield{tapped}. It gains {}. Exile that card at the beginning of your next end step. If it would leave the battlefield, exile it instead of putting it anywhere else.",
+        describe_choose_selection(choose),
+        join_with_and(&ability_words),
+    ))
 }
 
 fn describe_roll_choose_destroy_create_structural(effects: &[Effect]) -> Option<String> {
@@ -20081,7 +20203,12 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
     };
 
     if choose.count.is_single() {
-        return with_indefinite_article(&card_desc);
+        let selection = with_indefinite_article(&card_desc);
+        return if choose.count.random {
+            format!("{selection} at random")
+        } else {
+            selection
+        };
     }
     if let Some(runtime_count) = describe_runtime_choice_count(choose) {
         let mut selection = describe_plural_selection(runtime_count, &card_desc);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kheru Lich Lord
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-0b07e673932917064
Branch: codex/aws-card-fix-kheru-lich-lord
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0262
