### PR TITLE
Fix Ironsmith parse failure: Losheel, Clockwork Scholar

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -31,6 +31,7 @@ use super::grammar::abilities::{
     is_play_top_card_your_library_revealed_line_lexed, is_players_cant_cycle_line_lexed,
     is_players_cant_pay_life_or_sacrifice_line_lexed,
     is_players_play_top_card_libraries_revealed_line_lexed, is_players_skip_upkeep_line_lexed,
+    is_prevent_all_combat_damage_to_matching_permanents_line_lexed,
     is_prevent_all_combat_damage_to_source_line_lexed,
     is_prevent_all_damage_dealt_to_creatures_line_lexed,
     is_prevent_all_damage_to_source_by_creatures_line_lexed,
@@ -775,6 +776,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
         single_static_ability_ast_rule!(parse_during_your_turn_prevent_all_damage_to_source_line),
         single_static_ability_ast_rule!(parse_prevent_all_combat_damage_to_source_line),
+        single_static_ability_ast_rule!(
+            parse_prevent_all_combat_damage_to_matching_permanents_line
+        ),
         single_static_ability_ast_rule!(
             parse_prevent_all_noncombat_damage_to_other_creatures_you_control_line
         ),
@@ -7349,6 +7353,33 @@ pub(crate) fn parse_prevent_all_combat_damage_to_source_line(
     }
 
     Ok(None)
+}
+
+pub(crate) fn parse_prevent_all_combat_damage_to_matching_permanents_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if !is_prevent_all_combat_damage_to_matching_permanents_line_lexed(tokens) {
+        return Ok(None);
+    }
+    let Some((_phrase_idx, phrase_end)) = find_token_word_sequence_span(
+        tokens,
+        &[
+            "prevent", "all", "combat", "damage", "that", "would", "be", "dealt", "to",
+        ],
+    ) else {
+        return Ok(None);
+    };
+    let target_tokens = trim_commas(&tokens[phrase_end..]);
+    if target_tokens.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "prevent-all combat damage static line missing target filter (clause: '{}')",
+            render_token_slice(tokens)
+        )));
+    }
+    let filter = parse_object_filter_lexed(&target_tokens, false)?;
+    Ok(Some(
+        StaticAbility::prevent_all_combat_damage_to_permanents_matching(filter),
+    ))
 }
 
 pub(crate) fn parse_during_your_turn_prevent_all_damage_to_source_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2700,6 +2700,21 @@ pub(crate) fn is_prevent_all_noncombat_damage_to_other_creatures_you_control_lin
     )
 }
 
+pub(crate) fn is_prevent_all_combat_damage_to_matching_permanents_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    let words = TokenWordView::new(tokens).to_word_refs();
+    let prefix = [
+        "prevent", "all", "combat", "damage", "that", "would", "be", "dealt", "to",
+    ];
+    word_slice_starts_with(&words, &prefix)
+        && words.len() > prefix.len()
+        && !word_slice_eq(&words[prefix.len()..], &["this", "creature"])
+        && !word_slice_eq(&words[prefix.len()..], &["this", "permanent"])
+        && !word_slice_eq(&words[prefix.len()..], &["it"])
+        && !word_slice_contains_any_word(&words, &["turn"])
+}
+
 pub(crate) fn is_prevent_all_damage_to_source_by_creatures_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -177,6 +177,7 @@ pub enum StaticAbilityId {
     PreventAllDamageDealtToCreatures,
     PreventAllDamageToSelf,
     PreventAllCombatDamageToSelf,
+    PreventAllCombatDamageToPermanentsMatching,
     PreventAllDamageToSelfByCreatures,
     PreventDamageToYouFromSourceFilter,
     PreventDamageToSelfRemoveCounter,
@@ -433,6 +434,7 @@ impl StaticAbilityId {
             | PreventAllDamageDealtToCreatures
             | PreventAllDamageToSelf
             | PreventAllCombatDamageToSelf
+            | PreventAllCombatDamageToPermanentsMatching
             | PreventAllDamageToSelfByCreatures
             | PreventDamageToYouFromSourceFilter
             | PreventDamageToSelfRemoveCounter

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -186,6 +186,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     LevelAbility(Box<LevelAbilityModel<T, E, C, Cond>>),
     HexproofFrom(ObjectFilter),
     Protection(ProtectionFrom),
+    PreventAllCombatDamageToPermanentsMatching(ObjectFilter),
     RuleRestriction {
         restriction: Restriction,
         display: String,
@@ -865,6 +866,9 @@ where
             }
             StaticAbilityPayload::HexproofFrom(filter) => StaticAbilityPayload::HexproofFrom(filter),
             StaticAbilityPayload::Protection(from) => StaticAbilityPayload::Protection(from),
+            StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(filter) => {
+                StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(filter)
+            }
             StaticAbilityPayload::RuleRestriction {
                 restriction,
                 display,
@@ -3263,6 +3267,13 @@ impl<
             id: Some(StaticAbilityId::PreventAllCombatDamageToSelf),
             label: "prevent all combat damage to self".into(),
             payload: StaticAbilityPayload::None,
+        }
+    }
+    pub fn prevent_all_combat_damage_to_permanents_matching(filter: ObjectFilter) -> Self {
+        Self {
+            id: Some(StaticAbilityId::PreventAllCombatDamageToPermanentsMatching),
+            label: "prevent all combat damage to permanents matching filter".into(),
+            payload: StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(filter),
         }
     }
     pub fn prevent_all_damage_to_self() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38707,6 +38707,305 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn losheel_clockwork_scholar_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Losheel, Clockwork Scholar");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains(
+            "Prevent all combat damage that would be dealt to attacking artifact creatures you control."
+        ),
+        "expected Losheel's filtered combat prevention clause to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains("This ability triggers only once each turn"),
+        "expected Losheel's once-each-turn trigger text to render, got {rendered}"
+    );
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("PreventAllCombatDamageToPermanentsMatching")
+            && ability_debug.contains("attacking: true")
+            && ability_debug.contains("Artifact")
+            && ability_debug.contains("Creature")
+            && ability_debug.contains("controller: Some(You)"),
+        "expected Losheel to lower prevention to a filtered static replacement ability, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn losheel_test_creature(
+    game: &mut crate::game_state::GameState,
+    name: &str,
+    controller: PlayerId,
+    card_types: Vec<CardType>,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card = crate::card::CardBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn losheel_clockwork_scholar_prevents_only_attacking_artifact_creature_combat_damage() {
+    let losheel = parse_oracle_card_definition("Losheel, Clockwork Scholar");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&losheel, alice, Zone::Battlefield);
+    let protected_attacker = losheel_test_creature(
+        &mut game,
+        "Attacking Artifact Creature",
+        alice,
+        vec![CardType::Artifact, CardType::Creature],
+        2,
+        4,
+    );
+    let unprotected_attacker = losheel_test_creature(
+        &mut game,
+        "Attacking Nonartifact Creature",
+        alice,
+        vec![CardType::Creature],
+        2,
+        4,
+    );
+    let artifact_blocker = losheel_test_creature(
+        &mut game,
+        "Artifact Blocker",
+        bob,
+        vec![CardType::Creature],
+        3,
+        4,
+    );
+    let nonartifact_blocker = losheel_test_creature(
+        &mut game,
+        "Nonartifact Blocker",
+        bob,
+        vec![CardType::Creature],
+        3,
+        4,
+    );
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: protected_attacker,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    });
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: unprotected_attacker,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    });
+    combat
+        .blockers
+        .insert(protected_attacker, vec![artifact_blocker]);
+    combat
+        .blockers
+        .insert(unprotected_attacker, vec![nonartifact_blocker]);
+    game.combat = Some(combat.clone());
+    game.refresh_continuous_state();
+
+    crate::game_loop::execute_combat_damage_step(&mut game, &combat, false);
+
+    assert_eq!(
+        game.damage_on(protected_attacker),
+        0,
+        "Losheel should prevent combat damage to an attacking artifact creature Alice controls"
+    );
+    assert_eq!(
+        game.damage_on(unprotected_attacker),
+        3,
+        "Losheel should not prevent combat damage to a nonartifact attacking creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn losheel_clockwork_scholar_prevention_rejects_nonattacking_and_opponent_artifacts() {
+    let losheel = parse_oracle_card_definition("Losheel, Clockwork Scholar");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let losheel_id = game.create_object_from_definition(&losheel, alice, Zone::Battlefield);
+    let alice_attacking_artifact = losheel_test_creature(
+        &mut game,
+        "Alice Attacking Artifact",
+        alice,
+        vec![CardType::Artifact, CardType::Creature],
+        2,
+        2,
+    );
+    let alice_nonattacking_artifact = losheel_test_creature(
+        &mut game,
+        "Alice Nonattacking Artifact",
+        alice,
+        vec![CardType::Artifact, CardType::Creature],
+        2,
+        2,
+    );
+    let bob_attacking_artifact = losheel_test_creature(
+        &mut game,
+        "Bob Attacking Artifact",
+        bob,
+        vec![CardType::Artifact, CardType::Creature],
+        2,
+        2,
+    );
+    let damage_source = losheel_test_creature(
+        &mut game,
+        "Damage Source",
+        bob,
+        vec![CardType::Creature],
+        3,
+        3,
+    );
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: alice_attacking_artifact,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    });
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: bob_attacking_artifact,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    });
+    game.combat = Some(combat);
+    game.refresh_continuous_state();
+
+    let replacement = game
+        .effect_store
+        .replacement_effects
+        .effects()
+        .iter()
+        .find(|effect| effect.source == losheel_id)
+        .expect("Losheel should generate a static replacement effect");
+    let matcher = replacement
+        .matcher
+        .as_ref()
+        .expect("Losheel replacement should have a matcher");
+    let ctx = crate::events::context::EventContext::for_replacement_effect(
+        alice, losheel_id, &game,
+    );
+
+    let protected = crate::events::damage::DamageEvent::with_cause(
+        damage_source,
+        crate::events::DamageTarget::Object(alice_attacking_artifact),
+        3,
+        true,
+        crate::events::cause::EventCause::combat_damage(damage_source),
+    );
+    assert!(matcher.matches_event(&protected, &ctx));
+
+    let nonattacking = crate::events::damage::DamageEvent::with_cause(
+        damage_source,
+        crate::events::DamageTarget::Object(alice_nonattacking_artifact),
+        3,
+        true,
+        crate::events::cause::EventCause::combat_damage(damage_source),
+    );
+    assert!(!matcher.matches_event(&nonattacking, &ctx));
+
+    let opponent_controlled = crate::events::damage::DamageEvent::with_cause(
+        damage_source,
+        crate::events::DamageTarget::Object(bob_attacking_artifact),
+        3,
+        true,
+        crate::events::cause::EventCause::combat_damage(damage_source),
+    );
+    assert!(!matcher.matches_event(&opponent_controlled, &ctx));
+
+    let noncombat = crate::events::damage::DamageEvent::with_cause(
+        damage_source,
+        crate::events::DamageTarget::Object(alice_attacking_artifact),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert!(!matcher.matches_event(&noncombat, &ctx));
+
+    let unpreventable = crate::events::damage::DamageEvent::unpreventable_with_cause(
+        damage_source,
+        crate::events::DamageTarget::Object(alice_attacking_artifact),
+        3,
+        true,
+        crate::events::cause::EventCause::combat_damage(damage_source),
+    );
+    assert!(!matcher.matches_event(&unpreventable, &ctx));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn losheel_clockwork_scholar_artifact_creature_enter_trigger_is_once_each_turn() {
+    let losheel = parse_oracle_card_definition("Losheel, Clockwork Scholar");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+
+    let losheel_id = game.create_object_from_definition(&losheel, alice, Zone::Battlefield);
+    let artifact = losheel_test_creature(
+        &mut game,
+        "Entering Artifact Creature",
+        alice,
+        vec![CardType::Artifact, CardType::Creature],
+        1,
+        1,
+    );
+    let etb_event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            artifact,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &etb_event) {
+        if trigger.source == losheel_id {
+            trigger_queue.add(trigger);
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Losheel should trigger when an artifact creature Alice controls enters"
+    );
+    let trigger_debug = format!("{:#?}", trigger_queue.entries[0]);
+    assert!(
+        trigger_debug.contains("DrawCardsEffect") || trigger_debug.contains("Draw"),
+        "Losheel's trigger should draw a card, got {trigger_debug}"
+    );
+
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Losheel trigger should move to the stack");
+
+    let second_trigger_count = crate::triggers::check_triggers(&game, &etb_event)
+        .iter()
+        .filter(|entry| entry.source == losheel_id)
+        .count();
+    assert_eq!(
+        second_trigger_count, 0,
+        "Losheel's artifact-creature-enter trigger should trigger only once each turn"
+    );
+}
+
 #[test]
 fn alena_kessig_trapper_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Alena, Kessig Trapper");

--- a/crates/ironsmith-runtime/src/events/damage/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/damage/matchers.rs
@@ -183,6 +183,53 @@ impl ReplacementMatcher for CombatDamageMatcher {
     }
 }
 
+/// Matches preventable combat damage events dealt to an object matching a filter.
+#[derive(Debug, Clone)]
+pub struct PreventableCombatDamageToObjectMatcher {
+    pub filter: ObjectFilter,
+}
+
+impl PreventableCombatDamageToObjectMatcher {
+    pub fn new(filter: ObjectFilter) -> Self {
+        Self { filter }
+    }
+}
+
+impl ReplacementMatcher for PreventableCombatDamageToObjectMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        if event.event_kind() != EventKind::Damage {
+            return false;
+        }
+
+        let Some(damage) = downcast_event::<DamageEvent>(event) else {
+            return false;
+        };
+
+        if damage.is_unpreventable || !damage.is_combat {
+            return false;
+        }
+
+        let DamageTarget::Object(object_id) = damage.target else {
+            return false;
+        };
+
+        ctx.game
+            .object(object_id)
+            .is_some_and(|object| self.filter.matches(object, &ctx.filter_ctx, ctx.game))
+    }
+
+    fn priority(&self) -> ReplacementPriority {
+        ReplacementPriority::Other
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "When preventable combat damage would be dealt to {}",
+            self.filter.description()
+        )
+    }
+}
+
 /// Matches noncombat damage events.
 #[derive(Debug, Clone)]
 pub struct NoncombatDamageMatcher;

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -149,6 +149,12 @@ impl StaticAbility {
             Some(StaticAbilityId::PreventAllCombatDamageToSelf) => {
                 Self::prevent_all_combat_damage_to_self()
             }
+            Some(StaticAbilityId::PreventAllCombatDamageToPermanentsMatching) => {
+                return Err(StaticAbilityModelConversionError {
+                    detail: "filtered combat-damage prevention needs its object-filter payload"
+                        .to_string(),
+                });
+            }
             Some(StaticAbilityId::PreventAllDamageToSelfByCreatures) => {
                 Self::prevent_all_damage_to_self_by_creatures()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -27,7 +27,7 @@ use crate::events::damage::matchers::{
     DamageFromSelfCombatMatcher, DamageFromSelfMatcher, DamageFromSourceToObjectMatcher,
     DamageFromSourceToPlayerMatcher, DamageToObjectMatcher, DamageToOtherCreatureYouControlMatcher,
     DamageToPlayerOrObjectMatcher, DamageToSelfCombatMatcher, DamageToSelfConstraintMatcher,
-    DamageToSelfFromSourceFilterMatcher,
+    DamageToSelfFromSourceFilterMatcher, PreventableCombatDamageToObjectMatcher,
 };
 use crate::events::permanents::matchers::AttachedPermanentWouldBeDestroyedMatcher;
 use crate::events::traits::{
@@ -62,6 +62,27 @@ fn pluralize(word: &str) -> String {
     } else {
         format!("{word}s")
     }
+}
+
+fn pluralize_filter_description(description: &str) -> String {
+    let base = description
+        .trim()
+        .strip_prefix("a ")
+        .or_else(|| description.trim().strip_prefix("an "))
+        .unwrap_or_else(|| description.trim());
+    for suffix in [
+        " you control",
+        " you own",
+        " an opponent controls",
+        " an opponent owns",
+        " that player controls",
+        " that player owns",
+    ] {
+        if let Some(head) = base.strip_suffix(suffix) {
+            return format!("{}{}", pluralize(head.trim_end()), suffix);
+        }
+    }
+    pluralize(base)
 }
 
 fn indefinite_article(text: &str) -> &'static str {
@@ -1822,6 +1843,44 @@ impl StaticAbilityKind for PreventAllCombatDamageToSelf {
             source,
             controller,
             DamageToSelfCombatMatcher::new(),
+            ReplacementAction::Prevent,
+        ))
+    }
+}
+
+/// "Prevent all combat damage that would be dealt to [matching permanents]."
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreventAllCombatDamageToPermanentsMatching {
+    pub filter: ObjectFilter,
+}
+
+impl PreventAllCombatDamageToPermanentsMatching {
+    pub fn new(filter: ObjectFilter) -> Self {
+        Self { filter }
+    }
+}
+
+impl StaticAbilityKind for PreventAllCombatDamageToPermanentsMatching {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::PreventAllCombatDamageToPermanentsMatching
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "Prevent all combat damage that would be dealt to {}.",
+            pluralize_filter_description(&self.filter.description())
+        )
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            PreventableCombatDamageToObjectMatcher::new(self.filter.clone()),
             ReplacementAction::Prevent,
         ))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2358,6 +2358,12 @@ impl StaticAbility {
         Self::new(PreventAllCombatDamageToSelf)
     }
 
+    pub fn prevent_all_combat_damage_to_permanents_matching(
+        filter: crate::target::ObjectFilter,
+    ) -> Self {
+        Self::new(PreventAllCombatDamageToPermanentsMatching::new(filter))
+    }
+
     pub fn prevent_all_damage_to_self() -> Self {
         Self::new(PreventAllDamageToSelf)
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -914,6 +914,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::Protection(from) => {
                 StaticAbility::protection(from.clone())
             }
+            ironsmith_core::StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(
+                filter,
+            ) => StaticAbility::prevent_all_combat_damage_to_permanents_matching(filter.clone()),
             ironsmith_core::StaticAbilityPayload::HexproofFrom(filter) => {
                 StaticAbility::hexproof_from(filter.clone())
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Losheel, Clockwork Scholar
Initial parse error:
```
parser does not yet support line family: 'Prevent all combat damage that would be dealt to attacking artifact creatures you control.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all combat damage that would be dealt to attacking artifact creatures you control.'
```

Current worker: i-0a17319b561be14e6
Branch: codex/aws-card-fix-losheel-clockwork-scholar
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0013
