### PR TITLE
Fix Ironsmith parse failure: Sab-Sunen, Luxa Embodied

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
@@ -1363,16 +1363,35 @@ pub(crate) fn parse_cant_clause(
         )));
     }
 
-    if word_slice_starts_with(
+    if word_slice_starts_with_any(
         &normalized,
-        &["this", "cant", "attack", "or", "block", "unless"],
+        &[
+            &[
+                "this", "creature", "cant", "attack", "or", "block", "unless",
+            ],
+            &["this", "cant", "attack", "or", "block", "unless"],
+        ],
     ) && word_slice_ends_with(
         &normalized,
         &["even", "number", "of", "counters", "on", "it"],
     ) {
-        return Ok(Some(StaticAbility::rule_fallback_text(
-            format_negated_restriction_display(tokens),
+        let condition = crate::ConditionExpr::Not(Box::new(crate::ConditionExpr::SourceMatches(
+            ObjectFilter::source()
+                .with_total_counters_parity(crate::filter::ParityRequirement::Even),
         )));
+        return Ok(Some(
+            StaticAbility::restriction(
+                crate::effect::Restriction::attack_or_block(ObjectFilter::source()),
+                format_negated_restriction_display(tokens),
+            )
+            .with_condition(condition)
+            .unwrap_or_else(|| {
+                StaticAbility::restriction(
+                    crate::effect::Restriction::attack_or_block(ObjectFilter::source()),
+                    format_negated_restriction_display(tokens),
+                )
+            }),
+        ));
     }
 
     const CANT_ATTACK_OR_BLOCK_UNLESS_PREFIXES: &[&[&str]] = &[

--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -382,6 +382,27 @@ pub(super) fn apply_parity_filter_phrases(words: &[&str], filter: &mut ObjectFil
         }
     }
 
+    for (parity, phrases) in [
+        (
+            ParityRequirement::Odd,
+            &[
+                &["odd", "number", "of", "counters", "on", "it"][..],
+                &["odd", "number", "of", "counters", "on", "them"][..],
+            ][..],
+        ),
+        (
+            ParityRequirement::Even,
+            &[
+                &["even", "number", "of", "counters", "on", "it"][..],
+                &["even", "number", "of", "counters", "on", "them"][..],
+            ][..],
+        ),
+    ] {
+        if word_slice_contains_any_phrase(words, phrases) {
+            filter.total_counters_parity = Some(parity);
+        }
+    }
+
     if word_slice_contains_any_phrase(
         words,
         &[
@@ -988,6 +1009,15 @@ mod tests {
 
         assert_eq!(filter.mana_value_parity, Some(ParityRequirement::Odd));
         assert_eq!(filter.power_parity, Some(ParityRequirement::Chosen));
+    }
+
+    #[test]
+    fn parse_object_filter_lexed_detects_total_counter_parity() {
+        let tokens = tokenize_line("odd number of counters on it", 0);
+
+        let filter = parse_object_filter_lexed(&tokens, false).expect("object filter should parse");
+
+        assert_eq!(filter.total_counters_parity, Some(ParityRequirement::Odd));
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38769,6 +38769,56 @@ fn parse_oracle_card_definition(name: &str) -> CardDefinition {
         .unwrap_or_else(|err| panic!("strict parser regression failed for '{name}': {err:?}"))
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_sab_sunen_library_cards(game: &mut crate::game_state::GameState, player: PlayerId) {
+    for index in 0..3 {
+        let card = crate::card::CardBuilder::new(
+            CardId::new(),
+            &format!("Sab-Sunen Library Card {index}"),
+        )
+        .card_types(vec![CardType::Creature])
+        .build();
+        game.create_object_from_card(&card, player, Zone::Library);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_sab_sunen_first_main_phase(
+    game: &mut crate::game_state::GameState,
+    sab_sunen: ObjectId,
+    active_player: PlayerId,
+) {
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfPrecombatMainPhaseEvent::new(active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(game, &event)
+        .into_iter()
+        .filter(|entry| entry.source == sab_sunen)
+    {
+        trigger_queue.add(entry);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Sab-Sunen should trigger exactly once at its controller's first main phase"
+    );
+    crate::game_loop::put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Sab-Sunen trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(game).expect("Sab-Sunen trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn sab_sunen_plus_one_counters(game: &crate::game_state::GameState, sab_sunen: ObjectId) -> u32 {
+    game.object(sab_sunen)
+        .expect("Sab-Sunen should exist")
+        .counters
+        .get(&crate::object::CounterType::PlusOnePlusOne)
+        .copied()
+        .unwrap_or(0)
+}
+
 fn assert_oracle_card_parses_strict(name: &str) {
     let oracle = oracle_text_by_name()
         .get(name)
@@ -38793,6 +38843,144 @@ fn assert_oracle_card_fails_strict(name: &str) {
         result.is_err(),
         "strict parser regression expected failure for '{name}', but parse succeeded.\nOracle text:\n{}",
         oracle
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sab_sunen_luxa_embodied_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Sab-Sunen, Luxa Embodied");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        lower.contains("can't attack or block unless")
+            && lower.contains("even number of counters on it"),
+        "expected Sab-Sunen's even-counter attack/block restriction, got {rendered}"
+    );
+    assert!(
+        lower.contains("put a +1/+1 counter on")
+            && lower.contains("odd number of counters on it")
+            && lower.contains("draw two cards"),
+        "expected Sab-Sunen's put-counter-then-odd-counter draw clause, got {rendered}"
+    );
+    assert!(
+        !lower.contains("unsupported predicate") && !lower.contains("unsupported effect"),
+        "Sab-Sunen should compile without unsupported fallbacks, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sab_sunen_luxa_embodied_can_attack_and_block_only_with_even_counter_count() {
+    let def = parse_oracle_card_definition("Sab-Sunen, Luxa Embodied");
+    let blocker_def = CardDefinitionBuilder::new(CardId::new(), "Sab-Sunen Test Attacker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sab_sunen = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let attacker = game.create_object_from_definition(&blocker_def, bob, Zone::Battlefield);
+    game.remove_summoning_sickness(sab_sunen);
+    game.refresh_continuous_state();
+
+    assert!(
+        crate::rules::combat::can_attack(
+            game.object(sab_sunen).expect("Sab-Sunen exists"),
+            &game
+        ),
+        "zero counters is even, so Sab-Sunen should be able to attack"
+    );
+    assert!(
+        crate::rules::combat::can_block(
+            game.object(attacker).expect("attacker exists"),
+            game.object(sab_sunen).expect("Sab-Sunen exists"),
+            &game,
+        ),
+        "zero counters is even, so Sab-Sunen should be able to block"
+    );
+
+    game.add_counters(sab_sunen, crate::object::CounterType::PlusOnePlusOne, 1);
+    game.refresh_continuous_state();
+    assert!(
+        !crate::rules::combat::can_attack(
+            game.object(sab_sunen).expect("Sab-Sunen exists"),
+            &game
+        ),
+        "one counter is odd, so Sab-Sunen should not be able to attack"
+    );
+    assert!(
+        !crate::rules::combat::can_block(
+            game.object(attacker).expect("attacker exists"),
+            game.object(sab_sunen).expect("Sab-Sunen exists"),
+            &game,
+        ),
+        "one counter is odd, so Sab-Sunen should not be able to block"
+    );
+
+    game.add_counters(sab_sunen, crate::object::CounterType::PlusOnePlusOne, 1);
+    game.refresh_continuous_state();
+    assert!(
+        crate::rules::combat::can_attack(
+            game.object(sab_sunen).expect("Sab-Sunen exists"),
+            &game
+        ),
+        "two counters is even, so Sab-Sunen should be able to attack again"
+    );
+    assert!(
+        crate::rules::combat::can_block(
+            game.object(attacker).expect("attacker exists"),
+            game.object(sab_sunen).expect("Sab-Sunen exists"),
+            &game,
+        ),
+        "two counters is even, so Sab-Sunen should be able to block again"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sab_sunen_luxa_embodied_first_main_phase_draws_only_when_counter_total_becomes_odd() {
+    let def = parse_oracle_card_definition("Sab-Sunen, Luxa Embodied");
+
+    let mut odd_game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let odd_sab_sunen = odd_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    add_sab_sunen_library_cards(&mut odd_game, alice);
+    let bob_main_phase = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfPrecombatMainPhaseEvent::new(bob),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        crate::triggers::check_triggers(&odd_game, &bob_main_phase)
+            .into_iter()
+            .all(|entry| entry.source != odd_sab_sunen),
+        "Sab-Sunen should not trigger at the beginning of an opponent's first main phase"
+    );
+    resolve_sab_sunen_first_main_phase(&mut odd_game, odd_sab_sunen, alice);
+    assert_eq!(sab_sunen_plus_one_counters(&odd_game, odd_sab_sunen), 1);
+    assert_eq!(
+        odd_game.player(alice).expect("player exists").hand.len(),
+        2,
+        "moving from zero to one counter should satisfy the odd-counter draw branch"
+    );
+
+    let mut even_game = crate::tests::test_helpers::setup_two_player_game();
+    let even_sab_sunen = even_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    even_game.add_counters(
+        even_sab_sunen,
+        crate::object::CounterType::PlusOnePlusOne,
+        1,
+    );
+    add_sab_sunen_library_cards(&mut even_game, alice);
+    resolve_sab_sunen_first_main_phase(&mut even_game, even_sab_sunen, alice);
+    assert_eq!(sab_sunen_plus_one_counters(&even_game, even_sab_sunen), 2);
+    assert_eq!(
+        even_game.player(alice).expect("player exists").hand.len(),
+        0,
+        "moving from one to two counters should not satisfy the odd-counter draw branch"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -758,6 +758,7 @@ pub(super) fn substitute_legendary_source_reference(
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
     let uses_named_source_surface = lower.starts_with("this creature gets ")
         || conditional_static_self_surface
+        || lower.starts_with("this creature can't attack or block unless ")
         || lower.contains("if this land has ")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.contains(": this creature gets ")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11213,6 +11213,11 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             if let Some(text) = describe_source_matches_keyword_condition(filter) {
                 return text;
             }
+            if let Some(parity) = filter.total_counters_parity
+                && let Some(label) = parity.explicit_label()
+            {
+                return format!("it has an {label} number of counters on it");
+            }
             let desc = filter.description();
             let stripped = strip_leading_article(&desc).to_ascii_lowercase();
             if stripped == "permanent" {
@@ -11385,6 +11390,11 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
 	                        format!("{subject} is {phrase}")
 	                    }
 	                };
+	                if let Some(parity) = filter.total_counters_parity
+	                    && let Some(label) = parity.explicit_label()
+	                {
+	                    return format!("{subject} has an {label} number of counters on it");
+	                }
 
 	                if card_context
 	                    && !filter.card_types.is_empty()

--- a/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
@@ -511,10 +511,21 @@ impl RuleRestriction {
 }
 
 fn display_rule_restriction_condition(condition: &crate::ConditionExpr) -> Option<String> {
-    match condition {
-        crate::ConditionExpr::Not(inner) if is_you_have_max_speed_condition(inner) => {
-            Some("unless you have max speed".to_string())
+    if let crate::ConditionExpr::Not(inner) = condition {
+        if is_you_have_max_speed_condition(inner) {
+            return Some("unless you have max speed".to_string());
         }
+        if let crate::ConditionExpr::SourceMatches(filter) = inner.as_ref()
+            && let Some(parity) = filter.total_counters_parity
+            && let Some(label) = parity.explicit_label()
+        {
+            return Some(format!(
+                "unless it has an {label} number of counters on it"
+            ));
+        }
+    }
+
+    match condition {
         crate::ConditionExpr::ActivationTiming(
             crate::ability::ActivationTiming::DuringYourTurn,
         ) => Some("During your turn".to_string()),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sab-Sunen, Luxa Embodied
Initial parse error:
```
unsupported predicate (predicate: 'it odd number of counters on it'); oracle-only fallback also failed: unsupported predicate (predicate: 'it odd number of counters on it')
```

Current worker: i-0f81601679d85da51
Branch: codex/aws-card-fix-sab-sunen-luxa-embodied
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0014
