### PR TITLE
Fix Ironsmith parse failure: Rootpath Purifier

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -659,6 +659,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         multi_static_ability_ast_rule!(parse_all_are_color_and_type_addition_line),
         single_static_ability_ast_rule!(parse_all_cards_spells_permanents_add_chosen_color_line),
         single_static_ability_ast_rule!(parse_all_creatures_are_color_line),
+        single_static_ability_ast_rule!(parse_subjects_are_basic_line),
         single_static_ability_ast_rule!(parse_protection_from_colored_spells_line),
         single_static_ability_ast_rule!(parse_nonbasic_lands_are_basic_land_type_line),
         single_static_ability_ast_rule!(parse_land_type_addition_line),
@@ -6541,6 +6542,45 @@ pub(crate) fn parse_all_creatures_are_color_line(
     let filter = parse_object_filter(subject_tokens, false)?;
 
     Ok(Some(StaticAbility::set_colors(filter, color)))
+}
+
+pub(crate) fn parse_subjects_are_basic_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(be_idx) = find_index(&words, |word| matches!(*word, "is" | "are")) else {
+        return Ok(None);
+    };
+    if be_idx == 0 || !word_slice_eq(&words[be_idx + 1..], &["basic"]) {
+        return Ok(None);
+    }
+
+    let subject_tokens = trim_lexed_commas(&tokens[..be_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let subject_segments = split_lexed_slices_on_and(subject_tokens);
+    let filter = if subject_segments.len() > 1 {
+        let mut branches = Vec::with_capacity(subject_segments.len());
+        for segment in subject_segments {
+            let segment = trim_lexed_commas(segment);
+            if segment.is_empty() {
+                return Ok(None);
+            }
+            branches.push(parse_object_filter_lexed(segment, false)?);
+        }
+        let mut filter = ObjectFilter::default();
+        filter.any_of = branches;
+        filter
+    } else {
+        parse_object_filter_lexed(subject_tokens, false)?
+    };
+
+    Ok(Some(StaticAbility::add_supertypes(
+        filter,
+        vec![Supertype::Basic],
+    )))
 }
 
 pub(crate) fn parse_nonbasic_lands_are_basic_land_type_line(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -168,6 +168,100 @@ fn party_dude_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[test]
+fn rootpath_purifier_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Rootpath Purifier");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.abilities.iter().any(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => {
+                static_ability.id() == StaticAbilityId::AddSupertypes
+            }
+            _ => false,
+        }),
+        "Rootpath Purifier should parse its basic-supertype static ability strictly, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("AddSupertypes")
+            && ability_debug.contains("Basic")
+            && ability_debug.contains("Library")
+            && ability_debug.contains("Battlefield"),
+        "Rootpath Purifier should structurally add Basic to battlefield lands and library land cards, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("Lands you control")
+            && rendered.contains("land cards in your library")
+            && rendered.contains("are basic"),
+        "Rootpath Purifier compiled text should cover the full basic-supertype clause, got {rendered}"
+    );
+}
+
+#[test]
+fn rootpath_purifier_makes_only_your_lands_and_library_land_cards_basic() {
+    let rootpath = parse_oracle_card_definition("Rootpath Purifier");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+    let alice_battlefield_land = CardBuilder::new(CardId::new(), "Alice Battlefield Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let bob_battlefield_land = CardBuilder::new(CardId::new(), "Bob Battlefield Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let alice_library_land = CardBuilder::new(CardId::new(), "Alice Library Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let alice_library_spell = CardBuilder::new(CardId::new(), "Alice Library Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let bob_library_land = CardBuilder::new(CardId::new(), "Bob Library Land")
+        .card_types(vec![CardType::Land])
+        .build();
+
+    game.create_object_from_definition(&rootpath, alice, Zone::Battlefield);
+    let alice_battlefield_land_id =
+        game.create_object_from_card(&alice_battlefield_land, alice, Zone::Battlefield);
+    let bob_battlefield_land_id =
+        game.create_object_from_card(&bob_battlefield_land, bob, Zone::Battlefield);
+    let alice_library_land_id =
+        game.create_object_from_card(&alice_library_land, alice, Zone::Library);
+    let alice_library_spell_id =
+        game.create_object_from_card(&alice_library_spell, alice, Zone::Library);
+    let bob_library_land_id = game.create_object_from_card(&bob_library_land, bob, Zone::Library);
+
+    let is_basic = |game: &crate::game_state::GameState, id| {
+        game.current_characteristics(id)
+            .expect("object should have current characteristics")
+            .supertypes
+            .contains(&Supertype::Basic)
+    };
+
+    assert!(
+        is_basic(&game, alice_battlefield_land_id),
+        "Rootpath Purifier should make lands you control basic"
+    );
+    assert!(
+        is_basic(&game, alice_library_land_id),
+        "Rootpath Purifier should make land cards in your library basic"
+    );
+    assert!(
+        !is_basic(&game, bob_battlefield_land_id),
+        "Rootpath Purifier should not make lands opponents control basic"
+    );
+    assert!(
+        !is_basic(&game, alice_library_spell_id),
+        "Rootpath Purifier should not make nonland cards in your library basic"
+    );
+    assert!(
+        !is_basic(&game, bob_library_land_id),
+        "Rootpath Purifier should not make land cards in opponents' libraries basic"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rootpath Purifier
Initial parse error:
```
parser does not yet support line family: 'Lands you control and land cards in your library are basic.'; oracle-only fallback also failed: parser does not yet support line family: 'Lands you control and land cards in your library are basic.'
```

Current worker: i-06298343abf9c928a
Branch: codex/aws-card-fix-rootpath-purifier
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0008
