### PR TITLE
Fix Ironsmith parse failure: Strength of the Tajuru

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1728,6 +1728,64 @@ fn parse_choose_target_prelude_targets(
     ]))
 }
 
+fn parse_kicked_additional_targets_prelude(
+    target_tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    fn canonical_target_words(tokens: &[OwnedLexToken]) -> Vec<&str> {
+        LexedClause::new(tokens)
+            .word_refs()
+            .into_iter()
+            .filter(|word| {
+                !matches!(
+                    *word,
+                    "another" | "other" | "target" | "a" | "an" | "the"
+                )
+            })
+            .collect()
+    }
+
+    let Some(then_choose_idx) = find_token_word_sequence(target_tokens, &["then", "choose"])
+    else {
+        return Ok(None);
+    };
+
+    let first_target_tokens = trim_commas(&target_tokens[..then_choose_idx]);
+    let after_choose = trim_commas(&target_tokens[then_choose_idx + 2..]);
+    if first_target_tokens.is_empty() || after_choose.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(for_each_idx) = find_token_word_sequence(
+        &after_choose,
+        &["for", "each", "time", "this", "spell", "was", "kicked"],
+    ) else {
+        return Ok(None);
+    };
+
+    let additional_target_tokens = trim_commas(&after_choose[..for_each_idx]);
+    let suffix_words = LexedClause::new(&after_choose[for_each_idx..]).word_refs();
+    if additional_target_tokens.is_empty()
+        || !word_slice_eq(
+            &suffix_words,
+            &["for", "each", "time", "this", "spell", "was", "kicked"],
+        )
+    {
+        return Ok(None);
+    }
+
+    if canonical_target_words(&first_target_tokens)
+        != canonical_target_words(&additional_target_tokens)
+    {
+        return Ok(None);
+    }
+
+    let first_target = parse_target_phrase(&first_target_tokens)?;
+    let count = Value::Add(Box::new(Value::Fixed(1)), Box::new(Value::KickCount));
+    Ok(Some(vec![EffectAst::subject_verb_target_only(
+        TargetAst::WithCountValue(Box::new(first_target), ChoiceCount::dynamic_x(), count),
+    )]))
+}
+
 pub(crate) fn parse_choose_target_prelude_sentence(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
@@ -1743,6 +1801,10 @@ pub(crate) fn parse_choose_target_prelude_sentence(
     }
     if find_verb(target_tokens).is_some() {
         return Ok(None);
+    }
+
+    if let Some(effects) = parse_kicked_additional_targets_prelude(target_tokens)? {
+        return Ok(Some(effects));
     }
 
     if let Some(targets) = parse_choose_target_prelude_targets(target_tokens)? {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7489,6 +7489,48 @@ fn test_parse_multikicker_and_entwine_keyword_lines_compile_to_optional_costs() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_strength_of_the_tajuru_strict_and_renders_kicked_targets() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Strength of the Tajuru")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\n\
+             Choose target creature, then choose another target creature for each time this spell was kicked. Put X +1/+1 counters on each of them.",
+        )
+        .expect("Strength of the Tajuru should parse strictly");
+
+    assert_eq!(def.optional_costs.len(), 1);
+    assert_eq!(def.optional_costs[0].label, "Multikicker");
+    assert!(
+        def.optional_costs[0].repeatable,
+        "Strength of the Tajuru's multikicker should be repeatable"
+    );
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("WithCountValue") && debug.contains("KickCount"),
+        "expected target count to be structurally tied to the multikicker count, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains(
+            "Choose target creature, then choose another target creature for each time this spell was kicked. Put X +1/+1 counters on each of them"
+        ),
+        "expected Strength of the Tajuru compiled text to preserve kicked target clause, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("each target permanent"),
+        "Strength of the Tajuru should keep the counter effect tied to the chosen creatures, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_replicate_keyword_line_compiles_to_repeatable_optional_cost() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Replicate Probe")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2861,6 +2861,62 @@ fn structural_unwrap_render_wrappers(effect: &Effect) -> &Effect {
     effect
 }
 
+fn describe_kicked_additional_targets_put_counters(effects: &[&Effect]) -> Option<String> {
+    let [target_effect, for_each_effect] = effects else {
+        return None;
+    };
+    let target_tag = target_effect
+        .downcast_ref::<crate::effects::TaggedEffect>()?
+        .tag
+        .clone();
+    let target_only = structural_unwrap_render_wrappers(target_effect)
+        .downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+    let ChooseSpec::WithCountValue(target, count, count_value) = &target_only.target else {
+        return None;
+    };
+    if !count.is_dynamic_x() || count.is_up_to_dynamic_x() || count.is_random() {
+        return None;
+    }
+    let Value::Add(left, right) = count_value else {
+        return None;
+    };
+    let counts_one_plus_kicked = matches!(
+        (left.as_ref(), right.as_ref()),
+        (Value::Fixed(1), Value::KickCount) | (Value::KickCount, Value::Fixed(1))
+    );
+    if !counts_one_plus_kicked {
+        return None;
+    }
+
+    let for_each = structural_unwrap_render_wrappers(for_each_effect)
+        .downcast_ref::<crate::effects::ForEachObject>()?;
+    if !for_each.filter.tagged_constraints.iter().any(|constraint| {
+        constraint.tag == target_tag
+            && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+    }) {
+        return None;
+    }
+    let [put] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let put = structural_unwrap_render_wrappers(put)
+        .downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.distributed || put.target_count.is_some() || !matches!(put.target, ChooseSpec::Iterated)
+    {
+        return None;
+    }
+
+    let first_target = describe_choose_spec(target);
+    let additional_target = first_target
+        .strip_prefix("target ")
+        .map(|tail| format!("another target {tail}"))
+        .unwrap_or_else(|| format!("another {first_target}"));
+    Some(format!(
+        "Choose {first_target}, then choose {additional_target} for each time this spell was kicked. Put {} on each of them",
+        describe_put_counter_phrase(&put.amount, put.counter_type)
+    ))
+}
+
 fn for_each_moves_unchosen_iterated_to_zone(
     effect: &Effect,
     revealed_tag: &crate::TagKey,
@@ -3245,6 +3301,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     let raw_effects = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_kicked_additional_targets_put_counters(&raw_effects) {
+        return compact;
+    }
     fn unwrap_wrapped_effect(effect: &Effect) -> &Effect {
         if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
             return unwrap_wrapped_effect(&tagged.effect);

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -33,7 +33,9 @@ fn resolve_modal_count_value_for_source(
 pub fn requires_target_selection(spec: &ChooseSpec) -> bool {
     match spec {
         // Target wrapper - check the inner spec
-        ChooseSpec::Target(inner) | ChooseSpec::WithCount(inner, _) => {
+        ChooseSpec::Target(inner)
+        | ChooseSpec::WithCount(inner, _)
+        | ChooseSpec::WithCountValue(inner, _, _) => {
             requires_target_selection(inner)
         }
         // These require target selection during casting

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30568,6 +30568,177 @@ fn test_flashback_requires_enough_mana() {
 // =========================================================================
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn strength_of_the_tajuru_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(76_300), "Strength of the Tajuru")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Multikicker {1} (You may pay an additional {1} any number of times as you cast this spell.)\n\
+             Choose target creature, then choose another target creature for each time this spell was kicked. Put X +1/+1 counters on each of them.",
+        )
+        .expect("Strength of the Tajuru should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_strength_of_the_tajuru_no_kicks_requires_one_creature_target() {
+    let def = strength_of_the_tajuru_definition();
+    let effects = def.spell_effect.clone().expect("expected spell effects");
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    game.object_mut(source).expect("source").optional_costs_paid =
+        crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+
+    let creature_a = create_creature(&mut game, "Tajuru Target A", bob, 2, 2);
+    let creature_b = create_creature(&mut game, "Tajuru Target B", bob, 3, 3);
+
+    let requirements = extract_target_requirements_from_program_with_modes(
+        &game,
+        &effects,
+        alice,
+        Some(source),
+        None,
+    );
+    assert_eq!(requirements.len(), 1, "expected one target requirement");
+    assert_eq!(requirements[0].min_targets, 1);
+    assert_eq!(requirements[0].max_targets, Some(1));
+    assert!(
+        requirements[0]
+            .legal_targets
+            .contains(&Target::Object(creature_a))
+            && requirements[0]
+                .legal_targets
+                .contains(&Target::Object(creature_b)),
+        "both creatures should be legal no-kick targets, got {:?}",
+        requirements[0].legal_targets
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_strength_of_the_tajuru_two_kicks_requires_three_creature_targets() {
+    let def = strength_of_the_tajuru_definition();
+    let effects = def.spell_effect.clone().expect("expected spell effects");
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+    paid.pay_times(0, 2);
+    game.object_mut(source).expect("source").optional_costs_paid = paid;
+
+    let creature_a = create_creature(&mut game, "Tajuru Target A", bob, 2, 2);
+    let creature_b = create_creature(&mut game, "Tajuru Target B", bob, 3, 3);
+    let creature_c = create_creature(&mut game, "Tajuru Target C", bob, 4, 4);
+
+    let requirements = extract_target_requirements_from_program_with_modes(
+        &game,
+        &effects,
+        alice,
+        Some(source),
+        None,
+    );
+    assert_eq!(requirements.len(), 1, "expected one target requirement");
+    assert_eq!(requirements[0].min_targets, 3);
+    assert_eq!(requirements[0].max_targets, Some(3));
+    assert!(
+        [creature_a, creature_b, creature_c]
+            .into_iter()
+            .all(|id| requirements[0].legal_targets.contains(&Target::Object(id))),
+        "all three creatures should be legal kicked targets, got {:?}",
+        requirements[0].legal_targets
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_strength_of_the_tajuru_two_kicks_is_illegal_with_only_two_targets() {
+    let def = strength_of_the_tajuru_definition();
+    let effects = def.spell_effect.clone().expect("expected spell effects");
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+    paid.pay_times(0, 2);
+    game.object_mut(source).expect("source").optional_costs_paid = paid;
+
+    create_creature(&mut game, "Tajuru Target A", bob, 2, 2);
+    create_creature(&mut game, "Tajuru Target B", bob, 3, 3);
+
+    let requirements = extract_target_requirements_from_program_with_modes(
+        &game,
+        &effects,
+        alice,
+        Some(source),
+        None,
+    );
+    assert!(
+        requirements.is_empty(),
+        "two kicks require three creature targets, got {requirements:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_strength_of_the_tajuru_puts_x_counters_on_each_kicked_target() {
+    let def = strength_of_the_tajuru_definition();
+    let effects = def.spell_effect.clone().expect("expected spell effects");
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+    paid.pay_times(0, 2);
+    game.object_mut(source).expect("source").optional_costs_paid = paid.clone();
+
+    let creature_a = create_creature(&mut game, "Tajuru Target A", bob, 2, 2);
+    let creature_b = create_creature(&mut game, "Tajuru Target B", bob, 3, 3);
+    let creature_c = create_creature(&mut game, "Tajuru Target C", bob, 4, 4);
+    let untargeted = create_creature(&mut game, "Untargeted Creature", bob, 5, 5);
+
+    let entry = StackEntry::ability(source, alice, effects)
+        .with_targets(vec![
+            Target::Object(creature_a),
+            Target::Object(creature_b),
+            Target::Object(creature_c),
+        ])
+        .with_optional_costs_paid(paid)
+        .with_x(4);
+    game.push_to_stack(entry);
+
+    resolve_stack_entry(&mut game).expect("Strength of the Tajuru should resolve");
+
+    for target in [creature_a, creature_b, creature_c] {
+        let counters = game
+            .object(target)
+            .expect("target creature")
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(counters, 4, "target {target:?} should get X counters");
+    }
+    let untargeted_counters = game
+        .object(untargeted)
+        .expect("untargeted creature")
+        .counters
+        .get(&crate::object::CounterType::PlusOnePlusOne)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        untargeted_counters, 0,
+        "Strength of the Tajuru should affect only its chosen targets"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_everflowing_chalice_no_kicks() {
     use crate::cards::definitions::everflowing_chalice;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Strength of the Tajuru
Initial parse error:
```
object filter has unconsumed 'for each' clause 'for each time this spell was kicked' (full input: 'creature then choose another target creature for each time this spell was kicked'); oracle-only fallback also failed: object filter has unconsumed 'for each' clause 'for each time this spell was kicked' (full input: 'creature then choose another target creature for each time this spell was kicked')
```

Current worker: i-01894e78052c634b0
Branch: codex/aws-card-fix-strength-of-the-tajuru
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0012
