### PR TITLE
Fix Ironsmith parse failure: Windbrisk Heights

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -12,6 +12,7 @@ use super::grammar::filters::{
     parse_spell_filter_with_grammar_entrypoint_lexed,
 };
 use super::grammar::primitives as grammar;
+use super::grammar::structure::split_trailing_if_clause_lexed;
 use super::grammar::values::parse_value_comparison_tokens;
 use super::lexer::{
     LexStream, LexedClause, OwnedLexToken, TokenKind, token_word_refs, trim_lexed_commas,
@@ -1513,6 +1514,16 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
 
     if let Some(effect) = parse_cast_with_tagged_mana_value_limit_clause(&trimmed)? {
         return Ok(Some(effect));
+    }
+
+    if let Some(trailing_if) = split_trailing_if_clause_lexed(&trimmed)
+        && let Some(base_effect) = parse_cast_or_play_tagged_clause(trailing_if.leading_tokens)?
+    {
+        return Ok(Some(EffectAst::Conditional {
+            predicate: trailing_if.predicate,
+            if_true: vec![base_effect],
+            if_false: Vec::new(),
+        }));
     }
 
     let conditional_tagged_permission = parse_permission_lead_tokens(&trimmed)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2591,6 +2591,23 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::YouAttackedThisTurn);
     }
 
+    if filtered.len() == 9
+        && filtered[0] == "you"
+        && filtered[1] == "attacked"
+        && filtered[2] == "with"
+        && filtered[4] == "or"
+        && filtered[5] == "more"
+        && matches!(filtered[6], "creature" | "creatures")
+        && filtered[7] == "this"
+        && filtered[8] == "turn"
+        && let Some(count) = parse_named_number(filtered[3])
+    {
+        return Ok(PredicateAst::PlayerAttackedWithCreaturesThisTurnOrMore {
+            player: PlayerAst::You,
+            count,
+        });
+    }
+
     if matches!(
         filtered.as_slice(),
         ["that", "creature", "had", "to", "attack", "this", "combat"]

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -486,6 +486,13 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 count: *count,
             }
         }
+        PredicateAst::PlayerAttackedWithCreaturesThisTurnOrMore { player, count } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::PlayerAttackedWithCreaturesThisTurnOrMore {
+                player,
+                count: *count,
+            }
+        }
         PredicateAst::OpponentLostLifeThisTurn => Condition::OpponentLostLifeThisTurn,
         PredicateAst::YouHaveNoCardsInHand => {
             Condition::Not(Box::new(Condition::CardsInHandOrMore(1)))

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -506,6 +506,10 @@ pub(crate) enum PredicateAst {
         player: PlayerAst,
         count: u32,
     },
+    PlayerAttackedWithCreaturesThisTurnOrMore {
+        player: PlayerAst,
+        count: u32,
+    },
     OpponentLostLifeThisTurn,
     YouHaveNoCardsInHand,
     PlayerWouldDrawCard {

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -692,6 +692,10 @@ pub enum Condition {
         player: PlayerFilter,
         count: u32,
     },
+    PlayerAttackedWithCreaturesThisTurnOrMore {
+        player: PlayerFilter,
+        count: u32,
+    },
     AttackedThisTurn,
     OpponentLostLifeThisTurn,
     PermanentLeftBattlefieldThisTurn,

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10847,6 +10847,12 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 count_text
             )
         }
+        Condition::PlayerAttackedWithCreaturesThisTurnOrMore { player, count } => {
+            let subject = describe_player_filter(player);
+            let count_text = small_number_word(*count)
+                .unwrap_or_else(|| count.to_string());
+            format!("{subject} attacked with {count_text} or more creatures this turn")
+        }
         Condition::AttackedThisTurn => "you attacked this turn".to_string(),
         Condition::OpponentLostLifeThisTurn => {
             "an opponent was dealt damage this turn".to_string()

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1041,6 +1041,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::And(..) => {}
         Condition::Or(..) => {}
         Condition::PlayerCastSpellsThisTurnOrMore { .. } => {}
+        Condition::PlayerAttackedWithCreaturesThisTurnOrMore { .. } => {}
         Condition::PlayerTappedLandForManaThisTurn { .. } => {}
         Condition::PlayerGainedLifeThisTurnOrMore { .. } => {}
         Condition::PlayerHadLandEnterBattlefieldThisTurn { .. } => {}
@@ -1198,6 +1199,13 @@ pub fn evaluate_condition_external(
                 .map(|pid| game.turn_store.turn_history.spells_cast_by_player(*pid))
                 .sum();
             cast_count >= *count
+        }
+        Condition::PlayerAttackedWithCreaturesThisTurnOrMore { player, count } => {
+            matching_condition_players_external(game, ctx, player)
+                .into_iter()
+                .any(|player_id| {
+                    game.player_attacked_with_creatures_this_turn_or_more(player_id, *count)
+                })
         }
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
@@ -2436,6 +2444,13 @@ fn evaluate_condition_simple(
                 .sum();
             cast_count >= *count
         }
+        Condition::PlayerAttackedWithCreaturesThisTurnOrMore { player, count } => {
+            matching_condition_players_simple(game, controller, player)
+                .into_iter()
+                .any(|player_id| {
+                    game.player_attacked_with_creatures_this_turn_or_more(player_id, *count)
+                })
+        }
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
                 return false;
@@ -3091,6 +3106,13 @@ fn evaluate_condition(
                 .map(|pid| game.turn_store.turn_history.spells_cast_by_player(*pid))
                 .sum();
             Ok(cast_count >= *count)
+        }
+        Condition::PlayerAttackedWithCreaturesThisTurnOrMore { player, count } => {
+            Ok(matching_condition_players_exec(game, ctx, player)?
+                .into_iter()
+                .any(|player_id| {
+                    game.player_attacked_with_creatures_this_turn_or_more(player_id, *count)
+                }))
         }
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -7256,6 +7256,55 @@ impl GameState {
             .unwrap_or(0)
     }
 
+    pub fn player_attacked_with_creatures_this_turn_or_more(
+        &self,
+        player: PlayerId,
+        count: u32,
+    ) -> bool {
+        let required = count as usize;
+        if required == 0 {
+            return true;
+        }
+
+        let max_recorded_attackers = self
+            .turn_store
+            .turn_history
+            .event_records
+            .iter()
+            .chain(self.turn_store.turn_history.staged_event_records.iter())
+            .filter_map(|record| {
+                let attacked = record
+                    .event
+                    .downcast::<crate::events::combat::CreatureAttackedEvent>()?;
+                let controller_matches = record
+                    .object_snapshot
+                    .as_ref()
+                    .is_some_and(|snapshot| snapshot.controller == player)
+                    || record.object_snapshot.is_none()
+                        && self
+                            .object(attacked.attacker)
+                            .is_some_and(|object| self.controller_of(object) == player);
+                controller_matches.then_some(attacked.total_attackers)
+            })
+            .max()
+            .unwrap_or(0);
+        if max_recorded_attackers >= required {
+            return true;
+        }
+
+        self.turn_store
+            .turn_history
+            .creatures_attacked_this_turn
+            .iter()
+            .filter(|creature| {
+                self.object(**creature)
+                    .is_some_and(|object| self.controller_of(object) == player)
+            })
+            .take(required)
+            .count()
+            >= required
+    }
+
     /// Record an explicit combat damage assignment for the next combat damage step.
     pub fn set_combat_damage_assignment(
         &mut self,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Windbrisk Heights
Initial parse error:
```
could not find verb in effect clause (clause: 'play the exiled card without paying its mana cost if you attacked with three or more creatures this turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'play the exiled card without paying its mana cost if you attacked with three or more creatures this turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-02e4094a141e09701
Branch: codex/aws-card-fix-windbrisk-heights
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0268
