### PR TITLE
Fix Ironsmith parse failure: Wolf in _____ Clothing

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -860,6 +860,15 @@ pub(crate) fn parse_value_binding_clause(tokens: &[OwnedLexToken]) -> Option<Val
         | Some([
             "amount", "of", "damage", "it", "dealt", "to", "that", "player",
         ]) => return Some(Value::EventValue(EventValueSpec::Amount)),
+        Some([
+            "the", "number", "of", "unique", "vowels", "on", "that", "sticker",
+        ])
+        | Some(["number", "of", "unique", "vowels", "on", "that", "sticker"]) => {
+            return Some(Value::PendingEffectMetric {
+                source: EffectMetricSource::Outcome,
+                metric: EffectMetric::NameStickerUniqueVowels,
+            });
+        }
         Some(["the", "number", "of", "opponents", "you", "have"])
         | Some(["number", "of", "opponents", "you", "have"])
         | Some(["the", "number", "of", "opponents"])

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -814,8 +814,59 @@ fn parse_effect_sentence_with_where_x_lexed(
     }
 
     fn bind_dynamic_target_counts(effect: &mut EffectAst, replacement: &Value) {
-        let EffectAst::SubjectVerb(SubjectVerbEffectAst { action, .. }) = effect else {
-            return;
+        let action = match effect {
+            EffectAst::SubjectVerb(SubjectVerbEffectAst { action, .. }) => action,
+            EffectAst::Conditional {
+                if_true, if_false, ..
+            } => {
+                for effect in if_true.iter_mut().chain(if_false.iter_mut()) {
+                    bind_dynamic_target_counts(effect, replacement);
+                }
+                return;
+            }
+            EffectAst::UnlessPays { effects, .. }
+            | EffectAst::May { effects }
+            | EffectAst::MayByPlayer { effects, .. }
+            | EffectAst::ResolvedIfResult { effects, .. }
+            | EffectAst::ResolvedWhenResult { effects, .. }
+            | EffectAst::IfResult { effects, .. }
+            | EffectAst::WhenResult { effects, .. }
+            | EffectAst::ForEachOpponent { effects }
+            | EffectAst::ForEachPlayersFiltered { effects, .. }
+            | EffectAst::ForEachPlayer { effects }
+            | EffectAst::ForEachTargetPlayers { effects, .. }
+            | EffectAst::ForEachObject { effects, .. }
+            | EffectAst::ForEachTagged { effects, .. }
+            | EffectAst::ForEachOpponentDoesNot { effects, .. }
+            | EffectAst::ForEachPlayerDoesNot { effects, .. }
+            | EffectAst::ForEachOpponentDid { effects, .. }
+            | EffectAst::ForEachPlayerDid { effects, .. }
+            | EffectAst::ForEachTaggedPlayer { effects, .. }
+            | EffectAst::RepeatProcess { effects, .. }
+            | EffectAst::DelayedUntilNextEndStep { effects, .. }
+            | EffectAst::DelayedUntilNextUpkeep { effects, .. }
+            | EffectAst::DelayedUntilNextDrawStep { effects, .. }
+            | EffectAst::DelayedUntilEndStepOfExtraTurn { effects, .. }
+            | EffectAst::DelayedUntilEndOfCombat { effects }
+            | EffectAst::DelayedTriggerThisTurn { effects, .. }
+            | EffectAst::DelayedWhenLastObjectDiesThisTurn { effects, .. }
+            | EffectAst::VoteOption { effects, .. } => {
+                for effect in effects {
+                    bind_dynamic_target_counts(effect, replacement);
+                }
+                return;
+            }
+            EffectAst::UnlessAction {
+                effects,
+                alternative,
+                ..
+            } => {
+                for effect in effects.iter_mut().chain(alternative.iter_mut()) {
+                    bind_dynamic_target_counts(effect, replacement);
+                }
+                return;
+            }
+            _ => return,
         };
         match action {
             SubjectVerbActionAst::Explore { target }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -33,6 +33,7 @@ pub enum EffectMetric {
     CardTypesAmong,
     GreatestPlayerCount,
     IteratedPlayerCount,
+    NameStickerUniqueVowels,
     OtherNumber,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37729,6 +37729,219 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wolf_in_clothing_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Wolf in _____ Clothing");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered_lower.contains("put a name sticker on it")
+            && rendered_lower.contains("up to x target creatures")
+            && rendered_lower.contains("where x is the number of unique vowels on that sticker"),
+        "expected Wolf in _____ Clothing to render its name-sticker where-X clause, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("PutStickerEffect")
+            && ability_debug.contains("NameSticker")
+            && ability_debug.contains("ReflexiveTriggerEffect")
+            && ability_debug.contains("NameStickerUniqueVowels"),
+        "expected Wolf in _____ Clothing to lower to a name-sticker reflexive trigger using the unique-vowel value, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn wolf_in_clothing_enters_effects(def: &CardDefinition) -> Vec<Effect> {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) if triggered.trigger.display().contains("enters") => {
+                Some(triggered.effects.segments[0].default_effects.clone())
+            }
+            _ => None,
+        })
+        .expect("Wolf in _____ Clothing should have an enters triggered ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct WolfStickerDecisionMaker {
+    accept_name_sticker: bool,
+    unique_vowels: usize,
+    targets: Vec<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for WolfStickerDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept_name_sticker
+    }
+
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if ctx.description.contains("unique vowels") {
+            return vec![self.unique_vowels];
+        }
+        ctx.options
+            .iter()
+            .filter(|option| option.legal)
+            .map(|option| option.index)
+            .take(ctx.min)
+            .collect()
+    }
+
+    fn decide_targets(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<crate::game_state::Target> {
+        let requirement = ctx
+            .requirements
+            .first()
+            .expect("Wolf in _____ Clothing should ask for one target group");
+        let max_targets = requirement.max_targets.unwrap_or(self.unique_vowels);
+        self.targets
+            .iter()
+            .copied()
+            .map(crate::game_state::Target::Object)
+            .filter(|target| requirement.legal_targets.contains(target))
+            .take(max_targets)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn wolf_test_creature(
+    game: &mut crate::game_state::GameState,
+    name: &str,
+    controller: PlayerId,
+) -> ObjectId {
+    let card = crate::card::CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn wolf_enters_event(
+    game: &crate::game_state::GameState,
+    source_id: ObjectId,
+) -> crate::triggers::TriggerEvent {
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(source_id)
+            .expect("Wolf in _____ Clothing should be on the battlefield"),
+        game,
+    );
+    crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            source_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    )
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wolf_in_clothing_name_sticker_vowel_count_limits_reflexive_targets() {
+    let def = parse_oracle_card_definition("Wolf in _____ Clothing");
+    let effects = wolf_in_clothing_enters_effects(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let first = wolf_test_creature(&mut game, "First Target", bob);
+    let second = wolf_test_creature(&mut game, "Second Target", bob);
+    let third = wolf_test_creature(&mut game, "Third Target", bob);
+    let fourth = wolf_test_creature(&mut game, "Fourth Target", bob);
+    let mut dm = WolfStickerDecisionMaker {
+        accept_name_sticker: true,
+        unique_vowels: 3,
+        targets: vec![first, second, third, fourth],
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice)
+        .with_triggering_event(wolf_enters_event(&game, source_id))
+        .with_decision_maker(&mut dm);
+
+    for effect in &effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Wolf in _____ Clothing enters effects should resolve");
+    }
+
+    let reflexive_entry = game
+        .stack
+        .last()
+        .expect("accepting the name sticker should create a reflexive triggered ability");
+    assert_eq!(reflexive_entry.event_value_amount, Some(3));
+    assert_eq!(
+        reflexive_entry.targets.len(),
+        3,
+        "the reflexive trigger should choose no more targets than the unique-vowel count"
+    );
+
+    crate::game_loop::resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Wolf in _____ Clothing reflexive trigger should resolve");
+
+    for target in [first, second, third] {
+        assert_eq!(
+            game.calculated_power(target),
+            Some(1),
+            "chosen target should get -1/-1 until end of turn"
+        );
+        assert_eq!(
+            game.calculated_toughness(target),
+            Some(1),
+            "chosen target should get -1/-1 until end of turn"
+        );
+    }
+    assert_eq!(game.calculated_power(fourth), Some(2));
+    assert_eq!(game.calculated_toughness(fourth), Some(2));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wolf_in_clothing_declining_name_sticker_creates_no_reflexive_trigger() {
+    let def = parse_oracle_card_definition("Wolf in _____ Clothing");
+    let effects = wolf_in_clothing_enters_effects(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target = wolf_test_creature(&mut game, "Decline Target", bob);
+    let mut dm = WolfStickerDecisionMaker {
+        accept_name_sticker: false,
+        unique_vowels: 3,
+        targets: vec![target],
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice)
+        .with_triggering_event(wolf_enters_event(&game, source_id))
+        .with_decision_maker(&mut dm);
+
+    for effect in &effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Wolf in _____ Clothing declined enters effects should resolve");
+    }
+
+    assert!(
+        game.stack.is_empty(),
+        "declining the name sticker should not create the when-you-do reflexive trigger"
+    );
+    assert_eq!(game.calculated_power(target), Some(2));
+    assert_eq!(game.calculated_toughness(target), Some(2));
+}
+
 #[test]
 fn alena_kessig_trapper_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Alena, Kessig Trapper");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7811,6 +7811,9 @@ fn describe_effect_metric_value(
             "the greatest number of cards a player discarded this way".to_string()
         }
         crate::effect::EffectMetric::IteratedPlayerCount => "that many".to_string(),
+        crate::effect::EffectMetric::NameStickerUniqueVowels => {
+            "the number of unique vowels on that sticker".to_string()
+        }
         crate::effect::EffectMetric::OtherNumber => "the other result".to_string(),
     };
     match offset {
@@ -8494,7 +8497,7 @@ pub(super) fn choose_spec_allows_multiple(spec: &ChooseSpec) -> bool {
     match spec {
         ChooseSpec::Target(inner) => choose_spec_allows_multiple(inner),
         ChooseSpec::All(_) | ChooseSpec::EachPlayer(_) => true,
-        ChooseSpec::WithCount(inner, count) => {
+        ChooseSpec::WithCount(inner, count) | ChooseSpec::WithCountValue(inner, count, _) => {
             if count.is_dynamic_x() {
                 true
             } else if let Some(max) = count.max {
@@ -8504,6 +8507,25 @@ pub(super) fn choose_spec_allows_multiple(spec: &ChooseSpec) -> bool {
             }
         }
         _ => false,
+    }
+}
+
+fn choose_spec_where_x_count_value(spec: &ChooseSpec) -> Option<&Value> {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. } | ChooseSpec::Target(spec) => {
+            choose_spec_where_x_count_value(spec)
+        }
+        ChooseSpec::WithCount(inner, _) => choose_spec_where_x_count_value(inner),
+        ChooseSpec::WithCountValue(inner, count, value) => {
+            if count.is_dynamic_x()
+                && value.has_surface_hint(ironsmith_core::ValueSurfaceHint::WhereXIs)
+            {
+                Some(value)
+            } else {
+                choose_spec_where_x_count_value(inner)
+            }
+        }
+        _ => None,
     }
 }
 
@@ -9262,15 +9284,31 @@ pub(super) fn describe_apply_continuous_effect(
         return Some(text);
     }
 
+    let where_x_count_value = effect
+        .target_spec
+        .as_ref()
+        .and_then(choose_spec_where_x_count_value);
+    let display_target = if plural_target
+        && where_x_count_value.is_some()
+        && target.contains("target ")
+    {
+        format!("{target} each")
+    } else {
+        target.clone()
+    };
     let clauses = describe_apply_continuous_clauses(effect, plural_target);
     if clauses.is_empty() {
         return None;
     }
 
-    let mut text = format!("{target} {}", join_with_and(&clauses));
+    let mut text = format!("{display_target} {}", join_with_and(&clauses));
     if let Some(tail) = describe_apply_continuous_tail(effect) {
         text.push(' ');
         text.push_str(&tail);
+    }
+    if let Some(value) = where_x_count_value {
+        text.push_str(", where X is ");
+        text.push_str(&describe_value(value));
     }
     Some(text)
 }

--- a/crates/ironsmith-runtime/src/effect_text_shared.rs
+++ b/crates/ironsmith-runtime/src/effect_text_shared.rs
@@ -50,7 +50,7 @@ pub fn choose_spec_is_plural(spec: &ChooseSpec) -> bool {
     match spec {
         ChooseSpec::Target(inner) => choose_spec_is_plural(inner),
         ChooseSpec::All(_) | ChooseSpec::EachPlayer(_) => true,
-        ChooseSpec::WithCount(inner, count) => {
+        ChooseSpec::WithCount(inner, count) | ChooseSpec::WithCountValue(inner, count, _) => {
             if !count.dynamic_x && count.max == Some(1) {
                 false
             } else {

--- a/crates/ironsmith-runtime/src/effects/composition/reflexive_trigger.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/reflexive_trigger.rs
@@ -1,8 +1,11 @@
 //! Reflexive trigger effect implementation.
 
 use crate::decisions::context::{TargetRequirementContext, TargetsContext};
-use crate::effect::{Effect, EffectId, EffectOutcome, EffectPredicate, EffectPredicateRuntimeExt};
+use crate::effect::{
+    Effect, EffectId, EffectOutcome, EffectPredicate, EffectPredicateRuntimeExt, ExecutionFact,
+};
 use crate::effects::EffectExecutor;
+use crate::effects::helpers::resolve_value;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::{GameState, StackEntry};
 use crate::target::ChooseSpec;
@@ -62,7 +65,18 @@ fn choose_reflexive_targets(
     let mut chosen_targets = Vec::new();
 
     for spec in choices {
-        let count = spec.count();
+        let mut count = spec.count();
+        if count.is_dynamic_x() && let Some(value) = spec.count_value() {
+            let resolved = resolve_value(game, value, ctx).ok()?.max(0) as usize;
+            if count.up_to_x {
+                count.max = Some(resolved);
+            } else {
+                count.min = resolved;
+                count.max = Some(resolved);
+            }
+            count.dynamic_x = false;
+            count.up_to_x = false;
+        }
         let legal_targets = crate::targeting::compute_legal_targets_with_tagged_objects(
             game,
             spec,
@@ -96,6 +110,17 @@ fn choose_reflexive_targets(
     }
 
     Some(chosen_targets)
+}
+
+fn reflexive_event_value_amount(outcome: &EffectOutcome) -> Option<i32> {
+    outcome
+        .execution_facts
+        .iter()
+        .find_map(|fact| match fact {
+            ExecutionFact::OtherNumber(value) => Some(*value as i32),
+            _ => None,
+        })
+        .or_else(|| outcome.as_count())
 }
 
 #[cfg(test)]
@@ -222,13 +247,26 @@ impl EffectExecutor for ReflexiveTriggerEffect {
             return Ok(EffectOutcome::resolved());
         }
 
-        let targets = choose_reflexive_targets(game, ctx, &self.choices)
-            .ok_or(ExecutionError::InvalidTarget)?;
+        let event_value_amount = reflexive_event_value_amount(outcome);
+        let previous_event_value_amount = ctx.event_value_amount;
+        let targets = {
+            if let Some(amount) = event_value_amount {
+                ctx.event_value_amount = Some(amount);
+            }
+            let targets = choose_reflexive_targets(game, ctx, &self.choices);
+            ctx.event_value_amount = previous_event_value_amount;
+            targets
+        }
+        .ok_or(ExecutionError::InvalidTarget)?;
 
         let mut entry = StackEntry::ability(ctx.source, ctx.controller, self.effects.clone())
             .with_targets(targets)
             .with_optional_costs_paid(ctx.optional_costs_paid.clone())
             .with_tagged_objects(ctx.tagged_objects.clone());
+
+        if let Some(amount) = event_value_amount {
+            entry = entry.with_event_value_amount(amount);
+        }
 
         if let Some(x) = ctx.x_value {
             entry = entry.with_x(x);

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -352,6 +352,14 @@ fn resolve_effect_metric(
                 })
                 .unwrap_or(0)
         }
+        EffectMetric::NameStickerUniqueVowels => outcome
+            .execution_facts
+            .iter()
+            .find_map(|fact| match fact {
+                crate::effect::ExecutionFact::OtherNumber(value) => Some(*value as i32),
+                _ => None,
+            })
+            .unwrap_or(0),
         EffectMetric::OtherNumber => outcome
             .execution_facts
             .iter()
@@ -2382,7 +2390,12 @@ pub fn validate_target(
 
     match (target, spec) {
         // Selection wrappers do not change target legality.
-        (_, ChooseSpec::Target(inner) | ChooseSpec::WithCount(inner, _)) => {
+        (
+            _,
+            ChooseSpec::Target(inner)
+            | ChooseSpec::WithCount(inner, _)
+            | ChooseSpec::WithCountValue(inner, _, _),
+        ) => {
             validate_target(game, target, inner, ctx)
         }
         (ResolvedTarget::Object(id), ChooseSpec::Object(filter)) => {
@@ -2515,7 +2528,10 @@ pub fn resolve_objects_for_effect_with_choice_description(
     {
         if !ctx.targets.is_empty()
             && matches!(spec.base(), ChooseSpec::Object(_))
-            && !matches!(spec, ChooseSpec::WithCount(_, _))
+            && !matches!(
+                spec,
+                ChooseSpec::WithCount(_, _) | ChooseSpec::WithCountValue(_, _, _)
+            )
             && filter.tagged_constraints.is_empty()
         {
             if let Ok(objects) = resolve_objects_from_spec(game, spec, ctx)

--- a/crates/ironsmith-runtime/src/effects/permanents/put_sticker.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/put_sticker.rs
@@ -1,4 +1,5 @@
-use crate::effect::EffectOutcome;
+use crate::decisions::{SelectOptionsContext, SelectableOption};
+use crate::effect::{EffectOutcome, ExecutionFact};
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_single_object_from_spec;
 use crate::effects::{ExecutionContext, ExecutionError};
@@ -18,6 +19,31 @@ impl PutStickerEffect {
     pub fn new(target: ChooseSpec, action: KeywordActionKind) -> Self {
         Self { target, action }
     }
+}
+
+fn choose_name_sticker_unique_vowels(game: &GameState, ctx: &mut ExecutionContext) -> Option<u32> {
+    let options = (0..=6)
+        .map(|count| SelectableOption::new(count, count.to_string()))
+        .collect::<Vec<_>>();
+    let choice_ctx = SelectOptionsContext::new(
+        ctx.controller,
+        Some(ctx.source),
+        "Choose the number of unique vowels on the name sticker",
+        options,
+        1,
+        1,
+    );
+    let selected = ctx.decision_maker.decide_options(game, &choice_ctx);
+    if ctx.decision_maker.awaiting_choice() {
+        return None;
+    }
+    Some(
+        selected
+            .into_iter()
+            .next()
+            .filter(|count| *count <= 6)
+            .unwrap_or(0) as u32,
+    )
 }
 
 impl EffectExecutor for PutStickerEffect {
@@ -42,13 +68,26 @@ impl EffectExecutor for PutStickerEffect {
         let snapshot = game
             .object(object_id)
             .map(|object| ObjectSnapshot::from_object(object, game));
+        let unique_vowels = if self.action == KeywordActionKind::NameSticker {
+            let Some(count) = choose_name_sticker_unique_vowels(game, ctx) else {
+                return Ok(EffectOutcome::count(0));
+            };
+            Some(count)
+        } else {
+            None
+        };
+        let event_amount = unique_vowels.unwrap_or(1);
         let event = TriggerEvent::new_with_provenance(
-            KeywordActionEvent::new(self.action, ctx.controller, ctx.source, 1)
+            KeywordActionEvent::new(self.action, ctx.controller, ctx.source, event_amount)
                 .with_snapshot(snapshot),
             ctx.provenance,
         );
 
-        Ok(EffectOutcome::with_objects(vec![object_id]).with_event(event))
+        let mut outcome = EffectOutcome::with_objects(vec![object_id]).with_event(event);
+        if let Some(unique_vowels) = unique_vowels {
+            outcome = outcome.with_execution_fact(ExecutionFact::OtherNumber(unique_vowels));
+        }
+        Ok(outcome)
     }
 
     fn get_target_spec(&self) -> Option<&ChooseSpec> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wolf in _____ Clothing
Initial parse error:
```
unsupported where-x clause (clause: 'when you do up to x target creatures each get -1/-1 until end of turn where x is the number of unique vowels on that sticker'); oracle-only fallback also failed: unsupported where-x clause (clause: 'when you do up to x target creatures each get -1/-1 until end of turn where x is the number of unique vowels on that sticker')
```

Current worker: i-035f78e6bf9848bb0
Branch: codex/aws-card-fix-wolf-in-clothing
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
