### PR TITLE
Fix Ironsmith parse failure: Case of the Locked Hothouse

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -982,7 +982,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                 player,
                 spec: crate::grant::GrantSpec::new(
                     crate::grant::Grantable::play_from(),
-                    ObjectFilter::land(),
+                    ObjectFilter::default().with_type(CardType::Land),
                     Zone::Library,
                 ),
                 lifetime: PermissionLifetime::Static,
@@ -1009,7 +1009,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                     return Ok(None);
                 };
                 ObjectFilter {
-                    any_of: vec![ObjectFilter::land(), spell_filter],
+                    any_of: vec![ObjectFilter::default().with_type(CardType::Land), spell_filter],
                     ..ObjectFilter::default()
                 }
             };

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -1,7 +1,7 @@
 use super::line_family_handlers::{
     run_activation_line_family, run_additional_combat_after_this_phase_line_family,
     run_assign_damage_as_unblocked_enchanted_creature_controller_line_family,
-    run_champion_line_family, run_championed_with_this_trigger_line_family,
+    run_case_line_family, run_champion_line_family, run_championed_with_this_trigger_line_family,
     run_colon_nonactivation_statement_line_family, run_combined_static_line_family,
     run_draft_rule_line_family, run_escape_enters_with_counter_line_family,
     run_freerunning_line_family, run_graveyard_cast_control_condition_line_family,
@@ -49,7 +49,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 30] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 31] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -97,6 +97,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 30] = [
         priority: 37,
         heads: &["start"],
         run: run_start_your_engines_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "case-line",
+        priority: 37,
+        heads: &["to", "solved"],
+        run: run_case_line_family,
     },
     LineFamilyRuleDef {
         id: "learn-line",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -210,6 +210,118 @@ pub(super) fn run_start_your_engines_line_family(
     )))
 }
 
+pub(super) fn run_case_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let lower = raw.to_ascii_lowercase();
+
+    if str_starts_with(lower.as_str(), "to solve") {
+        return parse_case_to_solve_line(ctx, raw);
+    }
+    if str_starts_with(lower.as_str(), "solved") {
+        return parse_case_solved_line(ctx, raw);
+    }
+
+    Ok(None)
+}
+
+fn parse_case_to_solve_line(
+    ctx: &LineDispatchContext<'_>,
+    raw: &str,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let Some((label, body)) = str_split_once_char(raw, '\u{2014}') else {
+        return Ok(None);
+    };
+    if label.trim().to_ascii_lowercase() != "to solve" {
+        return Ok(None);
+    }
+
+    let condition = body
+        .split("(If unsolved")
+        .next()
+        .unwrap_or(body)
+        .trim()
+        .trim_end_matches('.')
+        .trim();
+    if condition.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "case solve line missing condition: '{}'",
+            ctx.line.info.raw_line
+        )));
+    }
+
+    let triggered_text = format!("At the beginning of your end step, if {condition}, solve.");
+    let triggered_line = rewrite_line_normalized(ctx.line, triggered_text.as_str())?;
+    let mut triggered = parse_triggered_line_cst(&triggered_line)?;
+    let unsolved_condition = PredicateAst::Not(Box::new(PredicateAst::SourceChosenOption(
+        "solved".to_string(),
+    )));
+    triggered.intervening_if = Some(match triggered.intervening_if.take() {
+        Some(condition) => PredicateAst::And(Box::new(condition), Box::new(unsolved_condition)),
+        None => unsolved_condition,
+    });
+    Ok(Some(LineDispatchResult::single(
+        RewriteLineCst::Triggered(triggered),
+        ctx.idx + 1,
+    )))
+}
+
+fn parse_case_solved_line(
+    ctx: &LineDispatchContext<'_>,
+    raw: &str,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let Some((label, body)) = str_split_once_char(raw, '\u{2014}') else {
+        return Ok(None);
+    };
+    if label.trim().to_ascii_lowercase() != "solved" {
+        return Ok(None);
+    }
+
+    let body = body.trim();
+    if body.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "case solved line missing ability body: '{}'",
+            ctx.line.info.raw_line
+        )));
+    }
+
+    let mut lines = Vec::new();
+    for ability_text in split_case_solved_static_body(body) {
+        let ability_line = rewrite_line_normalized(ctx.line, ability_text.as_str())?;
+        let Some(mut static_line) = parse_static_line_cst(&ability_line)? else {
+            return Err(CardTextError::ParseError(format!(
+                "parser could not lower case solved line: '{}'",
+                ctx.line.info.raw_line
+            )));
+        };
+        static_line.chosen_option_label = Some("solved".to_string());
+        lines.push(RewriteLineCst::Static(static_line));
+    }
+
+    Ok(Some(LineDispatchResult {
+        lines,
+        next_idx: ctx.idx + 1,
+    }))
+}
+
+fn split_case_solved_static_body(body: &str) -> Vec<String> {
+    let trimmed = body.trim().trim_end_matches('.').trim();
+    let lower = trimmed.to_ascii_lowercase();
+    let prefix = "you may look at the top card of your library any time, and you may ";
+    if let Some(rest) = lower.strip_prefix(prefix)
+        && !rest.is_empty()
+        && let Some(original_rest) = trimmed.get(prefix.len()..)
+    {
+        return vec![
+            "You may look at the top card of your library any time.".to_string(),
+            format!("You may {}.", original_rest.trim()),
+        ];
+    }
+
+    vec![format!("{}.", trimmed)]
+}
+
 pub(super) fn run_draft_rule_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -639,6 +639,28 @@ fn parse_card_types_among_predicate(words: &[&str]) -> Option<PredicateAst> {
     None
 }
 
+fn parse_you_control_count_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if words.len() < 6 || words[0] != "you" || words[1] != "control" {
+        return None;
+    }
+    let count = parse_named_number(words[2])?;
+    if words[3] != "or" || words[4] != "more" {
+        return None;
+    }
+
+    let filter = match &words[5..] {
+        ["land" | "lands"] => ObjectFilter::land().you_control(),
+        ["permanent" | "permanents"] => ObjectFilter::permanent().you_control(),
+        _ => return None,
+    };
+
+    Some(PredicateAst::ValueComparison {
+        left: Value::Count(filter),
+        operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+        right: Value::Fixed(count as i32),
+    })
+}
+
 fn parse_life_total_at_least_starting_predicate(words: &[&str]) -> Option<PredicateAst> {
     if matches!(
         words,
@@ -956,6 +978,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_card_types_among_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_you_control_count_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -680,6 +680,13 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         ));
     }
 
+    if matches!(choice_words, ["solve"]) {
+        return Ok(EffectAst::subject_verb_choose_named_option(
+            crate::cards::builders::PlayerAst::Implicit,
+            vec!["solved".to_string()],
+        ));
+    }
+
     if let Some((consumed, excluded_subtypes)) =
         parse_choose_creature_type_phrase_words(choice_words)?
         && consumed == choice_words.len()

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -381,6 +381,7 @@ pub enum Subtype {
     // Enchantment subtypes
     Aura,
     Background,
+    Case,
     Cartouche,
     Class,
     Curse,
@@ -662,6 +663,7 @@ impl Subtype {
         &[
             Subtype::Aura,
             Subtype::Background,
+            Subtype::Case,
             Subtype::Cartouche,
             Subtype::Class,
             Subtype::Curse,
@@ -981,6 +983,7 @@ impl Subtype {
             self,
             Subtype::Aura
                 | Subtype::Background
+                | Subtype::Case
                 | Subtype::Cartouche
                 | Subtype::Class
                 | Subtype::Curse

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -143,6 +143,172 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn case_of_the_locked_hothouse_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Case of the Locked Hothouse");
+    let lines = canonical_compiled_lines(&def);
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Case of the Locked Hothouse should parse its solve trigger strictly"
+    );
+    assert!(
+        ability_debug.contains("ChooseNamedOption")
+            && ability_debug.contains("solved")
+            && ability_debug.contains("SourceChosenOption")
+            && ability_debug.contains("LookAtTopCardOfLibrary"),
+        "expected solve effect and solved-gated static permissions, got {ability_debug}"
+    );
+    assert!(
+        lines.iter().any(|line| line == "To solve — You control seven or more lands."),
+        "expected Case solve clause in compiled text, got {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line == "Solved — You may look at the top card of your library any time, and you may play lands and cast creature and enchantment spells from the top of your library."),
+        "expected solved permission clause in compiled text, got {lines:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn case_of_the_locked_hothouse_solves_only_with_seven_lands() {
+    struct NoopDecisionMaker;
+    impl crate::decision::DecisionMaker for NoopDecisionMaker {}
+
+    let def = parse_oracle_card_definition("Case of the Locked Hothouse");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Case should have a beginning-of-end-step solve trigger");
+    let condition = triggered
+        .intervening_if
+        .as_ref()
+        .expect("solve trigger should be gated by the land-count condition");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let forest = CardDefinitionBuilder::new(CardId::from_raw(91_101), "Forest")
+        .card_types(vec![CardType::Land])
+        .build();
+
+    for _ in 0..6 {
+        game.create_object_from_definition(&forest, alice, Zone::Battlefield);
+    }
+    let mut eval_ctx = crate::condition_eval::ExternalEvaluationContext {
+        controller: alice,
+        source,
+        filter_source: Some(source),
+        ..Default::default()
+    };
+    assert!(
+        !crate::condition_eval::evaluate_condition_external(&game, condition, &eval_ctx),
+        "Case should remain unsolved while its controller has fewer than seven lands"
+    );
+
+    game.create_object_from_definition(&forest, alice, Zone::Battlefield);
+    eval_ctx.source = source;
+    assert!(
+        crate::condition_eval::evaluate_condition_external(&game, condition, &eval_ctx),
+        "Case should be solvable once its controller has seven lands"
+    );
+
+    let mut dm = NoopDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("solve trigger should resolve");
+    assert_eq!(game.chosen_named_option(source), Some("solved"));
+    assert!(
+        !crate::condition_eval::evaluate_condition_external(&game, condition, &eval_ctx),
+        "Case solve trigger condition should stop matching after the Case is solved"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn case_of_the_locked_hothouse_runtime_permissions_are_solved_gated() {
+    let def = parse_oracle_card_definition("Case of the Locked Hothouse");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.player(alice)
+            .expect("alice should exist")
+            .land_plays_per_turn,
+        2,
+        "the unsolved Case should still grant one additional land play"
+    );
+
+    let can_play_top_card = |card: crate::cards::CardDefinition, solved: bool| {
+        let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+        let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+        let card_id = game.create_object_from_definition(&card, alice, Zone::Library);
+        if solved {
+            game.set_chosen_named_option(source, "solved".to_string());
+        }
+        game.refresh_continuous_state();
+        game.effect_store
+            .grant_registry
+            .card_can_play_from_zone(&game, card_id, Zone::Library, alice)
+    };
+
+    let library_land = CardDefinitionBuilder::new(CardId::from_raw(91_201), "Library Forest")
+        .card_types(vec![CardType::Land])
+        .build();
+    assert!(
+        !can_play_top_card(library_land.clone(), false),
+        "top-library play permission should be inactive before the Case is solved"
+    );
+    assert!(
+        can_play_top_card(library_land, true),
+        "solved Case should let its controller play lands from the top of their library"
+    );
+
+    let library_creature = CardDefinitionBuilder::new(CardId::from_raw(91_202), "Library Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    assert!(
+        can_play_top_card(library_creature, true),
+        "solved Case should let its controller cast creature spells from the top of their library"
+    );
+
+    let library_enchantment =
+        CardDefinitionBuilder::new(CardId::from_raw(91_203), "Library Charm")
+            .card_types(vec![CardType::Enchantment])
+            .build();
+    assert!(
+        can_play_top_card(library_enchantment, true),
+        "solved Case should let its controller cast enchantment spells from the top of their library"
+    );
+
+    let library_artifact = CardDefinitionBuilder::new(CardId::from_raw(91_204), "Library Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    assert!(
+        !can_play_top_card(library_artifact, true),
+        "solved Case should not grant top-library play permission to unrelated card types"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {
     let def = parse_oracle_card_definition("Day of the Moon");
     let triggered = def

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -76,6 +76,9 @@ fn normalize_ast_surface_lines(lines: Vec<String>) -> Vec<String> {
 fn finalize_ast_surface_line(line: String) -> String {
     let mut line = line;
     let lower = line.to_ascii_lowercase();
+    if let Some(case_line) = normalize_case_to_solve_line(&line) {
+        return case_line;
+    }
     if lower.contains(
         "tap target creature or planeswalker. choose it. activated abilities of that permanent can't be activated this turn",
     ) {
@@ -111,6 +114,9 @@ fn finalize_ast_surface_line(line: String) -> String {
             "When this token dies: It deals 1 damage to any target",
             "When this token dies, it deals 1 damage to any target",
         );
+    if let Some(body) = solved_case_body(&line) {
+        return format!("Solved — {body}");
+    }
     line = line
         .replace(
             "Choose target creature you control. Choose target creature an opponent controls. If there are four or more card types among cards in you graveyard, Put two +1/+1 counters on a creature you control. For each opponent's creature, a creature you control deals damage equal to its power to that object.",
@@ -310,6 +316,47 @@ fn finalize_ast_surface_line(line: String) -> String {
     }
 }
 
+fn normalize_case_to_solve_line(line: &str) -> Option<String> {
+    let trimmed = line.trim().trim_end_matches('.');
+    let lower = trimmed.to_ascii_lowercase();
+    let condition = lower
+        .strip_prefix("at the beginning of your end step, if ")?
+        .strip_suffix(", solve")?;
+    let condition = normalize_case_solve_condition(condition);
+    Some(format!("To solve — {}.", capitalize_first(&condition)))
+}
+
+fn normalize_case_solve_condition(condition: &str) -> String {
+    let condition = condition
+        .strip_suffix(" and the chosen option isn't solved")
+        .unwrap_or(condition);
+    if let Some(rest) = condition.strip_prefix("there are ") {
+        if let Some(count) = rest.strip_suffix(" lands you control on the battlefield") {
+            return format!("you control {count} lands");
+        }
+        if let Some(count) = rest.strip_suffix(" permanents you control on the battlefield") {
+            return format!("you control {count} permanents");
+        }
+    }
+    condition.to_string()
+}
+
+fn solved_case_body(line: &str) -> Option<String> {
+    let trimmed = line.trim().trim_end_matches('.');
+    let solved = trimmed
+        .strip_suffix(". As long as the chosen option is solved")
+        .or_else(|| trimmed.strip_suffix(" as long as the chosen option is solved"))?;
+    let body = solved
+        .strip_prefix("This enchantment creature has ")
+        .or_else(|| solved.strip_prefix("This enchantment has "))
+        .or_else(|| solved.strip_prefix("This creature has "))
+        .unwrap_or(solved)
+        .trim();
+    let body = body
+        .replace("creature spells or enchantment spells", "creature and enchantment spells");
+    Some(body)
+}
+
 fn normalize_conditional_additional_x_counters(line: &str) -> String {
     let Some(rest) = line.strip_prefix(
         "This creature enters with X +1/+1 counters on it. This creature enters with X +1/+1 counters on it if ",
@@ -479,6 +526,16 @@ fn merge_specific_adjacent_surface_lines(lines: Vec<String>) -> Vec<String> {
             let right = lines[idx + 1].trim().trim_end_matches('.');
             let left_lower = left.to_ascii_lowercase();
             let right_lower = right.to_ascii_lowercase();
+            if let (Some(left_solved), Some(right_solved)) =
+                (solved_case_body(left), solved_case_body(right))
+            {
+                merged.push(format!(
+                    "Solved — {left_solved}, and {}.",
+                    lowercase_first(&right_solved)
+                ));
+                idx += 2;
+                continue;
+            }
             if left_lower.ends_with("at the beginning of the next end step, you lose 1 life")
                 && right_lower == "return this card to its owner's hand"
             {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11746,6 +11746,8 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 "no permanents left the battlefield this turn".to_string()
             } else if let Condition::CardsInHandOrMore(1) = inner.as_ref() {
                 "you have no cards in hand".to_string()
+            } else if let Condition::SourceChosenOption(option) = inner.as_ref() {
+                format!("the chosen option isn't {option}")
             } else if let Condition::PlayerControls { player, filter } = inner.as_ref() {
                 let subject = describe_player_filter(player);
                 let mut described_filter = filter.clone();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26906,6 +26906,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(choose_named_option) =
         effect.downcast_ref::<crate::effects::ChooseNamedOptionEffect>()
     {
+        if choose_named_option.options.as_slice() == ["solved"] {
+            return "Solve".to_string();
+        }
         let chooser = describe_player_filter(&choose_named_option.chooser);
         let choose_verb = player_verb(&chooser, "choose", "chooses");
         let options = choose_named_option


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Case of the Locked Hothouse
Initial parse error:
```
parser does not yet support line family: 'To solve — You control seven or more lands. (If unsolved, solve at the beginning of your end step.)'; oracle-only fallback also failed: parser does not yet support line family: 'To solve — You control seven or more lands.'
```

Current worker: i-0083c7c6c566b2a1c
Branch: codex/aws-card-fix-case-of-the-locked-hothouse
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0263
