### PR TITLE
Fix Ironsmith parse failure: Tromp the Domains

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -279,6 +279,30 @@ fn kin_tree_nurturer_endure_effect(def: &CardDefinition) -> &Effect {
 }
 
 #[test]
+fn tromp_the_domains_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Tromp the Domains");
+    let effect_debug = format!("{:#?}", def.spell_effect);
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        effect_debug.contains("ApplyContinuousEffect")
+            && effect_debug.contains("AddAbility")
+            && effect_debug.contains("Trample")
+            && effect_debug.contains("ModifyPowerToughness")
+            && effect_debug.contains("BasicLandTypesAmong"),
+        "Tromp the Domains should structurally grant trample and scale P/T by domain, got {effect_debug}"
+    );
+    assert!(
+        rendered_lower.contains("creatures you control")
+            && rendered_lower.contains("gain trample")
+            && rendered_lower.contains("get +1/+1 for each basic land type among lands you control"),
+        "expected Tromp the Domains compiled text to preserve the domain P/T clause, got {rendered}"
+    );
+}
+
+#[test]
 fn kin_tree_nurturer_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Kin-Tree Nurturer");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8440,6 +8440,10 @@ pub(super) fn describe_dynamic_runtime_pt_with_where_x(
     let power_is_variable = !matches!(power, Value::Fixed(_));
     let toughness_is_variable = !matches!(toughness, Value::Fixed(_));
 
+    if let Some(for_each_text) = describe_basic_land_type_pt_for_each(power, toughness) {
+        return Some(format!("{target} {gets} {for_each_text} {until_text}"));
+    }
+
     if matches!((power, toughness), (Value::X, Value::X)) {
         return Some(format!("{target} {gets} +X/+X {until_text}"));
     }
@@ -8476,6 +8480,38 @@ pub(super) fn describe_dynamic_runtime_pt_with_where_x(
     }
 
     None
+}
+
+pub(super) fn describe_basic_land_type_pt_for_each(
+    power: &Value,
+    toughness: &Value,
+) -> Option<String> {
+    let power_multiplier = basic_land_types_multiplier(power);
+    let toughness_multiplier = basic_land_types_multiplier(toughness);
+
+    let (power_per, toughness_per, filter) = match (power_multiplier, toughness_multiplier) {
+        (Some((power_filter, power_per)), Some((toughness_filter, toughness_per))) => {
+            if power_filter != toughness_filter {
+                return None;
+            }
+            (power_per, toughness_per, power_filter)
+        }
+        (Some((filter, power_per)), None) if matches!(toughness, Value::Fixed(0)) => {
+            (power_per, 0, filter)
+        }
+        (None, Some((filter, toughness_per))) if matches!(power, Value::Fixed(0)) => {
+            (0, toughness_per, filter)
+        }
+        _ => return None,
+    };
+
+    let each_text =
+        describe_basic_land_types_among(filter).replace("basic land types", "basic land type");
+    Some(format!(
+        "{}/{} for each {each_text}",
+        describe_signed_i32(power_per),
+        describe_signed_i32(toughness_per)
+    ))
 }
 
 pub(super) fn describe_signed_i32(value: i32) -> String {
@@ -8805,11 +8841,15 @@ pub(super) fn describe_apply_continuous_clauses(
                 power,
                 toughness,
             } => {
-                clauses.push(format!(
-                    "{gets} {}/{}",
-                    describe_signed_value(power),
-                    describe_toughness_delta_with_power_context(power, toughness)
-                ));
+                if let Some(for_each_text) = describe_basic_land_type_pt_for_each(power, toughness) {
+                    clauses.push(format!("{gets} {for_each_text}"));
+                } else {
+                    clauses.push(format!(
+                        "{gets} {}/{}",
+                        describe_signed_value(power),
+                        describe_toughness_delta_with_power_context(power, toughness)
+                    ));
+                }
             }
             crate::effects::continuous::RuntimeModification::ModifyPower { value } => {
                 clauses.push(format!("{gets} {} power", describe_signed_value(value)));

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -36529,6 +36529,92 @@ fn voices_from_the_void_discards_one_card_per_basic_land_type() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn tromp_the_domains_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Tromp the Domains")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Domain — Until end of turn, creatures you control gain trample and get +1/+1 for each basic land type among lands you control.",
+        )
+        .expect("Tromp the Domains should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tromp_the_domains_grants_trample_and_distinct_domain_pump_until_cleanup() {
+    use crate::cards::definitions::{basic_forest, basic_island};
+    use crate::game_loop::resolve_stack_entry_with_dm_and_triggers;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let tromp = tromp_the_domains_definition();
+    let spell_id = game.create_object_from_definition(&tromp, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice));
+
+    game.create_object_from_definition(&basic_forest(), alice, Zone::Battlefield);
+    game.create_object_from_definition(&basic_forest(), alice, Zone::Battlefield);
+    game.create_object_from_definition(&basic_island(), alice, Zone::Battlefield);
+
+    let alice_creature = create_creature(&mut game, "Tromping Bear", alice, 2, 2);
+    let bob_creature = create_creature(&mut game, "Untromped Bear", bob, 2, 2);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Tromp the Domains should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.calculated_power(alice_creature),
+        Some(4),
+        "Tromp should count distinct basic land types, not total lands"
+    );
+    assert_eq!(game.calculated_toughness(alice_creature), Some(4));
+    assert!(
+        game.current_has_static_ability_id(
+            alice_creature,
+            crate::static_abilities::StaticAbilityId::Trample,
+        ),
+        "Tromp should grant trample to creatures you control"
+    );
+    assert_eq!(
+        game.calculated_power(bob_creature),
+        Some(2),
+        "Tromp should not pump opponents' creatures"
+    );
+    assert!(
+        !game.current_has_static_ability_id(
+            bob_creature,
+            crate::static_abilities::StaticAbilityId::Trample,
+        ),
+        "Tromp should not grant trample to opponents' creatures"
+    );
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+
+    assert_eq!(game.calculated_power(alice_creature), Some(2));
+    assert_eq!(game.calculated_toughness(alice_creature), Some(2));
+    assert!(
+        !game.current_has_static_ability_id(
+            alice_creature,
+            crate::static_abilities::StaticAbilityId::Trample,
+        ),
+        "Tromp's effects should expire during cleanup"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn atraxa_grand_unifier_puts_one_card_per_type_into_hand_and_bottoms_the_rest() {
     use crate::effects::ExecutionContext;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tromp the Domains
Initial parse error:
```
compiled text dropped required semantic marker: each-basic-land-type
```

Current worker: i-093f084e798d5dd5d
Branch: codex/aws-card-fix-tromp-the-domains
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0012
