### PR TITLE
Fix Ironsmith parse failure: Oroku Saki, Shredder Rising

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -363,6 +363,7 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
                 grammar::kw("gift").value(KeywordDispatchHint::Gift),
                 grammar::kw("warp").value(KeywordDispatchHint::Warp),
                 grammar::kw("prowl").value(KeywordDispatchHint::AlternativeOrExertFamily),
+                grammar::kw("sneak").value(KeywordDispatchHint::AlternativeOrExertFamily),
                 grammar::kw("escalate").value(KeywordDispatchHint::Escalate),
                 grammar::kw("evoke").value(KeywordDispatchHint::Evoke),
                 grammar::kw("epic").value(KeywordDispatchHint::Epic),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -43,7 +43,8 @@ use super::util::{
     parse_morph_keyword_line_lexed, parse_multikicker_line_lexed, parse_offspring_line_lexed,
     parse_prowl_line_lexed, parse_reinforce_line_lexed, parse_replicate_line_lexed,
     parse_retrace_line_lexed, parse_self_free_cast_alternative_cost_line_lexed,
-    parse_squad_line_lexed, parse_transmute_line_lexed, parse_warp_line_lexed,
+    parse_sneak_line_lexed, parse_squad_line_lexed, parse_transmute_line_lexed,
+    parse_warp_line_lexed,
     parse_you_may_rather_than_spell_cost_line_lexed, preserve_keyword_prefix_for_parse,
 };
 
@@ -307,6 +308,9 @@ pub(super) fn lower_alternative_cast(
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     if let Some(method) = parse_prowl_line_lexed(tokens)? {
+        return Ok(LineAst::AlternativeCastingMethod(method.into()));
+    }
+    if let Some(method) = parse_sneak_line_lexed(tokens)? {
         return Ok(LineAst::AlternativeCastingMethod(method.into()));
     }
     if let Some(ability) = parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)? {
@@ -991,5 +995,6 @@ fn parse_alternative_cast_kind(tokens: &[OwnedLexToken]) -> Result<bool, CardTex
         || parse_jump_start_line_lexed(tokens)?.is_some()
         || parse_if_conditional_alternative_cost_line_lexed(tokens, rendered.as_str())?.is_some()
         || parse_prowl_line_lexed(tokens)?.is_some()
+        || parse_sneak_line_lexed(tokens)?.is_some()
         || parse_if_this_spell_costs_less_to_cast_line_lexed(tokens)?.is_some())
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -5108,6 +5108,45 @@ pub(crate) fn parse_blitz_line_lexed(
     parse_blitz_line(tokens)
 }
 
+pub(crate) fn parse_sneak_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
+    if !token_slice_first_is(tokens, "sneak") {
+        return Ok(None);
+    }
+
+    let (mana_cost, consumed_mana_tokens) =
+        leading_mana_cost_from_tokens(tokens.get(1..).unwrap_or_default()).ok_or_else(|| {
+            CardTextError::ParseError("sneak keyword missing mana cost".to_string())
+        })?;
+    let consumed_mana_tokens = consumed_mana_tokens.min(tokens.len().saturating_sub(1));
+    let tail_words = crate::runtime_backend::token_word_refs(
+        tokens.get(1 + consumed_mana_tokens..).unwrap_or_default(),
+    );
+    if !tail_words.is_empty()
+        && !word_slice_starts_with(
+            tail_words.as_slice(),
+            &["you", "may", "cast", "this", "spell"],
+        )
+    {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported sneak reminder text tail: '{}'",
+            tail_words.join(" ")
+        )));
+    }
+
+    Ok(Some(AlternativeCastingMethod::Composed {
+        name: "Sneak",
+        total_cost: TotalCost::from_costs(vec![
+            crate::costs::Cost::mana(mana_cost),
+            crate::costs::Cost::effect(crate::effect::Effect::new(
+                crate::effects::NinjutsuCostEffect::declare_blockers_step_only(),
+            )),
+        ]),
+        condition: None,
+    }))
+}
+
 pub(crate) fn parse_transmute_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<ParsedAbility>, CardTextError> {

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3722,11 +3722,28 @@ impl UnearthEffect {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct NinjutsuCostEffect;
+pub enum UnblockedAttackerReturnTiming {
+    #[default]
+    AfterBlockersDeclared,
+    DeclareBlockersStepOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct NinjutsuCostEffect {
+    pub timing: UnblockedAttackerReturnTiming,
+}
 
 impl NinjutsuCostEffect {
     pub fn new() -> Self {
-        Self
+        Self {
+            timing: UnblockedAttackerReturnTiming::AfterBlockersDeclared,
+        }
+    }
+
+    pub fn declare_blockers_step_only() -> Self {
+        Self {
+            timing: UnblockedAttackerReturnTiming::DeclareBlockersStepOnly,
+        }
     }
 }
 

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -136,7 +136,7 @@ pub use effect::{
     TagMatchingObjectsEffect, TagTriggeringDamageTargetEffect, TagTriggeringObjectEffect,
     TagTriggeringSourceEffect, TaggedEffect, TaggedLeavesAbilitySource, TakeInitiativeEffect,
     TapEffect, TargetOnlyEffect, TicketCountersEffect, TransformEffect, UnearthEffect,
-    UnlessActionEffect, UnlessPaysEffect, UntapEffect, Until,
+    UnblockedAttackerReturnTiming, UnlessActionEffect, UnlessPaysEffect, UntapEffect, Until,
     VariableCasualtyPlaneswalkerCopyEffect, VentureIntoDungeonEffect, VoteChoice, VoteEffect,
     VoteOption, WinTheGameEffect, WithIdEffect,
 };

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17322,6 +17322,60 @@ fn parse_ninjutsu_keyword_line_builds_hand_activated_ability() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oroku_saki_shredder_rising_sneak_keyword_strictly() {
+    let name = "Oroku Saki, Shredder Rising";
+    let oracle = oracle_card_info_by_name()
+        .get(name)
+        .unwrap_or_else(|| panic!("missing oracle text for regression card '{name}'"))
+        .oracle_text
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::from_raw(147_759), name)
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Ninja])
+        .power_toughness(PowerToughness::fixed(3, 1))
+        .parse_text(oracle)
+        .expect("Oroku Saki, Shredder Rising should parse strictly from oracle text");
+
+    assert_eq!(
+        def.alternative_casts.len(),
+        1,
+        "Oroku Saki should have one sneak alternative cast"
+    );
+    let sneak = &def.alternative_casts[0];
+    assert_eq!(sneak.name(), "Sneak");
+    assert_eq!(
+        sneak.mana_cost().map(ManaCost::to_oracle),
+        Some("{1}{B}".to_string())
+    );
+    let cost_debug = format!("{:?}", sneak.non_mana_costs());
+    assert!(
+        cost_debug.contains("NinjutsuCostEffect")
+            && cost_debug.contains("DeclareBlockersStepOnly"),
+        "sneak should structurally include a declare-blockers-only return-unblocked-attacker cost, got {cost_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Sneak {1}{B}"),
+        "compiled text should render the sneak keyword line, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever Oroku Saki deals combat damage to a player"),
+        "compiled text should keep Oroku Saki's combat-damage trigger, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported"),
+        "strict compiled text should not contain unsupported markers, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn source_cost_compiled_text_does_not_leak_placeholder_surfaces() {
     let memory_jar = CardDefinitionBuilder::new(CardId::new(), "Memory Jar Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1927,6 +1927,18 @@ pub(super) fn describe_alternative_cast_line(
                 .map(|cost| format!("Prowl {}", cost.to_oracle()))
                 .unwrap_or_else(|| "Prowl".to_string())
         }
+        method if method.is_composed_cost() && method.name().eq_ignore_ascii_case("Sneak") => {
+            method
+                .mana_cost()
+                .map(|cost| {
+                    format!(
+                        "Sneak {} (You may cast this spell for {} if you also return an unblocked attacker you control to hand during the declare blockers step. It enters tapped and attacking.)",
+                        cost.to_oracle(),
+                        cost.to_oracle()
+                    )
+                })
+                .unwrap_or_else(|| "Sneak".to_string())
+        }
         method if method.is_composed_cost() => {
             let name = method.name();
             let mana_cost = method.mana_cost();

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -1005,6 +1005,53 @@ fn casting_method_grants_flash_timing(
     )
 }
 
+fn casting_method_grants_declare_blockers_alt_timing(
+    game: &GameState,
+    player: PlayerId,
+    spell: &crate::object::Object,
+    casting_method: &CastingMethod,
+) -> bool {
+    if game.turn.phase != crate::game_state::Phase::Combat
+        || game.turn.step != Some(crate::game_state::Step::DeclareBlockers)
+    {
+        return false;
+    }
+
+    let method = match casting_method {
+        CastingMethod::Alternative(idx) => spell.alternative_casts.get(*idx).cloned(),
+        CastingMethod::PlayFrom {
+            zone,
+            use_alternative: Some(idx),
+            ..
+        }
+        | CastingMethod::SplitOtherHalfPlayFrom {
+            zone,
+            use_alternative: idx,
+            ..
+        } => {
+            crate::decision::resolve_play_from_alternative_method(game, player, spell, *zone, *idx)
+                .or_else(|| spell.cast_alternative_method.clone())
+        }
+        _ => None,
+    };
+
+    let Some(method) = method else {
+        return false;
+    };
+    if !method.name().eq_ignore_ascii_case("Sneak") {
+        return false;
+    }
+
+    method.non_mana_costs().iter().any(|cost| {
+        cost.effect_ref()
+            .and_then(|effect| effect.downcast_ref::<crate::effects::NinjutsuCostEffect>())
+            .is_some_and(|effect| {
+                effect.timing
+                    == crate::effects::UnblockedAttackerReturnTiming::DeclareBlockersStepOnly
+            })
+    })
+}
+
 fn casting_method_grants_library_search_timing(
     game: &GameState,
     spell: &crate::object::Object,
@@ -1031,6 +1078,12 @@ fn casting_method_grants_special_timing(
     casting_method: &CastingMethod,
 ) -> bool {
     casting_method_grants_flash_timing(ctx.game, ctx.player, spell, casting_method)
+        || casting_method_grants_declare_blockers_alt_timing(
+            ctx.game,
+            ctx.player,
+            spell,
+            casting_method,
+        )
         || (ctx.allow_library_search_cast_timing
             && casting_method_grants_library_search_timing(
                 ctx.game,

--- a/crates/ironsmith-runtime/src/effects/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/mod.rs
@@ -154,7 +154,8 @@ pub use permanents::{
     ExertCostEffect, FlipEffect, GrantObjectAbilityEffect, MeldEffect, MonstrosityEffect,
     NinjutsuCostEffect, NinjutsuEffect, PhaseInEffect, PhaseOutEffect, PutStickerEffect,
     ReconfigureEffect, RegenerateEffect, RenownEffect, SaddleCostEffect, SoulbondPairEffect,
-    SuspectEffect, TapEffect, TransformEffect, UmbraArmorEffect, UnearthEffect, UntapEffect,
+    SuspectEffect, TapEffect, TransformEffect, UmbraArmorEffect, UnblockedAttackerReturnTiming,
+    UnearthEffect, UntapEffect,
 };
 pub use player::{
     AdditionalLandPlaysEffect, AdditionalPhase, AdditionalPhasesEffect, BecomeMonarchEffect,

--- a/crates/ironsmith-runtime/src/effects/permanents/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/mod.rs
@@ -211,7 +211,7 @@ pub use flip::FlipEffect;
 pub use grant_object_ability::GrantObjectAbilityEffect;
 pub use meld::MeldEffect;
 pub use monstrosity::MonstrosityEffect;
-pub use ninjutsu::{NinjutsuCostEffect, NinjutsuEffect};
+pub use ninjutsu::{NinjutsuCostEffect, NinjutsuEffect, UnblockedAttackerReturnTiming};
 pub use phase_in::PhaseInEffect;
 pub use phase_out::PhaseOutEffect;
 pub use put_sticker::PutStickerEffect;

--- a/crates/ironsmith-runtime/src/effects/permanents/ninjutsu.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/ninjutsu.rs
@@ -7,6 +7,7 @@
 //!   battlefield tapped and attacking the recorded target.
 
 use crate::combat_state::{AttackTarget, AttackerInfo, get_attack_target, is_unblocked};
+use crate::costs::PaymentReason;
 use crate::decisions::make_decision;
 use crate::decisions::specs::ChooseObjectsSpec;
 use crate::effect::EffectOutcome;
@@ -19,16 +20,35 @@ use crate::game_state::{GameState, Phase, Step};
 use crate::ids::{ObjectId, PlayerId};
 use crate::types::CardType;
 use crate::zone::Zone;
-pub use ironsmith_core::{NinjutsuCostEffect, NinjutsuEffect};
+pub use ironsmith_core::{NinjutsuCostEffect, NinjutsuEffect, UnblockedAttackerReturnTiming};
 
-fn in_ninjutsu_window(game: &GameState) -> bool {
+fn in_unblocked_attacker_return_window(
+    game: &GameState,
+    timing: UnblockedAttackerReturnTiming,
+) -> bool {
     if game.turn.phase != Phase::Combat {
         return false;
     }
-    matches!(
-        game.turn.step,
-        Some(Step::DeclareBlockers | Step::CombatDamage | Step::EndCombat)
-    )
+    match timing {
+        UnblockedAttackerReturnTiming::AfterBlockersDeclared => matches!(
+            game.turn.step,
+            Some(Step::DeclareBlockers | Step::CombatDamage | Step::EndCombat)
+        ),
+        UnblockedAttackerReturnTiming::DeclareBlockersStepOnly => {
+            game.turn.step == Some(Step::DeclareBlockers)
+        }
+    }
+}
+
+fn unblocked_attacker_return_window_error(timing: UnblockedAttackerReturnTiming) -> &'static str {
+    match timing {
+        UnblockedAttackerReturnTiming::AfterBlockersDeclared => {
+            "Ninjutsu can only be activated during combat after blockers are declared"
+        }
+        UnblockedAttackerReturnTiming::DeclareBlockersStepOnly => {
+            "This cost can only be paid during the declare blockers step"
+        }
+    }
 }
 
 fn unblocked_attackers(game: &GameState, controller: PlayerId) -> Vec<ObjectId> {
@@ -63,19 +83,18 @@ impl EffectExecutor for NinjutsuCostEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        if !in_ninjutsu_window(game) {
+        if !in_unblocked_attacker_return_window(game, self.timing) {
             return Err(ExecutionError::Impossible(
-                "Ninjutsu can only be activated during combat after blockers are declared"
-                    .to_string(),
+                unblocked_attacker_return_window_error(self.timing).to_string(),
             ));
         }
 
         let Some(source_obj) = game.object(ctx.source) else {
             return Err(ExecutionError::ObjectNotFound(ctx.source));
         };
-        if source_obj.zone != Zone::Hand {
+        if !matches!(source_obj.zone, Zone::Hand | Zone::Stack) {
             return Err(ExecutionError::Impossible(
-                "Ninjutsu source must be in hand".to_string(),
+                "Ninjutsu source must be in hand or on the stack".to_string(),
             ));
         }
 
@@ -164,16 +183,54 @@ impl EffectExecutor for NinjutsuCostEffect {
 }
 
 impl CostExecutableEffect for NinjutsuCostEffect {
+    fn can_execute_as_cost_with_reason(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        reason: PaymentReason,
+    ) -> Result<(), CostValidationError> {
+        if !in_unblocked_attacker_return_window(game, self.timing) {
+            return Err(CostValidationError::Other(
+                unblocked_attacker_return_window_error(self.timing).to_string(),
+            ));
+        }
+
+        let Some(source_obj) = game.object(source) else {
+            return Err(CostValidationError::Other(
+                "Ninjutsu source does not exist".to_string(),
+            ));
+        };
+        let stack_allowed = reason == PaymentReason::CastSpell;
+        if source_obj.zone != Zone::Hand && !(stack_allowed && source_obj.zone == Zone::Stack) {
+            return Err(CostValidationError::Other(
+                if stack_allowed {
+                    "Ninjutsu source must be in hand or on the stack"
+                } else {
+                    "Ninjutsu source must be in hand"
+                }
+                .to_string(),
+            ));
+        }
+
+        if unblocked_attackers(game, controller).is_empty() {
+            return Err(CostValidationError::Other(
+                "No unblocked attacker you control to return".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     fn can_execute_as_cost(
         &self,
         game: &GameState,
         source: ObjectId,
         controller: PlayerId,
     ) -> Result<(), CostValidationError> {
-        if !in_ninjutsu_window(game) {
+        if !in_unblocked_attacker_return_window(game, self.timing) {
             return Err(CostValidationError::Other(
-                "Ninjutsu can only be activated during combat after blockers are declared"
-                    .to_string(),
+                unblocked_attacker_return_window_error(self.timing).to_string(),
             ));
         }
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1452,6 +1452,7 @@ pub(super) fn auto_pay_spell_tap_cost_steps(
         };
 
         let mut cost_ctx = CostContext::new(pending.spell_id, pending.caster, &mut *decision_maker)
+            .with_reason(crate::costs::PaymentReason::CastSpell)
             .with_provenance(pending.provenance);
         cost_ctx.tagged_objects = pending.tagged_objects.clone();
         cost_ctx.x_value = pending.x_value;
@@ -1498,6 +1499,7 @@ pub(super) fn continue_spell_cost_payment(
         ActivationCostStep::Cost(cost) => {
             let mut cost_ctx =
                 CostContext::new(pending.spell_id, pending.caster, &mut *decision_maker)
+                    .with_reason(crate::costs::PaymentReason::CastSpell)
                     .with_provenance(pending.provenance);
             cost_ctx.tagged_objects = pending.tagged_objects.clone();
             cost_ctx.x_value = pending.x_value;

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -998,6 +998,22 @@ pub(super) fn resolve_stack_entry_full(
                     ),
                     _ => false,
                 };
+                let cast_with_sneak = entry.optional_costs_paid.was_paid_label("Sneak")
+                    || obj.optional_costs_paid.was_paid_label("Sneak");
+                if cast_with_sneak {
+                    game.tap(result.new_id);
+                    if let Some(attack_target) = game
+                        .ninjutsu_attack_targets
+                        .remove(&entry.object_id)
+                        .and_then(|mut targets| targets.pop())
+                        && let Some(combat) = game.combat.as_mut()
+                    {
+                        combat.attackers.push(crate::combat_state::AttackerInfo {
+                            creature: result.new_id,
+                            target: attack_target,
+                        });
+                    }
+                }
                 if cast_with_dash {
                     let dash_haste = crate::effects::ApplyContinuousEffect::new(
                         crate::continuous::EffectTarget::Specific(result.new_id),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -31166,6 +31166,156 @@ fn oroku_saki_sneak_casting_method_is_only_available_during_declare_blockers() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn oroku_saki_priority_cast_with_sneak_pays_cost_and_enters_tapped_attacking() {
+    let mut game = setup_game();
+    let (alice, bob, attacker) = make_oroku_saki_sneak_combat(&mut game);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    if let Some(player) = game.player_mut(alice) {
+        player.mana_pool.add(ManaSymbol::Black, 1);
+        player.mana_pool.add(ManaSymbol::Colorless, 1);
+    }
+    let oroku = game.create_object_from_definition(
+        &oroku_saki_shredder_rising_definition(),
+        alice,
+        Zone::Hand,
+    );
+
+    let sneak_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Hand,
+                    casting_method: crate::alternative_cast::CastingMethod::Alternative(_),
+                } if *spell_id == oroku
+            )
+        })
+        .expect("Sneak should be offered as a real priority cast action");
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    state.set_auto_choose_single_pip_payment(false);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(sneak_action),
+        &mut dm,
+    )
+    .expect("selecting Sneak should start the cast flow");
+
+    let next_cost_ctx = match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::SelectOptions(
+            ctx,
+        )) => ctx,
+        other => panic!("expected next-cost chooser for Sneak cast, got {other:?}"),
+    };
+    let sneak_cost_index = next_cost_ctx
+        .options
+        .iter()
+        .find(|option| option.description.contains("unblocked attacker"))
+        .map(|option| option.index)
+        .expect("Sneak cast should include the unblocked-attacker return cost");
+
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::NextCostChoice(sneak_cost_index),
+        &mut dm,
+    )
+    .expect("paying the Sneak return cost from the stack should succeed");
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .iter()
+            .any(|id| game.object(*id).is_some_and(|obj| obj.name == "Oroku Saki Sneak Attacker")),
+        "Sneak should return the unblocked attacker to hand during casting"
+    );
+    assert!(
+        game.combat
+            .as_ref()
+            .is_some_and(|combat| !combat.attackers.iter().any(|info| info.creature == attacker)),
+        "the returned attacker should leave combat during Sneak cost payment"
+    );
+    let stack_oroku = state
+        .pending_cast
+        .as_ref()
+        .map(|pending| pending.spell_id)
+        .expect("Oroku Saki should still be pending after paying the Sneak return cost");
+    assert!(
+        game.object(stack_oroku)
+            .is_some_and(|obj| obj.zone == Zone::Stack),
+        "Oroku Saki should be proposed onto the stack during casting"
+    );
+    assert_eq!(
+        game.ninjutsu_attack_targets
+            .get(&stack_oroku)
+            .and_then(|targets| targets.last()),
+        Some(&AttackTarget::Player(bob)),
+        "Sneak should record the returned attacker's target for resolution"
+    );
+
+    match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::SelectOptions(
+            _,
+        )) => {}
+        other => panic!("expected mana payment prompt after Sneak cost, got {other:?}"),
+    }
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::ManaPipPayment(0),
+        &mut dm,
+    )
+    .expect("paying {B} for Sneak should succeed");
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::ManaPipPayment(0),
+        &mut dm,
+    )
+    .expect("paying {1} for Sneak should finish casting");
+
+    let stack_entry = game
+        .stack
+        .last()
+        .expect("Oroku Saki should remain on the stack after the Sneak cast is finalized");
+    assert_eq!(stack_entry.object_id, stack_oroku);
+    assert!(
+        stack_entry.optional_costs_paid.was_paid_label("Sneak"),
+        "the finalized stack entry should record that Sneak was used"
+    );
+
+    resolve_stack_entry(&mut game).expect("Oroku Saki sneak spell should resolve");
+
+    let entered = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| game.object(*id).is_some_and(|obj| obj.name == "Oroku Saki, Shredder Rising"))
+        .expect("Oroku Saki should enter the battlefield");
+    assert!(game.is_tapped(entered), "Oroku Saki should enter tapped after sneak");
+    assert!(
+        game.combat.as_ref().is_some_and(|combat| {
+            combat
+                .attackers
+                .iter()
+                .any(|info| info.creature == entered && info.target == AttackTarget::Player(bob))
+        }),
+        "Oroku Saki should enter attacking the returned attacker's target"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn oroku_saki_cast_with_sneak_enters_tapped_and_attacking() {
     let mut game = setup_game();
     let (alice, bob, _attacker) = make_oroku_saki_sneak_combat(&mut game);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -31001,6 +31001,210 @@ fn test_force_of_will_alternative_cost_casting_flow() {
     assert_eq!(exiled[0].name, "Counterspell");
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn oroku_saki_shredder_rising_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(147_759), "Oroku Saki, Shredder Rising")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Ninja])
+        .power_toughness(PowerToughness::fixed(3, 1))
+        .parse_text(
+            "Sneak {1}{B} (You may cast this spell for {1}{B} if you also return an unblocked attacker you control to hand during the declare blockers step. He enters tapped and attacking.)\n\
+             Whenever Oroku Saki deals combat damage to a player, you draw a card and lose 1 life.",
+        )
+        .expect("Oroku Saki, Shredder Rising should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn make_oroku_saki_sneak_combat(game: &mut GameState) -> (PlayerId, PlayerId, ObjectId) {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let attacker_card = CardBuilder::new(CardId::from_raw(147_760), "Oroku Saki Sneak Attacker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let attacker = game.create_object_from_card(&attacker_card, alice, Zone::Battlefield);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareBlockers);
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: attacker,
+            target: AttackTarget::Player(bob),
+        }],
+        ..crate::combat_state::CombatState::default()
+    });
+    (alice, bob, attacker)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oroku_saki_sneak_cost_returns_unblocked_attacker_from_stack() {
+    use crate::costs::{Cost, CostContext, CostPayer, PaymentReason};
+
+    let mut game = setup_game();
+    let (alice, bob, attacker) = make_oroku_saki_sneak_combat(&mut game);
+    let oroku = game.create_object_from_definition(
+        &oroku_saki_shredder_rising_definition(),
+        alice,
+        Zone::Stack,
+    );
+    let cost = Cost::effect(crate::effects::NinjutsuCostEffect::declare_blockers_step_only());
+    let mut dm = SelectFirstDecisionMaker;
+    let mut ctx = CostContext::new(oroku, alice, &mut dm).with_reason(PaymentReason::CastSpell);
+
+    cost.can_pay(&game, &ctx)
+        .expect("Oroku Saki sneak cost should be payable from the stack while casting");
+    cost.pay(&mut game, &mut ctx)
+        .expect("Oroku Saki sneak cost should return the unblocked attacker");
+
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .iter()
+            .any(|id| game.object(*id).is_some_and(|obj| obj.name == "Oroku Saki Sneak Attacker")),
+        "sneak should return the unblocked attacker to hand"
+    );
+    assert!(
+        game.combat
+            .as_ref()
+            .is_some_and(|combat| !combat.attackers.iter().any(|info| info.creature == attacker)),
+        "returned attacker should be removed from combat"
+    );
+    assert_eq!(
+        game.ninjutsu_attack_targets
+            .get(&oroku)
+            .and_then(|targets| targets.last()),
+        Some(&AttackTarget::Player(bob)),
+        "sneak should record the returned attacker's combat target for resolution"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oroku_saki_sneak_cost_requires_declare_blockers_unblocked_attacker() {
+    use crate::costs::{Cost, CostContext, CostPayer, PaymentReason};
+
+    let mut game = setup_game();
+    let (alice, bob, attacker) = make_oroku_saki_sneak_combat(&mut game);
+    let oroku = game.create_object_from_definition(
+        &oroku_saki_shredder_rising_definition(),
+        alice,
+        Zone::Stack,
+    );
+    let cost = Cost::effect(crate::effects::NinjutsuCostEffect::declare_blockers_step_only());
+    let mut dm = SelectFirstDecisionMaker;
+
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let ctx = CostContext::new(oroku, alice, &mut dm).with_reason(PaymentReason::CastSpell);
+    assert!(
+        cost.can_pay(&game, &ctx).is_err(),
+        "Oroku Saki sneak should not be payable before blockers are declared"
+    );
+
+    game.turn.step = Some(crate::game_state::Step::CombatDamage);
+    let ctx = CostContext::new(oroku, alice, &mut dm).with_reason(PaymentReason::CastSpell);
+    assert!(
+        cost.can_pay(&game, &ctx).is_err(),
+        "Oroku Saki sneak should only be payable during the declare blockers step"
+    );
+
+    game.turn.step = Some(crate::game_state::Step::DeclareBlockers);
+    let blocker = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(147_761), "Oroku Saki Sneak Blocker")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    if let Some(combat) = game.combat.as_mut() {
+        combat.blockers.insert(attacker, vec![blocker]);
+    }
+    let ctx = CostContext::new(oroku, alice, &mut dm).with_reason(PaymentReason::CastSpell);
+    assert!(
+        cost.can_pay(&game, &ctx).is_err(),
+        "Oroku Saki sneak should not be payable without an unblocked attacker"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oroku_saki_sneak_casting_method_is_only_available_during_declare_blockers() {
+    let mut game = setup_game();
+    let (alice, _bob, _attacker) = make_oroku_saki_sneak_combat(&mut game);
+    if let Some(player) = game.player_mut(alice) {
+        player.mana_pool.add(ManaSymbol::Colorless, 1);
+        player.mana_pool.add(ManaSymbol::Black, 1);
+    }
+    let oroku_def = oroku_saki_shredder_rising_definition();
+    let oroku = game.create_object_from_definition(&oroku_def, alice, Zone::Hand);
+    let spell = game.object(oroku).expect("Oroku Saki should exist");
+    let sneak = spell
+        .alternative_casts
+        .iter()
+        .find(|method| method.name() == "Sneak")
+        .cloned()
+        .expect("Oroku Saki should have a sneak alternative cast");
+
+    assert!(
+        crate::decision::can_cast_with_alternative_from_hand(&game, alice, spell, oroku, &sneak),
+        "Sneak should grant permission to cast Oroku Saki during the declare blockers step"
+    );
+
+    game.turn.step = Some(crate::game_state::Step::CombatDamage);
+    let spell = game.object(oroku).expect("Oroku Saki should still exist");
+    assert!(
+        !crate::decision::can_cast_with_alternative_from_hand(&game, alice, spell, oroku, &sneak),
+        "Sneak should not remain available after the declare blockers step"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oroku_saki_cast_with_sneak_enters_tapped_and_attacking() {
+    let mut game = setup_game();
+    let (alice, bob, _attacker) = make_oroku_saki_sneak_combat(&mut game);
+    let oroku = game.create_object_from_definition(
+        &oroku_saki_shredder_rising_definition(),
+        alice,
+        Zone::Stack,
+    );
+    game.ninjutsu_attack_targets
+        .insert(oroku, vec![AttackTarget::Player(bob)]);
+
+    let mut paid = crate::cost::OptionalCostsPaid::default();
+    paid.mark_label_paid("Sneak");
+    game.stack.push(
+        StackEntry::new(oroku, alice)
+            .with_casting_method(crate::alternative_cast::CastingMethod::Alternative(0))
+            .with_optional_costs_paid(paid),
+    );
+
+    resolve_stack_entry(&mut game).expect("Oroku Saki sneak spell should resolve");
+
+    let entered = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| game.object(*id).is_some_and(|obj| obj.name == "Oroku Saki, Shredder Rising"))
+        .expect("Oroku Saki should enter the battlefield");
+    assert!(game.is_tapped(entered), "Oroku Saki should enter tapped after sneak");
+    assert!(
+        game.combat.as_ref().is_some_and(|combat| {
+            combat
+                .attackers
+                .iter()
+                .any(|info| info.creature == entered && info.target == AttackTarget::Player(bob))
+        }),
+        "Oroku Saki should enter attacking the returned attacker's target"
+    );
+}
+
 #[test]
 fn test_non_mana_only_flashback_does_not_require_printed_mana_cost() {
     use crate::alternative_cast::{AlternativeCastingMethod, CastingMethod};


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Oroku Saki, Shredder Rising
Initial parse error:
```
parser does not yet support line family: 'Sneak {1}{B} (You may cast this spell for {1}{B} if you also return an unblocked attacker you control to hand during the declare blockers step. He enters tapped and attacking.)'; oracle-only fallback also failed: parser does not yet support line family: 'Sneak {1}{B}'
```

Current worker: i-0fbb7dd235628fb54
Branch: codex/aws-card-fix-oroku-saki-shredder-rising
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0008
