### PR TITLE
Fix Ironsmith parse failure: Avatar Roku, Firebender

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3428,7 +3428,11 @@ pub(crate) fn parse_trigger_clause_lexed(
                             }
                         }
                         if one_or_more {
-                            TriggerSpec::AttacksOneOrMore(filter)
+                            if player_subject && attacked_player_filter.is_none() {
+                                TriggerSpec::PlayerAttacks(filter)
+                            } else {
+                                TriggerSpec::AttacksOneOrMore(filter)
+                            }
                         } else {
                             TriggerSpec::Attacks(filter)
                         }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
@@ -369,6 +369,19 @@ pub(crate) fn parse_add_mana(
                 player, mana, amount,
             ));
         }
+        if let Some(last_mana_idx) = last_mana_idx
+            && let Some(amount) = tokens[..last_mana_idx]
+                .iter()
+                .filter_map(|token| token.as_word())
+                .find_map(ironsmith_core::parse_cardinal_word)
+            && amount > 1
+        {
+            return Ok(EffectAst::subject_verb_add_mana_scaled(
+                player,
+                mana,
+                Value::Fixed(amount as i32),
+            ));
+        }
         if let Some(amount) = parse_equal_to_aggregate_filter_value(tokens)
             .or_else(|| parse_add_mana_equal_amount_value(tokens))
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -980,17 +980,22 @@ pub(crate) fn parse_cant_effect_sentence_with_grammar_entrypoint_lexed(
     }
 
     let source_tapped_duration = cant_sentence_has_source_remains_tapped_duration(tokens);
-    let words = token_word_refs(tokens);
-    if word_slice_contains_all_words(&words, &["lose", "mana", "steps", "phases", "end"]) {
-        return Ok(Some(vec![
-            EffectAst::subject_verb_dont_lose_this_mana_as_steps_and_phases_end_this_turn(),
-        ]));
-    }
     let Some(prepared_clause) = prepare_cant_sentence_restriction_clause_lexed(tokens)? else {
         return Ok(None);
     };
     let duration = prepared_clause.duration;
     let clause_tokens = prepared_clause.clause_tokens;
+    let words = token_word_refs(&clause_tokens);
+    if word_slice_contains_all_words(&words, &["lose", "mana", "steps", "end"]) {
+        let include_phase_ends =
+            word_slice_contains_phrase(&words, &["steps", "and", "phases", "end"]);
+        return Ok(Some(vec![
+            EffectAst::subject_verb_dont_lose_this_mana_as_steps_end(
+                duration,
+                include_phase_ends,
+            ),
+        ]));
+    }
 
     let Some(restrictions) = parse_cant_restrictions(&clause_tokens)? else {
         return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -504,9 +504,15 @@ fn compile_subject_verb_effect(
 
             Ok((vec![move_rest], Vec::new()))
         }
-        SubjectVerbActionAst::DontLoseThisManaAsStepsAndPhasesEndThisTurn => Ok((
+        SubjectVerbActionAst::DontLoseThisManaAsStepsEnd {
+            duration,
+            include_phase_ends,
+        } => Ok((
             vec![Effect::new(
-                crate::effects::RetainManaUntilEndOfTurnEffect::you(),
+                crate::effects::RetainManaUntilEndOfTurnEffect::you_until(
+                    duration.clone(),
+                    *include_phase_ends,
+                ),
             )],
             Vec::new(),
         )),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -49,7 +49,7 @@ fn compile_delayed_trigger_spec(
         TriggerSpec::AttacksAndIsntBlocked(filter) => Ok(
             ironsmith_core::DelayedTriggerSpec::AttacksAndIsntBlocked(filter.clone()),
         ),
-        TriggerSpec::AttacksOneOrMore(filter) => Ok(
+        TriggerSpec::PlayerAttacks(filter) | TriggerSpec::AttacksOneOrMore(filter) => Ok(
             ironsmith_core::DelayedTriggerSpec::AttacksOneOrMore(filter.clone()),
         ),
         TriggerSpec::Blocks(filter) => {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -592,7 +592,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::ExchangeTextBoxes { .. }
         | SubjectVerbActionAst::ExchangeZones { .. }
         | SubjectVerbActionAst::PutRestOnBottomOfLibrary
-        | SubjectVerbActionAst::DontLoseThisManaAsStepsAndPhasesEndThisTurn
+        | SubjectVerbActionAst::DontLoseThisManaAsStepsEnd { .. }
         | SubjectVerbActionAst::ExchangeValues { .. }
         | SubjectVerbActionAst::ExileInsteadOfGraveyardThisTurn
         | SubjectVerbActionAst::ControlCombatChoicesThisTurn { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -20,6 +20,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::Attacks(filter) => Trigger::attacks(filter),
         TriggerSpec::AttacksAndIsntBlocked(filter) => Trigger::attacks_and_isnt_blocked(filter),
         TriggerSpec::AttacksWhileSaddled(filter) => Trigger::attacks_while_saddled(filter),
+        TriggerSpec::PlayerAttacks(filter) => Trigger::player_attacks(filter),
         TriggerSpec::AttacksOneOrMore(filter) => Trigger::attacks_one_or_more(filter),
         TriggerSpec::AttacksOneOrMoreWithMinTotal {
             filter,
@@ -531,7 +532,9 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         | TriggerSpec::ThisDealsCombatDamageToPlayer
         | TriggerSpec::DealsCombatDamageToPlayer { .. } => Some(PlayerFilter::DamagedPlayer),
         TriggerSpec::ThisAttacks | TriggerSpec::ThisBecomesBlocked => Some(PlayerFilter::Defending),
-        TriggerSpec::Attacks(filter) | TriggerSpec::AttacksOneOrMore(filter)
+        TriggerSpec::Attacks(filter)
+        | TriggerSpec::PlayerAttacks(filter)
+        | TriggerSpec::AttacksOneOrMore(filter)
             if filter
                 .attacking_player_or_planeswalker_controlled_by
                 .is_some() =>
@@ -611,6 +614,7 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             | TriggerSpec::ThisDealsCombatDamageToPlayer
             | TriggerSpec::DealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { .. }
+            | TriggerSpec::PlayerAttacks(_)
             | TriggerSpec::AttacksOneOrMore(_)
             | TriggerSpec::AttacksOneOrMoreWithMinTotal { .. }
             | TriggerSpec::AttacksYouOrPlaneswalkerYouControlOneOrMore(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -108,6 +108,7 @@ pub(crate) enum TriggerSpec {
     Attacks(ObjectFilter),
     AttacksAndIsntBlocked(ObjectFilter),
     AttacksWhileSaddled(ObjectFilter),
+    PlayerAttacks(ObjectFilter),
     AttacksOneOrMore(ObjectFilter),
     AttacksOneOrMoreWithMinTotal {
         filter: ObjectFilter,
@@ -833,7 +834,10 @@ pub(crate) enum SubjectVerbActionAst {
         zone2: Zone,
     },
     PutRestOnBottomOfLibrary,
-    DontLoseThisManaAsStepsAndPhasesEndThisTurn,
+    DontLoseThisManaAsStepsEnd {
+        duration: Until,
+        include_phase_ends: bool,
+    },
     ExchangeValues {
         left: ExchangeValueAst,
         right: ExchangeValueAst,
@@ -1885,9 +1889,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("zone2", zone2)
                 .finish(),
             Self::PutRestOnBottomOfLibrary => f.write_str("PutRestOnBottomOfLibrary"),
-            Self::DontLoseThisManaAsStepsAndPhasesEndThisTurn => {
-                f.write_str("DontLoseThisManaAsStepsAndPhasesEndThisTurn")
-            }
+            Self::DontLoseThisManaAsStepsEnd {
+                duration,
+                include_phase_ends,
+            } => f
+                .debug_struct("DontLoseThisManaAsStepsEnd")
+                .field("duration", duration)
+                .field("include_phase_ends", include_phase_ends)
+                .finish(),
             Self::ExchangeValues {
                 left,
                 right,
@@ -4993,11 +5002,17 @@ impl EffectAst {
         )
     }
 
-    pub(crate) fn subject_verb_dont_lose_this_mana_as_steps_and_phases_end_this_turn() -> Self {
+    pub(crate) fn subject_verb_dont_lose_this_mana_as_steps_end(
+        duration: crate::effect::Until,
+        include_phase_ends: bool,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::DontLoseThisManaAsStepsAndPhasesEndThisTurn,
+            SubjectVerbActionAst::DontLoseThisManaAsStepsEnd {
+                duration,
+                include_phase_ends,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -337,7 +337,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::ExchangeTextBoxes { .. }
             | SubjectVerbActionAst::ExchangeZones { .. }
             | SubjectVerbActionAst::PutRestOnBottomOfLibrary
-            | SubjectVerbActionAst::DontLoseThisManaAsStepsAndPhasesEndThisTurn
+            | SubjectVerbActionAst::DontLoseThisManaAsStepsEnd { .. }
             | SubjectVerbActionAst::ExchangeValues { .. }
             | SubjectVerbActionAst::ExileInsteadOfGraveyardThisTurn
             | SubjectVerbActionAst::ControlCombatChoicesThisTurn { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -82,6 +82,7 @@ fn trigger_supports_event_amount(trigger: &TriggerSpec) -> bool {
             | TriggerSpec::ThisDealsCombatDamageToPlayer
             | TriggerSpec::DealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { .. }
+            | TriggerSpec::PlayerAttacks(_)
             | TriggerSpec::AttacksOneOrMore(_)
             | TriggerSpec::AttacksOneOrMoreWithMinTotal { .. }
             | TriggerSpec::AttacksYouOrPlaneswalkerYouControlOneOrMore(_)
@@ -1887,7 +1888,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::ExchangeTextBoxes { .. }
             | SubjectVerbActionAst::ExchangeZones { .. }
             | SubjectVerbActionAst::PutRestOnBottomOfLibrary
-            | SubjectVerbActionAst::DontLoseThisManaAsStepsAndPhasesEndThisTurn
+            | SubjectVerbActionAst::DontLoseThisManaAsStepsEnd { .. }
             | SubjectVerbActionAst::ExchangeValues { .. }
             | SubjectVerbActionAst::ExileInsteadOfGraveyardThisTurn
             | SubjectVerbActionAst::ControlCombatChoicesThisTurn { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_primitives.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_primitives.rs
@@ -5,8 +5,9 @@ use super::super::grammar::effects::{
 };
 use super::super::grammar::primitives as grammar;
 use super::super::lexer::{
-    LexedClause, contains_token_word, word_slice_contains_any_word, word_slice_eq,
-    word_slice_eq_any, word_slice_matching_phrase, word_slice_starts_with,
+    LexedClause, contains_token_word, token_word_refs, word_slice_contains_any_word,
+    word_slice_contains_phrase, word_slice_eq, word_slice_eq_any, word_slice_matching_phrase,
+    word_slice_starts_with,
     word_slice_starts_with_any,
 };
 use super::super::lowering_support::rewrite_parsed_triggered_ability as parsed_triggered_ability;
@@ -72,6 +73,8 @@ const DONT_LOSE_THIS_MANA_PATTERNS: &[&[&str]] = &[
     &[
         "you", "don't", "lose", "this", "mana", "as", "steps", "and", "phases", "end",
     ],
+    &["you", "dont", "lose", "this", "mana", "as", "steps", "end"],
+    &["you", "don't", "lose", "this", "mana", "as", "steps", "end"],
 ];
 const ALL_CREATURES_ABLE_TO_BLOCK_PREFIXES: &[&[&str]] =
     &[&["all", "creatures", "able", "to", "block"]];
@@ -570,8 +573,14 @@ pub(crate) fn parse_dont_lose_this_mana_as_steps_and_phases_end_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
     if LexedClause::new(tokens).matches_any_words(DONT_LOSE_THIS_MANA_PATTERNS) {
+        let words = token_word_refs(tokens);
+        let include_phase_ends =
+            word_slice_contains_phrase(&words, &["steps", "and", "phases", "end"]);
         return Ok(Some(
-            EffectAst::subject_verb_dont_lose_this_mana_as_steps_and_phases_end_this_turn(),
+            EffectAst::subject_verb_dont_lose_this_mana_as_steps_end(
+                crate::effect::Until::EndOfTurn,
+                include_phase_ends,
+            ),
         ));
     }
     Ok(None)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2367,7 +2367,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::ExchangeTextBoxes { .. }
             | SubjectVerbActionAst::ExchangeZones { .. }
             | SubjectVerbActionAst::PutRestOnBottomOfLibrary
-            | SubjectVerbActionAst::DontLoseThisManaAsStepsAndPhasesEndThisTurn
+            | SubjectVerbActionAst::DontLoseThisManaAsStepsEnd { .. }
             | SubjectVerbActionAst::ExchangeValues { .. }
             | SubjectVerbActionAst::ExileInsteadOfGraveyardThisTurn
             | SubjectVerbActionAst::ControlCombatChoicesThisTurn { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
@@ -329,6 +329,30 @@ pub(crate) fn parse_add_mana(
                 player, mana, amount,
             ));
         }
+        if let Some(last_mana_idx) = last_mana_idx
+            && let Some(amount) = tokens[..last_mana_idx]
+                .iter()
+                .filter_map(|token| token.as_word())
+                .find_map(ironsmith_core::parse_cardinal_word)
+            && amount > 1
+        {
+            parser_trace_stack("parse_add_mana:scaled-cardinal", tokens);
+            return Ok(EffectAst::subject_verb_add_mana_scaled(
+                player,
+                mana,
+                Value::Fixed(amount as i32),
+            ));
+        }
+        if let Some((Value::Fixed(amount), _consumed)) = parse_value(tokens)
+            && amount > 1
+        {
+            parser_trace_stack("parse_add_mana:scaled-fixed", tokens);
+            return Ok(EffectAst::subject_verb_add_mana_scaled(
+                player,
+                mana,
+                Value::Fixed(amount),
+            ));
+        }
         if let Some(amount) = parse_equal_to_aggregate_filter_value(tokens)
             .or_else(|| parse_add_mana_equal_amount_value(tokens))
         {

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1450,15 +1450,25 @@ impl<E> ExecuteWithSourceEffect<E> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct RetainManaUntilEndOfTurnEffect {
     pub player: PlayerFilter,
+    pub duration: Until,
+    pub include_phase_ends: bool,
 }
 
 impl RetainManaUntilEndOfTurnEffect {
-    pub fn new(player: PlayerFilter) -> Self {
-        Self { player }
+    pub fn new(player: PlayerFilter, duration: Until, include_phase_ends: bool) -> Self {
+        Self {
+            player,
+            duration,
+            include_phase_ends,
+        }
     }
 
     pub fn you() -> Self {
-        Self::new(PlayerFilter::You)
+        Self::new(PlayerFilter::You, Until::EndOfTurn, true)
+    }
+
+    pub fn you_until(duration: Until, include_phase_ends: bool) -> Self {
+        Self::new(PlayerFilter::You, duration, include_phase_ends)
     }
 }
 

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -38,6 +38,9 @@ pub enum TriggerKind {
     AttacksWhileSaddled {
         filter: ObjectFilter,
     },
+    PlayerAttacks {
+        filter: ObjectFilter,
+    },
     AttacksOneOrMore {
         filter: ObjectFilter,
     },
@@ -392,6 +395,9 @@ impl Trigger {
             "attacks_while_saddled",
             TriggerKind::AttacksWhileSaddled { filter },
         )
+    }
+    pub fn player_attacks(filter: ObjectFilter) -> Self {
+        Self::typed("player_attacks", TriggerKind::PlayerAttacks { filter })
     }
     pub fn attacks_one_or_more(filter: ObjectFilter) -> Self {
         Self::typed(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37729,6 +37729,157 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn avatar_roku_firebender_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Avatar Roku, Firebender");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("Whenever a player attacks, add six {R}")
+            && rendered_lower
+                .contains("until end of combat, you don't lose this mana as steps end"),
+        "expected Avatar Roku attack trigger to keep six-red and end-of-combat mana-retention text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("{R}{R}{R}: Target creature gets +3/+0 until end of turn"),
+        "expected Avatar Roku activated pump ability in compiled text, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("player_attacks: true")
+            && debug.contains("AddScaledManaEffect")
+            && debug.contains("Fixed(\n                                                6")
+            && debug.contains("duration: EndOfCombat")
+            && debug.contains("include_phase_ends: false"),
+        "expected Avatar Roku to model player-attack trigger, six red mana, and steps-only retention structurally, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn avatar_roku_firebender_attack_trigger_adds_six_red_mana_once() {
+    let def = parse_oracle_card_definition("Avatar Roku, Firebender");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let attacker = CardDefinitionBuilder::new(CardId::new(), "Attack Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let attacker_id = game.create_object_from_definition(&attacker, bob, Zone::Battlefield);
+    game.remove_summoning_sickness(attacker_id);
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[crate::decision::AttackerDeclaration {
+            creature: attacker_id,
+            target: crate::combat_state::AttackTarget::Player(alice),
+        }],
+    )
+    .expect("attack declaration should succeed");
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Avatar Roku attack trigger should go on stack");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").mana_pool.red,
+        0,
+        "Avatar Roku should not add mana before the trigger resolves"
+    );
+    crate::game_loop::resolve_stack_entry(&mut game).expect("Avatar Roku trigger should resolve");
+    assert_eq!(
+        game.player(alice).expect("Alice exists").mana_pool.red,
+        6,
+        "Avatar Roku should add six red mana to its controller when a player attacks"
+    );
+    game.empty_mana_pools();
+    assert_eq!(
+        game.player(alice).expect("Alice exists").mana_pool.red,
+        6,
+        "Avatar Roku mana should survive combat step boundaries before end of combat"
+    );
+    game.turn.step = Some(crate::game_state::Step::EndCombat);
+    game.empty_mana_pools();
+    assert_eq!(
+        game.player(alice).expect("Alice exists").mana_pool.red,
+        0,
+        "Avatar Roku mana should not persist past end of combat"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn avatar_roku_firebender_activated_ability_pumps_only_creature_targets() {
+    let def = parse_oracle_card_definition("Avatar Roku, Firebender");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated.clone()),
+            _ => None,
+        })
+        .expect("Avatar Roku should have an activated pump ability");
+    let ChooseSpec::Target(inner) = &activated.choices[0] else {
+        panic!("Avatar Roku pump ability should target a creature");
+    };
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        panic!("Avatar Roku pump ability should use an object target");
+    };
+    assert!(
+        filter.card_types.contains(&CardType::Creature),
+        "Avatar Roku pump ability should require a creature target, got {filter:?}"
+    );
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Pump Target")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    assert_eq!(game.current_power(creature), Some(2));
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(creature)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::target_creature(),
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &activated.effects,
+        None,
+        &[],
+    )
+    .expect("Avatar Roku pump ability should resolve");
+    assert_eq!(
+        game.current_power(creature),
+        Some(5),
+        "Avatar Roku should give the target creature +3/+0 until end of turn"
+    );
+}
+
 #[test]
 fn alena_kessig_trapper_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Alena, Kessig Trapper");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28551,6 +28551,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             .collect::<Vec<_>>()
             .join("");
         let mana_text = if mana.is_empty() { "{0}" } else { &mana };
+        if let Value::Fixed(amount) = add_scaled.amount {
+            return format!(
+                "Add {} {}{}",
+                number_word(amount).unwrap_or_else(|| amount.to_string()),
+                mana_text,
+                describe_add_mana_destination_suffix(&add_scaled.player)
+            );
+        }
         if let Value::Count(filter) = &add_scaled.amount {
             return format!(
                 "Add {} for each {}{}",
@@ -29648,11 +29656,15 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return prompt.description.clone();
     }
     if let Some(retain) = effect.downcast_ref::<crate::effects::RetainManaUntilEndOfTurnEffect>() {
+        let duration = describe_until(&retain.duration);
+        let ending = if retain.include_phase_ends {
+            "steps and phases end"
+        } else {
+            "steps end"
+        };
         return match retain.player {
-            PlayerFilter::You => {
-                "Until end of turn, you don't lose this mana as steps and phases end".to_string()
-            }
-            _ => "Until end of turn, mana doesn't empty as steps and phases end".to_string(),
+            PlayerFilter::You => format!("{duration}, you don't lose this mana as {ending}"),
+            _ => format!("{duration}, mana doesn't empty as {ending}"),
         };
     }
     if let Some(conditional) = effect.downcast_ref::<crate::effects::ConditionalEffect>() {

--- a/crates/ironsmith-runtime/src/effects/context.rs
+++ b/crates/ironsmith-runtime/src/effects/context.rs
@@ -15,6 +15,7 @@ use crate::effects::VoteResult;
 use crate::events::cause::EventCause;
 use crate::game_state::{GameState, TargetAssignment};
 use crate::ids::{ObjectId, PlayerId};
+use crate::mana::ManaSymbol;
 use crate::provenance::ProvNodeId;
 use crate::replacement::{ReplacementEffect, ReplacementEffectId, ReplacementEffectKey};
 use crate::snapshot::ObjectSnapshot;
@@ -160,6 +161,8 @@ pub struct ManaExecutionContext {
     pub mana_usage_restrictions: Vec<crate::ability::ManaUsageRestriction>,
     /// Chosen creature type snapshot for mana produced by the source.
     pub mana_source_chosen_creature_type: Option<Subtype>,
+    /// Mana most recently added while resolving the current effect sequence.
+    pub last_mana_added: Option<(PlayerId, Vec<ManaSymbol>)>,
 }
 
 /// Ephemeral replacement effects scoped to the current resolution path.

--- a/crates/ironsmith-runtime/src/effects/mana/retain_mana_until_end_of_turn.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/retain_mana_until_end_of_turn.rs
@@ -1,5 +1,6 @@
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
+use crate::effects::helpers::resolve_player_filter;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 pub type RetainManaUntilEndOfTurnEffect = ironsmith_core::RetainManaUntilEndOfTurnEffect;
@@ -11,9 +12,16 @@ impl EffectExecutor for RetainManaUntilEndOfTurnEffect {
 
     fn execute(
         &self,
-        _game: &mut GameState,
-        _ctx: &mut ExecutionContext,
+        game: &mut GameState,
+        ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
+        let player = resolve_player_filter(game, &self.player, ctx)?;
+        if let Some((mana_player, mana)) = ctx.mana.last_mana_added.clone()
+            && mana_player == player
+            && !mana.is_empty()
+        {
+            game.add_mana_retention(player, mana, self.duration.clone(), self.include_phase_ends);
+        }
         Ok(EffectOutcome::resolved())
     }
 }

--- a/crates/ironsmith-runtime/src/effects/runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/runtime.rs
@@ -75,6 +75,19 @@ pub fn execute_effect(
     ctx: &mut ExecutionContext,
 ) -> Result<EffectOutcome, ExecutionError> {
     let mut outcome = effect.0.execute(game, ctx)?;
+    let added_mana = outcome
+        .events
+        .iter()
+        .rev()
+        .find_map(|event| event.downcast::<crate::events::ManaAddedEvent>());
+    if let Some(event) = added_mana {
+        ctx.mana.last_mana_added = Some((event.player, event.mana.clone()));
+    } else if effect
+        .downcast_ref::<crate::effects::RetainManaUntilEndOfTurnEffect>()
+        .is_none()
+    {
+        ctx.mana.last_mana_added = None;
+    }
 
     if !outcome.events.is_empty() {
         let execution_node = game.provenance_graph_mut().alloc_child(

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -23,6 +23,7 @@ use crate::effect::Until;
 use crate::events::{Event, EventKind, KeywordActionKind};
 use crate::filter::PlayerFilterExt;
 use crate::ids::{ObjectId, PlayerId, StableId, reset_runtime_id_counters};
+use crate::mana::ManaSymbol;
 use crate::object::{AttachmentTarget, AuraAttachmentFilter, Object};
 use crate::player::Player;
 use crate::prevention::PreventionEffectManager;
@@ -1594,6 +1595,16 @@ pub struct CombatChoiceControlEffect {
     pub timestamp: u64,
 }
 
+/// Temporary permission for specific mana to remain in a player's mana pool.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ManaRetentionEffect {
+    pub player: PlayerId,
+    pub mana: Vec<ManaSymbol>,
+    pub duration: Until,
+    pub include_phase_ends: bool,
+    pub created_turn: u32,
+}
+
 /// An effect that causes one player to control another player's decisions.
 #[derive(Debug, Clone)]
 pub struct PlayerControlEffect {
@@ -1970,6 +1981,9 @@ pub struct GameState {
     /// Temporary effects that redirect attacker/blocker choices this turn.
     pub combat_choice_control_effects: Vec<CombatChoiceControlEffect>,
 
+    /// Temporary effects that keep recently produced mana through step/phase ends.
+    pub mana_retention_effects: Vec<ManaRetentionEffect>,
+
     /// Timestamp counter for combat-choice control effects.
     pub combat_choice_control_timestamp: u64,
 
@@ -2180,6 +2194,7 @@ impl GameState {
             scoped_player_control_effects: Vec::new(),
             player_control_timestamp: 0,
             combat_choice_control_effects: Vec::new(),
+            mana_retention_effects: Vec::new(),
             combat_choice_control_timestamp: 0,
             saddled_until_end_of_turn: HashSet::new(),
             soulbond_pairs: HashMap::new(),
@@ -6977,6 +6992,7 @@ impl GameState {
         }
         self.turn_store.grant_cast_uses_this_turn.clear();
         self.saddled_until_end_of_turn.clear();
+        self.mana_retention_effects.clear();
         self.ninjutsu_attack_targets.clear();
         self.combat_damage_player_batch_hits.clear();
         self.speed_increase_triggered_this_turn.clear();
@@ -7190,6 +7206,37 @@ impl GameState {
             .retain(|effect| effect.expires_on_turn != current_turn);
     }
 
+    pub fn add_mana_retention(
+        &mut self,
+        player: PlayerId,
+        mana: Vec<ManaSymbol>,
+        duration: Until,
+        include_phase_ends: bool,
+    ) {
+        self.mana_retention_effects.push(ManaRetentionEffect {
+            player,
+            mana,
+            duration,
+            include_phase_ends,
+            created_turn: self.turn.turn_number,
+        });
+    }
+
+    fn mana_retention_applies_at_current_boundary(&self, effect: &ManaRetentionEffect) -> bool {
+        if !effect.include_phase_ends && self.turn.step.is_none() {
+            return false;
+        }
+        match effect.duration {
+            Until::EndOfCombat => {
+                self.turn.phase == Phase::Combat && self.turn.step != Some(Step::EndCombat)
+            }
+            Until::EndOfTurn => {
+                self.turn.turn_number == effect.created_turn && self.turn.step != Some(Step::Cleanup)
+            }
+            _ => self.turn.turn_number == effect.created_turn,
+        }
+    }
+
     fn clear_player_control_from_source(&mut self, stable_id: StableId) {
         self.player_control_effects.retain(|effect| {
             !(matches!(effect.duration, PlayerControlDuration::UntilSourceLeaves)
@@ -7206,10 +7253,48 @@ impl GameState {
     /// Empties all players' mana pools.
     /// Called at the end of each step and phase per MTG rules.
     pub fn empty_mana_pools(&mut self) {
+        let retained_mana: HashMap<PlayerId, Vec<ManaSymbol>> = self
+            .mana_retention_effects
+            .iter()
+            .filter(|effect| self.mana_retention_applies_at_current_boundary(effect))
+            .fold(HashMap::new(), |mut retained, effect| {
+                retained
+                    .entry(effect.player)
+                    .or_insert_with(Vec::new)
+                    .extend(effect.mana.iter().copied());
+                retained
+            });
+
         for player in &mut self.players {
+            let pool_before_empty = player.mana_pool.clone();
             player.mana_pool.empty();
             player.restricted_mana.clear();
+            if let Some(mana) = retained_mana.get(&player.id) {
+                for symbol in [
+                    ManaSymbol::White,
+                    ManaSymbol::Blue,
+                    ManaSymbol::Black,
+                    ManaSymbol::Red,
+                    ManaSymbol::Green,
+                    ManaSymbol::Colorless,
+                ] {
+                    let retained_count =
+                        mana.iter().filter(|retained| **retained == symbol).count() as u32;
+                    let preserved = retained_count.min(pool_before_empty.amount(symbol));
+                    if preserved > 0 {
+                        player.mana_pool.add(symbol, preserved);
+                    }
+                }
+            }
         }
+        let phase = self.turn.phase;
+        let step = self.turn.step;
+        let turn_number = self.turn.turn_number;
+        self.mana_retention_effects.retain(|effect| match effect.duration {
+            Until::EndOfCombat => phase == Phase::Combat && step != Some(Step::EndCombat),
+            Until::EndOfTurn => turn_number == effect.created_turn && step != Some(Step::Cleanup),
+            _ => turn_number == effect.created_turn,
+        });
     }
 
     /// Clears the tracking for OncePerTurn activated abilities.

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -19,6 +19,9 @@ pub struct AttacksTrigger {
     pub one_or_more: bool,
     /// Minimum number of total attackers required for this trigger to fire.
     pub min_total_attackers: usize,
+    /// Render the trigger using player-attack wording when the source text used
+    /// a player as the attacking subject.
+    pub player_attacks: bool,
 }
 
 impl AttacksTrigger {
@@ -28,6 +31,7 @@ impl AttacksTrigger {
             filter,
             one_or_more: false,
             min_total_attackers: 1,
+            player_attacks: false,
         }
     }
 
@@ -37,6 +41,17 @@ impl AttacksTrigger {
             filter,
             one_or_more: true,
             min_total_attackers: 1,
+            player_attacks: false,
+        }
+    }
+
+    /// Create a trigger for "whenever a player attacks" wording.
+    pub fn player_attacks(filter: ObjectFilter) -> Self {
+        Self {
+            filter,
+            one_or_more: true,
+            min_total_attackers: 1,
+            player_attacks: true,
         }
     }
 
@@ -50,6 +65,7 @@ impl AttacksTrigger {
             filter,
             one_or_more: true,
             min_total_attackers: min_total_attackers.max(1),
+            player_attacks: false,
         }
     }
 
@@ -212,6 +228,9 @@ impl TriggerMatcher for AttacksTrigger {
         };
 
         if self.one_or_more {
+            if self.player_attacks && self.min_total_attackers == 1 {
+                return format!("Whenever a player attacks{target_tail}");
+            }
             if self.min_total_attackers > 1 {
                 let min_total = ironsmith_core::cardinal_word(self.min_total_attackers as u32)
                     .unwrap_or_else(|| self.min_total_attackers.to_string());

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -455,6 +455,11 @@ impl Trigger {
         Self::new(AttacksTrigger::one_or_more(filter))
     }
 
+    /// Create a "when a player attacks" trigger.
+    pub fn player_attacks(filter: ObjectFilter) -> Self {
+        Self::new(AttacksTrigger::player_attacks(filter))
+    }
+
     /// Create a "when N or more [filter] attack" trigger that fires once per declaration.
     pub fn attacks_one_or_more_with_min_total(
         filter: ObjectFilter,

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -118,6 +118,7 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::AttacksWhileSaddled { filter } => {
             crate::triggers::Trigger::attacks_while_saddled(filter)
         }
+        TriggerKind::PlayerAttacks { filter } => crate::triggers::Trigger::player_attacks(filter),
         TriggerKind::AttacksOneOrMore { filter } => {
             crate::triggers::Trigger::attacks_one_or_more(filter)
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Avatar Roku, Firebender
Initial parse error:
```
unsupported restriction clause body (clause: 'you don't lose this mana as steps end'); oracle-only fallback also failed: unsupported restriction clause body (clause: 'you don't lose this mana as steps end')
```

Current worker: i-0b0ab6f4284f37e83
Branch: codex/aws-card-fix-avatar-roku-firebender
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
