### PR TITLE
Fix Ironsmith parse failure: Armageddon Clock

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activated_sentence_parsers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activated_sentence_parsers.rs
@@ -21,7 +21,10 @@ enum ActivatedSentenceModifier {
         parsed: Option<crate::ability::ManaUsageRestriction>,
         fallback_text: String,
     },
-    AdditionalRestriction(String),
+    AdditionalRestriction {
+        restriction: String,
+        timing: Option<ActivationTiming>,
+    },
     TriggerOnly,
     InlineEffect(EffectAst),
 }
@@ -132,9 +135,10 @@ fn parse_activated_sentence_modifier_lexed(
     }
 
     if is_any_player_may_activate_sentence_lexed(tokens) {
-        return Some(ActivatedSentenceModifier::AdditionalRestriction(
-            joined_activation_clause_text(tokens),
-        ));
+        return Some(ActivatedSentenceModifier::AdditionalRestriction {
+            restriction: joined_activation_clause_text(tokens),
+            timing: parse_activate_only_timing_lexed(tokens),
+        });
     }
 
     if is_trigger_only_restriction_sentence_lexed(tokens) {
@@ -146,9 +150,10 @@ fn parse_activated_sentence_modifier_lexed(
     }
 
     if is_inline_activated_text_modifier_sentence(tokens) {
-        return Some(ActivatedSentenceModifier::AdditionalRestriction(
-            joined_activation_clause_text(tokens),
-        ));
+        return Some(ActivatedSentenceModifier::AdditionalRestriction {
+            restriction: joined_activation_clause_text(tokens),
+            timing: None,
+        });
     }
 
     None
@@ -192,7 +197,13 @@ pub(super) fn collect_activated_sentence_modifiers<'a>(
                     additional_activation_restrictions.push(fallback_text);
                 }
             }
-            ActivatedSentenceModifier::AdditionalRestriction(restriction) => {
+            ActivatedSentenceModifier::AdditionalRestriction {
+                restriction,
+                timing: parsed_timing,
+            } => {
+                if let Some(parsed_timing) = parsed_timing {
+                    timing = parsed_timing;
+                }
                 additional_activation_restrictions.push(restriction);
             }
             ActivatedSentenceModifier::TriggerOnly => {}

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -556,6 +556,10 @@ const ACTIVATE_ONLY_ONCE_EACH_TURN_PREFIXES: &[&[&str]] =
     &[&["activate", "only", "once", "each", "turn"]];
 const ACTIVATE_ONLY_DURING_COMBAT_PREFIXES: &[&[&str]] =
     &[&["activate", "only", "during", "combat"]];
+const ACTIVATE_ONLY_DURING_UPKEEP_PREFIXES: &[&[&str]] = &[
+    &["activate", "only", "during", "any", "upkeep", "step"],
+    &["activate", "only", "during", "an", "upkeep", "step"],
+];
 const ACTIVATE_ONLY_DURING_YOUR_TURN_PREFIXES: &[&[&str]] =
     &[&["activate", "only", "during", "your", "turn"]];
 const THIS_ABILITY_TRIGGERS_ONLY_PREFIXES: &[&[&str]] = &[
@@ -578,6 +582,14 @@ pub(crate) fn parse_activate_only_timing_lexed(
         || primitives::words_find_phrase(tokens, &["during", "combat"]).is_some()
     {
         return Some(ActivationTiming::DuringCombat);
+    }
+    if primitives::words_match_any_prefix(tokens, ACTIVATE_ONLY_DURING_UPKEEP_PREFIXES).is_some()
+        || primitives::words_find_phrase(tokens, &["only", "during", "any", "upkeep", "step"])
+            .is_some()
+        || primitives::words_find_phrase(tokens, &["only", "during", "an", "upkeep", "step"])
+            .is_some()
+    {
+        return Some(ActivationTiming::DuringUpkeepStep);
     }
     if primitives::words_match_any_prefix(tokens, ACTIVATE_ONLY_DURING_YOUR_TURN_PREFIXES).is_some()
         || primitives::words_find_phrase(tokens, &["during", "your", "turn"]).is_some()

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/value_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/value_helpers.rs
@@ -3,7 +3,7 @@
 use crate::cards::builders::{CardTextError, IT_TAG, TagKey};
 use crate::effect::{Value, ValueComparisonOperator};
 use crate::target::{ChooseSpec, PlayerFilter};
-use crate::{ObjectFilter, Zone};
+use crate::{CounterType, ObjectFilter, Zone};
 use ironsmith_core::ValueSurfaceHint;
 use ironsmith_core::{EffectMetric, EffectMetricSource};
 
@@ -19,7 +19,7 @@ use super::lexer::{
 };
 use super::object_filters::{parse_object_filter, parse_object_filter_lexed};
 use super::util::{
-    is_article, parse_counter_type_word, parse_number, parse_number_word_i32, parse_value,
+    is_article, parse_counter_type_from_tokens, parse_number, parse_number_word_i32, parse_value,
     parse_value_expr_words, token_index_for_word_index, trim_commas,
 };
 
@@ -327,6 +327,31 @@ fn lower_words_end_with(words: &ValueHelperCompatWords, suffix: &[&str]) -> bool
     word_slice_ends_with(&words.to_word_refs(), suffix)
 }
 
+fn parse_counter_descriptor_before_reference(
+    tokens: &[OwnedLexToken],
+    start_word_idx: usize,
+) -> Option<(Option<CounterType>, usize)> {
+    let clause_words = ValueHelperCompatWords::new(tokens);
+    let clause_refs = clause_words.to_word_refs();
+    let counter_word_idx = clause_refs[start_word_idx..]
+        .iter()
+        .position(|word| matches!(*word, "counter" | "counters"))?
+        + start_word_idx;
+
+    if counter_word_idx == start_word_idx {
+        return Some((None, counter_word_idx));
+    }
+
+    let descriptor_start_token_idx = token_index_for_word_index(tokens, start_word_idx)?;
+    let descriptor_end_token_idx = token_index_for_word_index(tokens, counter_word_idx + 1)
+        .unwrap_or(tokens.len());
+    let descriptor_tokens = trim_lexed_edge_punctuation(
+        &tokens[descriptor_start_token_idx..descriptor_end_token_idx],
+    );
+    let counter_type = parse_counter_type_from_tokens(descriptor_tokens)?;
+    Some((Some(counter_type), counter_word_idx))
+}
+
 pub(crate) fn parse_equal_to_number_of_filter_value(tokens: &[OwnedLexToken]) -> Option<Value> {
     let word_view = ValueHelperCompatWords::new(tokens);
     let words_all = word_view.to_word_refs();
@@ -508,13 +533,8 @@ pub(crate) fn parse_equal_to_number_of_counters_on_reference_value(
         idx += 1;
     }
 
-    let mut counter_type = None;
-    if let Some(word) = clause_words.get(idx)
-        && let Some(parsed) = parse_counter_type_word(word)
-    {
-        counter_type = Some(parsed);
-        idx += 1;
-    }
+    let (counter_type, counter_word_idx) = parse_counter_descriptor_before_reference(tokens, idx)?;
+    idx = counter_word_idx;
 
     if !matches!(clause_words.get(idx), Some("counter" | "counters")) {
         return None;
@@ -894,13 +914,8 @@ pub(crate) fn parse_equal_to_number_of_counters_on_reference_value_lexed(
         idx += 1;
     }
 
-    let mut counter_type = None;
-    if let Some(word) = clause_words.get(idx)
-        && let Some(parsed) = parse_counter_type_word(word)
-    {
-        counter_type = Some(parsed);
-        idx += 1;
-    }
+    let (counter_type, counter_word_idx) = parse_counter_descriptor_before_reference(tokens, idx)?;
+    idx = counter_word_idx;
 
     if !matches!(clause_words.get(idx), Some("counter" | "counters")) {
         return None;

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -10,6 +10,7 @@ pub enum ActivationTiming {
     AnyTime,
     SorcerySpeed,
     DuringCombat,
+    DuringUpkeepStep,
     OncePerTurn,
     DuringYourTurn,
     DuringOpponentsTurn,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5737,6 +5737,51 @@ fn test_parse_source_deals_damage_to_target_equal_to_number_of_filter() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_armageddon_clock_strict_oracle_and_compiled_damage_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(295), "Armageddon Clock")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(6)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "At the beginning of your upkeep, put a doom counter on this artifact.\n\
+             At the beginning of your draw step, this artifact deals damage equal to the number of doom counters on it to each player.\n\
+             {4}: Remove a doom counter from this artifact. Any player may activate this ability but only during any upkeep step.",
+        )
+        .expect("Armageddon Clock oracle text should parse strictly");
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("BeginningOfUpkeepTrigger")
+            && debug.contains("PutCountersEffect")
+            && debug.contains("Named(\"doom\")"),
+        "expected Armageddon Clock upkeep trigger to put a doom counter, got {debug}"
+    );
+    assert!(
+        debug.contains("BeginningOfDrawStepTrigger")
+            && debug.contains("CountersOnSource(Named(\"doom\"))")
+            && debug.contains("ForPlayersEffect"),
+        "expected Armageddon Clock draw trigger to damage each player using doom counters, got {debug}"
+    );
+    assert!(
+        debug.contains("DuringUpkeepStep")
+            && debug.contains("any player may activate this ability but only during any upkeep step"),
+        "expected Armageddon Clock activation timing and any-player restriction, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("At the beginning of your draw step")
+            && rendered.contains("doom counters")
+            && rendered.contains("for each player"),
+        "expected compiled text to retain doom-counter damage to each player, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Any player may activate this ability but only during any upkeep step"),
+        "expected compiled text to retain the any-player upkeep timing clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_put_counter_then_it_deals_damage_equal_to_its_power() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Knockout Maneuver Variant")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11528,6 +11528,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 crate::ability::ActivationTiming::AnyTime => "any time",
                 crate::ability::ActivationTiming::SorcerySpeed => "sorcery speed",
                 crate::ability::ActivationTiming::DuringCombat => "during combat",
+                crate::ability::ActivationTiming::DuringUpkeepStep => "during upkeep",
                 crate::ability::ActivationTiming::OncePerTurn => "once per turn",
                 crate::ability::ActivationTiming::DuringYourTurn => "during your turn",
                 crate::ability::ActivationTiming::DuringOpponentsTurn => "during opponents' turns",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32501,6 +32501,7 @@ pub(super) fn describe_activation_timing_clause(timing: &ActivationTiming) -> Op
         ActivationTiming::AnyTime => None,
         ActivationTiming::SorcerySpeed => Some("Activate only as a sorcery"),
         ActivationTiming::DuringCombat => Some("Activate only during combat"),
+        ActivationTiming::DuringUpkeepStep => Some("Activate only during any upkeep step"),
         ActivationTiming::OncePerTurn => Some("Activate only once each turn"),
         ActivationTiming::DuringYourTurn => Some("Activate only during your turn"),
         ActivationTiming::DuringOpponentsTurn => Some("Activate only during an opponent's turn"),
@@ -32883,8 +32884,21 @@ pub(super) fn collect_activation_restriction_clauses(
     let mut clauses = Vec::new();
 
     if let Some(timing_clause) = describe_activation_timing_clause(timing) {
-        let normalized = normalize_activation_restriction_clause(timing_clause);
-        push_activation_restriction_clause(&mut clauses, normalized);
+        let timing_lower = timing_clause.to_ascii_lowercase();
+        let timing_is_already_embedded = matches!(timing, ActivationTiming::DuringUpkeepStep)
+            && additional_restrictions.iter().any(|restriction| {
+                let restriction_lower = restriction.to_ascii_lowercase();
+                restriction_lower.contains("only during any upkeep step")
+                    || restriction_lower.contains("only during an upkeep step")
+                    || restriction_lower.contains(&timing_lower)
+            });
+        if timing_is_already_embedded {
+            // Keep combined clauses such as "Any player may activate ... but only during..."
+            // intact instead of rendering a separate duplicate timing sentence.
+        } else {
+            let normalized = normalize_activation_restriction_clause(timing_clause);
+            push_activation_restriction_clause(&mut clauses, normalized);
+        }
     }
 
     for raw in additional_restrictions {
@@ -36319,6 +36333,7 @@ pub(super) fn describe_mana_activation_condition(condition: &crate::ConditionExp
             ActivationTiming::AnyTime => "Activate only as an instant".to_string(),
             ActivationTiming::SorcerySpeed => "Activate only as a sorcery".to_string(),
             ActivationTiming::DuringCombat => "Activate only during combat".to_string(),
+            ActivationTiming::DuringUpkeepStep => "Activate only during any upkeep step".to_string(),
             ActivationTiming::OncePerTurn => "Activate only once each turn".to_string(),
             ActivationTiming::DuringYourTurn => "Activate only during your turn".to_string(),
             ActivationTiming::DuringOpponentsTurn => {

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1637,6 +1637,9 @@ pub fn evaluate_condition_external(
                 crate::ability::ActivationTiming::DuringCombat => {
                     matches!(game.turn.phase, crate::game_state::Phase::Combat)
                 }
+                crate::ability::ActivationTiming::DuringUpkeepStep => {
+                    matches!(game.turn.step, Some(crate::game_state::Step::Upkeep))
+                }
                 crate::ability::ActivationTiming::SorcerySpeed => {
                     game.turn.active_player == ctx.controller
                         && matches!(

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -840,6 +840,51 @@ fn add_battlefield_actions(
             }
         }
     }
+
+    if game.can_activate_non_mana_abilities(player) {
+        for &perm_id in &game.battlefield {
+            let Some(perm) = game.object(perm_id) else {
+                continue;
+            };
+            if game.controller_of(perm) == player {
+                continue;
+            }
+            let Some(ability_summary) = view.ability_index_summary(perm_id) else {
+                continue;
+            };
+            if ability_summary.activated_ability_indices().is_empty() {
+                continue;
+            }
+            let source_facts = ActivationSourceFacts::for_source(game, perm_id, view);
+            let cached_abilities = view.abilities_rc(perm_id);
+            let abilities = cached_abilities.as_deref().unwrap_or(&perm.abilities);
+            for &ability_index in ability_summary.activated_ability_indices() {
+                let Some(ability) = abilities.get(ability_index) else {
+                    continue;
+                };
+                let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+                    continue;
+                };
+                if !activated_allows_any_player(activated) {
+                    continue;
+                }
+                if can_activate_ability_with_restrictions_with_view(
+                    game,
+                    perm_id,
+                    ability_index,
+                    activated,
+                    view,
+                    Some(battlefield_ability_ctx),
+                    Some(&source_facts),
+                ) {
+                    actions.push(LegalAction::ActivateAbility {
+                        source: perm_id,
+                        ability_index,
+                    });
+                }
+            }
+        }
+    }
 }
 
 fn collect_non_battlefield_source_ids(
@@ -1111,6 +1156,9 @@ fn activation_timing_allows(
     match timing {
         crate::ability::ActivationTiming::AnyTime => true,
         crate::ability::ActivationTiming::DuringCombat => matches!(game.turn.phase, Phase::Combat),
+        crate::ability::ActivationTiming::DuringUpkeepStep => {
+            matches!(game.turn.step, Some(crate::game_state::Step::Upkeep))
+        }
         crate::ability::ActivationTiming::SorcerySpeed => {
             if is_equip_ability(game, source, activated)
                 && player_may_activate_equip_abilities_any_time(game, controller, view)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -56,6 +56,36 @@ fn rampaging_aetherhood_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn armageddon_clock_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_210), "Armageddon Clock")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(6)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "At the beginning of your upkeep, put a doom counter on this artifact.\n\
+             At the beginning of your draw step, this artifact deals damage equal to the number of doom counters on it to each player.\n\
+             {4}: Remove a doom counter from this artifact. Any player may activate this ability but only during any upkeep step.",
+        )
+        .expect("Armageddon Clock should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn armageddon_clock_remove_counter_ability_index(game: &GameState, clock_id: ObjectId) -> usize {
+    game.object(clock_id)
+        .expect("Armageddon Clock should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                let debug = format!("{:?}", activated).to_ascii_lowercase();
+                debug.contains("removecounterseffect") && debug.contains("doom")
+            } else {
+                false
+            }
+        })
+        .expect("Armageddon Clock should have a doom-counter removal ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 struct RampagingAetherhoodDecisionMaker {
     accept_payment: bool,
     energy_to_pay: u32,
@@ -158,6 +188,131 @@ fn rampaging_aetherhood_payment_choice_cannot_pay_zero() {
         game.counter_count(aetherhood_id, crate::object::CounterType::PlusOnePlusOne),
         1,
         "the if-you-do branch should use the minimum paid amount"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn armageddon_clock_upkeep_trigger_adds_a_doom_counter() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let clock = armageddon_clock_definition();
+    let clock_id = game.create_object_from_definition(&clock, alice, Zone::Battlefield);
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Armageddon Clock should trigger at the beginning of your upkeep"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Armageddon Clock upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Armageddon Clock upkeep trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(clock_id, crate::object::CounterType::Named("doom")),
+        1,
+        "Armageddon Clock should get one doom counter during your upkeep"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn armageddon_clock_draw_trigger_deals_damage_equal_to_doom_counters_to_each_player() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let clock = armageddon_clock_definition();
+    let clock_id = game.create_object_from_definition(&clock, alice, Zone::Battlefield);
+    game.add_counters(clock_id, crate::object::CounterType::Named("doom"), 3)
+        .expect("doom counters should be addable to Armageddon Clock");
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Draw);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Armageddon Clock should trigger at the beginning of your draw step"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Armageddon Clock draw trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Armageddon Clock draw trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        17,
+        "Armageddon Clock should damage its controller equal to doom counters"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        17,
+        "Armageddon Clock should damage each other player equal to doom counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn armageddon_clock_any_player_activation_is_limited_to_upkeep_and_removes_doom_counter() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let clock = armageddon_clock_definition();
+    let clock_id = game.create_object_from_definition(&clock, alice, Zone::Battlefield);
+    game.add_counters(clock_id, crate::object::CounterType::Named("doom"), 2)
+        .expect("doom counters should be addable to Armageddon Clock");
+    let ability_index = armageddon_clock_remove_counter_ability_index(&game, clock_id);
+    game.player_mut(bob)
+        .expect("Bob should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 4);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(bob);
+    assert!(
+        !crate::decision::compute_legal_actions(&game, bob)
+            .into_iter()
+            .any(|action| matches!(action, crate::decision::LegalAction::ActivateAbility { source, ability_index: idx } if source == clock_id && idx == ability_index)),
+        "Armageddon Clock's any-player activation should not be legal outside upkeep"
+    );
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.priority_player = Some(bob);
+    let activate_action = crate::decision::compute_legal_actions(&game, bob)
+        .into_iter()
+        .find(|action| matches!(action, crate::decision::LegalAction::ActivateAbility { source, ability_index: idx } if *source == clock_id && *idx == ability_index))
+        .expect("Bob should be able to activate Armageddon Clock during an upkeep step");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Bob should be able to activate Armageddon Clock");
+    resolve_stack_entry(&mut game).expect("Armageddon Clock removal ability should resolve");
+
+    assert_eq!(
+        game.counter_count(clock_id, crate::object::CounterType::Named("doom")),
+        1,
+        "Armageddon Clock activation should remove one doom counter"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Armageddon Clock
Initial parse error:
```
missing damage amount (clause: 'damage equal to the number of doom counters on it to each player'); oracle-only fallback also failed: missing damage amount (clause: 'damage equal to the number of doom counters on it to each player')
```

Current worker: i-01c6f92d1be048361
Branch: codex/aws-card-fix-armageddon-clock
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0264
