### PR TITLE
Fix Ironsmith parse failure: Phyrexian Grimoire

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -128,7 +128,7 @@ mod trigger_support;
 
 pub(crate) use choose_effect_helpers::{
     compile_choose_objects_across_zones_with_subject, compile_choose_objects_with_subject,
-    compile_choose_player_with_subject,
+    compile_choose_player_with_subject, compile_choose_top_objects_with_subject,
 };
 pub(crate) use control_flow_handlers::{
     choose_spec_for_targeted_player_filter, collect_targeted_player_specs_from_filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/choose_effect_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/choose_effect_helpers.rs
@@ -16,6 +16,23 @@ pub(crate) fn compile_choose_objects_with_subject(
     (effects, subject.into_choices())
 }
 
+pub(crate) fn compile_choose_top_objects_with_subject(
+    subject: LoweredSubject,
+    filter: ObjectFilter,
+    count: ChoiceCount,
+    count_value: Option<Value>,
+    tag: TagKey,
+    zone: Zone,
+) -> (Vec<Effect>, Vec<ChooseSpec>) {
+    let chooser = subject.as_chooser();
+    let choose_effect = crate::effects::ChooseObjectsEffect::new(filter, count, chooser, tag)
+        .with_count_value_opt(count_value)
+        .in_zone(zone)
+        .top_only();
+    let effects = subject.prepend_target_prelude_if_needed(Effect::new(choose_effect));
+    (effects, subject.into_choices())
+}
+
 pub(crate) fn compile_choose_objects_across_zones_with_subject(
     subject: LoweredSubject,
     filter: ObjectFilter,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
@@ -233,6 +233,35 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
             ctx.last_player_filter = Some(followup_player);
             (effects, choices)
         }
+        EffectAst::ChooseTopObjects {
+            filter,
+            count,
+            count_value,
+            player,
+            tag,
+        } => {
+            let subject = LoweredSubject::resolve_chooser(*player, ctx, true, true, false)?;
+            let chooser = subject.clone_player_filter();
+            let mut resolved_filter = subject.resolve_object_refs_and_bind_player_refs_in_filter(filter, ctx)?;
+            if !matches!(chooser, PlayerFilter::ChosenPlayer) {
+                preserve_chooser_relative_player_filters(filter, &mut resolved_filter, &chooser);
+            }
+            let followup_player = choose_followup_player_filter(&resolved_filter, &chooser)
+                .unwrap_or_else(|| chooser.clone());
+            let choice_zone = resolved_filter.ensure_zone(Zone::Battlefield);
+            let (effects, choices) = compile_choose_top_objects_with_subject(
+                subject,
+                resolved_filter,
+                *count,
+                count_value.clone(),
+                tag.clone(),
+                choice_zone,
+            );
+            ctx.last_it_choice_is_set = tag.as_str() == IT_TAG;
+            ctx.last_object_tag = Some(tag.as_str().to_string());
+            ctx.last_player_filter = Some(followup_player);
+            (effects, choices)
+        }
         EffectAst::ChooseObjectsAcrossZones {
             filter,
             count,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -245,6 +245,7 @@ fn effect_tagged_filter(effect: &EffectAst) -> Option<&ObjectFilter> {
             _ => None,
         },
         EffectAst::ChooseObjects { filter, .. }
+        | EffectAst::ChooseTopObjects { filter, .. }
         | EffectAst::ChooseObjectsAcrossZones { filter, .. }
         | EffectAst::MayCastMatchingSpellWithoutPayingManaCost { filter, .. } => Some(filter),
         _ => None,
@@ -872,6 +873,7 @@ pub(crate) fn effect_references_its_controller(effect: &EffectAst) -> bool {
             )
         }
         EffectAst::ChooseObjects { player, .. }
+        | EffectAst::ChooseTopObjects { player, .. }
         | EffectAst::ChooseObjectsAcrossZones { player, .. }
         | EffectAst::MayCastMatchingSpellWithoutPayingManaCost { player, .. } => {
             matches!(player, PlayerAst::ItsController | PlayerAst::ItsOwner)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/condition_antecedent.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/condition_antecedent.rs
@@ -139,6 +139,7 @@ fn bind_condition_antecedent_in_effect(
             _ => {}
         },
         EffectAst::ChooseObjects { filter, .. }
+        | EffectAst::ChooseTopObjects { filter, .. }
         | EffectAst::ChooseObjectsAcrossZones { filter, .. } => {
             bind_condition_filter_antecedent(filter, antecedent);
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
@@ -188,7 +188,9 @@ pub(super) fn rewrite_normalize_additional_cost_sacrifice_tags(
     };
 
     let choose_tag = match first {
-        EffectAst::ChooseObjects { tag, .. } | EffectAst::ChooseObjectsAcrossZones { tag, .. }
+        EffectAst::ChooseObjects { tag, .. }
+        | EffectAst::ChooseTopObjects { tag, .. }
+        | EffectAst::ChooseObjectsAcrossZones { tag, .. }
             if tag.as_str() == IT_TAG =>
         {
             tag

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -3205,6 +3205,13 @@ pub(crate) enum EffectAst {
         player: PlayerAst,
         tag: TagKey,
     },
+    ChooseTopObjects {
+        filter: ObjectFilter,
+        count: ChoiceCount,
+        count_value: Option<Value>,
+        player: PlayerAst,
+        tag: TagKey,
+    },
     ChooseObjectsAcrossZones {
         filter: ObjectFilter,
         count: ChoiceCount,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
@@ -129,6 +129,7 @@ pub(crate) fn assert_effect_ast_variant_coverage(effect: &EffectAst) {
         EffectAst::ManaRestricted { .. } => {}
         EffectAst::SelfReplacement { .. } => {}
         EffectAst::ChooseObjects { .. } => {}
+        EffectAst::ChooseTopObjects { .. } => {}
         EffectAst::ChooseObjectsAcrossZones { .. } => {}
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}
         EffectAst::RepeatThisProcess => {}

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -921,6 +921,12 @@ fn advance_reference_frame_for_effect(
             tag,
             player,
             ..
+        }
+        | EffectAst::ChooseTopObjects {
+            filter,
+            tag,
+            player,
+            ..
         } => {
             let references_revealed_hand = filter.zone == Some(crate::zone::Zone::Hand)
                 && filter.owner.is_none()
@@ -2118,6 +2124,7 @@ fn resolve_effect_result_values_in_fields(
             SubjectVerbActionAst::AdditionalPhases { .. } => {}
         },
         EffectAst::ChooseObjects { count_value, .. }
+        | EffectAst::ChooseTopObjects { count_value, .. }
         | EffectAst::ChooseObjectsAcrossZones { count_value, .. } => {
             if let Some(count_value) = count_value.as_mut() {
                 resolve_effect_result_value(count_value, state)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2149,7 +2149,9 @@ pub(crate) fn explicit_player_for_carry(effect: &EffectAst) -> Option<CarryConte
             }
         }
         EffectAst::SubjectVerb(_) => subject_verb_player_action_player(effect)?,
-        EffectAst::ChooseObjects { player, .. } => *player,
+        EffectAst::ChooseObjects { player, .. } | EffectAst::ChooseTopObjects { player, .. } => {
+            *player
+        }
         _ => return None,
     };
 
@@ -2175,7 +2177,7 @@ pub(crate) fn effect_uses_implicit_player(effect: &EffectAst) -> bool {
                 Some(PlayerAst::Implicit)
             )
         }
-        EffectAst::ChooseObjects { player, .. } => {
+        EffectAst::ChooseObjects { player, .. } | EffectAst::ChooseTopObjects { player, .. } => {
             matches!(*player, PlayerAst::Implicit)
         }
         _ => false,
@@ -2359,7 +2361,8 @@ pub(crate) fn maybe_apply_carried_player(effect: &mut EffectAst, carried_context
                         *player = carried_player;
                     }
                 }
-                EffectAst::ChooseObjects { player, .. } => {
+                EffectAst::ChooseObjects { player, .. }
+                | EffectAst::ChooseTopObjects { player, .. } => {
                     if matches!(*player, PlayerAst::Implicit) {
                         *player = carried_player;
                     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -31,7 +31,7 @@ use crate::runtime_backend::token_primitives::{
 use crate::runtime_backend::util::trim_commas;
 use crate::runtime_backend::util::{
     helper_tag_for_tokens, is_article, non_article_token_word_refs, non_article_word_refs,
-    parse_subject, strip_leading_token_word_once_any, word_refs_except,
+    parse_number, parse_subject, strip_leading_token_word_once_any, word_refs_except,
 };
 use crate::target::{ChooseSpec, PlayerFilter, TaggedObjectConstraint, TaggedOpbjectRelation};
 use crate::types::CardType;
@@ -332,6 +332,99 @@ pub(crate) fn parse_look_at_top_then_put_one_hand_other_graveyard(
                 if_false: vec![EffectAst::subject_verb_move_to_zone(
                     TargetAst::Tagged(TagKey::from(IT_TAG), None),
                     Zone::Graveyard,
+                    false,
+                    ReturnControllerAst::Preserve,
+                    false,
+                    None,
+                )],
+            }],
+        },
+    ]))
+}
+
+pub(crate) fn parse_target_opponent_chooses_top_graveyard_card_then_move_remainder(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let first_tokens = trim_commas(sentences[sentence_idx].lowered());
+    let first_words = TokenWordView::new(&first_tokens);
+    let words = first_words.word_refs();
+    if !word_slice_starts_with(
+        &words,
+        &["target", "opponent", "chooses", "one", "of"],
+    ) {
+        return Ok(None);
+    }
+    let Some(top_idx) = word_slice_find_word(&words, "top") else {
+        return Ok(None);
+    };
+    let Some(top_token_idx) = first_words.token_index_for_word_index(top_idx) else {
+        return Ok(None);
+    };
+    let Some((top_count, used_count_tokens)) = parse_number(&first_tokens[top_token_idx + 1..])
+    else {
+        return Ok(None);
+    };
+    if top_count != 2 {
+        return Ok(None);
+    }
+    let filter_tokens = trim_commas(&first_tokens[top_token_idx + 1 + used_count_tokens..]);
+    let mut top_filter = parse_object_filter_lexed(&filter_tokens, false)?;
+    if top_filter.zone != Some(Zone::Graveyard) || top_filter.owner != Some(PlayerFilter::You) {
+        return Ok(None);
+    }
+    top_filter.controller = None;
+
+    let second_tokens = trim_commas(sentences[sentence_idx + 1].lowered());
+    let second_words = non_article_token_word_refs(&second_tokens);
+    if !word_slice_starts_with(&second_words, &["exile", "that", "card"])
+        || !word_slice_contains_any_phrase(
+            &second_words,
+            &[
+                &["put", "other", "one", "into", "your", "hand"],
+                &["put", "other", "into", "your", "hand"],
+            ],
+        )
+    {
+        return Ok(None);
+    }
+
+    let top_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "top_graveyard");
+    let chosen_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "chosen");
+    let mut choose_filter = ObjectFilter::tagged(top_tag.clone());
+    choose_filter.zone = Some(Zone::Graveyard);
+    let mut chosen_match_filter = ObjectFilter::default();
+    chosen_match_filter
+        .tagged_constraints
+        .push(TaggedObjectConstraint {
+            tag: TagKey::from(IT_TAG),
+            relation: TaggedOpbjectRelation::SameStableId,
+        });
+
+    Ok(Some(vec![
+        EffectAst::ChooseTopObjects {
+            filter: top_filter,
+            count: ChoiceCount::exactly(top_count as usize),
+            count_value: None,
+            player: PlayerAst::You,
+            tag: top_tag.clone(),
+        },
+        EffectAst::ChooseObjects {
+            filter: choose_filter,
+            count: ChoiceCount::exactly(1),
+            count_value: None,
+            player: PlayerAst::TargetOpponent,
+            tag: chosen_tag.clone(),
+        },
+        EffectAst::subject_verb_exile(TargetAst::Tagged(chosen_tag.clone(), None), false),
+        EffectAst::ForEachTagged {
+            tag: top_tag,
+            effects: vec![EffectAst::Conditional {
+                predicate: PredicateAst::TaggedMatches(chosen_tag, chosen_match_filter),
+                if_true: Vec::new(),
+                if_false: vec![EffectAst::subject_verb_move_to_zone(
+                    TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                    Zone::Hand,
                     false,
                     ReturnControllerAst::Preserve,
                     false,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -464,6 +464,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         parser: generic_subject_verb_sequences::parse_damage_prevention_counter_sequence,
     },
     SequenceRuleDef {
+        name: "target-opponent-chooses-top-graveyard-card-then-move-remainder",
+        feature_tag: Some("top-graveyard-choice-remainder"),
+        priority: 240,
+        consumed_sentences: 2,
+        predicate: first_word_target,
+        parser: generic_subject_verb_sequences::pairs::parse_target_opponent_chooses_top_graveyard_card_then_move_remainder,
+    },
+    SequenceRuleDef {
         name: "next-damage-prevention-then-gain-prevented-life",
         feature_tag: Some("damage-prevention-followup"),
         priority: 240,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38550,6 +38550,195 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+fn named_card(name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build()
+}
+
+fn zone_contains_named_card(game: &crate::game_state::GameState, zone: Zone, name: &str) -> bool {
+    game.objects_in_zone(zone).into_iter().any(|id| {
+        game.object(id)
+            .is_some_and(|object| object.zone == zone && object.name == name)
+    })
+}
+
+struct ChooseNamedObjectDecisionMaker {
+    name: &'static str,
+}
+
+impl crate::decision::DecisionMaker for ChooseNamedObjectDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx.min > 1 {
+            return ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.min)
+                .collect();
+        }
+        ctx.candidates
+            .iter()
+            .find(|candidate| {
+                candidate.legal
+                    && game
+                        .object(candidate.id)
+                        .is_some_and(|object| object.name == self.name)
+            })
+            .map(|candidate| vec![candidate.id])
+            .unwrap_or_else(|| {
+                ctx.candidates
+                    .iter()
+                    .filter(|candidate| candidate.legal)
+                    .map(|candidate| candidate.id)
+                    .take(ctx.min)
+                    .collect()
+            })
+    }
+}
+
+#[test]
+fn phyrexian_grimoire_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Phyrexian Grimoire");
+    let lines = canonical_compiled_lines(&def);
+
+    assert_eq!(
+        lines,
+        vec!["{4}, {T}: Target opponent chooses one of the top two cards of your graveyard. Exile that card and put the other one into your hand."],
+        "Phyrexian Grimoire should render the top-graveyard choice and remainder clause exactly"
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Phyrexian Grimoire should have an activated ability");
+    let ability_debug = format!("{activated:#?}");
+    assert!(
+        ability_debug.contains("Generic(\n                                        4")
+            && ability_debug.contains("TapEffect"),
+        "expected Phyrexian Grimoire to keep its {{4}}, {{T}} activation cost, got {ability_debug}"
+    );
+    let effects = &activated.effects.segments[0].default_effects;
+    let top_choice = effects[0]
+        .downcast_ref::<ChooseObjectsEffect>()
+        .expect("first effect should tag the top graveyard cards");
+    assert!(top_choice.top_only);
+    assert_eq!(top_choice.zone, Some(Zone::Graveyard));
+    assert_eq!(top_choice.filter.owner, Some(PlayerFilter::You));
+    assert_eq!(top_choice.count.max, Some(2));
+
+    let target = effects[1]
+        .downcast_ref::<TargetOnlyEffect>()
+        .expect("second effect should require a target opponent");
+    assert!(matches!(
+        target.target.base(),
+        ChooseSpec::Player(PlayerFilter::Opponent)
+    ));
+
+    let opponent_choice = effects[2]
+        .downcast_ref::<ChooseObjectsEffect>()
+        .expect("third effect should let the target opponent choose from the top graveyard cards");
+    assert_eq!(opponent_choice.chooser, PlayerFilter::target_opponent());
+    assert!(opponent_choice.count.is_single());
+    assert!(opponent_choice.filter.tagged_constraints.iter().any(|constraint| {
+        constraint.tag == top_choice.tag
+            && matches!(
+                constraint.relation,
+                crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            )
+    }));
+}
+
+#[test]
+fn phyrexian_grimoire_exiles_opponents_choice_and_returns_other_top_graveyard_card() {
+    let def = parse_oracle_card_definition("Phyrexian Grimoire");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Phyrexian Grimoire should have an activated ability");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.create_object_from_definition(&named_card("Bottom Card"), alice, Zone::Graveyard);
+    game.create_object_from_definition(&named_card("Second Card"), alice, Zone::Graveyard);
+    game.create_object_from_definition(&named_card("Top Card"), alice, Zone::Graveyard);
+
+    let mut dm = ChooseNamedObjectDecisionMaker {
+        name: "Second Card",
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &activated.effects,
+        None,
+        &[],
+    )
+    .expect("Phyrexian Grimoire ability should resolve");
+
+    assert!(zone_contains_named_card(&game, Zone::Exile, "Second Card"));
+    assert!(zone_contains_named_card(&game, Zone::Hand, "Top Card"));
+    assert!(zone_contains_named_card(&game, Zone::Graveyard, "Bottom Card"));
+}
+
+#[test]
+fn phyrexian_grimoire_with_one_graveyard_card_has_no_other_card_to_return() {
+    let def = parse_oracle_card_definition("Phyrexian Grimoire");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Phyrexian Grimoire should have an activated ability");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.create_object_from_definition(&named_card("Only Card"), alice, Zone::Graveyard);
+
+    let mut dm = ChooseNamedObjectDecisionMaker { name: "Only Card" };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &activated.effects,
+        None,
+        &[],
+    )
+    .expect("Phyrexian Grimoire ability should resolve with one graveyard card");
+
+    assert!(zone_contains_named_card(&game, Zone::Exile, "Only Card"));
+    assert!(
+        !zone_contains_named_card(&game, Zone::Hand, "Only Card"),
+        "the chosen card should be exiled, with no second top card to put into hand"
+    );
+}
+
 #[test]
 fn alena_kessig_trapper_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Alena, Kessig Trapper");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2655,6 +2655,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
+        .or_else(|| describe_target_opponent_choose_top_graveyard_then_move_remainder(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
 }
 
@@ -3062,6 +3063,96 @@ fn describe_choose_top_exile_then_play_structural(effects: &[Effect]) -> Option<
     let verb = if grant.allow_land { "play" } else { "cast" };
     Some(format!(
         "Exile the top card of your library. You may {verb} that card this turn"
+    ))
+}
+
+fn describe_target_opponent_choose_top_graveyard_then_move_remainder(
+    effects: &[Effect],
+) -> Option<String> {
+    let (top_effect, target_effect, choose_effect, exile_effect, for_each_effect) = match effects {
+        [top, choose, exile, for_each] => (top, None, choose, exile, for_each),
+        [top, target, choose, exile, for_each] => (top, Some(target), choose, exile, for_each),
+        _ => return None,
+    };
+    let top = top_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if let Some(target_effect) = target_effect {
+        let target = target_effect.downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+        if !matches!(target.target.base(), ChooseSpec::Player(PlayerFilter::Opponent)) {
+            return None;
+        }
+    }
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let exile = exile_effect.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachTaggedEffect>()?;
+    let top_count = choose_exact_count(top)?;
+
+    if !top.top_only
+        || top.is_search
+        || top_count == 0
+        || top_count != 2
+        || choose_primary_zone(top) != Some(Zone::Graveyard)
+        || top.filter.owner != Some(PlayerFilter::You)
+        || choose.filter.zone != Some(Zone::Graveyard)
+        || !choose.count.is_single()
+        || choose.chooser != PlayerFilter::Target(Box::new(PlayerFilter::Opponent))
+        || choose.tag == top.tag
+        || for_each.tag != top.tag
+        || exile.zone != Zone::Exile
+        || !matches!(exile.target.base(), ChooseSpec::Tagged(tag) if tag == &choose.tag)
+    {
+        return None;
+    }
+    if !choose.filter.tagged_constraints.iter().any(|constraint| {
+        constraint.tag == top.tag
+            && matches!(
+                constraint.relation,
+                crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            )
+    }) {
+        return None;
+    }
+
+    let [conditional_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let crate::effect::Condition::TaggedObjectMatches(condition_tag, condition_filter) =
+        &conditional.condition
+    else {
+        return None;
+    };
+    if condition_tag != &choose.tag
+        || !conditional.if_true.is_empty()
+        || conditional.if_false.len() != 1
+        || !condition_filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag.as_str() == "__it__"
+                && matches!(
+                    constraint.relation,
+                    crate::filter::TaggedOpbjectRelation::SameStableId
+                )
+        })
+    {
+        return None;
+    }
+    let move_remainder = conditional.if_false[0].downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    let moves_iterated_remainder = match move_remainder.target.base() {
+        ChooseSpec::Iterated => true,
+        ChooseSpec::Tagged(tag) => tag.as_str() == "__it__",
+        _ => false,
+    };
+    if move_remainder.zone != Zone::Hand || move_remainder.to_top || !moves_iterated_remainder {
+        return None;
+    }
+
+    let count_text = number_word(top_count as i32).unwrap_or_else(|| top_count.to_string());
+    let owner = top
+        .filter
+        .owner
+        .as_ref()
+        .map(describe_possessive_player_filter)
+        .unwrap_or_else(|| "a".to_string());
+    Some(format!(
+        "Target opponent chooses one of the top {count_text} cards of {owner} graveyard. Exile that card and put the other one into your hand"
     ))
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Phyrexian Grimoire
Initial parse error:
```
unsupported target phrase lacking object selector (clause: 'one'); oracle-only fallback also failed: unsupported target phrase lacking object selector (clause: 'one')
```

Current worker: i-0174eb1449fb0b0cc
Branch: codex/aws-card-fix-phyrexian-grimoire
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0010
