### PR TITLE
Fix Ironsmith parse failure: Foriysian Totem

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2973,11 +2973,6 @@ fn parse_source_is_descriptor_static_condition(
 
     let descriptor = descriptor_words[0];
     let mut filter = ObjectFilter::source();
-    if subject_words.len() == 2
-        && let Some(card_type) = parse_card_type(subject_words[1])
-    {
-        filter.all_card_types.push(card_type);
-    }
     if let Some(card_type) = parse_card_type(descriptor) {
         filter.all_card_types.push(card_type);
     } else if let Some(color) = parse_color(descriptor) {
@@ -2988,7 +2983,10 @@ fn parse_source_is_descriptor_static_condition(
         return Ok(None);
     }
 
-    Ok(Some(crate::ConditionExpr::SourceMatches(filter)))
+    Ok(Some(crate::ConditionExpr::SourceMatchesWithDisplay {
+        filter,
+        display: clause_words.join(" "),
+    }))
 }
 
 fn parse_devotion_static_condition(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -1222,17 +1222,40 @@ pub(crate) fn parse_each_creature_can_block_additional_creature_each_combat_line
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbilityAst>, CardTextError> {
     // High Ground: "Each creature can block an additional creature each combat."
-    let clause_words = crate::runtime_backend::token_word_refs(tokens);
-    if clause_words.len() < 9 {
+    let mut line_tokens = trim_edge_punctuation(tokens);
+    let mut condition = None;
+    let line_words = crate::runtime_backend::token_word_refs(&line_tokens);
+    if word_slice_starts_with(&line_words, &["as", "long", "as"]) {
+        let Some(comma_idx) = find_index(&line_tokens, |token| token.is_comma()) else {
+            return Ok(None);
+        };
+        condition = Some(parse_static_condition_clause(&trim_commas(
+            &line_tokens[3..comma_idx],
+        ))?);
+        line_tokens = trim_commas(&line_tokens[comma_idx + 1..]);
+    }
+
+    let clause_words = crate::runtime_backend::token_word_refs(&line_tokens);
+    if clause_words.len() < 8 {
         return Ok(None);
     }
-    let (_subject_len, you_control) = if word_slice_starts_with(
+    let subject_is_source = word_slice_find_word_where(&clause_words, |word| word == "can")
+        .and_then(|can_idx| {
+            (clause_words.get(can_idx + 1) == Some(&"block"))
+                .then(|| &clause_words[..can_idx])
+        })
+        .is_some_and(|subject_words| {
+            word_slice_eq(subject_words, &["it"]) || is_source_reference_words(subject_words)
+        });
+    let you_control = if word_slice_starts_with(
         &clause_words,
         &["each", "creature", "you", "control", "can", "block"],
     ) {
-        (4usize, true)
+        true
     } else if word_slice_starts_with(&clause_words, &["each", "creature", "can", "block"]) {
-        (2usize, false)
+        false
+    } else if subject_is_source {
+        false
     } else {
         return Ok(None);
     };
@@ -1251,12 +1274,25 @@ pub(crate) fn parse_each_creature_can_block_additional_creature_each_combat_line
     let mut additional = 1usize;
     let prev = clause_words[additional_word_idx - 1];
     if prev != "an" {
-        if let Some(prev_token_idx) = token_index_for_word_index(tokens, additional_word_idx - 1)
-            && let Some((count, used)) = parse_number(&tokens[prev_token_idx..])
+        if let Some(prev_token_idx) =
+            token_index_for_word_index(&line_tokens, additional_word_idx - 1)
+            && let Some((count, used)) = parse_number(&line_tokens[prev_token_idx..])
             && used > 0
         {
             additional = count as usize;
         }
+    }
+
+    let granted = StaticAbility::can_block_additional_creature_each_combat(additional);
+    if subject_is_source {
+        let ability = StaticAbilityAst::Static(granted);
+        return Ok(Some(match condition {
+            Some(condition) => StaticAbilityAst::ConditionalStaticAbility {
+                ability: Box::new(ability),
+                condition,
+            },
+            None => ability,
+        }));
     }
 
     let filter = if you_control {
@@ -1264,11 +1300,10 @@ pub(crate) fn parse_each_creature_can_block_additional_creature_each_combat_line
     } else {
         ObjectFilter::creature()
     };
-    let granted = StaticAbility::can_block_additional_creature_each_combat(additional);
     Ok(Some(StaticAbilityAst::GrantStaticAbility {
         filter,
         ability: Box::new(StaticAbilityAst::Static(granted)),
-        condition: None,
+        condition,
     }))
 }
 
@@ -2293,6 +2328,9 @@ pub(crate) fn parse_static_condition_clause(
     ) {
         return Ok(crate::ConditionExpr::SourceIsSoulbondPaired);
     }
+    if let Some(condition) = parse_source_is_descriptor_static_condition(&tokens, &clause_words)? {
+        return Ok(condition);
+    }
     if word_slice_eq_any(
         &clause_words,
         &[
@@ -2911,6 +2949,46 @@ pub(crate) fn parse_static_condition_clause(
         "unsupported static condition clause (clause: '{}')",
         clause_words.join(" ")
     )))
+}
+
+fn parse_source_is_descriptor_static_condition(
+    _tokens: &[OwnedLexToken],
+    clause_words: &[&str],
+) -> Result<Option<crate::ConditionExpr>, CardTextError> {
+    let Some(is_idx) = word_slice_find_word_where(clause_words, |word| word == "is") else {
+        return Ok(None);
+    };
+    let subject_words = &clause_words[..is_idx];
+    if !is_source_reference_words(subject_words) {
+        return Ok(None);
+    }
+
+    let mut descriptor_words = &clause_words[is_idx + 1..];
+    if descriptor_words.first().is_some_and(|word| is_article(word)) {
+        descriptor_words = &descriptor_words[1..];
+    }
+    if descriptor_words.len() != 1 {
+        return Ok(None);
+    }
+
+    let descriptor = descriptor_words[0];
+    let mut filter = ObjectFilter::source();
+    if subject_words.len() == 2
+        && let Some(card_type) = parse_card_type(subject_words[1])
+    {
+        filter.all_card_types.push(card_type);
+    }
+    if let Some(card_type) = parse_card_type(descriptor) {
+        filter.all_card_types.push(card_type);
+    } else if let Some(color) = parse_color(descriptor) {
+        filter.colors = Some(color);
+    } else if let Some(subtype) = parse_subtype_flexible(descriptor) {
+        filter = filter.with_subtype(subtype);
+    } else {
+        return Ok(None);
+    }
+
+    Ok(Some(crate::ConditionExpr::SourceMatches(filter)))
 }
 
 fn parse_devotion_static_condition(

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -748,6 +748,10 @@ pub enum Condition {
     SourceIsMonstrous,
     SourceIsFaceDown,
     SourceMatches(ObjectFilter),
+    SourceMatchesWithDisplay {
+        filter: ObjectFilter,
+        display: String,
+    },
     SourceHasNoCounter(CounterType),
     SourceHasCounterAtLeast {
         counter_type: CounterType,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38968,6 +38968,156 @@ fn alena_kessig_trapper_mana_runtime_uses_only_your_creatures_that_entered_this_
 }
 
 #[test]
+fn foriysian_totem_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Foriysian Totem");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("{T}: Add {R}."),
+        "expected Foriysian Totem's red mana ability to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "As long as this artifact is a creature, it can block an additional creature each combat."
+        ),
+        "expected Foriysian Totem's conditional additional-block clause to render, got {rendered}"
+    );
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("CanBlockAdditionalCreatureEachCombat")
+            && ability_debug.contains("SourceMatches")
+            && ability_debug.contains("Artifact")
+            && ability_debug.contains("Creature"),
+        "expected Foriysian Totem to lower to a conditional additional-block static ability, got {ability_debug}"
+    );
+}
+
+#[test]
+fn foriysian_totem_animation_and_conditional_additional_blocker_runtime() {
+    fn create_attacker(
+        game: &mut crate::game_state::GameState,
+        controller: PlayerId,
+        name: &str,
+    ) -> ObjectId {
+        let def = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        game.create_object_from_definition(&def, controller, Zone::Battlefield)
+    }
+
+    fn combat_with_two_attackers(
+        game: &mut crate::game_state::GameState,
+        attacker_controller: PlayerId,
+        defending_player: PlayerId,
+    ) -> (crate::combat_state::CombatState, ObjectId, ObjectId) {
+        let attacker_one = create_attacker(game, attacker_controller, "Foriysian Attacker One");
+        let attacker_two = create_attacker(game, attacker_controller, "Foriysian Attacker Two");
+        let mut combat = crate::combat_state::CombatState::default();
+        combat.attackers.push(crate::combat_state::AttackerInfo {
+            creature: attacker_one,
+            target: crate::combat_state::AttackTarget::Player(defending_player),
+        });
+        combat.attackers.push(crate::combat_state::AttackerInfo {
+            creature: attacker_two,
+            target: crate::combat_state::AttackTarget::Player(defending_player),
+        });
+        (combat, attacker_one, attacker_two)
+    }
+
+    let def = parse_oracle_card_definition("Foriysian Totem");
+    let animate_effect = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .segments
+                .first()
+                .and_then(|segment| segment.default_effects.first()),
+            _ => None,
+        })
+        .expect("Foriysian Totem should have an animation activated ability");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let totem = game.create_object_from_definition(&def, bob, Zone::Battlefield);
+
+    assert!(
+        !game.current_has_card_type(totem, CardType::Creature),
+        "Foriysian Totem should start as a noncreature artifact"
+    );
+    assert!(
+        !game.current_has_static_ability_id(
+            totem,
+            StaticAbilityId::CanBlockAdditionalCreatureEachCombat
+        ),
+        "Foriysian Totem should not have the extra-blocker ability before it is a creature"
+    );
+
+    let (mut combat, attacker_one, attacker_two) = combat_with_two_attackers(&mut game, alice, bob);
+    let declarations = vec![
+        crate::decision::BlockerDeclaration {
+            blocker: totem,
+            blocking: attacker_one,
+        },
+        crate::decision::BlockerDeclaration {
+            blocker: totem,
+            blocking: attacker_two,
+        },
+    ];
+    assert!(
+        crate::game_loop::apply_blocker_declarations(
+            &mut game,
+            &mut combat,
+            &mut crate::triggers::TriggerQueue::new(),
+            &declarations,
+            bob,
+        )
+        .is_err(),
+        "noncreature Foriysian Totem must not be able to block, let alone block multiple attackers"
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(totem, bob, &mut dm);
+    crate::effects::execute_effect(&mut game, animate_effect, &mut ctx)
+        .expect("Foriysian Totem animation ability should resolve");
+
+    assert!(game.current_has_card_type(totem, CardType::Artifact));
+    assert!(game.current_has_card_type(totem, CardType::Creature));
+    assert!(game.current_has_subtype(totem, Subtype::Giant));
+    assert_eq!(game.calculated_power(totem), Some(4));
+    assert_eq!(game.calculated_toughness(totem), Some(4));
+    assert!(game.current_has_static_ability_id(totem, StaticAbilityId::Trample));
+    assert!(game.current_has_static_ability_id(
+        totem,
+        StaticAbilityId::CanBlockAdditionalCreatureEachCombat
+    ));
+
+    let (mut combat, attacker_one, attacker_two) = combat_with_two_attackers(&mut game, alice, bob);
+    let declarations = vec![
+        crate::decision::BlockerDeclaration {
+            blocker: totem,
+            blocking: attacker_one,
+        },
+        crate::decision::BlockerDeclaration {
+            blocker: totem,
+            blocking: attacker_two,
+        },
+    ];
+    crate::game_loop::apply_blocker_declarations(
+        &mut game,
+        &mut combat,
+        &mut crate::triggers::TriggerQueue::new(),
+        &declarations,
+        bob,
+    )
+    .expect("creature Foriysian Totem should block two attackers with its conditional ability");
+}
+
+#[test]
 fn when_we_were_young_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("When We Were Young");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -38986,8 +38986,7 @@ fn foriysian_totem_strict_parser_and_text_regression() {
     let ability_debug = format!("{:#?}", def.abilities);
     assert!(
         ability_debug.contains("CanBlockAdditionalCreatureEachCombat")
-            && ability_debug.contains("SourceMatches")
-            && ability_debug.contains("Artifact")
+            && ability_debug.contains("SourceMatchesWithDisplay")
             && ability_debug.contains("Creature"),
         "expected Foriysian Totem to lower to a conditional additional-block static ability, got {ability_debug}"
     );
@@ -39115,6 +39114,57 @@ fn foriysian_totem_animation_and_conditional_additional_blocker_runtime() {
         bob,
     )
     .expect("creature Foriysian Totem should block two attackers with its conditional ability");
+
+    let artifact_type_eraser = CardDefinitionBuilder::new(CardId::new(), "Artifact Type Eraser")
+        .card_types(vec![CardType::Enchantment])
+        .with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::new(
+                crate::static_abilities::RemoveCardTypesForFilter::new(
+                    crate::target::ObjectFilter::specific(totem),
+                    vec![CardType::Artifact],
+                ),
+            ),
+        ))
+        .build();
+    game.create_object_from_definition(&artifact_type_eraser, alice, Zone::Battlefield);
+
+    assert!(
+        !game.current_has_card_type(totem, CardType::Artifact),
+        "a later type-changing effect should remove Foriysian Totem's artifact type"
+    );
+    assert!(
+        game.current_has_card_type(totem, CardType::Creature),
+        "Foriysian Totem should remain a creature after losing artifact"
+    );
+    assert!(
+        game.current_has_static_ability_id(
+            totem,
+            StaticAbilityId::CanBlockAdditionalCreatureEachCombat
+        ),
+        "the conditional extra-blocker ability should depend on being a creature, not still being an artifact"
+    );
+
+    let (mut combat, attacker_one, attacker_two) = combat_with_two_attackers(&mut game, alice, bob);
+    let declarations = vec![
+        crate::decision::BlockerDeclaration {
+            blocker: totem,
+            blocking: attacker_one,
+        },
+        crate::decision::BlockerDeclaration {
+            blocker: totem,
+            blocking: attacker_two,
+        },
+    ];
+    crate::game_loop::apply_blocker_declarations(
+        &mut game,
+        &mut combat,
+        &mut crate::triggers::TriggerQueue::new(),
+        &declarations,
+        bob,
+    )
+    .expect(
+        "creature Foriysian Totem should still block two attackers after losing artifact type",
+    );
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11261,6 +11261,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 format!("this permanent is {}", ensure_indefinite_article(&desc))
             }
         }
+        Condition::SourceMatchesWithDisplay { display, .. } => display.clone(),
         Condition::SourceHasNoCounter(counter_type) => {
             format!("there are no {} counters on it", counter_type.description())
         }

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -880,6 +880,13 @@ fn evaluate_condition_shared_core(
                     .is_some_and(|obj| filter.matches(obj, &filter_ctx, game)),
             )
         }
+        Condition::SourceMatchesWithDisplay { filter, .. } => {
+            let filter_ctx = game.filter_context_for(ctx.controller, Some(ctx.source));
+            Some(
+                game.object(ctx.source)
+                    .is_some_and(|obj| filter.matches(obj, &filter_ctx, game)),
+            )
+        }
         Condition::SourceCameUnderYourControlThisTurn => {
             Some(game.object(ctx.source).is_some_and(|obj| {
                 game.turn_store
@@ -983,7 +990,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::SourceDevouredCreaturesOrMore(..) => {}
         Condition::SourceIsMonstrous => {}
         Condition::SourceIsFaceDown => {}
-        Condition::SourceMatches(..) => {}
+        Condition::SourceMatches(..) | Condition::SourceMatchesWithDisplay { .. } => {}
         Condition::SourceHasNoCounter(..) => {}
         Condition::SourceHasCounterAtLeast { .. } => {}
         Condition::SourceHasCountersAtLeast(..) => {}
@@ -1764,6 +1771,11 @@ pub fn evaluate_condition_external(
             game.object(ctx.source)
                 .is_some_and(|obj| filter.matches(obj, &filter_ctx, game))
         }
+        Condition::SourceMatchesWithDisplay { filter, .. } => {
+            let filter_ctx = game.filter_context_for(ctx.controller, Some(ctx.source));
+            game.object(ctx.source)
+                .is_some_and(|obj| filter.matches(obj, &filter_ctx, game))
+        }
         Condition::TargetMatches(filter) => {
             let filter_ctx = condition_filter_context(
                 game,
@@ -2526,6 +2538,7 @@ fn evaluate_condition_simple(
         | Condition::SourceIsMonstrous
         | Condition::SourceIsFaceDown
         | Condition::SourceMatches(_)
+        | Condition::SourceMatchesWithDisplay { .. }
         | Condition::SourcePowerAtLeast(_) => false,
         Condition::Custom(_)
         | Condition::LifeTotalOrLess(_)
@@ -3286,6 +3299,12 @@ fn evaluate_condition(
         Condition::SourceIsMonstrous => Ok(game.is_monstrous(ctx.source)),
         Condition::SourceIsFaceDown => Ok(source_is_face_down_or_alternate_face(game, ctx.source)),
         Condition::SourceMatches(filter) => {
+            let filter_ctx = ctx.filter_context(game);
+            Ok(game
+                .object(ctx.source)
+                .is_some_and(|obj| filter.matches(obj, &filter_ctx, game)))
+        }
+        Condition::SourceMatchesWithDisplay { filter, .. } => {
             let filter_ctx = ctx.filter_context(game);
             Ok(game
                 .object(ctx.source)

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -881,6 +881,86 @@ fn flatten_static_condition_and(
     }
 }
 
+fn describe_source_matches_condition(filter: &ObjectFilter) -> Option<String> {
+    if !filter.source {
+        return None;
+    }
+
+    let article = |word: &str| {
+        if word
+            .as_bytes()
+            .first()
+            .is_some_and(|byte| matches!(*byte, b'a' | b'e' | b'i' | b'o' | b'u'))
+        {
+            "an"
+        } else {
+            "a"
+        }
+    };
+    let typed_descriptor = |word: &str| format!("{} {word}", article(word));
+
+    if filter.all_card_types.len() == 2
+        && filter.card_types.is_empty()
+        && filter.subtypes.is_empty()
+        && filter.colors.is_none()
+    {
+        let subject = filter.all_card_types[0].name();
+        let descriptor = filter.all_card_types[1].name();
+        return Some(format!(
+            "as long as this {subject} is {}",
+            typed_descriptor(descriptor)
+        ));
+    }
+
+    let subject = filter
+        .all_card_types
+        .first()
+        .map(|card_type| format!("this {}", card_type.name()))
+        .unwrap_or_else(|| "it".to_string());
+    if filter.all_card_types.len() == 1
+        && filter.card_types.is_empty()
+        && filter.subtypes.is_empty()
+    {
+        let descriptor = filter.all_card_types[0].name();
+        return Some(format!(
+            "as long as {subject} is {}",
+            typed_descriptor(descriptor)
+        ));
+    }
+    if filter.all_card_types.len() <= 1
+        && filter.card_types.len() == 1
+        && filter.subtypes.is_empty()
+    {
+        let descriptor = filter.card_types[0].name();
+        return Some(format!(
+            "as long as {subject} is {}",
+            typed_descriptor(descriptor)
+        ));
+    }
+    if filter.all_card_types.len() <= 1
+        && filter.card_types.is_empty()
+        && filter.subtypes.len() == 1
+    {
+        let descriptor = filter.subtypes[0].display_name();
+        return Some(format!(
+            "as long as {subject} is {}",
+            typed_descriptor(&descriptor)
+        ));
+    }
+    if filter.all_card_types.len() <= 1
+        && filter.card_types.is_empty()
+        && filter.subtypes.is_empty()
+        && let Some(colors) = filter.colors
+    {
+        let colors = color_list(colors);
+        if !colors.is_empty() {
+            return Some(format!("as long as {subject} is {}", join_with_and(&colors)));
+        }
+    }
+
+    None
+}
+
 pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> String {
     match condition {
         crate::ConditionExpr::And(_, _) => {
@@ -977,6 +1057,8 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::SourceIsSoulbondPaired => {
             "as long as this creature is paired with another creature".to_string()
         }
+        crate::ConditionExpr::SourceMatches(filter) => describe_source_matches_condition(filter)
+            .unwrap_or_else(|| format!("as long as {filter:?}")),
         crate::ConditionExpr::PlayerHasCardTypesInGraveyardOrMore { player, count } => {
             let graveyard_owner = match player {
                 crate::target::PlayerFilter::You => "your".to_string(),
@@ -2088,6 +2170,15 @@ impl StaticAbilityKind for GrantAbility {
             }
         };
         if let Some(condition) = &self.condition {
+            if self.source_only
+                && self.ability.id() == StaticAbilityId::CanBlockAdditionalCreatureEachCombat
+            {
+                let condition_text = describe_static_condition(condition);
+                if let Some(rest) = condition_text.strip_prefix("as long as ") {
+                    let ability_text = raw_ability_text.to_ascii_lowercase();
+                    return format!("as long as {rest}, it {ability_text}");
+                }
+            }
             if self.source_only
                 && self.ability.is_keyword()
                 && leading_source_keyword_condition(condition)

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1059,6 +1059,9 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         }
         crate::ConditionExpr::SourceMatches(filter) => describe_source_matches_condition(filter)
             .unwrap_or_else(|| format!("as long as {filter:?}")),
+        crate::ConditionExpr::SourceMatchesWithDisplay { display, .. } => {
+            format!("as long as {display}")
+        }
         crate::ConditionExpr::PlayerHasCardTypesInGraveyardOrMore { player, count } => {
             let graveyard_owner = match player {
                 crate::target::PlayerFilter::You => "your".to_string(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Foriysian Totem
Initial parse error:
```
unsupported static condition clause (clause: 'this artifact is a creature'); oracle-only fallback also failed: unsupported static condition clause (clause: 'this artifact is a creature')
```

Current worker: i-0e345e5d9a1794753
Branch: codex/aws-card-fix-foriysian-totem
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0015
