### PR TITLE
Fix Ironsmith parse failure: Party Dude

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3406,6 +3406,16 @@ pub(crate) fn parse_trigger_clause_lexed(
         .copied()
         .ok_or_else(|| CardTextError::ParseError("empty trigger clause".to_string()))?;
 
+    if word_slice_ends_with(&words, &["are", "attacked"]) && words.len() > 2 {
+        let attacked_player_words = &words[..words.len() - 2];
+        if let Some(player_filter) = parse_trigger_subject_player_filter(attacked_player_words) {
+            let mut filter = ObjectFilter::creature();
+            filter.attacking_player_or_planeswalker_controlled_by = Some(player_filter.clone());
+            filter.targets_only_player = Some(player_filter);
+            return Ok(TriggerSpec::AttacksOneOrMore(filter));
+        }
+    }
+
     match last {
         "attack" | "attacks" => {
             let attack_word_idx = words.len().saturating_sub(1);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -1,6 +1,8 @@
 use super::super::effect_ast_traversal::for_each_nested_effects_mut;
 use super::super::ir::RewriteActivatedLine;
 use super::*;
+use crate::effect::Effect;
+use crate::object::CounterType;
 use ironsmith_core::TotalCostKind;
 
 fn activated_effect_may_be_mana_ability_lexed(tokens: &[OwnedLexToken]) -> bool {
@@ -533,6 +535,40 @@ fn lower_rewrite_activated_to_chunk_impl(
         return Err(CardTextError::ParseError(
             "unresolved X in mana ability".to_string(),
         ));
+    }
+
+    if let Some(level_text) = normalized_effect_text.strip_prefix("level ")
+        && let Ok(level) = level_text.parse::<u32>()
+    {
+        let parsed = ParsedAbility {
+            ability: Ability {
+                kind: AbilityKind::Activated(ActivatedAbility {
+                    mana_cost: normalized_cost,
+                    effects: ResolutionProgram::from_effects(vec![Effect::put_counters_on_source(
+                        CounterType::Level,
+                        1,
+                    )]),
+                    choices: vec![],
+                    timing: ActivationTiming::SorcerySpeed,
+                    is_loyalty_ability: line.is_loyalty_ability,
+                    additional_restrictions: vec![format!("__ironsmith_class_level:{level}")],
+                    activation_restrictions: vec![],
+                    mana_output: None,
+                    activation_condition: None,
+                    mana_usage_restrictions: vec![],
+                }),
+                functional_zones: vec![Zone::Battlefield],
+            }
+            .into(),
+            text: Some(line.info.raw_line.trim().to_string()),
+            effects_ast: None,
+            reference_imports: ReferenceImports::default(),
+            trigger_spec: None,
+        };
+        return Ok(LoweredRewriteActivatedLine {
+            chunk: LineAst::Ability(parsed),
+            restrictions,
+        });
     }
 
     if let Some(mana_output) = extract_fixed_mana_output_lexed(&effect_parse_tokens) {

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -459,6 +459,72 @@ fn combine_level_ability_statics(
     out
 }
 
+const CLASS_LEVEL_MARKER_PREFIX: &str = "__ironsmith_class_level:";
+
+fn class_level_marker(ability: &ironsmith::ability::ActivatedAbility) -> Option<u32> {
+    ability
+        .additional_restrictions
+        .iter()
+        .find_map(|restriction| restriction.strip_prefix(CLASS_LEVEL_MARKER_PREFIX))
+        .and_then(|level| level.parse::<u32>().ok())
+}
+
+fn class_level_activation_condition(level: u32) -> ironsmith::ConditionExpr {
+    let required_counters = level.saturating_sub(2);
+    if required_counters == 0 {
+        return ironsmith::ConditionExpr::SourceHasNoCounter(ironsmith::CounterType::Level);
+    }
+    ironsmith::ConditionExpr::And(
+        Box::new(ironsmith::ConditionExpr::SourceHasCounterAtLeast {
+            counter_type: ironsmith::CounterType::Level,
+            count: required_counters,
+        }),
+        Box::new(ironsmith::ConditionExpr::Not(Box::new(
+            ironsmith::ConditionExpr::SourceHasCounterAtLeast {
+                counter_type: ironsmith::CounterType::Level,
+                count: required_counters + 1,
+            },
+        ))),
+    )
+}
+
+fn and_condition(
+    left: Option<ironsmith::ConditionExpr>,
+    right: ironsmith::ConditionExpr,
+) -> ironsmith::ConditionExpr {
+    left.map(|left| ironsmith::ConditionExpr::And(Box::new(left), Box::new(right.clone())))
+        .unwrap_or(right)
+}
+
+fn apply_class_level_runtime_gates(definition: &mut ironsmith::cards::CardDefinition) {
+    if !definition.card.subtypes.contains(&ironsmith::Subtype::Class) {
+        return;
+    }
+
+    let mut current_level = None;
+    for ability in &mut definition.abilities {
+        if let ironsmith::ability::AbilityKind::Activated(activated) = &mut ability.kind
+            && let Some(level) = class_level_marker(activated)
+        {
+            activated.activation_condition = Some(and_condition(
+                activated.activation_condition.take(),
+                class_level_activation_condition(level),
+            ));
+            current_level = Some(level);
+            continue;
+        }
+
+        let Some(level) = current_level else {
+            continue;
+        };
+        if let ironsmith::ability::AbilityKind::Triggered(triggered) = &mut ability.kind
+            && triggered.presentation_label.is_none()
+        {
+            triggered.presentation_label = Some(format!("{CLASS_LEVEL_MARKER_PREFIX}{level}"));
+        }
+    }
+}
+
 fn runtime_definition_from_core_model(
     definition: compiler::CardDefinition,
 ) -> Result<ironsmith::cards::CardDefinition, CompilerIntegrationError> {
@@ -470,6 +536,7 @@ fn runtime_definition_from_core_model(
         runtime_optional_cost_from_core_model,
     )?;
     definition.abilities = combine_level_ability_statics(definition.abilities);
+    apply_class_level_runtime_gates(&mut definition);
     if let Some(spell_effect) = &mut definition.spell_effect {
         remove_redundant_target_only_effects_in_program(spell_effect);
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -141,6 +141,34 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[test]
+fn party_dude_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Party Dude");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("AttacksTrigger")
+            || ability_debug.contains("AttacksOneOrMore")
+            || ability_debug.contains("one_or_more: true"),
+        "Party Dude should parse the opponent-attacked trigger strictly, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("WithCount")
+            && ability_debug.contains("ChoiceCount")
+            && ability_debug.contains("Hand")
+            && ability_debug.contains("WhereXIs"),
+        "Party Dude should structurally keep the hand-size X pump and up-to-one target, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("{1}{G}: Level 2")
+            && rendered.contains("{4}{G}: Level 3")
+            && rendered.contains("Whenever one or more of your opponents are attacked")
+            && rendered.contains("up to one target attacking creature gets +X/+X until end of turn, where X is the number of cards in your hand"),
+        "expected Party Dude compiled text to preserve class level and opponent-attacked pump clauses, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14019,6 +14019,21 @@ pub(super) fn describe_inline_ability_with_self_subject(
             }
         }
         AbilityKind::Activated(activated) => {
+            if let Some(level) = activated.additional_restrictions.iter().find_map(|restriction| {
+                restriction.strip_prefix("__ironsmith_class_level:")
+            }) {
+                let effects = activated.effects.flattened_default_effects();
+                if let [effect] = effects
+                    && let Some(put) = effect.downcast_ref::<crate::effects::PutCountersEffect>()
+                    && put.counter_type == crate::CounterType::Level
+                    && matches!(put.target, ChooseSpec::Source)
+                {
+                    return format!(
+                        "{}: Level {level}",
+                        describe_cost_list(activated.mana_cost.costs())
+                    );
+                }
+            }
             let mut line = String::new();
             let mut pre = Vec::new();
             if !activated.mana_cost.costs().is_empty() {
@@ -14740,7 +14755,7 @@ fn apply_triggered_presentation_label(
         return line;
     };
     let label = label.trim();
-    if label.is_empty() || line.starts_with(label) {
+    if label.is_empty() || label.starts_with("__ironsmith_") || line.starts_with(label) {
         return line;
     }
     format!("{label} — {line}")
@@ -33209,6 +33224,9 @@ pub(super) fn collect_activation_restriction_clauses(
     }
 
     for raw in additional_restrictions {
+        if raw.starts_with("__ironsmith_class_level:") {
+            continue;
+        }
         if raw
             .to_ascii_lowercase()
             .contains("exhaust ability only once")
@@ -35892,6 +35910,24 @@ fn describe_backup_keyword(triggered: &crate::ability::TriggeredAbility) -> Opti
     Some(format!("Backup {}", backup.amount))
 }
 
+fn describe_class_level_activation(activated: &crate::ability::ActivatedAbility) -> Option<String> {
+    let level = activated
+        .additional_restrictions
+        .iter()
+        .find_map(|restriction| restriction.strip_prefix("__ironsmith_class_level:"))?;
+    let [effect] = activated.effects.flattened_default_effects() else {
+        return None;
+    };
+    let put = effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.counter_type != crate::CounterType::Level || !matches!(put.target, ChooseSpec::Source) {
+        return None;
+    }
+    Some(format!(
+        "{}: Level {level}",
+        describe_cost_list(activated.mana_cost.costs())
+    ))
+}
+
 pub(super) fn describe_ability(
     index: usize,
     ability: &Ability,
@@ -36205,6 +36241,9 @@ pub(super) fn describe_ability(
             vec![line]
         }
         AbilityKind::Activated(activated) => {
+            if let Some(level_text) = describe_class_level_activation(activated) {
+                return vec![level_text];
+            }
             if activated.choices.is_empty()
                 && matches!(activated.timing, ActivationTiming::SorcerySpeed)
                 && activated.effects.segments.len() == 1
@@ -36535,6 +36574,9 @@ pub(super) fn card_self_reference_phrase_for_card(card: &crate::card::Card) -> &
     }
     if card.subtypes.contains(&Subtype::Fortification) {
         return "this Fortification";
+    }
+    if card.subtypes.contains(&Subtype::Class) {
+        return "this Class";
     }
     if card.subtypes.contains(&Subtype::Saga) {
         return "this Saga";

--- a/crates/ironsmith-runtime/src/decision/io.rs
+++ b/crates/ironsmith-runtime/src/decision/io.rs
@@ -955,6 +955,23 @@ impl DecisionMaker for SelectFirstDecisionMaker {
         legal.into_iter().take(count).collect()
     }
 
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<Target> {
+        let mut proposed = Vec::new();
+        for requirement in &ctx.requirements {
+            let count = requirement
+                .max_targets
+                .unwrap_or(1)
+                .max(requirement.min_targets)
+                .min(requirement.legal_targets.len());
+            proposed.extend(requirement.legal_targets.iter().take(count).copied());
+        }
+        normalize_targets_for_requirements(&ctx.requirements, proposed).unwrap_or_default()
+    }
+
     fn decide_options(
         &mut self,
         _game: &GameState,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2185,6 +2185,220 @@ fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup()
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn party_dude_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_144), "Party Dude")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Class])
+        .parse_text(
+            "(Gain the next level as a sorcery to add its ability.)\n\
+             When this Class enters, each player creates a Food token.\n\
+             {1}{G}: Level 2\n\
+             Whenever an artifact an opponent controls is put into a graveyard from the battlefield, draw a card.\n\
+             {4}{G}: Level 3\n\
+             Whenever one or more of your opponents are attacked, up to one target attacking creature gets +X/+X until end of turn, where X is the number of cards in your hand.",
+        )
+        .expect("Party Dude should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_cards_in_hand(game: &mut GameState, player: PlayerId, count: u32) {
+    for index in 0..count {
+        let card = CardBuilder::new(CardId::from_raw(72_200 + index), "Hand Filler").build();
+        game.create_object_from_card(&card, player, Zone::Hand);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_party_dude_at_level(game: &mut GameState, party_dude_id: ObjectId, level: u32) {
+    let counters = level.saturating_sub(1);
+    if counters > 0 {
+        game.add_counters(party_dude_id, crate::object::CounterType::Level, counters);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn party_dude_level_ability_index(game: &GameState, party_dude_id: ObjectId, level: u32) -> usize {
+    game.object(party_dude_id)
+        .expect("Party Dude should be on the battlefield")
+        .abilities
+        .iter()
+        .enumerate()
+        .find_map(|(index, ability)| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated
+                    .additional_restrictions
+                    .iter()
+                    .any(|restriction| restriction == &format!("__ironsmith_class_level:{level}")) =>
+            {
+                Some(index)
+            }
+            _ => None,
+        })
+        .expect("Party Dude should have the requested class level ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn party_dude_can_activate_level(game: &GameState, party_dude_id: ObjectId, level: u32) -> bool {
+    let ability_index = party_dude_level_ability_index(game, party_dude_id, level);
+    crate::decision::compute_legal_actions(game, PlayerId::from_index(0))
+        .iter()
+        .any(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == party_dude_id && *idx == ability_index
+            )
+        })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn party_dude_pumps_target_attacking_creature_when_an_opponent_is_attacked() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let party_dude = party_dude_definition();
+    let party_dude_id = game.create_object_from_definition(&party_dude, alice, Zone::Battlefield);
+    put_party_dude_at_level(&mut game, party_dude_id, 3);
+    put_cards_in_hand(&mut game, alice, 3);
+    let attacker = create_creature(&mut game, "Party Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(attacker);
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker,
+            target: AttackTarget::Player(charlie),
+        }],
+    )
+    .expect("Bob should be able to attack Charlie");
+    game.combat = Some(combat.clone());
+    assert_eq!(trigger_queue.entries.len(), 1, "Party Dude should trigger once");
+
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Party Dude trigger should go on the stack with a target");
+    resolve_stack_entry(&mut game).expect("Party Dude trigger should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.calculated_power(attacker),
+        Some(5),
+        "Party Dude should give +X/+X where X is its controller's hand size"
+    );
+    assert_eq!(game.calculated_toughness(attacker), Some(5));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn party_dude_does_not_trigger_before_level_three_when_an_opponent_is_attacked() {
+    for level in [1, 2] {
+        let mut game = setup_three_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let charlie = PlayerId::from_index(2);
+
+        let party_dude = party_dude_definition();
+        let party_dude_id =
+            game.create_object_from_definition(&party_dude, alice, Zone::Battlefield);
+        put_party_dude_at_level(&mut game, party_dude_id, level);
+        let attacker = create_creature(&mut game, "Early Party Attacker", bob, 2, 2);
+        game.remove_summoning_sickness(attacker);
+        game.turn.active_player = bob;
+        game.turn.phase = Phase::Combat;
+        game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+        let mut combat = CombatState::default();
+        let mut trigger_queue = TriggerQueue::new();
+        apply_attacker_declarations(
+            &mut game,
+            &mut combat,
+            &mut trigger_queue,
+            &[AttackerDeclaration {
+                creature: attacker,
+                target: AttackTarget::Player(charlie),
+            }],
+        )
+        .expect("Bob should be able to attack Charlie");
+
+        assert!(
+            trigger_queue.entries.is_empty(),
+            "Party Dude should not have its level 3 attack trigger at level {level}"
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn party_dude_class_level_activations_are_level_gated() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let party_dude = party_dude_definition();
+    let party_dude_id = game.create_object_from_definition(&party_dude, alice, Zone::Battlefield);
+
+    assert!(party_dude_can_activate_level(&game, party_dude_id, 2));
+    assert!(!party_dude_can_activate_level(&game, party_dude_id, 3));
+
+    game.add_counters(party_dude_id, crate::object::CounterType::Level, 1);
+    assert!(!party_dude_can_activate_level(&game, party_dude_id, 2));
+    assert!(party_dude_can_activate_level(&game, party_dude_id, 3));
+
+    game.add_counters(party_dude_id, crate::object::CounterType::Level, 1);
+    assert!(!party_dude_can_activate_level(&game, party_dude_id, 2));
+    assert!(!party_dude_can_activate_level(&game, party_dude_id, 3));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn party_dude_does_not_trigger_when_its_controller_is_attacked() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let party_dude = party_dude_definition();
+    let party_dude_id = game.create_object_from_definition(&party_dude, alice, Zone::Battlefield);
+    put_party_dude_at_level(&mut game, party_dude_id, 3);
+    let attacker = create_creature(&mut game, "Uninvited Attacker", bob, 2, 2);
+    game.remove_summoning_sickness(attacker);
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("Bob should be able to attack Alice");
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("empty trigger queue should process");
+
+    assert!(
+        game.stack.is_empty(),
+        "Party Dude should not trigger when its controller, not an opponent, is attacked"
+    );
+}
+
 #[test]
 fn guardian_of_the_ages_loses_defender_and_stops_triggering() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -946,6 +946,10 @@ pub(crate) fn check_triggers_with_view(
                 continue;
             }
 
+            if !class_level_trigger_is_active(obj, trigger_ability) {
+                continue;
+            }
+
             if trigger_ability.trigger.matches(trigger_event, &ctx) {
                 let trigger_count = trigger_ability
                     .trigger
@@ -1394,6 +1398,26 @@ pub(crate) fn check_triggers_with_view(
     append_additional_trigger_copies(game, view, &mut triggered);
 
     triggered
+}
+
+fn class_level_trigger_is_active(
+    source: &crate::object::Object,
+    triggered: &crate::ability::TriggeredAbility,
+) -> bool {
+    let Some(level) = triggered
+        .presentation_label
+        .as_deref()
+        .and_then(|label| label.strip_prefix("__ironsmith_class_level:"))
+        .and_then(|level| level.parse::<u32>().ok())
+    else {
+        return true;
+    };
+    source
+        .counters
+        .get(&crate::CounterType::Level)
+        .copied()
+        .unwrap_or(0)
+        >= level.saturating_sub(1)
 }
 
 fn collect_attached_source_lki_triggers(

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -201,6 +201,13 @@ impl TriggerMatcher for AttacksTrigger {
         } else {
             subject
         };
+        let passive_opponent_attacked = self.one_or_more
+            && attacked_target_must_be_player
+            && matches!(attacked_player.as_ref(), Some(PlayerFilter::Opponent))
+            && display_filter == ObjectFilter::creature();
+        if passive_opponent_attacked {
+            return "Whenever one or more of your opponents are attacked".to_string();
+        }
         let target_tail = match (attacked_player.as_ref(), attacked_target_must_be_player) {
             (Some(PlayerFilter::Opponent), true) => " an opponent",
             (Some(PlayerFilter::Any), true) => " a player",

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
@@ -427,6 +427,17 @@ impl ZoneChangeTrigger {
         } else {
             subject_description_for_zone_change(&self.object_filter)
         };
+        if let Some(rest) = filter_desc
+            .strip_prefix("an opponent's ")
+            .or_else(|| filter_desc.strip_prefix("opponent's "))
+        {
+            let article = if matches!(rest.chars().next(), Some('a' | 'e' | 'i' | 'o' | 'u')) {
+                "an"
+            } else {
+                "a"
+            };
+            filter_desc = format!("{article} {rest} an opponent controls");
+        }
         if self.to == ZonePattern::Specific(Zone::Battlefield)
             && enters_origin_phrase(self).is_some()
             && let Some(stripped) = filter_desc.strip_suffix(" you own")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Party Dude
Initial parse error:
```
unsupported triggered line: 'Whenever one or more of your opponents are attacked, up to one target attacking creature gets +X/+X until end of turn, where X is the number of cards in your hand.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever one or more of your opponents are attacked, up to one target attacking creature gets +X/+X until end of turn, where X is the number of cards in your hand.'
```

Current worker: i-0692616db63540f77
Branch: codex/aws-card-fix-party-dude
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0003
