### PR TITLE
Fix Ironsmith parse failure: Prototype Portal

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -226,6 +226,72 @@ struct SplitRewriteActivatedEffectText {
     mana_restrictions: Vec<String>,
 }
 
+fn parse_standalone_x_definition_value(tokens: &[OwnedLexToken]) -> Option<crate::effect::Value> {
+    let words = token_word_refs(tokens);
+    let value_tokens = if word_slice_starts_with(&words, &["where", "x", "is"]) {
+        tokens.to_vec()
+    } else if word_slice_starts_with(&words, &["x", "is"]) {
+        let tail_start = token_index_for_word_index(tokens, 2)?;
+        let mut synthetic = vec![
+            OwnedLexToken::word("where".to_string(), TextSpan::synthetic()),
+            OwnedLexToken::word("x".to_string(), TextSpan::synthetic()),
+            OwnedLexToken::word("is".to_string(), TextSpan::synthetic()),
+        ];
+        synthetic.extend_from_slice(&tokens[tail_start..]);
+        synthetic
+    } else {
+        return None;
+    };
+
+    parse_value_binding_clause(&value_tokens).or_else(|| {
+        let value_words = token_word_refs(&value_tokens);
+        matches!(
+            value_words.get(3..),
+            Some(["the", "mana", "value", "of", "that", "card"])
+                | Some(["that", "card", "mana", "value"])
+                | Some(["that", "cards", "mana", "value"])
+        )
+        .then(|| {
+            crate::effect::Value::ManaValueOf(Box::new(ChooseSpec::Tagged(TagKey::from(
+                crate::tag::SOURCE_EXILED_TAG,
+            ))))
+        })
+    })
+}
+
+fn is_standalone_x_definition_sentence(tokens: &[OwnedLexToken]) -> bool {
+    parse_standalone_x_definition_value(tokens).is_some()
+}
+
+fn activated_x_definition_value(tokens: &[OwnedLexToken]) -> Option<crate::effect::Value> {
+    split_lexed_sentences(tokens)
+        .into_iter()
+        .find_map(parse_standalone_x_definition_value)
+}
+
+fn bind_activated_x_definition_to_mana_cost(
+    cost: TotalCost,
+    x_value: Option<crate::effect::Value>,
+) -> TotalCost {
+    let Some(x_value) = x_value else {
+        return cost;
+    };
+
+    cost.try_map(|component| {
+        if let Some(mana_cost) = component.mana_cost_ref()
+            && mana_cost.has_x()
+        {
+            Ok(Cost::dynamic_mana(ironsmith_core::DynamicManaCost::from_x(
+                mana_cost.clone(),
+                x_value.clone(),
+            )))
+        } else {
+            Ok(component)
+        }
+    })
+    .unwrap_or_else(|_: std::convert::Infallible| unreachable!())
+}
+
 fn finalize_rewrite_activated_effect_sentences(
     mut restrictions: ParsedRestrictions,
     sentence_tokens: Vec<Vec<OwnedLexToken>>,
@@ -249,6 +315,8 @@ fn finalize_rewrite_activated_effect_sentences(
             )
         {
             mana_restrictions.push(sentence);
+        } else if is_standalone_x_definition_sentence(&tokens) {
+            continue;
         } else if is_any_player_may_activate_sentence_lexed(&tokens) {
             restrictions.activation.push(sentence);
         } else {
@@ -365,6 +433,8 @@ fn split_rewrite_activated_effect_text_fallback(
             )
         {
             mana_restrictions.push(sentence);
+        } else if is_standalone_x_definition_sentence(&tokens) {
+            continue;
         } else if is_any_player_may_activate_sentence_lexed(&tokens) {
             restrictions.activation.push(sentence);
         } else {
@@ -502,6 +572,7 @@ fn lower_rewrite_activated_to_chunk_impl(
     cost_parse_tokens: &[OwnedLexToken],
     effect_parse_tokens: &[OwnedLexToken],
 ) -> Result<LoweredRewriteActivatedLine, CardTextError> {
+    let x_definition_value = activated_x_definition_value(effect_parse_tokens);
     let SplitRewriteActivatedEffectText {
         effect_text,
         effect_parse_tokens,
@@ -515,7 +586,10 @@ fn lower_rewrite_activated_to_chunk_impl(
         )));
     }
 
-    let normalized_cost = line.cost.clone();
+    let normalized_cost = bind_activated_x_definition_to_mana_cost(
+        line.cost.clone(),
+        x_definition_value,
+    );
     let ability_text = rewrite_activated_display_text(line);
     let additional_activation_restrictions = if ability_text
         .as_deref()

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -17,6 +17,7 @@ use crate::static_abilities::StaticAbility;
 use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
+use ironsmith_core::CostComponent;
 
 mod activated_lowering;
 mod damage_and_cost_rewrites;
@@ -95,7 +96,9 @@ use super::ir::{
     RewriteSagaChapterLine, RewriteSemanticDocument, RewriteSemanticItem, RewriteStatementLine,
     RewriteStaticLine, RewriteTriggeredLine,
 };
-use super::keyword_static::parse_if_this_spell_costs_less_to_cast_line_lexed;
+use super::keyword_static::{
+    parse_if_this_spell_costs_less_to_cast_line_lexed, parse_value_binding_clause,
+};
 use super::lexer::{
     OwnedLexToken, TokenKind, TokenWordView, lex_line, render_token_slice, split_lexed_sentences,
     token_word_refs, trim_lexed_commas,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -26011,6 +26011,48 @@ fn parse_semblance_anvil_keeps_shared_exiled_card_type_cost_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn prototype_portal_strict_parser_keeps_imprint_copy_and_x_definition() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(90_401), "Prototype Portal")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Imprint — When this artifact enters, you may exile an artifact card from your hand.\n\
+             {X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card.",
+        )
+        .expect("Prototype Portal should parse strictly");
+
+    assert_eq!(
+        crate::compiled_text::compiled_text_lines(&def),
+        vec![
+            "Imprint — When this artifact enters, you may exile an artifact card from your hand."
+                .to_string(),
+            "{X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card."
+                .to_string(),
+        ],
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Prototype Portal should have an activated ability");
+    assert!(
+        activated.mana_cost.dynamic_mana_cost().is_some(),
+        "Prototype Portal's {{X}} cost should lower to a dynamic mana cost"
+    );
+    let ability_debug = format!("{:?}", activated);
+    assert!(
+        ability_debug.contains("CreateTokenCopyEffect")
+            && ability_debug.contains(crate::tag::SOURCE_EXILED_TAG),
+        "activated ability should create a token copy of the source-exiled card, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_spells_cost_modifier_keeps_noncreature_qualifier() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Glowrider Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14036,8 +14036,12 @@ pub(super) fn describe_inline_ability_with_self_subject(
             }
             let mut line = String::new();
             let mut pre = Vec::new();
+            let mut trailing_x_definition = None;
             if !activated.mana_cost.costs().is_empty() {
-                pre.push(describe_cost_list(activated.mana_cost.costs()));
+                let (cost_text, x_definition) =
+                    describe_cost_list_with_trailing_x_definition(activated.mana_cost.costs());
+                pre.push(cost_text);
+                trailing_x_definition = x_definition;
             }
             if !activated.choices.is_empty()
                 && !(!activated.effects.is_empty()
@@ -14079,6 +14083,12 @@ pub(super) fn describe_inline_ability_with_self_subject(
                     &effects,
                     self_subject,
                 ));
+            }
+            if let Some(x_definition) = trailing_x_definition {
+                if !line.is_empty() {
+                    line.push_str(". ");
+                }
+                line.push_str(&x_definition);
             }
             let restriction_clauses = collect_activation_restriction_clauses(
                 &activated.timing,
@@ -17439,6 +17449,39 @@ fn describe_dynamic_mana_cost(dynamic: &ironsmith_core::DynamicManaCost) -> Stri
     } else {
         text
     }
+}
+
+fn describe_cost_list_with_trailing_x_definition(
+    costs: &[crate::costs::Cost],
+) -> (String, Option<String>) {
+    let mut parts = describe_cost_component_parts(costs);
+    let mut trailing = None;
+    for cost in costs {
+        let Some(dynamic) = cost.dynamic_mana_cost_ref() else {
+            continue;
+        };
+        let Some(x_value) = dynamic.x_value.as_ref() else {
+            continue;
+        };
+        let full = describe_dynamic_mana_cost(dynamic);
+        let base_dynamic = ironsmith_core::DynamicManaCost::new(
+            dynamic.base.clone(),
+            None,
+            dynamic.additional_generic.clone(),
+            dynamic.multiplier.clone(),
+            dynamic.display_hint.clone(),
+        );
+        let base = describe_dynamic_mana_cost(&base_dynamic);
+        if let Some(part) = parts.iter_mut().find(|part| **part == full) {
+            *part = base;
+        }
+        trailing = Some(if value_is_source_exiled_mana_value(x_value) {
+            "X is the mana value of that card".to_string()
+        } else {
+            format!("X is {}", describe_value(x_value))
+        });
+    }
+    (parts.join(", "), trailing)
 }
 
 fn describe_total_cost_payment(cost: &crate::cost::TotalCost) -> String {
@@ -30203,6 +30246,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             ChooseSpec::Tagged(tag) if tag.as_str().starts_with("exile_cost_") => {
                 "the exiled card".to_string()
             }
+            ChooseSpec::Object(filter) if is_source_exiled_cards_filter(filter) => {
+                "the exiled card".to_string()
+            }
             ChooseSpec::Tagged(tag)
                 if tag.as_str().starts_with("__sentence_helper_exiled")
                     && create_copy.set_base_power_toughness.is_some()
@@ -36347,9 +36393,13 @@ pub(super) fn describe_ability(
                 format!("Activated ability {index}")
             };
             let mut pre = Vec::new();
+            let mut trailing_x_definition = None;
             if !activated.mana_cost.costs().is_empty() {
+                let (cost_text, x_definition) =
+                    describe_cost_list_with_trailing_x_definition(activated.mana_cost.costs());
+                trailing_x_definition = x_definition;
                 if let Some(cost_text) = normalize_zone_bound_self_exile_cost(
-                    Some(describe_cost_list(activated.mana_cost.costs())),
+                    Some(cost_text),
                     ability,
                 ) {
                     pre.push(cost_text);
@@ -36394,6 +36444,12 @@ pub(super) fn describe_ability(
                         .replace("this spell", &lowercase_first(subject));
                 }
                 line.push_str(&effects);
+            }
+            if let Some(x_definition) = trailing_x_definition {
+                if !line.is_empty() {
+                    line.push_str(". ");
+                }
+                line.push_str(&x_definition);
             }
             let restriction_clauses = collect_activation_restriction_clauses(
                 &activated.timing,

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -1241,6 +1241,10 @@ fn activation_cost_component_precheck_with_view(
         return available >= count as usize;
     }
 
+    if let Some(dynamic_mana) = cost.dynamic_mana_cost_ref() {
+        return dynamic_activation_mana_cost_resolves(game, controller, source, dynamic_mana);
+    }
+
     if game
         .validate_cost_for_payment_reason(controller, source, cost, reason)
         .is_err()
@@ -1257,6 +1261,17 @@ fn activation_cost_component_precheck_with_view(
 
     let check_ctx = crate::costs::CostCheckContext::new(source, controller).with_reason(reason);
     crate::costs::can_pay_with_check_context(&*cost.0, game, &check_ctx).is_ok()
+}
+
+fn dynamic_activation_mana_cost_resolves(
+    game: &GameState,
+    controller: PlayerId,
+    source: ObjectId,
+    dynamic_mana: &ironsmith_core::DynamicManaCost,
+) -> bool {
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, controller, &mut dm);
+    crate::special_actions::resolve_dynamic_mana_cost(game, dynamic_mana, &mut ctx).is_ok()
 }
 
 fn activation_printed_costs_precheck_with_view(
@@ -1579,6 +1594,9 @@ fn activation_cost_is_payable_with_view(
         // cost modifiers reprice the mana portion. The payment flow will enforce
         // the actual mana payment later.
         return true;
+    }
+    if let Some(dynamic_mana) = cost.dynamic_mana_cost_ref() {
+        return dynamic_activation_mana_cost_resolves(game, controller, source, dynamic_mana);
     }
     if cost.is_remove_counters() {
         return true;

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -806,6 +806,28 @@ pub fn apply_priority_response_with_dm(
 
             append_activation_cost_steps_from_components(cost.costs(), &mut remaining_cost_steps);
             for cost_component in cost.costs() {
+                if let Some(dynamic_mana) = cost_component.dynamic_mana_cost_ref() {
+                    let mut execution_ctx =
+                        ExecutionContext::new(*source, player, &mut *decision_maker)
+                            .with_provenance(activation_provenance);
+                    let resolved = crate::special_actions::resolve_dynamic_mana_cost(
+                        game,
+                        dynamic_mana,
+                        &mut execution_ctx,
+                    )
+                    .map_err(|err| {
+                        GameLoopError::InvalidState(format!(
+                            "failed to resolve dynamic activation mana cost: {err:?}"
+                        ))
+                    })?;
+                    mana_cost_to_pay = Some(game.adjust_mana_cost_for_payment_reason(
+                        player,
+                        Some(*source),
+                        &resolved,
+                        crate::costs::PaymentReason::ActivateAbility,
+                    ));
+                    continue;
+                }
                 match cost_component.processing_mode() {
                     crate::costs::CostProcessingMode::ManaPayment { cost } => {
                         mana_cost_to_pay = Some(cost);

--- a/crates/ironsmith-runtime/src/game_loop/priority_state.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_state.rs
@@ -529,6 +529,10 @@ pub(crate) fn append_activation_cost_steps_from_cost(
 ) {
     use crate::costs::CostProcessingMode;
 
+    if cost.dynamic_mana_cost_ref().is_some() {
+        return;
+    }
+
     let mode = cost.processing_mode();
     let description = mode.display();
     match mode {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30337,6 +30337,159 @@ fn test_cipher_copy_cast_prompts_for_targets_before_resolving() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn prototype_portal_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(90_401), "Prototype Portal")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Imprint — When this artifact enters, you may exile an artifact card from your hand.\n\
+             {X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card.",
+        )
+        .expect("Prototype Portal should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_prototype_portal_imprint(
+    game: &mut GameState,
+    portal_id: ObjectId,
+    controller: PlayerId,
+) {
+    let triggered_effects = game
+        .object(portal_id)
+        .expect("Prototype Portal should exist")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.effects.clone()),
+            _ => None,
+        })
+        .expect("Prototype Portal should have an imprint trigger");
+    game.stack.push(
+        StackEntry::ability(portal_id, controller, triggered_effects).with_triggering_event(
+            TriggerEvent::new_with_provenance(
+                EnterBattlefieldEvent::new(portal_id, Zone::Hand),
+                crate::provenance::ProvNodeId::default(),
+            ),
+        ),
+    );
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(game, &mut dm)
+        .expect("Prototype Portal imprint trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn prototype_portal_imprints_artifact_and_copies_it_for_exact_dynamic_x_cost() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let portal = prototype_portal_definition();
+    let fuel_card = CardBuilder::new(CardId::from_raw(90_402), "Portal Fuel")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let fuel_id = game.create_object_from_card(&fuel_card, alice, Zone::Hand);
+    let portal_id = game.create_object_from_definition(&portal, alice, Zone::Battlefield);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. }
+                    if source == portal_id
+            )),
+        "Prototype Portal should not be activatable before a card is imprinted"
+    );
+
+    resolve_prototype_portal_imprint(&mut game, portal_id, alice);
+
+    assert!(
+        game.object(fuel_id).is_none(),
+        "the imprinted card should receive a fresh object id after moving to exile"
+    );
+    let imprinted = game.get_imprinted_cards(portal_id);
+    assert_eq!(
+        imprinted.len(),
+        1,
+        "Prototype Portal should source-link the exiled artifact card"
+    );
+    let imprinted_id = imprinted[0];
+    let imprinted_object = game
+        .object(imprinted_id)
+        .expect("imprinted card should exist in exile");
+    assert_eq!(imprinted_object.zone, Zone::Exile);
+    assert_eq!(imprinted_object.name, "Portal Fuel");
+
+    let activated = game
+        .object(portal_id)
+        .expect("Prototype Portal should exist")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated.clone()),
+            _ => None,
+        })
+        .expect("Prototype Portal should have an activated ability");
+
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+    let mut dm = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(portal_id, alice, &mut dm);
+    assert!(
+        crate::special_actions::pay_total_cost_with_choice_in_context(
+            &mut game,
+            alice,
+            portal_id,
+            &activated.mana_cost,
+            crate::costs::PaymentReason::ActivateAbility,
+            &mut ctx,
+        )
+        .is_err(),
+        "Prototype Portal activation should not accept less mana than the imprinted card's mana value"
+    );
+    assert!(
+        !game.is_tapped(portal_id),
+        "failed dynamic mana payment should not pay the tap cost"
+    );
+
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+    crate::special_actions::pay_total_cost_with_choice_in_context(
+        &mut game,
+        alice,
+        portal_id,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut ctx,
+    )
+    .expect("Prototype Portal activation should accept mana equal to imprinted card's mana value");
+    assert!(game.is_tapped(portal_id), "Prototype Portal should tap as a cost");
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").mana_pool.total(),
+        0,
+        "Prototype Portal should spend exactly three mana for the imprinted mana value"
+    );
+
+    execute_resolution_program(&mut game, &mut ctx, alice, portal_id, &activated.effects, None, &[])
+        .expect("Prototype Portal activation should resolve");
+
+    let copied_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .filter(|object| object.name == "Portal Fuel" && object.kind == ObjectKind::Token)
+        .count();
+    assert_eq!(
+        copied_tokens, 1,
+        "Prototype Portal should create one token copy of the imprinted artifact card"
+    );
+}
+
 #[test]
 fn test_rebound_exiles_on_resolution_and_schedules_next_upkeep_cast() {
     use crate::ability::Ability;

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -2353,11 +2353,24 @@ fn resolve_and_adjust_component_in_context(
     crate::cost::adjusted_component_for_check(game, payer, source, component, reason)
 }
 
-fn resolve_dynamic_mana_cost(
+pub(crate) fn resolve_dynamic_mana_cost(
     game: &GameState,
     dynamic_mana: &ironsmith_core::DynamicManaCost,
     execution_ctx: &mut ExecutionContext<'_>,
 ) -> Result<ManaCost, CostPaymentError> {
+    let source_exiled = game
+        .get_exiled_with_source_links(execution_ctx.source)
+        .iter()
+        .filter_map(|id| {
+            game.object(*id).map(|object| {
+                ObjectSnapshot::from_object_with_calculated_characteristics(object, game)
+            })
+        })
+        .collect::<Vec<_>>();
+    if !source_exiled.is_empty() {
+        execution_ctx.set_tagged_objects(crate::tag::SOURCE_EXILED_TAG, source_exiled);
+    }
+
     let x_value = if let Some(value) = dynamic_mana.x_value.as_ref() {
         resolve_dynamic_u32(game, value, execution_ctx)?
     } else if dynamic_mana.base.has_x() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Prototype Portal
Initial parse error:
```
could not find verb in effect clause (clause: 'x is the mana value of that card'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'x is the mana value of that card'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-07be01c0f2292739e
Branch: codex/aws-card-fix-prototype-portal
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0010
