### PR TITLE
Fix Ironsmith parse failure: Friendly Fire

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
@@ -694,6 +694,12 @@ pub(crate) fn parse_add_mana_equal_amount_value_lexed(tokens: &[OwnedLexToken]) 
         &["that", "card", "mana", "value"],
         &["that", "card's", "mana", "value"],
         &["that", "cards", "mana", "value"],
+        &["the", "revealed", "card", "mana", "value"],
+        &["the", "revealed", "card's", "mana", "value"],
+        &["the", "revealed", "cards", "mana", "value"],
+        &["revealed", "card", "mana", "value"],
+        &["revealed", "card's", "mana", "value"],
+        &["revealed", "cards", "mana", "value"],
         &[
             "the",
             "mana",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2525,6 +2525,28 @@ pub(crate) fn parse_subject(tokens: &[OwnedLexToken]) -> SubjectAst {
         return SubjectAst::Player(player);
     }
 
+    if word_slice_starts_with(slice, &["target"])
+        && word_slice_ends_with_any(
+            slice,
+            &[
+                &["controller"],
+                &["controllers"],
+                &["controller's"],
+                &["controllers'"],
+                &["owner"],
+                &["owners"],
+                &["owner's"],
+                &["owners'"],
+            ],
+        )
+    {
+        let player = match slice.last().copied() {
+            Some("owner" | "owners" | "owner's" | "owners'") => PlayerAst::ItsOwner,
+            _ => PlayerAst::ItsController,
+        };
+        return SubjectAst::Player(player);
+    }
+
     if word_slice_starts_with(slice, &["its", "controller"]) {
         return SubjectAst::Player(PlayerAst::ItsController);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/choice_damage_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/choice_damage_family.rs
@@ -587,6 +587,7 @@ pub(crate) fn parse_sentence_target_player_reveals_random_card_from_hand_matched
             | PlayerAst::TargetOpponent
             | PlayerAst::Opponent
             | PlayerAst::That
+            | PlayerAst::ItsController
     ) {
         return Ok(None);
     }
@@ -643,6 +644,9 @@ pub(crate) fn parse_sentence_target_player_reveals_random_card_from_hand_matched
             PlayerAst::TargetOpponent => PlayerFilter::target_opponent(),
             PlayerAst::Opponent => PlayerFilter::Opponent,
             PlayerAst::That => PlayerFilter::IteratedPlayer,
+            PlayerAst::ItsController => {
+                PlayerFilter::ControllerOf(crate::filter::ObjectRef::Target)
+            }
             _ => return Ok(None),
         }),
         ..ObjectFilter::default()

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -313,6 +313,31 @@ pub(crate) fn parse_deal_damage_to_target_equal_to_clause(
         let filter = parse_object_filter(&target_tokens[1..], false)?;
         return Ok(Some(EffectAst::subject_verb_damage_each(amount, filter)));
     }
+    if crate::runtime_backend::lexer::word_slice_eq_any(
+        &target_words,
+        &[
+            &["that", "creature", "and", "that", "player"],
+            &["that", "creatures", "and", "that", "player"],
+        ],
+    ) {
+        let creature_target = TargetAst::Object(
+            ObjectFilter::creature(),
+            span_from_tokens(&target_tokens),
+            None,
+        );
+        return Ok(Some(EffectAst::Sequence {
+            effects: vec![
+                EffectAst::subject_verb_damage(
+                    amount.clone(),
+                    TargetAst::Player(
+                        PlayerFilter::ControllerOf(crate::target::ObjectRef::Target),
+                        None,
+                    ),
+                ),
+                EffectAst::subject_verb_damage(amount, creature_target),
+            ],
+        }));
+    }
     let target = parse_target_phrase(&target_tokens)?;
     Ok(Some(EffectAst::subject_verb_damage(amount, target)))
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10029,6 +10029,39 @@ fn test_parse_ignite_memories_keeps_random_hand_reveal_and_damage_link() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_friendly_fire_keeps_controller_random_reveal_and_double_damage_link() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Friendly Fire")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Target creature's controller reveals a card at random from their hand. Friendly Fire deals damage to that creature and that player equal to the revealed card's mana value.",
+        )
+        .expect("Friendly Fire should parse");
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("ChooseObjectsEffect")
+            && debug.contains("random: true")
+            && debug.contains("ControllerOf(Target)")
+            && debug.contains("RevealTaggedEffect")
+            && debug.matches("DealDamageEffect").count() == 2
+            && debug.contains("ManaValueOf"),
+        "expected controller random reveal and linked damage to creature and controller, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Target creature's controller reveals a card at random from their hand")
+            && rendered.contains("Friendly Fire deals damage to that creature and that player equal to the revealed card's mana value"),
+        "expected Friendly Fire compiled text to preserve the random reveal and shared revealed-card damage amount, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_singe_mind_ogre_keeps_random_hand_reveal_and_life_loss_link() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Singe-Mind Ogre")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -2257,19 +2257,6 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     {
         return "Target player reveals a card at random from their hand. Deal damage to that player equal to that card's mana value.".to_string();
     }
-    if lower_compact.contains("chooses at random a card, reveal it")
-        && lower_compact.contains(
-            "deals damage equal to its mana value to its controller, then deal damage equal to its mana value to target creature",
-        )
-    {
-        let source = normalized
-            .split_once(", reveal it, ")
-            .and_then(|(_, rest)| rest.split_once(" deals damage equal to its mana value"))
-            .map(|(source, _)| source.trim())
-            .filter(|source| !source.is_empty())
-            .unwrap_or("This spell");
-        return format!("Target creature's controller reveals a card at random from their hand. {source} deals damage to that creature and that player equal to the revealed card's mana value.");
-    }
     if lower_compact
         == "exile two target creatures. for each object exiled this way, that player reveals cards from the top of that player's library until they reveal a creature card. put it onto the battlefield. shuffle that player's library."
     {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -2257,6 +2257,19 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     {
         return "Target player reveals a card at random from their hand. Deal damage to that player equal to that card's mana value.".to_string();
     }
+    if lower_compact.contains("chooses at random a card, reveal it")
+        && lower_compact.contains(
+            "deals damage equal to its mana value to its controller, then deal damage equal to its mana value to target creature",
+        )
+    {
+        let source = normalized
+            .split_once(", reveal it, ")
+            .and_then(|(_, rest)| rest.split_once(" deals damage equal to its mana value"))
+            .map(|(source, _)| source.trim())
+            .filter(|source| !source.is_empty())
+            .unwrap_or("This spell");
+        return format!("Target creature's controller reveals a card at random from their hand. {source} deals damage to that creature and that player equal to the revealed card's mana value.");
+    }
     if lower_compact
         == "exile two target creatures. for each object exiled this way, that player reveals cards from the top of that player's library until they reveal a creature card. put it onto the battlefield. shuffle that player's library."
     {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3239,7 +3239,98 @@ fn describe_each_creature_and_player_damage_cant_regenerate_structural(
     ))
 }
 
+fn effect_without_surface_wrappers(effect: &Effect) -> &Effect {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return effect_without_surface_wrappers(&tagged.effect);
+    }
+    if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+        return effect_without_surface_wrappers(&with_id.effect);
+    }
+    effect
+}
+
+fn mana_value_of_tag(value: &Value, tag: &TagKey) -> bool {
+    match value {
+        Value::SurfaceHinted { value, .. } => mana_value_of_tag(value, tag),
+        Value::ManaValueOf(spec) => {
+            matches!(spec.as_ref(), ChooseSpec::Tagged(candidate) if candidate == tag)
+        }
+        _ => false,
+    }
+}
+
+fn describe_target_controller_random_reveal_then_shared_damage(
+    effects: &[Effect],
+) -> Option<String> {
+    let refs = effects.iter().collect::<Vec<_>>();
+    describe_target_controller_random_reveal_then_shared_damage_refs(&refs)
+}
+
+fn describe_target_controller_random_reveal_then_shared_damage_refs(
+    effects: &[&Effect],
+) -> Option<String> {
+    let [choose_effect, reveal_effect, first_damage_effect, second_damage_effect] = effects else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if choose.chooser != PlayerFilter::ControllerOf(crate::target::ObjectRef::Target)
+        || choose.zone != Some(Zone::Hand)
+        || !choose.count.random
+        || choose.count.min != 1
+        || choose.count.max != Some(1)
+        || choose.filter.zone != Some(Zone::Hand)
+        || choose.filter.owner
+            != Some(PlayerFilter::ControllerOf(
+                crate::target::ObjectRef::Target,
+            ))
+    {
+        return None;
+    }
+
+    let reveal = reveal_effect.downcast_ref::<crate::effects::RevealTaggedEffect>()?;
+    if reveal.tag != choose.tag {
+        return None;
+    }
+
+    let Some(first_damage) = effect_without_surface_wrappers(first_damage_effect)
+        .downcast_ref::<crate::effects::DealDamageEffect>()
+    else {
+        return None;
+    };
+    let Some(second_damage) = effect_without_surface_wrappers(second_damage_effect)
+        .downcast_ref::<crate::effects::DealDamageEffect>()
+    else {
+        return None;
+    };
+    if !mana_value_of_tag(&first_damage.amount, &choose.tag)
+        || !mana_value_of_tag(&second_damage.amount, &choose.tag)
+    {
+        return None;
+    }
+
+    let damages_controller_then_creature = matches!(
+        first_damage.target,
+        ChooseSpec::Player(PlayerFilter::ControllerOf(crate::target::ObjectRef::Target))
+    ) && is_target_creature_spec(&second_damage.target);
+    let damages_creature_then_controller = is_target_creature_spec(&first_damage.target)
+        && matches!(
+            second_damage.target,
+            ChooseSpec::Player(PlayerFilter::ControllerOf(crate::target::ObjectRef::Target))
+        );
+    if !damages_controller_then_creature && !damages_creature_then_controller {
+        return None;
+    }
+
+    Some(
+        "Target creature's controller reveals a card at random from their hand. Deal damage to that creature and that player equal to the revealed card's mana value"
+            .to_string(),
+    )
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_target_controller_random_reveal_then_shared_damage(effects) {
+        return compact;
+    }
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
     }
@@ -4424,6 +4515,11 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         .collect::<Vec<_>>();
 
     if let Some(compact) = describe_reveal_hand_choose_move(&filtered) {
+        return compact;
+    }
+    if let Some(compact) =
+        describe_target_controller_random_reveal_then_shared_damage_refs(&filtered)
+    {
         return compact;
     }
     if let Some(compact) = describe_exile_graveyard_reflexive_copy_artifact(&filtered) {
@@ -13271,6 +13367,10 @@ fn normalize_haunting_echoes_text(text: &str) -> Option<String> {
 pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> {
     if effects.len() < 2 {
         return None;
+    }
+
+    if let Some(compact) = describe_target_controller_random_reveal_then_shared_damage(effects) {
+        return Some(compact);
     }
 
     if effects.len() >= 3

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27006,7 +27006,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(choose) = effect.downcast_ref::<crate::effects::ChooseObjectsEffect>() {
         let chooser = describe_player_filter(&choose.chooser);
-        let choose_verb = player_verb(&chooser, "choose", "chooses");
+        let choose_verb = if choose.count.random {
+            player_verb(&chooser, "choose at random", "chooses at random")
+        } else {
+            player_verb(&chooser, "choose", "chooses")
+        };
         let search_like = choose.is_search
             || (choose_primary_zone(choose) == Some(Zone::Library)
                 && choose.tag.as_str().starts_with("searched"));

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3768,6 +3768,54 @@ fn friendly_fire_reveals_random_card_from_target_creature_controller_and_damages
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn friendly_fire_requires_a_creature_target_not_a_noncreature() {
+    let friendly_fire = CardDefinitionBuilder::new(CardId::from_raw(70_007), "Friendly Fire")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Target creature's controller reveals a card at random from their hand. Friendly Fire deals damage to that creature and that player equal to the revealed card's mana value.",
+        )
+        .expect("Friendly Fire should parse");
+    let effects = friendly_fire
+        .spell_effect
+        .as_ref()
+        .expect("Friendly Fire should have spell effects");
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let creature = CardBuilder::new(CardId::from_raw(70_008), "Target Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let artifact = CardBuilder::new(CardId::from_raw(70_009), "Untargetable Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let creature_id = game.create_object_from_card(&creature, bob, Zone::Battlefield);
+    let artifact_id = game.create_object_from_card(&artifact, bob, Zone::Battlefield);
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(
+        requirements.len(),
+        1,
+        "Friendly Fire should have exactly one target creature requirement, got {requirements:?}"
+    );
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(creature_id)),
+        "creatures should be legal Friendly Fire targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(artifact_id)),
+        "noncreatures should not be legal Friendly Fire targets, got {legal_targets:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn singe_mind_ogre_reveals_a_random_card_from_target_players_hand_and_makes_them_lose_life() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3704,6 +3704,70 @@ fn ignite_memories_reveals_a_random_card_from_target_players_hand_and_damages_th
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn friendly_fire_reveals_random_card_from_target_creature_controller_and_damages_both() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let friendly_fire = CardDefinitionBuilder::new(CardId::from_raw(70_004), "Friendly Fire")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Target creature's controller reveals a card at random from their hand. Friendly Fire deals damage to that creature and that player equal to the revealed card's mana value.",
+        )
+        .expect("Friendly Fire should parse");
+
+    let target_card = CardBuilder::new(CardId::from_raw(70_005), "Target Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let revealed_card = CardBuilder::new(CardId::from_raw(70_006), "Expensive Secret")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+
+    let target_id = game.create_object_from_card(&target_card, bob, Zone::Battlefield);
+    let revealed_id = game.create_object_from_card(&revealed_card, bob, Zone::Hand);
+    let spell_id = game.create_object_from_definition(&friendly_fire, alice, Zone::Stack);
+    game.stack.push(
+        crate::game_state::StackEntry::new(spell_id, alice)
+            .with_targets(vec![crate::game_state::Target::Object(target_id)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::target(crate::target::ChooseSpec::Object(
+                    crate::filter::ObjectFilter::creature(),
+                )),
+                range: 0..1,
+            }]),
+    );
+
+    let bob_life_before = game.player(bob).expect("bob exists").life;
+    let mut dm = CaptureRevealDecisionMaker::default();
+
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Friendly Fire should resolve");
+
+    assert!(
+        dm.view_calls.iter().all(|(_, subject, zone, public, cards)| {
+            *subject == bob && *zone == Zone::Hand && *public && cards == &vec![revealed_id]
+        }),
+        "Friendly Fire should publicly reveal the random card from the target creature controller's hand"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        bob_life_before - 5,
+        "Friendly Fire should damage the target creature's controller by the revealed card's mana value"
+    );
+    assert_eq!(
+        game.damage_on(target_id),
+        5,
+        "Friendly Fire should damage the target creature by the revealed card's mana value"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn singe_mind_ogre_reveals_a_random_card_from_target_players_hand_and_makes_them_lose_life() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Friendly Fire
Initial parse error:
```
missing damage amount (clause: 'damage to that creature and that player equal to the revealed card's mana value'); oracle-only fallback also failed: missing damage amount (clause: 'damage to that creature and that player equal to the revealed card's mana value')
```

Current worker: i-0fc3d8953b581f8d7
Branch: codex/aws-card-fix-friendly-fire
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0004
