### PR TITLE
Fix Ironsmith parse failure: Throne of Eldraine

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -527,6 +527,7 @@ pub(crate) fn is_opening_hand_begin_game_static_line_lexed(tokens: &[OwnedLexTok
 const ACTIVATE_ONLY_RESTRICTION_PREFIXES: &[&[&str]] =
     &[&["activate", "only"], &["activate", "no", "more", "than"]];
 const SPEND_MANA_RESTRICTION_PREFIXES: &[&[&str]] = &[
+    &["spend", "only", "mana"],
     &["spend", "this", "mana", "only"],
     &["spend", "that", "mana", "only"],
     &["this", "mana", "cant", "be", "spent", "to", "cast"],
@@ -836,6 +837,21 @@ fn parse_special_mana_usage_spell_filter_words(words: &[&str]) -> Option<ObjectF
     let words = strip_leading_article_word_refs(words);
     if words.is_empty() {
         return None;
+    }
+
+    if matches!(
+        words,
+        ["monocolored", "spell" | "spells", "of", "that", "color"]
+            | [
+                "monocolored",
+                "spell" | "spells",
+                "of",
+                "the",
+                "chosen",
+                "color"
+            ]
+    ) {
+        return Some(ObjectFilter::default().monocolored().of_chosen_color());
     }
 
     if matches!(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -237,7 +237,9 @@ fn finalize_rewrite_activated_effect_sentences(
     for tokens in sentence_tokens {
         let sentence = render_token_slice(&tokens).trim().to_string();
         let sentence_words = token_word_refs(&tokens);
-        if parse_mana_usage_restriction_sentence_lexed(&tokens).is_some()
+        if is_activation_mana_source_restriction_sentence(sentence_words.as_slice()) {
+            restrictions.activation.push(sentence);
+        } else if parse_mana_usage_restriction_sentence_lexed(&tokens).is_some()
             || parse_mana_spend_bonus_sentence_lexed(&tokens).is_some()
             || word_slice_starts_with(
                 sentence_words.as_slice(),
@@ -353,7 +355,9 @@ fn split_rewrite_activated_effect_text_fallback(
             continue;
         };
         let sentence_words = token_word_refs(&tokens);
-        if parse_mana_usage_restriction_sentence_lexed(&tokens).is_some()
+        if is_activation_mana_source_restriction_sentence(sentence_words.as_slice()) {
+            restrictions.activation.push(sentence);
+        } else if parse_mana_usage_restriction_sentence_lexed(&tokens).is_some()
             || parse_mana_spend_bonus_sentence_lexed(&tokens).is_some()
             || word_slice_starts_with(
                 sentence_words.as_slice(),
@@ -378,6 +382,11 @@ fn split_rewrite_activated_effect_text_fallback(
         restrictions,
         mana_restrictions,
     }
+}
+
+fn is_activation_mana_source_restriction_sentence(words: &[&str]) -> bool {
+    word_slice_starts_with(words, &["spend", "only", "mana"])
+        && word_slice_ends_with(words, &["to", "activate", "this", "ability"])
 }
 
 fn parse_activated_effects_lexed(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40359,6 +40359,232 @@ fn james_wandering_dad_follow_him_models_activate_only_mana_usage_restriction() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn throne_of_eldraine_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Throne of Eldraine");
+    let def = parse_oracle_card_definition("Throne of Eldraine");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("spend this mana only to cast monocolored spells of that color"),
+        "expected Throne of Eldraine mana spend restriction to render, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("spend only mana of the chosen color to activate this ability"),
+        "expected Throne of Eldraine activation mana-source restriction to render, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn throne_of_eldraine_models_mana_and_activation_restrictions() {
+    let def = parse_oracle_card_definition("Throne of Eldraine");
+    let ids: Vec<StaticAbilityId> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        ids.contains(&StaticAbilityId::ChooseColorAsEnters),
+        "Throne of Eldraine should choose a color as it enters, got {ids:?}"
+    );
+
+    let mana_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.is_mana_ability() => Some(activated),
+            _ => None,
+        })
+        .expect("Throne of Eldraine should have a mana ability");
+    let has_monocolored_chosen_restriction = mana_activated
+        .mana_usage_restrictions
+        .iter()
+        .any(|restriction| {
+            matches!(
+                restriction,
+                crate::ability::ManaUsageRestriction::CastSpellMatching {
+                    filter,
+                    restrict_to_matching_spell: true,
+                    ..
+                } if filter.monocolored && filter.chosen_color
+            )
+        });
+    assert!(
+        has_monocolored_chosen_restriction,
+        "Throne of Eldraine mana should be restricted to monocolored spells of the chosen color"
+    );
+
+    let draw_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated
+                    .effects
+                    .iter()
+                    .any(|effect| effect.downcast_ref::<DrawCardsEffect>().is_some()) =>
+            {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("Throne of Eldraine should have a draw activated ability");
+    assert!(
+        draw_activated.additional_restrictions.iter().any(|restriction| {
+            restriction.eq_ignore_ascii_case(
+                "spend only mana of the chosen color to activate this ability",
+            )
+        }),
+        "draw ability should preserve chosen-color activation mana restriction"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn throne_of_eldraine_runtime_adds_chosen_color_mana_and_draws_two_cards() {
+    let def = parse_oracle_card_definition("Throne of Eldraine");
+    let mana_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.is_mana_ability() => {
+                Some(activated.clone())
+            }
+            _ => None,
+        })
+        .expect("Throne of Eldraine should have a mana ability");
+    let draw_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated
+                    .effects
+                    .iter()
+                    .any(|effect| effect.downcast_ref::<DrawCardsEffect>().is_some()) =>
+            {
+                Some(activated.clone())
+            }
+            _ => None,
+        })
+        .expect("Throne of Eldraine should have a draw activated ability");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let throne_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    game.set_chosen_color(throne_id, Color::White);
+
+    let mut mana_ctx = crate::effects::ExecutionContext::new(throne_id, alice, &mut dm)
+        .with_mana_usage_restrictions(mana_activated.mana_usage_restrictions.clone());
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut mana_ctx,
+        alice,
+        throne_id,
+        &mana_activated.effects,
+        None,
+        &[],
+    )
+    .expect("Throne of Eldraine mana ability should resolve");
+    let player = game.player(alice).expect("alice exists");
+    assert_eq!(player.mana_pool.white, 4);
+    assert_eq!(player.restricted_mana.len(), 4);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .empty();
+    game.player_mut(alice)
+        .expect("alice exists")
+        .restricted_mana
+        .clear();
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 2);
+    let insufficient = crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        throne_id,
+        &draw_activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    );
+    assert!(
+        insufficient.is_err(),
+        "draw ability should not be payable with only two mana"
+    );
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .empty();
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Blue, 3);
+    let wrong_color = crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        throne_id,
+        &draw_activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    );
+    assert!(
+        wrong_color.is_err(),
+        "draw ability should require mana of Throne's chosen color"
+    );
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .empty();
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 3);
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        throne_id,
+        &draw_activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("draw ability should be payable with three mana and an untapped Throne");
+
+    let filler = CardDefinitionBuilder::new(CardId::new(), "Library Filler")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_definition(&filler, alice, Zone::Library);
+    game.create_object_from_definition(&filler, alice, Zone::Library);
+    let hand_before = game.player(alice).expect("alice exists").hand.len();
+    let mut draw_ctx = crate::effects::ExecutionContext::new(throne_id, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut draw_ctx,
+        alice,
+        throne_id,
+        &draw_activated.effects,
+        None,
+        &[],
+    )
+    .expect("Throne of Eldraine draw ability should resolve");
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        hand_before + 2,
+        "draw ability should draw exactly two cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn jetfire_ingenious_scientist_card_parses_strictly() {
     let def = parse_oracle_card_definition("Jetfire, Ingenious Scientist // Jetfire, Air Guardian");
     assert!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33042,6 +33042,13 @@ fn activated_mana_output_amount(activated: &crate::ability::ActivatedAbility) ->
             total += *amount;
             found = true;
         }
+        if let Some(add_chosen) = effect.downcast_ref::<crate::effects::AddManaOfChosenColorEffect>()
+            && let Value::Fixed(amount) = &add_chosen.amount
+            && *amount > 0
+        {
+            total += *amount;
+            found = true;
+        }
     }
 
     found.then_some(total)
@@ -33126,6 +33133,13 @@ fn describe_special_mana_usage_spell_filter_target(
 
     if filter == &ObjectFilter::default().owned_by(PlayerFilter::NotYou) {
         return Some("spells you don't own".to_string());
+    }
+
+    if filter == &ObjectFilter::default().monocolored().of_chosen_color() {
+        if pluralize_origin_spell {
+            return Some("monocolored spells of that color".to_string());
+        }
+        return Some("a monocolored spell of that color".to_string());
     }
 
     None

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -2170,52 +2170,15 @@ pub(super) fn apply_mana_payment_response_activation(
         // Pay the mana and finalize
         let mut pending = pending;
         if let Some(ref cost) = pending.mana_cost_to_pay {
-            let allow_any_color =
-                game.can_spend_mana_as_any_color(pending.activator, Some(pending.source));
-            let allow_black_life = game.player_can_pay_black_with_life_for_reason(
+            if !game.try_pay_mana_cost_with_reason(
                 pending.activator,
                 Some(pending.source),
+                cost,
+                x_value,
                 crate::costs::PaymentReason::ActivateAbility,
-            );
-            let life_to_pay_preview = {
-                let Some(player) = game.player(pending.activator) else {
-                    return Err(GameLoopError::InvalidState(
-                        "Cannot pay mana cost - payer not found".to_string(),
-                    ));
-                };
-                let mut preview_pool = player.mana_pool.clone();
-                let (_, life_to_pay) = preview_pool
-                    .try_pay_tracking_life_with_any_color_and_black_life(
-                        cost,
-                        x_value,
-                        allow_any_color,
-                        allow_black_life,
-                    );
-                life_to_pay
-            };
-            if life_to_pay_preview > 0 && !game.can_pay_life(pending.activator, life_to_pay_preview)
-            {
+            ) {
                 return Err(GameLoopError::InvalidState(
-                    "Cannot pay mana cost - insufficient life for life payment".to_string(),
-                ));
-            }
-            let mut life_to_pay = 0u32;
-            if let Some(player) = game.player_mut(pending.activator) {
-                // Pay mana and track life for Phyrexian/K'rrik-style costs.
-                let (_, paid_life) = player
-                    .mana_pool
-                    .try_pay_tracking_life_with_any_color_and_black_life(
-                        cost,
-                        x_value,
-                        allow_any_color,
-                        allow_black_life,
-                    );
-                life_to_pay = paid_life;
-            }
-            // Deduct life for mana pips paid with life.
-            if life_to_pay > 0 && !game.pay_life(pending.activator, life_to_pay) {
-                return Err(GameLoopError::InvalidState(
-                    "Cannot pay mana cost - insufficient life for life payment".to_string(),
+                    "Cannot pay mana cost - insufficient mana".to_string(),
                 ));
             }
         }

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -6377,7 +6377,13 @@ impl GameState {
         let allow_any_color = self.can_spend_mana_as_any_color(payer, source);
         let allow_black_life =
             self.player_can_pay_black_with_life_for_reason(payer, source, reason);
-        let mut preview_pool = player.mana_pool.clone();
+        let mut preview_pool = if let Some(symbol) = source.and_then(|source| {
+            self.chosen_color_activation_mana_restriction(source, cost, reason)
+        }) {
+            self.mana_pool_restricted_to_symbol(&player.mana_pool, symbol)
+        } else {
+            player.mana_pool.clone()
+        };
         let (can_pay, life_to_pay) = preview_pool
             .try_pay_tracking_life_with_any_color_and_black_life(
                 cost,
@@ -6418,6 +6424,42 @@ impl GameState {
         let allow_black_life =
             self.player_can_pay_black_with_life_for_reason(payer, source, reason);
         let original_pool = self.player(payer).map(|player| player.mana_pool.clone());
+        if let Some(symbol) = source.and_then(|source| {
+            self.chosen_color_activation_mana_restriction(source, cost, reason)
+        }) {
+            let Some(original_pool) = original_pool else {
+                return false;
+            };
+            let mut restricted_pool = self.mana_pool_restricted_to_symbol(&original_pool, symbol);
+            let (paid, life_to_pay) = restricted_pool
+                .try_pay_tracking_life_with_any_color_and_black_life(
+                    cost,
+                    x_value,
+                    allow_any_color,
+                    allow_black_life,
+                );
+            if !paid || !self.can_pay_life_with_reason(payer, life_to_pay, reason) {
+                return false;
+            }
+
+            let spent = original_pool
+                .amount(symbol)
+                .saturating_sub(restricted_pool.amount(symbol));
+            if let Some(player) = self.player_mut(payer) {
+                if spent > 0 && !player.mana_pool.remove(symbol, spent) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            if life_to_pay > 0 && !self.pay_life(payer, life_to_pay) {
+                if let Some(player) = self.player_mut(payer) {
+                    player.mana_pool = original_pool;
+                }
+                return false;
+            }
+            return true;
+        }
         let (paid, life_to_pay) = {
             let Some(player) = self.player_mut(payer) else {
                 return false;
@@ -6447,6 +6489,46 @@ impl GameState {
             return false;
         }
         true
+    }
+
+    fn chosen_color_activation_mana_restriction(
+        &self,
+        source: ObjectId,
+        cost: &crate::mana::ManaCost,
+        reason: crate::costs::PaymentReason,
+    ) -> Option<crate::mana::ManaSymbol> {
+        if reason != crate::costs::PaymentReason::ActivateAbility {
+            return None;
+        }
+
+        let object = self.object(source)?;
+        let has_restricted_activation = object.abilities.iter().any(|ability| {
+            let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+                return false;
+            };
+            activated.mana_cost.costs().iter().any(|component| {
+                component
+                    .mana_cost_ref()
+                    .is_some_and(|activation_cost| activation_cost == cost)
+            }) && activated.additional_restrictions.iter().any(|restriction| {
+                restriction.eq_ignore_ascii_case(
+                    "spend only mana of the chosen color to activate this ability",
+                )
+            })
+        });
+
+        has_restricted_activation
+            .then(|| self.chosen_color(source).map(crate::mana::ManaSymbol::from_color))?
+    }
+
+    fn mana_pool_restricted_to_symbol(
+        &self,
+        pool: &crate::player::ManaPool,
+        symbol: crate::mana::ManaSymbol,
+    ) -> crate::player::ManaPool {
+        let mut restricted = crate::player::ManaPool::new();
+        restricted.add(symbol, pool.amount(symbol));
+        restricted
     }
 
     /// Gets a reference to a player by ID.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Throne of Eldraine
Initial parse error:
```
could not find verb in effect clause (clause: 'spend only mana of the chosen color to activate this ability'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'spend only mana of the chosen color to activate this ability'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0c0ff56520bae94bd
Branch: codex/aws-card-fix-throne-of-eldraine
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0010
