### PR TITLE
Fix Ironsmith parse failure: Travel Through Caradhras

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -81,6 +81,37 @@ fn effect_needs_followup_library_shuffle(effect: &EffectAst) -> bool {
     found
 }
 
+fn shuffle_library_if_previous_effect_happened() -> EffectAst {
+    EffectAst::IfResult {
+        predicate: IfResultPredicate::Did,
+        effects: vec![EffectAst::subject_verb(
+            SubjectVerbRoleAst::LibraryOwner,
+            PlayerAst::You,
+            SubjectVerbActionAst::ShuffleLibrary,
+        )],
+    }
+}
+
+fn append_library_shuffle_followup_to_latest_search(effects: &mut Vec<EffectAst>) -> bool {
+    let Some(last) = effects.last_mut() else {
+        return false;
+    };
+
+    if let EffectAst::VoteOption { effects, .. } = last
+        && effects.iter().any(effect_contains_search_library)
+    {
+        effects.push(shuffle_library_if_previous_effect_happened());
+        return true;
+    }
+
+    if effect_contains_search_library(last) {
+        effects.push(shuffle_library_if_previous_effect_happened());
+        return true;
+    }
+
+    false
+}
+
 fn is_if_you_search_library_this_way_shuffle_sentence(tokens: &[OwnedLexToken]) -> bool {
     let words = crate::runtime_backend::util::non_article_token_word_refs(tokens);
     matches!(
@@ -226,7 +257,7 @@ fn pre_rule_library_shuffle_followups(
                 route: None,
             }));
         }
-        if state.effects.iter().any(effect_contains_search_library) {
+        if append_library_shuffle_followup_to_latest_search(state.effects) {
             return Ok(Some(PreParseFollowupResult::Handled {
                 consumed_sentences: 1,
                 route: None,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -729,6 +729,10 @@ fn parse_effect_sentence_lexed_inner(
         return Ok(effects);
     }
 
+    if let Some(effect) = parse_vote_subject_verb(tokens)? {
+        return Ok(vec![effect]);
+    }
+
     if let Some((route, mut effects)) = parse_top_level_subject_verb_recognition(tokens)? {
         crate::parse_trace::event(format!("effect-route: {route}"));
         normalize_search_followup_shuffles(&mut effects);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41746,6 +41746,7 @@ fn strict_parse_vote_regression_cards() {
         "Brago's Representative",
         "Tivit, Seller of Secrets",
         "Elrond of the White Council",
+        "Travel Through Caradhras",
     ] {
         assert_oracle_card_parses_strict(name);
     }
@@ -41884,6 +41885,231 @@ fn vote_regression_elrond_preserves_voter_choice_branch_and_owner_attack_restric
             && debug.contains("CantAttackItsOwner")
             && debug.contains("VoteCount(\"aid\")"),
         "expected Elrond to keep the fellowship voter choice branch, the owner-attack restriction, and the aid vote loop, got {debug}"
+    );
+}
+
+#[test]
+fn travel_through_caradhras_regression_renders_council_dilemma_vote_branches() {
+    let def = parse_oracle_card_definition("Travel Through Caradhras");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        lower.contains("council's dilemma")
+            && rendered.contains("Starting with you, each player votes for Redhorn Pass or Mines of Moria")
+            && rendered.contains("For each Redhorn Pass vote, search your library for a basic land card and put it onto the battlefield tapped")
+            && rendered.contains("If you search your library this way, shuffle")
+            && rendered.contains("For each Mines of Moria vote, return a card from your graveyard to your hand")
+            && rendered.contains("Exile Travel Through Caradhras"),
+        "expected Travel Through Caradhras to render its council dilemma branches, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("VoteCount")
+            && debug.contains("\"redhorn pass\"")
+            && debug.contains("ChooseObjectsEffect")
+            && debug.contains("PutOntoBattlefieldEffect")
+            && debug.contains("ShuffleLibraryEffect")
+            && debug.contains("\"mines of moria\"")
+            && debug.contains("ReturnFromGraveyardToHandEffect"),
+        "expected Travel Through Caradhras to keep both vote-count branches structurally, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct TravelVoteDecisionMaker {
+    votes: Vec<usize>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for TravelVoteDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if !self.votes.is_empty() {
+            vec![self.votes.remove(0)]
+        } else {
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        let max = ctx.max.unwrap_or(ctx.candidates.len()).max(ctx.min);
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .take(max)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn basic_land_for_travel_test(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .supertypes(vec![Supertype::Basic])
+        .card_types(vec![CardType::Land])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn graveyard_card_for_travel_test(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Creature])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_travel_through_caradhras_with_votes(
+    votes: Vec<usize>,
+) -> (
+    crate::game_state::GameState,
+    Vec<crate::triggers::TriggerEvent>,
+    ObjectId,
+    Vec<ObjectId>,
+    Vec<ObjectId>,
+) {
+    let def = parse_oracle_card_definition("Travel Through Caradhras");
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Travel Through Caradhras should compile to spell effects");
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+    let forest = basic_land_for_travel_test(91_201, "Travel Forest");
+    let island = basic_land_for_travel_test(91_202, "Travel Island");
+    let grave_one = graveyard_card_for_travel_test(91_203, "Travel Grave One");
+    let grave_two = graveyard_card_for_travel_test(91_204, "Travel Grave Two");
+    let land_ids = vec![
+        game.create_object_from_definition(&forest, alice, Zone::Library),
+        game.create_object_from_definition(&island, alice, Zone::Library),
+    ];
+    let graveyard_ids = vec![
+        game.create_object_from_definition(&grave_one, alice, Zone::Graveyard),
+        game.create_object_from_definition(&grave_two, alice, Zone::Graveyard),
+    ];
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = TravelVoteDecisionMaker { votes };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    let events = crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        program,
+        None,
+        &[],
+    )
+    .expect("Travel Through Caradhras should resolve");
+    (game, events, source, land_ids, graveyard_ids)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn travel_search_event_count(events: &[crate::triggers::TriggerEvent]) -> usize {
+    events
+        .iter()
+        .filter_map(|event| event.downcast::<crate::events::SearchLibraryEvent>())
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn travel_shuffle_event_count(events: &[crate::triggers::TriggerEvent]) -> usize {
+    events
+        .iter()
+        .filter_map(|event| event.downcast::<crate::events::ShuffleLibraryEvent>())
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn travel_zone_names(game: &crate::game_state::GameState, zone: Zone) -> Vec<String> {
+    game.objects_in_zone(zone)
+        .into_iter()
+        .filter_map(|id| game.object(id).map(|object| object.name.clone()))
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn travel_through_caradhras_runtime_redhorn_pass_votes_search_lands_and_exile_source() {
+    let (game, events, _source, _land_ids, _graveyard_ids) =
+        resolve_travel_through_caradhras_with_votes(vec![0, 0]);
+
+    let battlefield_lands = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter(|&id| {
+            game.object(id)
+                .is_some_and(|object| object.name.starts_with("Travel ") && object.is_land())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        battlefield_lands.len(),
+        2,
+        "two Redhorn Pass votes should put two basic lands onto the battlefield; battlefield={:?} library={:?} searches={} shuffles={}",
+        travel_zone_names(&game, Zone::Battlefield),
+        travel_zone_names(&game, Zone::Library),
+        travel_search_event_count(&events),
+        travel_shuffle_event_count(&events)
+    );
+    assert!(
+        battlefield_lands.iter().all(|&id| game.is_tapped(id)),
+        "Redhorn Pass lands should enter tapped"
+    );
+    let graveyard_names = travel_zone_names(&game, Zone::Graveyard);
+    assert!(
+        graveyard_names.contains(&"Travel Grave One".to_string())
+            && graveyard_names.contains(&"Travel Grave Two".to_string()),
+        "Mines of Moria branch should not run for Redhorn Pass votes"
+    );
+    assert_eq!(travel_search_event_count(&events), 2, "two Redhorn Pass votes should search twice");
+    assert!(
+        travel_shuffle_event_count(&events) >= 1,
+        "searching this way should shuffle the library"
+    );
+    assert_eq!(
+        travel_zone_names(&game, Zone::Exile),
+        vec!["Travel Through Caradhras".to_string()],
+        "Travel Through Caradhras should exile itself after resolving"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn travel_through_caradhras_runtime_mines_votes_return_graveyard_cards_without_searching() {
+    let (game, events, _source, _land_ids, _graveyard_ids) =
+        resolve_travel_through_caradhras_with_votes(vec![1, 1]);
+
+    let hand_names = travel_zone_names(&game, Zone::Hand);
+    assert!(
+        hand_names.contains(&"Travel Grave One".to_string())
+            && hand_names.contains(&"Travel Grave Two".to_string()),
+        "Mines of Moria votes should return both graveyard cards to hand"
+    );
+    let library_names = travel_zone_names(&game, Zone::Library);
+    assert!(
+        library_names.contains(&"Travel Forest".to_string())
+            && library_names.contains(&"Travel Island".to_string()),
+        "Redhorn Pass branch should not search lands for Mines of Moria votes"
+    );
+    assert_eq!(travel_search_event_count(&events), 0, "Mines-only votes should not search");
+    assert_eq!(travel_shuffle_event_count(&events), 0, "Mines-only votes should not shuffle");
+    assert_eq!(
+        travel_zone_names(&game, Zone::Exile),
+        vec!["Travel Through Caradhras".to_string()],
+        "Travel Through Caradhras should exile itself after resolving"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -709,8 +709,30 @@ fn rewrite_spell_resolution_damage_source(def: &CardDefinition, rendered: &str) 
     if !(def.card.is_instant() || def.card.is_sorcery()) || def.card.name.contains(" // ") {
         return rendered.to_string();
     }
-    rewrite_damage_phrases_for_permanent_abilities(rendered, &def.card.name, false)
-        .replace("Exile this source", &format!("Exile {}", def.card.name))
+    let rendered = rewrite_damage_phrases_for_permanent_abilities(rendered, &def.card.name, false)
+        .replace("Exile this source", &format!("Exile {}", def.card.name));
+    rewrite_standalone_spell_self_exile(&rendered, &def.card.name)
+}
+
+fn rewrite_standalone_spell_self_exile(rendered: &str, card_name: &str) -> String {
+    let needle = "Exile this";
+    let replacement = format!("Exile {card_name}");
+    let mut out = String::with_capacity(rendered.len() + card_name.len());
+    let mut rest = rendered;
+
+    while let Some(idx) = rest.find(needle) {
+        out.push_str(&rest[..idx]);
+        let after = &rest[idx + needle.len()..];
+        if matches!(after.chars().next(), None | Some('.') | Some(',') | Some(';')) {
+            out.push_str(&replacement);
+        } else {
+            out.push_str(needle);
+        }
+        rest = after;
+    }
+
+    out.push_str(rest);
+    out
 }
 
 fn ability_has_begin_on_battlefield_pregame(ability: &Ability) -> bool {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -97,6 +97,135 @@ fn describe_discard_hand_add_mana_draw_sequence(effects: &[&Effect]) -> Option<S
     ))
 }
 
+fn title_case_vote_option(option: &str) -> String {
+    option
+        .split_whitespace()
+        .enumerate()
+        .map(|(idx, word)| {
+            if idx > 0 && matches!(word, "a" | "an" | "and" | "of" | "or" | "the") {
+                return word.to_string();
+            }
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn describe_search_basic_land_battlefield_tapped_shuffle(effects: &[Effect]) -> Option<String> {
+    let [search_effect, shuffle_effect] = effects else {
+        return None;
+    };
+    let search_with_id = search_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let sequence = search_with_id
+        .effect
+        .downcast_ref::<crate::effects::SequenceEffect>()?;
+    let [choose_effect, put_effect] = sequence.effects.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let put_each = put_effect.downcast_ref::<crate::effects::ForEachTaggedEffect>()?;
+    let [put_effect] = put_each.effects.as_slice() else {
+        return None;
+    };
+    let put = put_effect.downcast_ref::<crate::effects::PutOntoBattlefieldEffect>()?;
+    let shuffle = shuffle_effect.downcast_ref::<crate::effects::IfEffect>()?;
+    let [shuffle_then] = shuffle.then.as_slice() else {
+        return None;
+    };
+    let shuffle_library = shuffle_then.downcast_ref::<crate::effects::ShuffleLibraryEffect>()?;
+
+    if !choose.is_search
+        || choose.chooser != PlayerFilter::You
+        || choose.zone != Some(Zone::Library)
+        || choose.filter.zone != Some(Zone::Library)
+        || choose.filter.owner != Some(PlayerFilter::You)
+        || choose.filter.card_types.as_slice() != [CardType::Land]
+        || !choose.filter.supertypes.contains(&Supertype::Basic)
+        || !choose.count.is_single()
+        || put_each.tag != choose.tag
+        || !matches!(put.target, ChooseSpec::Iterated)
+        || !put.tapped
+        || put.controller != PlayerFilter::You
+        || shuffle.condition != search_with_id.id
+        || shuffle.predicate != EffectPredicate::Happened
+        || !shuffle.else_.is_empty()
+        || shuffle_library.player != PlayerFilter::You
+    {
+        return None;
+    }
+
+    Some(
+        "search your library for a basic land card and put it onto the battlefield tapped. If you search your library this way, shuffle"
+            .to_string(),
+    )
+}
+
+fn describe_council_dilemma_named_vote_sequence(effects: &[Effect]) -> Option<String> {
+    let [vote_effect, repeat_effects @ ..] = effects else {
+        return None;
+    };
+    let vote = vote_effect.downcast_ref::<crate::effects::VoteEffect>()?;
+    let crate::effects::VoteChoice::NamedOptions(options) = &vote.choice else {
+        return None;
+    };
+    if vote.secret
+        || vote.controller_extra_votes != 0
+        || vote.controller_optional_extra_votes != 0
+        || options.len() < 2
+        || repeat_effects.len() != options.len()
+        || options.iter().any(|option| !option.effects_per_vote.is_empty())
+    {
+        return None;
+    }
+
+    let mut clauses = Vec::new();
+    for (option, repeat_effect) in options.iter().zip(repeat_effects.iter()) {
+        let repeat = repeat_effect.downcast_ref::<crate::effects::RepeatEffectsEffect>()?;
+        let Value::VoteCount(repeat_option) = &repeat.count else {
+            return None;
+        };
+        if !repeat_option.eq_ignore_ascii_case(&option.name) {
+            return None;
+        }
+
+        let body = describe_search_basic_land_battlefield_tapped_shuffle(&repeat.effects)
+            .unwrap_or_else(|| {
+                let mut body = describe_effect_list(&repeat.effects)
+                    .trim()
+                    .trim_end_matches('.')
+                    .to_string();
+                body = body.replace(
+                    ", put it onto the battlefield tapped",
+                    " and put it onto the battlefield tapped",
+                );
+                body
+            });
+        clauses.push(format!(
+            "For each {} vote, {}",
+            title_case_vote_option(&option.name),
+            lowercase_first(&body)
+        ));
+    }
+
+    let option_names = options
+        .iter()
+        .map(|option| title_case_vote_option(&option.name))
+        .collect::<Vec<_>>();
+    let mut text = format!(
+        "Council's dilemma — Starting with you, each player votes for {}",
+        join_with_or(&option_names)
+    );
+    if !clauses.is_empty() {
+        text.push_str(". ");
+        text.push_str(&clauses.join(". "));
+    }
+    Some(text)
+}
+
 fn describe_planeswalk_chaos_vote_sequence(effects: &[&Effect]) -> Option<String> {
     let [vote_effect, planeswalk_effect, chaos_effect] = effects else {
         return None;
@@ -2634,6 +2763,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
             .is_some()
     {
         return describe_structural_multisentence_effect_list(rest);
+    }
+
+    if let Some(compact) = describe_council_dilemma_named_vote_sequence(effects) {
+        return Some(compact);
     }
 
     if effects.len() == 3 {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Travel Through Caradhras
Initial parse error:
```
unsupported target phrase (clause: 'redhorn pass vote'); oracle-only fallback also failed: unsupported target phrase (clause: 'redhorn pass vote')
```

Current worker: i-01d84634bf3728451
Branch: codex/aws-card-fix-travel-through-caradhras
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0006
