### PR TITLE
Fix Ironsmith parse failure: Sphere of Truth

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -576,6 +576,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_passthrough_rule!(
             parse_prevent_damage_to_source_put_counters_line
         ),
+        single_static_ability_ast_rule!(parse_prevent_damage_to_you_from_source_filter_line),
         single_static_ability_ast_rule!(parse_replace_damage_with_counters_instead_line),
         single_static_ability_ast_rule!(parse_choose_color_as_enters_line),
         single_static_ability_ast_rule!(parse_damage_redirect_to_source_controller_line),
@@ -7004,6 +7005,79 @@ pub(crate) fn parse_prevent_damage_to_other_creature_you_control_put_counters_li
             display_text_for_tokens(tokens, true),
         ),
     ))
+}
+
+fn parse_damage_source_filter_words(words: &[&str]) -> Option<ObjectFilter> {
+    let mut words = strip_leading_article_word_refs(words).to_vec();
+    if word_slice_last_is_any(&words, &["source", "sources"]) {
+        words.pop();
+    }
+    if words.is_empty() {
+        return Some(ObjectFilter::default());
+    }
+
+    let mut filter = ObjectFilter::default();
+    let mut colors: Option<ColorSet> = None;
+    for word in words {
+        if matches!(word, "and" | "or") {
+            continue;
+        }
+        if let Some(color) = parse_color(word) {
+            colors = Some(colors.unwrap_or_else(ColorSet::new).union(color));
+            continue;
+        }
+        if let Some(card_type) = parse_card_type(word) {
+            filter.card_types.push(card_type);
+            continue;
+        }
+        return None;
+    }
+    if let Some(colors) = colors {
+        filter.colors = Some(colors);
+    }
+    Some(filter)
+}
+
+pub(crate) fn parse_prevent_damage_to_you_from_source_filter_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !word_slice_first_is(&words, "if") {
+        return Ok(None);
+    }
+    let Some(would_idx) = word_slice_find_phrase_start(
+        &words,
+        &["would", "deal", "damage", "to", "you"],
+    ) else {
+        return Ok(None);
+    };
+    if would_idx <= 1 {
+        return Ok(None);
+    }
+    let tail = &words[would_idx + 5..];
+    if tail.len() != 5
+        || !word_slice_first_is(tail, "prevent")
+        || !word_slice_eq(&tail[2..], &["of", "that", "damage"])
+    {
+        return Ok(None);
+    }
+    let Some(amount) = parse_number_word_i32(tail[1]).filter(|amount| *amount > 0) else {
+        return Ok(None);
+    };
+    let Some(source_filter) = parse_damage_source_filter_words(&words[1..would_idx]) else {
+        return Ok(None);
+    };
+    let display = format!(
+        "If {}, prevent {} of that damage.",
+        words[1..would_idx + 5].join(" "),
+        tail[1]
+    );
+
+    Ok(Some(StaticAbility::prevent_damage_to_you_from_source_filter(
+        amount as u32,
+        source_filter,
+        display,
+    )))
 }
 
 pub(crate) fn parse_replace_damage_with_counters_instead_line(

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -176,6 +176,7 @@ pub enum StaticAbilityId {
     PreventAllDamageToSelf,
     PreventAllCombatDamageToSelf,
     PreventAllDamageToSelfByCreatures,
+    PreventDamageToYouFromSourceFilter,
     PreventDamageToSelfRemoveCounter,
     PreventDamageToSelfPutCountersInstead,
     PreventConstrainedDamageToSelfPutCountersInstead,
@@ -429,6 +430,7 @@ impl StaticAbilityId {
             | PreventAllDamageToSelf
             | PreventAllCombatDamageToSelf
             | PreventAllDamageToSelfByCreatures
+            | PreventDamageToYouFromSourceFilter
             | PreventDamageToSelfRemoveCounter
             | PreventDamageToSelfPutCountersInstead
             | PreventConstrainedDamageToSelfPutCountersInstead

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -475,6 +475,11 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         source_filter: Option<ObjectFilter>,
         combat_only: Option<bool>,
     },
+    PreventDamageToYouFromSourceFilter {
+        amount: u32,
+        source_filter: ObjectFilter,
+        display: String,
+    },
     ReplaceDamageWithCountersInstead {
         counter_type: CounterType,
         display: String,
@@ -1389,6 +1394,15 @@ where
                 display,
                 source_filter,
                 combat_only,
+            },
+            StaticAbilityPayload::PreventDamageToYouFromSourceFilter {
+                amount,
+                source_filter,
+                display,
+            } => StaticAbilityPayload::PreventDamageToYouFromSourceFilter {
+                amount,
+                source_filter,
+                display,
             },
             StaticAbilityPayload::ReplaceDamageWithCountersInstead {
                 counter_type,
@@ -2504,6 +2518,22 @@ impl<
                 display,
                 source_filter,
                 combat_only,
+            },
+        }
+    }
+    pub fn prevent_damage_to_you_from_source_filter(
+        amount: u32,
+        source_filter: ObjectFilter,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::PreventDamageToYouFromSourceFilter),
+            label: display.clone(),
+            payload: StaticAbilityPayload::PreventDamageToYouFromSourceFilter {
+                amount,
+                source_filter,
+                display,
             },
         }
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -15607,6 +15607,135 @@ fn parse_oracle_healing_grace_strict_and_keeps_source_choice_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn sphere_of_truth_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Sphere of Truth");
+    let def = parse_oracle_card_definition("Sphere of Truth");
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("If a white source would deal damage to you, prevent 2 of that damage"),
+        "expected Sphere of Truth partial prevention wording, got {rendered}"
+    );
+    assert!(
+        debug.contains("PreventDamageToYouFromSourceFilter") && debug.contains("amount: 2"),
+        "expected Sphere of Truth to compile to a white-source partial prevention static ability, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sphere_of_truth_reduces_each_white_source_damage_event_to_you_by_two() {
+    let sphere = parse_oracle_card_definition("Sphere of Truth");
+    let white_source = CardDefinitionBuilder::new(CardId::from_raw(91_200), "White Damage Source")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let red_source = CardDefinitionBuilder::new(CardId::from_raw(91_201), "Red Damage Source")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sphere_id = game.create_object_from_definition(&sphere, alice, Zone::Battlefield);
+    let white_source_id = game.create_object_from_definition(&white_source, bob, Zone::Battlefield);
+    let red_source_id = game.create_object_from_definition(&red_source, bob, Zone::Battlefield);
+
+    game.update_replacement_effects();
+    assert!(
+        game.effect_store
+            .replacement_effects
+            .effects()
+            .iter()
+            .any(|replacement| {
+                replacement.source == sphere_id
+                    && matches!(
+                        replacement.replacement,
+                        crate::replacement::ReplacementAction::Modify(
+                            crate::replacement::EventModification::Subtract(2)
+                        )
+                    )
+            }),
+        "Sphere of Truth should register a static partial-prevention replacement"
+    );
+
+    let (white_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        white_source_id,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(white_damage, 1, "3 white damage to you should be reduced by 2");
+
+    let (small_white_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        white_source_id,
+        crate::events::DamageTarget::Player(alice),
+        1,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        small_white_damage, 0,
+        "1 white damage to you should be fully prevented"
+    );
+
+    let (red_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        red_source_id,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(red_damage, 3, "nonwhite source damage should not be reduced");
+
+    let (damage_to_other_player, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        white_source_id,
+        crate::events::DamageTarget::Player(bob),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        damage_to_other_player, 3,
+        "white source damage to a player other than you should not be reduced"
+    );
+
+    let no_prevention = CardDefinitionBuilder::new(CardId::from_raw(91_202), "No Prevention")
+        .card_types(vec![CardType::Enchantment])
+        .with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::damage_cant_be_prevented(),
+        ))
+        .build();
+    game.create_object_from_definition(&no_prevention, bob, Zone::Battlefield);
+
+    let (unpreventable_white_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        white_source_id,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        unpreventable_white_damage, 3,
+        "Sphere of Truth should not reduce damage while damage can't be prevented"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn healing_grace_runtime_prevents_up_to_three_damage_and_gains_life() {
     struct ChooseNamedSourceDecisionMaker {
         source_name: &'static str,

--- a/crates/ironsmith-runtime/src/events/damage/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/damage/matchers.rs
@@ -249,6 +249,71 @@ impl ReplacementMatcher for DamageFromSourceMatcher {
     }
 }
 
+/// Matches preventable damage from a source filter to a player filter.
+#[derive(Debug, Clone)]
+pub struct DamageFromSourceToPlayerMatcher {
+    pub source_filter: ObjectFilter,
+    pub player_filter: PlayerFilter,
+}
+
+impl DamageFromSourceToPlayerMatcher {
+    pub fn new(source_filter: ObjectFilter, player_filter: PlayerFilter) -> Self {
+        Self {
+            source_filter,
+            player_filter,
+        }
+    }
+
+    pub fn to_you(source_filter: ObjectFilter) -> Self {
+        Self::new(source_filter, PlayerFilter::You)
+    }
+}
+
+impl ReplacementMatcher for DamageFromSourceToPlayerMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        if event.event_kind() != EventKind::Damage {
+            return false;
+        }
+
+        let Some(damage) = downcast_event::<DamageEvent>(event) else {
+            return false;
+        };
+
+        if damage.is_unpreventable {
+            return false;
+        }
+
+        let DamageTarget::Player(player_id) = damage.target else {
+            return false;
+        };
+        if !self
+            .player_filter
+            .matches_player(player_id, &ctx.filter_ctx)
+        {
+            return false;
+        }
+
+        ctx.game.object(damage.source).is_some_and(|source_obj| {
+            self.source_filter
+                .matches(source_obj, &ctx.filter_ctx, ctx.game)
+        }) || ctx
+            .event_source_snapshot
+            .filter(|snapshot| snapshot.object_id == damage.source)
+            .is_some_and(|snapshot| {
+                self.source_filter
+                    .matches_snapshot(snapshot, &ctx.filter_ctx, ctx.game)
+            })
+    }
+
+    fn priority(&self) -> ReplacementPriority {
+        ReplacementPriority::Other
+    }
+
+    fn display(&self) -> String {
+        "When damage would be dealt to a player by a matching source".to_string()
+    }
+}
+
 /// Matches damage from a source filter to an object target filter.
 #[derive(Debug, Clone)]
 pub struct DamageFromSourceToObjectMatcher {
@@ -1080,6 +1145,55 @@ mod tests {
     }
 
     #[test]
+    fn test_damage_from_source_to_player_matcher() {
+        let mut game = setup_game();
+        let alice = crate::ids::PlayerId::from_index(0);
+        let bob = crate::ids::PlayerId::from_index(1);
+
+        let replacement_source_card = CardBuilder::new(CardId::new(), "Prevention Source")
+            .card_types(vec![CardType::Enchantment])
+            .build();
+        let replacement_source =
+            game.create_object_from_card(&replacement_source_card, alice, Zone::Battlefield);
+
+        let creature_source_card = CardBuilder::new(CardId::new(), "Creature Source")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let creature_source =
+            game.create_object_from_card(&creature_source_card, bob, Zone::Battlefield);
+
+        let artifact_source_card = CardBuilder::new(CardId::new(), "Artifact Source")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_source =
+            game.create_object_from_card(&artifact_source_card, bob, Zone::Battlefield);
+
+        let matcher = DamageFromSourceToPlayerMatcher::to_you(ObjectFilter::creature());
+        let ctx = EventContext::for_replacement_effect(alice, replacement_source, &game);
+
+        let matching_damage = damage(creature_source, DamageTarget::Player(alice), 3, false);
+        assert!(matcher.matches_event(&matching_damage, &ctx));
+
+        let nonmatching_source = damage(artifact_source, DamageTarget::Player(alice), 3, false);
+        assert!(!matcher.matches_event(&nonmatching_source, &ctx));
+
+        let wrong_player = damage(creature_source, DamageTarget::Player(bob), 3, false);
+        assert!(!matcher.matches_event(&wrong_player, &ctx));
+
+        let object_target = damage(
+            creature_source,
+            DamageTarget::Object(replacement_source),
+            3,
+            false,
+        );
+        assert!(!matcher.matches_event(&object_target, &ctx));
+
+        let unpreventable =
+            unpreventable_damage(creature_source, DamageTarget::Player(alice), 3, false);
+        assert!(!matcher.matches_event(&unpreventable, &ctx));
+    }
+
+    #[test]
     fn test_damage_source_filter_matchers_use_lki_for_departed_source() {
         let mut game = setup_game();
         let alice = crate::ids::PlayerId::from_index(0);
@@ -1111,6 +1225,10 @@ mod tests {
             .with_event_source_snapshot(Some(&source_snapshot));
 
         assert!(DamageFromSourceMatcher::from_creature().matches_event(&from_creature, &ctx));
+        assert!(DamageFromSourceToPlayerMatcher::to_you(ObjectFilter::creature()).matches_event(
+            &damage(source, DamageTarget::Player(alice), 3, false),
+            &ctx
+        ));
         assert!(
             PreventableDamageConstraintMatcher::from_filter(
                 ObjectFilter::creature(),

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -25,8 +25,9 @@ use crate::events::context::EventContext;
 use crate::events::damage::DamageEvent;
 use crate::events::damage::matchers::{
     DamageFromSelfCombatMatcher, DamageFromSelfMatcher, DamageFromSourceToObjectMatcher,
-    DamageToObjectMatcher, DamageToOtherCreatureYouControlMatcher, DamageToPlayerOrObjectMatcher,
-    DamageToSelfCombatMatcher, DamageToSelfConstraintMatcher, DamageToSelfFromSourceFilterMatcher,
+    DamageFromSourceToPlayerMatcher, DamageToObjectMatcher, DamageToOtherCreatureYouControlMatcher,
+    DamageToPlayerOrObjectMatcher, DamageToSelfCombatMatcher, DamageToSelfConstraintMatcher,
+    DamageToSelfFromSourceFilterMatcher,
 };
 use crate::events::permanents::matchers::AttachedPermanentWouldBeDestroyedMatcher;
 use crate::events::traits::{
@@ -1876,6 +1877,47 @@ impl StaticAbilityKind for PreventAllDamageToSelfByCreatures {
             controller,
             DamageToSelfFromSourceFilterMatcher::from_creature(),
             ReplacementAction::Prevent,
+        ))
+    }
+}
+
+/// "If a matching source would deal damage to you, prevent N of that damage."
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreventDamageToYouFromSourceFilter {
+    pub amount: u32,
+    pub source_filter: ObjectFilter,
+    pub display: String,
+}
+
+impl PreventDamageToYouFromSourceFilter {
+    pub fn new(amount: u32, source_filter: ObjectFilter, display: impl Into<String>) -> Self {
+        Self {
+            amount,
+            source_filter,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for PreventDamageToYouFromSourceFilter {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::PreventDamageToYouFromSourceFilter
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            DamageFromSourceToPlayerMatcher::to_you(self.source_filter.clone()),
+            ReplacementAction::Modify(EventModification::Subtract(self.amount)),
         ))
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2339,6 +2339,18 @@ impl StaticAbility {
         Self::new(PreventAllDamageToSelfByCreatures)
     }
 
+    pub fn prevent_damage_to_you_from_source_filter(
+        amount: u32,
+        source_filter: crate::target::ObjectFilter,
+        display: impl Into<String>,
+    ) -> Self {
+        Self::new(PreventDamageToYouFromSourceFilter::new(
+            amount,
+            source_filter,
+            display,
+        ))
+    }
+
     pub fn prevent_damage_to_self_remove_counter(
         counter_type: crate::object::CounterType,
         amount: u32,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1401,6 +1401,15 @@ impl StaticAbilityModelInterpreter {
                 source_filter.clone(),
                 *combat_only,
             ),
+            ironsmith_core::StaticAbilityPayload::PreventDamageToYouFromSourceFilter {
+                amount,
+                source_filter,
+                display,
+            } => StaticAbility::prevent_damage_to_you_from_source_filter(
+                *amount,
+                source_filter.clone(),
+                display.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::ReplaceDamageWithCountersInstead {
                 counter_type,
                 display,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sphere of Truth
Initial parse error:
```
could not find verb in effect clause (clause: 'prevent 2 of that damage'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'prevent 2 of that damage'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0c8c59e5142da2d34
Branch: codex/aws-card-fix-sphere-of-truth
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0004
