### PR TITLE
Fix Ironsmith parse failure: Spider-Man No More

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
@@ -45,6 +45,56 @@ fn parse_attached_with_base_power_toughness_clause(
     Ok(Some((power, toughness, preserve_other_types)))
 }
 
+fn parse_attached_transform_loss_removes_all_abilities(tokens: &[OwnedLexToken]) -> bool {
+    let loss_words = crate::runtime_backend::lexer::token_word_refs(tokens);
+    matches!(
+        loss_words.as_slice(),
+        ["lose", "all", "other", "abilities"]
+            | ["loses", "all", "other", "abilities"]
+            | ["lose", "all", "other", "card", "types", "and", "abilities"]
+            | ["loses", "all", "other", "card", "types", "and", "abilities"]
+    )
+}
+
+fn split_attached_transform_base_pt_and_keyword_grant(
+    tokens: &[OwnedLexToken],
+) -> Option<(Vec<OwnedLexToken>, Vec<OwnedLexToken>)> {
+    for idx in 1..tokens.len() {
+        let Some(word) = tokens[idx].as_word() else {
+            continue;
+        };
+        if !matches!(word, "has" | "have") {
+            continue;
+        }
+
+        let prev_word = tokens[..idx]
+            .iter()
+            .rev()
+            .find_map(OwnedLexToken::as_word)?;
+        if !matches!(prev_word, "it" | "they" | "and") {
+            continue;
+        }
+
+        let prev_idx = tokens[..idx]
+            .iter()
+            .rposition(|token| token.as_word().is_some())?;
+        let base_end = if matches!(prev_word, "it" | "they" | "and") {
+            prev_idx
+        } else {
+            idx
+        };
+        let base_tokens = trim_edge_punctuation(&tokens[..base_end]);
+        let keyword_tokens = trim_edge_punctuation(&tokens[idx + 1..]);
+        if base_tokens.is_empty() || keyword_tokens.is_empty() {
+            continue;
+        }
+
+        return Some((base_tokens, keyword_tokens));
+    }
+
+    None
+}
+
 pub(crate) fn display_text_for_tokens(
     tokens: &[OwnedLexToken],
     capitalize_effect_start: bool,
@@ -909,6 +959,7 @@ pub(crate) fn parse_attached_type_transform_line(
 
     let mut out = Vec::new();
     let mut preserve_other_types = false;
+    let mut loss_consumed = false;
 
     if let Some(with_idx) = with_idx {
         let ability_end = lose_idx.unwrap_or(remainder.len());
@@ -927,11 +978,63 @@ pub(crate) fn parse_attached_type_transform_line(
             )));
         }
 
-        if let Some((power, toughness, with_preserve_other_types)) =
+        if let Some((base_tokens, keyword_tokens)) =
+            split_attached_transform_base_pt_and_keyword_grant(&ability_tokens)
+        {
+            let Some((power, toughness, with_preserve_other_types)) =
+                parse_attached_with_base_power_toughness_clause(&base_tokens)?
+            else {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported attached transform granted ability (clause: '{}')",
+                    line_words.join(" ")
+                )));
+            };
+            preserve_other_types = with_preserve_other_types;
+            out.push(
+                StaticAbility::set_base_power_toughness(filter.clone(), power, toughness).into(),
+            );
+
+            if let Some(lose_idx) = lose_idx {
+                let loss_tokens = trim_commas(&remainder[lose_idx..]);
+                if parse_attached_transform_loss_removes_all_abilities(&loss_tokens) {
+                    out.push(StaticAbility::remove_all_abilities(filter.clone()).into());
+                    loss_consumed = true;
+                }
+            }
+
+            let Some(actions) = parse_ability_line(&keyword_tokens) else {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported attached transform granted ability (clause: '{}')",
+                    line_words.join(" ")
+                )));
+            };
+            for action in actions {
+                reject_unimplemented_keyword_actions(
+                    std::slice::from_ref(&action),
+                    &line_words.join(" "),
+                )?;
+                if !action.lowers_to_static_ability() {
+                    return Err(CardTextError::ParseError(format!(
+                        "unsupported attached transform granted ability (clause: '{}')",
+                        line_words.join(" ")
+                    )));
+                }
+                out.push(StaticAbilityAst::AttachedKeywordActionGrant {
+                    display: format!(
+                        "{subject_text} has {}",
+                        action.display_text().to_ascii_lowercase()
+                    ),
+                    action,
+                    condition: None,
+                });
+            }
+        } else if let Some((power, toughness, with_preserve_other_types)) =
             parse_attached_with_base_power_toughness_clause(&ability_tokens)?
         {
             preserve_other_types = with_preserve_other_types;
-            out.push(StaticAbility::set_base_power_toughness(filter.clone(), power, toughness).into());
+            out.push(
+                StaticAbility::set_base_power_toughness(filter.clone(), power, toughness).into(),
+            );
         } else if let Some(parsed) = parse_attached_granted_activated_line(&ability_tokens)? {
             out.push(StaticAbilityAst::AttachedObjectAbilityGrant {
                 ability: parsed,
@@ -957,7 +1060,8 @@ pub(crate) fn parse_attached_type_transform_line(
         }
     }
 
-    if !set_card_types.is_empty() {
+    let descriptor_has_card_types = !set_card_types.is_empty();
+    if descriptor_has_card_types {
         if preserve_other_types {
             out.push(StaticAbility::add_card_types(filter.clone(), set_card_types).into());
         } else {
@@ -965,7 +1069,15 @@ pub(crate) fn parse_attached_type_transform_line(
         }
     }
     if !add_subtypes.is_empty() {
-        out.push(StaticAbility::add_subtypes(filter.clone(), add_subtypes).into());
+        if !preserve_other_types
+            && !descriptor_has_card_types
+            && add_subtypes.iter().all(crate::types::Subtype::is_creature_type)
+            && word_slice_starts_with(&line_words, &["enchanted", "creature"])
+        {
+            out.push(StaticAbility::set_creature_subtypes(filter.clone(), add_subtypes).into());
+        } else {
+            out.push(StaticAbility::add_subtypes(filter.clone(), add_subtypes).into());
+        }
     }
     if !set_colors.is_empty() {
         out.push(StaticAbility::set_colors(filter.clone(), set_colors).into());
@@ -974,16 +1086,12 @@ pub(crate) fn parse_attached_type_transform_line(
         out.push(StaticAbility::make_colorless(filter.clone()).into());
     }
 
-    if let Some(lose_idx) = lose_idx {
+    if let Some(lose_idx) = lose_idx
+        && !loss_consumed
+    {
         let loss_tokens = trim_commas(&remainder[lose_idx..]);
         let loss_words = crate::runtime_backend::lexer::token_word_refs(&loss_tokens);
-        if matches!(
-            loss_words.as_slice(),
-            ["lose", "all", "other", "abilities"]
-                | ["loses", "all", "other", "abilities"]
-                | ["lose", "all", "other", "card", "types", "and", "abilities"]
-                | ["loses", "all", "other", "card", "types", "and", "abilities"]
-        ) {
+        if parse_attached_transform_loss_removes_all_abilities(&loss_tokens) {
             out.push(StaticAbility::remove_all_abilities(filter.clone()).into());
         } else if !matches!(
             loss_words.as_slice(),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -14876,6 +14876,53 @@ fn parse_swift_reconfiguration_vehicle_transform_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_spider_man_no_more_transform_strict_and_compiled_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Spider-Man No More")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant creature\nEnchanted creature is a Citizen with base power and toughness 1/1. It has defender and loses all other abilities.",
+        )
+        .expect("Spider-Man No More should parse strictly");
+
+    let static_ids: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        static_ids.contains(&StaticAbilityId::SetBasePowerToughnessForFilter),
+        "expected base power/toughness static ability, got {static_ids:?}"
+    );
+    assert!(
+        static_ids.contains(&StaticAbilityId::RemoveAllAbilitiesForFilter),
+        "expected ability-removal static ability, got {static_ids:?}"
+    );
+    assert!(
+        static_ids.contains(&StaticAbilityId::AttachedAbilityGrant),
+        "expected attached defender grant, got {static_ids:?}"
+    );
+    assert!(
+        static_ids.contains(&StaticAbilityId::SetCreatureSubtypes),
+        "expected Citizen to replace other creature types, got {static_ids:?}"
+    );
+
+    let compiled = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        compiled.contains("Enchanted creature is a Citizen with base power and toughness 1/1."),
+        "expected compact transform wording, got {compiled}"
+    );
+    assert!(
+        compiled.contains("It has defender and loses all other abilities."),
+        "expected defender-plus-other-abilities wording, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_ensoul_artifact_style_transform_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Ensoul Artifact")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -870,6 +870,115 @@ pub(super) fn merge_blockability_lines(lines: Vec<String>) -> Vec<String> {
     merged
 }
 
+pub(super) fn merge_attached_transform_keyword_loss_lines(lines: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::with_capacity(lines.len());
+    let mut idx = 0usize;
+
+    while idx < lines.len() {
+        let mut consumed = 0usize;
+        let mut subject: Option<String> = None;
+        let mut base_pt: Option<String> = None;
+        let mut replacement_subtypes: Option<String> = None;
+        let mut granted_keywords: Vec<String> = Vec::new();
+        let mut loses_all_abilities = false;
+
+        while idx + consumed < lines.len() && consumed < 5 {
+            let line = lines[idx + consumed].trim().trim_end_matches('.');
+            let candidate_subject =
+                if let Some(loss_subject) = split_lose_all_abilities_clause(line) {
+                    loses_all_abilities = true;
+                    Some(loss_subject)
+                } else if let Some((have_subject, keyword)) = split_have_clause(line) {
+                    granted_keywords.push(normalize_keyword_predicate_case(&keyword));
+                    Some(have_subject)
+                } else if let Some((predicate_subject, verb, predicate)) =
+                    split_subject_predicate_clause(line)
+                {
+                    match verb {
+                        "has" | "have" => {
+                            if let Some(pt) = predicate.strip_prefix("base power and toughness ") {
+                                base_pt = Some(pt.trim().to_string());
+                                Some(predicate_subject.to_string())
+                            } else {
+                                break;
+                            }
+                        }
+                        "is" | "are" => {
+                            let lower = predicate.to_ascii_lowercase();
+                            if lower.contains("in addition to")
+                                || matches!(
+                                    lower.as_str(),
+                                    "creature"
+                                        | "artifact"
+                                        | "enchantment"
+                                        | "land"
+                                        | "planeswalker"
+                                        | "battle"
+                                        | "colorless"
+                                        | "white"
+                                        | "blue"
+                                        | "black"
+                                        | "red"
+                                        | "green"
+                                )
+                            {
+                                break;
+                            }
+                            replacement_subtypes = Some(lower);
+                            Some(predicate_subject.to_string())
+                        }
+                        _ => break,
+                    }
+                } else {
+                    break;
+                };
+
+            let Some(candidate_subject) = candidate_subject else {
+                break;
+            };
+            if let Some(subject) = &subject {
+                if !conditioned_subjects_equivalent(subject, &candidate_subject) {
+                    break;
+                }
+            } else {
+                subject = Some(candidate_subject);
+            }
+            consumed += 1;
+        }
+
+        if consumed >= 4
+            && loses_all_abilities
+            && base_pt.is_some()
+            && replacement_subtypes.is_some()
+            && !granted_keywords.is_empty()
+            && subject
+                .as_deref()
+                .is_some_and(|subject| !subject_is_plural(subject))
+        {
+            let subject = subject.expect("merged transform group has a subject");
+            let replacement_subtypes = replacement_subtypes.expect("checked replacement subtype");
+            let base_pt = base_pt.expect("checked base pt");
+            let subtype_phrase = capitalize_first(&replacement_subtypes);
+            let article = indefinite_article_for_phrase(&replacement_subtypes);
+
+            merged.push(format!(
+                "{subject} is {article} {subtype_phrase} with base power and toughness {base_pt}."
+            ));
+            merged.push(format!(
+                "It has {} and loses all other abilities.",
+                join_with_and(&granted_keywords)
+            ));
+            idx += consumed;
+            continue;
+        }
+
+        merged.push(lines[idx].clone());
+        idx += 1;
+    }
+
+    merged
+}
+
 pub(super) fn merge_lose_all_transform_lines(lines: Vec<String>) -> Vec<String> {
     let mut merged = Vec::with_capacity(lines.len());
     let mut idx = 0usize;

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -814,9 +814,11 @@ fn merge_ast_surface_lines(mut lines: Vec<String>) -> Vec<String> {
         let merged = merge_conditioned_spell_and_activation_tax_lines(
             merge_adjacent_simple_mana_add_lines(drop_redundant_spell_cost_lines(
                 merge_specific_adjacent_surface_lines(merge_lose_all_transform_lines(
-                    merge_blockability_lines(annotate_color_choice_exclusions(
-                        merge_same_true_type_addition_lines(merge_same_true_keyword_grant_lines(
-                            merge_subject_predicate_surface_lines(previous.clone()),
+                    merge_attached_transform_keyword_loss_lines(merge_blockability_lines(
+                        annotate_color_choice_exclusions(merge_same_true_type_addition_lines(
+                            merge_same_true_keyword_grant_lines(
+                                merge_subject_predicate_surface_lines(previous.clone()),
+                            ),
                         )),
                     )),
                 )),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2109,6 +2109,65 @@ fn glamdring_equipped_creature_gets_first_strike_and_graveyard_scaled_power() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn spider_man_no_more_attached_creature_becomes_citizen_defender_only() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let host = CardDefinitionBuilder::new(CardId::from_raw(72_120), "Heroic Bearer")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Advisor])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text("Flying\nTrample")
+        .expect("host creature should parse");
+    let aura = CardDefinitionBuilder::new(CardId::from_raw(72_121), "Spider-Man No More")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text(
+            "Enchant creature\nEnchanted creature is a Citizen with base power and toughness 1/1. It has defender and loses all other abilities.",
+        )
+        .expect("Spider-Man No More should parse");
+
+    let host_id = game.create_object_from_definition(&host, alice, Zone::Battlefield);
+    let aura_id = game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+    if let Some(aura_object) = game.object_mut(aura_id) {
+        aura_object.attached_to = Some(crate::object::AttachmentTarget::Object(host_id));
+    }
+    if let Some(host_object) = game.object_mut(host_id) {
+        host_object.attachments.push(aura_id);
+    }
+
+    let characteristics = game
+        .calculated_characteristics(host_id)
+        .expect("enchanted creature should have calculated characteristics");
+    assert_eq!(
+        (characteristics.power, characteristics.toughness),
+        (Some(1), Some(1)),
+        "Spider-Man No More should set the enchanted creature's base power/toughness to 1/1"
+    );
+    assert!(
+        characteristics.subtypes.contains(&Subtype::Citizen),
+        "Spider-Man No More should make the enchanted creature a Citizen, got {:?}",
+        characteristics.subtypes
+    );
+    assert!(
+        !characteristics.subtypes.contains(&Subtype::Human)
+            && !characteristics.subtypes.contains(&Subtype::Advisor),
+        "Spider-Man No More should remove other creature types, got {:?}",
+        characteristics.subtypes
+    );
+    assert!(
+        game.object_has_ability(host_id, &StaticAbility::defender()),
+        "Spider-Man No More should grant defender after removing other abilities"
+    );
+    assert!(
+        !game.object_has_ability(host_id, &StaticAbility::flying())
+            && !game.object_has_ability(host_id, &StaticAbility::trample()),
+        "Spider-Man No More should remove the enchanted creature's previous abilities"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn frontier_warmonger_grants_menace_only_to_qualifying_attackers_until_cleanup() {
     let mut game = setup_three_player_game();
     let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Spider-Man No More
Initial parse error:
```
unsupported attached transform granted ability (clause: 'enchanted creature is a citizen with base power and toughness 1/1 it has defender and loses all other abilities'); oracle-only fallback also failed: unsupported attached transform granted ability (clause: 'enchanted creature is a citizen with base power and toughness 1/1 it has defender and loses all other abilities')
```

Current worker: i-0617335b4f893c692
Branch: codex/aws-card-fix-spider-man-no-more
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0012
