### PR TITLE
Fix Ironsmith parse failure: Matter Reshaper

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -26978,6 +26978,45 @@ fn parse_conditional_type_list_predicate_uses_rightmost_comma_split() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn matter_reshaper_parses_and_renders_conditional_may_otherwise() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Matter Reshaper")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Colorless],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "({C} represents colorless mana.)\n\
+             When this creature dies, reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with mana value 3 or less. Otherwise, put that card into your hand.",
+        )
+        .expect("Matter Reshaper should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        lower.contains("when this creature dies, reveal the top card of your library"),
+        "expected Matter Reshaper death trigger to render, got {rendered}"
+    );
+    assert!(
+        lower.contains(
+            "you may put that card onto the battlefield if it's a permanent card with mana value 3 or less"
+        ),
+        "expected conditional may battlefield clause, got {rendered}"
+    );
+    assert!(
+        lower.contains("otherwise, put that card into your hand"),
+        "expected otherwise hand clause, got {rendered}"
+    );
+    assert!(
+        !lower.contains("you may if"),
+        "Matter Reshaper should not render malformed conditional permission text: {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_counter_unless_where_x_fails_strictly() {
     let result = CardDefinitionBuilder::new(CardId::from_raw(1), "Rethink Variant")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11538,6 +11538,21 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                     };
                     return format!("{possessive} power {comparison}");
                 }
+                let mut without_mana_value = filter.clone();
+                without_mana_value.mana_value = None;
+                if card_context
+                    && without_mana_value == ObjectFilter::permanent_card()
+                    && let Some((_, rest)) = stripped.split_once(" with mana value ")
+                {
+                    return if subject == "it" {
+                        format!("it's a permanent card with mana value {}", rest.trim())
+                    } else {
+                        format!(
+                            "{subject} is a permanent card with mana value {}",
+                            rest.trim()
+                        )
+                    };
+                }
                 if let Some((_, rest)) = stripped.split_once(" with mana value ") {
                     let possessive = if subject == "it" {
                         "its"

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -11778,6 +11778,18 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 2;
             continue;
         }
+        if idx + 2 < filtered.len()
+            && let Some(reveal_top) =
+                filtered[idx].downcast_ref::<crate::effects::RevealTopEffect>()
+            && let Some(with_id) = filtered[idx + 1].downcast_ref::<crate::effects::WithIdEffect>()
+            && let Some(if_effect) = filtered[idx + 2].downcast_ref::<crate::effects::IfEffect>()
+            && let Some(compact) =
+                describe_reveal_top_may_put_otherwise_hand(reveal_top, with_id, if_effect)
+        {
+            parts.push(compact);
+            idx += 3;
+            continue;
+        }
         if idx + 1 < filtered.len()
             && let Some(with_id) = filtered[idx].downcast_ref::<crate::effects::WithIdEffect>()
             && let Some(deal) = filtered[idx + 1].downcast_ref::<crate::effects::DealDamageEffect>()
@@ -13684,6 +13696,104 @@ pub(super) fn describe_reveal_top_then_if_put_into_hand(
 
     Some(format!(
         "{reveal_sentence}. If {condition_text}, {move_sentence}"
+    ))
+}
+
+fn move_to_zone_for_tag<'a>(
+    effect: &'a Effect,
+    tag: &crate::TagKey,
+) -> Option<&'a crate::effects::MoveToZoneEffect> {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return move_to_zone_for_tag(&tagged.effect, tag);
+    }
+    let move_to_zone = effect.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    matches!(move_to_zone.target.base(), ChooseSpec::Tagged(target_tag) if target_tag == tag)
+        .then_some(move_to_zone)
+}
+
+fn describe_reveal_top_may_put_otherwise_hand(
+    reveal_top: &crate::effects::RevealTopEffect,
+    with_id: &crate::effects::WithIdEffect,
+    if_effect: &crate::effects::IfEffect,
+) -> Option<String> {
+    if if_effect.condition != with_id.id
+        || !matches!(if_effect.predicate, EffectPredicate::DidNotHappen)
+        || !if_effect.else_.is_empty()
+        || if_effect.then.len() != 1
+    {
+        return None;
+    }
+
+    let reveal_tag = reveal_top.tag.as_ref()?;
+    let may = with_id.effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let [may_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let conditional = may_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+        return None;
+    }
+    let Condition::TaggedObjectMatches(cond_tag, _) = &conditional.condition else {
+        return None;
+    };
+    if cond_tag != reveal_tag {
+        return None;
+    }
+
+    let battlefield_move = move_to_zone_for_tag(&conditional.if_true[0], reveal_tag)?;
+    if battlefield_move.zone != Zone::Battlefield || battlefield_move.to_top {
+        return None;
+    }
+    let hand_move = move_to_zone_for_tag(&if_effect.then[0], reveal_tag)?;
+    if hand_move.zone != Zone::Hand || hand_move.to_top {
+        return None;
+    }
+
+    let revealer = describe_player_filter(&reveal_top.player);
+    let revealer_is_you = revealer == "you";
+    let reveal_sentence = if revealer_is_you {
+        "Reveal the top card of your library".to_string()
+    } else {
+        let verb = player_verb(&revealer, "reveal", "reveals");
+        format!("{revealer} {verb} the top card of their library")
+    };
+
+    let decider = may
+        .decider
+        .as_ref()
+        .map(describe_player_filter)
+        .unwrap_or_else(|| "you".to_string());
+    let may_prefix = if decider == "you" {
+        "You may".to_string()
+    } else {
+        format!("{decider} may")
+    };
+
+    let tapped_suffix = if battlefield_move.enters_tapped {
+        " tapped"
+    } else {
+        ""
+    };
+    let owner_control_suffix = if choose_spec_allows_multiple(&battlefield_move.target) {
+        " under their owners' control"
+    } else {
+        " under its owner's control"
+    };
+    let controller_suffix = match battlefield_move.battlefield_controller {
+        crate::effects::BattlefieldController::Preserve => "",
+        crate::effects::BattlefieldController::Owner => owner_control_suffix,
+        crate::effects::BattlefieldController::You => " under your control",
+    };
+    let condition = lowercase_first(&describe_condition(&conditional.condition));
+
+    let hand_clause = if revealer_is_you {
+        "put that card into your hand".to_string()
+    } else {
+        format!("{revealer} puts that card into their hand")
+    };
+
+    Some(format!(
+        "{reveal_sentence}. {may_prefix} put that card onto the battlefield{tapped_suffix}{controller_suffix} if {condition}. Otherwise, {hand_clause}"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7047,6 +7047,177 @@ fn test_pending_zone_change_still_drives_non_delayed_triggered_abilities() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn matter_reshaper_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_806), "Matter Reshaper")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Colorless],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "({C} represents colorless mana.)\n\
+             When this creature dies, reveal the top card of your library. You may put that card onto the battlefield if it's a permanent card with mana value 3 or less. Otherwise, put that card into your hand.",
+        )
+        .expect("Matter Reshaper should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn matter_reshaper_test_card(
+    raw_id: u32,
+    name: &str,
+    card_types: Vec<CardType>,
+    mana_value: u8,
+) -> crate::card::Card {
+    let mut builder = CardBuilder::new(CardId::from_raw(raw_id), name).card_types(card_types);
+    if mana_value > 0 {
+        builder = builder.mana_cost(ManaCost::from_pips(vec![vec![
+            ManaSymbol::Generic(mana_value),
+        ]]));
+    }
+    builder.build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_matter_reshaper_death_trigger(
+    game: &mut GameState,
+    reshaper_id: ObjectId,
+    dm: &mut dyn DecisionMaker,
+) {
+    let mut trigger_queue = TriggerQueue::new();
+    game.move_object_by_effect(reshaper_id, Zone::Graveyard)
+        .expect("Matter Reshaper should move to graveyard");
+    drain_pending_trigger_events(game, &mut trigger_queue);
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Matter Reshaper death trigger should go on the stack");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "Matter Reshaper death should create one trigger"
+    );
+    resolve_stack_entry_with(game, dm).expect("Matter Reshaper death trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn matter_reshaper_accepts_small_permanent_card_onto_battlefield() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let reshaper = matter_reshaper_definition();
+    let reshaper_id = game.create_object_from_definition(&reshaper, alice, Zone::Battlefield);
+    let top_card = matter_reshaper_test_card(72_807, "Revealed Land", vec![CardType::Land], 0);
+    let top_id = game.create_object_from_card(&top_card, alice, Zone::Library);
+    let top_stable = game.object(top_id).expect("top card exists").stable_id;
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_matter_reshaper_death_trigger(&mut game, reshaper_id, &mut dm);
+
+    let revealed_id = game
+        .find_object_by_stable_id(top_stable)
+        .expect("revealed card should still exist");
+    assert!(
+        game.battlefield.contains(&revealed_id),
+        "accepted small permanent card should move to the battlefield"
+    );
+    assert!(
+        !game.player(alice).expect("alice exists").hand.contains(&revealed_id),
+        "accepted small permanent card should not also move to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn matter_reshaper_declined_small_permanent_card_goes_to_hand() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let reshaper = matter_reshaper_definition();
+    let reshaper_id = game.create_object_from_definition(&reshaper, alice, Zone::Battlefield);
+    let top_card = matter_reshaper_test_card(72_808, "Declined Land", vec![CardType::Land], 0);
+    let top_id = game.create_object_from_card(&top_card, alice, Zone::Library);
+    let top_stable = game.object(top_id).expect("top card exists").stable_id;
+
+    let mut dm = AutoPassDecisionMaker;
+    resolve_matter_reshaper_death_trigger(&mut game, reshaper_id, &mut dm);
+
+    let revealed_id = game
+        .find_object_by_stable_id(top_stable)
+        .expect("revealed card should still exist");
+    assert!(
+        game.player(alice).expect("alice exists").hand.contains(&revealed_id),
+        "declining the optional battlefield move should put the card into hand"
+    );
+    assert!(
+        !game.battlefield.contains(&revealed_id),
+        "declined card should not move to the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn matter_reshaper_nonpermanent_card_goes_to_hand() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let reshaper = matter_reshaper_definition();
+    let reshaper_id = game.create_object_from_definition(&reshaper, alice, Zone::Battlefield);
+    let top_card = matter_reshaper_test_card(
+        72_809,
+        "Revealed Instant",
+        vec![CardType::Instant],
+        2,
+    );
+    let top_id = game.create_object_from_card(&top_card, alice, Zone::Library);
+    let top_stable = game.object(top_id).expect("top card exists").stable_id;
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_matter_reshaper_death_trigger(&mut game, reshaper_id, &mut dm);
+
+    let revealed_id = game
+        .find_object_by_stable_id(top_stable)
+        .expect("revealed card should still exist");
+    assert!(
+        game.player(alice).expect("alice exists").hand.contains(&revealed_id),
+        "nonpermanent revealed card should go to hand"
+    );
+    assert!(
+        !game.battlefield.contains(&revealed_id),
+        "nonpermanent revealed card should not move to the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn matter_reshaper_large_permanent_card_goes_to_hand() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let reshaper = matter_reshaper_definition();
+    let reshaper_id = game.create_object_from_definition(&reshaper, alice, Zone::Battlefield);
+    let top_card = matter_reshaper_test_card(
+        72_810,
+        "Large Creature",
+        vec![CardType::Creature],
+        4,
+    );
+    let top_id = game.create_object_from_card(&top_card, alice, Zone::Library);
+    let top_stable = game.object(top_id).expect("top card exists").stable_id;
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_matter_reshaper_death_trigger(&mut game, reshaper_id, &mut dm);
+
+    let revealed_id = game
+        .find_object_by_stable_id(top_stable)
+        .expect("revealed card should still exist");
+    assert!(
+        game.player(alice).expect("alice exists").hand.contains(&revealed_id),
+        "permanent card with mana value greater than three should go to hand"
+    );
+    assert!(
+        !game.battlefield.contains(&revealed_id),
+        "large permanent card should not move to the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_portcullis_exiles_entrying_creature_and_returns_it_when_it_leaves() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Matter Reshaper
Initial parse error:
```
compiled text contains malformed output: malformed-conditional-permission
```

Current worker: i-09ad73ffd7987c5ab
Branch: codex/aws-card-fix-matter-reshaper
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0012
