### PR TITLE
Fix Ironsmith parse failure: Final Punishment

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -817,6 +817,26 @@ pub(crate) fn parse_life_equal_to_value(
     ) {
         return Ok(Some(Value::LifeLostThisTurn(PlayerFilter::IteratedPlayer)));
     }
+    if matches!(
+        amount_words.as_slice(),
+        [
+            "equal", "to", "the", "damage", "already", "dealt", "to", "that", "player",
+            "this", "turn"
+        ] | [
+            "equal", "to", "damage", "already", "dealt", "to", "that", "player", "this",
+            "turn"
+        ] | [
+            "equal", "to", "the", "amount", "of", "damage", "already", "dealt", "to",
+            "that", "player", "this", "turn"
+        ] | [
+            "equal", "to", "amount", "of", "damage", "already", "dealt", "to", "that",
+            "player", "this", "turn"
+        ]
+    ) {
+        return Ok(Some(Value::DamageDealtToPlayersThisTurn(
+            PlayerFilter::target_player(),
+        )));
+    }
     if let Some(value) = parse_dynamic_cost_modifier_value(amount_tokens)? {
         return Ok(Some(value));
     }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -94,6 +94,7 @@ pub enum Value {
     LifeGainedThisTurn(PlayerFilter),
     LifeLostThisTurn(PlayerFilter),
     CardsDiscardedThisTurn(PlayerFilter),
+    DamageDealtToPlayersThisTurn(PlayerFilter),
     NoncombatDamageDealtToPlayersThisTurn(PlayerFilter),
     NoncombatDamageDealtBySourcesControlledThisTurn {
         player: PlayerFilter,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11407,6 +11407,29 @@ fn parse_oracle_tainted_sigil_strictly_parses_and_renders_total_life_lost() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_final_punishment_strictly_parses_and_renders_damage_dealt_this_turn() {
+    assert_oracle_card_parses_strict("Final Punishment");
+
+    let def = parse_oracle_card_definition("Final Punishment");
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Target player loses life equal to the damage already dealt to that player this turn."
+                .to_string(),
+        ],
+        "expected Final Punishment to render its target player's prior damage amount"
+    );
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("DamageDealtToPlayersThisTurn") && debug.contains("Target"),
+        "expected Final Punishment to structurally use damage dealt to the target player this turn, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_one_or_more_etb_trigger_binds_that_much_to_zone_change_count() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Artillerist Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8076,6 +8076,19 @@ pub(crate) fn describe_value(value: &Value) -> String {
                 describe_player_filter(filter)
             ),
         },
+        Value::DamageDealtToPlayersThisTurn(filter) => match filter {
+            PlayerFilter::You => "the damage already dealt to you this turn".to_string(),
+            PlayerFilter::Opponent => {
+                "the damage already dealt to your opponents this turn".to_string()
+            }
+            PlayerFilter::Target(_) => {
+                "the damage already dealt to that player this turn".to_string()
+            }
+            _ => format!(
+                "the damage already dealt to {} this turn",
+                describe_player_filter(filter)
+            ),
+        },
         Value::NoncombatDamageDealtToPlayersThisTurn(filter) => match filter {
             PlayerFilter::You => {
                 "the total amount of noncombat damage dealt to you this turn".to_string()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1756,6 +1756,7 @@ fn describe_life_amount_phrase(amount: &Value) -> String {
             | Value::Speed(_)
             | Value::LifeGainedThisTurn(_)
             | Value::LifeLostThisTurn(_)
+            | Value::DamageDealtToPlayersThisTurn(_)
     ) {
         return format!("life equal to {}", describe_value(amount));
     }
@@ -28601,6 +28602,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 | Value::Speed(_)
                 | Value::LifeGainedThisTurn(_)
                 | Value::LifeLostThisTurn(_)
+                | Value::DamageDealtToPlayersThisTurn(_)
                 | Value::CardsDiscardedThisTurn(_)
                 | Value::EffectMetric { .. }
                 | Value::EffectMetricOffset { .. }
@@ -28752,6 +28754,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 | Value::Speed(_)
                 | Value::LifeGainedThisTurn(_)
                 | Value::LifeLostThisTurn(_)
+                | Value::DamageDealtToPlayersThisTurn(_)
         ) {
             return format!(
                 "{} {} life equal to {}",

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4360,6 +4360,7 @@ fn resolve_value_with_context(
         | Value::LifeGainedThisTurn(_)
         | Value::LifeLostThisTurn(_)
         | Value::CardsDiscardedThisTurn(_)
+        | Value::DamageDealtToPlayersThisTurn(_)
         | Value::NoncombatDamageDealtToPlayersThisTurn(_)
         | Value::NoncombatDamageDealtBySourcesControlledThisTurn { .. }
         | Value::MaxCardsDrawnThisTurn(_)

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1357,6 +1357,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::LifeGainedThisTurn(_)
         | Value::LifeLostThisTurn(_)
         | Value::CardsDiscardedThisTurn(_)
+        | Value::DamageDealtToPlayersThisTurn(_)
         | Value::NoncombatDamageDealtToPlayersThisTurn(_)
         | Value::NoncombatDamageDealtBySourcesControlledThisTurn { .. }
         | Value::MaxCardsDrawnThisTurn(_)

--- a/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
@@ -122,6 +122,7 @@ fn value_mentions_iterated_player(value: &crate::effect::Value) -> bool {
         | crate::effect::Value::DevotionToChosenColor(player)
         | crate::effect::Value::LifeGainedThisTurn(player)
         | crate::effect::Value::LifeLostThisTurn(player)
+        | crate::effect::Value::DamageDealtToPlayersThisTurn(player)
         | crate::effect::Value::NoncombatDamageDealtToPlayersThisTurn(player)
         | crate::effect::Value::MaxCardsDrawnThisTurn(player)
         | crate::effect::Value::LandsEnteredBattlefieldThisTurn(player)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1182,6 +1182,16 @@ pub fn resolve_value(
             Ok(total as i32)
         }
 
+        Value::DamageDealtToPlayersThisTurn(player_spec) => {
+            let player_ids =
+                resolve_player_filter_to_list(game, player_spec, &ctx.filter_context(game), ctx)?;
+            let total = game
+                .turn_store
+                .turn_history
+                .total_damage_to_players(&player_ids);
+            Ok(total as i32)
+        }
+
         Value::NoncombatDamageDealtToPlayersThisTurn(player_spec) => {
             let player_ids =
                 resolve_player_filter_to_list(game, player_spec, &ctx.filter_context(game), ctx)?;

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -17429,6 +17429,125 @@ fn test_tainted_sigil_gains_no_life_when_no_player_lost_life_this_turn() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn final_punishment_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(90_018), "Final Punishment")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Target player loses life equal to the damage already dealt to that player this turn.",
+        )
+        .expect("Final Punishment should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn record_player_damage_this_turn(
+    game: &mut GameState,
+    source: ObjectId,
+    player: PlayerId,
+    amount: u32,
+    is_combat: bool,
+) {
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            source,
+            crate::events::DamageTarget::Player(player),
+            amount,
+            is_combat,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&event);
+    game.player_mut(player)
+        .expect("damaged player should exist")
+        .life -= amount as i32;
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn final_punishment_makes_target_player_lose_life_equal_to_all_prior_damage_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let damage_source = ObjectId::from_raw(90_019);
+
+    record_player_damage_this_turn(&mut game, damage_source, bob, 3, true);
+    record_player_damage_this_turn(&mut game, damage_source, bob, 4, false);
+    record_player_damage_this_turn(&mut game, damage_source, alice, 5, false);
+    game.player_mut(bob)
+        .expect("Bob should exist")
+        .life -= 2;
+
+    let creature = create_creature(&mut game, "Irrelevant Target", bob, 1, 1);
+    let creature_damage = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            damage_source,
+            crate::events::DamageTarget::Object(creature),
+            9,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&creature_damage);
+
+    let final_punishment = final_punishment_definition();
+    let spell_id = game.create_object_from_definition(&final_punishment, alice, Zone::Stack);
+    game.stack.push(
+        crate::game_state::StackEntry::new(spell_id, alice)
+            .with_targets(vec![crate::game_state::Target::Player(bob)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::target_player(),
+                range: 0..1,
+            }]),
+    );
+
+    let bob_life_before = game.player(bob).expect("Bob should exist").life;
+    resolve_stack_entry(&mut game).expect("Final Punishment should resolve");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        bob_life_before - 7,
+        "Final Punishment should count combat and noncombat damage already dealt to its target player, and ignore other life loss or other targets"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn final_punishment_makes_target_player_lose_no_life_when_they_were_not_damaged_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let damage_source = ObjectId::from_raw(90_020);
+
+    record_player_damage_this_turn(&mut game, damage_source, alice, 6, false);
+
+    let final_punishment = final_punishment_definition();
+    let spell_id = game.create_object_from_definition(&final_punishment, alice, Zone::Stack);
+    game.stack.push(
+        crate::game_state::StackEntry::new(spell_id, alice)
+            .with_targets(vec![crate::game_state::Target::Player(bob)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::target_player(),
+                range: 0..1,
+            }]),
+    );
+
+    let bob_life_before = game.player(bob).expect("Bob should exist").life;
+    resolve_stack_entry(&mut game).expect("Final Punishment should resolve");
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        bob_life_before,
+        "Final Punishment should use the target player's damage total, not damage dealt to another player"
+    );
+}
+
 #[test]
 fn test_source_lki_refreshes_when_exile_source_moves_it() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -305,6 +305,22 @@ fn describe_cost_modifier_amount(amount: &Value) -> (String, Option<String>) {
             };
             ("{X}".to_string(), Some(format!("where X is {phrase}")))
         }
+        Value::DamageDealtToPlayersThisTurn(player) => {
+            let phrase = match player {
+                PlayerFilter::You => "the damage already dealt to you this turn".to_string(),
+                PlayerFilter::Opponent => {
+                    "the damage already dealt to your opponents this turn".to_string()
+                }
+                PlayerFilter::Target(_) => {
+                    "the damage already dealt to that player this turn".to_string()
+                }
+                _ => format!(
+                    "the damage already dealt to {} this turn",
+                    describe_player_filter_for_spell_target(player)
+                ),
+            };
+            ("{X}".to_string(), Some(format!("where X is {phrase}")))
+        }
         Value::NoncombatDamageDealtBySourcesControlledThisTurn { player, colors } => {
             let source = match (player, colors) {
                 (PlayerFilter::You, Some(colors))

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -280,6 +280,13 @@ impl TurnHistory {
             .sum()
     }
 
+    pub fn total_damage_to_players(&self, players: &[PlayerId]) -> u32 {
+        players
+            .iter()
+            .map(|player| self.total_damage_to_player(*player))
+            .sum()
+    }
+
     pub fn total_creature_damage_to_player(&self, player: PlayerId) -> u32 {
         self.projected_records()
             .filter_map(|record| {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Final Punishment
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to the damage already dealt to that player this turn'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to the damage already dealt to that player this turn')
```

Current worker: i-00a0e7bde51e18a4d
Branch: codex/aws-card-fix-final-punishment
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0014
