### PR TITLE
Fix Ironsmith parse failure: Kayla's Music Box

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -164,6 +164,12 @@ fn parse_tagged_cast_or_play_target_inner<'a>(
                     tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
                     as_copy: false,
                 }),
+                grammar::phrase(&["cards", "you", "own", "exiled", "with", "this"]).value(
+                    TaggedPermissionTarget {
+                        tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+                        as_copy: false,
+                    },
+                ),
                 grammar::phrase(&["that", "revealed", "card"]).value(TaggedPermissionTarget {
                     tag: TagKey::from("__last_revealed__"),
                     as_copy: false,
@@ -740,6 +746,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
     };
     let player = lead.player;
     let allow_land = lead.allow_land;
+    let rest_words = token_word_refs(rest_tokens);
 
     if let Some((target_ref, tagged_tail_tokens)) =
         parse_tagged_cast_or_play_target_tokens(rest_tokens)
@@ -843,7 +850,6 @@ pub(crate) fn parse_permission_clause_spec_lexed(
         }));
     }
 
-    let rest_words = token_word_refs(rest_tokens);
     if prefixed_lifetime.is_none()
         && player == PlayerAst::You
         && !allow_land

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -1042,6 +1042,9 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     && grammar::words_match_any_prefix(after_then, PUT_BACK_PREFIXES).is_some()
                     && grammar::contains_word(after_then, "any")
                     && grammar::contains_word(after_then, "order");
+                let allow_exile_face_down_followup = has_back_ref
+                    && word_slice_first_is(&after_words, "exile")
+                    && word_slice_contains_phrase(&after_words, &["face", "down"]);
                 let allow_clash_followup = starts_with_clash;
                 if has_effect_head && (!has_back_ref || allow_backref_split)
                     || has_effect_head && allow_clash_followup
@@ -1055,6 +1058,7 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     || has_effect_head && allow_put_battlefield_with_counter_followup
                     || has_effect_head && allow_put_into_hand_followup
                     || has_effect_head && allow_put_back_in_any_order_followup
+                    || has_effect_head && allow_exile_face_down_followup
                 {
                     split_point = Some(i);
                     break;

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1057,6 +1057,36 @@ fn dream_thiefs_bandana_keeps_look_exile_and_while_exiled_permission() {
     );
 }
 
+#[test]
+fn kaylas_music_box_strict_parser_and_compiled_text_regression() {
+    let oracle = oracle_text_by_name()
+        .get("Kayla's Music Box")
+        .expect("Kayla's Music Box should exist in cards.json");
+    let def = CardDefinitionBuilder::new(CardId::new(), "Kayla's Music Box")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact])
+        .parse_text(oracle.clone())
+        .expect("Kayla's Music Box oracle text should parse strictly");
+    let debug = format!("{:#?}", def.abilities);
+    let rendered = canonical_compiled_lines(&def);
+
+    assert_eq!(
+        rendered,
+        vec![
+            "{W}, {T}: Look at the top card of your library, then exile it face down."
+                .to_string(),
+            "{T}: Until end of turn, you may play cards you own exiled with Kayla's Music Box."
+                .to_string(),
+        ],
+        "Kayla's Music Box should preserve its look/exile and source-exiled play clauses"
+    );
+    assert!(debug.contains("LookAtTopCardsEffect"), "{debug}");
+    assert!(debug.contains("ExileEffect"), "{debug}");
+    assert!(debug.contains("face_down: true"), "{debug}");
+    assert!(debug.contains("GrantPlayTaggedEffect"), "{debug}");
+    assert!(debug.contains("UntilEndOfTurn"), "{debug}");
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn cogwork_librarian_strict_parser_and_compiled_text_regression() {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -759,6 +759,7 @@ pub(super) fn substitute_legendary_source_reference(
     let uses_named_source_surface = lower.starts_with("this creature gets ")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
+        || lower.contains("exiled with this")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.contains(": this creature gets ")
         || lower.contains(": whenever this creature deals combat damage to a player");
@@ -775,7 +776,11 @@ pub(super) fn substitute_legendary_source_reference(
         .replace("This creature", source_name)
         .replace("this creature", source_name)
         .replace("This land", source_name)
-        .replace("this land", source_name);
+        .replace("this land", source_name)
+        .replace(
+            "exiled with this",
+            &format!("exiled with {source_name}"),
+        );
     let lower_source_name = source_name.to_ascii_lowercase();
     if lower_source_name != source_name {
         substituted.replace(&lower_source_name, source_name)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32358,6 +32358,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else {
             "cast"
         };
+        if (grant_play_tagged.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+            || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled"))
+            && grant_play_tagged.duration == crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+            && !grant_play_tagged.allow_any_color_for_cast
+            && matches!(grant_play_tagged.player, PlayerFilter::You)
+        {
+            return format!(
+                "Until end of turn, you may {verb} cards you own exiled with this"
+            );
+        }
         let helper_tag = grant_play_tagged.tag.as_str().starts_with("targeted_")
             || grant_play_tagged.tag.as_str().starts_with("__source_")
             || grant_play_tagged.tag.as_str() == "__it__"

--- a/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
@@ -141,13 +141,32 @@ impl EffectExecutor for GrantPlayTaggedEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let player_id = resolve_player_filter(game, &self.player, ctx)?;
-        let snapshots = ctx.get_tagged_all(self.tag.as_str()).cloned().or_else(|| {
-            (self.tag.as_str() == "__source_exiled__").then(|| {
-                ctx.tagged_objects
+        let tag = self.tag.as_str();
+        let snapshots = ctx.get_tagged_all(tag).cloned().or_else(|| {
+            (tag == crate::tag::SOURCE_EXILED_TAG
+                || crate::cards::is_sentence_helper_tag(tag, "exiled"))
+            .then(|| {
+                let source_exiled = game
+                    .get_exiled_with_source_links(ctx.source)
                     .iter()
-                    .filter(|(tag, _)| tag.as_str().starts_with("__sentence_helper_exiled"))
-                    .flat_map(|(_, snapshots)| snapshots.iter().cloned())
-                    .collect::<Vec<_>>()
+                    .filter_map(|id| {
+                        game.object(*id).map(|object| {
+                            crate::snapshot::ObjectSnapshot::from_object(object, game)
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                if !source_exiled.is_empty() {
+                    return source_exiled;
+                }
+                if tag == crate::tag::SOURCE_EXILED_TAG {
+                    return ctx
+                        .tagged_objects
+                        .iter()
+                        .filter(|(tag, _)| tag.as_str().starts_with("__sentence_helper_exiled"))
+                        .flat_map(|(_, snapshots)| snapshots.iter().cloned())
+                        .collect::<Vec<_>>();
+                }
+                Vec::new()
             })
         });
         let Some(snapshots) = snapshots.filter(|snapshots| !snapshots.is_empty()) else {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -747,6 +747,257 @@ fn keeper_of_the_flame_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn kaylas_music_box_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_951), "Kayla's Music Box")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{W}, {T}: Look at the top card of your library, then exile it face down. (You may look at it any time.)\n\
+             {T}: Until end of turn, you may play cards you own exiled with Kayla's Music Box.",
+        )
+        .expect("Kayla's Music Box should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_ability_to_stack(
+    game: &mut GameState,
+    player: PlayerId,
+    source: ObjectId,
+    ability_index: usize,
+) {
+    let stack_before = game.stack.len();
+    let activate_action = crate::decision::compute_legal_actions(game, player)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source: action_source, ability_index: idx }
+                    if *action_source == source && *idx == ability_index
+            )
+        })
+        .expect("requested activated ability should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let mut progress = apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("activation should start");
+
+    for _ in 0..8 {
+        if game.stack.len() > stack_before {
+            return;
+        }
+        progress = match progress {
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) => {
+                let option = ctx
+                    .options
+                    .iter()
+                    .find(|option| option.legal)
+                    .expect("activation should have a payable cost option");
+                apply_priority_response_with_dm(
+                    game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(option.index),
+                    &mut dm,
+                )
+                .expect("cost choice should continue activation")
+            }
+            crate::decision::GameProgress::Continue
+            | crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            ) => break,
+            other => panic!("unexpected activation progress for Kayla's Music Box: {other:?}"),
+        };
+    }
+
+    assert!(
+        game.stack.len() > stack_before,
+        "activated ability should be on the stack after costs are paid"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kaylas_music_box_exiles_face_down_and_grants_temporary_play_permission() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let kayla = kaylas_music_box_definition();
+    let kayla_id = game.create_object_from_definition(&kayla, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(kayla_id);
+
+    let first_ability_index = game
+        .object(kayla_id)
+        .expect("Kayla's Music Box should exist")
+        .abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => {
+                format!("{:?}", activated.effects).contains("LookAtTopCardsEffect")
+            }
+            _ => false,
+        })
+        .expect("Kayla's Music Box should have the look/exile activated ability");
+    let second_ability_index = game
+        .object(kayla_id)
+        .expect("Kayla's Music Box should exist")
+        .abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => {
+                format!("{:?}", activated.effects).contains("GrantPlayTaggedEffect")
+            }
+            _ => false,
+        })
+        .expect("Kayla's Music Box should have the source-exiled play ability");
+
+    let first_ability_debug = format!(
+        "{:?}",
+        game.object(kayla_id)
+            .expect("Kayla's Music Box should exist")
+            .abilities[first_ability_index]
+    );
+    assert!(
+        first_ability_debug.contains("ManaPaymentCost")
+            && first_ability_debug.contains("White"),
+        "the look/exile ability should structurally require white mana: {first_ability_debug}"
+    );
+
+    let land = CardBuilder::new(CardId::new(), "Kayla Test Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let spell = CardBuilder::new(CardId::new(), "Kayla Test Spell")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::new())
+        .build();
+    let land_library_id = game.create_object_from_card(&land, alice, Zone::Library);
+    let spell_library_id = game.create_object_from_card(&spell, alice, Zone::Library);
+    let land_stable = game
+        .object(land_library_id)
+        .expect("land should be in library")
+        .stable_id;
+    let spell_stable = game
+        .object(spell_library_id)
+        .expect("spell should be in library")
+        .stable_id;
+
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::White, 2);
+    activate_ability_to_stack(&mut game, alice, kayla_id, first_ability_index);
+    assert!(game.is_tapped(kayla_id), "activation should tap Kayla's Music Box");
+    resolve_stack_entry(&mut game).expect("first Kayla activation should resolve");
+    game.untap(kayla_id);
+    activate_ability_to_stack(&mut game, alice, kayla_id, first_ability_index);
+    resolve_stack_entry(&mut game).expect("second Kayla activation should resolve");
+
+    let exiled_land_id = game
+        .find_object_by_stable_id(land_stable)
+        .expect("the land should still be tracked after exile");
+    let exiled_spell_id = game
+        .find_object_by_stable_id(spell_stable)
+        .expect("the spell should still be tracked after exile");
+    let other_source = CardBuilder::new(CardId::new(), "Other Exile Source")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let other_source_id = game.create_object_from_card(&other_source, alice, Zone::Battlefield);
+    let other_spell = CardBuilder::new(CardId::new(), "Other Exiled Spell")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::new())
+        .build();
+    let other_exiled_id = game.create_object_from_card(&other_spell, alice, Zone::Exile);
+    game.add_exiled_with_source_link(other_source_id, other_exiled_id);
+
+    for exiled_id in [exiled_land_id, exiled_spell_id] {
+        assert!(game.exile.contains(&exiled_id), "card should be in exile");
+        assert!(game.is_face_down(exiled_id), "Kayla should exile the card face down");
+        assert!(
+            game.can_player_look_at_face_down_exiled_card(exiled_id, alice),
+            "Kayla's controller should be allowed to look at the face-down exiled card"
+        );
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice,
+            ),
+            "the second ability should be required before the exiled card can be played"
+        );
+    }
+
+    game.untap(kayla_id);
+    activate_ability_to_stack(&mut game, alice, kayla_id, second_ability_index);
+    resolve_stack_entry(&mut game).expect("Kayla play-permission activation should resolve");
+
+    for exiled_id in [exiled_land_id, exiled_spell_id] {
+        assert!(
+            game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice,
+            ),
+            "Kayla should grant play permission for cards exiled with it"
+        );
+    }
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            other_exiled_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Kayla should not grant play permission for cards exiled with another source"
+    );
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::PlayLand { land_id } if *land_id == exiled_land_id
+        )),
+        "Kayla should expose a land play action for a land exiled with it"
+    );
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, from_zone: Zone::Exile, .. }
+                if *spell_id == exiled_spell_id
+        )),
+        "Kayla should expose a cast action for a spell exiled with it"
+    );
+
+    game.turn.turn_number += 1;
+    for exiled_id in [exiled_land_id, exiled_spell_id] {
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice,
+            ),
+            "Kayla's play permission should expire at end of turn"
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn goblin_kites_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_955), "Goblin Kites")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kayla's Music Box
Initial parse error:
```
unsupported trailing look clause (clause: 'the top card of your library then exile it face down'); oracle-only fallback also failed: unsupported trailing look clause (clause: 'the top card of your library then exile it face down')
```

Current worker: i-01ba9e5755a0fc6f8
Branch: codex/aws-card-fix-kayla-s-music-box
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0010
