### PR TITLE
Fix Ironsmith parse failure: Shiny Impetus

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -4513,31 +4513,36 @@ pub(crate) fn parse_anthem_and_goaded_line(
         build_anthem_static_ability(&clause).into(),
         crate::static_abilities::StaticAbility::attached_goaded_by_source_controller(format!(
             "{} is goaded",
-            capitalize_display_subject(display_subject)
+            capitalize_display_subject(&display_subject)
         ))
         .into(),
     ]))
 }
 
-fn attached_goaded_display_subject(subject: &AnthemSubjectAst) -> Option<&'static str> {
+fn attached_goaded_display_subject(subject: &AnthemSubjectAst) -> Option<String> {
     let AnthemSubjectAst::Filter(filter) = subject else {
         return None;
     };
-    let has_attached_tag = filter.tagged_constraints.iter().any(|constraint| {
-        matches!(
+    let attachment = filter.tagged_constraints.iter().find_map(|constraint| {
+        if !matches!(
             constraint.relation,
             crate::filter::TaggedOpbjectRelation::IsTaggedObject
-        ) && matches!(constraint.tag.as_str(), "enchanted" | "equipped")
-    });
-    if !has_attached_tag {
-        return None;
-    }
+        ) {
+            return None;
+        }
+        match constraint.tag.as_str() {
+            "enchanted" => Some("enchanted"),
+            "equipped" => Some("equipped"),
+            _ => None,
+        }
+    })?;
 
-    if filter.card_types.contains(&CardType::Creature) {
-        Some("enchanted creature")
+    let noun = if filter.card_types.contains(&CardType::Creature) {
+        "creature"
     } else {
-        Some("enchanted permanent")
-    }
+        "permanent"
+    };
+    Some(format!("{attachment} {noun}"))
 }
 
 fn capitalize_display_subject(subject: &str) -> String {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -4480,6 +4480,74 @@ pub(crate) fn parse_anthem_and_keyword_line(
     Ok(Some(result))
 }
 
+pub(crate) fn parse_anthem_and_goaded_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(get_idx) = anthem_token_offset(tokens, |token| {
+        token.is_word("get") || token.is_word("gets")
+    }) else {
+        return Ok(None);
+    };
+
+    let Some(and_idx) = anthem_token_offset_from(tokens, get_idx + 1, |token| token.is_word("and"))
+    else {
+        return Ok(None);
+    };
+
+    let tail_tokens = trim_edge_punctuation(&tokens[and_idx + 1..]);
+    let tail_words = crate::runtime_backend::token_word_refs(&tail_tokens);
+    if !matches!(tail_words.as_slice(), ["is", "goaded"] | ["are", "goaded"]) {
+        return Ok(None);
+    }
+
+    let clause = parse_anthem_clause(tokens, get_idx, and_idx)?;
+    let display_subject = attached_goaded_display_subject(&clause.subject).ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "unsupported goaded anthem subject (clause: '{}')",
+            clause_words.join(" ")
+        ))
+    })?;
+
+    Ok(Some(vec![
+        build_anthem_static_ability(&clause).into(),
+        crate::static_abilities::StaticAbility::attached_goaded_by_source_controller(format!(
+            "{} is goaded",
+            capitalize_display_subject(display_subject)
+        ))
+        .into(),
+    ]))
+}
+
+fn attached_goaded_display_subject(subject: &AnthemSubjectAst) -> Option<&'static str> {
+    let AnthemSubjectAst::Filter(filter) = subject else {
+        return None;
+    };
+    let has_attached_tag = filter.tagged_constraints.iter().any(|constraint| {
+        matches!(
+            constraint.relation,
+            crate::filter::TaggedOpbjectRelation::IsTaggedObject
+        ) && matches!(constraint.tag.as_str(), "enchanted" | "equipped")
+    });
+    if !has_attached_tag {
+        return None;
+    }
+
+    if filter.card_types.contains(&CardType::Creature) {
+        Some("enchanted creature")
+    } else {
+        Some("enchanted permanent")
+    }
+}
+
+fn capitalize_display_subject(subject: &str) -> String {
+    let mut chars = subject.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
 fn push_type_color_additions_for_anthem_subject(
     result: &mut Vec<StaticAbilityAst>,
     clause: &ParsedAnthemClause,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -685,6 +685,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
             id: stringify!(parse_anthem_and_keyword_line),
             rule: StaticAbilityLineRuleAst::Multi(parse_anthem_and_keyword_line),
         },
+        multi_static_ability_ast_rule!(parse_anthem_and_goaded_line),
         multi_static_ability_ast_passthrough_rule!(parse_anthem_and_granted_ability_line),
         multi_static_ability_ast_passthrough_rule!(
             parse_subject_has_keywords_and_cant_be_blocked_line

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -75,8 +75,10 @@ pub enum StaticAbilityId {
     CantBeBlockedExceptByNOrMore,
     CanAttackAsThoughNoDefender,
     MustAttack,
+    GoadedBySourceController,
     MustAttackAttachedController,
     AllCreaturesAttackAttachedControllerEachCombatIfAble,
+    AttachedGoadedBySourceController,
     ExertAttack,
     MustBlock,
     CantAttack,
@@ -328,8 +330,10 @@ impl StaticAbilityId {
             | CantBeBlockedExceptByNOrMore
             | CanAttackAsThoughNoDefender
             | MustAttack
+            | GoadedBySourceController
             | MustAttackAttachedController
             | AllCreaturesAttackAttachedControllerEachCombatIfAble
+            | AttachedGoadedBySourceController
             | ExertAttack
             | MustBlock
             | CantAttack

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1799,6 +1799,10 @@ impl<
         Self::identified(StaticAbilityId::MustAttack, "must attack")
     }
 
+    pub fn attached_goaded_by_source_controller(display: impl Into<String>) -> Self {
+        Self::identified(StaticAbilityId::AttachedGoadedBySourceController, display)
+    }
+
     pub fn all_creatures_attack_attached_controller_each_combat_if_able() -> Self {
         Self::identified(
             StaticAbilityId::AllCreaturesAttackAttachedControllerEachCombatIfAble,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -465,6 +465,30 @@ fn parse_shiny_impetus_oracle_and_compiled_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_equipment_attached_goaded_anthem_preserves_equipped_subject() {
+    let def = parse_oracle_card_definition("Bloodthirsty Blade");
+    let rendered_lines = canonical_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered_lines
+            .iter()
+            .any(|line| line == "Equipped creature gets +2/+0 and is goaded."),
+        "Bloodthirsty Blade should keep the Equipment subject in compiled text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("Enchanted creature is goaded"),
+        "Equipment goad text should not render as enchanted, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("Anthem") && ability_debug.contains("AttachedGoadedBySourceController"),
+        "Bloodthirsty Blade should structurally model equipment anthem and goad, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn shiny_impetus_buffs_and_goads_enchanted_creature_away_from_aura_controller() {
     let shiny_impetus = parse_oracle_card_definition("Shiny Impetus");
     let creature = CardDefinitionBuilder::new(CardId::from_raw(91_120), "Grizzly Bears")

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -440,6 +440,246 @@ fn public_enemy_does_not_force_attack_when_enchanted_creatures_controller_cant_b
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_shiny_impetus_oracle_and_compiled_text() {
+    let def = parse_oracle_card_definition("Shiny Impetus");
+    let rendered_lines = canonical_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Enchant creature".to_string(),
+            "Enchanted creature gets +2/+2 and is goaded.".to_string(),
+            "Whenever enchanted creature attacks, create a Treasure token.".to_string(),
+        ],
+        "Shiny Impetus should keep its exact compiled oracle shape, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("Anthem")
+            && ability_debug.contains("AttachedGoadedBySourceController")
+            && ability_debug.contains("CreateTokenEffect"),
+        "Shiny Impetus should structurally model anthem, goad, and Treasure trigger, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn shiny_impetus_buffs_and_goads_enchanted_creature_away_from_aura_controller() {
+    let shiny_impetus = parse_oracle_card_definition("Shiny Impetus");
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_120), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+        ],
+        20,
+    );
+
+    let enchanted_creature = game.create_object_from_definition(&creature, bob, Zone::Battlefield);
+    let aura = game.create_object_from_definition(&shiny_impetus, alice, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura,
+        crate::object::AttachmentTarget::Object(enchanted_creature),
+    ));
+    game.remove_summoning_sickness(enchanted_creature);
+    game.turn.active_player = bob;
+
+    assert_eq!(game.current_power(enchanted_creature), Some(4));
+    assert_eq!(game.current_toughness(enchanted_creature), Some(4));
+    assert!(
+        game.is_goaded(enchanted_creature),
+        "Shiny Impetus should make the enchanted creature goaded"
+    );
+
+    let combat = crate::combat_state::CombatState::default();
+    let options = crate::decision::compute_legal_attackers(&game, &combat);
+    let attacker_option = options
+        .iter()
+        .find(|option| option.creature == enchanted_creature)
+        .expect("enchanted creature should be attack-capable");
+    assert!(
+        attacker_option.must_attack,
+        "goaded enchanted creature should be required to attack"
+    );
+    assert!(
+        !attacker_option
+            .valid_targets
+            .contains(&crate::combat_state::AttackTarget::Player(alice)),
+        "goaded creature should not attack the Aura controller while another player is attackable"
+    );
+    assert!(
+        attacker_option
+            .valid_targets
+            .contains(&crate::combat_state::AttackTarget::Player(charlie)),
+        "goaded creature should attack a non-goading player when able"
+    );
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let wrong_target = [crate::AttackerDeclaration {
+        creature: enchanted_creature,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    }];
+    assert!(
+        crate::game_loop::apply_attacker_declarations(
+            &mut game,
+            &mut combat,
+            &mut trigger_queue,
+            &wrong_target,
+        )
+        .is_err(),
+        "attacking the Aura controller should be illegal while a non-goading player is attackable"
+    );
+
+    let correct_target = [crate::AttackerDeclaration {
+        creature: enchanted_creature,
+        target: crate::combat_state::AttackTarget::Player(charlie),
+    }];
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &correct_target,
+    )
+    .expect("attacking a non-goading player should be legal");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn shiny_impetus_creates_treasure_when_enchanted_creature_attacks() {
+    let shiny_impetus = parse_oracle_card_definition("Shiny Impetus");
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_122), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+        ],
+        20,
+    );
+
+    let enchanted_creature = game.create_object_from_definition(&creature, bob, Zone::Battlefield);
+    let aura = game.create_object_from_definition(&shiny_impetus, alice, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura,
+        crate::object::AttachmentTarget::Object(enchanted_creature),
+    ));
+    game.remove_summoning_sickness(enchanted_creature);
+    game.turn.active_player = bob;
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let attack = [crate::AttackerDeclaration {
+        creature: enchanted_creature,
+        target: crate::combat_state::AttackTarget::Player(charlie),
+    }];
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &attack,
+    )
+    .expect("enchanted creature should be able to attack a non-goading player");
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Shiny Impetus should queue exactly one attack trigger"
+    );
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Shiny Impetus attack trigger should go on the stack");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "Shiny Impetus should create exactly one attack trigger"
+    );
+
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Shiny Impetus attack trigger should resolve");
+    let treasure_count = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id).is_some_and(|object| {
+                object.name == "Treasure" && game.controller_of(object) == alice
+            })
+        })
+        .count();
+    assert_eq!(
+        treasure_count, 1,
+        "Shiny Impetus should create one Treasure controlled by the Aura controller"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn shiny_impetus_allows_attacking_aura_controller_when_no_other_player_is_attackable() {
+    let shiny_impetus = parse_oracle_card_definition("Shiny Impetus");
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_121), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+        ],
+        20,
+    );
+
+    let enchanted_creature = game.create_object_from_definition(&creature, bob, Zone::Battlefield);
+    let aura = game.create_object_from_definition(&shiny_impetus, alice, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura,
+        crate::object::AttachmentTarget::Object(enchanted_creature),
+    ));
+    game.remove_summoning_sickness(enchanted_creature);
+    game.effect_store
+        .cant_effects
+        .add_cant_attack_defenders(enchanted_creature, [charlie]);
+    game.turn.active_player = bob;
+
+    let combat = crate::combat_state::CombatState::default();
+    let options = crate::decision::compute_legal_attackers(&game, &combat);
+    let attacker_option = options
+        .iter()
+        .find(|option| option.creature == enchanted_creature)
+        .expect("enchanted creature should still be able to attack the Aura controller");
+    assert!(
+        attacker_option.must_attack,
+        "goad should still require attacking if only the goading player can be attacked"
+    );
+    assert_eq!(
+        attacker_option.valid_targets,
+        vec![crate::combat_state::AttackTarget::Player(alice)],
+        "when no non-goading player is attackable, goad should allow attacking the Aura controller"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_lantern_of_insight_public_top_library_static() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Lantern of Insight Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -581,6 +581,48 @@ fn shiny_impetus_buffs_and_goads_enchanted_creature_away_from_aura_controller() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn shiny_impetus_stops_buffing_and_goading_when_aura_leaves_battlefield() {
+    let shiny_impetus = parse_oracle_card_definition("Shiny Impetus");
+    let creature = CardDefinitionBuilder::new(CardId::from_raw(91_123), "Grizzly Bears")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+        ],
+        20,
+    );
+
+    let enchanted_creature = game.create_object_from_definition(&creature, bob, Zone::Battlefield);
+    let aura = game.create_object_from_definition(&shiny_impetus, alice, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura,
+        crate::object::AttachmentTarget::Object(enchanted_creature),
+    ));
+
+    assert_eq!(game.current_power(enchanted_creature), Some(4));
+    assert_eq!(game.current_toughness(enchanted_creature), Some(4));
+    assert!(game.is_goaded(enchanted_creature));
+
+    game.move_object_by_effect(aura, Zone::Graveyard)
+        .expect("Shiny Impetus should move to graveyard");
+
+    assert_eq!(game.current_power(enchanted_creature), Some(2));
+    assert_eq!(game.current_toughness(enchanted_creature), Some(2));
+    assert!(
+        !game.is_goaded(enchanted_creature),
+        "Shiny Impetus should stop goading after it leaves the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn shiny_impetus_creates_treasure_when_enchanted_creature_attacks() {
     let shiny_impetus = parse_oracle_card_definition("Shiny Impetus");
     let creature = CardDefinitionBuilder::new(CardId::from_raw(91_122), "Grizzly Bears")

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -18,6 +18,7 @@ use crate::continuous::{
 };
 use crate::cost::OptionalCostsPaid;
 use crate::decision::KeywordPaymentContribution;
+use crate::derived_view::DerivedGameView;
 use crate::dungeon::ActiveDungeonProgress;
 use crate::effect::Until;
 use crate::events::{Event, EventKind, KeywordActionKind};
@@ -2921,12 +2922,42 @@ impl GameState {
 
     pub fn active_goaders_for(&self, creature: ObjectId) -> HashSet<PlayerId> {
         let current_turn = self.turn.turn_number;
-        self.effect_store
+        let mut goaders: HashSet<PlayerId> = self
+            .effect_store
             .goad_effects
             .iter()
             .filter(|effect| effect.creature == creature && effect.is_active(self, current_turn))
             .map(|effect| effect.goaded_by)
-            .collect()
+            .collect();
+
+        let view = DerivedGameView::new(self);
+        let static_abilities = view
+            .calculated_characteristics(creature)
+            .map(|chars| chars.static_abilities)
+            .or_else(|| {
+                self.object(creature).map(|object| {
+                    object
+                        .abilities
+                        .iter()
+                        .filter_map(|ability| match &ability.kind {
+                            AbilityKind::Static(static_ability) => Some(static_ability.clone()),
+                            _ => None,
+                        })
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+
+        if let Some(object) = self.object(creature) {
+            let controller = self.controller_of(object);
+            for ability in static_abilities {
+                if let Some(player) = ability.goaded_by_player(self, creature, controller) {
+                    goaders.insert(player);
+                }
+            }
+        }
+
+        goaders
     }
 
     pub fn is_goaded(&self, creature: ObjectId) -> bool {
@@ -7787,22 +7818,25 @@ impl GameState {
             && let Some(source_obj) = self.object(source_id)
         {
             tagged_objects.extend(source_obj.cast_tagged_objects.clone());
+            let source_is_aura = source_obj.subtypes.contains(&crate::types::Subtype::Aura)
+                || (source_obj.card_types.contains(&crate::types::CardType::Enchantment)
+                    && source_obj.aura_attach_filter.is_some());
+            let source_is_equipment = source_obj
+                .subtypes
+                .contains(&crate::types::Subtype::Equipment);
             if let Some(attached_target) = source_obj.attached_to {
                 match attached_target {
                     AttachmentTarget::Object(attached_id) => {
                         if let Some(attached_obj) = self.object(attached_id) {
                             let attached_snapshot =
                                 crate::snapshot::ObjectSnapshot::from_object(attached_obj, self);
-                            if source_obj.subtypes.contains(&crate::types::Subtype::Aura) {
+                            if source_is_aura {
                                 tagged_objects.insert(
                                     crate::tag::TagKey::from("enchanted"),
                                     vec![attached_snapshot.clone()],
                                 );
                             }
-                            if source_obj
-                                .subtypes
-                                .contains(&crate::types::Subtype::Equipment)
-                            {
+                            if source_is_equipment {
                                 tagged_objects.insert(
                                     crate::tag::TagKey::from("equipped"),
                                     vec![attached_snapshot],
@@ -7811,7 +7845,7 @@ impl GameState {
                         }
                     }
                     AttachmentTarget::Player(attached_player) => {
-                        if source_obj.subtypes.contains(&crate::types::Subtype::Aura) {
+                        if source_is_aura {
                             tagged_players.insert(
                                 crate::tag::TagKey::from("enchanted"),
                                 vec![attached_player],

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -748,6 +748,80 @@ impl StaticAbilityKind for MustAttack {
     // by checking if creatures have this ability, rather than using a tracker.
 }
 
+/// Goaded by the controller of another permanent, usually an Aura.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GoadedBySourceController {
+    source: ObjectId,
+}
+
+impl GoadedBySourceController {
+    pub const fn new(source: ObjectId) -> Self {
+        Self { source }
+    }
+}
+
+impl StaticAbilityKind for GoadedBySourceController {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::GoadedBySourceController
+    }
+
+    fn display(&self) -> String {
+        "Goaded".to_string()
+    }
+
+    fn goaded_by_player(
+        &self,
+        game: &GameState,
+        _source: ObjectId,
+        _controller: PlayerId,
+    ) -> Option<PlayerId> {
+        game.object(self.source).map(|object| game.controller_of(object))
+    }
+}
+
+/// The object enchanted/equipped by this permanent is goaded by this permanent's controller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachedGoadedBySourceController {
+    display: String,
+}
+
+impl AttachedGoadedBySourceController {
+    pub fn new(display: impl Into<String>) -> Self {
+        Self {
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for AttachedGoadedBySourceController {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::AttachedGoadedBySourceController
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_effects(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+        _game: &GameState,
+    ) -> Vec<crate::continuous::ContinuousEffect> {
+        vec![
+            crate::continuous::ContinuousEffect::new(
+                source,
+                controller,
+                crate::continuous::EffectTarget::AttachedTo(source),
+                crate::continuous::Modification::AddAbility(
+                    crate::static_abilities::StaticAbility::goaded_by_source_controller(source),
+                ),
+            )
+            .with_source_type(crate::continuous::EffectSourceType::StaticAbility),
+        ]
+    }
+}
+
 /// Must attack the controller of the object enchanted/equipped by another source if able.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MustAttackAttachedController {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -100,6 +100,9 @@ impl StaticAbility {
             Some(StaticAbilityId::MayAssignDamageAsUnblocked) => {
                 Self::may_assign_damage_as_unblocked()
             }
+            Some(StaticAbilityId::AttachedGoadedBySourceController) => {
+                Self::attached_goaded_by_source_controller(label)
+            }
             Some(StaticAbilityId::DoesntUntap) => Self::doesnt_untap(),
             Some(StaticAbilityId::BoastTwiceEachTurn) => Self::boast_twice_each_turn(),
             Some(StaticAbilityId::EquipAbilitiesAnyTime) => Self::equip_abilities_any_time(),

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -403,6 +403,16 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Player currently goading this creature through a static ability.
+    fn goaded_by_player(
+        &self,
+        _game: &GameState,
+        _source: ObjectId,
+        _controller: PlayerId,
+    ) -> Option<PlayerId> {
+        None
+    }
+
     /// Attacking-group legality hook for "can't attack unless ... also attacks" style clauses.
     ///
     /// Return:
@@ -1216,6 +1226,15 @@ impl StaticAbility {
         self.0.required_attack_player(game, source, controller)
     }
 
+    pub fn goaded_by_player(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<PlayerId> {
+        self.0.goaded_by_player(game, source, controller)
+    }
+
     pub fn can_attack_with_attacking_group(
         &self,
         game: &GameState,
@@ -1749,8 +1768,16 @@ impl StaticAbility {
         Self::new(MustAttack)
     }
 
+    pub fn goaded_by_source_controller(source: ObjectId) -> Self {
+        Self::new(GoadedBySourceController::new(source))
+    }
+
     pub fn must_attack_attached_controller(attachment_source: ObjectId) -> Self {
         Self::new(MustAttackAttachedController::new(attachment_source))
+    }
+
+    pub fn attached_goaded_by_source_controller(display: impl Into<String>) -> Self {
+        Self::new(AttachedGoadedBySourceController::new(display))
     }
 
     pub fn all_creatures_attack_attached_controller_each_combat_if_able() -> Self {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Shiny Impetus
Initial parse error:
```
unsupported trailing anthem clause (clause: 'enchanted creature gets +2/+2 and is goaded'); oracle-only fallback also failed: unsupported trailing anthem clause (clause: 'enchanted creature gets +2/+2 and is goaded')
```

Current worker: i-04507f95ccbddaad4
Branch: codex/aws-card-fix-shiny-impetus
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0004
