### PR TITLE
Fix Ironsmith parse failure: Hatchery Spider

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -983,34 +983,53 @@ pub(crate) fn parse_top_cards_put_match_into_hand_rest_graveyard(
     Ok(Some(effects))
 }
 
-fn parse_any_number_from_looked_cards_action(
+fn parse_matching_from_looked_cards_action(
     tokens: &[OwnedLexToken],
-) -> Option<(ObjectFilter, Zone, bool)> {
+) -> Option<(ObjectFilter, ChoiceCount, Zone, bool)> {
     let action_tokens = trim_commas(tokens);
     let action_words = TokenWordView::new(&action_tokens);
     let action_word_refs = action_words.word_refs();
-    if !word_slice_starts_with(&action_word_refs, &["any", "number", "of"]) {
-        return None;
-    }
+
+    let (count, counted_tokens) = if word_slice_starts_with(
+        &action_word_refs,
+        &["any", "number", "of"],
+    ) {
+        let filter_start = action_words.token_index_for_word_index(3)?;
+        (
+            ChoiceCount::any_number(),
+            trim_commas(&action_tokens[filter_start..]),
+        )
+    } else {
+        let (mut count, rest) = looked_cards_choice_count(&action_tokens)?;
+        if !count.is_any_number() && count.max != Some(1) {
+            return None;
+        }
+        if count.is_single() {
+            count = ChoiceCount::up_to(1);
+        }
+        (count, rest)
+    };
+
+    let counted_words = TokenWordView::new(&counted_tokens);
+    let counted_word_refs = counted_words.word_refs();
 
     let Some((from_among_word_idx, from_among_len)) =
-        effect_sentences::find_from_among_looked_cards_phrase(&action_words)
+        effect_sentences::find_from_among_looked_cards_phrase(&counted_words)
     else {
         return None;
     };
-    if from_among_word_idx <= 3 {
+    if from_among_word_idx == 0 {
         return None;
     }
-    let filter_start = action_words.token_index_for_word_index(3)?;
-    let filter_end = action_words
+    let filter_end = counted_words
         .token_index_for_word_index(from_among_word_idx)
-        .unwrap_or(action_tokens.len());
-    let filter_tokens = trim_commas(&action_tokens[filter_start..filter_end]);
+        .unwrap_or(counted_tokens.len());
+    let filter_tokens = trim_commas(&counted_tokens[..filter_end]);
     let mut filter = effect_sentences::parse_looked_card_choice_filter(&filter_tokens)?;
     effect_sentences::normalize_search_library_filter(&mut filter);
     filter.zone = None;
 
-    let after_from_words = &action_word_refs[from_among_word_idx + from_among_len..];
+    let after_from_words = &counted_word_refs[from_among_word_idx + from_among_len..];
     let (zone, tapped) = if word_slice_starts_with_any(
         after_from_words,
         &[&["into", "your", "hand"], &["into", "hand"]],
@@ -1033,7 +1052,7 @@ fn parse_any_number_from_looked_cards_action(
         return None;
     };
 
-    Some((filter, zone, tapped))
+    Some((filter, count, zone, tapped))
 }
 
 pub(crate) fn parse_top_cards_put_any_matching_to_zone_rest_bottom(
@@ -1051,8 +1070,8 @@ pub(crate) fn parse_top_cards_put_any_matching_to_zone_rest_bottom(
         return Ok(None);
     };
     let chooser = effect_sentences::leading_may_actor_to_player(action_match.actor, player);
-    let Some((filter, zone, tapped)) =
-        parse_any_number_from_looked_cards_action(action_match.tail_tokens)
+    let Some((filter, choice_count, zone, tapped)) =
+        parse_matching_from_looked_cards_action(action_match.tail_tokens)
     else {
         return Ok(None);
     };
@@ -1096,12 +1115,14 @@ pub(crate) fn parse_top_cards_put_any_matching_to_zone_rest_bottom(
     if reveal_top {
         effects.push(EffectAst::subject_verb_reveal_tagged(looked_tag.clone()));
     }
-    effects.push(EffectAst::ChooseObjects {
+    effects.push(EffectAst::ChooseObjectsAcrossZones {
         filter: choose_filter,
-        count: ChoiceCount::any_number(),
+        count: choice_count,
         count_value: None,
         player: chooser,
         tag: chosen_tag.clone(),
+        zones: vec![Zone::Library],
+        search_mode: None,
     });
     effects.push(EffectAst::ForEachTagged {
         tag: chosen_tag.clone(),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35119,6 +35119,40 @@ fn parse_oracle_quandrix_apprentice_uses_looked_land_choice_and_bottom_remainder
 }
 
 #[test]
+fn parse_oracle_hatchery_spider_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Hatchery Spider");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert_eq!(def.card.name, "Hatchery Spider");
+    assert!(
+        rendered_lower.contains(
+            "you may put a green permanent card with mana value x or less from among them onto the battlefield"
+        ),
+        "expected Hatchery Spider to render the revealed-card battlefield choice, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("put the rest on the bottom of your library in a random order"),
+        "expected Hatchery Spider to render the revealed-card remainder clause, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("tagged '") && !rendered_lower.contains("tagged object"),
+        "Hatchery Spider compiled text must not leak internal tag markers, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("YouCastThisSpellTrigger")
+            && debug.contains("LookAtTopCardsEffect")
+            && debug.contains("RevealTaggedEffect")
+            && debug.contains("ChooseObjectsEffect")
+            && debug.contains("LessThanOrEqualExpr(")
+            && debug.contains("PutTaggedRemainderOnLibraryBottomEffect"),
+        "expected Hatchery Spider to lower through structured reveal/choice/remainder effects, got {debug}"
+    );
+}
+
+#[test]
 fn parse_oracle_expressive_iteration_splits_looked_cards_by_destination() {
     let def = parse_oracle_card_definition("Expressive Iteration");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -21742,6 +21742,11 @@ fn normalize_looked_card_filter_description(filter: &ObjectFilter, card_desc: &s
     {
         card_desc = format!("{prefix} card");
     }
+    if !card_desc.contains(" card")
+        && let Some((head, tail)) = card_desc.split_once(" with ")
+    {
+        card_desc = format!("{head} card with {tail}");
+    }
     card_desc
 }
 
@@ -22104,7 +22109,16 @@ fn describe_look_at_top_then_put_any_matching_to_zone_rest_bottom(
         return None;
     }
     let (zone, tapped) = for_each_moves_tag_to_public_zone(move_chosen, choose.tag.as_str())?;
-    let matching = describe_any_number_filter_from_looked_cards(look_at_top, choose)?;
+    let matching = if choose.count.is_any_number() {
+        format!(
+            "any number of {}",
+            describe_any_number_filter_from_looked_cards(look_at_top, choose)?
+        )
+    } else if choose.count.max == Some(1) {
+        describe_choose_filter_from_looked_cards(look_at_top, choose)?
+    } else {
+        return None;
+    };
     let owner = describe_possessive_player_filter(&look_at_top.player);
     let (count_text, noun, count_where_clause) =
         describe_top_count_noun_and_where_clause(&look_at_top.count);
@@ -22146,7 +22160,7 @@ fn describe_look_at_top_then_put_any_matching_to_zone_rest_bottom(
     };
 
     Some(format!(
-        "{opener} the top {count_text} {noun} of {owner} library{count_where_clause}. {put_prefix} any number of {matching} from among them {destination}. Put the rest on the bottom of {owner} library{order_text}"
+        "{opener} the top {count_text} {noun} of {owner} library{count_where_clause}. {put_prefix} {matching} from among them {destination}. Put the rest on the bottom of {owner} library{order_text}"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/effects/cards/look_at_top.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/look_at_top.rs
@@ -7,6 +7,7 @@ use crate::effects::helpers::{resolve_player_filter, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 use crate::snapshot::ObjectSnapshot;
+use ironsmith_core::ValueSurfaceHint;
 pub use ironsmith_core::LookAtTopCardsEffect;
 
 /// Effect that looks at the top N cards of a player's library and tags them.
@@ -21,6 +22,9 @@ impl EffectExecutor for LookAtTopCardsEffect {
             return Ok(EffectOutcome::count(0));
         };
         let count = resolve_value(game, &self.count, ctx)?.max(0) as usize;
+        if self.count.has_surface_hint(ValueSurfaceHint::WhereXIs) {
+            ctx.x_value = Some(count as u32);
+        }
         if count == 0 {
             return Ok(EffectOutcome::count(0));
         }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -37005,6 +37005,221 @@ fn quandrix_apprentice_magecraft_can_decline_the_land_pick() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn hatchery_spider_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(91_200), "Hatchery Spider")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spider])
+        .power_toughness(PowerToughness::fixed(5, 7))
+        .parse_text(
+            "Reach\nUndergrowth — When you cast this spell, reveal the top X cards of your library, where X is the number of creature cards in your graveyard. You may put a green permanent card with mana value X or less from among them onto the battlefield. Put the rest on the bottom of your library in a random order.",
+        )
+        .expect("Hatchery Spider should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct HatcherySpiderDecisionMaker {
+    choice_name: Option<&'static str>,
+    legal_names: Vec<String>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for HatcherySpiderDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        self.legal_names = ctx
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.name.clone())
+            .collect();
+        let Some(choice_name) = self.choice_name else {
+            return Vec::new();
+        };
+        ctx.candidates
+            .iter()
+            .find(|candidate| {
+                candidate.legal
+                    && game
+                        .object(candidate.id)
+                        .is_some_and(|object| object.name == choice_name)
+            })
+            .map(|candidate| vec![candidate.id])
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_hatchery_spider_graveyard_creatures(game: &mut GameState, player: PlayerId, count: u32) {
+    for index in 0..count {
+        let card = CardBuilder::new(
+            CardId::from_raw(91_210 + index),
+            format!("Undergrowth Creature {index}"),
+        )
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+        game.create_object_from_card(&card, player, Zone::Graveyard);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_hatchery_spider_library(game: &mut GameState, player: PlayerId) -> Vec<ObjectId> {
+    let bottom = CardBuilder::new(CardId::from_raw(91_220), "Unrevealed Green Permanent")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let nonpermanent = CardBuilder::new(CardId::from_raw(91_221), "Green Instant")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let nongreen = CardBuilder::new(CardId::from_raw(91_222), "Colorless Rock")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let expensive = CardBuilder::new(CardId::from_raw(91_223), "Expensive Green Beast")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let legal = CardBuilder::new(CardId::from_raw(91_224), "Legal Green Permanent")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    vec![
+        game.create_object_from_card(&bottom, player, Zone::Library),
+        game.create_object_from_card(&nonpermanent, player, Zone::Library),
+        game.create_object_from_card(&nongreen, player, Zone::Library),
+        game.create_object_from_card(&expensive, player, Zone::Library),
+        game.create_object_from_card(&legal, player, Zone::Library),
+    ]
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hatchery_spider_cast_trigger_puts_one_eligible_revealed_permanent_onto_battlefield() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = hatchery_spider_definition();
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Hatchery Spider should have its cast trigger");
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    add_hatchery_spider_graveyard_creatures(&mut game, alice, 4);
+    let ids = add_hatchery_spider_library(&mut game, alice);
+    let expensive_id = ids[3];
+    let nongreen_id = ids[2];
+    let nonpermanent_id = ids[1];
+
+    let mut dm = HatcherySpiderDecisionMaker {
+        choice_name: Some("Legal Green Permanent"),
+        legal_names: Vec::new(),
+    };
+    resolve_triggered_ability_from_spell_cast(&mut game, triggered, source_id, alice, &mut dm);
+
+    assert!(
+        dm.legal_names
+            .iter()
+            .any(|name| name == "Legal Green Permanent"),
+        "Hatchery Spider should allow the green permanent with mana value X or less, got {:?}",
+        dm.legal_names
+    );
+    for illegal_name in [
+        "Expensive Green Beast",
+        "Colorless Rock",
+        "Green Instant",
+        "Unrevealed Green Permanent",
+    ] {
+        assert!(
+            !dm.legal_names.iter().any(|name| name == illegal_name),
+            "Hatchery Spider should not allow {illegal_name} as a battlefield choice, got {:?}",
+            dm.legal_names
+        );
+    }
+
+    let battlefield_names: Vec<_> = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| object.name.clone()))
+        .collect();
+    assert!(
+        battlefield_names.contains(&"Legal Green Permanent".to_string()),
+        "Hatchery Spider should put the chosen green permanent with mana value X or less onto the battlefield, got {battlefield_names:?}"
+    );
+    for id in [expensive_id, nongreen_id, nonpermanent_id] {
+        assert_eq!(
+            game.object(id).expect("revealed card exists").zone,
+            Zone::Library,
+            "ineligible revealed cards should be put on the bottom of the library, not moved elsewhere"
+        );
+    }
+    assert!(
+        game.player(alice).expect("alice exists").graveyard.len() >= 4,
+        "Hatchery Spider should not mill revealed cards into the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hatchery_spider_cast_trigger_can_decline_the_revealed_permanent_choice() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = hatchery_spider_definition();
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Hatchery Spider should have its cast trigger");
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    add_hatchery_spider_graveyard_creatures(&mut game, alice, 4);
+    let ids = add_hatchery_spider_library(&mut game, alice);
+
+    let mut dm = HatcherySpiderDecisionMaker {
+        choice_name: None,
+        legal_names: Vec::new(),
+    };
+    resolve_triggered_ability_from_spell_cast(&mut game, triggered, source_id, alice, &mut dm);
+
+    for id in ids {
+        assert_eq!(
+            game.object(id).expect("library card exists").zone,
+            Zone::Library,
+            "declining Hatchery Spider should leave every revealed card in the library"
+        );
+    }
+    assert!(
+        game.battlefield.is_empty(),
+        "declining Hatchery Spider should not put a revealed card onto the battlefield"
+    );
+}
+
 // ============================================================================
 // Saga Integration Tests
 // ============================================================================


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hatchery Spider
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-08dbf8f53d3575a14
Branch: codex/aws-card-fix-hatchery-spider
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0007
