### PR TITLE
Fix Ironsmith parse failure: Dinrova Horror

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/token_copy_control_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/token_copy_control_family.rs
@@ -982,8 +982,36 @@ pub(crate) fn parse_sentence_comma_then_chain_special(
         return Ok(None);
     }
 
+    if is_that_player_tail && head_is_single_return_to_hand(&head_effects) {
+        bind_that_player_tail_to_returned_owner(&mut tail_effects);
+    }
+
     head_effects.append(&mut tail_effects);
     Ok(Some(head_effects))
+}
+
+fn head_is_single_return_to_hand(effects: &[EffectAst]) -> bool {
+    let [effect] = effects else {
+        return false;
+    };
+
+    matches!(
+        effect,
+        EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::ReturnToHand { .. },
+            ..
+        })
+    )
+}
+
+fn bind_that_player_tail_to_returned_owner(effects: &mut [EffectAst]) {
+    for effect in effects {
+        if let EffectAst::SubjectVerb(subject_verb) = effect
+            && subject_verb.subject.player == PlayerAst::That
+        {
+            subject_verb.subject.player = PlayerAst::ItsOwner;
+        }
+    }
 }
 
 pub(crate) fn parse_destroy_then_land_controller_graveyard_count_damage_sentence(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -30510,6 +30510,41 @@ fn parse_comma_then_that_player_discards_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_dinrova_horror_strict_oracle_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Dinrova Horror")
+        .mana_cost(crate::mana::ManaCost::from_pips(vec![
+            vec![crate::mana::ManaSymbol::Generic(4)],
+            vec![crate::mana::ManaSymbol::Blue],
+            vec![crate::mana::ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Horror])
+        .power_toughness(crate::card::PowerToughness::fixed(4, 4))
+        .parse_text(
+            "When this creature enters, return target permanent to its owner's hand, then that player discards a card.",
+        )
+        .expect("Dinrova Horror should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("OwnerOf(Tagged"),
+        "expected Dinrova Horror's discard to bind to the returned permanent's owner, got {abilities_debug}"
+    );
+    assert!(
+        !abilities_debug.contains("IteratedPlayer"),
+        "Dinrova Horror should not leave an unbound that-player reference, got {abilities_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "When this creature enters, return target permanent to its owner's hand, then that player discards a card."
+        ),
+        "expected Dinrova Horror's return-then-discard clause to render compactly, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_comma_then_return_source_to_hand_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Cyclopean Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2646,12 +2646,59 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         }
     }
 
+    if let Some(compact) = describe_return_to_hand_then_owner_discards(effects) {
+        return Some(compact);
+    }
+
     describe_roll_choose_destroy_create_structural(effects)
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_return_to_hand_then_owner_discards(effects: &[Effect]) -> Option<String> {
+    let [return_effect, discard_effect] = effects else {
+        return None;
+    };
+    let returned_tag = effect_tag(return_effect)?;
+    unwrap_effect_tag(return_effect).downcast_ref::<crate::effects::ReturnToHandEffect>()?;
+    let discard = discard_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+    if discard.count != Value::Fixed(1)
+        || discard.random
+        || discard.any_number
+        || discard.card_filter.is_some()
+        || discard.player
+            != PlayerFilter::OwnerOf(crate::filter::ObjectRef::Tagged(returned_tag.clone()))
+    {
+        return None;
+    }
+
+    let return_text = describe_effect(return_effect)
+        .trim_end_matches('.')
+        .to_string();
+    Some(format!("{return_text}, then that player discards a card."))
+}
+
+fn effect_tag(effect: &Effect) -> Option<&crate::TagKey> {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return Some(&tagged.tag);
+    }
+    if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        return Some(&tag_all.tag);
+    }
+    None
+}
+
+fn unwrap_effect_tag(effect: &Effect) -> &Effect {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return unwrap_effect_tag(&tagged.effect);
+    }
+    if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        return unwrap_effect_tag(&tag_all.effect);
+    }
+    effect
 }
 
 fn describe_roll_choose_destroy_create_structural(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3808,6 +3808,126 @@ fn singe_mind_ogre_reveals_a_random_card_from_target_players_hand_and_makes_them
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dinrova_horror_returns_target_and_its_owner_discards() {
+    struct ChooseDiscardCardDecisionMaker {
+        card_to_discard: ObjectId,
+    }
+
+    impl DecisionMaker for ChooseDiscardCardDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            if ctx
+                .candidates
+                .iter()
+                .any(|candidate| candidate.id == self.card_to_discard && candidate.legal)
+            {
+                vec![self.card_to_discard]
+            } else {
+                ctx.candidates
+                    .iter()
+                    .filter(|candidate| candidate.legal)
+                    .map(|candidate| candidate.id)
+                    .take(ctx.min)
+                    .collect()
+            }
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let dinrova = CardDefinitionBuilder::new(CardId::from_raw(78_010), "Dinrova Horror")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "When this creature enters, return target permanent to its owner's hand, then that player discards a card.",
+        )
+        .expect("Dinrova Horror should parse for runtime test");
+    let dinrova_id = game.create_object_from_definition(&dinrova, alice, Zone::Battlefield);
+
+    let borrowed_permanent = CardBuilder::new(CardId::from_raw(78_011), "Borrowed Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let target_id = game.create_object_from_card(&borrowed_permanent, alice, Zone::Battlefield);
+    game.set_current_controller(target_id, bob);
+
+    let alice_discard = CardBuilder::new(CardId::from_raw(78_012), "Alice Discard")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let bob_hand_card = CardBuilder::new(CardId::from_raw(78_013), "Bob Keeps")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let alice_discard_id = game.create_object_from_card(&alice_discard, alice, Zone::Hand);
+    let _bob_hand_id = game.create_object_from_card(&bob_hand_card, bob, Zone::Hand);
+
+    let etb_trigger = dinrova
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Dinrova Horror should have an enters trigger");
+    let target_spec = etb_trigger
+        .choices
+        .first()
+        .cloned()
+        .expect("Dinrova Horror should target a permanent");
+    let event = TriggerEvent::new_with_provenance(
+        EnterBattlefieldEvent::new(dinrova_id, Zone::Stack),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut dm = ChooseDiscardCardDecisionMaker {
+        card_to_discard: alice_discard_id,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(dinrova_id, alice, &mut dm)
+        .with_triggering_event(event)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target_id)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: target_spec,
+            range: 0..1,
+        }]);
+
+    for effect in &etb_trigger.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Dinrova Horror ETB effect should resolve");
+    }
+
+    assert!(
+        game.player(alice).is_some_and(|player| player
+            .hand
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|obj| obj.name == "Borrowed Relic"))),
+        "the targeted permanent should return to its owner's hand"
+    );
+    assert!(
+        game.player(alice).is_some_and(|player| player
+            .graveyard
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|obj| obj.name == "Alice Discard"))),
+        "the target's owner should discard a card"
+    );
+    assert!(
+        game.player(bob).is_some_and(|player| player
+            .hand
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|obj| obj.name == "Bob Keeps"))),
+        "the target's controller should not discard when they do not own the returned permanent"
+    );
+}
+
 #[test]
 fn test_monarch_changes_when_creature_deals_combat_damage_to_monarch() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dinrova Horror
Initial parse error:
```
triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Fixed(1), player: IteratedPlayer, random: false, any_number: false, card_filter: None, tag: Some(TagKey("discarded_0")) }); oracle-only fallback also failed: triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Fixed(1), player: IteratedPlayer, random: false, any_number: false, card_filter: None, tag: Some(TagKey("discarded_0")) })
```

Current worker: i-01a9dcb71f6da781f
Branch: codex/aws-card-fix-dinrova-horror
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
