### PR TITLE
Fix Ironsmith parse failure: Vexing Shusher

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -94,14 +94,7 @@ fn compile_effect_inner(
         return compile_subject_verb_effect(subject_verb, ctx);
     }
     if let EffectAst::Sequence { effects } = effect {
-        let mut compiled_effects = Vec::new();
-        let mut choices = Vec::new();
-        for child in effects {
-            let (mut child_effects, mut child_choices) = compile_effect(child, ctx)?;
-            compiled_effects.append(&mut child_effects);
-            choices.append(&mut child_choices);
-        }
-        return Ok((compiled_effects, choices));
+        return compile_effects(effects, ctx);
     }
     if let EffectAst::ManaRestricted {
         effects,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -880,6 +880,22 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         );
     }
 
+    if token_slice_first_is(tokens, "target")
+        && find_negation_span(tokens).is_some()
+        && let (duration, clause_tokens) =
+            parse_restriction_duration(tokens)?.unwrap_or((Until::Forever, tokens.to_vec()))
+        && let Some(restrictions) = parse_cant_restrictions(&clause_tokens)?
+        && let [parsed] = restrictions.as_slice()
+        && let Some(target) = parsed.target.clone()
+    {
+        return Ok(EffectAst::Sequence {
+            effects: vec![
+                EffectAst::subject_verb_target_only(target),
+                EffectAst::subject_verb_cant(parsed.restriction.clone(), duration, None),
+            ],
+        });
+    }
+
     if token_slice_first_is(tokens, "target") && find_verb(tokens).is_none() {
         let looks_like_restriction_clause = find_negation_span(tokens).is_some()
             || word_slice_contains_any_word(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2534,6 +2534,80 @@ fn test_parse_uncounterable_from_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn vexing_shusher_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Vexing Shusher");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("This spell can't be countered."),
+        "expected static uncounterable line for Vexing Shusher, got {rendered}"
+    );
+    assert!(
+        rendered.contains("{R/G}: Target spell can't be countered."),
+        "expected targeted activated uncounterable line for Vexing Shusher, got {rendered}"
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Vexing Shusher should have an activated ability");
+    let default_effects = activated
+        .effects
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .collect::<Vec<_>>();
+    fn find_target_only(effect: &crate::effect::Effect) -> Option<&TargetOnlyEffect> {
+        effect.downcast_ref::<TargetOnlyEffect>().or_else(|| {
+            effect
+                .downcast_ref::<TaggedEffect>()
+                .and_then(|tagged| find_target_only(&tagged.effect))
+        })
+    }
+    fn find_cant_effect(effect: &crate::effect::Effect) -> Option<&crate::effects::CantEffect> {
+        effect.downcast_ref::<crate::effects::CantEffect>().or_else(|| {
+            effect
+                .downcast_ref::<TaggedEffect>()
+                .and_then(|tagged| find_cant_effect(&tagged.effect))
+        })
+    }
+
+    let target_only = default_effects
+        .iter()
+        .find_map(|effect| find_target_only(effect))
+        .expect("Vexing Shusher activation should expose a target-only spell choice");
+    assert_eq!(
+        target_only.target.inner(),
+        &ChooseSpec::spell(),
+        "Vexing Shusher activation should target a spell, got {:?}",
+        target_only.target
+    );
+
+    let cant_effect = default_effects
+        .iter()
+        .find_map(|effect| find_cant_effect(effect))
+        .expect("Vexing Shusher activation should apply a cant-be-countered effect");
+    match &cant_effect.restriction {
+        crate::effect::Restriction::BeCountered(filter) => {
+            assert_eq!(filter.zone, Some(Zone::Stack));
+            assert_eq!(filter.stack_kind, Some(crate::filter::StackObjectKind::Spell));
+            assert!(
+                filter.tagged_constraints.iter().any(|constraint| {
+                    constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                }),
+                "Vexing Shusher's restriction should be tied to the chosen spell target, got {filter:?}"
+            );
+        }
+        other => panic!("expected Vexing Shusher be-countered restriction, got {other:?}"),
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_spells_cant_be_countered_as_rule_restriction() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Global No Counter")
         .parse_text("Spells can't be countered.")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -19175,9 +19175,6 @@ pub(super) fn describe_tagged_target_then_cant_restriction(
     let target_only = tagged
         .effect
         .downcast_ref::<crate::effects::TargetOnlyEffect>()?;
-    if cant.duration != crate::effect::Until::EndOfTurn {
-        return None;
-    }
     if let crate::effect::Restriction::BlockSpecificAttacker { blockers, attacker } =
         &cant.restriction
         && attacker.tagged_constraints.iter().any(|constraint| {
@@ -19185,11 +19182,39 @@ pub(super) fn describe_tagged_target_then_cant_restriction(
                 && constraint.tag.as_str() == tagged.tag.as_str()
         })
     {
+        if cant.duration != crate::effect::Until::EndOfTurn {
+            return None;
+        }
         let subject = capitalize_first(&describe_choose_spec(&target_only.target));
         let blockers = pluralize_noun_phrase(strip_leading_article(&blockers.description()));
         return Some(format!(
             "{subject} can't be blocked by {blockers} this turn"
         ));
+    }
+    if let crate::effect::Restriction::BeCountered(filter) = &cant.restriction {
+        if !matches!(
+            cant.duration,
+            crate::effect::Until::Forever | crate::effect::Until::EndOfTurn
+        ) {
+            return None;
+        }
+        if !filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag.as_str() == tagged.tag.as_str()
+        }) {
+            return None;
+        }
+
+        let subject = capitalize_first(&describe_choose_spec(&target_only.target));
+        let suffix = if cant.duration == crate::effect::Until::EndOfTurn {
+            " this turn"
+        } else {
+            ""
+        };
+        return Some(format!("{subject} can't be countered{suffix}"));
+    }
+    if cant.duration != crate::effect::Until::EndOfTurn {
+        return None;
     }
     let (filter, restriction_text) = match &cant.restriction {
         crate::effect::Restriction::Block(filter) => (filter, "can't block this turn"),

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -131,6 +131,9 @@ fn normalize_restriction_for_resolution(
         Restriction::BeBlocked(filter) => Restriction::be_blocked(
             collapse_tagged_filter_to_specific_objects(filter, ctx, game),
         ),
+        Restriction::BeCountered(filter) => Restriction::be_countered(
+            collapse_tagged_filter_to_specific_objects(filter, ctx, game),
+        ),
         Restriction::MustBeBlocked(filter) => Restriction::must_be_blocked(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11103,6 +11103,151 @@ fn stack_spell_with_granted_static_ability_still_executes_spell_effect() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn vexing_shusher_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(489_898), "Vexing Shusher")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Red, ManaSymbol::Green],
+            vec![ManaSymbol::Red, ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Goblin, Subtype::Shaman])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("This spell can't be countered.\n{R/G}: Target spell can't be countered.")
+        .expect("Vexing Shusher should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn vexing_shusher_activation_targets_spell_and_stops_countering_it() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let shusher = vexing_shusher_definition();
+    let shusher_id = game.create_object_from_definition(&shusher, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. }
+                    if source == shusher_id
+            )),
+        "Vexing Shusher activation should be illegal without a spell target"
+    );
+
+    let target_card = CardBuilder::new(CardId::new(), "Target Spell")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .build();
+    let target_spell = game.create_object_from_card(&target_card, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+
+    let ability_index = game
+        .object(shusher_id)
+        .expect("Vexing Shusher should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Vexing Shusher should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == shusher_id && *idx == ability_index
+            )
+        })
+        .expect("Vexing Shusher activation should be legal with a spell target and mana");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Vexing Shusher activation should start");
+
+    let progress = match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::HybridChoice(_),
+        ) => apply_priority_response_with_dm(
+            &mut game,
+            &mut trigger_queue,
+            &mut state,
+            &PriorityResponse::HybridChoice(0),
+            &mut dm,
+        )
+        .expect("choosing the red side of {R/G} should continue activation"),
+        other => other,
+    };
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Vexing Shusher, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_spell)]),
+        &mut dm,
+    )
+    .expect("choosing the target spell should complete activation");
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").mana_pool.total(),
+        0,
+        "Vexing Shusher activation should spend the chosen hybrid mana"
+    );
+
+    resolve_stack_entry(&mut game).expect("Vexing Shusher ability should resolve");
+    assert!(
+        !game.can_be_countered(target_spell),
+        "targeted spell should not be counterable after Vexing Shusher resolves"
+    );
+
+    let counter_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Counter Source")
+            .card_types(vec![CardType::Instant])
+            .build(),
+        bob,
+        Zone::Stack,
+    );
+    let mut counter_dm = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(counter_source, bob, &mut counter_dm);
+    let outcome = crate::effects::execute_effect(
+        &mut game,
+        &Effect::counter(crate::target::ChooseSpec::SpecificObject(target_spell)),
+        &mut ctx,
+    )
+    .expect("counter attempt should resolve as protected");
+
+    assert_eq!(outcome.status, crate::effect::OutcomeStatus::Protected);
+    assert!(
+        game.stack.iter().any(|entry| entry.object_id == target_spell),
+        "protected target spell should remain on the stack after a counter attempt"
+    );
+}
+
 #[test]
 fn magma_mine_activated_ability_sacrifices_source_and_deals_counter_scaled_damage_to_player() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vexing Shusher
Initial parse error:
```
unsupported target-only restriction clause (clause: 'target spell cant be countered') [rule=target-only-restriction]; oracle-only fallback also failed: unsupported target-only restriction clause (clause: 'target spell cant be countered') [rule=target-only-restriction]
```

Current worker: i-0dcdb1783d0257abb
Branch: codex/aws-card-fix-vexing-shusher
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0004
