### PR TITLE
Fix Ironsmith parse failure: Voidstone Gargoyle

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -533,6 +533,18 @@ fn parse_spell_restriction_subject_filter(words: &[&str]) -> Option<ObjectFilter
             continue;
         }
 
+        if word_slice_starts_with(&words[idx..], &["the", "chosen", "name"]) {
+            filter.name = Some("{chosen name}".to_string());
+            idx += 3;
+            continue;
+        }
+
+        if word_slice_starts_with(&words[idx..], &["chosen", "name"]) {
+            filter.name = Some("{chosen name}".to_string());
+            idx += 2;
+            continue;
+        }
+
         if word_slice_at_is(words, idx, "x")
             && word_slice_at_is(words, idx + 1, "in")
             && word_slice_at_is_any(words, idx + 2, &["their", "its"])

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -1229,10 +1229,12 @@ pub(crate) fn parse_activated_abilities_cant_be_activated_line(
     // which is correct for many adjective chains, but incorrect for this rules pattern.
     let subject_words = crate::runtime_backend::util::non_article_token_word_refs(&subject_tokens);
 
-    let filter = if matches!(
+    let chosen_name_subject = matches!(
         subject_words.as_slice(),
         ["sources", "with", "chosen", "name"] | ["sources", "with", "the", "chosen", "name"]
-    ) {
+    );
+
+    let filter = if chosen_name_subject {
         let mut filter = ObjectFilter::default();
         filter.name = Some("{chosen name}".to_string());
         filter
@@ -1267,7 +1269,11 @@ pub(crate) fn parse_activated_abilities_cant_be_activated_line(
         Restriction::activate_abilities_of(filter)
     };
 
-    let display_subject = subject_words.join(" ");
+    let display_subject = if chosen_name_subject {
+        "sources with the chosen name".to_string()
+    } else {
+        subject_words.join(" ")
+    };
     let display = if non_mana_only {
         format!(
             "Activated abilities of {display_subject} can't be activated unless they're mana abilities."
@@ -1375,10 +1381,12 @@ pub(crate) fn parse_activated_abilities_cant_be_activated_line_lexed(
 
     let subject_words = crate::runtime_backend::util::non_article_token_word_refs(subject_tokens);
 
-    let filter = if matches!(
+    let chosen_name_subject = matches!(
         subject_words.as_slice(),
         ["sources", "with", "chosen", "name"] | ["sources", "with", "the", "chosen", "name"]
-    ) {
+    );
+
+    let filter = if chosen_name_subject {
         let mut filter = ObjectFilter::default();
         filter.name = Some("{chosen name}".to_string());
         filter
@@ -1412,7 +1420,11 @@ pub(crate) fn parse_activated_abilities_cant_be_activated_line_lexed(
         Restriction::activate_abilities_of(filter)
     };
 
-    let display_subject = subject_words.join(" ");
+    let display_subject = if chosen_name_subject {
+        "sources with the chosen name".to_string()
+    } else {
+        subject_words.join(" ")
+    };
     let display = if non_mana_only {
         format!(
             "Activated abilities of {display_subject} can't be activated unless they're mana abilities."
@@ -2400,13 +2412,25 @@ pub(crate) fn parse_choose_card_name_as_enters_line(
     else {
         return Ok(None);
     };
-    if !word_slice_eq(&words[idx..], &["choose", "a", "card", "name"]) {
+    let nonland = if word_slice_eq(&words[idx..], &["choose", "a", "nonland", "card", "name"]) {
+        true
+    } else if word_slice_eq(&words[idx..], &["choose", "a", "card", "name"]) {
+        false
+    } else {
         return Ok(None);
-    }
+    };
 
-    Ok(Some(StaticAbility::choose_card_name_as_enters(format!(
-        "As {display_subject} enters, choose a card name."
-    ))))
+    let display = if nonland {
+        format!("As {display_subject} enters, choose a nonland card name.")
+    } else {
+        format!("As {display_subject} enters, choose a card name.")
+    };
+
+    Ok(Some(if nonland {
+        StaticAbility::choose_nonland_card_name_as_enters(display)
+    } else {
+        StaticAbility::choose_card_name_as_enters(display)
+    }))
 }
 
 pub(crate) fn parse_source_is_chosen_type_in_addition_line(

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -351,7 +351,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         condition: Option<Condition>,
     },
     ChoosePlayerAsEnters(String),
-    ChooseCardNameAsEnters(String),
+    ChooseCardNameAsEnters { display: String, nonland: bool },
     ChooseCreatureTypeAsEnters(String),
     ChooseNamedOptionAsEnters {
         options: Vec<String>,
@@ -1135,8 +1135,8 @@ where
             StaticAbilityPayload::ChoosePlayerAsEnters(display) => {
                 StaticAbilityPayload::ChoosePlayerAsEnters(display)
             }
-            StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
-                StaticAbilityPayload::ChooseCardNameAsEnters(display)
+            StaticAbilityPayload::ChooseCardNameAsEnters { display, nonland } => {
+                StaticAbilityPayload::ChooseCardNameAsEnters { display, nonland }
             }
             StaticAbilityPayload::ChooseCreatureTypeAsEnters(display) => {
                 StaticAbilityPayload::ChooseCreatureTypeAsEnters(display)
@@ -3087,7 +3087,21 @@ impl<
         Self {
             id: Some(StaticAbilityId::ChooseCardNameAsEnters),
             label: display.clone(),
-            payload: StaticAbilityPayload::ChooseCardNameAsEnters(display),
+            payload: StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                nonland: false,
+            },
+        }
+    }
+    pub fn choose_nonland_card_name_as_enters(display: impl Into<String>) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::ChooseCardNameAsEnters),
+            label: display.clone(),
+            payload: StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                nonland: true,
+            },
         }
     }
     pub fn redirect_damage_from_you_and_other_permanents_to_source() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -50210,3 +50210,143 @@ fn occult_epiphany_runtime_x_zero_draws_discards_and_creates_no_tokens() {
         "X=0 should create no Spirit tokens"
     );
 }
+
+#[test]
+fn voidstone_gargoyle_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Voidstone Gargoyle");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("ChooseCardNameAsEnters")
+            && ability_debug.contains("nonland: true"),
+        "Voidstone Gargoyle should choose a nonland card name as it enters, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("CastSpellsMatching")
+            && ability_debug.contains("{chosen name}")
+            && ability_debug.contains("ActivateAbilitiesOf"),
+        "Voidstone Gargoyle should restrict spells and activated abilities with the chosen name, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("As this creature enters, choose a nonland card name."),
+        "expected nonland card-name choice text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Spells with the chosen name can't be cast."),
+        "expected chosen-name spell cast restriction text, got {rendered}"
+    );
+    assert!(
+        rendered
+            .contains("Activated abilities of sources with the chosen name can't be activated."),
+        "expected chosen-name activated ability restriction text, got {rendered}"
+    );
+}
+
+#[test]
+fn voidstone_gargoyle_as_enters_choice_records_nonland_names_and_rejects_land_names() {
+    struct ChooseName(&'static str);
+
+    impl crate::decision::DecisionMaker for ChooseName {
+        fn decide_text(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::TextInputContext,
+        ) -> String {
+            self.0.to_string()
+        }
+    }
+
+    let def = parse_oracle_card_definition("Voidstone Gargoyle");
+    let alice = PlayerId::from_index(0);
+
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let gargoyle = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let result = game
+        .move_object_with_etb_processing_with_dm(
+            gargoyle,
+            Zone::Battlefield,
+            &mut ChooseName("Lightning Bolt"),
+        )
+        .expect("Voidstone Gargoyle should enter with ETB processing");
+    assert_eq!(
+        game.chosen_named_option(result.new_id),
+        Some("Lightning Bolt"),
+        "nonland card names should be recorded for Voidstone Gargoyle"
+    );
+
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let gargoyle = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let result = game
+        .move_object_with_etb_processing_with_dm(gargoyle, Zone::Battlefield, &mut ChooseName("Forest"))
+        .expect("Voidstone Gargoyle should enter even if a land name is offered");
+    assert_eq!(
+        game.chosen_named_option(result.new_id),
+        None,
+        "land card names should not be accepted for a nonland card-name choice"
+    );
+}
+
+#[test]
+fn voidstone_gargoyle_runtime_blocks_casting_only_spells_with_the_chosen_name() {
+    let def = parse_oracle_card_definition("Voidstone Gargoyle");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let gargoyle = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.set_chosen_named_option(gargoyle, "Lightning Bolt".to_string());
+
+    let lightning_bolt = CardDefinitionBuilder::new(CardId::new(), "Lightning Bolt")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let shock = CardDefinitionBuilder::new(CardId::new(), "Shock")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let bolt_id = game.create_object_from_definition(&lightning_bolt, bob, Zone::Hand);
+    let shock_id = game.create_object_from_definition(&shock, bob, Zone::Hand);
+
+    game.update_cant_effects();
+
+    let bolt = game.object(bolt_id).expect("Lightning Bolt should exist");
+    let shock = game.object(shock_id).expect("Shock should exist");
+    assert!(
+        crate::decision::violates_any_cant_cast_restriction(&game, bob, bolt),
+        "Voidstone Gargoyle should stop the chosen spell name from being cast"
+    );
+    assert!(
+        !crate::decision::violates_any_cant_cast_restriction(&game, bob, shock),
+        "Voidstone Gargoyle should not stop differently named spells from being cast"
+    );
+}
+
+#[test]
+fn voidstone_gargoyle_runtime_blocks_activated_abilities_only_from_sources_with_the_chosen_name() {
+    let def = parse_oracle_card_definition("Voidstone Gargoyle");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let gargoyle = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.set_chosen_named_option(gargoyle, "Lightning Bolt".to_string());
+
+    let named_source = CardDefinitionBuilder::new(CardId::new(), "Lightning Bolt")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{T}: Add {C}.")
+        .expect("named activated source should parse");
+    let other_source = CardDefinitionBuilder::new(CardId::new(), "Sol Ring")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{T}: Add {C}.")
+        .expect("other activated source should parse");
+    let named_id = game.create_object_from_definition(&named_source, bob, Zone::Battlefield);
+    let other_id = game.create_object_from_definition(&other_source, bob, Zone::Battlefield);
+
+    game.update_cant_effects();
+
+    assert!(
+        !game.can_activate_abilities_of(named_id),
+        "Voidstone Gargoyle should stop abilities of sources with the chosen name"
+    );
+    assert!(
+        game.can_activate_abilities_of(other_id),
+        "Voidstone Gargoyle should not stop abilities of differently named sources"
+    );
+}

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -50350,3 +50350,75 @@ fn voidstone_gargoyle_runtime_blocks_activated_abilities_only_from_sources_with_
         "Voidstone Gargoyle should not stop abilities of differently named sources"
     );
 }
+
+#[test]
+fn voidstone_gargoyle_runtime_blocks_non_battlefield_source_abilities_with_the_chosen_name() {
+    fn hand_gain_life_ability() -> crate::ability::Ability {
+        crate::ability::Ability {
+            kind: crate::ability::AbilityKind::Activated(crate::ability::ActivatedAbility {
+                mana_cost: crate::cost::TotalCost::free(),
+                effects: crate::resolution::ResolutionProgram::from_effects(vec![
+                    crate::effect::Effect::gain_life(1),
+                ]),
+                choices: vec![],
+                timing: crate::ability::ActivationTiming::AnyTime,
+                additional_restrictions: vec![],
+                activation_restrictions: vec![],
+                mana_output: None,
+                activation_condition: None,
+                mana_usage_restrictions: vec![],
+                is_loyalty_ability: false,
+            }),
+            functional_zones: vec![Zone::Hand],
+        }
+    }
+
+    let def = parse_oracle_card_definition("Voidstone Gargoyle");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+
+    let gargoyle = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.set_chosen_named_option(gargoyle, "Lightning Bolt".to_string());
+
+    let named_source = CardDefinitionBuilder::new(CardId::new(), "Lightning Bolt")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let other_source = CardDefinitionBuilder::new(CardId::new(), "Shock")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let named_id = game.create_object_from_definition(&named_source, bob, Zone::Hand);
+    let other_id = game.create_object_from_definition(&other_source, bob, Zone::Hand);
+    game.object_mut(named_id)
+        .expect("named hand source should exist")
+        .abilities
+        .push(hand_gain_life_ability());
+    game.object_mut(other_id)
+        .expect("other hand source should exist")
+        .abilities
+        .push(hand_gain_life_ability());
+
+    game.update_cant_effects();
+    let actions = crate::decision::compute_legal_actions(&game, bob);
+
+    assert!(
+        !game.can_activate_abilities_of(named_id)
+            && !actions.iter().any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. } if *source == named_id
+            )),
+        "Voidstone Gargoyle should stop hand-zone abilities of sources with the chosen name"
+    );
+    assert!(
+        game.can_activate_abilities_of(other_id)
+            && actions.iter().any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. } if *source == other_id
+            )),
+        "Voidstone Gargoyle should not stop hand-zone abilities of differently named sources"
+    );
+}

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -590,7 +590,14 @@ pub(crate) fn spell_matches_cast_filter(
     spell: &crate::object::Object,
     spell_filter: &crate::target::ObjectFilter,
 ) -> bool {
-    spell_filter.matches(spell, &crate::target::FilterContext::default(), game)
+    let mut cast_filter = spell_filter.clone();
+    if cast_filter.zone == Some(Zone::Stack)
+        && matches!(cast_filter.stack_kind, Some(crate::filter::StackObjectKind::Spell))
+    {
+        cast_filter.zone = None;
+        cast_filter.stack_kind = None;
+    }
+    cast_filter.matches(spell, &crate::target::FilterContext::default(), game)
 }
 
 pub(crate) fn snapshot_matches_cast_filter(
@@ -598,7 +605,14 @@ pub(crate) fn snapshot_matches_cast_filter(
     snapshot: &crate::snapshot::ObjectSnapshot,
     spell_filter: &crate::target::ObjectFilter,
 ) -> bool {
-    spell_filter.matches_snapshot(snapshot, &crate::target::FilterContext::default(), game)
+    let mut cast_filter = spell_filter.clone();
+    if cast_filter.zone == Some(Zone::Stack)
+        && matches!(cast_filter.stack_kind, Some(crate::filter::StackObjectKind::Spell))
+    {
+        cast_filter.zone = None;
+        cast_filter.stack_kind = None;
+    }
+    cast_filter.matches_snapshot(snapshot, &crate::target::FilterContext::default(), game)
 }
 
 pub(crate) fn spells_cast_this_turn_matching_filter(

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -812,6 +812,35 @@ pub(crate) trait RestrictionExt {
     );
 }
 
+fn resolve_chosen_name_spell_filters(
+    game: &crate::game_state::GameState,
+    source: Option<crate::ids::ObjectId>,
+    spell_filter: &ObjectFilter,
+) -> Vec<ObjectFilter> {
+    let Some(source) = source else {
+        return vec![spell_filter.clone()];
+    };
+    if spell_filter.name.as_deref() != Some("{chosen name}") {
+        return vec![spell_filter.clone()];
+    }
+
+    game.chosen_named_option(source)
+        .map(|chosen_names| {
+            chosen_names
+                .lines()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(|name| {
+                    let mut resolved = spell_filter.clone();
+                    resolved.name = Some(name.to_string());
+                    resolved
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|filters| !filters.is_empty())
+        .unwrap_or_default()
+}
+
 impl RestrictionExt for Restriction {
     fn apply(
         &self,
@@ -867,9 +896,12 @@ impl RestrictionExt for Restriction {
                 }
             }
             Restriction::CastSpellsMatching(filter, spell_filter) => {
+                let spell_filters = resolve_chosen_name_spell_filters(game, source, spell_filter);
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
-                        tracker.add_cant_cast_filter(player.id, spell_filter.clone());
+                        for spell_filter in &spell_filters {
+                            tracker.add_cant_cast_filter(player.id, spell_filter.clone());
+                        }
                     }
                 }
             }

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -841,6 +841,27 @@ fn resolve_chosen_name_spell_filters(
         .unwrap_or_default()
 }
 
+fn activation_restriction_candidate_ids(game: &GameState, filter: &ObjectFilter) -> Vec<ObjectId> {
+    if let Some(zone) = filter.zone {
+        return game.objects_in_zone(zone);
+    }
+
+    let mut ids = Vec::new();
+    for zone in [
+        Zone::Battlefield,
+        Zone::Hand,
+        Zone::Graveyard,
+        Zone::Exile,
+        Zone::Command,
+        Zone::Stack,
+    ] {
+        ids.extend(game.objects_in_zone(zone));
+    }
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
 impl RestrictionExt for Restriction {
     fn apply(
         &self,
@@ -920,7 +941,7 @@ impl RestrictionExt for Restriction {
                 }
             }
             Restriction::ActivateAbilitiesOf(filter) => {
-                for &obj_id in &game.battlefield {
+                for obj_id in activation_restriction_candidate_ids(game, filter) {
                     if let Some(obj) = game.object(obj_id)
                         && filter.matches(obj, &ctx, game)
                     {
@@ -929,7 +950,7 @@ impl RestrictionExt for Restriction {
                 }
             }
             Restriction::ActivateTapAbilitiesOf(filter) => {
-                for &obj_id in &game.battlefield {
+                for obj_id in activation_restriction_candidate_ids(game, filter) {
                     if let Some(obj) = game.object(obj_id)
                         && filter.matches(obj, &ctx, game)
                     {
@@ -938,7 +959,7 @@ impl RestrictionExt for Restriction {
                 }
             }
             Restriction::ActivateNonManaAbilitiesOf(filter) => {
-                for &obj_id in &game.battlefield {
+                for obj_id in activation_restriction_candidate_ids(game, filter) {
                     if let Some(obj) = game.object(obj_id)
                         && filter.matches(obj, &ctx, game)
                     {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -4535,11 +4535,15 @@ impl GameState {
                             self.set_chosen_player(new_id, options[chosen_idx]);
                         }
                     }
-                    if static_ability.card_name_choice_as_enters().is_some() {
+                    if let Some(spec) = static_ability.card_name_choice_as_enters() {
                         let choice_ctx = crate::decisions::context::TextInputContext::new(
                             controller,
                             Some(new_id),
-                            "Choose a card name",
+                            if spec.nonland {
+                                "Choose a nonland card name"
+                            } else {
+                                "Choose a card name"
+                            },
                         )
                         .with_placeholder("Enter a card name")
                         .require_known_value(true);
@@ -4553,8 +4557,15 @@ impl GameState {
                         }
                         let mut registry = CardRegistry::new();
                         registry.ensure_cards_loaded([chosen_name]);
-                        let canonical_name = registry
-                            .get(chosen_name)
+                        let definition = registry.get(chosen_name);
+                        if spec.nonland
+                            && definition.is_none_or(|definition| {
+                                definition.card.card_types.contains(&crate::types::CardType::Land)
+                            })
+                        {
+                            continue;
+                        }
+                        let canonical_name = definition
                             .map(|definition| definition.name().to_string())
                             .unwrap_or_else(|| chosen_name.to_string());
                         self.set_chosen_named_option(new_id, canonical_name);

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1483,12 +1483,23 @@ impl StaticAbilityKind for ChoosePlayerAsEnters {
 /// "As this enters, choose a card name."
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChooseCardNameAsEnters {
+    pub nonland: bool,
     pub display: String,
 }
 
 impl ChooseCardNameAsEnters {
     pub fn new(display: String) -> Self {
-        Self { display }
+        Self {
+            nonland: false,
+            display,
+        }
+    }
+
+    pub fn nonland(display: String) -> Self {
+        Self {
+            nonland: true,
+            display,
+        }
     }
 }
 
@@ -1502,7 +1513,9 @@ impl StaticAbilityKind for ChooseCardNameAsEnters {
     }
 
     fn card_name_choice_as_enters(&self) -> Option<ChooseCardNameAsEntersSpec> {
-        Some(ChooseCardNameAsEntersSpec)
+        Some(ChooseCardNameAsEntersSpec {
+            nonland: self.nonland,
+        })
     }
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -945,7 +945,9 @@ pub struct ChoosePlayerAsEntersSpec;
 
 /// Spec for "as this enters, choose a card name" abilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ChooseCardNameAsEntersSpec;
+pub struct ChooseCardNameAsEntersSpec {
+    pub nonland: bool,
+}
 
 /// Spec for "as this enters, choose a basic land type" abilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -2581,6 +2583,10 @@ impl StaticAbility {
 
     pub fn choose_card_name_as_enters(display: String) -> Self {
         Self::new(ChooseCardNameAsEnters::new(display))
+    }
+
+    pub fn choose_nonland_card_name_as_enters(display: String) -> Self {
+        Self::new(ChooseCardNameAsEnters::nonland(display))
     }
 
     pub fn choose_basic_land_type_as_enters(display: String) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1157,8 +1157,12 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ChoosePlayerAsEnters(display) => {
                 StaticAbility::choose_player_as_enters(display.clone())
             }
-            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
-                StaticAbility::choose_card_name_as_enters(display.clone())
+            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters { display, nonland } => {
+                if *nonland {
+                    StaticAbility::choose_nonland_card_name_as_enters(display.clone())
+                } else {
+                    StaticAbility::choose_card_name_as_enters(display.clone())
+                }
             }
             ironsmith_core::StaticAbilityPayload::ChooseCreatureTypeAsEnters(display) => {
                 StaticAbility::choose_creature_type_as_enters(display.clone())
@@ -1828,11 +1832,12 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
     }
 
     fn card_name_choice_as_enters(&self) -> Option<super::ChooseCardNameAsEntersSpec> {
-        matches!(
-            self.payload(),
-            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters(_)
-        )
-        .then_some(super::ChooseCardNameAsEntersSpec)
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters { nonland, .. } => {
+                Some(super::ChooseCardNameAsEntersSpec { nonland: *nonland })
+            }
+            _ => None,
+        }
     }
 
     fn basic_land_type_choice_as_enters(&self) -> Option<super::ChooseBasicLandTypeAsEntersSpec> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Voidstone Gargoyle
Initial parse error:
```
parser does not yet support line family: 'As this creature enters, choose a nonland card name.'; oracle-only fallback also failed: parser does not yet support line family: 'As this creature enters, choose a nonland card name.'
```

Current worker: i-05a7d3de4af05f7bd
Branch: codex/aws-card-fix-voidstone-gargoyle
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0003
