### PR TITLE
Fix Ironsmith parse failure: Pako, Arcane Retriever

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -16,8 +16,9 @@ use super::super::permission_helpers::{
     parse_until_your_next_turn_may_play_tagged_clause,
 };
 use super::super::token_primitives::find_index;
-use super::super::util::{parse_subject, span_from_tokens, trim_commas, words};
+use super::super::util::{parse_subject, span_from_tokens, trim_commas};
 use super::dispatch_entry::parse_reveal_top_count_put_all_matching_into_hand_rest_graveyard;
+use super::sentence_helpers::parse_counter_descriptor;
 use super::zone_handlers::parse_exile_top_library_clause;
 use crate::cards::builders::{
     CardTextError, ChoiceCount, EffectAst, IT_TAG, LibraryBottomOrderAst, LibraryConsultModeAst,
@@ -151,6 +152,55 @@ fn parse_exile_top_library_then_play_bundle(
     };
 
     Ok(Some(vec![exile_effect, permission_effect]))
+}
+
+fn parse_each_player_exile_top_library_put_counters_bundle(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<EffectAst>> {
+    let tokens = trim_commas(tokens);
+    let and_idx = find_index(&tokens, |token| token.is_word("and"))?;
+    let exile_clause = trim_commas(&tokens[..and_idx]);
+    let put_clause = trim_commas(&tokens[and_idx + 1..]);
+    if !exile_clause
+        .first()
+        .is_some_and(|token| token.is_word("exile"))
+        || !put_clause
+            .first()
+            .is_some_and(|token| token.is_word("put"))
+    {
+        return None;
+    }
+
+    let exile_effect = parse_exile_top_library_clause(&exile_clause[1..], None)?;
+    if !matches!(exile_effect, EffectAst::ForEachPlayer { .. }) {
+        return None;
+    }
+
+    let on_idx = find_index(&put_clause, |token| token.is_word("on"))?;
+    let descriptor = trim_commas(&put_clause[1..on_idx]);
+    let target_tail = trim_commas(&put_clause[on_idx + 1..]);
+    let target_words = crate::runtime_backend::token_word_refs(&target_tail);
+    if !word_slice_eq(&target_words, &["each", "of", "them"])
+        && !word_slice_eq(&target_words, &["each", "of", "those", "cards"])
+    {
+        return None;
+    }
+    let (count, counter_type) = parse_counter_descriptor(&descriptor).ok()?;
+
+    let filter = ObjectFilter::tagged(crate::tag::SOURCE_EXILED_TAG).in_zone(Zone::Exile);
+    Some(vec![
+        exile_effect,
+        EffectAst::ForEachObject {
+            filter,
+            effects: vec![EffectAst::subject_verb_put_counters(
+                counter_type,
+                Value::Fixed(count as i32),
+                TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                None,
+                false,
+            )],
+        },
+    ])
 }
 
 fn parse_choose_type_then_phase_out_bundle(
@@ -1801,6 +1851,9 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
         return Some(effects);
     }
     if let Some(effects) = parse_shape_anew_bundle(tokens) {
+        return Some(effects);
+    }
+    if let Some(effects) = parse_each_player_exile_top_library_put_counters_bundle(tokens) {
         return Some(effects);
     }
     if let Some(effects) = parse_reveal_until_land_put_all_graveyard_bundle(tokens) {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -427,6 +427,18 @@ pub(crate) fn parse_exile_top_library_clause(
             )],
         });
     }
+    if word_slice_starts_with(&owner_words, &["each", "player", "library"])
+        || word_slice_starts_with(&owner_words, &["each", "players", "library"])
+    {
+        return Some(EffectAst::ForEachPlayer {
+            effects: vec![EffectAst::subject_verb_exile_top_of_library(
+                PlayerAst::That,
+                count,
+                vec![helper_tag_for_tokens(&tokens, "exiled")],
+                Vec::new(),
+            )],
+        });
+    }
 
     let default_player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
     let (player, used_words) = parse_library_owner_prefix(&owner_words, default_player)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -63,6 +63,29 @@ fn this_way_object_count_value() -> Value {
     }
 }
 
+fn this_way_filtered_count_value(tokens: &[OwnedLexToken]) -> Option<Value> {
+    if !tokens_reference_objects_this_way(tokens) || !grammar::contains_word(tokens, "exiled") {
+        return None;
+    }
+    let action_idx = find_token_index(tokens, |token| token.is_word("exiled"))?;
+    let filter_tokens = trim_commas(&tokens[..action_idx]);
+    let mut filter = if filter_tokens.is_empty()
+        || ZoneCounterCompatWords::new(&filter_tokens)
+            .to_word_refs()
+            .iter()
+            .all(|word| matches!(*word, "card" | "cards" | "object" | "objects"))
+    {
+        ObjectFilter::default()
+    } else {
+        parse_object_filter(&filter_tokens, false).ok()?
+    };
+    filter = filter.in_zone(Zone::Exile).match_tagged(
+        TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+        TaggedOpbjectRelation::IsTaggedObject,
+    );
+    Some(Value::Count(filter))
+}
+
 fn render_clause_words(tokens: &[OwnedLexToken]) -> String {
     ZoneCounterCompatWords::new(tokens).to_word_refs().join(" ")
 }
@@ -592,6 +615,10 @@ pub(crate) fn parse_put_counters(tokens: &[OwnedLexToken]) -> Result<EffectAst, 
             let mut count =
                 if let Some(dynamic) = parse_create_for_each_dynamic_count(&count_filter_tokens) {
                     dynamic
+                } else if let Some(filtered_count) =
+                    this_way_filtered_count_value(&count_filter_tokens)
+                {
+                    filtered_count
                 } else if tokens_reference_objects_this_way(&count_filter_tokens) {
                     this_way_object_count_value()
                 } else {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46943,6 +46943,33 @@ fn parse_etali_attack_exiles_each_players_top_card_and_casts_any_number() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_pako_arcane_retriever_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Pako, Arcane Retriever");
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("ForPlayersEffect")
+            && abilities_debug.contains("ExileTopOfLibraryEffect")
+            && abilities_debug.contains("ForEachObject")
+            && abilities_debug.contains("PutCountersEffect")
+            && abilities_debug.contains("excluded_card_types")
+            && abilities_debug.contains("Creature"),
+        "expected Pako to lower to per-player top-library exile, fetch counters, and a noncreature count filter, got {abilities_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("exile the top card of each player's library")
+            && rendered.contains("put a fetch counter")
+            && rendered.contains("for each noncreature card exiled this way"),
+        "expected Pako compiled text to preserve the each-player exile and noncreature-exiled-this-way clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn villainous_wealth_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Villainous Wealth");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -19236,6 +19236,9 @@ pub(super) fn describe_tagged_this_way_action(filter: &ObjectFilter) -> Option<&
         if tag == "__it__" && filter.zone == Some(Zone::Exile) {
             return Some("exiled");
         }
+        if tag == crate::tag::SOURCE_EXILED_TAG && filter.zone == Some(Zone::Exile) {
+            return Some("exiled");
+        }
         if tag.starts_with("exiled_") || crate::cards::is_sentence_helper_tag(tag, "exiled") {
             Some("exiled")
         } else if tag.starts_with("revealed_")

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -261,6 +261,160 @@ fn put_test_cards_in_zone(game: &mut GameState, player: PlayerId, zone: Zone, co
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn pako_arcane_retriever_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_300), "Pako, Arcane Retriever")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elemental, Subtype::Dog])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Partner with Haldan, Avid Arcanist\n\
+             Haste\n\
+             Whenever Pako attacks, exile the top card of each player's library and put a fetch counter on each of them. Put a +1/+1 counter on Pako for each noncreature card exiled this way.",
+        )
+        .expect("Pako, Arcane Retriever should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_named_library_card(
+    game: &mut GameState,
+    owner: PlayerId,
+    id: u32,
+    name: &str,
+    card_types: Vec<CardType>,
+) {
+    let mut builder = CardBuilder::new(CardId::from_raw(id), name).card_types(card_types.clone());
+    if card_types.contains(&CardType::Creature) {
+        builder = builder.power_toughness(PowerToughness::fixed(2, 2));
+    }
+    let card = builder.build();
+    game.create_object_from_card(&card, owner, Zone::Library);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_pako_attack(game: &mut GameState, pako_id: ObjectId) {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: pako_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("Pako attack declaration should be legal");
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Pako should trigger once when it attacks"
+    );
+    put_triggers_on_stack(game, &mut trigger_queue).expect("Pako trigger should go on the stack");
+    while !game.stack.is_empty() {
+        resolve_stack_entry(game).expect("Pako attack trigger should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pako_attack_exiles_each_players_top_card_adds_fetch_and_counts_noncreatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let pako = pako_arcane_retriever_definition();
+    let pako_id = game.create_object_from_definition(&pako, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(pako_id);
+    put_named_library_card(
+        &mut game,
+        alice,
+        74_301,
+        "Alice Noncreature",
+        vec![CardType::Sorcery],
+    );
+    put_named_library_card(
+        &mut game,
+        bob,
+        74_302,
+        "Bob Creature",
+        vec![CardType::Creature],
+    );
+
+    resolve_pako_attack(&mut game, pako_id);
+
+    let exiled_names = game
+        .exile
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect::<Vec<_>>();
+    assert!(
+        exiled_names.contains(&"Alice Noncreature".to_string())
+            && exiled_names.contains(&"Bob Creature".to_string()),
+        "Pako should exile the top card of each player's library, got {exiled_names:?}"
+    );
+    for &exiled_id in &game.exile {
+        assert_eq!(
+            game.counter_count(exiled_id, crate::object::CounterType::Named("fetch")),
+            1,
+            "each exiled card should get one fetch counter"
+        );
+    }
+    assert_eq!(
+        game.counter_count(pako_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Pako should get one +1/+1 counter for only the noncreature card exiled this way"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pako_attack_with_only_creature_cards_exiled_adds_no_plus_one_counters() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let pako = pako_arcane_retriever_definition();
+    let pako_id = game.create_object_from_definition(&pako, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(pako_id);
+    put_named_library_card(
+        &mut game,
+        alice,
+        74_303,
+        "Alice Creature",
+        vec![CardType::Creature],
+    );
+    put_named_library_card(
+        &mut game,
+        bob,
+        74_304,
+        "Bob Creature",
+        vec![CardType::Creature],
+    );
+
+    resolve_pako_attack(&mut game, pako_id);
+
+    assert_eq!(
+        game.exile.len(),
+        2,
+        "Pako should still exile one card from each player"
+    );
+    assert_eq!(
+        game.counter_count(pako_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Pako should not get +1/+1 counters when only creature cards were exiled"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn attack_with_toad(
     game: &mut GameState,
     toad_id: ObjectId,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pako, Arcane Retriever
Initial parse error:
```
compiled text dropped required semantic marker: noncreature-exiled-this-way
```

Current worker: i-06ecce12f47e8bc97
Branch: codex/aws-card-fix-pako-arcane-retriever
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0265
