### PR TITLE
Fix Ironsmith parse failure: Gnarled Sage

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2533,6 +2533,9 @@ pub(crate) fn parse_static_condition_clause(
             dungeon_name: Some(clause_words[name_start..].join(" ")),
         });
     }
+    if let Some(condition) = parse_cards_drawn_this_turn_static_condition(&tokens) {
+        return Ok(condition);
+    }
     if clause_words
         == [
             "your", "life", "total", "is", "less", "than", "or", "equal", "to", "half", "your",
@@ -3041,6 +3044,48 @@ fn parse_conjoined_static_condition_clause(
         }
     }
     None
+}
+
+fn parse_cards_drawn_this_turn_static_condition(
+    tokens: &[OwnedLexToken],
+) -> Option<crate::ConditionExpr> {
+    let clause_word_view = AnthemNormalizedWords::new(tokens);
+    let clause_words = clause_word_view.word_refs();
+    let (player, count_start_word_idx) = match clause_words.as_slice() {
+        ["youve", "drawn", ..] => (PlayerFilter::You, 2usize),
+        ["you", "have", "drawn", ..] | ["you", "ve", "drawn", ..] => {
+            (PlayerFilter::You, 3usize)
+        }
+        ["an", "opponent", "has", "drawn", ..] => (PlayerFilter::Opponent, 4usize),
+        ["opponent", "has", "drawn", ..] => (PlayerFilter::Opponent, 3usize),
+        ["opponents", "have", "drawn", ..] => (PlayerFilter::Opponent, 3usize),
+        ["a", "player", "has", "drawn", ..] => (PlayerFilter::Any, 4usize),
+        ["player", "has", "drawn", ..] => (PlayerFilter::Any, 3usize),
+        ["players", "have", "drawn", ..] => (PlayerFilter::Any, 3usize),
+        _ => return None,
+    };
+
+    let count_start_idx = clause_word_view.token_index_for_word_index(count_start_word_idx)?;
+    let count_tokens = tokens.get(count_start_idx..)?;
+    let (count, used) = parse_number(count_tokens)?;
+    let tail_tokens = count_tokens.get(used..)?;
+    let tail_word_view = AnthemNormalizedWords::new(tail_tokens);
+    let tail_words = tail_word_view.word_refs();
+    if !word_slice_eq_any(
+        &tail_words,
+        &[
+            &["or", "more", "cards", "this", "turn"],
+            &["or", "more", "card", "this", "turn"],
+        ],
+    ) {
+        return None;
+    }
+
+    Some(crate::ConditionExpr::ValueComparison {
+        left: crate::effect::Value::MaxCardsDrawnThisTurn(player),
+        operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+        right: crate::effect::Value::Fixed(count as i32),
+    })
 }
 
 fn parse_cards_in_hand_static_condition(tokens: &[OwnedLexToken]) -> Option<crate::ConditionExpr> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37548,6 +37548,95 @@ fn parse_oracle_banefire_threshold_restrictions_regression() {
     );
 }
 
+#[test]
+fn gnarled_sage_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Gnarled Sage");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability) if static_ability.id() == StaticAbilityId::Reach
+        )),
+        "Gnarled Sage should parse reach strictly, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("MaxCardsDrawnThisTurn")
+            && ability_debug.contains("GreaterThanOrEqual")
+            && ability_debug.contains("Vigilance"),
+        "expected drawn-two-cards condition to guard vigilance structurally, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "This creature gets +0/+2 and has vigilance as long as you've drawn two or more cards this turn"
+        ),
+        "expected Gnarled Sage conditional buff text, got {rendered}"
+    );
+}
+
+#[test]
+fn gnarled_sage_drawn_two_cards_condition_controls_buff_and_vigilance() {
+    fn stage_cards_drawn(
+        game: &mut crate::game_state::GameState,
+        player: PlayerId,
+        count: u32,
+    ) {
+        let cards = (0..count).map(|_| game.new_object_id()).collect();
+        let event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::other::CardsDrawnEvent::new(player, cards, count > 0),
+            crate::provenance::ProvNodeId::default(),
+        );
+        game.stage_turn_history_event(&event);
+    }
+
+    let oracle = oracle_text_by_name()
+        .get("Gnarled Sage")
+        .expect("Gnarled Sage oracle text")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Gnarled Sage")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Treefolk, Subtype::Druid])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(oracle)
+        .expect("Gnarled Sage should parse strictly");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sage_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert_eq!(game.calculated_power(sage_id), Some(4));
+    assert_eq!(game.calculated_toughness(sage_id), Some(4));
+    assert!(!game.object_has_static_ability_id(sage_id, StaticAbilityId::Vigilance));
+
+    stage_cards_drawn(&mut game, bob, 2);
+    assert_eq!(game.calculated_toughness(sage_id), Some(4));
+    assert!(
+        !game.object_has_static_ability_id(sage_id, StaticAbilityId::Vigilance),
+        "opponent drawing two cards should not satisfy Gnarled Sage's 'you've drawn' condition"
+    );
+
+    game.turn_store.turn_history.clear_for_new_turn();
+    stage_cards_drawn(&mut game, alice, 1);
+    assert_eq!(game.calculated_toughness(sage_id), Some(4));
+    assert!(
+        !game.object_has_static_ability_id(sage_id, StaticAbilityId::Vigilance),
+        "drawing only one card should not satisfy Gnarled Sage's condition"
+    );
+
+    game.turn_store.turn_history.clear_for_new_turn();
+    stage_cards_drawn(&mut game, alice, 2);
+    assert_eq!(game.calculated_power(sage_id), Some(4));
+    assert_eq!(game.calculated_toughness(sage_id), Some(6));
+    assert!(game.object_has_static_ability_id(sage_id, StaticAbilityId::Vigilance));
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_drakuseth_maw_of_flames_multi_target_regression() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11840,6 +11840,26 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 );
             }
             if let (
+                Value::MaxCardsDrawnThisTurn(player),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                Value::Fixed(count),
+            ) = (left, operator, right)
+                && *count >= 0
+            {
+                let count_text =
+                    small_number_word(*count as u32).unwrap_or_else(|| count.to_string());
+                let subject = match player {
+                    PlayerFilter::You => "you've".to_string(),
+                    PlayerFilter::Opponent | PlayerFilter::NotYou => "an opponent has".to_string(),
+                    PlayerFilter::Any => "a player has".to_string(),
+                    _ => {
+                        let described = describe_player_filter(player);
+                        format!("{} {}", described, player_verb(&described, "have", "has"))
+                    }
+                };
+                return format!("{subject} drawn {count_text} or more cards this turn");
+            }
+            if let (
                 Value::Count(filter),
                 crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
                 Value::Fixed(count),

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1103,6 +1103,22 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             )
         }
         crate::ConditionExpr::ValueComparison {
+            left: Value::MaxCardsDrawnThisTurn(player),
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: Value::Fixed(count),
+        } if *count >= 0 => {
+            let count_text = number_word_u32(*count as u32).unwrap_or_else(|| count.to_string());
+            let subject = match player {
+                crate::target::PlayerFilter::You => "you've".to_string(),
+                crate::target::PlayerFilter::Opponent | crate::target::PlayerFilter::NotYou => {
+                    "an opponent has".to_string()
+                }
+                crate::target::PlayerFilter::Any => "a player has".to_string(),
+                _ => format!("{} has", describe_static_player(player)),
+            };
+            format!("as long as {subject} drawn {count_text} or more cards this turn")
+        }
+        crate::ConditionExpr::ValueComparison {
             left,
             operator,
             right,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gnarled Sage
Initial parse error:
```
unsupported static condition clause (clause: 'youve drawn two or more cards this turn'); oracle-only fallback also failed: unsupported static condition clause (clause: 'youve drawn two or more cards this turn')
```

Current worker: i-0bcb2301b45a00b3b
Branch: codex/aws-card-fix-gnarled-sage
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
