### PR TITLE
Fix Ironsmith parse failure: Kin-Tree Nurturer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -11,6 +11,14 @@ struct EffectCompileHandlerDef {
     run: EffectCompileHandler,
 }
 
+fn describe_value_for_mode(value: &Value) -> String {
+    match value {
+        Value::Fixed(amount) => amount.to_string(),
+        Value::X => "X".to_string(),
+        _ => "that many".to_string(),
+    }
+}
+
 const EFFECT_COMPILE_HANDLERS: [EffectCompileHandlerDef; 14] = [
     EffectCompileHandlerDef {
         run: effect_combat_resource_handlers::try_compile_combat_and_damage_effect,
@@ -425,6 +433,51 @@ fn compile_subject_verb_effect(
             let effect =
                 tag_object_target_effect(Effect::explore(spec.clone()), &spec, ctx, "explored");
             Ok((vec![effect], choices))
+        }
+        SubjectVerbActionAst::Endure { target, amount } => {
+            let (spec, choices) =
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let amount = resolve_value_it_tag(amount, &current_reference_env(ctx))?;
+            let Value::Fixed(token_size) = amount.clone() else {
+                return Err(CardTextError::ParseError(
+                    "unsupported variable endure token size".to_string(),
+                ));
+            };
+            if token_size < 0 {
+                return Err(CardTextError::ParseError(
+                    "unsupported negative endure count".to_string(),
+                ));
+            }
+            let token_text = format!("{token_size}/{token_size} white Spirit creature token");
+            let token = token_definition_for(token_text.as_str()).ok_or_else(|| {
+                CardTextError::ParseError("unsupported endure Spirit token".to_string())
+            })?;
+            let amount_text = describe_value_for_mode(&amount);
+            let counter_description = if amount == Value::Fixed(1) {
+                "Put a +1/+1 counter on it".to_string()
+            } else {
+                format!("Put {amount_text} +1/+1 counters on it")
+            };
+            let token_description = if amount == Value::Fixed(1) {
+                "Create a 1/1 white Spirit creature token".to_string()
+            } else {
+                format!("Create a {amount_text}/{amount_text} white Spirit creature token")
+            };
+            let modes = vec![
+                crate::effect::EffectMode::new(
+                    counter_description,
+                    vec![Effect::put_counters(
+                        crate::object::CounterType::PlusOnePlusOne,
+                        amount.clone(),
+                        spec,
+                    )],
+                ),
+                crate::effect::EffectMode::new(
+                    token_description,
+                    vec![Effect::create_tokens(token, Value::Fixed(1))],
+                ),
+            ];
+            Ok((vec![Effect::choose_one(modes)], choices))
         }
         SubjectVerbActionAst::Exploit => {
             let id = ctx.next_effect_id();

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -78,6 +78,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::Transform { target }
             | SubjectVerbActionAst::Convert { target }
             | SubjectVerbActionAst::Explore { target }
+            | SubjectVerbActionAst::Endure { target, .. }
             | SubjectVerbActionAst::Connive { target, .. }
             | SubjectVerbActionAst::ExchangeControlHeterogeneous {
                 permanent1: target, ..
@@ -564,6 +565,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::Support { .. }
         | SubjectVerbActionAst::Adapt { .. }
         | SubjectVerbActionAst::Explore { .. }
+        | SubjectVerbActionAst::Endure { .. }
         | SubjectVerbActionAst::Exploit
         | SubjectVerbActionAst::ConniveIterated
         | SubjectVerbActionAst::OpenAttraction

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -728,6 +728,10 @@ pub(crate) enum SubjectVerbActionAst {
     Explore {
         target: TargetAst,
     },
+    Endure {
+        target: TargetAst,
+        amount: Value,
+    },
     Exploit,
     Connive {
         target: TargetAst,
@@ -1736,6 +1740,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::Fateseal { count } => f.debug_tuple("Fateseal").field(count).finish(),
             Self::Populate { count, .. } => f.debug_tuple("Populate").field(count).finish(),
             Self::Explore { target } => f.debug_tuple("Explore").field(target).finish(),
+            Self::Endure { target, amount } => f
+                .debug_struct("Endure")
+                .field("target", target)
+                .field("amount", amount)
+                .finish(),
             Self::Exploit => f.write_str("Exploit"),
             Self::Connive { target, count } => f
                 .debug_struct("Connive")
@@ -4975,6 +4984,14 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::Explore { target },
+        )
+    }
+
+    pub(crate) fn subject_verb_endure(target: TargetAst, amount: Value) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::Endure { target, amount },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -309,6 +309,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::Support { .. }
             | SubjectVerbActionAst::Adapt { .. }
             | SubjectVerbActionAst::Explore { .. }
+            | SubjectVerbActionAst::Endure { .. }
             | SubjectVerbActionAst::Exploit
             | SubjectVerbActionAst::ConniveIterated
             | SubjectVerbActionAst::OpenAttraction

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -374,6 +374,9 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::Explore { target } => {
                     maybe_tag_target(target, frame, id_gen, "explored")?;
                 }
+                SubjectVerbActionAst::Endure { target, .. } => {
+                    maybe_tag_target(target, frame, id_gen, "endured")?;
+                }
                 SubjectVerbActionAst::Connive { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "connived")?;
                 }
@@ -1859,6 +1862,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::Support { .. }
             | SubjectVerbActionAst::Adapt { .. }
             | SubjectVerbActionAst::Explore { .. }
+            | SubjectVerbActionAst::Endure { .. }
             | SubjectVerbActionAst::Exploit
             | SubjectVerbActionAst::ConniveIterated
             | SubjectVerbActionAst::OpenAttraction
@@ -2500,6 +2504,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::Transform { target }
             | SubjectVerbActionAst::Convert { target }
             | SubjectVerbActionAst::Explore { target }
+            | SubjectVerbActionAst::Endure { target, .. }
             | SubjectVerbActionAst::Connive { target, .. }
             | SubjectVerbActionAst::FightIterated { creature2: target }
             | SubjectVerbActionAst::Exile { target, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -2291,6 +2291,44 @@ pub(crate) fn parse_keyword_mechanic_clause(
         return Ok(Some(explore));
     }
 
+    if let Some(endure_idx) = clause_words
+        .iter()
+        .position(|word| matches!(*word, "endure" | "endures"))
+    {
+        let amount_tokens = trim_commas(&clause_tokens[endure_idx + 1..]);
+        let (amount, used) = parse_value(&amount_tokens).ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "missing endure count (clause: '{}')",
+                clause_words.join(" ")
+            ))
+        })?;
+        if used != amount_tokens.len() {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported endure count tail (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+
+        let subject_tokens = &clause_tokens[..endure_idx];
+        let subject_word_view = ClausePatternCompatWords::new(subject_tokens);
+        let subject_words = subject_word_view.to_word_refs();
+        let target = if subject_words.is_empty()
+            || word_slice_eq_any(
+                &subject_words,
+                &[
+                    &["it"],
+                    &["this"],
+                    &["this", "creature"],
+                    &["this", "permanent"],
+                ],
+            ) {
+            TargetAst::Source(span_from_tokens(subject_tokens))
+        } else {
+            parse_target_phrase(subject_tokens)?
+        };
+        return Ok(Some(EffectAst::subject_verb_endure(target, amount)));
+    }
+
     Ok(None)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -1977,6 +1977,7 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::Transform { target }
             | SubjectVerbActionAst::Convert { target }
             | SubjectVerbActionAst::Explore { target }
+            | SubjectVerbActionAst::Endure { target, .. }
             | SubjectVerbActionAst::Connive { target, .. }
             | SubjectVerbActionAst::MoveToLibraryNthFromTop { target, .. }
             | SubjectVerbActionAst::MoveToLibraryTopOrBottomChoice { target }
@@ -2339,6 +2340,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::Support { .. }
             | SubjectVerbActionAst::Adapt { .. }
             | SubjectVerbActionAst::Explore { .. }
+            | SubjectVerbActionAst::Endure { .. }
             | SubjectVerbActionAst::Exploit
             | SubjectVerbActionAst::ConniveIterated
             | SubjectVerbActionAst::OpenAttraction
@@ -2710,6 +2712,10 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
             }
             | SubjectVerbActionAst::Explore {
                 target: effect_target,
+            }
+            | SubjectVerbActionAst::Endure {
+                target: effect_target,
+                ..
             }
             | SubjectVerbActionAst::GainControl {
                 target: effect_target,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -819,6 +819,7 @@ fn parse_effect_sentence_with_where_x_lexed(
         };
         match action {
             SubjectVerbActionAst::Explore { target }
+            | SubjectVerbActionAst::Endure { target, .. }
             | SubjectVerbActionAst::Connive { target, .. }
             | SubjectVerbActionAst::ExchangeTextBoxes { target }
             | SubjectVerbActionAst::Attach { target, .. }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -262,6 +262,124 @@ fn rootpath_purifier_makes_only_your_lands_and_library_land_cards_basic() {
     );
 }
 
+fn kin_tree_nurturer_endure_effect(def: &CardDefinition) -> &Effect {
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Kin-Tree Nurturer should compile an enters trigger");
+    let effects = triggered.effects.flattened_default_effects();
+    let [effect] = effects else {
+        panic!("Kin-Tree Nurturer should have exactly one endure effect, got {effects:#?}");
+    };
+    effect
+}
+
+#[test]
+fn kin_tree_nurturer_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Kin-Tree Nurturer");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join("\n");
+    let oracle = oracle_text_by_name()
+        .get("Kin-Tree Nurturer")
+        .expect("Kin-Tree Nurturer oracle text")
+        .clone();
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            &oracle,
+            &compiled,
+            Some(crate::semantic_compare::EmbeddingConfig {
+                dims: 384,
+                mismatch_threshold: 0.99,
+            }),
+        );
+
+    assert!(
+        ability_debug.contains("ChooseModeEffect")
+            && ability_debug.contains("PutCountersEffect")
+            && ability_debug.contains("CreateTokenEffect")
+            && ability_debug.contains("Spirit"),
+        "Kin-Tree Nurturer should structurally lower endure to counter-or-Spirit modes, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("Lifelink")
+            && rendered.contains("When this creature enters, it endures 1."),
+        "expected Kin-Tree Nurturer compiled text to preserve lifelink and endure, got {rendered}"
+    );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Kin-Tree Nurturer semantic comparison to clear target, score={similarity}, mismatch={mismatch}, compiled={compiled:?}"
+    );
+}
+
+#[test]
+fn kin_tree_nurturer_endure_counter_mode_puts_counter_on_it() {
+    let def = parse_oracle_card_definition("Kin-Tree Nurturer");
+    let effect = kin_tree_nurturer_endure_effect(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![0]));
+
+    crate::effects::execute_effect(&mut game, effect, &mut ctx)
+        .expect("Kin-Tree Nurturer endure counter mode should resolve");
+
+    assert_eq!(
+        game.counter_count(source, CounterType::PlusOnePlusOne),
+        1,
+        "counter mode should put one +1/+1 counter on Kin-Tree Nurturer"
+    );
+    assert!(
+        game.objects_in_zone(Zone::Battlefield)
+            .into_iter()
+            .filter(|&id| id != source)
+            .filter_map(|id| game.object(id))
+            .all(|object| object.name != "Spirit"),
+        "counter mode should not create the Spirit token branch"
+    );
+}
+
+#[test]
+fn kin_tree_nurturer_endure_token_mode_creates_white_spirit() {
+    let def = parse_oracle_card_definition("Kin-Tree Nurturer");
+    let effect = kin_tree_nurturer_endure_effect(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![1]));
+
+    crate::effects::execute_effect(&mut game, effect, &mut ctx)
+        .expect("Kin-Tree Nurturer endure token mode should resolve");
+
+    assert_eq!(
+        game.counter_count(source, CounterType::PlusOnePlusOne),
+        0,
+        "token mode should not put the counter branch on Kin-Tree Nurturer"
+    );
+    let spirits = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter(|&id| id != source)
+        .filter_map(|id| game.object(id))
+        .filter(|object| {
+            object.name == "Spirit"
+                && object.card_types == [CardType::Creature]
+                && object.subtypes == [Subtype::Spirit]
+                && object.color_override == Some(crate::color::ColorSet::WHITE)
+                && object.base_power == Some(crate::card::PtValue::Fixed(1))
+                && object.base_toughness == Some(crate::card::PtValue::Fixed(1))
+                && game.controller_of(object) == alice
+        })
+        .count();
+    assert_eq!(spirits, 1, "token mode should create one 1/1 white Spirit");
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_day_of_the_moon_goads_creatures_with_chosen_name() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26104,6 +26104,46 @@ fn describe_unless_any_player_pays_search_prefix(
     ))
 }
 
+fn describe_endure_mode(choose_mode: &crate::effects::ChooseModeEffect) -> Option<String> {
+    if choose_mode.modes.len() != 2
+        || choose_mode.choose_count != Value::Fixed(1)
+        || choose_mode.min_choose_count != Value::Fixed(1)
+        || choose_mode.allow_repeated_modes
+    {
+        return None;
+    }
+
+    let mut counter_amount = None;
+    let mut token_size = None;
+    for mode in &choose_mode.modes {
+        let [effect] = mode.effects.as_slice() else {
+            return None;
+        };
+        if let Some(put) = effect.downcast_ref::<crate::effects::PutCountersEffect>() {
+            if put.counter_type != CounterType::PlusOnePlusOne
+                || !matches!(put.target, ChooseSpec::Source)
+                || put.target_count.is_some()
+                || put.distributed
+            {
+                return None;
+            }
+            counter_amount = Some(put.amount.clone());
+            continue;
+        }
+        if let Some(create) = effect.downcast_ref::<crate::effects::CreateTokenEffect>() {
+            token_size = Some(endure_spirit_token_size(create)?);
+            continue;
+        }
+        return None;
+    }
+
+    let amount = counter_amount?;
+    if token_size.as_ref() != Some(&amount) {
+        return None;
+    }
+    Some(format!("it endures {}", describe_value(&amount)))
+}
+
 pub(super) fn describe_tap_or_untap_mode(
     choose_mode: &crate::effects::ChooseModeEffect,
 ) -> Option<String> {
@@ -29980,6 +30020,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return compact;
     }
     if let Some(choose_mode) = effect.downcast_ref::<crate::effects::ChooseModeEffect>() {
+        if let Some(compact) = describe_endure_mode(choose_mode) {
+            return compact;
+        }
         if let Some(compact) = describe_tap_or_untap_mode(choose_mode) {
             return compact;
         }
@@ -34525,6 +34568,41 @@ fn is_fabricate_servo_token(create: &crate::effects::CreateTokenEffect) -> bool 
             })
         )
         && token.abilities.is_empty()
+}
+
+fn endure_spirit_token_size(create: &crate::effects::CreateTokenEffect) -> Option<Value> {
+    if create.controller != PlayerFilter::You
+        || create.controller_target.is_some()
+        || create.suppress_aura_attachment_choice
+        || create.enters_tapped
+        || create.enters_attacking
+        || create.exile_at_end_of_combat
+        || create.sacrifice_at_end_of_combat
+        || create.sacrifice_at_next_end_step
+        || create.exile_at_next_end_step
+        || create.count != Value::Fixed(1)
+    {
+        return None;
+    }
+
+    let token = &create.token;
+    if !token.card.is_token
+        || token.card.name != "Spirit"
+        || token.card.color_indicator != Some(crate::color::ColorSet::WHITE)
+        || token.card.card_types != [CardType::Creature]
+        || token.card.subtypes != [Subtype::Spirit]
+        || !token.abilities.is_empty()
+    {
+        return None;
+    }
+
+    match token.card.power_toughness {
+        Some(crate::card::PowerToughness {
+            power: crate::card::PtValue::Fixed(power),
+            toughness: crate::card::PtValue::Fixed(toughness),
+        }) if power == toughness => Some(Value::Fixed(power)),
+        _ => None,
+    }
 }
 
 fn describe_structural_afflict_keyword(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kin-Tree Nurturer
Initial parse error:
```
could not find verb in effect clause (clause: 'it endures 1'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'it endures 1'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-00f776c656eb2e2da
Branch: codex/aws-card-fix-kin-tree-nurturer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0010
