### PR TITLE
Fix Ironsmith parse failure: Summon: Leviathan

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
@@ -3,9 +3,6 @@ use super::*;
 const EACH_PLAYER_PREFIXES: &[&[&str]] = &[&["each", "player"]];
 const EACH_PLAYER_EXILES_ALL_PREFIXES: &[&[&str]] = &[&["each", "player", "exiles", "all"]];
 const EXILE_PREFIXES: &[&[&str]] = &[&["exile"]];
-const RETURN_EACH_CREATURE_ISNT_PREFIXES: &[&[&str]] =
-    &[&["return", "each", "creature", "that", "isnt"]];
-
 pub(crate) fn is_enters_as_copy_clause_lexed(tokens: &[OwnedLexToken]) -> bool {
     let as_copy_idx = primitives::words_find_phrase(tokens, &["as", "a", "copy"])
         .or_else(|| primitives::words_find_phrase(tokens, &["as", "an", "copy"]))
@@ -290,13 +287,6 @@ pub(crate) fn has_face_down_clause_sentence_lexed(
         && !primitives::contains_word(tokens, "manifest")
         && !primitives::contains_word(tokens, "pile");
     !simple_exile_face_down
-}
-
-pub(crate) fn has_return_each_creature_that_isnt_list_clause_sentence_lexed(
-    tokens: &[OwnedLexToken],
-) -> bool {
-    primitives::words_match_any_prefix(tokens, RETURN_EACH_CREATURE_ISNT_PREFIXES).is_some()
-        && primitives::contains_word(tokens, "or")
 }
 
 pub(crate) fn has_unsupported_negated_untap_clause_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -921,6 +921,67 @@ pub(super) fn parse_object_filter_inner(
             }
         }
 
+        let mut list_idx = target_idx;
+        let mut saw_list_connector = false;
+        let mut pending_card_types = Vec::new();
+        let mut pending_supertypes = Vec::new();
+        let mut pending_subtypes = Vec::new();
+        let mut pending_colors = ColorSet::new();
+        let mut pending_indices = Vec::new();
+        while list_idx < all_words.len() {
+            let negated_word = all_words[list_idx];
+            if is_article(negated_word) {
+                list_idx += 1;
+                continue;
+            }
+            if matches!(negated_word, "and" | "or") {
+                saw_list_connector = true;
+                list_idx += 1;
+                continue;
+            }
+            let mut consumed = false;
+            if is_outlaw_word(negated_word) {
+                push_outlaw_subtypes(&mut pending_subtypes);
+                consumed = true;
+            }
+            if let Some(card_type) = parse_card_type(negated_word) {
+                push_unique(&mut pending_card_types, card_type);
+                consumed = true;
+            }
+            if let Some(supertype) = parse_supertype_word(negated_word) {
+                push_unique(&mut pending_supertypes, supertype);
+                consumed = true;
+            }
+            if let Some(color) = parse_color(negated_word) {
+                pending_colors = pending_colors.union(color);
+                consumed = true;
+            }
+            if let Some(subtype) = parse_subtype_flexible(negated_word) {
+                push_unique(&mut pending_subtypes, subtype);
+                consumed = true;
+            }
+            if !consumed {
+                break;
+            }
+            pending_indices.push(list_idx);
+            list_idx += 1;
+        }
+        if saw_list_connector {
+            for card_type in pending_card_types {
+                push_unique(&mut filter.excluded_card_types, card_type);
+            }
+            for supertype in pending_supertypes {
+                push_unique(&mut filter.excluded_supertypes, supertype);
+            }
+            filter.excluded_colors = filter.excluded_colors.union(pending_colors);
+            for subtype in pending_subtypes {
+                push_unique(&mut filter.excluded_subtypes, subtype);
+            }
+            for index in pending_indices {
+                negated_word_indices.insert(index);
+            }
+        }
+
         let negated_word = all_words[target_idx];
         if negated_word == "attacking" {
             filter.nonattacking = true;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -34,7 +34,9 @@ use super::super::util::{
     remove_through_first_word as remove_through_first_word_tokens, strip_leading_word_refs_any,
 };
 use super::super::value_helpers::{parse_number_from_lexed, parse_value_from_lexed};
-use super::dispatch_inner::parse_subject_verb_extension_sentence;
+use super::dispatch_inner::{
+    parse_sentence_delayed_trigger_this_turn, parse_subject_verb_extension_sentence,
+};
 use super::lex_chain_helpers::{
     find_verb_lexed, has_effect_head_without_verb_lexed, segment_has_effect_head_lexed,
     split_effect_chain_on_and_lexed, split_segments_on_comma_effect_head_lexed,
@@ -857,6 +859,9 @@ pub(crate) fn parse_effect_chain_with_subject_verb_primitives_lexed(
 
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     if starts_with_until_end_of_turn_trigger_clause(&clause_words) {
+        if let Some(effects) = parse_sentence_delayed_trigger_this_turn(tokens)? {
+            return Ok(effects);
+        }
         return Err(CardTextError::ParseError(format!(
             "unsupported until-end-of-turn permission clause (clause: '{}')",
             clause_words.join(" ")

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
@@ -118,10 +118,39 @@ pub(crate) fn parse_delayed_until_next_end_step_sentence(
     }
 }
 
+fn split_delayed_trigger_clause_on_effect_comma(
+    tokens: &[OwnedLexToken],
+) -> Option<(&[OwnedLexToken], &[OwnedLexToken])> {
+    for (split_idx, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::Comma {
+            continue;
+        }
+        let mut trigger_tokens = trim_commas(&tokens[..split_idx]);
+        if trigger_tokens
+            .first()
+            .is_some_and(|token| token.is_word("when") || token.is_word("whenever"))
+        {
+            trigger_tokens = trigger_tokens[1..].to_vec();
+        }
+        if trigger_tokens.is_empty() || parse_trigger_clause_lexed(&trigger_tokens).is_err() {
+            continue;
+        }
+        let effect_tokens = trim_commas(&tokens[split_idx + 1..]);
+        if !effect_tokens.is_empty() {
+            return Some((&tokens[..split_idx], &tokens[split_idx + 1..]));
+        }
+    }
+    None
+}
+
 pub(crate) fn parse_sentence_delayed_trigger_this_turn(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
-    if grammar::words_match_prefix(tokens, &["this", "turn"]).is_some() {
+    if grammar::words_match_prefix(tokens, &["this", "turn"])
+        .or_else(|| grammar::words_match_prefix(tokens, &["until", "end", "of", "turn"]))
+        .or_else(|| grammar::words_match_prefix(tokens, &["until", "the", "end", "of", "turn"]))
+        .is_some()
+    {
         let Some((_duration, delayed_clause)) =
             super::super::grammar::primitives::split_lexed_once_on_delimiter(
                 tokens,
@@ -138,10 +167,7 @@ pub(crate) fn parse_sentence_delayed_trigger_this_turn(
             return Ok(None);
         }
         let Some((trigger_part, effect_part)) =
-            super::super::grammar::primitives::split_lexed_once_on_delimiter(
-                &delayed_clause,
-                super::super::lexer::TokenKind::Comma,
-            )
+            split_delayed_trigger_clause_on_effect_comma(&delayed_clause)
         else {
             return Ok(None);
         };

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -414,10 +414,6 @@ sentence_unsupported_adapters_lexed!(
         sentence_has_face_down_clause
     ),
     (
-        sentence_has_return_each_creature_that_isnt_list_clause_rule_lexed,
-        sentence_has_return_each_creature_that_isnt_list_clause
-    ),
-    (
         sentence_has_unsupported_negated_untap_clause_rule_lexed,
         sentence_has_unsupported_negated_untap_clause
     ),
@@ -555,13 +551,6 @@ fn sentence_has_spent_to_cast_clause(words: &[&str], _: &[OwnedLexToken]) -> boo
 
 fn sentence_has_face_down_clause(words: &[&str], tokens: &[OwnedLexToken]) -> bool {
     effect_grammar::has_face_down_clause_sentence_lexed(words, tokens)
-}
-
-fn sentence_has_return_each_creature_that_isnt_list_clause(
-    _: &[&str],
-    tokens: &[OwnedLexToken],
-) -> bool {
-    effect_grammar::has_return_each_creature_that_isnt_list_clause_sentence_lexed(tokens)
 }
 
 fn sentence_has_unsupported_negated_untap_clause(_: &[&str], tokens: &[OwnedLexToken]) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sentence_unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sentence_unsupported.rs
@@ -3,7 +3,7 @@ use super::super::rule_engine::{LexClauseView, LexUnsupportedDiagnoser, LexUnsup
 use super::dispatch_inner as inner;
 use crate::cards::builders::CardTextError;
 
-const SENTENCE_UNSUPPORTED_RULES_LEXED: [LexUnsupportedRuleDef; 28] = [
+const SENTENCE_UNSUPPORTED_RULES_LEXED: [LexUnsupportedRuleDef; 27] = [
     LexUnsupportedRuleDef {
         id: "enters-as-copy",
         priority: 20,
@@ -211,14 +211,6 @@ const SENTENCE_UNSUPPORTED_RULES_LEXED: [LexUnsupportedRuleDef; 28] = [
         shape_mask: 0,
         message: "unsupported face-down clause",
         predicate: inner::sentence_has_face_down_clause_rule_lexed,
-    },
-    LexUnsupportedRuleDef {
-        id: "return-each-creature-that-isnt-list",
-        priority: 370,
-        heads: &["return"],
-        shape_mask: 0,
-        message: "unsupported return-each-creature-that-isnt-list clause",
-        predicate: inner::sentence_has_return_each_creature_that_isnt_list_clause_rule_lexed,
     },
     LexUnsupportedRuleDef {
         id: "negated-untap",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38151,6 +38151,290 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn summon_leviathan_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Summon: Leviathan");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains(
+            "return each creature that isn't a kraken, leviathan, merfolk, octopus, or serpent to its owner's hand"
+        ),
+        "expected Summon: Leviathan to render the chapter I excluded-type return clause, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains(
+            "until end of turn, whenever a kraken, leviathan, merfolk, octopus, or serpent attacks, draw a card"
+        ),
+        "expected Summon: Leviathan to render the chapter II/III delayed attack trigger, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Ward {2}"),
+        "expected Summon: Leviathan to keep ward, got {rendered}"
+    );
+}
+
+#[test]
+fn summon_leviathan_chapter_i_returns_only_non_sea_creatures() {
+    struct NoChoices;
+    impl crate::decision::DecisionMaker for NoChoices {}
+
+    let def = summon_leviathan_definition_for_regression();
+    let chapter = summon_leviathan_chapter(&def, &[1]);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let human = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Human Probe", vec![Subtype::Human]),
+        alice,
+        Zone::Battlefield,
+    );
+    let bob_human = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Bob Human Probe", vec![Subtype::Human]),
+        bob,
+        Zone::Battlefield,
+    );
+    let kraken = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Kraken Probe", vec![Subtype::Kraken]),
+        alice,
+        Zone::Battlefield,
+    );
+    let leviathan = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Leviathan Probe", vec![Subtype::Leviathan]),
+        bob,
+        Zone::Battlefield,
+    );
+    let merfolk = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Merfolk Probe", vec![Subtype::Merfolk]),
+        bob,
+        Zone::Battlefield,
+    );
+    let octopus = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Octopus Probe", vec![Subtype::Octopus]),
+        alice,
+        Zone::Battlefield,
+    );
+    let serpent = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Serpent Probe", vec![Subtype::Serpent]),
+        bob,
+        Zone::Battlefield,
+    );
+    let human_stable = game.object(human).expect("human exists").stable_id;
+    let bob_human_stable = game.object(bob_human).expect("bob human exists").stable_id;
+    let kraken_stable = game.object(kraken).expect("kraken exists").stable_id;
+    let leviathan_stable = game.object(leviathan).expect("leviathan exists").stable_id;
+    let merfolk_stable = game.object(merfolk).expect("merfolk exists").stable_id;
+    let octopus_stable = game.object(octopus).expect("octopus exists").stable_id;
+    let serpent_stable = game.object(serpent).expect("serpent exists").stable_id;
+    let source_stable = game.object(source).expect("source exists").stable_id;
+
+    let mut dm = NoChoices;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &chapter.effects,
+        None,
+        &[],
+    )
+    .expect("Summon: Leviathan chapter I should resolve");
+
+    let human = game
+        .find_object_by_stable_id(human_stable)
+        .expect("human should still be tracked");
+    let kraken = game
+        .find_object_by_stable_id(kraken_stable)
+        .expect("kraken should still be tracked");
+    let bob_human = game
+        .find_object_by_stable_id(bob_human_stable)
+        .expect("bob human should still be tracked");
+    let leviathan = game
+        .find_object_by_stable_id(leviathan_stable)
+        .expect("leviathan should still be tracked");
+    let merfolk = game
+        .find_object_by_stable_id(merfolk_stable)
+        .expect("merfolk should still be tracked");
+    let octopus = game
+        .find_object_by_stable_id(octopus_stable)
+        .expect("octopus should still be tracked");
+    let serpent = game
+        .find_object_by_stable_id(serpent_stable)
+        .expect("serpent should still be tracked");
+    let source = game
+        .find_object_by_stable_id(source_stable)
+        .expect("source should still be tracked");
+
+    assert_eq!(game.object(human).expect("human exists").zone, Zone::Hand);
+    assert_eq!(game.object(bob_human).expect("bob human exists").zone, Zone::Hand);
+    assert_eq!(
+        game.object(kraken).expect("kraken exists").zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        game.object(leviathan).expect("leviathan exists").zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        game.object(merfolk).expect("merfolk exists").zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        game.object(octopus).expect("octopus exists").zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        game.object(serpent).expect("serpent exists").zone,
+        Zone::Battlefield
+    );
+    assert_eq!(game.object(source).expect("source exists").zone, Zone::Battlefield);
+}
+
+#[test]
+fn summon_leviathan_chapter_ii_iii_delayed_attack_trigger_draws_for_matching_types_only() {
+    struct NoChoices;
+    impl crate::decision::DecisionMaker for NoChoices {}
+
+    let def = summon_leviathan_definition_for_regression();
+    let chapter = summon_leviathan_chapter(&def, &[2, 3]);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let sea_attackers = [
+        game.create_object_from_definition(
+            &summon_leviathan_test_creature("Kraken Attacker", vec![Subtype::Kraken]),
+            alice,
+            Zone::Battlefield,
+        ),
+        game.create_object_from_definition(
+            &summon_leviathan_test_creature("Leviathan Attacker", vec![Subtype::Leviathan]),
+            alice,
+            Zone::Battlefield,
+        ),
+        game.create_object_from_definition(
+            &summon_leviathan_test_creature("Merfolk Attacker", vec![Subtype::Merfolk]),
+            alice,
+            Zone::Battlefield,
+        ),
+        game.create_object_from_definition(
+            &summon_leviathan_test_creature("Octopus Attacker", vec![Subtype::Octopus]),
+            alice,
+            Zone::Battlefield,
+        ),
+        game.create_object_from_definition(
+            &summon_leviathan_test_creature("Serpent Attacker", vec![Subtype::Serpent]),
+            alice,
+            Zone::Battlefield,
+        ),
+    ];
+    let human = game.create_object_from_definition(
+        &summon_leviathan_test_creature("Human Attacker", vec![Subtype::Human]),
+        alice,
+        Zone::Battlefield,
+    );
+    for idx in 0..sea_attackers.len() {
+        game.create_object_from_definition(
+            &summon_leviathan_test_creature(&format!("Draw Filler {idx}"), vec![Subtype::Human]),
+            alice,
+            Zone::Library,
+        );
+    }
+
+    let mut dm = NoChoices;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &chapter.effects,
+        None,
+        &[],
+    )
+    .expect("Summon: Leviathan chapter II/III should schedule delayed trigger");
+    assert_eq!(game.effect_store.delayed_triggers.len(), 1);
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let human_attack = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::new(
+            human,
+            crate::triggers::AttackEventTarget::Player(bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(&mut game, &human_attack) {
+        trigger_queue.add(trigger);
+    }
+    assert!(
+        trigger_queue.is_empty(),
+        "nonmatching Human attacker should not trigger Summon: Leviathan"
+    );
+
+    for (idx, attacker) in sea_attackers.into_iter().enumerate() {
+        let attack = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::combat::CreatureAttackedEvent::new(
+                attacker,
+                crate::triggers::AttackEventTarget::Player(bob),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        for trigger in crate::triggers::check_delayed_triggers(&mut game, &attack) {
+            trigger_queue.add(trigger);
+        }
+        crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+            .expect("matching sea-creature attack should put delayed trigger on stack");
+        crate::game_loop::resolve_stack_entry(&mut game)
+            .expect("Summon: Leviathan delayed draw trigger should resolve");
+
+        assert_eq!(
+            game.player(alice).expect("Alice exists").hand.len(),
+            idx + 1,
+            "each matching sea-creature attack should draw one card"
+        );
+    }
+}
+
+fn summon_leviathan_definition_for_regression() -> CardDefinition {
+    let oracle = oracle_text_by_name()
+        .get("Summon: Leviathan")
+        .expect("missing Summon: Leviathan oracle text")
+        .clone();
+    CardDefinitionBuilder::new(CardId::new(), "Summon: Leviathan")
+        .card_types(vec![CardType::Enchantment, CardType::Creature])
+        .subtypes(vec![Subtype::Saga, Subtype::Leviathan])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .parse_text(oracle)
+        .expect("Summon: Leviathan should parse strictly")
+}
+
+fn summon_leviathan_chapter<'a>(
+    def: &'a CardDefinition,
+    chapters: &[u32],
+) -> &'a crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered.trigger.saga_chapters() == Some(chapters) => Some(triggered),
+            _ => None,
+        })
+        .expect("Summon: Leviathan chapter ability should compile")
+}
+
+fn summon_leviathan_test_creature(name: &str, subtypes: Vec<Subtype>) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .subtypes(subtypes)
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build()
+}
+
+#[test]
 fn alena_kessig_trapper_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Alena, Kessig Trapper");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -20669,6 +20669,17 @@ fn describe_return_to_hand_excluded_subtypes(
 
     let mut base_filter = filter.clone();
     base_filter.excluded_subtypes.clear();
+    if base_filter == ObjectFilter::creature() {
+        let excluded = filter
+            .excluded_subtypes
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>();
+        return Some(format!(
+            "each creature that isn't {} to its owner's hand",
+            with_indefinite_article(&join_with_or(&excluded))
+        ));
+    }
     let target_text = describe_choose_spec(&ChooseSpec::All(base_filter));
     let excluded = filter
         .excluded_subtypes
@@ -31763,9 +31774,15 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         }
         let trigger_display = schedule.trigger.display();
         let mut trigger_text = trigger_display.trim().trim_end_matches('.').to_string();
+        let trigger_event_clause = {
+            let trigger_lower = trigger_text.to_ascii_lowercase();
+            trigger_lower.starts_with("when ")
+                || trigger_lower.starts_with("whenever ")
+                || trigger_lower.starts_with("if ")
+        };
         if schedule.until_end_of_turn {
             let trigger_lower = trigger_text.to_ascii_lowercase();
-            if !trigger_lower.contains(" this turn") {
+            if !trigger_event_clause && !trigger_lower.contains(" this turn") {
                 trigger_text.push_str(" this turn");
             }
         }
@@ -31877,6 +31894,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             || trigger_lower.starts_with("whenever ")
             || trigger_lower.starts_with("if ")
         {
+            if schedule.until_end_of_turn {
+                return format!(
+                    "Until end of turn, {}, {delayed_text}",
+                    lowercase_first(&trigger_text)
+                );
+            }
             return format!("{trigger_text}, {delayed_text}");
         }
         if trigger_lower.starts_with("at ") {

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -186,6 +186,32 @@ impl AttacksTrigger {
     }
 }
 
+fn simple_creature_subtype_attack_subject(filter: &ObjectFilter) -> Option<String> {
+    if filter.subtypes.len() < 2 {
+        return None;
+    }
+
+    let mut base_filter = filter.clone();
+    base_filter.subtypes.clear();
+    if base_filter != ObjectFilter::creature() {
+        return None;
+    }
+
+    let names = filter
+        .subtypes
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>();
+    match names.as_slice() {
+        [] | [_] => None,
+        [first, second] => Some(format!("{first} or {second}")),
+        _ => {
+            let (last, rest) = names.split_last()?;
+            Some(format!("{}, or {last}", rest.join(", ")))
+        }
+    }
+}
+
 fn pluralize_attack_subject(subject: &str) -> String {
     if subject == "creature" {
         return "creatures".to_string();
@@ -273,6 +299,11 @@ impl TriggerMatcher for AttacksTrigger {
                 "Whenever {} or more {subject} attack{target_tail}",
                 self.min_total_attackers,
             );
+        }
+        if target_tail.is_empty()
+            && let Some(subject) = simple_creature_subtype_attack_subject(&display_filter)
+        {
+            return format!("Whenever a {subject} attacks");
         }
         format!(
             "Whenever {} attacks{target_tail}",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Summon: Leviathan
Initial parse error:
```
unsupported return-each-creature-that-isnt-list clause (clause: 'return each creature that isnt a kraken leviathan merfolk octopus or serpent to its owners hand') [rule=return-each-creature-that-isnt-list]; oracle-only fallback also failed: unsupported return-each-creature-that-isnt-list clause (clause: 'return each creature that isnt a kraken leviathan merfolk octopus or serpent to its owners hand') [rule=return-each-creature-that-isnt-list]
```

Current worker: i-0ecc78580210d6ace
Branch: codex/aws-card-fix-summon-leviathan
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0007
