### PR TITLE
Fix Ironsmith parse failure: Scavenger's Talent

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -790,6 +790,11 @@ pub(crate) fn compile_annotated_effects_with_context(
         }
 
         let (mut effect_list, effect_choices) = compile_effect(&current.effect, ctx)?;
+        ensure_return_effect_exports_annotated_tag(
+            &current.effect,
+            current.out_env.known_last_object_tag(),
+            &mut effect_list,
+        );
         if let Some(id) = current.assigned_effect_id {
             if !effect_list.is_empty() {
                 assign_effect_result_id(
@@ -814,6 +819,42 @@ pub(crate) fn compile_annotated_effects_with_context(
 
     let compiled = prepend_missing_target_choice_prelude(compiled, &choices);
     Ok((compiled, choices))
+}
+
+fn ensure_return_effect_exports_annotated_tag(
+    ast: &EffectAst,
+    tag: Option<&TagKey>,
+    effects: &mut Vec<Effect>,
+) {
+    let Some(tag) = tag else {
+        return;
+    };
+    if !tag.as_str().starts_with("returned_") || !effect_ast_returns_to_battlefield(ast) {
+        return;
+    }
+    let Some(effect) = effects.pop() else {
+        return;
+    };
+    if effect_has_tag(&effect, tag) {
+        effects.push(effect);
+    } else {
+        effects.push(effect.tag(tag.clone()));
+    }
+}
+
+fn effect_ast_returns_to_battlefield(ast: &EffectAst) -> bool {
+    matches!(
+        ast,
+        EffectAst::SubjectVerb(subject_verb)
+            if matches!(subject_verb.action, SubjectVerbActionAst::ReturnToBattlefield { .. })
+    )
+}
+
+fn effect_has_tag(effect: &Effect, tag: &TagKey) -> bool {
+    let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() else {
+        return false;
+    };
+    tagged.tag == *tag || effect_has_tag(&tagged.effect, tag)
 }
 
 fn assign_effect_result_id(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -526,6 +526,47 @@ fn lower_rewrite_activated_to_chunk_impl(
     let normalized_effect_text = effect_text.to_ascii_lowercase();
     let normalized_raw_line = line.info.raw_line.to_ascii_lowercase();
 
+    if let Some(level) = parse_class_level_activation_level(effect_text.as_str()) {
+        let effects_ast = vec![EffectAst::subject_verb_put_counters(
+            crate::object::CounterType::Level,
+            crate::effect::Value::fixed(1),
+            TargetAst::Source(None),
+            None,
+            false,
+        )];
+        let mut parsed = ParsedAbility {
+            ability: Ability {
+                kind: AbilityKind::Activated(ActivatedAbility {
+                    mana_cost: normalized_cost,
+                    effects: ResolutionProgram::default(),
+                    choices: vec![],
+                    timing: ActivationTiming::SorcerySpeed,
+                    is_loyalty_ability: line.is_loyalty_ability,
+                    additional_restrictions: additional_activation_restrictions,
+                    activation_restrictions: vec![],
+                    activation_condition: class_level_activation_condition(level),
+                    mana_output: None,
+                    mana_usage_restrictions: vec![],
+                }),
+                functional_zones: vec![Zone::Battlefield],
+            }
+            .into(),
+            text: ability_text,
+            effects_ast: Some(effects_ast),
+            reference_imports: ReferenceImports::default(),
+            trigger_spec: None,
+        };
+        apply_pending_mana_restrictions(&mut parsed, &mana_restrictions)?;
+        apply_chosen_option_condition_to_activated(
+            &mut parsed,
+            line.chosen_option_label.as_deref(),
+        );
+        return Ok(LoweredRewriteActivatedLine {
+            chunk: LineAst::Ability(parsed),
+            restrictions,
+        });
+    }
+
     if str_contains(normalized_effect_text.as_str(), "add x mana")
         && !str_contains(normalized_raw_line.as_str(), "where x is")
         && !activation_cost_defines_x_for_mana_ability(&normalized_cost)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/damage_and_cost_rewrites.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/damage_and_cost_rewrites.rs
@@ -118,6 +118,72 @@ pub(crate) fn parse_each_player_and_their_creatures_damage_sentence_rewrite(
     }])
 }
 
+pub(crate) fn parse_class_level_activation_level(effect_text: &str) -> Option<u32> {
+    let normalized = effect_text
+        .trim()
+        .trim_end_matches('.')
+        .trim()
+        .to_ascii_lowercase();
+    let rest = normalized.strip_prefix("level ")?.trim();
+    if rest.is_empty() || !rest.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    rest.parse().ok()
+}
+
+pub(crate) fn class_level_activation_condition(level: u32) -> Option<crate::ConditionExpr> {
+    let required_counters = level.checked_sub(2)?;
+    Some(crate::ConditionExpr::ValueComparison {
+        left: crate::effect::Value::CountersOnSource(crate::object::CounterType::Level),
+        operator: crate::effect::ValueComparisonOperator::Equal,
+        right: crate::effect::Value::fixed(required_counters as i32),
+    })
+}
+
+fn class_level_counter_threshold(level: u32) -> Option<u32> {
+    level.checked_sub(1)
+}
+
+fn apply_class_level_condition_to_new_ability(ability: &mut Ability, required_counters: u32) {
+    let condition = crate::ConditionExpr::SourceHasCounterAtLeast {
+        counter_type: crate::object::CounterType::Level,
+        count: required_counters,
+    };
+    match &mut ability.kind {
+        AbilityKind::Triggered(triggered) => {
+            triggered.intervening_if = Some(match triggered.intervening_if.take() {
+                Some(existing) => {
+                    crate::ConditionExpr::And(Box::new(existing), Box::new(condition))
+                }
+                None => condition,
+            });
+        }
+        AbilityKind::Activated(activated) => {
+            if is_class_level_activation_condition(activated.activation_condition.as_ref()) {
+                return;
+            }
+            activated.activation_condition = Some(match activated.activation_condition.take() {
+                Some(existing) => {
+                    crate::ConditionExpr::And(Box::new(existing), Box::new(condition))
+                }
+                None => condition,
+            });
+        }
+        AbilityKind::Static(_) => {}
+    }
+}
+
+fn is_class_level_activation_condition(condition: Option<&crate::ConditionExpr>) -> bool {
+    matches!(
+        condition,
+        Some(crate::ConditionExpr::ValueComparison {
+            left: crate::effect::Value::CountersOnSource(crate::object::CounterType::Level),
+            operator: crate::effect::ValueComparisonOperator::Equal,
+            right: crate::effect::Value::Fixed(_),
+        })
+    )
+}
+
 #[allow(dead_code)]
 pub(crate) fn lower_rewrite_document(
     doc: RewriteSemanticDocument,
@@ -145,12 +211,22 @@ pub(crate) fn lower_normalized_card_ast(
     } = ast;
 
     let mut level_abilities = Vec::new();
+    let mut active_class_level_counter_threshold = None;
     let mut last_restrictable_ability: Option<usize> = None;
     let mut state = RewriteLoweredCardState::default();
 
     for item in items {
         match item {
             NormalizedCardItem::Line(line) => {
+                let class_level_for_line = parse_class_level_activation_level(
+                    line.info
+                        .raw_line
+                        .split_once(':')
+                        .map(|(_, effect)| effect)
+                        .unwrap_or(line.info.raw_line.as_str()),
+                );
+                let class_level_threshold_for_new_abilities = active_class_level_counter_threshold;
+                let abilities_before = builder.abilities.len();
                 rewrite_lower_line_ast(
                     &mut builder,
                     &mut state,
@@ -159,6 +235,14 @@ pub(crate) fn lower_normalized_card_ast(
                     allow_unsupported,
                     &mut last_restrictable_ability,
                 )?;
+                if let Some(required_counters) = class_level_threshold_for_new_abilities {
+                    for ability in &mut builder.abilities[abilities_before..] {
+                        apply_class_level_condition_to_new_ability(ability, required_counters);
+                    }
+                }
+                if let Some(level) = class_level_for_line {
+                    active_class_level_counter_threshold = class_level_counter_threshold(level);
+                }
             }
             NormalizedCardItem::Modal(modal) => {
                 let abilities_before = builder.abilities.len();

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -207,6 +207,343 @@ fn parse_robe_of_the_archmagi_compiled_text_includes_class_equip_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_scavengers_talent_oracle_and_compiled_text() {
+    let def = parse_oracle_card_definition("Scavenger's Talent");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert_eq!(
+        rendered,
+        "Whenever one or more creatures you control die, create a Food token. This ability triggers only once each turn.\n\
+{1}{B}: Level 2\n\
+Whenever you sacrifice a permanent, target player mills two cards.\n\
+{2}{B}: Level 3\n\
+At the beginning of your end step, you may sacrifice three other nonland permanents. If you do, return a creature card from your graveyard to the battlefield with a finality counter on it."
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(activated.len(), 2, "expected two class level activations");
+    assert!(activated.iter().all(|ability| {
+        matches!(
+            ability.timing,
+            crate::ability::ActivationTiming::SorcerySpeed
+        )
+    }));
+
+    assert_eq!(
+        activated[0].activation_condition,
+        Some(crate::ConditionExpr::ValueComparison {
+            left: crate::effect::Value::CountersOnSource(crate::object::CounterType::Level),
+            operator: crate::effect::ValueComparisonOperator::Equal,
+            right: crate::effect::Value::fixed(0),
+        })
+    );
+    assert_eq!(
+        activated[1].activation_condition,
+        Some(crate::ConditionExpr::ValueComparison {
+            left: crate::effect::Value::CountersOnSource(crate::object::CounterType::Level),
+            operator: crate::effect::ValueComparisonOperator::Equal,
+            right: crate::effect::Value::fixed(1),
+        })
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn scavengers_talent_level_activations_add_counters_and_gate_triggers() {
+    struct NoopDecisionMaker;
+    impl crate::decision::DecisionMaker for NoopDecisionMaker {}
+
+    fn condition_applies(
+        game: &crate::game_state::GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        condition: &crate::ConditionExpr,
+    ) -> bool {
+        crate::condition_eval::evaluate_condition_external(
+            game,
+            condition,
+            &crate::condition_eval::ExternalEvaluationContext {
+                controller,
+                source,
+                filter_source: Some(source),
+                ..Default::default()
+            },
+        )
+    }
+
+    let def = parse_oracle_card_definition("Scavenger's Talent");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let activated = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let level_two = activated[0].effects.clone();
+    let level_two_condition = activated[0]
+        .activation_condition
+        .as_ref()
+        .expect("Level 2 activation should require level 1")
+        .clone();
+    let level_three = activated[1].effects.clone();
+    let level_three_condition = activated[1]
+        .activation_condition
+        .as_ref()
+        .expect("Level 3 activation should require Level 2")
+        .clone();
+
+    let sacrifice_trigger_condition = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered
+                    .trigger
+                    .downcast_ref::<crate::triggers::other::PlayerSacrificesTrigger>()
+                    .is_some() => triggered.intervening_if.as_ref(),
+            _ => None,
+        })
+        .expect("Level 2 sacrifice trigger should have a level gate")
+        .clone();
+    let end_step_trigger_condition = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered
+                    .trigger
+                    .downcast_ref::<crate::triggers::phase_step::BeginningOfEndStepTrigger>()
+                    .is_some() => triggered.intervening_if.as_ref(),
+            _ => None,
+        })
+        .expect("Level 3 end-step trigger should have a level gate")
+        .clone();
+
+    assert!(condition_applies(&game, source, alice, &level_two_condition));
+    assert!(!condition_applies(
+        &game,
+        source,
+        alice,
+        &level_three_condition
+    ));
+    assert!(!condition_applies(
+        &game,
+        source,
+        alice,
+        &sacrifice_trigger_condition
+    ));
+
+    let mut dm = NoopDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &level_two,
+        None,
+        &[],
+    )
+    .expect("Level 2 activation should resolve");
+    assert_eq!(
+        game.counter_count(source, crate::object::CounterType::Level),
+        1
+    );
+    assert!(condition_applies(
+        &game,
+        source,
+        alice,
+        &level_three_condition
+    ));
+    assert!(!condition_applies(
+        &game,
+        source,
+        alice,
+        &level_two_condition
+    ));
+    assert!(condition_applies(
+        &game,
+        source,
+        alice,
+        &sacrifice_trigger_condition
+    ));
+    assert!(!condition_applies(
+        &game,
+        source,
+        alice,
+        &end_step_trigger_condition
+    ));
+
+    let mut dm = NoopDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &level_three,
+        None,
+        &[],
+    )
+    .expect("Level 3 activation should resolve");
+    assert_eq!(
+        game.counter_count(source, crate::object::CounterType::Level),
+        2
+    );
+    assert!(condition_applies(
+        &game,
+        source,
+        alice,
+        &end_step_trigger_condition
+    ));
+    assert!(!condition_applies(
+        &game,
+        source,
+        alice,
+        &level_three_condition
+    ));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn scavengers_talent_level_three_branch_sacrifices_and_returns_with_finality() {
+    struct AcceptAndChooseLegal;
+
+    impl crate::decision::DecisionMaker for AcceptAndChooseLegal {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+
+        fn decide_objects(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.max.unwrap_or(ctx.min))
+                .collect()
+        }
+    }
+
+    fn artifact(name: &str) -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Artifact])
+            .build()
+    }
+
+    let def = parse_oracle_card_definition("Scavenger's Talent");
+    let end_step = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered
+                    .trigger
+                    .downcast_ref::<crate::triggers::phase_step::BeginningOfEndStepTrigger>()
+                    .is_some() => Some(triggered),
+            _ => None,
+        })
+        .expect("Scavenger's Talent should have a level-three end-step trigger");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.add_counters(source, crate::object::CounterType::Level, 2);
+
+    let _first =
+        game.create_object_from_definition(&artifact("First Bauble"), alice, Zone::Battlefield);
+    let _second =
+        game.create_object_from_definition(&artifact("Second Bauble"), alice, Zone::Battlefield);
+    let _third =
+        game.create_object_from_definition(&artifact("Third Bauble"), alice, Zone::Battlefield);
+    let land = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Spare Swamp")
+            .card_types(vec![CardType::Land])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let _reanimated = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Graveyard Bear")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+
+    let mut dm = AcceptAndChooseLegal;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &end_step.effects,
+        None,
+        &[],
+    )
+    .expect("Scavenger's Talent level-three trigger should resolve");
+
+    let graveyard_names = game
+        .objects_in_zone(Zone::Graveyard)
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .map(|object| object.name.as_str())
+        .collect::<Vec<_>>();
+    for sacrificed in ["First Bauble", "Second Bauble", "Third Bauble"] {
+        assert!(
+            graveyard_names.contains(&sacrificed),
+            "expected {sacrificed} in graveyard, got {graveyard_names:?}"
+        );
+    }
+    assert_eq!(
+        game.object(source).map(|object| object.zone),
+        Some(Zone::Battlefield),
+        "the source should not be a legal 'other' sacrifice choice"
+    );
+    assert_eq!(
+        game.object(land).map(|object| object.zone),
+        Some(Zone::Battlefield),
+        "land permanents should not be sacrificed by the nonland choice"
+    );
+    let reanimated = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Graveyard Bear")
+        })
+        .expect("Graveyard Bear should return to the battlefield");
+    assert_eq!(
+        game.counter_count(reanimated, crate::object::CounterType::Finality),
+        1,
+        "end-step effects: {:#?}",
+        end_step.effects
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn day_of_the_moon_chapter_resolution_goads_only_chosen_name() {
     struct ChooseMemnite;
 

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -1677,6 +1677,9 @@ pub(super) fn is_keyword_style_line(line: &str) -> bool {
     if is_keyword_phrase(&lower) || normalize_keyword_list_phrase(&lower).is_some() {
         return true;
     }
+    if lower.contains(": level ") {
+        return true;
+    }
     [
         "enchant ",
         "equip ",

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -3201,6 +3201,18 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             "sacrifice three creatures",
         )
         .replace(
+            "you may sacrifice three another nonland permanents you control",
+            "you may sacrifice three other nonland permanents",
+        )
+        .replace(
+            "Whenever one or more a creature you control dies",
+            "Whenever one or more creatures you control die",
+        )
+        .replace(
+            "whenever one or more a creature you control dies",
+            "whenever one or more creatures you control die",
+        )
+        .replace(
             "you may sacrifice another creature you control",
             "you may sacrifice another creature",
         )

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12212,6 +12212,20 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 2;
             continue;
         }
+        if idx + 2 < filtered.len()
+            && let Some(choose) =
+                filtered[idx].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some(put) = filtered[idx + 2].downcast_ref::<crate::effects::PutCountersEffect>()
+            && let Some(compact) = describe_choose_then_move_to_battlefield_with_counter(
+                choose,
+                filtered[idx + 1],
+                put,
+            )
+        {
+            parts.push(compact);
+            idx += 3;
+            continue;
+        }
         if idx + 1 < filtered.len()
             && let Some(choose) =
                 filtered[idx].downcast_ref::<crate::effects::ChooseObjectsEffect>()
@@ -17154,6 +17168,37 @@ fn describe_loyalty_activation_prefix_for_activated(
     })
 }
 
+fn describe_class_level_activation_level(
+    activated: &crate::ability::ActivatedAbility,
+) -> Option<u32> {
+    if !activated.choices.is_empty()
+        || !matches!(activated.timing, ActivationTiming::SorcerySpeed)
+        || activated.effects.segments.len() != 1
+        || !activated.effects.segments[0].self_replacements.is_empty()
+        || activated.effects.segments[0].default_effects.len() != 1
+    {
+        return None;
+    }
+    let put = activated.effects.segments[0].default_effects[0]
+        .downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.counter_type != CounterType::Level
+        || put.amount != Value::Fixed(1)
+        || !matches!(put.target.base(), ChooseSpec::Source)
+    {
+        return None;
+    }
+    match &activated.activation_condition {
+        Some(crate::ConditionExpr::ValueComparison {
+            left: Value::CountersOnSource(counter_type),
+            operator: crate::effect::ValueComparisonOperator::Equal,
+            right: Value::Fixed(required_counters),
+        }) if *counter_type == CounterType::Level && *required_counters >= 0 => {
+            Some(*required_counters as u32 + 2)
+        }
+        _ => None,
+    }
+}
+
 fn loyalty_prefix_amount(value: &Value) -> Option<String> {
     match value.unhinted() {
         Value::Fixed(amount) => Some((*amount).max(0).to_string()),
@@ -20834,6 +20879,73 @@ pub(super) fn describe_choose_then_move_to_battlefield(
     ))
 }
 
+fn describe_choose_then_move_to_battlefield_with_counter(
+    choose: &crate::effects::ChooseObjectsEffect,
+    move_effect: &Effect,
+    put_counters: &crate::effects::PutCountersEffect,
+) -> Option<String> {
+    let move_to_zone = unwrap_tag_wrappers_for_countered_move(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    let ChooseSpec::Tagged(counter_target_tag) = put_counters.target.base() else {
+        return None;
+    };
+    if choose.is_search
+        || !choose.count.is_single()
+        || !move_to_battlefield_uses_chosen_tag(move_to_zone, choose.tag.as_str())
+        || !effect_has_tag_wrapper(move_effect, counter_target_tag.as_str())
+        || put_counters.amount != Value::Fixed(1)
+    {
+        return None;
+    }
+
+    let counter_text = describe_counter_type(put_counters.counter_type);
+    let tapped = if move_to_zone.enters_tapped {
+        " tapped"
+    } else {
+        ""
+    };
+    let control_suffix = match move_to_zone.battlefield_controller {
+        crate::effects::BattlefieldController::Preserve => String::new(),
+        crate::effects::BattlefieldController::Owner => " under its owner's control".to_string(),
+        crate::effects::BattlefieldController::You => String::new(),
+    };
+
+    if choose_primary_zone(choose)? == Zone::Graveyard
+        && choose.chooser == PlayerFilter::You
+        && choose.filter.owner.as_ref() == Some(&PlayerFilter::You)
+    {
+        return Some(format!(
+            "return {} from your graveyard to the battlefield{tapped}{control_suffix} with a {counter_text} counter on it",
+            describe_choose_selection(choose)
+        ));
+    }
+
+    let moved = describe_choose_then_move_to_battlefield(choose, move_to_zone)?;
+    Some(format!(
+        "{moved} with a {counter_text} counter on it"
+    ))
+}
+
+fn effect_has_tag_wrapper(effect: &Effect, tag: &str) -> bool {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        tagged.tag.as_str() == tag || effect_has_tag_wrapper(&tagged.effect, tag)
+    } else if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        tag_all.tag.as_str() == tag || effect_has_tag_wrapper(&tag_all.effect, tag)
+    } else {
+        false
+    }
+}
+
+fn unwrap_tag_wrappers_for_countered_move(effect: &Effect) -> &Effect {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return unwrap_tag_wrappers_for_countered_move(&tagged.effect);
+    }
+    if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        return unwrap_tag_wrappers_for_countered_move(&tag_all.effect);
+    }
+    effect
+}
+
 pub(super) fn describe_choose_then_move_to_library(
     choose: &crate::effects::ChooseObjectsEffect,
     move_to_zone: &crate::effects::MoveToZoneEffect,
@@ -24217,6 +24329,7 @@ fn describe_with_id_if_clause(
     }
 
     let then_text = describe_effect_list(&if_effect.then);
+    let then_text = compact_choose_return_with_counter_text(&then_text);
     let else_text = describe_effect_list(&if_effect.else_);
 
     let condition = if with_id
@@ -24396,6 +24509,26 @@ fn describe_with_id_if_clause(
             lowercase_first(&else_text)
         ))
     }
+}
+
+fn compact_choose_return_with_counter_text(text: &str) -> String {
+    let trimmed = text.trim();
+    let Some(rest) = trimmed
+        .strip_prefix("you choose ")
+        .or_else(|| trimmed.strip_prefix("You choose "))
+    else {
+        return text.to_string();
+    };
+    let Some((chosen, tail)) = rest.split_once(". Return it from graveyard to the battlefield. Put a ")
+    else {
+        return text.to_string();
+    };
+    let Some(counter) = tail.strip_suffix(" counter on it") else {
+        return text.to_string();
+    };
+    format!(
+        "return {chosen} from your graveyard to the battlefield with a {counter} counter on it"
+    )
 }
 
 fn describe_declined_may_mill_then_damage(
@@ -35685,6 +35818,10 @@ pub(super) fn split_trigger_intervening_if(
                     None => limit,
                 });
             }
+            crate::ConditionExpr::SourceHasCounterAtLeast {
+                counter_type: CounterType::Level,
+                ..
+            } => {}
             other => non_limit.push(other),
         }
     }
@@ -36132,6 +36269,12 @@ pub(super) fn describe_ability(
             vec![line]
         }
         AbilityKind::Activated(activated) => {
+            if let Some(level) = describe_class_level_activation_level(activated) {
+                return vec![format!(
+                    "{}: Level {level}",
+                    describe_cost_list(activated.mana_cost.costs())
+                )];
+            }
             if activated.choices.is_empty()
                 && matches!(activated.timing, ActivationTiming::SorcerySpeed)
                 && activated.effects.segments.len() == 1


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Scavenger's Talent
Initial parse error:
```
could not find verb in effect clause (clause: 'level 2'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'level 2'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0dc33c611408e105c
Branch: codex/aws-card-fix-scavenger-s-talent
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
