### PR TITLE
Fix Ironsmith parse failure: Squee, the Immortal

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -913,6 +913,21 @@ pub(crate) fn parse_permission_clause_spec_lexed(
 
     if matches!(
         rest_words.as_slice(),
+        ["this", "card", "from", "exile"] | ["this", "spell", "from", "exile"]
+    ) {
+        return Ok(Some(PermissionClauseSpec::GrantBySpec {
+            player,
+            spec: crate::grant::GrantSpec::new(
+                crate::grant::Grantable::play_from(),
+                ObjectFilter::source(),
+                Zone::Exile,
+            ),
+            lifetime: PermissionLifetime::Static,
+        }));
+    }
+
+    if matches!(
+        rest_words.as_slice(),
         [
             "this",
             "card",
@@ -1047,6 +1062,8 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                 Some(Zone::Library)
             } else if word_slice_eq(&zone_words, &["from", "your", "graveyard"]) {
                 Some(Zone::Graveyard)
+            } else if word_slice_eq(&zone_words, &["from", "exile"]) {
+                Some(Zone::Exile)
             } else {
                 None
             };

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -5,7 +5,8 @@ use super::line_family_handlers::{
     run_colon_nonactivation_statement_line_family, run_combined_static_line_family,
     run_draft_rule_line_family, run_escape_enters_with_counter_line_family,
     run_freerunning_line_family, run_graveyard_cast_control_condition_line_family,
-    run_keyword_line_family, run_labeled_line_family, run_learn_line_family,
+    run_graveyard_or_exile_cast_line_family, run_keyword_line_family, run_labeled_line_family,
+    run_learn_line_family,
     run_max_speed_labeled_line_family, run_non_turn_conditional_untap_line_family,
     run_partner_variant_keyword_line_family, run_partner_with_keyword_line_family,
     run_split_top_and_face_down_look_line_family, run_split_top_look_and_top_land_play_line_family,
@@ -49,7 +50,7 @@ struct LineFamilyRuleDef {
     run: LineFamilyRuleFn,
 }
 
-const LINE_FAMILY_RULES: [LineFamilyRuleDef; 30] = [
+const LINE_FAMILY_RULES: [LineFamilyRuleDef; 31] = [
     LineFamilyRuleDef {
         id: "trailing-keyword-activation",
         priority: 10,
@@ -199,6 +200,12 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 30] = [
         priority: 76,
         heads: &["you"],
         run: run_graveyard_cast_control_condition_line_family,
+    },
+    LineFamilyRuleDef {
+        id: "graveyard-or-exile-cast",
+        priority: 76,
+        heads: &["you"],
+        run: run_graveyard_or_exile_cast_line_family,
     },
     LineFamilyRuleDef {
         id: "additional-combat-after-this-phase",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -414,6 +414,43 @@ pub(super) fn run_graveyard_cast_control_condition_line_family(
     )))
 }
 
+pub(super) fn run_graveyard_or_exile_cast_line_family(
+    ctx: &LineDispatchContext<'_>,
+) -> Result<Option<LineDispatchResult>, CardTextError> {
+    let raw = ctx.line.info.raw_line.trim();
+    let raw_no_period = raw.trim_end_matches('.');
+    if raw_no_period.to_ascii_lowercase()
+        != "you may cast this card from your graveyard or from exile"
+    {
+        return Ok(None);
+    }
+
+    let graveyard_line =
+        rewrite_line_normalized(ctx.line, "You may cast this card from your graveyard.")?;
+    let exile_line = rewrite_line_normalized(ctx.line, "You may cast this card from exile.")?;
+
+    let Some(graveyard_static) = parse_static_line_cst(&graveyard_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower graveyard-or-exile cast line graveyard half: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+    let Some(exile_static) = parse_static_line_cst(&exile_line)? else {
+        return Err(CardTextError::ParseError(format!(
+            "parser could not lower graveyard-or-exile cast line exile half: '{}'",
+            ctx.line.info.raw_line
+        )));
+    };
+
+    Ok(Some(LineDispatchResult {
+        lines: vec![
+            RewriteLineCst::Static(graveyard_static),
+            RewriteLineCst::Static(exile_static),
+        ],
+        next_idx: ctx.idx + 1,
+    }))
+}
+
 pub(super) fn run_champion_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
@@ -13,6 +13,11 @@ pub(super) fn infer_static_ability_functional_zones(normalized_line: &str) -> Op
     {
         return Some(vec![Zone::Graveyard]);
     }
+    if str_contains(normalized.as_str(), "cast this card from exile")
+        || str_contains(normalized.as_str(), "play this card from exile")
+    {
+        return Some(vec![Zone::Exile]);
+    }
 
     let mut zones = Vec::new();
     for (needles, zone) in [

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -495,6 +495,12 @@ where
             return format!("{may_prefix} cast this card from your graveyard");
         }
         if matches!(self.grantable, Grantable::PlayFrom)
+            && self.zone == Zone::Exile
+            && self.filter == ObjectFilter::source()
+        {
+            return format!("{may_prefix} cast this card from exile");
+        }
+        if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Graveyard
             && self.filter.card_types.as_slice() == [CardType::Land]
         {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1908,6 +1908,23 @@ fn test_parse_eelectrocute_roll_six_graveyard_cast_condition_and_exile_clause() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_squee_the_immortal_graveyard_or_exile_cast_permission() {
+    assert_oracle_card_parses_strict("Squee, the Immortal");
+    let def = parse_oracle_card_definition("Squee, the Immortal");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+
+    assert!(
+        rendered.contains("You may cast this card from your graveyard or from exile")
+            && debug.contains("grantable: PlayFrom")
+            && debug.contains("zone: Graveyard")
+            && debug.contains("zone: Exile"),
+        "expected Squee to parse into source play-from-graveyard and play-from-exile grants, got rendered={rendered}; debug={debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_max_speed_draw_replacement_static_ability() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Vnwxt Parse Test")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1345,6 +1345,28 @@ fn describe_structural_rampage_pair(first: &Ability, second: &Ability) -> Option
     Some(format!("Rampage {amount}"))
 }
 
+fn describe_structural_graveyard_or_exile_cast_pair(
+    first: &Ability,
+    second: &Ability,
+) -> Option<String> {
+    fn play_from_source_zone(ability: &Ability) -> Option<Zone> {
+        let AbilityKind::Static(static_ability) = &ability.kind else {
+            return None;
+        };
+        let spec = static_ability.grant_spec()?;
+        (matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+            && spec.filter == crate::target::ObjectFilter::source())
+        .then_some(spec.zone)
+    }
+
+    match (play_from_source_zone(first), play_from_source_zone(second)) {
+        (Some(Zone::Graveyard), Some(Zone::Exile)) | (Some(Zone::Exile), Some(Zone::Graveyard)) => {
+            Some("You may cast this card from your graveyard or from exile".to_string())
+        }
+        _ => None,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CounterKeywordAmount {
     Fixed(u32),
@@ -2169,6 +2191,16 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                     describe_structural_rampage_pair(ability, &def.abilities[ability_idx + 1])
             {
                 output.push(format!("Keyword ability {}: {keyword}", ability_idx + 1));
+                ability_idx += 2;
+                continue;
+            }
+            if ability_idx + 1 < def.abilities.len()
+                && let Some(permission) = describe_structural_graveyard_or_exile_cast_pair(
+                    ability,
+                    &def.abilities[ability_idx + 1],
+                )
+            {
+                output.push(format!("Static ability {}: {permission}", ability_idx + 1));
                 ability_idx += 2;
                 continue;
             }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -24492,6 +24492,146 @@ fn test_marang_river_prowler_castable_from_graveyard_with_green_permanent() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn squee_the_immortal_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_616), "Squee, the Immortal")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .supertypes(vec![Supertype::Legendary])
+        .subtypes(vec![Subtype::Goblin])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text("You may cast this card from your graveyard or from exile.")
+        .expect("Squee, the Immortal should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_squee_the_immortal_castable_from_graveyard() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 3);
+
+    let squee = squee_the_immortal_definition();
+    let squee_id = game.create_object_from_definition(&squee, alice, Zone::Graveyard);
+
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            squee_id,
+            Zone::Graveyard,
+            alice,
+        ),
+        "Squee should grant permission to cast itself from graveyard"
+    );
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom { use_alternative: None, .. },
+            } if *spell_id == squee_id
+        )),
+        "Squee should expose a normal-cost cast action from graveyard; got {actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_squee_the_immortal_castable_from_exile() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 3);
+
+    let squee = squee_the_immortal_definition();
+    let squee_id = game.create_object_from_definition(&squee, alice, Zone::Exile);
+
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            squee_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Squee should grant permission to cast itself from exile"
+    );
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Exile,
+                casting_method: CastingMethod::PlayFrom { use_alternative: None, .. },
+            } if *spell_id == squee_id
+        )),
+        "Squee should expose a normal-cost cast action from exile; got {actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_squee_the_immortal_not_castable_from_unlisted_zone() {
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 3);
+
+    let squee = squee_the_immortal_definition();
+    let squee_id = game.create_object_from_definition(&squee, alice, Zone::Library);
+
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            squee_id,
+            Zone::Library,
+            alice,
+        ),
+        "Squee should not grant permission from library"
+    );
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, .. } if *spell_id == squee_id
+        )),
+        "Squee should not be castable from library; got {actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn eelectrocute_definition() -> crate::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_615), "Eelectrocute")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Squee, the Immortal
Initial parse error:
```
parser does not yet support line family: 'You may cast this card from your graveyard or from exile.'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast this card from your graveyard or from exile.'
```

Current worker: i-011c45a192cdba3d9
Branch: codex/aws-card-fix-squee-the-immortal
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0004
