### PR TITLE
Fix Ironsmith parse failure: Maestros Ascendancy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -599,6 +599,131 @@ pub(crate) fn parse_unsupported_play_cast_permission_clause(
     parse_unsupported_play_cast_permission_clause_lexed(tokens)
 }
 
+fn find_word_phrase_index(words: &[&str], phrase: &[&str]) -> Option<usize> {
+    if phrase.is_empty() || words.len() < phrase.len() {
+        return None;
+    }
+    words.windows(phrase.len()).position(|window| window == phrase)
+}
+
+fn token_slice_for_word_range<'a>(
+    tokens: &'a [OwnedLexToken],
+    start_word: usize,
+    end_word: usize,
+) -> Option<&'a [OwnedLexToken]> {
+    let start = token_index_for_word_index(tokens, start_word)?;
+    let end = if end_word == token_word_refs(tokens).len() {
+        tokens.len()
+    } else if start_word == end_word {
+        start
+    } else {
+        token_index_for_word_index(tokens, end_word)?
+    };
+    Some(&tokens[start..end])
+}
+
+fn parse_sacrificing_additional_cost_tokens(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<crate::costs::Cost>, CardTextError> {
+    let words = token_word_refs(tokens);
+    let Some(rest) = words.strip_prefix(&["sacrificing"]) else {
+        return Ok(None);
+    };
+    if rest.is_empty() {
+        return Ok(None);
+    }
+    let Some(filter_tokens) = token_slice_for_word_range(tokens, 1, words.len()) else {
+        return Ok(None);
+    };
+    let Some(filter) = parse_permission_subject_filter_tokens_lexed(filter_tokens)? else {
+        return Ok(None);
+    };
+    Ok(Some(crate::costs::Cost::sacrifice(filter.you_control())))
+}
+
+fn parse_once_each_turn_graveyard_cast_permission(
+    tokens: &[OwnedLexToken],
+    clause_refs: &[&str],
+) -> Result<Option<PermissionClauseSpec>, CardTextError> {
+    const PREFIX: &[&str] = &[
+        "once", "during", "each", "of", "your", "turns", "you", "may", "cast",
+    ];
+    const GRAVEYARD_SUFFIX: &[&str] = &["from", "your", "graveyard"];
+    const ADDITIONAL_COST_SUFFIX: &[&str] = &[
+        "in", "addition", "to", "paying", "its", "other", "costs",
+    ];
+    const EXILE_AFTER_RESOLUTION_SUFFIX: &[&str] = &[
+        "if", "a", "spell", "cast", "this", "way", "would", "be", "put", "into", "your",
+        "graveyard", "exile", "it", "instead",
+    ];
+
+    if !word_slice_starts_with(clause_refs, PREFIX) {
+        return Ok(None);
+    }
+
+    let (main_refs, exiles_after_resolution) = if word_slice_ends_with(
+        clause_refs,
+        EXILE_AFTER_RESOLUTION_SUFFIX,
+    ) {
+        (
+            &clause_refs[..clause_refs.len() - EXILE_AFTER_RESOLUTION_SUFFIX.len()],
+            true,
+        )
+    } else {
+        (clause_refs, false)
+    };
+    let Some(from_idx) = find_word_phrase_index(main_refs, GRAVEYARD_SUFFIX) else {
+        return Ok(None);
+    };
+    let subject_start = PREFIX.len();
+    if from_idx <= subject_start {
+        return Ok(None);
+    }
+    let Some(subject_tokens) = token_slice_for_word_range(tokens, subject_start, from_idx) else {
+        return Ok(None);
+    };
+    let Some(filter) =
+        parse_permission_subject_filter_tokens_lexed(trim_lexed_commas(subject_tokens))?
+    else {
+        return Ok(None);
+    };
+
+    let after_graveyard_idx = from_idx + GRAVEYARD_SUFFIX.len();
+    let additional_costs = if after_graveyard_idx == main_refs.len() {
+        Vec::new()
+    } else {
+        let cost_refs = &main_refs[after_graveyard_idx..];
+        if !word_slice_starts_with(cost_refs, &["by"])
+            || !word_slice_ends_with(cost_refs, ADDITIONAL_COST_SUFFIX)
+        {
+            return Ok(None);
+        }
+        let cost_start = after_graveyard_idx + 1;
+        let cost_end = main_refs.len() - ADDITIONAL_COST_SUFFIX.len();
+        let Some(cost_tokens) = token_slice_for_word_range(tokens, cost_start, cost_end) else {
+            return Ok(None);
+        };
+        let Some(cost) =
+            parse_sacrificing_additional_cost_tokens(trim_lexed_commas(cost_tokens))?
+        else {
+            return Ok(None);
+        };
+        vec![cost]
+    };
+
+    let grantable =
+        crate::grant::Grantable::once_each_turn_graveyard_cast_from_cards_mana_cost_exiles_after_resolution(
+            additional_costs,
+            exiles_after_resolution,
+        );
+
+    Ok(Some(PermissionClauseSpec::GrantBySpec {
+        player: PlayerAst::You,
+        spec: crate::grant::GrantSpec::new(grantable, filter, Zone::Graveyard),
+        lifetime: PermissionLifetime::Static,
+    }))
+}
+
 pub(crate) fn parse_permission_clause_spec_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<PermissionClauseSpec>, CardTextError> {
@@ -614,6 +739,10 @@ pub(crate) fn parse_permission_clause_spec_lexed(
     let clause_refs = token_word_refs(tokens);
     if clause_refs.is_empty() {
         return Ok(None);
+    }
+
+    if let Some(spec) = parse_once_each_turn_graveyard_cast_permission(tokens, &clause_refs)? {
+        return Ok(Some(spec));
     }
 
     if clause_refs

--- a/crates/ironsmith-core/src/cost_model.rs
+++ b/crates/ironsmith-core/src/cost_model.rs
@@ -353,6 +353,13 @@ where
         }
     }
 
+    fn sacrifice_filter(&self) -> Option<&ObjectFilter> {
+        match self {
+            Self::Sacrifice(filter) => Some(filter),
+            _ => None,
+        }
+    }
+
     fn is_mana_cost(&self) -> bool {
         matches!(self, Self::Mana(_) | Self::DynamicMana(_))
     }
@@ -401,6 +408,10 @@ pub trait CostComponent: Clone + std::fmt::Debug + PartialEq {
     fn mana(mana_cost: ManaCost) -> Self;
 
     fn display(&self) -> String;
+
+    fn sacrifice_filter(&self) -> Option<&ObjectFilter> {
+        None
+    }
 
     fn is_mana_cost(&self) -> bool {
         false

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -96,11 +96,21 @@ impl<C: CostComponent> DerivedAlternativeCast<C> {
     }
 
     pub fn once_each_turn_graveyard_cast_from_cards_mana_cost(additional_costs: Vec<C>) -> Self {
+        Self::once_each_turn_graveyard_cast_from_cards_mana_cost_exiles_after_resolution(
+            additional_costs,
+            false,
+        )
+    }
+
+    pub fn once_each_turn_graveyard_cast_from_cards_mana_cost_exiles_after_resolution(
+        additional_costs: Vec<C>,
+        exiles_after_resolution: bool,
+    ) -> Self {
         Self::GraveyardCastFromCardManaCost {
             additional_costs,
             usage_limit: Some(GrantUsageLimit::OnceDuringEachOfYourTurns),
             condition: None,
-            exiles_after_resolution: false,
+            exiles_after_resolution,
         }
     }
 
@@ -213,6 +223,18 @@ where
         Self::DerivedAlternativeCast(
             DerivedAlternativeCast::once_each_turn_graveyard_cast_from_cards_mana_cost(
                 additional_costs,
+            ),
+        )
+    }
+
+    pub fn once_each_turn_graveyard_cast_from_cards_mana_cost_exiles_after_resolution(
+        additional_costs: Vec<C>,
+        exiles_after_resolution: bool,
+    ) -> Self {
+        Self::DerivedAlternativeCast(
+            DerivedAlternativeCast::once_each_turn_graveyard_cast_from_cards_mana_cost_exiles_after_resolution(
+                additional_costs,
+                exiles_after_resolution,
             ),
         )
     }
@@ -395,7 +417,59 @@ where
             }
         }
 
+        fn list_card_types(types: &[CardType]) -> String {
+            let names = types
+                .iter()
+                .map(|card_type| card_type.to_string().to_ascii_lowercase())
+                .collect::<Vec<_>>();
+            match names.as_slice() {
+                [] => String::new(),
+                [one] => one.clone(),
+                [left, right] => format!("{left} or {right}"),
+                _ => {
+                    let Some((last, rest)) = names.split_last() else {
+                        return String::new();
+                    };
+                    format!("{}, or {last}", rest.join(", "))
+                }
+            }
+        }
+
+        fn is_simple_card_type_filter(filter: &ObjectFilter) -> bool {
+            if filter.card_types.is_empty() {
+                return false;
+            }
+            let mut normalized = filter.clone();
+            normalized.card_types.clear();
+            normalized.zone = None;
+            normalized == ObjectFilter::default()
+        }
+
+        fn article_for(phrase: &str) -> &'static str {
+            match phrase.chars().next().map(|c| c.to_ascii_lowercase()) {
+                Some('a' | 'e' | 'i' | 'o' | 'u') => "an",
+                _ => "a",
+            }
+        }
+
+        fn merged_simple_any_of_card_type_filter(filter: &ObjectFilter) -> Option<ObjectFilter> {
+            if filter.any_of.is_empty() {
+                return None;
+            }
+            let mut merged = ObjectFilter::default();
+            for branch in &filter.any_of {
+                if !is_simple_card_type_filter(branch) || branch.card_types.len() != 1 {
+                    return None;
+                }
+                merged.card_types.push(branch.card_types[0]);
+            }
+            Some(merged)
+        }
+
         fn castable_filter_description(filter: &ObjectFilter) -> String {
+            if let Some(merged) = merged_simple_any_of_card_type_filter(filter) {
+                return castable_filter_description(&merged);
+            }
             if !filter.any_of.is_empty() {
                 return filter
                     .any_of
@@ -407,6 +481,20 @@ where
             if *filter == ObjectFilter::noncreature_spell() {
                 return "noncreature spells".to_string();
             }
+            if is_simple_card_type_filter(filter) {
+                let permanent_types = [
+                    CardType::Artifact,
+                    CardType::Creature,
+                    CardType::Enchantment,
+                    CardType::Planeswalker,
+                    CardType::Battle,
+                ];
+                if filter.card_types == permanent_types {
+                    return "a permanent spell".to_string();
+                }
+                let type_text = list_card_types(&filter.card_types);
+                return format!("{} {type_text} spell", article_for(type_text.as_str()));
+            }
             let description = filter.description();
             if description.contains("permanent") {
                 description.replace("permanent", "spell")
@@ -414,6 +502,43 @@ where
                 description
             } else {
                 format!("{description} spells")
+            }
+        }
+
+        fn sacrifice_cost_filter_description(filter: &ObjectFilter) -> Option<String> {
+            let mut normalized = filter.clone();
+            normalized.controller = None;
+            normalized.zone = None;
+            if !matches!(filter.controller, None | Some(PlayerFilter::You))
+                || !is_simple_card_type_filter(&normalized)
+            {
+                return None;
+            }
+            let type_text = list_card_types(&normalized.card_types);
+            Some(format!("{} {type_text}", article_for(type_text.as_str())))
+        }
+
+        fn graveyard_cast_cost_text<C: CostComponent>(additional_costs: &[C]) -> String {
+            if let [cost] = additional_costs
+                && let Some(filter) = cost.sacrifice_filter()
+                && let Some(filter_text) = sacrifice_cost_filter_description(filter)
+            {
+                return format!(
+                    "sacrificing {filter_text} in addition to paying its other costs"
+                );
+            }
+
+            if additional_costs.is_empty() {
+                "paying its mana cost".to_string()
+            } else {
+                format!(
+                    "paying its mana cost plus {}",
+                    additional_costs
+                        .iter()
+                        .map(CostComponent::display)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
             }
         }
 
@@ -708,19 +833,10 @@ where
         ) = &self.grantable
             && self.zone == Zone::Graveyard
         {
-            let filter_desc = castable_filter_description(&filter);
-            let cost_text = if additional_costs.is_empty() {
-                "paying its mana cost".to_string()
-            } else {
-                format!(
-                    "paying its mana cost plus {}",
-                    additional_costs
-                        .iter()
-                        .map(CostComponent::display)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            };
+            let mut cast_filter = self.filter.clone();
+            cast_filter.zone = None;
+            let filter_desc = castable_filter_description(&cast_filter);
+            let cost_text = graveyard_cast_cost_text(additional_costs);
             if self.filter == ObjectFilter::source() {
                 let mut line = format!("{may_prefix} cast this card from your graveyard");
                 if let Some(condition) = condition
@@ -742,12 +858,18 @@ where
             } else {
                 ""
             };
-            return format!(
+            let mut line = format!(
                 "{prefix}{} cast {} from your graveyard by {}",
                 may_prefix.to_ascii_lowercase(),
                 filter_desc,
                 cost_text
             );
+            if *exiles_after_resolution {
+                line.push_str(
+                    ". If a spell cast this way would be put into your graveyard, exile it instead",
+                );
+            }
+            return line;
         }
         if let Grantable::Ability(ability) = &self.grantable
             && ability.grant_has_flash()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2453,6 +2453,32 @@ fn test_parse_eelectrocute_roll_six_graveyard_cast_condition_and_exile_clause() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_maestros_ascendancy_graveyard_cast_cost_and_exile_clause() {
+    assert_oracle_card_parses_strict("Maestros Ascendancy");
+    let def = parse_oracle_card_definition("Maestros Ascendancy");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+    assert!(
+        rendered.contains(
+            "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs"
+        ) && rendered.contains(
+            "If a spell cast this way would be put into your graveyard, exile it instead"
+        ),
+        "expected Maestros Ascendancy to render its graveyard cast permission, sacrifice additional cost, and exile clause, got {rendered}"
+    );
+    assert!(
+        debug.contains("GraveyardCastFromCardManaCost")
+            && debug.contains("OnceDuringEachOfYourTurns")
+            && debug.contains("Sacrifice")
+            && debug.contains("Creature")
+            && debug.contains("exiles_after_resolution: true"),
+        "expected Maestros Ascendancy to lower to a once-per-turn graveyard cast grant with creature sacrifice and exile-after-resolution, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_oracle_squee_the_immortal_graveyard_or_exile_cast_permission() {
     assert_oracle_card_parses_strict("Squee, the Immortal");
     let def = parse_oracle_card_definition("Squee, the Immortal");

--- a/crates/ironsmith-runtime/src/cost.rs
+++ b/crates/ironsmith-runtime/src/cost.rs
@@ -26,6 +26,12 @@ impl ironsmith_core::CostComponent for Cost {
         self.display()
     }
 
+    fn sacrifice_filter(&self) -> Option<&crate::target::ObjectFilter> {
+        self.effect_ref()
+            .and_then(|effect| effect.downcast_ref::<crate::effects::SacrificeEffect>())
+            .map(|sacrifice| &sacrifice.filter)
+    }
+
     fn is_mana_cost(&self) -> bool {
         self.is_mana_cost()
     }

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -213,6 +213,14 @@ fn append_graveyard_granted_alternative_cast_actions_for_card(
         ) {
             continue;
         }
+        if !can_pay_non_mana_cost_sequence_for_cast(
+            game,
+            player,
+            card_id,
+            method.non_mana_costs(),
+        ) {
+            continue;
+        }
 
         actions.push(LegalAction::CastSpell {
             spell_id: card_id,
@@ -269,6 +277,14 @@ fn append_graveyard_granted_adventure_alternative_cast_actions_for_card(
             &requirements,
             &casting_method,
             view,
+        ) {
+            continue;
+        }
+        if !can_pay_non_mana_cost_sequence_for_cast(
+            game,
+            player,
+            card_id,
+            method.non_mana_costs(),
         ) {
             continue;
         }

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -2243,7 +2243,7 @@ fn tagged_dependency_satisfied_by_prior_cost(
         })
 }
 
-fn can_pay_non_mana_cost_sequence_for_cast(
+pub(crate) fn can_pay_non_mana_cost_sequence_for_cast(
     game: &GameState,
     player: PlayerId,
     source: ObjectId,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -23143,6 +23143,300 @@ fn test_bosh_iron_golem_uses_sacrificed_artifact_mana_value_for_damage() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn maestros_ascendancy_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(92_180), "Maestros Ascendancy")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.",
+        )
+        .expect("Maestros Ascendancy should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn zero_mana_spell_card(name: &str, card_type: CardType) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .card_types(vec![card_type])
+        .mana_cost(ManaCost::new())
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn maestros_graveyard_cast_action(
+    game: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    spell_id: ObjectId,
+) -> Option<LegalAction> {
+    compute_legal_actions(game, player)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: action_spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom {
+                    source,
+                    zone: Zone::Graveyard,
+                    use_alternative: Some(_),
+                },
+            } if *action_spell_id == spell_id && *source == source_id
+        ))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn finish_maestros_cast_with_sacrifice(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    state: &mut PriorityLoopState,
+    mut progress: GameProgress,
+    sacrifice_id: ObjectId,
+) {
+    for _ in 0..6 {
+        progress = match progress {
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) => {
+                let option_index = ctx
+                    .options
+                    .iter()
+                    .find(|option| option.description.to_ascii_lowercase().contains("sacrifice"))
+                    .map(|option| option.index)
+                    .expect("Maestros cast should prompt for the sacrifice cost step");
+                apply_priority_response(
+                    game,
+                    trigger_queue,
+                    state,
+                    &PriorityResponse::NextCostChoice(option_index),
+                )
+                .expect("Maestros cast should accept sacrifice cost step")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectObjects(ctx),
+            ) => {
+                assert!(
+                    ctx.candidates
+                        .iter()
+                        .any(|candidate| candidate.id == sacrifice_id && candidate.legal),
+                    "Maestros cast should allow sacrificing a creature you control"
+                );
+                apply_priority_response(
+                    game,
+                    trigger_queue,
+                    state,
+                    &PriorityResponse::CardCostChoice(sacrifice_id),
+                )
+                .expect("Maestros cast should accept the sacrificed creature")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            ) => return,
+            other => panic!("unexpected Maestros cast flow state: {other:?}"),
+        };
+    }
+    panic!("Maestros cast did not finish paying costs");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn maestros_ascendancy_casts_graveyard_spell_by_sacrificing_creature_and_exiles_it() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let source_id = game.create_object_from_definition(
+        &maestros_ascendancy_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let buried_spell = zero_mana_spell_card("Buried Scheme", CardType::Sorcery);
+    let spell_id = game.create_object_from_card(&buried_spell, alice, Zone::Graveyard);
+    let fodder = CardBuilder::new(CardId::new(), "Maestros Fodder")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let fodder_id = game.create_object_from_card(&fodder, alice, Zone::Battlefield);
+
+    let action = maestros_graveyard_cast_action(&game, alice, source_id, spell_id)
+        .expect("Maestros Ascendancy should offer the graveyard sorcery cast");
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(action),
+    )
+    .expect("Maestros graveyard cast should start");
+    finish_maestros_cast_with_sacrifice(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        progress,
+        fodder_id,
+    );
+
+    assert!(
+        game.player(alice)
+            .expect("Alice exists")
+            .graveyard
+            .iter()
+            .any(|id| game.object(*id).is_some_and(|obj| obj.name == "Maestros Fodder")),
+        "the sacrificed creature should be put into its owner's graveyard as a cost"
+    );
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| game.object(entry.object_id).is_some_and(|obj| obj.name == "Buried Scheme")),
+        "the graveyard spell should be on the stack after paying Maestros Ascendancy's cost"
+    );
+
+    resolve_stack_entry(&mut game).expect("Maestros-cast spell should resolve");
+    assert!(
+        game.exile
+            .iter()
+            .any(|id| game.object(*id).is_some_and(|obj| obj.name == "Buried Scheme")),
+        "a spell cast with Maestros Ascendancy should be exiled instead of returning to the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn maestros_ascendancy_requires_creature_cost_and_instant_or_sorcery_card() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let source_id = game.create_object_from_definition(
+        &maestros_ascendancy_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let buried_instant = zero_mana_spell_card("Buried Instant", CardType::Instant);
+    let instant_id = game.create_object_from_card(&buried_instant, alice, Zone::Graveyard);
+    assert!(
+        maestros_graveyard_cast_action(&game, alice, source_id, instant_id).is_none(),
+        "Maestros Ascendancy should not offer the cast when you cannot sacrifice a creature"
+    );
+
+    let fodder = CardBuilder::new(CardId::new(), "Spare Informant")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&fodder, alice, Zone::Battlefield);
+    let artifact = zero_mana_spell_card("Buried Artifact", CardType::Artifact);
+    let artifact_id = game.create_object_from_card(&artifact, alice, Zone::Graveyard);
+    assert!(
+        maestros_graveyard_cast_action(&game, alice, source_id, artifact_id).is_none(),
+        "Maestros Ascendancy should not grant the alternative cast to non-instant non-sorcery cards"
+    );
+    assert!(
+        maestros_graveyard_cast_action(&game, alice, source_id, instant_id).is_some(),
+        "after a creature is available, Maestros Ascendancy should offer an instant from the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn maestros_ascendancy_is_once_each_turn_and_only_on_your_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let source_id = game.create_object_from_definition(
+        &maestros_ascendancy_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let first_spell = zero_mana_spell_card("First Buried Spell", CardType::Sorcery);
+    let first_spell_id = game.create_object_from_card(&first_spell, alice, Zone::Graveyard);
+    let second_spell = zero_mana_spell_card("Second Buried Spell", CardType::Sorcery);
+    let second_spell_id = game.create_object_from_card(&second_spell, alice, Zone::Graveyard);
+    let first_fodder = CardBuilder::new(CardId::new(), "First Fodder")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let first_fodder_id = game.create_object_from_card(&first_fodder, alice, Zone::Battlefield);
+    let second_fodder = CardBuilder::new(CardId::new(), "Second Fodder")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_card(&second_fodder, alice, Zone::Battlefield);
+
+    let action = maestros_graveyard_cast_action(&game, alice, source_id, first_spell_id)
+        .expect("first Maestros cast should be available");
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(action),
+    )
+    .expect("first Maestros cast should start");
+    finish_maestros_cast_with_sacrifice(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        progress,
+        first_fodder_id,
+    );
+    resolve_stack_entry(&mut game).expect("first Maestros spell should resolve");
+
+    assert!(
+        maestros_graveyard_cast_action(&game, alice, source_id, second_spell_id).is_none(),
+        "Maestros Ascendancy should not offer a second graveyard cast from the same source in one turn"
+    );
+
+    let mut opponent_turn_game = setup_game();
+    opponent_turn_game.turn.phase = Phase::FirstMain;
+    opponent_turn_game.turn.step = None;
+    opponent_turn_game.turn.active_player = bob;
+    opponent_turn_game.turn.priority_player = Some(alice);
+    let opponent_turn_source = opponent_turn_game.create_object_from_definition(
+        &maestros_ascendancy_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let flash_spell = CardDefinitionBuilder::new(CardId::new(), "Grave Flash Probe")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::new())
+        .parse_text("Flash")
+        .expect("flash probe should parse");
+    let flash_spell_id =
+        opponent_turn_game.create_object_from_definition(&flash_spell, alice, Zone::Graveyard);
+    let fodder = CardBuilder::new(CardId::new(), "Opponent Turn Fodder")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    opponent_turn_game.create_object_from_card(&fodder, alice, Zone::Battlefield);
+    assert!(
+        maestros_graveyard_cast_action(
+            &opponent_turn_game,
+            alice,
+            opponent_turn_source,
+            flash_spell_id,
+        )
+        .is_none(),
+        "Maestros Ascendancy's once-during-your-turn permission should not function on another player's turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn demon_of_fates_design_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(92_200), "Demon of Fate's Design")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Maestros Ascendancy
Initial parse error:
```
parser does not yet support line family: 'Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.'; oracle-only fallback also failed: parser does not yet support line family: 'Once during each of your turns, you may cast an instant or sorcery spell from your graveyard by sacrificing a creature in addition to paying its other costs. If a spell cast this way would be put into your graveyard, exile it instead.'
```

Current worker: i-0901fa3715676c7bb
Branch: codex/aws-card-fix-maestros-ascendancy
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0012
