### PR TITLE
Fix Ironsmith parse failure: Sword of the Squeak

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -487,16 +487,6 @@ pub(super) fn parse_object_filter_inner(
         &all_words,
         &[&["power", "or", "toughness"], &["toughness", "or", "power"]],
     );
-    if has_power_or_toughness_clause
-        && !all_words
-            .iter()
-            .any(|word| matches!(*word, "spell" | "spells"))
-    {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported power-or-toughness object filter (clause: '{}')",
-            all_words.join(" ")
-        )));
-    }
     let reference_stage =
         apply_reference_and_tag_stage(&mut filter, &mut all_words, &mut segment_tokens);
     if reference_stage.early_return {
@@ -1447,10 +1437,15 @@ pub(super) fn parse_object_filter_inner(
         filter = disjunction;
     }
 
-    if has_power_or_toughness_clause && saw_spell {
+    if has_power_or_toughness_clause {
         let mut power_or_toughness_cmp = None;
+        let mut power_or_toughness_reference = crate::filter::PtReference::Effective;
         for idx in 0..all_words.len() {
-            let (_, value_tokens) = match all_words.get(idx..) {
+            let (reference, value_tokens) = match all_words.get(idx..) {
+                Some(["base", "power", "or", "toughness", rest @ ..])
+                | Some(["base", "toughness", "or", "power", rest @ ..]) => {
+                    (crate::filter::PtReference::Base, rest)
+                }
                 Some(["power", "or", "toughness", rest @ ..])
                 | Some(["toughness", "or", "power", rest @ ..]) => {
                     (crate::filter::PtReference::Effective, rest)
@@ -1463,6 +1458,7 @@ pub(super) fn parse_object_filter_inner(
                 continue;
             };
             power_or_toughness_cmp = Some(cmp);
+            power_or_toughness_reference = reference;
             break;
         }
         if let Some(cmp) = power_or_toughness_cmp {
@@ -1473,9 +1469,11 @@ pub(super) fn parse_object_filter_inner(
 
             let mut power_branch = base.clone();
             power_branch.power = Some(cmp.clone());
+            power_branch.power_reference = power_or_toughness_reference;
 
             let mut toughness_branch = base;
             toughness_branch.toughness = Some(cmp);
+            toughness_branch.toughness_reference = power_or_toughness_reference;
 
             let mut disjunction = ObjectFilter::default();
             disjunction.any_of = vec![power_branch, toughness_branch];

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4081,6 +4081,25 @@ fn rewrite_parser_root_nonlexed_object_filter_entrypoint_matches_grammar_lexed_o
 }
 
 #[test]
+fn object_filter_parses_base_power_or_toughness_disjunction() {
+    let tokens = lex_line("creature you control with base power or toughness 1", 0)
+        .expect("rewrite lexer should classify base power-or-toughness filter");
+
+    let filter = super::parse_object_filter(&tokens, false)
+        .expect("object filter should parse base power-or-toughness disjunction");
+    let debug = format!("{filter:?}");
+
+    assert!(
+        debug.contains("any_of")
+            && debug.contains("power: Some(Equal(1))")
+            && debug.contains("power_reference: Base")
+            && debug.contains("toughness: Some(Equal(1))")
+            && debug.contains("toughness_reference: Base"),
+        "expected base power/toughness disjunction branches, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_grammar_spell_filter_entrypoint_matches_parser_root_output() {
     let text = "creature spells with power or toughness 2 or less";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify comparison spell filter");

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1708,7 +1708,7 @@ impl ObjectFilter {
                 remaining.retain(|subtype| !outlaw_pack.contains(subtype));
             }
             parts.extend(remaining.iter().map(std::string::ToString::to_string));
-            Some(parts.join(" or "))
+            Some(join_or_list(&parts))
         } else {
             None
         };
@@ -2192,6 +2192,18 @@ fn describe_simple_any_of_keyword_clause(any_of: &[ObjectFilter]) -> Option<Stri
     }
 
     Some(labels.join(" or "))
+}
+
+fn join_or_list(parts: &[String]) -> String {
+    match parts.len() {
+        0 => String::new(),
+        1 => parts[0].clone(),
+        2 => format!("{} or {}", parts[0], parts[1]),
+        _ => {
+            let head = parts[..parts.len() - 1].join(", ");
+            format!("{head}, or {}", parts[parts.len() - 1])
+        }
+    }
 }
 
 fn describe_possessive_player_filter(filter: &PlayerFilter) -> String {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13896,6 +13896,48 @@ fn aquamorph_entity_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn sword_of_the_squeak_strict_parser_and_compiled_text_regression() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Sword of the Squeak")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Equipped creature gets +1/+1 for each creature you control with base power or toughness 1.\n\
+             Whenever a Hamster, Mouse, Rat, or Squirrel you control enters, you may attach this Equipment to that creature.\n\
+             Equip {2}",
+        )
+        .expect("Sword of the Squeak should parse strictly");
+
+    let debug = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        debug.contains("power_reference: base") && debug.contains("toughness_reference: base"),
+        "expected base power/toughness count branches, got {debug}"
+    );
+    assert!(
+        debug.contains("attachobjectseffect") && debug.contains("manapaymentcost"),
+        "expected optional attach trigger and equip cost, got {debug}"
+    );
+
+    let compiled = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        compiled.contains(
+            "Equipped creature gets +1/+1 for each creature you control with base power or toughness 1"
+        ),
+        "expected base power-or-toughness scaling text, got {compiled}"
+    );
+    assert!(
+        compiled.contains(
+            "Whenever a Hamster, Mouse, Rat, or Squirrel you control enters, you may attach this Equipment to that creature"
+        ),
+        "expected optional attach trigger text, got {compiled}"
+    );
+    assert!(
+        compiled.contains("Equip {2}"),
+        "expected equip cost text, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_this_creature_enters_from_your_graveyard() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Phyrexian Dragon Engine")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28909,6 +28909,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(attach) = effect.downcast_ref::<crate::effects::AttachObjectsEffect>() {
         let triggering_tag = TagKey::from("triggering");
+        if matches!(attach.objects, ChooseSpec::Source)
+            && matches!(&attach.target, ChooseSpec::Tagged(tag) if tag == &triggering_tag)
+        {
+            return "Attach this source to that creature".to_string();
+        }
         if choose_spec_references_exact_tag(&attach.objects, &triggering_tag)
             && matches!(&attach.target, ChooseSpec::Tagged(tag) if tag.as_str().starts_with("created_"))
         {

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3566,7 +3566,7 @@ impl ObjectFilterExt for ObjectFilter {
                 remaining.retain(|subtype| !outlaw_pack.contains(subtype));
             }
             parts.extend(remaining.iter().map(std::string::ToString::to_string));
-            Some(parts.join(" or "))
+            Some(join_or_list(&parts))
         } else {
             None
         };
@@ -4049,6 +4049,18 @@ fn describe_simple_any_of_keyword_clause(any_of: &[ObjectFilter]) -> Option<Stri
     }
 
     Some(labels.join(" or "))
+}
+
+fn join_or_list(parts: &[String]) -> String {
+    match parts.len() {
+        0 => String::new(),
+        1 => parts[0].clone(),
+        2 => format!("{} or {}", parts[0], parts[1]),
+        _ => {
+            let head = parts[..parts.len() - 1].join(", ");
+            format!("{head}, or {}", parts[parts.len() - 1])
+        }
+    }
 }
 
 fn plus_minus_counter_delta(counters: &std::collections::HashMap<CounterType, u32>) -> i32 {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2109,6 +2109,236 @@ fn glamdring_equipped_creature_gets_first_strike_and_graveyard_scaled_power() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn sword_of_the_squeak_counts_base_power_or_toughness_and_attaches_to_entering_rodents() {
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::events::zones::ZoneChangeEvent;
+    use crate::object::{AttachmentTarget, CounterType};
+
+    struct MayAttachDecisionMaker {
+        accept: bool,
+    }
+
+    impl DecisionMaker for MayAttachDecisionMaker {
+        fn decide_boolean(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            self.accept
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let sword = CardDefinitionBuilder::new(CardId::from_raw(72_301), "Sword of the Squeak")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "Equipped creature gets +1/+1 for each creature you control with base power or toughness 1.\n\
+             Whenever a Hamster, Mouse, Rat, or Squirrel you control enters, you may attach this Equipment to that creature.\n\
+             Equip {2}",
+        )
+        .expect("Sword of the Squeak should parse for runtime tests");
+    let sword_id = game.create_object_from_definition(&sword, alice, Zone::Battlefield);
+
+    let bearer_id = create_creature(&mut game, "Sword Bearer", alice, 2, 2);
+    if let Some(equipment) = game.object_mut(sword_id) {
+        equipment.attached_to = Some(AttachmentTarget::Object(bearer_id));
+    }
+    if let Some(bearer) = game.object_mut(bearer_id) {
+        bearer.attachments.push(sword_id);
+    }
+
+    create_creature(&mut game, "Base Power One", alice, 1, 3);
+    create_creature(&mut game, "Base Toughness One", alice, 3, 1);
+    create_creature(&mut game, "Base One One", alice, 1, 1);
+    create_creature(&mut game, "Opponent One One", bob, 1, 1);
+    let effectively_one_one = create_creature(&mut game, "Counter-Modified Zero", alice, 0, 0);
+    game.add_counters(effectively_one_one, CounterType::PlusOnePlusOne, 1)
+        .expect("add +1/+1 counter to nonmatching base 0/0");
+
+    assert_eq!(
+        (game.calculated_power(bearer_id), game.calculated_toughness(bearer_id)),
+        (Some(5), Some(5)),
+        "Sword should count each controlled creature with base power or base toughness 1 once"
+    );
+
+    if let Some(equipment) = game.object_mut(sword_id) {
+        equipment.attached_to = None;
+    }
+    if let Some(bearer) = game.object_mut(bearer_id) {
+        bearer.attachments.clear();
+    }
+    assert_eq!(
+        (game.calculated_power(bearer_id), game.calculated_toughness(bearer_id)),
+        (Some(2), Some(2)),
+        "Sword should not buff creatures while unattached"
+    );
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    let equip_actions = compute_legal_actions(&game, alice);
+    assert!(
+        equip_actions.iter().any(|action| matches!(
+            action,
+            LegalAction::ActivateAbility { source, .. } if *source == sword_id
+        )),
+        "Equip {{2}} should be legal with two mana and a creature you control"
+    );
+
+    let hamster = CardBuilder::new(CardId::from_raw(72_302), "Helpful Hamster")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Hamster])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let hamster_id = game.create_object_from_card(&hamster, alice, Zone::Battlefield);
+    let hamster_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(hamster_id).expect("hamster exists"),
+        &game,
+    );
+    let hamster_event = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            hamster_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(hamster_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        check_triggers(&game, &hamster_event).len(),
+        1,
+        "Sword should trigger for a Hamster you control entering"
+    );
+
+    let bear_id = create_creature(&mut game, "Plain Bear", alice, 2, 2);
+    let bear_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(bear_id).expect("bear exists"),
+        &game,
+    );
+    let bear_event = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            bear_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(bear_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        check_triggers(&game, &bear_event).len(),
+        0,
+        "Sword should not trigger for unrelated creature types"
+    );
+
+    let squirrel = CardBuilder::new(CardId::from_raw(72_303), "Opponent Squirrel")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Squirrel])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let opponent_squirrel_id = game.create_object_from_card(&squirrel, bob, Zone::Battlefield);
+    let opponent_squirrel_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(opponent_squirrel_id)
+            .expect("opponent squirrel exists"),
+        &game,
+    );
+    let opponent_squirrel_event = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            opponent_squirrel_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(opponent_squirrel_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        check_triggers(&game, &opponent_squirrel_event).len(),
+        0,
+        "Sword should not trigger for an opponent's qualifying creature"
+    );
+
+    let triggered = sword
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Sword should have an optional attach trigger");
+
+    let mut accept_dm = MayAttachDecisionMaker { accept: true };
+    let mut accept_ctx = ExecutionContext::new_default(sword_id, alice)
+        .with_decision_maker(&mut accept_dm)
+        .with_triggering_event(hamster_event);
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut accept_ctx)
+            .expect("accepted Sword trigger should attach to the entering Hamster");
+    }
+    assert_eq!(
+        game.object(sword_id).and_then(|object| object.attached_to),
+        Some(AttachmentTarget::Object(hamster_id)),
+        "accepting the trigger should attach Sword to the entering Hamster"
+    );
+
+    if let Some(equipment) = game.object_mut(sword_id) {
+        equipment.attached_to = None;
+    }
+    if let Some(hamster) = game.object_mut(hamster_id) {
+        hamster.attachments.clear();
+    }
+    let mouse = CardBuilder::new(CardId::from_raw(72_304), "Declined Mouse")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Mouse])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let mouse_id = game.create_object_from_card(&mouse, alice, Zone::Battlefield);
+    let mouse_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(mouse_id).expect("mouse exists"),
+        &game,
+    );
+    let mouse_event = TriggerEvent::new_with_provenance(
+        ZoneChangeEvent::with_cause(
+            mouse_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(mouse_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        check_triggers(&game, &mouse_event).len(),
+        1,
+        "Sword should trigger for a Mouse you control entering"
+    );
+    let mut decline_dm = MayAttachDecisionMaker { accept: false };
+    let mut decline_ctx = ExecutionContext::new_default(sword_id, alice)
+        .with_decision_maker(&mut decline_dm)
+        .with_triggering_event(mouse_event);
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut decline_ctx)
+            .expect("declined Sword trigger should resolve cleanly");
+    }
+    assert_eq!(
+        game.object(sword_id).and_then(|object| object.attached_to),
+        None,
+        "declining the trigger should leave Sword unattached"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup() {
     let mut game = setup_three_player_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -601,9 +601,78 @@ fn strip_article(text: String) -> String {
     text
 }
 
+fn describe_power_or_toughness_any_of_filter(filter: &ObjectFilter) -> Option<String> {
+    let [left, right] = filter.any_of.as_slice() else {
+        return None;
+    };
+
+    let (power_branch, toughness_branch) = match (
+        left.power.as_ref(),
+        left.toughness.as_ref(),
+        right.power.as_ref(),
+        right.toughness.as_ref(),
+    ) {
+        (Some(_), None, None, Some(_)) => (left, right),
+        (None, Some(_), Some(_), None) => (right, left),
+        _ => return None,
+    };
+
+    let power_cmp = power_branch.power.as_ref()?;
+    let toughness_cmp = toughness_branch.toughness.as_ref()?;
+    if power_cmp != toughness_cmp
+        || power_branch.power_reference != toughness_branch.toughness_reference
+    {
+        return None;
+    }
+
+    let mut power_base = power_branch.clone();
+    power_base.power = None;
+    power_base.power_reference = crate::filter::PtReference::Effective;
+    let mut toughness_base = toughness_branch.clone();
+    toughness_base.toughness = None;
+    toughness_base.toughness_reference = crate::filter::PtReference::Effective;
+    if power_base != toughness_base {
+        return None;
+    }
+
+    let axis = match power_branch.power_reference {
+        crate::filter::PtReference::Effective => "power or toughness",
+        crate::filter::PtReference::Base => "base power or toughness",
+    };
+    Some(format!(
+        "{} with {axis} {}",
+        strip_article(power_base.description()),
+        filter_comparison_display(power_cmp)
+    ))
+}
+
+fn filter_comparison_display(cmp: &crate::filter::Comparison) -> String {
+    match cmp {
+        crate::filter::Comparison::Equal(n) => n.to_string(),
+        crate::filter::Comparison::LessThan(n) => format!("less than {n}"),
+        crate::filter::Comparison::LessThanOrEqual(n) => format!("{n} or less"),
+        crate::filter::Comparison::GreaterThan(n) => format!("greater than {n}"),
+        crate::filter::Comparison::GreaterThanOrEqual(n) => format!("{n} or greater"),
+        crate::filter::Comparison::NotEqual(n) => format!("not {n}"),
+        crate::filter::Comparison::OneOf(values) => values
+            .iter()
+            .map(i32::to_string)
+            .collect::<Vec<_>>()
+            .join(" or "),
+        other => crate::target::ObjectFilter::default()
+            .with_power(other.clone())
+            .description()
+            .trim_start_matches("a permanent with power ")
+            .to_string(),
+    }
+}
+
 fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
     match expr {
         AnthemCountExpression::MatchingFilter(filter) => {
+            if let Some(subject) = describe_power_or_toughness_any_of_filter(filter) {
+                return subject;
+            }
             let mut subject = pluralized_subject_text(filter);
             if filter.owner.is_none()
                 && !filter.single_graveyard
@@ -683,6 +752,12 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
 }
 
 fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Option<String> {
+    if let AnthemCountExpression::MatchingFilter(filter) = expr
+        && let Some(subject) = describe_power_or_toughness_any_of_filter(filter)
+    {
+        return Some(subject);
+    }
+
     if let AnthemCountExpression::MatchingFilter(filter) = expr
         && !filter.any_of.is_empty()
         && filter


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sword of the Squeak
Initial parse error:
```
unsupported 'for each' filter in anthem clause (clause: 'for each creature you control with base power or toughness 1'); oracle-only fallback also failed: unsupported 'for each' filter in anthem clause (clause: 'for each creature you control with base power or toughness 1')
```

Current worker: i-059e2f5a5d359c51f
Branch: codex/aws-card-fix-sword-of-the-squeak
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0009
