### PR TITLE
Fix Ironsmith parse failure: Mighty Servant of Leuk-o

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2332,7 +2332,13 @@ pub(crate) fn parse_trigger_clause_lexed(
         )
     }) {
         let subject_words = &words[..crew_word_idx];
-        let source_filter = if is_source_reference_words(subject_words) {
+        let source_becomes_crewed = subject_words
+            .last()
+            .is_some_and(|word| *word == "becomes")
+            && is_source_reference_words(&subject_words[..subject_words.len().saturating_sub(1)]);
+        let source_filter = if source_becomes_crewed {
+            Some(ObjectFilter::default())
+        } else if is_source_reference_words(subject_words) {
             Some(ObjectFilter::source())
         } else {
             let subject_end = word_view
@@ -2345,7 +2351,9 @@ pub(crate) fn parse_trigger_clause_lexed(
                 .token_index_after_words(crew_word_idx + 1)
                 .unwrap_or(tokens.len());
             let tail_words = &words[crew_word_idx + 1..];
-            let object_filter = if tail_words.is_empty()
+            let object_filter = if source_becomes_crewed {
+                ObjectFilter::source().with_subtype(Subtype::Vehicle)
+            } else if tail_words.is_empty()
                 || word_slice_eq_any(
                     tail_words,
                     &[&["a", "vehicle"], &["vehicle"], &["vehicles"]],

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/mod.rs
@@ -28,9 +28,9 @@ use super::super::util::{
     non_article_word_refs, parse_alternative_cast_words, parse_card_type, parse_color,
     parse_counter_type_from_tokens, parse_counter_type_word, parse_filter_counter_constraint_words,
     parse_filter_keyword_constraint_words, parse_mana_symbol_word_flexible, parse_non_color,
-    parse_non_subtype, parse_non_supertype, parse_non_type, parse_number, parse_subtype_flexible,
-    parse_subtype_word, parse_supertype_word, parse_unsigned_pt_word, parse_zone_word,
-    push_outlaw_subtypes, trim_commas, word_refs_except,
+    parse_non_subtype, parse_non_supertype, parse_non_type, parse_number, parse_number_word_u32,
+    parse_subtype_flexible, parse_subtype_word, parse_supertype_word, parse_unsigned_pt_word,
+    parse_zone_word, push_outlaw_subtypes, trim_commas, word_refs_except,
 };
 use super::super::value_helpers::parse_filter_comparison_tokens;
 use super::primitives::{self, TokenWordView, split_lexed_slices_on_and, split_lexed_slices_on_or};

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1318,6 +1318,42 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::SourceIsSaddled);
     }
 
+    if let Some(was_idx) = find_index(&filtered, |word| *word == "was") {
+        let subject_words = &filtered[..was_idx];
+        let is_source_subject = is_source_reference_words(subject_words)
+            || word_slice_eq_any(subject_words, &[&["it"], &["its"]]);
+        let tail = &filtered[was_idx + 1..];
+        if is_source_subject
+            && tail.len() >= 5
+            && word_slice_starts_with(tail, &["crewed", "by", "exactly"])
+        {
+            let Some(count) = tail.get(3).and_then(|word| parse_number_word_u32(word)) else {
+                return Err(CardTextError::ParseError(format!(
+                    "missing crew-count predicate quantity (predicate: '{}')",
+                    filtered.join(" ")
+                )));
+            };
+            let filter_words = &tail[4..];
+            if filter_words.is_empty() {
+                return Err(CardTextError::ParseError(format!(
+                    "missing crew-count predicate filter (predicate: '{}')",
+                    filtered.join(" ")
+                )));
+            }
+            let filter_tokens = filter_words
+                .iter()
+                .map(|word| OwnedLexToken::word((*word).to_string(), TextSpan::synthetic()))
+                .collect::<Vec<_>>();
+            let filter = parse_object_filter(&filter_tokens, false).map_err(|_| {
+                CardTextError::ParseError(format!(
+                    "unsupported crew-count predicate filter (predicate: '{}')",
+                    filtered.join(" ")
+                ))
+            })?;
+            return Ok(PredicateAst::SourceCrewedByExactly { count, filter });
+        }
+    }
+
     if let Some(is_idx) = find_index(&filtered, |word| matches!(*word, "is" | "are")) {
         let subject_words = &filtered[..is_idx];
         let is_source_subject = is_source_reference_words(subject_words)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -538,6 +538,12 @@ pub(crate) fn compile_condition_from_predicate_ast(
         }
         PredicateAst::SourceIsTapped => Condition::SourceIsTapped,
         PredicateAst::SourceIsSaddled => Condition::SourceIsSaddled,
+        PredicateAst::SourceCrewedByExactly { count, filter } => {
+            Condition::SourceCrewedByExactly {
+                count: *count,
+                filter: filter.clone(),
+            }
+        }
         PredicateAst::SourceMatches(filter) => Condition::SourceMatches(filter.clone()),
         PredicateAst::TriggeringObjectHadToAttackThisCombat => {
             Condition::TriggeringObjectHadToAttackThisCombat

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -70,6 +70,13 @@ fn default_trigger_last_object_tag(trigger: &TriggerSpec) -> Option<&'static str
     }
     if matches!(
         trigger,
+        TriggerSpec::KeywordActionTaggedObject { object_tag, .. }
+            if object_tag.as_str() == IT_TAG
+    ) {
+        return Some(IT_TAG);
+    }
+    if matches!(
+        trigger,
         TriggerSpec::ThisDealsDamageTo(_)
             | TriggerSpec::ThisDealsCombatDamageTo(_)
             | TriggerSpec::DealsCombatDamageTo { .. }
@@ -192,15 +199,15 @@ fn rewrite_prepare_effects_from_normalized(
     if include_trigger_prelude {
         let needs_triggering_prelude = default_last_object_tag
             .as_ref()
-            .is_some_and(|tag| tag.as_str() == "triggering")
+            .is_some_and(|tag| matches!(tag.as_str(), "triggering" | IT_TAG))
             || effects_reference_tag(reference_effects, "triggering");
         if needs_triggering_prelude {
-            prelude.insert(
-                0,
-                EffectPreludeTag::TriggeringObject(crate::cards::builders::TagKey::from(
-                    "triggering",
-                )),
-            );
+            let tag = default_last_object_tag
+                .as_ref()
+                .filter(|tag| tag.as_str() == IT_TAG)
+                .cloned()
+                .unwrap_or_else(|| crate::cards::builders::TagKey::from("triggering"));
+            prelude.insert(0, EffectPreludeTag::TriggeringObject(tag));
         }
         if effects_reference_tag(reference_effects, "triggering_source") {
             prelude.insert(

--- a/crates/ironsmith-compiler/src/runtime_backend/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/mod.rs
@@ -237,7 +237,12 @@ pub(crate) fn trigger_frequency_condition(
 ) -> Option<crate::ConditionExpr> {
     max_triggers_per_turn.map(|limit| {
         let text = text.unwrap_or_default();
-        if limit == 1 && text_uses_first_time_each_turn(text) {
+        if limit == 1
+            && text_uses_first_time_each_turn(text)
+            && text.to_ascii_lowercase().contains("becomes crewed")
+        {
+            crate::ConditionExpr::SourceFirstCrewedThisTurn
+        } else if limit == 1 && text_uses_first_time_each_turn(text) {
             crate::ConditionExpr::FirstTimeThisTurn
         } else if text_uses_do_this_only_each_turn(text) {
             crate::ConditionExpr::DoThisMaxTimesEachTurn(limit)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -519,6 +519,10 @@ pub(crate) enum PredicateAst {
     },
     SourceIsTapped,
     SourceIsSaddled,
+    SourceCrewedByExactly {
+        count: u32,
+        filter: ObjectFilter,
+    },
     SourceMatches(ObjectFilter),
     TriggeringObjectHadToAttackThisCombat,
 
@@ -597,6 +601,7 @@ impl PredicateAst {
             PredicateAst::SourceChosenOption(_)
             | PredicateAst::SourceIsTapped
             | PredicateAst::SourceIsSaddled
+            | PredicateAst::SourceCrewedByExactly { .. }
             | PredicateAst::SourceMatches(_)
             | PredicateAst::SourceHasNoCounter(_)
             | PredicateAst::SourceHasCounterAtLeast { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -570,6 +570,47 @@ fn words_start_nested_triggered_ability(words_after_verb: &[&str]) -> bool {
     )
 }
 
+fn quoted_nested_ability_end_and_duration(
+    tokens: &[OwnedLexToken],
+    gain_token_idx: usize,
+) -> Option<(usize, Until)> {
+    let open_quote_idx = gain_token_idx + 1;
+    if !tokens
+        .get(open_quote_idx)
+        .is_some_and(|token| token.kind == TokenKind::Quote)
+    {
+        return None;
+    }
+
+    let close_quote_idx = tokens
+        .iter()
+        .enumerate()
+        .skip(open_quote_idx + 1)
+        .find_map(|(idx, token)| (token.kind == TokenKind::Quote).then_some(idx))?;
+    let tail_tokens = trim_commas(tokens.get(close_quote_idx + 1..).unwrap_or_default());
+    if tail_tokens.is_empty() {
+        return None;
+    }
+
+    let tail_word_view = GainAbilityWordView::new(&tail_tokens);
+    let tail_words = tail_word_view.to_word_refs();
+    let Some((start, len, duration)) = parse_simple_ability_duration(&tail_words) else {
+        return None;
+    };
+    if start != 0 {
+        return None;
+    }
+    let trailing_word_idx = start + len;
+    let trailing_token_idx = tail_word_view
+        .token_index_for_word_index(trailing_word_idx)
+        .unwrap_or(tail_tokens.len());
+    if !trim_edge_punctuation(&tail_tokens[trailing_token_idx..]).is_empty() {
+        return None;
+    }
+
+    Some((close_quote_idx, duration))
+}
+
 fn parse_leading_simple_ability_duration(tokens: &[OwnedLexToken]) -> Option<(usize, Until)> {
     let clause_word_view = GainAbilityWordView::new(tokens);
     let clause_words = clause_word_view.to_word_refs();
@@ -1159,6 +1200,11 @@ pub(crate) fn parse_gain_ability_sentence(
         }
     }
 
+    let nested_quoted_ability = if words_start_nested_triggered_ability(after_gain) {
+        quoted_nested_ability_end_and_duration(tokens, gain_token_idx)
+    } else {
+        None
+    };
     let duration_phrase = if words_start_nested_triggered_ability(after_gain) {
         None
     } else {
@@ -1167,6 +1213,7 @@ pub(crate) fn parse_gain_ability_sentence(
     let duration = duration_phrase
         .as_ref()
         .map(|(_, _, duration)| duration.clone())
+        .or_else(|| nested_quoted_ability.as_ref().map(|(_, duration)| duration.clone()))
         .or_else(|| {
             leading_duration_phrase
                 .as_ref()
@@ -1174,7 +1221,9 @@ pub(crate) fn parse_gain_ability_sentence(
         })
         .unwrap_or(Until::Forever);
     let has_explicit_duration =
-        duration_phrase.is_some() || leading_duration_phrase.as_ref().is_some();
+        duration_phrase.is_some()
+            || nested_quoted_ability.is_some()
+            || leading_duration_phrase.as_ref().is_some();
 
     let shared_get_tail_word_idx = if !losing {
         word_slice_find_any_phrase_start(after_gain, &[&["and", "get"], &["and", "gets"]])
@@ -1252,7 +1301,9 @@ pub(crate) fn parse_gain_ability_sentence(
         .or(shared_has_tail_word_idx)
         .map(|idx| gain_idx + 1 + idx)
         .or(ability_end_word_idx);
-    let ability_end_token_idx = if let Some(end_word_idx) = ability_end_word_idx {
+    let ability_end_token_idx = if let Some((end_token_idx, _)) = nested_quoted_ability {
+        end_token_idx
+    } else if let Some(end_word_idx) = ability_end_word_idx {
         token_index_for_word_index(tokens, end_word_idx).unwrap_or(tokens.len())
     } else {
         tokens.len()
@@ -2186,6 +2237,30 @@ mod tests {
         assert!(
             string_contains(&debug, "duration: EndOfTurn"),
             "explicit source ability grant duration should be preserved, got {debug}"
+        );
+    }
+
+    #[test]
+    fn quoted_nested_trigger_grant_keeps_outer_until_end_of_turn_duration() {
+        let tokens = tokenize_line(
+            "It gains \"Whenever this creature deals combat damage to a player, draw two cards\" until end of turn.",
+            0,
+        );
+        let effect = parse_gain_ability_sentence(&tokens)
+            .expect("quoted nested trigger grant should parse")
+            .expect("quoted nested trigger grant should produce effects")
+            .into_iter()
+            .next()
+            .expect("quoted nested trigger grant should produce one effect");
+
+        let debug = format!("{effect:?}");
+        assert!(
+            string_contains(&debug, "GrantAbilities")
+                && string_contains(&debug, "ParsedObjectAbility")
+                && string_contains(&debug, "duration: EndOfTurn")
+                && string_contains(&debug, "Draw")
+                && string_contains(&debug, "Fixed(2)"),
+            "expected quoted combat-damage draw trigger to be granted until end of turn, got {debug}"
         );
     }
 

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -744,6 +744,10 @@ pub enum Condition {
     ItIsNight,
     SourceIsTapped,
     SourceIsSaddled,
+    SourceCrewedByExactly {
+        count: u32,
+        filter: ObjectFilter,
+    },
     SourceDevouredCreaturesOrMore(u32),
     SourceIsMonstrous,
     SourceIsFaceDown,
@@ -785,6 +789,7 @@ pub enum Condition {
     },
     ThisAbilityResolvedThisTurnExactly(u32),
     FirstTimeThisTurn,
+    SourceFirstCrewedThisTurn,
     MaxTimesEachTurn(u32),
     DoThisMaxTimesEachTurn(u32),
     TriggeringObjectWasEnchanted,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40375,6 +40375,7 @@ strict_parse_card_expected_fail_test!(
 );
 strict_parse_card_expected_fail_test!(strict_parse_lake_of_the_dead, "Lake of the Dead");
 strict_parse_card_test!(strict_parse_maskwood_nexus, "Maskwood Nexus");
+strict_parse_card_test!(strict_parse_mighty_servant_of_leuk_o, "Mighty Servant of Leuk-o");
 strict_parse_card_test!(strict_parse_mox_amber, "Mox Amber");
 strict_parse_card_test!(strict_parse_nesting_grounds, "Nesting Grounds");
 strict_parse_card_test!(strict_parse_nine_lives_familiar, "Nine-Lives Familiar");
@@ -40440,6 +40441,32 @@ fn skeleton_crew_compiled_text_keeps_graveyard_leave_trigger() {
             && rendered.contains("Whenever one or more creature cards leave your graveyard, create a 2/2 black Skeleton Pirate creature token")
             && rendered.contains("{5}{B}: Return this card from your graveyard to the battlefield tapped"),
         "expected Skeleton Crew compiled text to preserve anthem, graveyard-leave trigger, and graveyard activation, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mighty_servant_of_leuk_o_compiled_text_keeps_crew_count_granted_trigger() {
+    let def = parse_oracle_card_definition("Mighty Servant of Leuk-o");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Whenever this Vehicle becomes crewed for the first time each turn")
+            && rendered.contains("crewed by exactly two creatures")
+            && rendered.contains("Whenever this creature deals combat damage to a player")
+            && rendered.contains("Draw two cards")
+            && rendered.contains("until end of turn")
+            && rendered.contains("Crew 4"),
+        "expected Mighty Servant of Leuk-o compiled text to preserve crew-count trigger and temporary combat-damage draw grant, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("SourceFirstCrewedThisTurn")
+            && abilities_debug.contains("SourceCrewedByExactly")
+            && abilities_debug.contains("AddAbilityGeneric")
+            && abilities_debug.contains("ThisDealsCombatDamageToPlayerTrigger")
+            && abilities_debug.contains("CrewCostEffect"),
+        "expected Mighty Servant of Leuk-o structure to include first-crew, exact crew count, granted damage trigger, and Crew 4, got {abilities_debug}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11201,6 +11201,17 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::SourceIsTapped => "this source is tapped".to_string(),
         Condition::SourceIsSaddled => "this source is saddled".to_string(),
+        Condition::SourceCrewedByExactly { count, filter } => {
+            let count_text = small_number_word(*count).unwrap_or_else(|| count.to_string());
+            let filter_text = if *count == 1 {
+                filter.description()
+            } else {
+                pluralize_noun_phrase(&filter.description())
+            };
+            format!(
+                "this source was crewed by exactly {count_text} {filter_text}"
+            )
+        }
         Condition::SourceDevouredCreaturesOrMore(count) => {
             if *count == 1 {
                 "this source devoured a creature".to_string()
@@ -11675,6 +11686,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::FirstTimeThisTurn => "this is the first time this ability triggered this turn"
             .to_string(),
+        Condition::SourceFirstCrewedThisTurn => {
+            "this is the first time this source was crewed this turn".to_string()
+        }
         Condition::ThisAbilityResolvedThisTurnExactly(count) => format!(
             "this is the {} time this ability has resolved this turn",
             ordinal_number_word(*count)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -35673,6 +35673,9 @@ pub(super) fn split_trigger_intervening_if(
             crate::ConditionExpr::FirstTimeThisTurn => {
                 first_time_this_turn = true;
             }
+            crate::ConditionExpr::SourceFirstCrewedThisTurn => {
+                first_time_this_turn = true;
+            }
             crate::ConditionExpr::DoThisMaxTimesEachTurn(limit) => {
                 do_this_max_times_each_turn = Some(match do_this_max_times_each_turn {
                     Some(existing) => existing.min(limit),

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -11,6 +11,9 @@ use crate::zone::Zone;
 
 use crate::triggers::{TriggerEvent, TriggerIdentity};
 
+const CREWERS_TAG: &str = "crewed_it_this_turn";
+const FIRST_CREWED_THIS_TURN_TAG: &str = "__first_crewed_this_turn";
+
 fn source_is_face_down_or_alternate_face(game: &GameState, source: ObjectId) -> bool {
     // `SourceIsFaceDown` is also used by daybound/nightbound lowering to mean
     // "this DFC is currently showing its alternate face."
@@ -599,6 +602,104 @@ fn creature_card_was_put_into_your_graveyard_this_turn(game: &GameState, player:
     })
 }
 
+fn source_crewed_by_exactly(
+    game: &GameState,
+    controller: PlayerId,
+    source: ObjectId,
+    filter_source: Option<ObjectId>,
+    triggering_event: Option<&TriggerEvent>,
+    count: u32,
+    filter: &crate::target::ObjectFilter,
+) -> bool {
+    if let Some(event) = triggering_event
+        && let Some(keyword_action) = event.downcast::<crate::events::KeywordActionEvent>()
+        && keyword_action.action == crate::events::KeywordActionKind::Crew
+    {
+        let filter_ctx = game.filter_context_for(controller, filter_source);
+        return keyword_action
+            .object_tags
+            .get(&crate::TagKey::from(CREWERS_TAG))
+            .map(|crewers| {
+                crewers
+                    .iter()
+                    .filter(|snapshot| filter.matches_snapshot(snapshot, &filter_ctx, game))
+                    .count() as u32
+            })
+            .unwrap_or(0)
+            == count;
+    }
+
+    let filter_ctx = game.filter_context_for(controller, filter_source);
+    game.turn_store
+        .turn_history
+        .crewed_this_turn
+        .get(&source)
+        .map(|crewers| {
+            crewers
+                .iter()
+                .filter(|id| {
+                    game.object(**id)
+                        .is_some_and(|obj| filter.matches(obj, &filter_ctx, game))
+                })
+                .count() as u32
+        })
+        .unwrap_or(0)
+        == count
+}
+
+fn source_first_crewed_this_turn(
+    _game: &GameState,
+    source: ObjectId,
+    triggering_event: Option<&TriggerEvent>,
+) -> bool {
+    if let Some(event) = triggering_event
+        && let Some(keyword_action) = event.downcast::<crate::events::KeywordActionEvent>()
+        && keyword_action.action == crate::events::KeywordActionKind::Crew
+    {
+        return keyword_action
+            .object_tags
+            .get(&crate::TagKey::from(FIRST_CREWED_THIS_TURN_TAG))
+            .is_some_and(|snapshots| {
+                snapshots
+                    .iter()
+                    .any(|snapshot| snapshot.object_id == source)
+            });
+    }
+
+    false
+}
+
+fn source_crewed_by_exactly_from_resolution_tags(
+    game: &GameState,
+    ctx: &ExecutionContext,
+    count: u32,
+    filter: &crate::target::ObjectFilter,
+) -> bool {
+    let Some(crewers) = ctx.get_tagged_all("crewed_it_this_turn") else {
+        return source_crewed_by_exactly(
+            game,
+            ctx.controller,
+            ctx.source,
+            Some(ctx.source),
+            ctx.triggering_event.as_ref(),
+            count,
+            filter,
+        );
+    };
+    let filter_ctx = ctx.filter_context(game);
+    crewers
+        .iter()
+        .filter(|snapshot| {
+            if let Some(obj) = game.object(snapshot.object_id) {
+                filter.matches(obj, &filter_ctx, game)
+            } else {
+                filter.matches_snapshot(snapshot, &filter_ctx, game)
+            }
+        })
+        .count() as u32
+        == count
+}
+
 fn object_matching_entered_battlefield_this_turn(
     game: &GameState,
     ctx: SharedConditionContext<'_>,
@@ -980,6 +1081,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::TargetManaValueLteColorsSpentToCastThisSpell => {}
         Condition::SourceIsTapped => {}
         Condition::SourceIsSaddled => {}
+        Condition::SourceCrewedByExactly { .. } => {}
         Condition::SourceDevouredCreaturesOrMore(..) => {}
         Condition::SourceIsMonstrous => {}
         Condition::SourceIsFaceDown => {}
@@ -1006,6 +1108,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::PlayerOwnsCardNamedInZones { .. } => {}
         Condition::ThisAbilityResolvedThisTurnExactly(..) => {}
         Condition::FirstTimeThisTurn => {}
+        Condition::SourceFirstCrewedThisTurn => {}
         Condition::MaxTimesEachTurn(..) => {}
         Condition::DoThisMaxTimesEachTurn(..) => {}
         Condition::TriggeringObjectWasEnchanted => {}
@@ -1365,6 +1468,11 @@ pub fn evaluate_condition_external(
             .trigger_identity
             .map(|id| game.trigger_fire_count_this_turn(ctx.source, id) == 0)
             .unwrap_or(true),
+        Condition::SourceFirstCrewedThisTurn => source_first_crewed_this_turn(
+            game,
+            ctx.source,
+            ctx.triggering_event,
+        ),
         Condition::MaxTimesEachTurn(limit) | Condition::DoThisMaxTimesEachTurn(limit) => ctx
             .trigger_identity
             .map(|id| game.trigger_fire_count_this_turn(ctx.source, id) < *limit)
@@ -1754,6 +1862,15 @@ pub fn evaluate_condition_external(
         }
         Condition::SourceIsTapped => game.is_tapped(ctx.source),
         Condition::SourceIsSaddled => game.is_saddled(ctx.source),
+        Condition::SourceCrewedByExactly { count, filter } => source_crewed_by_exactly(
+            game,
+            ctx.controller,
+            ctx.source,
+            ctx.filter_source,
+            ctx.triggering_event,
+            *count,
+            filter,
+        ),
         Condition::SourceDevouredCreaturesOrMore(count) => {
             game.devoured_count(ctx.source) >= *count
         }
@@ -2470,6 +2587,7 @@ fn evaluate_condition_simple(
             player_had_land_enter_battlefield_this_turn(game, player_id)
         }
         Condition::FirstTimeThisTurn
+        | Condition::SourceFirstCrewedThisTurn
         | Condition::MaxTimesEachTurn(_)
         | Condition::DoThisMaxTimesEachTurn(_) => true,
         Condition::TriggeringObjectWasEnchanted
@@ -2522,6 +2640,7 @@ fn evaluate_condition_simple(
         | Condition::TargetManaValueLteColorsSpentToCastThisSpell
         | Condition::SourceIsTapped
         | Condition::SourceIsSaddled
+        | Condition::SourceCrewedByExactly { .. }
         | Condition::SourceDevouredCreaturesOrMore(_)
         | Condition::SourceIsMonstrous
         | Condition::SourceIsFaceDown
@@ -3280,6 +3399,9 @@ fn evaluate_condition(
         }
         Condition::SourceIsTapped => Ok(game.is_tapped(ctx.source)),
         Condition::SourceIsSaddled => Ok(game.is_saddled(ctx.source)),
+        Condition::SourceCrewedByExactly { count, filter } => Ok(
+            source_crewed_by_exactly_from_resolution_tags(game, ctx, *count, filter),
+        ),
         Condition::SourceDevouredCreaturesOrMore(count) => {
             Ok(game.devoured_count(ctx.source) >= *count)
         }
@@ -3442,6 +3564,7 @@ fn evaluate_condition(
             }))
         }
         Condition::FirstTimeThisTurn
+        | Condition::SourceFirstCrewedThisTurn
         | Condition::MaxTimesEachTurn(_)
         | Condition::DoThisMaxTimesEachTurn(_) => Ok(true),
         Condition::TriggeringObjectWasEnchanted => Ok(ctx

--- a/crates/ironsmith-runtime/src/effects/composition/tag_triggering_object.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/tag_triggering_object.rs
@@ -95,6 +95,15 @@ impl EffectExecutor for TagTriggeringObjectEffect {
             return Ok(EffectOutcome::count(0));
         }
 
+        if let Some(keyword_action) = event.downcast::<crate::events::KeywordActionEvent>()
+            && let Some(snapshots) = keyword_action.object_tags.get(&self.tag)
+        {
+            let tagged = snapshots.clone();
+            let count = tagged.len() as i32;
+            set_triggering_object_tags(ctx, self.tag.as_str(), tagged);
+            return Ok(EffectOutcome::count(count));
+        }
+
         let object_id = event.object_id().ok_or_else(|| {
             ExecutionError::UnresolvableValue("triggering event missing object".to_string())
         })?;

--- a/crates/ironsmith-runtime/src/effects/permanents/crew.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/crew.rs
@@ -26,6 +26,9 @@ use crate::types::CardType;
 pub type CrewCostEffect = ironsmith_core::CrewCostEffect;
 
 const CREWED_VEHICLE_TAG: &str = "__it__";
+const CREW_ACTIVATION_TAG: &str = "__crew_activation";
+const CREWERS_TAG: &str = "crewed_it_this_turn";
+const FIRST_CREWED_THIS_TURN_TAG: &str = "__first_crewed_this_turn";
 
 fn crew_candidates(game: &GameState, controller: PlayerId) -> Vec<ObjectId> {
     game.battlefield
@@ -166,20 +169,46 @@ fn keyword_crew_event(
     crewer: ObjectId,
     vehicle: ObjectId,
     controller: PlayerId,
+    crew_count: usize,
+    all_crewers: &[ObjectId],
+    is_activation_event: bool,
+    is_first_crewed_this_turn: bool,
     provenance: crate::provenance::ProvNodeId,
 ) -> TriggerEvent {
     let crewer_snapshot = game
         .object(crewer)
         .map(|obj| ObjectSnapshot::from_object_with_calculated_characteristics(obj, game));
     let mut object_tags = HashMap::new();
-    if let Some(vehicle_snapshot) = game
+    let vehicle_snapshot = game
         .object(vehicle)
-        .map(|obj| ObjectSnapshot::from_object_with_calculated_characteristics(obj, game))
-    {
-        object_tags.insert(TagKey::from(CREWED_VEHICLE_TAG), vec![vehicle_snapshot]);
+        .map(|obj| ObjectSnapshot::from_object_with_calculated_characteristics(obj, game));
+    if let Some(vehicle_snapshot) = vehicle_snapshot {
+        object_tags.insert(TagKey::from(CREWED_VEHICLE_TAG), vec![vehicle_snapshot.clone()]);
+        if is_activation_event {
+            object_tags.insert(TagKey::from(CREW_ACTIVATION_TAG), vec![vehicle_snapshot.clone()]);
+            if is_first_crewed_this_turn {
+                object_tags.insert(
+                    TagKey::from(FIRST_CREWED_THIS_TURN_TAG),
+                    vec![vehicle_snapshot],
+                );
+            }
+        }
+    }
+    if is_activation_event {
+        let crewer_snapshots = all_crewers
+            .iter()
+            .filter_map(|id| {
+                game.object(*id).map(|obj| {
+                    ObjectSnapshot::from_object_with_calculated_characteristics(obj, game)
+                })
+            })
+            .collect::<Vec<_>>();
+        if !crewer_snapshots.is_empty() {
+            object_tags.insert(TagKey::from(CREWERS_TAG), crewer_snapshots);
+        }
     }
     TriggerEvent::new_with_provenance(
-        KeywordActionEvent::new(KeywordActionKind::Crew, controller, crewer, 1)
+        KeywordActionEvent::new(KeywordActionKind::Crew, controller, crewer, crew_count as u32)
             .with_snapshot(crewer_snapshot)
             .with_object_tags(object_tags),
         provenance,
@@ -258,7 +287,14 @@ impl EffectExecutor for CrewCostEffect {
         }
 
         let mut events = Vec::new();
-        for id in &chosen {
+        let crew_count = chosen.len();
+        let is_first_crewed_this_turn = game
+            .turn_store
+            .turn_history
+            .crewed_this_turn
+            .get(&ctx.source)
+            .is_none_or(|crewers| crewers.is_empty());
+        for (idx, id) in chosen.iter().enumerate() {
             if game.object(*id).is_some() && !game.is_tapped(*id) {
                 game.tap(*id);
                 events.push(TriggerEvent::new_with_provenance(
@@ -270,6 +306,10 @@ impl EffectExecutor for CrewCostEffect {
                     *id,
                     ctx.source,
                     controller,
+                    crew_count,
+                    &chosen,
+                    idx == 0,
+                    is_first_crewed_this_turn,
                     ctx.provenance,
                 ));
             }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -776,6 +776,193 @@ fn create_vanilla_creature(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn mighty_servant_of_leuk_o_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(274_545), "Mighty Servant of Leuk-o")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Vehicle])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .parse_text(
+            "Trample\n\
+             Ward—Discard a card.\n\
+             Whenever this Vehicle becomes crewed for the first time each turn, if it was crewed by exactly two creatures, it gains \"Whenever this creature deals combat damage to a player, draw two cards\" until end of turn.\n\
+             Crew 4",
+        )
+        .expect("Mighty Servant of Leuk-o should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseCrewByNameDecisionMaker {
+    names: Vec<&'static str>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseCrewByNameDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx.description.to_ascii_lowercase().contains("crew") {
+            return ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .filter_map(|candidate| {
+                    game.object(candidate.id).and_then(|object| {
+                        self.names
+                            .contains(&object.name.as_str())
+                            .then_some(candidate.id)
+                    })
+                })
+                .collect();
+        }
+        AutoPassDecisionMaker.decide_objects(game, ctx)
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_mighty_servant_crew(
+    game: &mut GameState,
+    vehicle_id: ObjectId,
+    controller: PlayerId,
+    crew_names: Vec<&'static str>,
+) -> TriggerQueue {
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = ChooseCrewByNameDecisionMaker { names: crew_names };
+    let provenance = game.provenance_graph_mut().alloc_root(
+        crate::provenance::ProvenanceNodeKind::EffectExecution {
+            source: vehicle_id,
+            controller,
+        },
+    );
+    let mut ctx = crate::effects::ExecutionContext::new(vehicle_id, controller, &mut dm)
+        .with_provenance(provenance);
+    let crew = crate::effects::CrewCostEffect::new(4);
+    let outcome = crate::effects::EffectExecutor::execute(&crew, game, &mut ctx)
+        .expect("Mighty Servant of Leuk-o crew cost should be payable");
+    for event in outcome.events {
+        game.queue_trigger_event(provenance, event);
+    }
+    drain_pending_trigger_events(game, &mut trigger_queue);
+
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mighty_servant_two_creature_crew_grants_damage_draw_until_cleanup() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mighty = mighty_servant_of_leuk_o_definition();
+    let vehicle_id = game.create_object_from_definition(&mighty, alice, Zone::Battlefield);
+    let crew_one = create_vanilla_creature(&mut game, "Crew One", alice, 2, 2);
+    let crew_two = create_vanilla_creature(&mut game, "Crew Two", alice, 2, 2);
+    for idx in 0..2 {
+        let card = CardBuilder::new(CardId::from_raw(274_600 + idx), format!("Draw Fodder {idx}"))
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+
+    let mut trigger_queue =
+        activate_mighty_servant_crew(&mut game, vehicle_id, alice, vec!["Crew One", "Crew Two"]);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Mighty Servant should trigger when first crewed by exactly two creatures"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Mighty Servant crew-count trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Mighty Servant crew-count trigger should resolve");
+
+    game.untap(crew_one);
+    game.untap(crew_two);
+    let repeated_trigger_queue =
+        activate_mighty_servant_crew(&mut game, vehicle_id, alice, vec!["Crew One", "Crew Two"]);
+    assert!(
+        repeated_trigger_queue.entries.is_empty(),
+        "Mighty Servant should not retrigger when the same two creatures crew it again that turn"
+    );
+
+    let combat_damage = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            vehicle_id,
+            crate::events::DamageTarget::Player(bob),
+            6,
+            true,
+            crate::events::cause::EventCause::combat_damage(vehicle_id),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut damage_trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &combat_damage) {
+        damage_trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        damage_trigger_queue.entries.len(),
+        1,
+        "granted combat-damage trigger should be present after exact two-creature crew"
+    );
+    let hand_before = game.player(alice).expect("alice exists").hand.len();
+    put_triggers_on_stack(&mut game, &mut damage_trigger_queue)
+        .expect("granted combat-damage trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("granted combat-damage trigger should resolve");
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        hand_before + 2,
+        "Mighty Servant's granted trigger should draw two cards"
+    );
+
+    execute_cleanup_step(&mut game);
+    let expired_triggers = crate::triggers::check_triggers(&game, &combat_damage);
+    assert!(
+        expired_triggers.is_empty(),
+        "Mighty Servant's granted combat-damage trigger should expire at cleanup"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mighty_servant_crew_condition_requires_exactly_two_on_first_crew() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mighty = mighty_servant_of_leuk_o_definition();
+    let vehicle_id = game.create_object_from_definition(&mighty, alice, Zone::Battlefield);
+    create_vanilla_creature(&mut game, "Solo Crew", alice, 4, 4);
+    create_vanilla_creature(&mut game, "Later Crew One", alice, 2, 2);
+    create_vanilla_creature(&mut game, "Later Crew Two", alice, 2, 2);
+
+    let solo_trigger_queue =
+        activate_mighty_servant_crew(&mut game, vehicle_id, alice, vec!["Solo Crew"]);
+    assert!(
+        solo_trigger_queue.entries.is_empty(),
+        "Mighty Servant should not trigger when first crewed by one creature"
+    );
+
+    let later_trigger_queue = activate_mighty_servant_crew(
+        &mut game,
+        vehicle_id,
+        alice,
+        vec!["Later Crew One", "Later Crew Two"],
+    );
+    assert!(
+        later_trigger_queue.entries.is_empty(),
+        "Mighty Servant should not trigger on a later crew activation even if that activation used exactly two creatures"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn cho_arrim_alchemist_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(19647), "Cho-Arrim Alchemist")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -918,12 +918,32 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::SourceIsMonstrous => {
             "as long as this creature is monstrous".to_string()
         }
+        crate::ConditionExpr::SourceCrewedByExactly { count, filter } => {
+            let count_text = ironsmith_core::cardinal_word(*count)
+                .unwrap_or_else(|| count.to_string());
+            let filter_text = if *count == 1 {
+                filter.description()
+            } else {
+                let desc = filter.description();
+                if desc.ends_with('s') {
+                    desc
+                } else {
+                    format!("{desc}s")
+                }
+            };
+            format!(
+                "if it was crewed by exactly {count_text} {filter_text}"
+            )
+        }
         crate::ConditionExpr::SourceDevouredCreaturesOrMore(count) => {
             if *count == 1 {
                 "if it devoured a creature".to_string()
             } else {
                 format!("if it devoured {count} or more creatures")
             }
+        }
+        crate::ConditionExpr::SourceFirstCrewedThisTurn => {
+            "if it was crewed for the first time this turn".to_string()
         }
         crate::ConditionExpr::EnchantedPermanentIsCreature => {
             "as long as enchanted permanent is a creature".to_string()

--- a/crates/ironsmith-runtime/src/triggers/other/keyword_action.rs
+++ b/crates/ironsmith-runtime/src/triggers/other/keyword_action.rs
@@ -10,6 +10,8 @@ use crate::triggers::TriggerEvent;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
 use crate::types::CardType;
 
+const CREW_ACTIVATION_TAG: &str = "__crew_activation";
+
 fn is_plain_other_card_filter(filter: &ObjectFilter) -> bool {
     filter.other
         && !filter.source
@@ -167,6 +169,12 @@ impl TriggerMatcher for KeywordActionTrigger {
             if !matches {
                 return false;
             }
+            if self.action == KeywordActionKind::Crew
+                && object_filter.source
+                && !e.object_tags.contains_key(&TagKey::from(CREW_ACTIVATION_TAG))
+            {
+                return false;
+            }
         }
 
         match &self.player {
@@ -254,6 +262,18 @@ impl TriggerMatcher for KeywordActionTrigger {
         if self.action == KeywordActionKind::Crew
             && let Some(source_filter) = &self.source_filter
         {
+            if self
+                .tagged_object_filter
+                .as_ref()
+                .is_some_and(|(_, object_filter)| object_filter.source)
+            {
+                let object = self
+                    .tagged_object_filter
+                    .as_ref()
+                    .map(|(_, object_filter)| object_filter.description())
+                    .unwrap_or_else(|| "this Vehicle".to_string());
+                return format!("Whenever {object} becomes crewed");
+            }
             let object = self
                 .tagged_object_filter
                 .as_ref()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mighty Servant of Leuk-o
Initial parse error:
```
unsupported trailing draw clause (clause: 'two cards until end of turn'); oracle-only fallback also failed: unsupported trailing draw clause (clause: 'two cards until end of turn')
```

Current worker: i-01b92f36169f58d8b
Branch: codex/aws-card-fix-mighty-servant-of-leuk-o
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0001
