### PR TITLE
Fix Ironsmith parse failure: Bloodthirsty Adversary

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1865,6 +1865,26 @@ impl Effect {
         without_paying_mana_cost: bool,
         cost_reduction: Option<crate::mana::ManaCost>,
     ) -> Self {
+        Self::cast_tagged_with_options(
+            tag,
+            player,
+            allow_land,
+            as_copy,
+            without_paying_mana_cost,
+            cost_reduction,
+            false,
+        )
+    }
+
+    pub fn cast_tagged_with_options(
+        tag: crate::tag::TagKey,
+        player: crate::target::PlayerFilter,
+        allow_land: bool,
+        as_copy: bool,
+        without_paying_mana_cost: bool,
+        cost_reduction: Option<crate::mana::ManaCost>,
+        any_number: bool,
+    ) -> Self {
         Self::new(crate::effects::CastTaggedEffect {
             tag,
             player,
@@ -1872,6 +1892,7 @@ impl Effect {
             as_copy,
             without_paying_mana_cost,
             cost_reduction,
+            any_number,
         })
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -12,7 +12,7 @@ use super::super::lexer::{
     LexStream, LexToken, OwnedLexToken, TokenKind, TokenWordView, contains_token_kind,
     find_token_word, token_slice_first_is, token_slice_first_is_any, token_slice_last_is,
     token_slice_starts_with_at, trim_lexed_commas, word_slice_at_is, word_slice_contains_any_word,
-    word_slice_contains_word, word_slice_ends_with, word_slice_first_is_any,
+    word_slice_contains_word, word_slice_ends_with, word_slice_first_is_any, word_slice_starts_with,
     word_slice_strip_prefix,
 };
 use super::super::token_primitives::{find_index_with, rfind_index_with};
@@ -578,6 +578,17 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
         return Some(IfResultPredicate::Did);
     }
     if is_unqualified_this_way_result("you") {
+        return Some(IfResultPredicate::Did);
+    }
+    if words.len() >= 7
+        && words[0] == "you"
+        && words[1] == "pay"
+        && words[2] == "this"
+        && words[3] == "cost"
+        && words[4] == "one"
+        && words[5] == "or"
+        && words[6] == "more"
+    {
         return Some(IfResultPredicate::Did);
     }
     if is_unqualified_this_way_result("they") {
@@ -1162,7 +1173,16 @@ pub(crate) fn split_leading_result_prefix_lexed<'a>(
     if predicate_tokens.is_empty() {
         return None;
     }
-    let predicate = parse_if_result_predicate(predicate_tokens)?;
+    let predicate_words = parser_text_non_article_words(predicate_tokens);
+    let predicate_word_refs = predicate_words.iter().map(String::as_str).collect::<Vec<_>>();
+    let predicate = if word_slice_starts_with(
+        &predicate_word_refs,
+        &["you", "pay", "this", "cost", "one", "or", "more"],
+    ) {
+        IfResultPredicate::Did
+    } else {
+        parse_if_result_predicate(predicate_tokens)?
+    };
 
     let trailing_tokens = trim_lexed_commas(&trimmed[comma_idx + 1..]);
     if trailing_tokens.is_empty() {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/parser_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/parser_support.rs
@@ -57,6 +57,7 @@ pub(crate) fn looks_like_reflexive_followup_intro_lexed(tokens: &[OwnedLexToken]
     looks_like_when_one_or_more_this_way_followup_lexed(tokens)
         || looks_like_when_it_connives_this_way_followup_lexed(tokens)
         || looks_like_when_you_do_followup_lexed(tokens)
+        || looks_like_when_you_pay_this_cost_followup_lexed(tokens)
         || looks_like_otherwise_followup_lexed(tokens)
 }
 
@@ -229,6 +230,27 @@ fn parse_when_you_do_followup_intro_inner<'a>(
 
 fn looks_like_when_you_do_followup_lexed(tokens: &[OwnedLexToken]) -> bool {
     starts_with_lexed_parser(tokens, 0, parse_when_you_do_followup_intro_inner)
+}
+
+fn parse_when_you_pay_this_cost_followup_intro_inner<'a>(
+    input: &mut LexStream<'a>,
+) -> Result<(), ErrMode<ContextError>> {
+    (
+        grammar::kw("when"),
+        grammar::kw("you"),
+        grammar::kw("pay"),
+        grammar::kw("this"),
+        grammar::kw("cost"),
+        grammar::kw("one"),
+        grammar::kw("or"),
+        grammar::kw("more"),
+    )
+        .void()
+        .parse_next(input)
+}
+
+fn looks_like_when_you_pay_this_cost_followup_lexed(tokens: &[OwnedLexToken]) -> bool {
+    starts_with_lexed_parser(tokens, 0, parse_when_you_pay_this_cost_followup_intro_inner)
 }
 
 fn parse_otherwise_followup_intro_inner<'a>(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2713,6 +2713,18 @@ pub(crate) fn wrap_target_count(target: TargetAst, target_count: Option<ChoiceCo
     }
 }
 
+fn wrap_target_count_with_value(
+    target: TargetAst,
+    target_count: Option<ChoiceCount>,
+    target_count_value: Option<Value>,
+) -> TargetAst {
+    match (target_count, target_count_value) {
+        (Some(count), Some(value)) => TargetAst::WithCountValue(Box::new(target), count, value),
+        (Some(count), None) => TargetAst::WithCount(Box::new(target), count),
+        (None, _) => target,
+    }
+}
+
 fn choice_count_from_value(value: &Value, up_to: bool) -> ChoiceCount {
     match value {
         Value::X => {
@@ -2872,6 +2884,7 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
     let mut other = false;
     let span = span_from_tokens(tokens);
     let mut target_count: Option<ChoiceCount> = None;
+    let mut target_count_value: Option<Value> = None;
     let mut explicit_target = false;
 
     let all_words = crate::runtime_backend::token_word_refs(tokens);
@@ -3126,6 +3139,10 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
         idx += 2;
         if let Some((value, used)) = parse_number_or_x_value(&tokens[idx..]) {
             target_count = Some(choice_count_from_value(&value, true));
+            idx += used;
+        } else if let Some((value, used)) = parse_value_expr(&tokens[idx..]) {
+            target_count = Some(ChoiceCount::up_to_dynamic_x());
+            target_count_value = Some(value);
             idx += used;
         } else {
             let next_word = tokens
@@ -3956,9 +3973,10 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
     } else {
         None
     };
-    Ok(wrap_target_count(
+    Ok(wrap_target_count_with_value(
         TargetAst::Object(filter, target_span, it_span),
         target_count,
+        target_count_value,
     ))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -1141,11 +1141,15 @@ fn choose_followup_player_filter(
 pub(crate) fn hand_exile_filter_and_count(
     target: &TargetAst,
     ctx: &EffectLoweringContext,
-) -> Result<Option<(ObjectFilter, ChoiceCount, Vec<Zone>)>, CardTextError> {
-    let (filter, count) = match target {
-        TargetAst::Object(filter, _, _) => (filter, ChoiceCount::exactly(1)),
+) -> Result<Option<(ObjectFilter, ChoiceCount, Option<Value>, Vec<Zone>)>, CardTextError> {
+    let (filter, count, count_value) = match target {
+        TargetAst::Object(filter, _, _) => (filter, ChoiceCount::exactly(1), None),
         TargetAst::WithCount(inner, count) => match inner.as_ref() {
-            TargetAst::Object(filter, _, _) => (filter, *count),
+            TargetAst::Object(filter, _, _) => (filter, *count, None),
+            _ => return Ok(None),
+        },
+        TargetAst::WithCountValue(inner, count, count_value) => match inner.as_ref() {
+            TargetAst::Object(filter, _, _) => (filter, *count, Some(count_value.clone())),
             _ => return Ok(None),
         },
         _ => return Ok(None),
@@ -1157,7 +1161,7 @@ pub(crate) fn hand_exile_filter_and_count(
     let Some(zones) = zones else {
         return Ok(None);
     };
-    Ok(Some((resolved_filter, count, zones)))
+    Ok(Some((resolved_filter, count, count_value, zones)))
 }
 
 fn normalize_hand_or_graveyard_cross_zone_filter(filter: &mut ObjectFilter) {
@@ -1225,7 +1229,7 @@ pub(crate) fn lower_hand_exile_target(
     face_down: bool,
     ctx: &mut EffectLoweringContext,
 ) -> Result<Option<(Vec<Effect>, Vec<ChooseSpec>)>, CardTextError> {
-    let Some((mut filter, count, zones)) = hand_exile_filter_and_count(target, ctx)? else {
+    let Some((mut filter, count, count_value, zones)) = hand_exile_filter_and_count(target, ctx)? else {
         return Ok(None);
     };
     strip_choice_zones_from_filter(&mut filter, &zones);
@@ -1256,6 +1260,7 @@ pub(crate) fn lower_hand_exile_target(
 
     prelude.push(Effect::new(
         crate::effects::ChooseObjectsEffect::new(filter, count, chooser, tag_key.clone())
+            .with_count_value_opt(count_value)
             .in_zones(zones),
     ));
     prelude.push(Effect::new(
@@ -1412,10 +1417,10 @@ pub(crate) fn lower_may_imprint_from_hand_effect(
         return Ok(None);
     }
 
-    let Some((filter, count, zones)) = hand_exile_filter_and_count(target, ctx)? else {
+    let Some((filter, count, count_value, zones)) = hand_exile_filter_and_count(target, ctx)? else {
         return Ok(None);
     };
-    if !count.is_single() || zones.as_slice() != [Zone::Hand] {
+    if !count.is_single() || count_value.is_some() || zones.as_slice() != [Zone::Hand] {
         return Ok(None);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1873,6 +1873,7 @@ fn compile_subject_verb_effect(
             as_copy,
             without_paying_mana_cost,
             cost_reduction,
+            any_number,
         } => {
             let resolved_tag = if tag.as_str() == "__last_revealed__" {
                 TagKey::from(ctx.last_revealed_tag.clone().ok_or_else(|| {
@@ -1904,13 +1905,14 @@ fn compile_subject_verb_effect(
                 _ => resolve_non_target_player_filter(*player, &current_reference_env(ctx))?,
             };
             Ok((
-                vec![Effect::cast_tagged(
+                vec![Effect::cast_tagged_with_options(
                     resolved_tag,
                     player_filter,
                     *allow_land,
                     *as_copy,
                     *without_paying_mana_cost,
                     cost_reduction.clone(),
+                    *any_number,
                 )],
                 Vec::new(),
             ))
@@ -5132,12 +5134,20 @@ fn compile_subject_verb_effect(
                 },
             )
         }
-        SubjectVerbActionAst::PayMana { cost } => {
+        SubjectVerbActionAst::PayMana {
+            cost,
+            any_number_of_times,
+        } => {
             compile_player_role_effect(role, player, ctx, false, false, true, |subject| {
-                Effect::new(crate::effects::PayManaEffect::new(
+                let effect = crate::effects::PayManaEffect::new(
                     cost.clone(),
                     ChooseSpec::Player(subject.into_player_filter()),
-                ))
+                );
+                Effect::new(if *any_number_of_times {
+                    effect.any_number_of_times()
+                } else {
+                    effect
+                })
             })
         }
         SubjectVerbActionAst::DoubleManaPool => {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1037,6 +1037,7 @@ pub(crate) enum SubjectVerbActionAst {
         as_copy: bool,
         without_paying_mana_cost: bool,
         cost_reduction: Option<ManaCost>,
+        any_number: bool,
     },
     GrantPlayTaggedUntilEndOfTurn {
         tag: TagKey,
@@ -1599,6 +1600,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     PayMana {
         cost: ManaCost,
+        any_number_of_times: bool,
     },
     DoubleManaPool,
     EmptyManaPool,
@@ -2218,6 +2220,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 as_copy,
                 without_paying_mana_cost,
                 cost_reduction,
+                any_number,
             } => f
                 .debug_struct("CastTagged")
                 .field("tag", tag)
@@ -2226,6 +2229,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("as_copy", as_copy)
                 .field("without_paying_mana_cost", without_paying_mana_cost)
                 .field("cost_reduction", cost_reduction)
+                .field("any_number", any_number)
                 .finish(),
             Self::GrantPlayTaggedUntilEndOfTurn {
                 tag,
@@ -3069,7 +3073,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("PayAnyEnergy")
                 .field("min_amount", min_amount)
                 .finish(),
-            Self::PayMana { cost } => f.debug_tuple("PayMana").field(cost).finish(),
+            Self::PayMana {
+                cost,
+                any_number_of_times,
+            } => f
+                .debug_struct("PayMana")
+                .field("cost", cost)
+                .field("any_number_of_times", any_number_of_times)
+                .finish(),
             Self::DoubleManaPool => f.write_str("DoubleManaPool"),
             Self::EmptyManaPool => f.write_str("EmptyManaPool"),
             Self::SetLifeTotal { amount } => f.debug_tuple("SetLifeTotal").field(amount).finish(),
@@ -3667,6 +3678,7 @@ impl EffectAst {
                 as_copy,
                 without_paying_mana_cost,
                 cost_reduction,
+                any_number: false,
             },
         )
     }
@@ -6081,10 +6093,21 @@ impl EffectAst {
     }
 
     pub(crate) fn subject_verb_pay_mana(player: PlayerAst, cost: ManaCost) -> Self {
+        Self::subject_verb_pay_mana_repeated(player, cost, false)
+    }
+
+    pub(crate) fn subject_verb_pay_mana_repeated(
+        player: PlayerAst,
+        cost: ManaCost,
+        any_number_of_times: bool,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::AffectedPlayer,
             player,
-            SubjectVerbActionAst::PayMana { cost },
+            SubjectVerbActionAst::PayMana {
+                cost,
+                any_number_of_times,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1677,7 +1677,7 @@ fn resolve_effect_sequence_references_with_state(
         let _ = effects_reference_it_tag(remaining) || effects_reference_its_controller(remaining);
         let assigned_effect_id =
             maybe_assign_effect_result_id(effects, idx, id_gen, state.allow_life_event_value);
-        state.last_effect_id = if matches!(
+        let next_last_effect_id = if matches!(
             effect,
             EffectAst::ResolvedIfResult { .. }
                 | EffectAst::ResolvedWhenResult { .. }
@@ -1688,10 +1688,30 @@ fn resolve_effect_sequence_references_with_state(
         } else {
             assigned_effect_id
         };
+        state.last_effect_id = if state.bind_unbound_x_to_last_effect && next_last_effect_id.is_none()
+        {
+            saved_last_effect_id
+        } else {
+            next_last_effect_id
+        };
         resolved.push(effect);
     }
 
     Ok(resolved)
+}
+
+fn resolve_effect_result_values_in_target(
+    target: &mut TargetAst,
+    state: EffectReferenceResolutionState,
+) -> Result<(), CardTextError> {
+    match target {
+        TargetAst::WithCount(inner, _) => resolve_effect_result_values_in_target(inner, state),
+        TargetAst::WithCountValue(inner, _, value) => {
+            resolve_effect_result_values_in_target(inner, state)?;
+            resolve_effect_result_value(value, state)
+        }
+        _ => Ok(()),
+    }
 }
 
 fn advance_reference_env_for_effect(
@@ -1844,6 +1864,9 @@ fn resolve_effect_result_values_in_fields(
             SubjectVerbActionAst::CounterUnlessPays { cost, .. } => {
                 resolve_effect_result_values_in_total_cost(cost, state)?;
             }
+            SubjectVerbActionAst::Exile { target, .. } => {
+                resolve_effect_result_values_in_target(target, state)?;
+            }
             SubjectVerbActionAst::PreventDamageToTargetPutCounters {
                 amount: Some(amount),
                 ..
@@ -1947,7 +1970,6 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::Destroy { .. }
             | SubjectVerbActionAst::DestroyAll { .. }
             | SubjectVerbActionAst::DestroyAllOfChosenColor { .. }
-            | SubjectVerbActionAst::Exile { .. }
             | SubjectVerbActionAst::ExileAll { .. }
             | SubjectVerbActionAst::LookAtHand { .. }
             | SubjectVerbActionAst::Counter { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -966,6 +966,58 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         return Ok(EffectAst::subject_verb_clear_suspected(None));
     }
 
+    if word_slice_eq_any(
+        &clause_words,
+        &[
+            &["copy", "them"],
+            &["copy", "those", "cards"],
+            &["copy", "the", "exiled", "cards"],
+        ],
+    ) {
+        return Ok(EffectAst::subject_verb_tag_matching_objects(
+            ObjectFilter::tagged(TagKey::from(IT_TAG)),
+            vec![Zone::Exile],
+            TagKey::from(crate::cards::builders::COPIED_STACK_OBJECT_TAG),
+        ));
+    }
+
+    if word_slice_eq_any(
+        &clause_words,
+        &[
+            &[
+                "cast", "any", "number", "of", "the", "copies", "without", "paying", "their",
+                "mana", "costs",
+            ],
+            &[
+                "cast", "the", "copies", "without", "paying", "their", "mana", "costs",
+            ],
+            &[
+                "cast", "the", "copy", "without", "paying", "its", "mana", "cost",
+            ],
+        ],
+    ) {
+        return Ok(EffectAst::SubjectVerb(
+            crate::runtime_backend::ast::SubjectVerbEffectAst {
+                subject: crate::runtime_backend::ast::SubjectVerbSubjectAst {
+                    role: SubjectVerbRoleAst::Actor,
+                    player: PlayerAst::Implicit,
+                },
+                action: SubjectVerbActionAst::CastTagged {
+                    tag: TagKey::from(crate::cards::builders::COPIED_STACK_OBJECT_TAG),
+                    player: PlayerAst::Implicit,
+                    allow_land: false,
+                    as_copy: true,
+                    without_paying_mana_cost: true,
+                    cost_reduction: None,
+                    any_number: word_slice_contains_phrase(
+                        &clause_words,
+                        &["any", "number"],
+                    ),
+                },
+            },
+        ));
+    }
+
     if word_slice_starts_with(&clause_words, &["cast", "target"])
         && let Some(without_word_idx) = word_slice_find_phrase_start(
             &clause_words,
@@ -987,6 +1039,7 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
                     as_copy: false,
                     without_paying_mana_cost: true,
                     cost_reduction: None,
+                    any_number: false,
                 },
             },
         ));

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -928,6 +928,16 @@ fn parse_effect_sentences_from_sentence_inputs(
         let sentence_text = crate::runtime_backend::token_word_refs(sentence).join(" ");
         let _sentence_scope = parse_trace::scope(format!("effect sentence: \"{}\"", sentence_text));
 
+        if let Some((effect, consumed_sentences)) =
+            try_parse_pay_this_cost_reflexive_sequence(&sentences, sentence_idx)?
+        {
+            parse_trace::event("sequence subject/verb rule: pay-this-cost-reflexive -> MayByPlayer".to_string());
+            effects.push(effect);
+            carried_context = None;
+            sentence_idx += consumed_sentences;
+            continue;
+        }
+
         if let Some(mut matched) = try_parse_subject_verb_sequence_rule(&sentences, sentence_idx)? {
             let stage = if let Some(feature_tag) = matched.feature_tag {
                 format!(
@@ -1261,6 +1271,115 @@ fn parse_effect_sentences_lexed_inner(
     apply_trailing_counter_constraint_to_destroy_all(&mut effects, tokens);
     maybe_repair_that_player_gain_control_if_do_rewards(&mut effects, tokens);
     Ok(effects)
+}
+
+fn sentence_words_start_with(sentence: &[OwnedLexToken], prefix: &[&str]) -> bool {
+    let words = crate::runtime_backend::token_word_refs(sentence);
+    words.len() >= prefix.len()
+        && words
+            .iter()
+            .zip(prefix.iter())
+            .all(|(word, expected)| word == expected)
+}
+
+fn drop_copied_object_marker_effects(effects: &mut Vec<EffectAst>) {
+    effects.retain(|effect| {
+        !matches!(
+            effect,
+            EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                action: SubjectVerbActionAst::TagMatchingObjects { tag, .. },
+                ..
+            }) if tag.as_str() == crate::cards::builders::COPIED_STACK_OBJECT_TAG
+        )
+    });
+}
+
+fn retarget_cast_copies_to_last_object(effects: &mut [EffectAst]) {
+    for effect in effects {
+        match effect {
+            EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                action:
+                    SubjectVerbActionAst::CastTagged {
+                        tag, as_copy: true, ..
+                    },
+                ..
+            }) if tag.as_str() == crate::cards::builders::COPIED_STACK_OBJECT_TAG => {
+                *tag = TagKey::from(IT_TAG);
+            }
+            EffectAst::May { effects }
+            | EffectAst::MayByPlayer { effects, .. }
+            | EffectAst::WhenResult { effects, .. }
+            | EffectAst::IfResult { effects, .. }
+            | EffectAst::ResolvedWhenResult { effects, .. }
+            | EffectAst::ResolvedIfResult { effects, .. }
+            | EffectAst::Sequence { effects }
+            | EffectAst::ForEachOpponent { effects }
+            | EffectAst::ForEachPlayer { effects }
+            | EffectAst::ForEachPlayersFiltered { effects, .. }
+            | EffectAst::ForEachTargetPlayers { effects, .. }
+            | EffectAst::ForEachTaggedPlayer { effects, .. }
+            | EffectAst::ForEachTagged { effects, .. }
+            | EffectAst::ForEachObject { effects, .. }
+            | EffectAst::RepeatEffects { effects, .. } => retarget_cast_copies_to_last_object(effects),
+            _ => {}
+        }
+    }
+}
+
+fn try_parse_pay_this_cost_reflexive_sequence(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<(EffectAst, usize)>, CardTextError> {
+    let Some(pay_sentence) = sentences.get(sentence_idx).map(SentenceInput::lowered) else {
+        return Ok(None);
+    };
+    let Some(followup_sentence) = sentences.get(sentence_idx + 1).map(SentenceInput::lowered) else {
+        return Ok(None);
+    };
+    if !sentence_words_start_with(pay_sentence, &["you", "may", "pay"])
+        || !sentence_words_start_with(
+            followup_sentence,
+            &["when", "you", "pay", "this", "cost", "one", "or", "more"],
+        )
+    {
+        return Ok(None);
+    }
+
+    let mut pay_effects = parse_effect_sentence_lexed(pay_sentence)?;
+    if pay_effects.len() != 1 {
+        return Ok(None);
+    }
+
+    let followup_words = crate::runtime_backend::token_word_refs(followup_sentence);
+    let copies_exiled_objects = word_slice_contains_phrase(&followup_words, &["copy", "them"]);
+    let mut followup_effects = parse_effect_sentence_lexed(followup_sentence)?;
+    if copies_exiled_objects
+        && let Some(EffectAst::WhenResult { effects, .. }) = followup_effects.first_mut()
+    {
+        drop_copied_object_marker_effects(effects);
+    }
+    let mut consumed_sentences = 2;
+    if let Some(cast_sentence) = sentences.get(sentence_idx + 2).map(SentenceInput::lowered)
+        && sentence_words_start_with(cast_sentence, &["you", "may", "cast"])
+    {
+        let mut cast_effects = parse_effect_sentence_lexed(cast_sentence)?;
+        if copies_exiled_objects {
+            retarget_cast_copies_to_last_object(&mut cast_effects);
+        }
+        if let Some(EffectAst::WhenResult { effects, .. }) = followup_effects.first_mut() {
+            effects.extend(cast_effects);
+            consumed_sentences = 3;
+        }
+    }
+
+    let mut pay_effect = pay_effects.remove(0);
+    match &mut pay_effect {
+        EffectAst::MayByPlayer { effects, .. } | EffectAst::May { effects } => {
+            effects.extend(followup_effects);
+            Ok(Some((pay_effect, consumed_sentences)))
+        }
+        _ => Ok(None),
+    }
 }
 
 fn reflected_prevent_next_damage_from_tokens(tokens: &[OwnedLexToken]) -> Option<EffectAst> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
@@ -135,6 +135,7 @@ pub(crate) fn parse_effect_sentence_inner_lexed(
                     as_copy: false,
                     without_paying_mana_cost: true,
                     cost_reduction: None,
+                    any_number: false,
                 },
             }),
         ]);
@@ -171,6 +172,7 @@ pub(crate) fn parse_effect_sentence_inner_lexed(
                     as_copy: false,
                     without_paying_mana_cost: true,
                     cost_reduction: None,
+                    any_number: false,
                 },
             }),
         ]);

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -943,8 +943,12 @@ pub(crate) fn parse_pay(
             })?
     };
 
-    Ok(EffectAst::subject_verb_pay_mana(
+    let any_number_of_times =
+        word_slice_contains_phrase(&clause_words, &["any", "number", "of", "times"]);
+
+    Ok(EffectAst::subject_verb_pay_mana_repeated(
         player,
         ManaCost::from_pips(pips),
+        any_number_of_times,
     ))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -1258,6 +1258,7 @@ pub(crate) fn parse_top_cards_may_cast_match_rest_bottom(
             as_copy: false,
             without_paying_mana_cost: true,
             cost_reduction: None,
+            any_number: false,
         },
     }));
     effects.push(

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1786,11 +1786,21 @@ impl BecomeColorChoiceEffect {
 pub struct PayManaEffect {
     pub cost: crate::mana::ManaCost,
     pub player: ChooseSpec,
+    pub any_number_of_times: bool,
 }
 
 impl PayManaEffect {
     pub fn new(cost: crate::mana::ManaCost, player: ChooseSpec) -> Self {
-        Self { cost, player }
+        Self {
+            cost,
+            player,
+            any_number_of_times: false,
+        }
+    }
+
+    pub fn any_number_of_times(mut self) -> Self {
+        self.any_number_of_times = true;
+        self
     }
 }
 
@@ -5541,6 +5551,7 @@ pub struct CastTaggedEffect {
     pub as_copy: bool,
     pub without_paying_mana_cost: bool,
     pub cost_reduction: Option<ManaCost>,
+    pub any_number: bool,
 }
 
 impl CastTaggedEffect {
@@ -5552,6 +5563,7 @@ impl CastTaggedEffect {
             as_copy: false,
             without_paying_mana_cost: false,
             cost_reduction: None,
+            any_number: false,
         }
     }
 
@@ -5572,6 +5584,11 @@ impl CastTaggedEffect {
 
     pub fn cost_reduction(mut self, reduction: ManaCost) -> Self {
         self.cost_reduction = Some(reduction);
+        self
+    }
+
+    pub fn any_number(mut self) -> Self {
+        self.any_number = true;
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -704,6 +704,35 @@ fn parse_shiny_impetus_oracle_and_compiled_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn bloodthirsty_adversary_strict_parser_compiled_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Bloodthirsty Adversary");
+    let def = parse_oracle_card_definition("Bloodthirsty Adversary");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "When this creature enters, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on this creature, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs"
+        ),
+        "Bloodthirsty Adversary compiled text should preserve repeat payment, dynamic targets, copying, and free copy casting, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("PayManaEffect")
+            && abilities_debug.contains("any_number_of_times: true")
+            && abilities_debug.contains("ReflexiveTriggerEffect")
+            && abilities_debug.contains("WithCountValue")
+            && abilities_debug.contains("EffectValue")
+            && abilities_debug.contains("ExileEffect")
+            && abilities_debug.contains("CastTaggedEffect")
+            && abilities_debug.contains("as_copy: true")
+            && abilities_debug.contains("any_number: true")
+            && !abilities_debug.contains("__copied_stack_object__"),
+        "Bloodthirsty Adversary should structurally tie payment count to exile targets and cast the exiled tagged cards as copies, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_equipment_attached_goaded_anthem_preserves_equipped_subject() {
     let def = parse_oracle_card_definition("Bloodthirsty Blade");
     let rendered_lines = canonical_compiled_lines(&def);

--- a/crates/ironsmith-runtime/src/cards/definitions/dawn_charm.rs
+++ b/crates/ironsmith-runtime/src/cards/definitions/dawn_charm.rs
@@ -106,6 +106,7 @@ mod tests {
             crew_contributors: vec![],
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
             chosen_modes: None,
         });
         id

--- a/crates/ironsmith-runtime/src/cards/definitions/library_of_leng.rs
+++ b/crates/ironsmith-runtime/src/cards/definitions/library_of_leng.rs
@@ -301,6 +301,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that discards a land
@@ -395,6 +396,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that DECLINES to discard
@@ -530,6 +532,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that chooses to use Library of Leng

--- a/crates/ironsmith-runtime/src/cards/definitions/mox_diamond.rs
+++ b/crates/ironsmith-runtime/src/cards/definitions/mox_diamond.rs
@@ -314,6 +314,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that discards a land
@@ -392,6 +393,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that declines to discard
@@ -469,6 +471,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that would discard a land (but there are none)
@@ -539,6 +542,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that discards a land

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6815,7 +6815,7 @@ pub(super) fn describe_choose_spec(spec: &ChooseSpec) -> String {
         ChooseSpec::SpecificObject(_) => "that object".to_string(),
         ChooseSpec::SpecificPlayer(_) => "that player".to_string(),
         ChooseSpec::Iterated => "that object".to_string(),
-        ChooseSpec::WithCount(inner, count) | ChooseSpec::WithCountValue(inner, count, _) => {
+        ChooseSpec::WithCount(inner, count) => {
             let inner_text = describe_choose_spec(inner);
             let random_suffix = if count.is_random() {
                 if count.is_single() {
@@ -6912,6 +6912,38 @@ pub(super) fn describe_choose_spec(spec: &ChooseSpec) -> String {
                             )
                         }
                     }
+                }
+            }
+        }
+        ChooseSpec::WithCountValue(inner, count, value) => {
+            let inner_text = describe_choose_spec(inner);
+            let random_suffix = if count.is_random() {
+                if count.is_single() {
+                    " chosen at random"
+                } else {
+                    " at random"
+                }
+            } else {
+                ""
+            };
+            let count_text = describe_effect_count_backref(value)
+                .unwrap_or_else(|| describe_value(value));
+            if let ChooseSpec::Target(target_inner) = inner.as_ref() {
+                let target_desc = describe_choose_spec(target_inner);
+                let base = strip_leading_article(&target_desc);
+                let plural = pluralize_relative_object_phrase(base);
+                if count.is_up_to_dynamic_x() {
+                    format!("up to {count_text} target {plural}{random_suffix}")
+                } else {
+                    format!("{count_text} target {plural}{random_suffix}")
+                }
+            } else {
+                let base = strip_leading_article(&inner_text);
+                let plural = pluralize_relative_object_phrase(base);
+                if count.is_up_to_dynamic_x() {
+                    format!("up to {count_text} {plural}{random_suffix}")
+                } else {
+                    format!("{count_text} {plural}{random_suffix}")
                 }
             }
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3104,6 +3104,91 @@ fn filter_references_tag(filter: &ObjectFilter, tag: &TagKey) -> bool {
     })
 }
 
+fn describe_may_pay_mana_then_reflexive_counted_copy(
+    may: &crate::effects::MayEffect,
+) -> Option<String> {
+    let [pay_effect, reflexive_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    if may.decider.as_ref() != Some(&PlayerFilter::You) {
+        return None;
+    }
+
+    let pay_with_id = pay_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let pay = pay_with_id.effect.downcast_ref::<crate::effects::PayManaEffect>()?;
+    if !pay.any_number_of_times || !matches!(pay.player, ChooseSpec::Player(PlayerFilter::You)) {
+        return None;
+    }
+
+    let reflexive = reflexive_effect.downcast_ref::<crate::effects::ReflexiveTriggerEffect>()?;
+    if reflexive.condition != pay_with_id.id
+        || reflexive.predicate != crate::effect::EffectPredicate::Happened
+    {
+        return None;
+    }
+    let [put_effect, exile_effect, may_cast_effect] = reflexive.effects.as_slice() else {
+        return None;
+    };
+
+    fn unwrap_tagged(effect: &Effect) -> &Effect {
+        if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+            return &tagged.effect;
+        }
+        effect
+    }
+
+    let put = unwrap_tagged(put_effect).downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.distributed
+        || put.target_count.is_some()
+        || !matches!(put.target.base(), ChooseSpec::Source)
+        || !matches!(put.amount, Value::EffectValue(effect_id) if effect_id == pay_with_id.id)
+    {
+        return None;
+    }
+
+    let tagged_exile = exile_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let exile = tagged_exile
+        .effect
+        .downcast_ref::<crate::effects::ExileEffect>()?;
+    let ChooseSpec::WithCountValue(_, count, value) = &exile.spec else {
+        return None;
+    };
+    if !count.is_up_to_dynamic_x()
+        || !matches!(value, Value::EffectValue(effect_id) if *effect_id == pay_with_id.id)
+    {
+        return None;
+    }
+
+    let may_cast = may_cast_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may_cast.decider.as_ref() != Some(&PlayerFilter::You) {
+        return None;
+    }
+    let [cast_effect] = may_cast.effects.as_slice() else {
+        return None;
+    };
+    let cast = cast_effect.downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    if cast.tag != tagged_exile.tag
+        || !cast.as_copy
+        || !cast.without_paying_mana_cost
+        || !cast.any_number
+        || cast.allow_land
+        || cast.cost_reduction.is_some()
+        || cast.player != PlayerFilter::You
+    {
+        return None;
+    }
+
+    let counter = describe_counter_type(put.counter_type);
+    let target = describe_choose_spec(&put.target);
+    let exile_text = describe_choose_spec(&exile.spec)
+        .replace("target instants or sorcery cards", "target instant and/or sorcery cards")
+        .replace(" in your graveyard", " from your graveyard");
+    Some(format!(
+        "you may pay {} any number of times. When you pay this cost one or more times, put that many {counter} counters on {target}, then exile {exile_text} and copy them. You may cast any number of the copies without paying their mana costs",
+        pay.cost.to_oracle()
+    ))
+}
+
 fn describe_may_choose_pay_for_each_then_untap_tagged(effects: &[&Effect]) -> Option<String> {
     let [may_effect, if_effect] = effects else {
         return None;
@@ -29874,13 +29959,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             || crate::cards::is_sentence_helper_tag(tag, "searched");
         let spec = crate::target::ChooseSpec::Tagged(cast_tagged.tag.clone());
         let target = if cast_tagged.as_copy {
-            let tag_is_numbered = tag.rsplit_once('_').is_some_and(|(_, suffix)| {
-                !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
-            });
-            if tag == "it" || tag_is_numbered {
-                "the copy".to_string()
+            if cast_tagged.any_number {
+                "any number of the copies".to_string()
             } else {
-                format!("a copy of {}", describe_choose_spec(&spec))
+                let tag_is_numbered = tag.rsplit_once('_').is_some_and(|(_, suffix)| {
+                    !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit())
+                });
+                if tag == "it" || tag_is_numbered {
+                    "the copy".to_string()
+                } else {
+                    format!("a copy of {}", describe_choose_spec(&spec))
+                }
             }
         } else if helper_tag {
             "that card".to_string()
@@ -29905,6 +29994,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return text;
     }
     if let Some(may) = effect.downcast_ref::<crate::effects::MayEffect>() {
+        if let Some(compact) = describe_may_pay_mana_then_reflexive_counted_copy(may) {
+            return compact;
+        }
         if let Some(compact) = describe_may_enlist(may) {
             return compact;
         }
@@ -31278,11 +31370,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(pay_mana) = effect.downcast_ref::<crate::effects::PayManaEffect>() {
         let player = describe_choose_spec(&pay_mana.player);
+        let suffix = if pay_mana.any_number_of_times {
+            " any number of times"
+        } else {
+            ""
+        };
         return format!(
             "{} {} {}",
             player,
             player_verb(&player, "pay", "pays"),
-            pay_mana.cost.to_oracle()
+            format!("{}{suffix}", pay_mana.cost.to_oracle())
         );
     }
     if let Some(add_any) = effect.downcast_ref::<crate::effects::AddManaOfAnyColorEffect>() {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -3945,6 +3945,26 @@ impl Effect {
         without_paying_mana_cost: bool,
         cost_reduction: Option<crate::mana::ManaCost>,
     ) -> Self {
+        Self::cast_tagged_with_options(
+            tag,
+            player,
+            allow_land,
+            as_copy,
+            without_paying_mana_cost,
+            cost_reduction,
+            false,
+        )
+    }
+
+    pub fn cast_tagged_with_options(
+        tag: impl Into<crate::tag::TagKey>,
+        player: PlayerFilter,
+        allow_land: bool,
+        as_copy: bool,
+        without_paying_mana_cost: bool,
+        cost_reduction: Option<crate::mana::ManaCost>,
+        any_number: bool,
+    ) -> Self {
         use crate::effects::CastTaggedEffect;
         let effect = CastTaggedEffect::new(tag, player);
         let effect = if allow_land {
@@ -3960,6 +3980,11 @@ impl Effect {
         };
         let effect = if let Some(cost_reduction) = cost_reduction {
             effect.cost_reduction(cost_reduction)
+        } else {
+            effect
+        };
+        let effect = if any_number {
+            effect.any_number()
         } else {
             effect
         };

--- a/crates/ironsmith-runtime/src/effects/cards/search_overrides.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/search_overrides.rs
@@ -599,6 +599,7 @@ fn cast_from_library_while_searching(
         saddle_contributors: vec![],
         chosen_modes: None,
         tagged_objects: std::collections::HashMap::new(),
+        effect_outcomes: std::collections::HashMap::new(),
     };
     game.push_to_stack(stack_entry);
 

--- a/crates/ironsmith-runtime/src/effects/composition/reflexive_trigger.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/reflexive_trigger.rs
@@ -4,7 +4,7 @@ use crate::decisions::context::{TargetRequirementContext, TargetsContext};
 use crate::effect::{Effect, EffectId, EffectOutcome, EffectPredicate, EffectPredicateRuntimeExt};
 use crate::effects::EffectExecutor;
 use crate::effects::{ExecutionContext, ExecutionError};
-use crate::game_state::{GameState, StackEntry};
+use crate::game_state::{GameState, StackEntry, TargetAssignment};
 use crate::target::ChooseSpec;
 use crate::targeting::normalize_targets_for_requirements;
 
@@ -58,11 +58,26 @@ fn choose_reflexive_targets(
     game: &GameState,
     ctx: &mut ExecutionContext,
     choices: &[ChooseSpec],
-) -> Option<Vec<crate::game_state::Target>> {
+) -> Option<(Vec<crate::game_state::Target>, Vec<TargetAssignment>)> {
     let mut chosen_targets = Vec::new();
+    let mut assignments = Vec::new();
 
     for spec in choices {
         let count = spec.count();
+        let (min_targets, max_targets) = if count.dynamic_x || spec.count_value().is_some() {
+            let resolved = if let Some(value) = spec.count_value() {
+                crate::effects::helpers::resolve_value(game, value, ctx).ok()?.max(0) as usize
+            } else {
+                ctx.x_value? as usize
+            };
+            if count.up_to_x {
+                (0, Some(resolved))
+            } else {
+                (resolved, Some(resolved))
+            }
+        } else {
+            (count.min, count.max)
+        };
         let legal_targets = crate::targeting::compute_legal_targets_with_tagged_objects(
             game,
             spec,
@@ -71,7 +86,7 @@ fn choose_reflexive_targets(
             Some(&ctx.tagged_objects),
         );
 
-        if legal_targets.len() < count.min {
+        if legal_targets.len() < min_targets {
             return None;
         }
 
@@ -82,8 +97,8 @@ fn choose_reflexive_targets(
             vec![TargetRequirementContext {
                 description: describe_choice(spec),
                 legal_targets: legal_targets.clone(),
-                min_targets: count.min,
-                max_targets: count.max,
+                min_targets,
+                max_targets,
             }],
         );
         let selected = ctx.decision_maker.decide_targets(game, &targets_ctx);
@@ -92,10 +107,16 @@ fn choose_reflexive_targets(
         }
         let selected = normalize_targets_for_requirements(&targets_ctx.requirements, selected)?;
 
+        let start = chosen_targets.len();
         chosen_targets.extend(selected);
+        let end = chosen_targets.len();
+        assignments.push(TargetAssignment {
+            spec: spec.clone(),
+            range: start..end,
+        });
     }
 
-    Some(chosen_targets)
+    Some((chosen_targets, assignments))
 }
 
 #[cfg(test)]
@@ -139,11 +160,14 @@ mod tests {
         let choices =
             vec![ChooseSpec::target(ChooseSpec::creature()).with_count(ChoiceCount::exactly(2))];
 
-        let selected = choose_reflexive_targets(&game, &mut ctx, &choices).expect("valid targets");
+        let (selected, assignments) =
+            choose_reflexive_targets(&game, &mut ctx, &choices).expect("valid targets");
 
         assert_eq!(selected.len(), 2);
         assert_eq!(selected[0], Target::Object(first));
         assert_eq!(selected[1], Target::Object(second));
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].range, 0..2);
     }
 
     #[cfg(ironsmith_runtime_parser_tests)]
@@ -217,18 +241,24 @@ impl EffectExecutor for ReflexiveTriggerEffect {
     ) -> Result<EffectOutcome, ExecutionError> {
         let outcome = ctx
             .get_outcome(self.condition)
-            .ok_or(ExecutionError::EffectNotFound(self.condition))?;
-        if !self.predicate.evaluate_outcome(outcome) {
+            .ok_or(ExecutionError::EffectNotFound(self.condition))?
+            .clone();
+        if !self.predicate.evaluate_outcome(&outcome) {
             return Ok(EffectOutcome::resolved());
         }
 
-        let targets = choose_reflexive_targets(game, ctx, &self.choices)
+        let (targets, target_assignments) = choose_reflexive_targets(game, ctx, &self.choices)
             .ok_or(ExecutionError::InvalidTarget)?;
 
         let mut entry = StackEntry::ability(ctx.source, ctx.controller, self.effects.clone())
             .with_targets(targets)
+            .with_target_assignments(target_assignments)
             .with_optional_costs_paid(ctx.optional_costs_paid.clone())
-            .with_tagged_objects(ctx.tagged_objects.clone());
+            .with_tagged_objects(ctx.tagged_objects.clone())
+            .with_effect_outcomes(std::collections::HashMap::from([(
+                self.condition,
+                outcome,
+            )]));
 
         if let Some(x) = ctx.x_value {
             entry = entry.with_x(x);

--- a/crates/ironsmith-runtime/src/effects/mana/pay_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/pay_mana.rs
@@ -1,7 +1,8 @@
 //! Pay mana effect implementation.
 
 use crate::ability::ActivatedAbilityRuntimeExt as _;
-use crate::decision::DecisionMaker;
+use crate::decision::{DecisionMaker, FallbackStrategy};
+use crate::decisions::ask_may_choice;
 use crate::decisions::context::{SelectOptionsContext, SelectableOption};
 use crate::effect::EffectOutcome;
 use crate::effects::helpers::resolve_player_from_spec;
@@ -149,6 +150,31 @@ impl EffectExecutor for PayManaEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let player_id = resolve_player_from_spec(game, &self.player, ctx)?;
+        if self.any_number_of_times {
+            let mut paid = 0;
+            loop {
+                if !try_pay_interactively(self, game, ctx, player_id) {
+                    break;
+                }
+                paid += 1;
+                let pay_again = ask_may_choice(
+                    game,
+                    &mut ctx.decision_maker,
+                    player_id,
+                    ctx.source,
+                    format!("Pay {} again", self.cost.to_oracle()),
+                    FallbackStrategy::Decline,
+                );
+                if !pay_again {
+                    break;
+                }
+            }
+            return if paid > 0 {
+                Ok(EffectOutcome::count(paid))
+            } else {
+                Ok(EffectOutcome::impossible())
+            };
+        }
         if try_pay_interactively(self, game, ctx, player_id) {
             Ok(EffectOutcome::count(1))
         } else {

--- a/crates/ironsmith-runtime/src/effects/player/cast_source.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_source.rs
@@ -109,6 +109,7 @@ impl EffectExecutor for CastSourceEffect {
             saddle_contributors: vec![],
             chosen_modes: None,
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         };
 
         game.push_to_stack(stack_entry);

--- a/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
@@ -5,6 +5,7 @@
 //! immediately during resolution and returns an outcome that can be used by
 //! subsequent "If you don't" clauses.
 
+use crate::decisions::context::{SelectObjectsContext, SelectableObject};
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::zones::{
@@ -12,6 +13,7 @@ use crate::effects::zones::{
 };
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::{GameState, StackEntry, Target, TargetAssignment};
+use crate::snapshot::ObjectSnapshot;
 use crate::zone::Zone;
 pub use ironsmith_core::CastTaggedEffect;
 
@@ -331,6 +333,67 @@ impl EffectExecutor for CastTaggedEffect {
         use crate::alternative_cast::CastingMethod;
         use crate::effects::helpers::resolve_player_filter;
 
+        let caster = resolve_player_filter(game, &self.player, ctx)?;
+        if self.any_number {
+            let Some(snapshots) = ctx.get_tagged_all(self.tag.as_str()).cloned() else {
+                return Ok(EffectOutcome::target_invalid());
+            };
+            let candidates = snapshots
+                .iter()
+                .filter_map(|snapshot| {
+                    let object_id = if game.object(snapshot.object_id).is_some() {
+                        Some(snapshot.object_id)
+                    } else {
+                        game.find_object_by_stable_id(snapshot.stable_id)
+                    }?;
+                    let object = game.object(object_id)?;
+                    Some(SelectableObject::new(object_id, object.name.clone()))
+                })
+                .collect::<Vec<_>>();
+            if candidates.is_empty() {
+                return Ok(EffectOutcome::count(0));
+            }
+            let choice = SelectObjectsContext::new(
+                caster,
+                Some(ctx.source),
+                "Cast any number of copies",
+                candidates.clone(),
+                0,
+                Some(candidates.len()),
+            );
+            let selected = ctx.decision_maker.decide_objects(game, &choice);
+            if ctx.decision_maker.awaiting_choice() {
+                return Ok(EffectOutcome::count(0));
+            }
+
+            let original_tagged = ctx.tagged_objects.get(&self.tag).cloned();
+            let mut outcomes = Vec::new();
+            for object_id in selected {
+                if !candidates
+                    .iter()
+                    .any(|candidate| candidate.id == object_id && candidate.legal)
+                {
+                    continue;
+                }
+                let Some(object) = game.object(object_id) else {
+                    continue;
+                };
+                let snapshot =
+                    ObjectSnapshot::from_object_with_calculated_characteristics(object, game);
+                ctx.set_tagged_objects(self.tag.clone(), vec![snapshot]);
+                let mut single = self.clone();
+                single.any_number = false;
+                outcomes.push(single.execute(game, ctx)?);
+            }
+            match original_tagged {
+                Some(snapshots) => ctx.set_tagged_objects(self.tag.clone(), snapshots),
+                None => {
+                    ctx.tagged_objects.remove(&self.tag);
+                }
+            }
+            return Ok(EffectOutcome::aggregate_summing_counts(outcomes));
+        }
+
         let Some(snapshot) = ctx.get_tagged(self.tag.as_str()) else {
             return Ok(EffectOutcome::target_invalid());
         };
@@ -359,8 +422,6 @@ impl EffectExecutor for CastTaggedEffect {
         let x_value = mana_cost
             .as_ref()
             .and_then(|cost| if cost.has_x() { Some(0u32) } else { None });
-
-        let caster = resolve_player_filter(game, &self.player, ctx)?;
 
         if self.as_copy {
             let copy_id = game.new_object_id();
@@ -605,6 +666,7 @@ impl EffectExecutor for CastTaggedEffect {
             saddle_contributors: vec![],
             chosen_modes: None,
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         };
 
         game.push_to_stack(stack_entry);

--- a/crates/ironsmith-runtime/src/effects/player/discover.rs
+++ b/crates/ironsmith-runtime/src/effects/player/discover.rs
@@ -144,6 +144,7 @@ impl EffectExecutor for DiscoverEffect {
                         saddle_contributors: vec![],
                         chosen_modes: None,
                         tagged_objects: std::collections::HashMap::new(),
+                        effect_outcomes: std::collections::HashMap::new(),
                     };
                     game.push_to_stack(stack_entry);
                     selected_object = Some(new_id);

--- a/crates/ironsmith-runtime/src/effects/player/exile_until_match_cast.rs
+++ b/crates/ironsmith-runtime/src/effects/player/exile_until_match_cast.rs
@@ -140,6 +140,7 @@ impl EffectExecutor for ExileUntilMatchCastEffect {
                         saddle_contributors: vec![],
                         chosen_modes: None,
                         tagged_objects: std::collections::HashMap::new(),
+                        effect_outcomes: std::collections::HashMap::new(),
                     };
                     game.push_to_stack(stack_entry);
                     casted_card = Some((candidate_id, new_id, from_zone));

--- a/crates/ironsmith-runtime/src/effects/player/may_cast_miracle.rs
+++ b/crates/ironsmith-runtime/src/effects/player/may_cast_miracle.rs
@@ -176,6 +176,7 @@ impl EffectExecutor for MayCastForMiracleCostEffect {
                 saddle_contributors: vec![],
                 chosen_modes: None,
                 tagged_objects: std::collections::HashMap::new(),
+                effect_outcomes: std::collections::HashMap::new(),
             };
 
             game.push_to_stack(stack_entry);

--- a/crates/ironsmith-runtime/src/effects/player/runtime_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/player/runtime_helpers.rs
@@ -404,6 +404,7 @@ pub(super) fn cast_effect_driven_spell_with_payment(
         saddle_contributors: vec![],
         chosen_modes: None,
         tagged_objects: std::collections::HashMap::new(),
+        effect_outcomes: std::collections::HashMap::new(),
     };
     game.push_to_stack(stack_entry);
 

--- a/crates/ironsmith-runtime/src/effects/stack/copy_spell.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/copy_spell.rs
@@ -57,6 +57,7 @@ pub(crate) fn resolving_source_stack_entry(ctx: &ExecutionContext) -> StackEntry
     entry.event_value_amount = ctx.event_value_amount;
     entry.chosen_modes = ctx.chosen_modes.clone();
     entry.tagged_objects = ctx.tagged_objects.clone();
+    entry.effect_outcomes = ctx.effect_outcomes.clone();
     entry
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -602,6 +602,7 @@ pub(super) fn resolve_stack_entry_full(
     if let Some(source_snapshot) = entry.source_snapshot.clone() {
         ctx = ctx.with_source_snapshot(source_snapshot);
     }
+    ctx.effect_outcomes = entry.effect_outcomes.clone();
     let mut tagged_objects = entry.tagged_objects.clone();
     let source_exiled = game
         .get_exiled_with_source_links(execution_source)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -192,6 +192,270 @@ fn rampaging_aetherhood_declining_payment_gets_energy_without_counters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn bloodthirsty_adversary_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_201), "Bloodthirsty Adversary")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Vampire])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "Haste\n\
+             When this creature enters, you may pay {2}{R} any number of times. When you pay this cost one or more times, put that many +1/+1 counters on this creature, then exile up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them. You may cast any number of the copies without paying their mana costs.",
+        )
+        .expect("Bloodthirsty Adversary should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct BloodthirstyAdversaryDecisionMaker {
+    boolean_answers: Vec<bool>,
+    selected_objects: Vec<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for BloodthirstyAdversaryDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        if self.boolean_answers.is_empty() {
+            false
+        } else {
+            self.boolean_answers.remove(0)
+        }
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx.description == "Cast any number of copies" {
+            return ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .collect();
+        }
+        let max = ctx.max.unwrap_or(self.selected_objects.len());
+        self.selected_objects
+            .iter()
+            .copied()
+            .filter(|id| ctx.candidates.iter().any(|candidate| candidate.legal && candidate.id == *id))
+            .take(max)
+            .collect()
+    }
+
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<crate::game_state::Target> {
+        let legal_targets = ctx
+            .requirements
+            .iter()
+            .flat_map(|requirement| requirement.legal_targets.iter())
+            .copied()
+            .collect::<Vec<_>>();
+        self.selected_objects
+            .iter()
+            .copied()
+            .map(crate::game_state::Target::Object)
+            .filter(|target| legal_targets.contains(target))
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_bloodthirsty_adversary_enter_trigger_on_stack(game: &mut GameState, source_id: ObjectId) {
+    let alice = PlayerId::from_index(0);
+    let triggered_effects = game
+        .object(source_id)
+        .expect("Bloodthirsty Adversary should be on the battlefield")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.effects.clone()),
+            _ => None,
+        })
+        .expect("Bloodthirsty Adversary should have an enters trigger");
+    game.stack.push(
+        crate::game_state::StackEntry::ability(source_id, alice, triggered_effects)
+            .with_triggering_event(TriggerEvent::new_with_provenance(
+                EnterBattlefieldEvent::new(source_id, Zone::Hand),
+                crate::provenance::ProvNodeId::default(),
+            )),
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn shock_probe_card() -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(74_202), "Shock Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Instant])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bloodthirsty_adversary_declined_payment_does_not_exile_or_add_counters() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let adversary = bloodthirsty_adversary_definition();
+    let adversary_id = game.create_object_from_definition(&adversary, alice, Zone::Battlefield);
+    let shock_id = game.create_object_from_card(&shock_probe_card(), alice, Zone::Graveyard);
+
+    put_bloodthirsty_adversary_enter_trigger_on_stack(&mut game, adversary_id);
+    let mut dm = BloodthirstyAdversaryDecisionMaker {
+        boolean_answers: vec![false],
+        selected_objects: vec![shock_id],
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Bloodthirsty Adversary trigger should resolve when payment is declined");
+
+    assert_eq!(
+        game.counter_count(adversary_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "declining payment should not add counters"
+    );
+    assert_eq!(
+        game.object(shock_id).expect("Shock Probe should still exist").zone,
+        Zone::Graveyard,
+        "declining payment should not exile graveyard cards"
+    );
+    assert!(game.stack.is_empty(), "declining payment should not cast a copy");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bloodthirsty_adversary_paid_zero_target_branch_keeps_graveyard_card() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let adversary = bloodthirsty_adversary_definition();
+    let adversary_id = game.create_object_from_definition(&adversary, alice, Zone::Battlefield);
+    let shock_id = game.create_object_from_card(&shock_probe_card(), alice, Zone::Graveyard);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    put_bloodthirsty_adversary_enter_trigger_on_stack(&mut game, adversary_id);
+    let mut dm = BloodthirstyAdversaryDecisionMaker {
+        boolean_answers: vec![true, false, false],
+        selected_objects: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Bloodthirsty Adversary trigger should resolve with zero selected targets");
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Bloodthirsty Adversary zero-target reflexive trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(adversary_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "paying the cost should still add counters when zero targets are chosen"
+    );
+    assert_eq!(
+        game.object(shock_id).expect("Shock Probe should still exist").zone,
+        Zone::Graveyard,
+        "choosing zero targets should leave eligible graveyard cards in the graveyard"
+    );
+    assert!(game.stack.is_empty(), "choosing zero targets should not cast a copy");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bloodthirsty_adversary_pays_twice_targets_two_and_casts_both_copies() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let adversary = bloodthirsty_adversary_definition();
+    let adversary_id = game.create_object_from_definition(&adversary, alice, Zone::Battlefield);
+    let shock_id = game.create_object_from_card(&shock_probe_card(), alice, Zone::Graveyard);
+    let shock_stable_id = game
+        .object(shock_id)
+        .expect("Shock Probe should exist")
+        .stable_id;
+    let flame_id = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(74_203), "Flame Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        alice,
+        Zone::Graveyard,
+    );
+    let flame_stable_id = game
+        .object(flame_id)
+        .expect("Flame Probe should exist")
+        .stable_id;
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 4);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+
+    put_bloodthirsty_adversary_enter_trigger_on_stack(&mut game, adversary_id);
+    let mut dm = BloodthirstyAdversaryDecisionMaker {
+        boolean_answers: vec![true, true, false, true],
+        selected_objects: vec![shock_id, flame_id],
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Bloodthirsty Adversary trigger should resolve after two payments");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "paying one or more times should put the reflexive trigger on the stack"
+    );
+    assert_eq!(
+        game.stack[0].targets.len(),
+        2,
+        "paying twice should allow up to two targets for the reflexive trigger"
+    );
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Bloodthirsty Adversary reflexive trigger should exile and cast copies");
+
+    assert_eq!(
+        game.counter_count(adversary_id, crate::object::CounterType::PlusOnePlusOne),
+        2,
+        "paying twice should add two +1/+1 counters"
+    );
+    assert_eq!(
+        game.object(
+            game.find_object_by_stable_id(shock_stable_id)
+                .expect("Shock Probe should still exist"),
+        )
+            .expect("Shock Probe should still exist")
+            .zone,
+        Zone::Exile,
+        "the first selected card should be exiled"
+    );
+    assert_eq!(
+        game.object(
+            game.find_object_by_stable_id(flame_stable_id)
+                .expect("Flame Probe should still exist"),
+        )
+            .expect("Flame Probe should still exist")
+            .zone,
+        Zone::Exile,
+        "the second selected card should be exiled"
+    );
+    assert_eq!(
+        game.stack.len(),
+        2,
+        "both card copies should be cast onto the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_950), "Twenty-Toed Toad")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -20,7 +20,7 @@ use crate::cost::OptionalCostsPaid;
 use crate::decision::KeywordPaymentContribution;
 use crate::derived_view::DerivedGameView;
 use crate::dungeon::ActiveDungeonProgress;
-use crate::effect::Until;
+use crate::effect::{EffectId, EffectOutcome, Until};
 use crate::events::{Event, EventKind, KeywordActionKind};
 use crate::filter::PlayerFilterExt;
 use crate::ids::{ObjectId, PlayerId, StableId, reset_runtime_id_counters};
@@ -1703,6 +1703,8 @@ pub struct StackEntry {
     /// This supports resolution-time references like `sacrifice_cost_0`.
     pub tagged_objects:
         std::collections::HashMap<crate::tag::TagKey, Vec<crate::snapshot::ObjectSnapshot>>,
+    /// Prior effect outcomes preserved for delayed/reflexive resolution.
+    pub effect_outcomes: std::collections::HashMap<EffectId, EffectOutcome>,
 }
 
 /// A mana ability granted to a player until end of turn.
@@ -1747,6 +1749,7 @@ impl StackEntry {
             crew_contributors: Vec::new(),
             saddle_contributors: Vec::new(),
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         }
     }
 
@@ -1785,6 +1788,7 @@ impl StackEntry {
             crew_contributors: Vec::new(),
             saddle_contributors: Vec::new(),
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         }
     }
 
@@ -1920,6 +1924,14 @@ impl StackEntry {
         tagged: std::collections::HashMap<crate::tag::TagKey, Vec<crate::snapshot::ObjectSnapshot>>,
     ) -> Self {
         self.tagged_objects = tagged;
+        self
+    }
+
+    pub fn with_effect_outcomes(
+        mut self,
+        outcomes: std::collections::HashMap<EffectId, EffectOutcome>,
+    ) -> Self {
+        self.effect_outcomes = outcomes;
         self
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Bloodthirsty Adversary
Initial parse error:
```
unsupported dynamic or missing target count after 'up to' (found 'that' in clause: 'up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them'); oracle-only fallback also failed: unsupported dynamic or missing target count after 'up to' (found 'that' in clause: 'up to that many target instant and/or sorcery cards with mana value 3 or less from your graveyard and copy them')
```

Current worker: i-03d9e1ee55ca742f4
Branch: codex/aws-card-fix-bloodthirsty-adversary
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0012
