### PR TITLE
Fix Ironsmith parse failure: Bösium Strip

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1,6 +1,6 @@
 use crate::effect::{Until, Value, ValueComparisonOperator};
 use crate::host::{CardTextError, EffectAst, IT_TAG, PlayerAst, PredicateAst, TagKey};
-use crate::target::ObjectFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
 use winnow::combinator::alt;
@@ -1055,11 +1055,17 @@ pub(crate) fn parse_permission_clause_spec_lexed(
             };
         if let Some(from_idx) = find_token_index(zone_grant_tokens, |token| token.is_word("from")) {
             let zone_words = token_word_refs(&zone_grant_tokens[from_idx..]);
+            let top_of_your_graveyard = word_slice_eq(
+                &zone_words,
+                &["from", "the", "top", "of", "your", "graveyard"],
+            );
             let zone = if word_slice_eq(
                 &zone_words,
                 &["from", "the", "top", "of", "your", "library"],
             ) {
                 Some(Zone::Library)
+            } else if top_of_your_graveyard {
+                Some(Zone::Graveyard)
             } else if word_slice_eq(&zone_words, &["from", "your", "graveyard"]) {
                 Some(Zone::Graveyard)
             } else if word_slice_eq(&zone_words, &["from", "exile"]) {
@@ -1070,7 +1076,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
             if let Some(zone) = zone {
                 let subject_tokens = trim_lexed_commas(&zone_grant_tokens[..from_idx]);
                 let subject_words = token_word_refs(subject_tokens);
-                let filter = if word_slice_eq(&subject_words, &["spells"]) {
+                let mut filter = if word_slice_eq(&subject_words, &["spells"]) {
                     ObjectFilter::default()
                 } else if let Some(filter) =
                     parse_permission_subject_filter_tokens_lexed(subject_tokens)?
@@ -1079,6 +1085,14 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                 } else {
                     return Ok(None);
                 };
+                if top_of_your_graveyard {
+                    filter.owner = Some(PlayerFilter::You);
+                    filter.top_of_graveyard = true;
+                    for branch in &mut filter.any_of {
+                        branch.owner = Some(PlayerFilter::You);
+                        branch.top_of_graveyard = true;
+                    }
+                }
                 return Ok(Some(PermissionClauseSpec::GrantBySpec {
                     player,
                     spec: crate::grant::GrantSpec::new(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -567,6 +567,47 @@ pub(crate) fn parse_may_cast_target_graveyard_spell_then_exile_replacement(
     let first_words = LexedClause::new(&first).word_refs();
     let second_words = LexedClause::new(&second).word_refs();
 
+    let first_is_top_graveyard_temporary_cast = word_slice_starts_with(
+        &first_words,
+        &["until", "end", "of", "turn", "you", "may", "cast"],
+    ) && word_slice_contains_phrase(
+        &first_words,
+        &["from", "the", "top", "of", "your", "graveyard"],
+    ) && word_slice_contains_all_words(&first_words, &["instant", "sorcery", "spells"]);
+    let second_is_cast_this_way_to_any_graveyard_replacement = word_slice_eq(
+        &second_words,
+        &[
+            "if", "a", "spell", "cast", "this", "way", "would", "be", "put", "into", "a",
+            "graveyard", "exile", "it", "instead",
+        ],
+    );
+    if first_is_top_graveyard_temporary_cast
+        && second_is_cast_this_way_to_any_graveyard_replacement
+    {
+        let mut filter = ObjectFilter::default();
+        filter.zone = Some(Zone::Graveyard);
+        filter.owner = Some(PlayerFilter::You);
+        filter.top_of_graveyard = true;
+        filter.card_types = vec![CardType::Instant, CardType::Sorcery];
+
+        return Ok(Some(vec![EffectAst::subject_verb_grant_by_spec(
+            crate::grant::GrantSpec::new(
+                crate::grant::Grantable::DerivedAlternativeCast(
+                    crate::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
+                        additional_costs: Vec::new(),
+                        usage_limit: None,
+                        condition: None,
+                        exiles_after_resolution: true,
+                    },
+                ),
+                filter,
+                Zone::Graveyard,
+            ),
+            PlayerAst::You,
+            crate::grant::GrantDuration::UntilEndOfTurn,
+        )]));
+    }
+
     let has_from_graveyard =
         word_slice_contains_phrase(&first_words, &["from", "your", "graveyard"]);
     let without_paying_mana_cost =

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -61,6 +61,10 @@ fn first_word_you(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
     sentence_head_word_is(sentences, sentence_idx, "you")
 }
 
+fn first_word_you_or_until(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
+    sentence_head_word_in(sentences, sentence_idx, &["you", "until"])
+}
+
 fn first_word_look(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
     sentence_head_word_is(sentences, sentence_idx, "look")
 }
@@ -444,7 +448,7 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         feature_tag: Some("cast-target-graveyard-spell-replacement"),
         priority: 242,
         consumed_sentences: 2,
-        predicate: first_word_you,
+        predicate: first_word_you_or_until,
         parser: generic_subject_verb_sequences::pairs::parse_may_cast_target_graveyard_spell_then_exile_replacement,
     },
     SequenceRuleDef {

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -362,6 +362,7 @@ pub struct ObjectFilter {
     pub first_spell_cast_each_turn: bool,
     pub owner: Option<PlayerFilter>,
     pub single_graveyard: bool,
+    pub top_of_graveyard: bool,
     pub targets_player: Option<PlayerFilter>,
     pub targets_object: Option<Box<ObjectFilter>>,
     pub targets_any_of: bool,
@@ -681,6 +682,7 @@ impl ObjectFilter {
         generic.cast_by = self.cast_by.clone();
         generic.first_spell_cast_each_turn = self.first_spell_cast_each_turn;
         generic.single_graveyard = self.single_graveyard;
+        generic.top_of_graveyard = self.top_of_graveyard;
         self != &generic
     }
 
@@ -774,6 +776,11 @@ impl ObjectFilter {
 
     pub fn single_graveyard(mut self) -> Self {
         self.single_graveyard = true;
+        self
+    }
+
+    pub fn top_of_graveyard(mut self) -> Self {
+        self.top_of_graveyard = true;
         self
     }
 
@@ -1935,7 +1942,14 @@ impl ObjectFilter {
             };
             if zone == Zone::Exile && has_source_exiled_constraint {
             } else if let Some(zone_name) = zone_name {
-                if let Some(owner) = &self.owner {
+                if zone == Zone::Graveyard && self.top_of_graveyard {
+                    let graveyard = self
+                        .owner
+                        .as_ref()
+                        .map(|owner| format!("{} graveyard", describe_possessive_player_filter(owner)))
+                        .unwrap_or_else(|| "a graveyard".to_string());
+                    parts.push(format!("on top of {graveyard}"));
+                } else if let Some(owner) = &self.owner {
                     parts.push(format!(
                         "in {} {}",
                         describe_possessive_player_filter(owner),

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -417,6 +417,19 @@ where
             }
         }
 
+        fn top_graveyard_castable_filter(filter: &ObjectFilter) -> ObjectFilter {
+            let mut filter = filter.clone();
+            filter.zone = None;
+            filter.owner = None;
+            filter.top_of_graveyard = false;
+            for branch in &mut filter.any_of {
+                branch.zone = None;
+                branch.owner = None;
+                branch.top_of_graveyard = false;
+            }
+            filter
+        }
+
         fn flashback_filter_description(filter: &ObjectFilter) -> String {
             if filter.any_of.len() == 2 {
                 let first = &filter.any_of[0];
@@ -511,6 +524,16 @@ where
             && self.filter == ObjectFilter::default()
         {
             return format!("{may_prefix} play lands and cast spells from your graveyard");
+        }
+        if matches!(self.grantable, Grantable::PlayFrom)
+            && self.zone == Zone::Graveyard
+            && self.filter.top_of_graveyard
+        {
+            let filter = top_graveyard_castable_filter(&self.filter);
+            return format!(
+                "{may_prefix} cast {} from the top of your graveyard",
+                castable_filter_description(&filter)
+            );
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Library

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -24923,6 +24923,28 @@ fn elvish_refueler_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn bosium_strip_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Bösium Strip");
+    let lines = canonical_compiled_lines(&def);
+    let expected = "{3}, {T}: Until end of turn, you may cast instant and sorcery spells from the top of your graveyard. If a spell cast this way would be put into a graveyard, exile it instead.";
+
+    assert!(
+        lines.iter().any(|line| line == expected),
+        "expected Bösium Strip top-graveyard cast permission line, got {lines:?}"
+    );
+
+    let debug = format!("{:#?}", def);
+    assert!(
+        debug.contains("GrantBySpecEffect")
+            && debug.contains("GraveyardCastFromCardManaCost")
+            && debug.contains("top_of_graveyard: true")
+            && debug.contains("exiles_after_resolution: true"),
+        "expected Bösium Strip to lower to a top-graveyard cast grant that exiles spells cast this way, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_mercenary_token_with_tap_pump_ability() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Mercenary Token Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32324,6 +32324,39 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         {
             return "That card's owner may play it for as long as it remains exiled".to_string();
         }
+        if let crate::grant::Grantable::DerivedAlternativeCast(
+            crate::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
+                exiles_after_resolution: true,
+                ..
+            },
+        ) = &grant.spec.grantable
+            && grant.spec.zone == Zone::Graveyard
+            && grant.spec.filter.top_of_graveyard
+            && grant.duration == crate::grant::GrantDuration::UntilEndOfTurn
+        {
+            let spell_text = if grant
+                .spec
+                .filter
+                .card_types
+                .contains(&crate::types::CardType::Instant)
+                && grant
+                    .spec
+                    .filter
+                    .card_types
+                    .contains(&crate::types::CardType::Sorcery)
+            {
+                "instant and sorcery spells".to_string()
+            } else {
+                let mut filter = grant.spec.filter.clone();
+                filter.zone = None;
+                filter.owner = None;
+                filter.top_of_graveyard = false;
+                format!("{} spells", strip_indefinite_article(&filter.description()))
+            };
+            return format!(
+                "Until end of turn, you may cast {spell_text} from the top of your graveyard. If a spell cast this way would be put into a graveyard, exile it instead"
+            );
+        }
         let duration = match grant.duration {
             crate::grant::GrantDuration::UntilEndOfTurn => " until end of turn",
             crate::grant::GrantDuration::UntilYourNextTurnEnd => " until the end of your next turn",

--- a/crates/ironsmith-runtime/src/effects/stack/counter.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/counter.rs
@@ -11,6 +11,51 @@ use crate::target::ChooseSpec;
 use crate::zone::Zone;
 pub use ironsmith_core::CounterEffect;
 
+fn countered_spell_exiles_due_to_cast_method(
+    game: &GameState,
+    target_id: crate::ids::ObjectId,
+) -> bool {
+    let Some(entry) = game.stack.iter().find(|entry| entry.object_id == target_id) else {
+        return false;
+    };
+    let Some(object) = game.object(target_id) else {
+        return false;
+    };
+
+    match &entry.casting_method {
+        crate::alternative_cast::CastingMethod::Alternative(idx) => object
+            .alternative_casts
+            .get(*idx)
+            .map(|method| method.exiles_after_resolution())
+            .unwrap_or(false),
+        crate::alternative_cast::CastingMethod::GrantedEscape { .. }
+        | crate::alternative_cast::CastingMethod::GrantedFlashback
+        | crate::alternative_cast::CastingMethod::SplitOtherHalfPlayFrom { .. } => true,
+        crate::alternative_cast::CastingMethod::PlayFrom {
+            use_alternative: Some(idx),
+            zone,
+            ..
+        } => crate::decision::resolve_play_from_alternative_method(
+            game,
+            entry.controller,
+            object,
+            *zone,
+            *idx,
+        )
+        .or_else(|| object.cast_alternative_method.clone())
+        .map(|method| method.exiles_after_resolution())
+        .unwrap_or(false),
+        crate::alternative_cast::CastingMethod::Normal
+        | crate::alternative_cast::CastingMethod::FaceDown
+        | crate::alternative_cast::CastingMethod::SplitOtherHalf
+        | crate::alternative_cast::CastingMethod::Fuse
+        | crate::alternative_cast::CastingMethod::PlayFrom {
+            use_alternative: None,
+            ..
+        } => false,
+    }
+}
+
 /// Effect that counters a target spell on the stack.
 ///
 /// This removes the spell from the stack and puts it into its owner's graveyard.
@@ -66,11 +111,16 @@ impl EffectExecutor for CounterEffect {
         // Find the stack entry for this object
         if game.stack.iter().any(|e| e.object_id == target_id) {
             let additional_effects = ctx.additional_replacement_effects_snapshot();
+            let destination = if countered_spell_exiles_due_to_cast_method(game, target_id) {
+                Zone::Exile
+            } else {
+                Zone::Graveyard
+            };
             let outcome = process_zone_change_with_additional_effects(
                 game,
                 target_id,
                 Zone::Stack,
-                Zone::Graveyard,
+                destination,
                 ctx.cause.clone(),
                 &mut ctx.decision_maker,
                 &additional_effects,

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1793,6 +1793,19 @@ impl ObjectFilterExt for ObjectFilter {
             }
         }
 
+        if self.top_of_graveyard {
+            if object.zone != Zone::Graveyard {
+                return false;
+            }
+            let is_top_card = game
+                .player(object.owner)
+                .and_then(|player| player.graveyard.last())
+                .is_some_and(|top_id| *top_id == object.id);
+            if !is_top_card {
+                return false;
+            }
+        }
+
         if let Some(kind) = self.stack_kind {
             if let Some(entry) = stack_entry {
                 if !Self::stack_entry_matches_kind(entry, kind) {
@@ -2508,6 +2521,19 @@ impl ObjectFilterExt for ObjectFilter {
             && snapshot.zone != *zone
         {
             return false;
+        }
+
+        if self.top_of_graveyard {
+            if snapshot.zone != Zone::Graveyard {
+                return false;
+            }
+            let is_top_card = game
+                .player(snapshot.owner)
+                .and_then(|player| player.graveyard.last())
+                .is_some_and(|top_id| *top_id == snapshot.object_id);
+            if !is_top_card {
+                return false;
+            }
         }
 
         // Controller check
@@ -3788,7 +3814,14 @@ impl ObjectFilterExt for ObjectFilter {
                 // Keep wording compact: "card exiled with this permanent" is
                 // clearer than appending an extra "in exile" qualifier.
             } else if let Some(zone_name) = zone_name {
-                if let Some(owner) = &self.owner {
+                if zone == Zone::Graveyard && self.top_of_graveyard {
+                    let graveyard = self
+                        .owner
+                        .as_ref()
+                        .map(|owner| format!("{} graveyard", describe_possessive_player_filter(owner)))
+                        .unwrap_or_else(|| "a graveyard".to_string());
+                    parts.push(format!("on top of {graveyard}"));
+                } else if let Some(owner) = &self.owner {
                     parts.push(format!(
                         "in {} {}",
                         describe_possessive_player_filter(owner),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -24732,6 +24732,289 @@ fn test_legend_rule_with_different_controllers() {
 // ============================================================================
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn bosium_strip_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_700), "Bösium Strip")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{3}, {T}: Until end of turn, you may cast instant and sorcery spells from the top of your graveyard. If a spell cast this way would be put into a graveyard, exile it instead.",
+        )
+        .expect("Bösium Strip should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn bosium_test_spell(id: u32, name: &str, card_type: CardType) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![card_type])
+        .parse_text("Scry 1.")
+        .expect("Bösium test spell should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_bosium_strip_activation(
+    game: &mut GameState,
+    bosium_id: ObjectId,
+    controller: PlayerId,
+) {
+    let activated = game
+        .object(bosium_id)
+        .expect("Bösium Strip should exist")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated.clone()),
+            _ => None,
+        })
+        .expect("Bösium Strip should have an activated ability");
+
+    let mut dm = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(bosium_id, controller, &mut dm);
+    for effect in &activated.effects {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Bösium Strip activation effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_bosium_strip_grants_only_top_instant_or_sorcery_from_graveyard() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.turn.active_player = alice;
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 2);
+
+    let bosium_id = game.create_object_from_definition(&bosium_strip_definition(), alice, Zone::Battlefield);
+    let lower_instant = bosium_test_spell(72_701, "Buried Instant", CardType::Instant);
+    let lower_instant_id = game.create_object_from_definition(&lower_instant, alice, Zone::Graveyard);
+    let top_sorcery = bosium_test_spell(72_702, "Top Sorcery", CardType::Sorcery);
+    let top_sorcery_id = game.create_object_from_definition(&top_sorcery, alice, Zone::Graveyard);
+
+    assert!(
+        !compute_legal_actions(&game, alice).iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { from_zone: Zone::Graveyard, .. }
+        )),
+        "graveyard spells should not be castable before Bösium Strip resolves"
+    );
+
+    resolve_bosium_strip_activation(&mut game, bosium_id, alice);
+    let actions = compute_legal_actions(&game, alice);
+
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom {
+                    zone: Zone::Graveyard,
+                    use_alternative: Some(_),
+                    ..
+                },
+            } if *spell_id == top_sorcery_id
+        )),
+        "Bösium Strip should allow casting the top instant or sorcery from graveyard, got {actions:?}"
+    );
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, from_zone: Zone::Graveyard, .. }
+                if *spell_id == lower_instant_id
+        )),
+        "Bösium Strip should not allow casting a non-top graveyard instant, got {actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_bosium_strip_does_not_grant_top_creature_or_buried_spell() {
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.turn.active_player = alice;
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 2);
+
+    let bosium_id = game.create_object_from_definition(&bosium_strip_definition(), alice, Zone::Battlefield);
+    let buried_sorcery = bosium_test_spell(72_703, "Buried Sorcery", CardType::Sorcery);
+    let buried_sorcery_id = game.create_object_from_definition(&buried_sorcery, alice, Zone::Graveyard);
+    let top_creature = CardBuilder::new(CardId::from_raw(72_704), "Top Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let top_creature_id = game.create_object_from_card(&top_creature, alice, Zone::Graveyard);
+
+    resolve_bosium_strip_activation(&mut game, bosium_id, alice);
+    let actions = compute_legal_actions(&game, alice);
+
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, from_zone: Zone::Graveyard, .. }
+                if *spell_id == buried_sorcery_id || *spell_id == top_creature_id
+        )),
+        "Bösium Strip should require the top graveyard card to be an instant or sorcery, got {actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_bosium_strip_cast_spell_exiles_on_resolution() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.turn.active_player = alice;
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+
+    let bosium_id = game.create_object_from_definition(&bosium_strip_definition(), alice, Zone::Battlefield);
+    let spell = bosium_test_spell(72_705, "Top Instant", CardType::Instant);
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Graveyard);
+    let stable_id = game.object(spell_id).expect("spell should exist").stable_id;
+
+    resolve_bosium_strip_activation(&mut game, bosium_id, alice);
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+            } if *id == spell_id
+        ))
+        .expect("Bösium Strip should allow casting the top instant");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+        &mut dm,
+    )
+    .expect("Bösium Strip graveyard cast should start");
+    resolve_stack_entry(&mut game).expect("Bösium-cast spell should resolve");
+
+    let moved_id = game
+        .find_object_by_stable_id(stable_id)
+        .expect("spell should still be tracked after resolution");
+    assert_eq!(
+        game.object(moved_id).expect("spell should exist").zone,
+        Zone::Exile,
+        "spell cast with Bösium Strip should be exiled on resolution"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_bosium_strip_cast_spell_exiles_when_countered() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.turn.active_player = alice;
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+
+    let bosium_id = game.create_object_from_definition(&bosium_strip_definition(), alice, Zone::Battlefield);
+    let spell = bosium_test_spell(72_706, "Countered Top Instant", CardType::Instant);
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Graveyard);
+    let stable_id = game.object(spell_id).expect("spell should exist").stable_id;
+
+    resolve_bosium_strip_activation(&mut game, bosium_id, alice);
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+            } if *id == spell_id
+        ))
+        .expect("Bösium Strip should allow casting the top instant");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+        &mut dm,
+    )
+    .expect("Bösium Strip graveyard cast should start");
+
+    let stack_spell = game
+        .find_object_by_stable_id(stable_id)
+        .expect("spell should be on the stack");
+    let counter_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(72_707), "Counter Source")
+            .card_types(vec![CardType::Instant])
+            .build(),
+        bob,
+        Zone::Stack,
+    );
+    let mut counter_ctx = crate::effects::ExecutionContext::new(counter_source, bob, &mut dm);
+    crate::effects::execute_effect(
+        &mut game,
+        &Effect::new(crate::effects::CounterEffect::new(
+            crate::target::ChooseSpec::SpecificObject(stack_spell),
+        )),
+        &mut counter_ctx,
+    )
+    .expect("counter effect should resolve");
+
+    let moved_id = game
+        .find_object_by_stable_id(stable_id)
+        .expect("countered spell should still be tracked");
+    assert_eq!(
+        game.object(moved_id).expect("spell should exist").zone,
+        Zone::Exile,
+        "spell cast with Bösium Strip should be exiled if countered"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_marang_river_prowler_not_castable_from_graveyard_without_black_or_green_permanent() {
     use crate::decision::compute_legal_actions;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Bösium Strip
Initial parse error:
```
could not find verb in effect clause (clause: 'until end of turn you may cast instant and sorcery spells from the top of your graveyard'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'until end of turn you may cast instant and sorcery spells from the top of your graveyard'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-09a7a2344590db216
Branch: codex/aws-card-fix-b-sium-strip
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0010
