### PR TITLE
Fix Ironsmith parse failure: Fatal Grudge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
@@ -1036,12 +1036,26 @@ pub(super) fn apply_reference_and_tag_stage(
         all_words.drain(..2);
     }
 
+    let references_sacrifice_cost_object = word_slice_contains_any_phrase(
+        all_words,
+        &[
+            &["the", "sacrificed", "creature"],
+            &["the", "sacrificed", "artifact"],
+            &["the", "sacrificed", "permanent"],
+            &["a", "sacrificed", "creature"],
+            &["a", "sacrificed", "artifact"],
+            &["a", "sacrificed", "permanent"],
+            &["sacrificed", "creature"],
+            &["sacrificed", "artifact"],
+            &["sacrificed", "permanent"],
+        ],
+    );
     let has_share_card_type = (word_slice_contains_word(all_words, "share")
         || word_slice_contains_word(all_words, "shares"))
         && (word_slice_contains_word(all_words, "card")
             || word_slice_contains_word(all_words, "permanent"))
         && word_slice_contains_word(all_words, "type")
-        && word_slice_contains_word(all_words, "it");
+        && (word_slice_contains_word(all_words, "it") || references_sacrifice_cost_object);
     let has_share_color = word_slice_contains_word(all_words, "shares")
         && word_slice_contains_word(all_words, "color")
         && word_slice_contains_word(all_words, "it");
@@ -1086,20 +1100,6 @@ pub(super) fn apply_reference_and_tag_stage(
     let has_lt_mana_value_as_tagged =
         word_slice_contains_any_phrase(all_words, &[&["lesser", "mana", "value"]])
             && !has_equal_or_lesser_mana_value;
-    let references_sacrifice_cost_object = word_slice_contains_any_phrase(
-        all_words,
-        &[
-            &["the", "sacrificed", "creature"],
-            &["the", "sacrificed", "artifact"],
-            &["the", "sacrificed", "permanent"],
-            &["a", "sacrificed", "creature"],
-            &["a", "sacrificed", "artifact"],
-            &["a", "sacrificed", "permanent"],
-            &["sacrificed", "creature"],
-            &["sacrificed", "artifact"],
-            &["sacrificed", "permanent"],
-        ],
-    );
     let references_it_for_mana_value =
         crate::runtime_backend::lexer::word_slice_contains_any_word(all_words, &["it", "its"])
             || word_slice_contains_any_phrase(

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1417,25 +1417,33 @@ impl ObjectFilter {
                         .push("that shares a creature type with that object".to_string());
                 }
                 TaggedOpbjectRelation::SharesCardType => {
-                    let permanent_type_context = self.zone == Some(Zone::Battlefield)
-                        || (!self.card_types.is_empty()
-                            && self.card_types.iter().all(|card_type| {
-                                matches!(
-                                    card_type,
-                                    CardType::Artifact
-                                        | CardType::Creature
-                                        | CardType::Enchantment
-                                        | CardType::Land
-                                        | CardType::Planeswalker
-                                        | CardType::Battle
-                                )
-                            }));
-                    if permanent_type_context {
-                        post_noun_qualifiers
-                            .push("that shares a permanent type with that object".to_string());
+                    if constraint.tag.as_str().starts_with("sacrifice_cost_")
+                        || constraint.tag.as_str().starts_with("sacrificed_")
+                    {
+                        post_noun_qualifiers.push(
+                            "that shares a card type with the sacrificed permanent".to_string(),
+                        );
                     } else {
-                        post_noun_qualifiers
-                            .push("that shares a card type with that object".to_string());
+                        let permanent_type_context = self.zone == Some(Zone::Battlefield)
+                            || (!self.card_types.is_empty()
+                                && self.card_types.iter().all(|card_type| {
+                                    matches!(
+                                        card_type,
+                                        CardType::Artifact
+                                            | CardType::Creature
+                                            | CardType::Enchantment
+                                            | CardType::Land
+                                            | CardType::Planeswalker
+                                            | CardType::Battle
+                                    )
+                                }));
+                        if permanent_type_context {
+                            post_noun_qualifiers
+                                .push("that shares a permanent type with that object".to_string());
+                        } else {
+                            post_noun_qualifiers
+                                .push("that shares a card type with that object".to_string());
+                        }
                     }
                 }
                 TaggedOpbjectRelation::AttachedToTaggedObject => {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -27272,6 +27272,29 @@ fn parse_additional_cost_sacrificed_power_reference_clause() {
     );
 }
 
+#[test]
+fn parse_oracle_fatal_grudge_shared_card_type_cost_reference_regression() {
+    let def = parse_oracle_card_definition("Fatal Grudge");
+    let debug = format!("{def:#?}");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        debug.contains("SharesCardType") && debug.contains("sacrificed_0"),
+        "Fatal Grudge should structurally link the opponent sacrifice filter to the sacrificed permanent, got {debug}"
+    );
+    assert!(
+        rendered_lower.contains("as an additional cost to cast this spell, sacrifice a nonland permanent"),
+        "Fatal Grudge should preserve its nonland additional cost, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains(
+            "each opponent chooses a permanent they control that shares a card type with the sacrificed permanent and sacrifices it"
+        ),
+        "Fatal Grudge should render the shared-card-type opponent choice, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_additional_cost_discard_clause() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -18489,6 +18489,59 @@ pub(super) fn describe_for_players_choose_then_sacrifice(
         return None;
     }
     let choose = for_players.effects[0].downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if let Some(sacrifice) = for_players.effects[1]
+        .downcast_ref::<crate::effects::SacrificeTargetEffect>()
+        && choose_primary_zone(choose) == Some(Zone::Battlefield)
+        && !choose.is_search
+        && choose.count.is_single()
+        && choose.chooser == PlayerFilter::IteratedPlayer
+        && matches!(&sacrifice.target, ChooseSpec::Tagged(tag) if tag == &choose.tag)
+    {
+        let (subject, choose_verb, sacrifice_verb, controls) = match for_players.filter {
+            PlayerFilter::Any => ("Each player", "chooses", "sacrifices", "they control"),
+            PlayerFilter::Opponent => ("Each opponent", "chooses", "sacrifices", "they control"),
+            PlayerFilter::You => ("You", "choose", "sacrifice", "you control"),
+            _ => return None,
+        };
+        let mut selected_filter = choose.filter.clone();
+        selected_filter.zone = None;
+        let mut selection = selected_filter.description();
+        if let Some(rest) = selection.strip_suffix(" that player controls") {
+            selection = rest.to_string();
+        }
+        if choose.filter.controller == Some(PlayerFilter::IteratedPlayer) {
+            for head in [
+                "a permanent",
+                "an artifact",
+                "a creature",
+                "an enchantment",
+                "a land",
+                "a planeswalker",
+                "a battle",
+                "a card",
+                "permanent",
+                "artifact",
+                "creature",
+                "enchantment",
+                "land",
+                "planeswalker",
+                "battle",
+                "card",
+            ] {
+                if selection == head {
+                    selection = format!("{head} {controls}");
+                    break;
+                }
+                if let Some(rest) = selection.strip_prefix(&format!("{head} ")) {
+                    selection = format!("{head} {controls} {rest}");
+                    break;
+                }
+            }
+        }
+        return Some(format!(
+            "{subject} {choose_verb} {selection} and {sacrifice_verb} it"
+        ));
+    }
     let sacrifice = sacrifice_view(&for_players.effects[1])?;
     if choose_primary_zone(choose) != Some(Zone::Battlefield)
         || choose.is_search

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3273,25 +3273,33 @@ impl ObjectFilterExt for ObjectFilter {
                         .push("that shares a creature type with that object".to_string());
                 }
                 TaggedOpbjectRelation::SharesCardType => {
-                    let permanent_type_context = self.zone == Some(Zone::Battlefield)
-                        || (!self.card_types.is_empty()
-                            && self.card_types.iter().all(|card_type| {
-                                matches!(
-                                    card_type,
-                                    CardType::Artifact
-                                        | CardType::Creature
-                                        | CardType::Enchantment
-                                        | CardType::Land
-                                        | CardType::Planeswalker
-                                        | CardType::Battle
-                                )
-                            }));
-                    if permanent_type_context {
-                        post_noun_qualifiers
-                            .push("that shares a permanent type with that object".to_string());
+                    if constraint.tag.as_str().starts_with("sacrifice_cost_")
+                        || constraint.tag.as_str().starts_with("sacrificed_")
+                    {
+                        post_noun_qualifiers.push(
+                            "that shares a card type with the sacrificed permanent".to_string(),
+                        );
                     } else {
-                        post_noun_qualifiers
-                            .push("that shares a card type with that object".to_string());
+                        let permanent_type_context = self.zone == Some(Zone::Battlefield)
+                            || (!self.card_types.is_empty()
+                                && self.card_types.iter().all(|card_type| {
+                                    matches!(
+                                        card_type,
+                                        CardType::Artifact
+                                            | CardType::Creature
+                                            | CardType::Enchantment
+                                            | CardType::Land
+                                            | CardType::Planeswalker
+                                            | CardType::Battle
+                                    )
+                                }));
+                        if permanent_type_context {
+                            post_noun_qualifiers
+                                .push("that shares a permanent type with that object".to_string());
+                        } else {
+                            post_noun_qualifiers
+                                .push("that shares a card type with that object".to_string());
+                        }
                     }
                 }
                 TaggedOpbjectRelation::AttachedToTaggedObject => {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -18572,6 +18572,332 @@ fn necrotic_fumes_cost_prompt_has_no_legal_creature_without_controller_creature(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn fatal_grudge_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(100_790), "Fatal Grudge")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "As an additional cost to cast this spell, sacrifice a nonland permanent.\n\
+             Each opponent chooses a permanent they control that shares a card type with the sacrificed permanent and sacrifices it.\n\
+             Draw a card.",
+        )
+        .expect("Fatal Grudge should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct FatalGrudgeDecisionMaker;
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for FatalGrudgeDecisionMaker {
+    fn decide_priority(
+        &mut self,
+        game: &GameState,
+        ctx: &crate::decisions::context::PriorityContext,
+    ) -> crate::decision::LegalAction {
+        if let Some(action) = ctx.actions.iter().find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::CastSpell { spell_id, .. }
+                    if game
+                        .object(*spell_id)
+                        .is_some_and(|obj| obj.name == "Fatal Grudge")
+            )
+        }) {
+            return action.clone();
+        }
+
+        crate::decision::LegalAction::PassPriority
+    }
+
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        ctx.options
+            .iter()
+            .find(|option| {
+                option.legal && option.description.to_ascii_lowercase().contains("sacrifice")
+            })
+            .or_else(|| ctx.options.iter().find(|option| option.legal))
+            .map(|option| vec![option.index])
+            .unwrap_or_default()
+    }
+
+    fn decide_objects(
+        &mut self,
+        game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        for name in ["Cost Servo", "Cost Relic", "Matching Bear"] {
+            if let Some(candidate) = ctx.candidates.iter().find(|candidate| {
+                candidate.legal
+                    && game
+                        .object(candidate.id)
+                        .is_some_and(|object| object.name == name)
+            }) {
+                return vec![candidate.id];
+            }
+        }
+
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .take(ctx.min)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn fatal_grudge_sacrifices_matching_opponent_permanent_and_draws() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let fatal_grudge = fatal_grudge_definition();
+    let cost_permanent = CardBuilder::new(CardId::new(), "Cost Servo")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let matching_permanent = CardBuilder::new(CardId::new(), "Matching Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let nonmatching_permanent = CardBuilder::new(CardId::new(), "Nonmatching Shrine")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let drawn_card = CardBuilder::new(CardId::new(), "Drawn Card")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+
+    let source_id = game.create_object_from_definition(&fatal_grudge, alice, Zone::Stack);
+    let cost_id = game.create_object_from_card(&cost_permanent, alice, Zone::Battlefield);
+    let matching_id = game.create_object_from_card(&matching_permanent, bob, Zone::Battlefield);
+    let nonmatching_id =
+        game.create_object_from_card(&nonmatching_permanent, bob, Zone::Battlefield);
+    game.create_object_from_card(&drawn_card, alice, Zone::Library);
+
+    let cost_snapshot = game
+        .object(cost_id)
+        .map(|object| {
+            crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+                object, &game,
+            )
+        })
+        .expect("cost permanent should exist before sacrifice");
+    game.move_object_by_effect(cost_id, Zone::Graveyard);
+    let mut tags = std::collections::HashMap::new();
+    tags.insert(crate::tag::TagKey::from("sacrificed_0"), vec![cost_snapshot]);
+    let mut dm = FatalGrudgeDecisionMaker;
+    let mut ctx =
+        crate::effects::ExecutionContext::new(source_id, alice, &mut dm).with_tagged_objects(tags);
+    let program = fatal_grudge.spell_effect.as_ref().expect("spell effect");
+    super::stack_resolution::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source_id,
+        program,
+        None,
+        &[],
+    )
+    .expect("Fatal Grudge should resolve");
+    assert!(
+        !game.battlefield.contains(&cost_id),
+        "Fatal Grudge setup should remove the paid nonland permanent from the battlefield"
+    );
+    assert!(
+        !game.battlefield.contains(&matching_id),
+        "Bob should sacrifice the permanent sharing a card type with the sacrificed permanent"
+    );
+    assert!(
+        game.battlefield.contains(&nonmatching_id),
+        "Bob's nonmatching permanent should remain on the battlefield"
+    );
+    assert!(
+        game.player(alice).expect("alice exists").hand.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Drawn Card")
+        }),
+        "Fatal Grudge should draw a card after the sacrifice instruction"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn fatal_grudge_does_not_sacrifice_when_opponent_has_no_matching_card_type() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let fatal_grudge = fatal_grudge_definition();
+    let cost_permanent = CardBuilder::new(CardId::new(), "Cost Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let nonmatching_permanent = CardBuilder::new(CardId::new(), "Bob Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let drawn_card = CardBuilder::new(CardId::new(), "Branch Drawn Card")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+
+    let source_id = game.create_object_from_definition(&fatal_grudge, alice, Zone::Stack);
+    let cost_id = game.create_object_from_card(&cost_permanent, alice, Zone::Battlefield);
+    let nonmatching_id =
+        game.create_object_from_card(&nonmatching_permanent, bob, Zone::Battlefield);
+    game.create_object_from_card(&drawn_card, alice, Zone::Library);
+
+    let cost_snapshot = game
+        .object(cost_id)
+        .map(|object| {
+            crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+                object, &game,
+            )
+        })
+        .expect("cost permanent should exist before sacrifice");
+    game.move_object_by_effect(cost_id, Zone::Graveyard);
+    let mut tags = std::collections::HashMap::new();
+    tags.insert(crate::tag::TagKey::from("sacrificed_0"), vec![cost_snapshot]);
+    let mut dm = FatalGrudgeDecisionMaker;
+    let mut ctx =
+        crate::effects::ExecutionContext::new(source_id, alice, &mut dm).with_tagged_objects(tags);
+    let program = fatal_grudge.spell_effect.as_ref().expect("spell effect");
+    super::stack_resolution::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source_id,
+        program,
+        None,
+        &[],
+    )
+    .expect("Fatal Grudge should resolve without a matching permanent");
+
+    assert!(
+        game.battlefield.contains(&nonmatching_id),
+        "Bob should not sacrifice a permanent that shares no card type with the sacrificed permanent"
+    );
+    assert!(
+        game.player(alice).expect("alice exists").hand.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Branch Drawn Card")
+        }),
+        "Fatal Grudge should still draw when no opponent permanent matches"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn fatal_grudge_additional_cost_rejects_land_only_payment() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let fatal_grudge = fatal_grudge_definition();
+    let land = CardBuilder::new(CardId::new(), "Only Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let spell_id = game.create_object_from_definition(&fatal_grudge, alice, Zone::Hand);
+    let land_id = game.create_object_from_card(&land, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(crate::decision::LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    );
+
+    let progress = match progress {
+        Ok(crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectOptions(ctx),
+        )) => {
+            let sacrifice_option = ctx
+                .options
+                .iter()
+                .find(|opt| opt.description.to_ascii_lowercase().contains("sacrifice"))
+                .expect("Fatal Grudge should present an object-selection cost option")
+                .index;
+            apply_priority_response(
+                &mut game,
+                &mut trigger_queue,
+                &mut state,
+                &PriorityResponse::NextCostChoice(sacrifice_option),
+            )
+        }
+        other => other,
+    };
+
+    match progress {
+        Ok(crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectObjects(ctx),
+        )) => {
+            assert!(
+                ctx.candidates
+                    .iter()
+                    .all(|candidate| candidate.id != land_id || !candidate.legal),
+                "Fatal Grudge should not offer a land as a legal nonland additional-cost payment"
+            );
+            let err = apply_priority_response(
+                &mut game,
+                &mut trigger_queue,
+                &mut state,
+                &PriorityResponse::CardCostChoice(land_id),
+            )
+            .expect_err("Fatal Grudge should reject a land cost choice");
+            let detail = format!("{err:?}").to_ascii_lowercase();
+            assert!(
+                detail.contains("cost")
+                    || detail.contains("legal")
+                    || detail.contains("candidate"),
+                "expected a cost legality failure for land-only payment, got {detail}"
+            );
+        }
+        Err(err) => {
+            let detail = format!("{err:?}").to_ascii_lowercase();
+            assert!(
+                detail.contains("cost") || detail.contains("additional") || detail.contains("pay"),
+                "expected a cost-payment failure with only a land available, got {detail}"
+            );
+        }
+        other => panic!("Fatal Grudge should not be castable with only a land payment: {other:?}"),
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_corpse_cobble_flashback_from_graveyard_still_uses_sacrificed_power() {
     use crate::cards::definitions::{grizzly_bears, llanowar_elves};


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Fatal Grudge
Initial parse error:
```
compiled text dropped required semantic marker: shares-a-card-type
```

Current worker: i-02e47581c2dd0ef57
Branch: codex/aws-card-fix-fatal-grudge
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
