### PR TITLE
Fix Ironsmith parse failure: Djinn Illuminatus

### DIFF
--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -39,6 +39,21 @@ pub enum DerivedAlternativeCast<C> {
     },
 }
 
+/// A granted optional cost whose exact cost is derived from the granted card.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DerivedOptionalCost {
+    /// Replicate using the spell's mana cost.
+    ReplicateFromCardManaCost,
+}
+
+impl DerivedOptionalCost {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::ReplicateFromCardManaCost => "Replicate",
+        }
+    }
+}
+
 impl<C> DerivedAlternativeCast<C> {
     pub fn display_name(&self) -> &'static str {
         match self {
@@ -141,6 +156,8 @@ pub enum Grantable<SA, E, C, Cond> {
     AlternativeCast(AlternativeCastingMethod<E, C, Cond>),
     /// Grant an alternative casting method whose exact cost is derived from the card.
     DerivedAlternativeCast(DerivedAlternativeCast<C>),
+    /// Grant an optional cost whose exact cost is derived from the card.
+    DerivedOptionalCost(DerivedOptionalCost),
     /// Grant the ability to play a card from a non-hand zone as if it were in hand.
     PlayFrom,
 }
@@ -228,6 +245,11 @@ where
             ),
         )
     }
+
+    /// Create a grantable for replicate whose optional cost is the granted card's mana cost.
+    pub fn replicate_from_cards_mana_cost() -> Self {
+        Self::DerivedOptionalCost(DerivedOptionalCost::ReplicateFromCardManaCost)
+    }
 }
 
 impl<SA, E, C, Cond> Grantable<SA, E, C, Cond>
@@ -243,6 +265,7 @@ where
             Self::Ability(a) => a.grant_display(),
             Self::AlternativeCast(m) => m.name().to_string(),
             Self::DerivedAlternativeCast(spec) => spec.display_name().to_string(),
+            Self::DerivedOptionalCost(spec) => spec.display_name().to_string(),
             Self::PlayFrom => "play from zone".to_string(),
         }
     }
@@ -667,6 +690,18 @@ where
             return format!(
                 "{may_prefix} pay {{X}} rather than pay the mana cost for {} you cast, where X is that spell's mana value",
                 castable_filter_description(&self.filter)
+            );
+        }
+        if let Grantable::DerivedOptionalCost(DerivedOptionalCost::ReplicateFromCardManaCost) =
+            &self.grantable
+        {
+            let cast_desc = castable_filter_description(&self.filter);
+            let filter_desc = cast_desc
+                .strip_suffix(" spells")
+                .map(|base| format!("{base} spell you cast"))
+                .unwrap_or(cast_desc);
+            return format!(
+                "Each {filter_desc} has replicate. The replicate cost is equal to its mana cost"
             );
         }
         if let Grantable::DerivedAlternativeCast(

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -147,8 +147,8 @@ pub use filter_model::{
     TaggedObjectConstraint, TaggedOpbjectRelation, TargetabilityConstraint,
 };
 pub use grant_model::{
-    DerivedAlternativeCast, GrantDuration, GrantSpec, GrantStaticAbility, GrantUsageLimit,
-    Grantable,
+    DerivedAlternativeCast, DerivedOptionalCost, GrantDuration, GrantSpec, GrantStaticAbility,
+    GrantUsageLimit, Grantable,
 };
 pub use ids::{
     CardId, IdCountersSnapshot, ObjectId, PlayerId, StableId, reset_runtime_id_counters,

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3,9 +3,9 @@ use std::any::Any;
 use crate::{
     Ability, AbilityKind, ActivatedAbility, AlternativeCastingMethod, AnthemValue, CardType, Color,
     ColorSet, Condition, CostComponent, CounterType, DamagedBySource, DerivedAlternativeCast,
-    GrantSpec, Grantable, KeywordActionKind, ManaCost, ManaSpendPermission, ObjectFilter,
-    PlayerFilter, ProtectionFrom, Restriction, StaticAbilityId, Subtype, SubtypeFamily, Supertype,
-    TotalCost, TriggeredAbility, Value, Zone,
+    DerivedOptionalCost, GrantSpec, Grantable, KeywordActionKind, ManaCost, ManaSpendPermission,
+    ObjectFilter, PlayerFilter, ProtectionFrom, Restriction, StaticAbilityId, Subtype,
+    SubtypeFamily, Supertype, TotalCost, TriggeredAbility, Value, Zone,
 };
 
 type AbilityModel<T, E, C, Cond> = Ability<StaticAbility<T, E, C, Cond>, T, E, C>;
@@ -720,6 +720,9 @@ where
                 }
                 Grantable::DerivedAlternativeCast(spec) => {
                     Grantable::DerivedAlternativeCast(map_derived_alternative_cast(spec, map_cost)?)
+                }
+                Grantable::DerivedOptionalCost(DerivedOptionalCost::ReplicateFromCardManaCost) => {
+                    Grantable::DerivedOptionalCost(DerivedOptionalCost::ReplicateFromCardManaCost)
                 }
                 Grantable::PlayFrom => Grantable::PlayFrom,
             })

--- a/crates/ironsmith-runtime/src/derived_view.rs
+++ b/crates/ironsmith-runtime/src/derived_view.rs
@@ -752,7 +752,9 @@ impl<'a> DerivedGameView<'a> {
                         }
                     })
                 }
-                Grantable::Ability(_) | Grantable::PlayFrom => None,
+                Grantable::Ability(_) | Grantable::DerivedOptionalCost(_) | Grantable::PlayFrom => {
+                    None
+                }
             })
             .collect();
         self.granted_alternative_casts
@@ -788,7 +790,8 @@ impl<'a> DerivedGameView<'a> {
                 }),
                 Grantable::Ability(_)
                 | Grantable::AlternativeCast(_)
-                | Grantable::DerivedAlternativeCast(_) => None,
+                | Grantable::DerivedAlternativeCast(_)
+                | Grantable::DerivedOptionalCost(_) => None,
             })
             .collect();
         self.granted_play_from
@@ -828,7 +831,9 @@ impl<'a> DerivedGameView<'a> {
                         }
                     })
                 }
-                Grantable::Ability(_) | Grantable::PlayFrom => None,
+                Grantable::Ability(_) | Grantable::DerivedOptionalCost(_) | Grantable::PlayFrom => {
+                    None
+                }
             })
             .collect()
     }

--- a/crates/ironsmith-runtime/src/grant.rs
+++ b/crates/ironsmith-runtime/src/grant.rs
@@ -42,6 +42,7 @@ use crate::types::CardType;
 use crate::zone::Zone;
 
 pub type DerivedAlternativeCast = ironsmith_core::DerivedAlternativeCast<Cost>;
+pub type DerivedOptionalCost = ironsmith_core::DerivedOptionalCost;
 pub type Grantable = ironsmith_core::Grantable<
     StaticAbility,
     crate::effect::Effect,
@@ -72,6 +73,10 @@ impl ironsmith_core::GrantStaticAbility for StaticAbility {
 
 pub trait DerivedAlternativeCastRuntimeExt {
     fn materialize_for(&self, card: &Object) -> Option<AlternativeCastingMethod>;
+}
+
+pub trait DerivedOptionalCostRuntimeExt {
+    fn materialize_for(&self, card: &Object) -> Option<crate::cost::OptionalCost>;
 }
 
 impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
@@ -200,6 +205,17 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
                     }),
                     *exiles_after_resolution,
                 ))
+            }
+        }
+    }
+}
+
+impl DerivedOptionalCostRuntimeExt for DerivedOptionalCost {
+    fn materialize_for(&self, card: &Object) -> Option<crate::cost::OptionalCost> {
+        match self {
+            Self::ReplicateFromCardManaCost => {
+                let mana_cost = card.mana_cost.clone()?;
+                Some(crate::cost::OptionalCost::replicate(TotalCost::mana(mana_cost)))
             }
         }
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -398,6 +398,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::Grantable::DerivedAlternativeCast(spec) => {
                 crate::grant::Grantable::DerivedAlternativeCast(spec.clone())
             }
+            ironsmith_core::Grantable::DerivedOptionalCost(spec) => {
+                crate::grant::Grantable::DerivedOptionalCost(spec.clone())
+            }
             ironsmith_core::Grantable::PlayFrom => crate::grant::Grantable::PlayFrom,
         };
         crate::grant::GrantSpec {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Djinn Illuminatus
Initial parse error:
```
unsupported trailing granted-keyword clause (clause: 'each instant and sorcery spell you cast has replicate the replicate cost is equal to its mana cost'); oracle-only fallback also failed: unsupported trailing granted-keyword clause (clause: 'each instant and sorcery spell you cast has replicate the replicate cost is equal to its mana cost')
```

Current worker: i-0c9d578c7865d813e
Branch: codex/aws-card-fix-djinn-illuminatus
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/20260528T174010Z-controller-rolling-baked-wave0268
