### PR TITLE
Fix Ironsmith parse failure: Jarad's Orders

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -477,10 +477,17 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
     let first_tokens = trim_commas(sentences[sentence_idx].lowered());
     let first_effects = effect_sentences::parse_effect_chain(&first_tokens)?;
+    let (search_effect, reveal_after_search) = match first_effects.as_slice() {
+        [search_effect] => (search_effect, false),
+        [search_effect, EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::RevealTagged { .. },
+            ..
+        })] => (search_effect, true),
+        _ => return Ok(None),
+    };
     let (mut search_filter, count, count_value, chooser, library_player, search_mode) =
-        match first_effects.as_slice() {
-            [
-                EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        match search_effect {
+            EffectAst::SubjectVerb(SubjectVerbEffectAst {
                     action:
                         SubjectVerbActionAst::SearchLibrary {
                             filter,
@@ -492,8 +499,7 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
                             ..
                         },
                     ..
-                }),
-            ] => (
+                }) => (
                 filter.clone(),
                 *count,
                 count_value.clone(),
@@ -501,8 +507,7 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
                 *player,
                 *search_mode,
             ),
-            [
-                EffectAst::ChooseObjectsAcrossZones {
+            EffectAst::ChooseObjectsAcrossZones {
                     filter,
                     count,
                     count_value,
@@ -510,8 +515,7 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
                     zones,
                     search_mode,
                     ..
-                },
-            ] if zones.as_slice() == [Zone::Library] => (
+                } if zones.as_slice() == [Zone::Library] => (
                 filter.clone(),
                 *count,
                 count_value.clone(),
@@ -521,7 +525,7 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
             ),
             _ => return Ok(None),
         };
-    if count.min != 2 || count.max != Some(2) || count_value.is_some() {
+    if count.min > 2 || count.max != Some(2) || count_value.is_some() {
         return Ok(None);
     }
 
@@ -558,8 +562,13 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
     hand_filter.zone = Some(Zone::Library);
     let iterated_is_hand_card =
         ObjectFilter::default().same_stable_id_as_tagged(TagKey::from(IT_TAG));
+    let hand_choice_count = if count.min == 0 {
+        ChoiceCount::up_to(1)
+    } else {
+        ChoiceCount::exactly(1)
+    };
 
-    Ok(Some(vec![
+    let mut effects = vec![
         EffectAst::ChooseObjectsAcrossZones {
             filter: search_filter,
             count,
@@ -569,9 +578,14 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
             zones: vec![Zone::Library],
             search_mode: Some(search_mode),
         },
+    ];
+    if reveal_after_search {
+        effects.push(EffectAst::subject_verb_reveal_tagged(searched_tag.clone()));
+    }
+    effects.extend([
         EffectAst::ChooseObjects {
             filter: hand_filter,
-            count: ChoiceCount::exactly(1),
+            count: hand_choice_count,
             count_value: None,
             player: chooser,
             tag: hand_tag.clone(),
@@ -604,7 +618,9 @@ pub(crate) fn parse_search_two_then_put_one_hand_other_graveyard_then_shuffle(
             library_player,
             SubjectVerbActionAst::ShuffleLibrary,
         ),
-    ]))
+    ]);
+
+    Ok(Some(effects))
 }
 
 pub(crate) fn parse_search_face_down_exile_conditional_cast_else_hand(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4371,15 +4371,32 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     fn describe_search_two_split_hand_graveyard(effects: &[&Effect]) -> Option<String> {
-        let [
-            search_effect,
-            choose_effect,
-            hand_effect,
-            graveyard_effect,
-            shuffle_effect,
-        ] = effects
-        else {
-            return None;
+        let (search_effect, reveal_effect, choose_effect, hand_effect, graveyard_effect, shuffle_effect) =
+            match effects {
+                [search_effect, choose_effect, hand_effect, graveyard_effect, shuffle_effect] => {
+                    (*search_effect, None, *choose_effect, *hand_effect, *graveyard_effect, *shuffle_effect)
+                }
+                [
+                    search_effect,
+                    reveal_effect,
+                    choose_effect,
+                    hand_effect,
+                    graveyard_effect,
+                    shuffle_effect,
+                ] => (
+                    *search_effect,
+                    Some(*reveal_effect),
+                    *choose_effect,
+                    *hand_effect,
+                    *graveyard_effect,
+                    *shuffle_effect,
+                ),
+                _ => return None,
+            };
+        let reveal = if let Some(reveal_effect) = reveal_effect {
+            Some(reveal_effect.downcast_ref::<crate::effects::RevealTaggedEffect>()?)
+        } else {
+            None
         };
         let search = search_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
         let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
@@ -4399,10 +4416,10 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
 
         if !search.is_search
             || choose.is_search
-            || search.count.min != 2
+            || search.count.min > 2
             || search.count.max != Some(2)
             || search.count_value.is_some()
-            || choose.count.min != 1
+            || choose.count.min > 1
             || choose.count.max != Some(1)
             || choose.count_value.is_some()
             || search.chooser != choose.chooser
@@ -4419,12 +4436,18 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         {
             return None;
         }
+        if let Some(reveal) = reveal
+            && reveal.tag != search.tag
+        {
+            return None;
+        }
 
+        let selection = describe_choose_selection(search);
+        let reveal_text = if reveal.is_some() { " and reveal them" } else { "" };
         if search.chooser == PlayerFilter::You {
-            return Some(
-                "Search your library for two cards. Put one into your hand and the other into your graveyard. Then shuffle"
-                    .to_string(),
-            );
+            return Some(format!(
+                "Search your library for {selection}{reveal_text}. Put one into your hand and the other into your graveyard. Then shuffle"
+            ));
         }
 
         let player = describe_player_filter(&search.chooser);
@@ -4432,11 +4455,11 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         let possessive = describe_possessive_player_filter(&search.chooser);
         let shuffle_verb = player_verb(&player, "shuffle", "shuffles");
         Some(format!(
-            "{capitalized} searches {possessive} library for two cards. Put one into {possessive} hand and the other into {possessive} graveyard. Then {player} {shuffle_verb}"
+            "{capitalized} searches {possessive} library for {selection}{reveal_text}. Put one into {possessive} hand and the other into {possessive} graveyard. Then {player} {shuffle_verb}"
         ))
     }
 
-    if filtered.len() == 5
+    if (filtered.len() == 5 || filtered.len() == 6)
         && let Some(compact) = describe_search_two_split_hand_graveyard(&filtered)
     {
         return compact;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jarad's Orders
Initial parse error:
```
unsupported target phrase (clause: 'one'); oracle-only fallback also failed: unsupported target phrase (clause: 'one')
```

Current worker: i-0ffaed32df7bb03ff
Branch: codex/aws-card-fix-jarad-s-orders
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0267
