### PR TITLE
Fix Ironsmith parse failure: From Under the Floorboards

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
@@ -36,34 +36,44 @@ pub(crate) fn compile_statement_effects_with_imports(
 pub(crate) fn materialize_prepared_statement_effects(
     prepared: &PreparedEffectsForLowering,
 ) -> Result<LoweredEffects, CardTextError> {
-    if let [
+    if let Some((
         EffectAst::SelfReplacement {
             predicate,
             if_true,
             if_false,
         },
-    ] = prepared.effects.as_slice()
+        prefix_effects,
+    )) = prepared.effects.split_last()
+        && prefix_effects
+            .iter()
+            .all(|effect| !matches!(effect, EffectAst::SelfReplacement { .. }))
     {
-        let default_effects =
-            compile_statement_effects_with_imports(if_false, &prepared.imports)?.effects;
-        let replacement_effects =
-            compile_statement_effects_with_imports(if_true, &prepared.imports)?.effects;
+        let prefix_lowered =
+            compile_statement_effects_with_imports(prefix_effects, &prepared.imports)?;
+        let default_lowered = compile_statement_effects_with_imports(if_false, &prepared.imports)?;
+        let replacement_lowered =
+            compile_statement_effects_with_imports(if_true, &prepared.imports)?;
         let condition = compile_condition_from_predicate_ast_with_env(
             predicate,
             &prepared.initial_env,
             prepared.imports.last_object_tag.as_ref(),
         )?;
+        let mut default_effects = prefix_lowered.effects.flattened_default_effects().to_vec();
+        default_effects.extend(default_lowered.effects.flattened_default_effects().to_vec());
+        let mut choices = prefix_lowered.choices;
+        choices.extend(default_lowered.choices);
+        choices.extend(replacement_lowered.choices);
         return Ok(LoweredEffects {
             effects: crate::resolution::ResolutionProgram::new(vec![
                 crate::resolution::ResolutionSegment {
-                    default_effects: default_effects.flattened_default_effects().to_vec(),
+                    default_effects,
                     self_replacements: vec![crate::resolution::SelfReplacementBranch::new(
                         condition,
-                        replacement_effects.flattened_default_effects().to_vec(),
+                        replacement_lowered.effects.flattened_default_effects().to_vec(),
                     )],
                 },
             ]),
-            choices: Vec::new(),
+            choices,
             exports: prepared.exports.clone(),
         });
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/line_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/line_lowering.rs
@@ -4,7 +4,9 @@ use crate::cards::builders::{
     PlayerAst, StaticAbilityAst, TriggerSpec,
 };
 use crate::runtime_backend::activation_and_restrictions::last_created_token_info;
-use crate::runtime_backend::effect_ast_traversal::for_each_nested_effects_mut;
+use crate::runtime_backend::effect_ast_traversal::{
+    for_each_nested_effects, for_each_nested_effects_mut,
+};
 use crate::runtime_backend::lexer::{word_slice_contains_any_word, word_slice_contains_phrase};
 use crate::target::{ChooseSpec, PlayerFilter};
 use crate::zone::Zone;
@@ -108,6 +110,136 @@ fn rewrite_prior_token_placeholders(effects: &mut [EffectAst], token_info: &(Str
             }
         });
     }
+}
+
+fn rewrite_prior_token_placeholder_effect_from_template(
+    effect: &mut EffectAst,
+    template: &(SubjectVerbActionAst, PlayerAst),
+) {
+    let (template_action, template_player) = template;
+    let SubjectVerbActionAst::CreateTokenWithMods {
+        name: template_name,
+        dynamic_power_toughness: template_dynamic_power_toughness,
+        player: template_action_player,
+        attached_to: template_attached_to,
+        tapped: template_tapped,
+        attacking: template_attacking,
+        exile_at_end_of_combat: template_exile_at_end_of_combat,
+        sacrifice_at_end_of_combat: template_sacrifice_at_end_of_combat,
+        sacrifice_at_next_end_step: template_sacrifice_at_next_end_step,
+        exile_at_next_end_step: template_exile_at_next_end_step,
+        granted_abilities: template_granted_abilities,
+        ..
+    } = template_action
+    else {
+        return;
+    };
+    if let EffectAst::SubjectVerb(subject_verb) = effect
+        && let SubjectVerbActionAst::CreateTokenWithMods {
+            name,
+            dynamic_power_toughness,
+            player,
+            attached_to,
+            tapped,
+            attacking,
+            exile_at_end_of_combat,
+            sacrifice_at_end_of_combat,
+            sacrifice_at_next_end_step,
+            exile_at_next_end_step,
+            granted_abilities,
+            ..
+        } = &mut subject_verb.action
+        && matches!(name.as_str(), "of those" | "those")
+    {
+        *name = template_name.clone();
+        *dynamic_power_toughness = template_dynamic_power_toughness.clone();
+        *player = *template_action_player;
+        *attached_to = template_attached_to.clone();
+        *tapped = *template_tapped;
+        *attacking = *template_attacking;
+        *exile_at_end_of_combat = *template_exile_at_end_of_combat;
+        *sacrifice_at_end_of_combat = *template_sacrifice_at_end_of_combat;
+        *sacrifice_at_next_end_step = *template_sacrifice_at_next_end_step;
+        *exile_at_next_end_step = *template_exile_at_next_end_step;
+        *granted_abilities = template_granted_abilities.clone();
+        subject_verb.subject.player = *template_player;
+    }
+}
+
+fn rewrite_prior_token_placeholders_from_template(
+    effects: &mut [EffectAst],
+    template: &(SubjectVerbActionAst, PlayerAst),
+) {
+    for effect in effects {
+        rewrite_prior_token_placeholder_effect_from_template(effect, template);
+        for_each_nested_effects_mut(effect, true, |nested| {
+            for nested_effect in nested {
+                rewrite_prior_token_placeholder_effect_from_template(nested_effect, template);
+            }
+        });
+    }
+}
+
+fn effect_references_prior_token_placeholder(effect: &EffectAst) -> bool {
+    if let EffectAst::SubjectVerb(subject_verb) = effect
+        && let SubjectVerbActionAst::CreateTokenWithMods { name, .. } = &subject_verb.action
+        && matches!(name.as_str(), "of those" | "those")
+    {
+        return true;
+    }
+
+    let mut found = false;
+    for_each_nested_effects(effect, true, |nested| {
+        if !found {
+            found = nested.iter().any(effect_references_prior_token_placeholder);
+        }
+    });
+    found
+}
+
+fn created_token_template_from_effect(
+    effect: &EffectAst,
+) -> Option<(SubjectVerbActionAst, PlayerAst)> {
+    match effect {
+        EffectAst::SubjectVerb(subject_verb) => match &subject_verb.action {
+            SubjectVerbActionAst::CreateTokenWithMods { .. } => {
+                Some((subject_verb.action.clone(), subject_verb.subject.player))
+            }
+            _ => {
+                let mut found = None;
+                for_each_nested_effects(effect, true, |nested| {
+                    if found.is_none() {
+                        found = token_template_before_prior_token_placeholder(nested);
+                    }
+                });
+                found
+            }
+        },
+        _ => {
+            let mut found = None;
+            for_each_nested_effects(effect, true, |nested| {
+                if found.is_none() {
+                    found = token_template_before_prior_token_placeholder(nested);
+                }
+            });
+            found
+        }
+    }
+}
+
+fn token_template_before_prior_token_placeholder(
+    effects: &[EffectAst],
+) -> Option<(SubjectVerbActionAst, PlayerAst)> {
+    let mut latest_token_template = None;
+    for effect in effects {
+        if effect_references_prior_token_placeholder(effect) {
+            return latest_token_template;
+        }
+        if let Some(token_template) = created_token_template_from_effect(effect) {
+            latest_token_template = Some(token_template);
+        }
+    }
+    None
 }
 
 fn compile_trailing_instead_if_condition(
@@ -935,7 +1067,13 @@ fn lower_statement_chunk(
     }) {
         builder.aura_attach_filter = Some(enchant_filter);
     }
-    if let Some(token_info) = state.latest_created_token.clone() {
+    if let Some(token_template) = token_template_before_prior_token_placeholder(&prepared.effects) {
+        rewrite_prior_token_placeholders_from_template(&mut prepared.effects, &token_template);
+        prepared = super::rewrite_prepare_effects_for_lowering(
+            &prepared.effects,
+            prepared.imports.clone(),
+        )?;
+    } else if let Some(token_info) = state.latest_created_token.clone() {
         rewrite_prior_token_placeholders(&mut prepared.effects, &token_info);
         prepared = super::rewrite_prepare_effects_for_lowering(
             &prepared.effects,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -44686,6 +44686,31 @@ fn parse_aangs_journey_kicked_search_slots_as_self_replacement() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_from_under_the_floorboards_madness_self_replacement() {
+    let def = parse_oracle_card_definition("From Under the Floorboards");
+    let debug = format!("{:#?}", def.spell_effect);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        debug.contains("SelfReplacementBranch")
+            && debug.contains("ThisSpellPaidLabel")
+            && debug.contains("Madness")
+            && debug.contains("CreateTokenEffect")
+            && debug.contains("enters_tapped: true")
+            && debug.contains("GainLifeEffect"),
+        "expected From Under the Floorboards to lower madness as a tapped-token/life self-replacement, got {debug}"
+    );
+    assert!(
+        rendered.contains("Create three tapped 2/2 black Zombie creature tokens and you gain 3 life")
+            && rendered.contains("If this spell's madness cost was paid, instead create X of those tokens and you gain X life")
+            && rendered.contains("Madness {X}{B}{B}")
+            && !rendered.contains("token tokens"),
+        "expected From Under the Floorboards compiled text to preserve the madness replacement clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_kicked_multi_zone_search_to_battlefield_as_self_replacement() {
     let def = CardDefinitionBuilder::new(CardId::new(), "The Five Doctors Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -483,10 +483,118 @@ fn describe_single_self_replacement_segment(
     ) {
         return Some(counter_unless_text);
     }
+    if let Some(token_life_text) = describe_token_life_self_replacement(
+        &segment.default_effects,
+        &branch.replacement_effects,
+        &condition_text,
+    ) {
+        return Some(token_life_text);
+    }
     Some(format!(
         "{default_text}. If {condition_text}, {} instead",
         rewrite_self_replacement_referent_phrase(&default_text, &replacement_text)
     ))
+}
+
+fn describe_token_life_self_replacement(
+    default_effects: &[Effect],
+    replacement_effects: &[Effect],
+    condition_text: &str,
+) -> Option<String> {
+    let default_create = token_life_create_effect(default_effects)?;
+    let replacement_create = token_life_create_effect(replacement_effects)?;
+    if !same_token_life_replacement_token(default_create, replacement_create) {
+        return None;
+    }
+
+    let default_clause = describe_token_life_clause(default_effects, false)?;
+    let replacement_clause = describe_token_life_clause(replacement_effects, true)?;
+    Some(format!(
+        "{default_clause}. If {condition_text}, instead {replacement_clause}"
+    ))
+}
+
+fn token_life_create_effect(effects: &[Effect]) -> Option<&crate::effects::CreateTokenEffect> {
+    let [create_effect, gain_effect] = effects else {
+        return None;
+    };
+    let create = unwrap_tagged_effect(create_effect)
+        .downcast_ref::<crate::effects::CreateTokenEffect>()?;
+    let gain = unwrap_tagged_effect(gain_effect).downcast_ref::<crate::effects::GainLifeEffect>()?;
+    if create.controller != PlayerFilter::You
+        || create.controller_target.is_some()
+        || create.enters_attacking
+        || create.exile_at_end_of_combat
+        || create.sacrifice_at_end_of_combat
+        || create.sacrifice_at_next_end_step
+        || create.exile_at_next_end_step
+        || gain.player != ChooseSpec::Player(PlayerFilter::You)
+    {
+        return None;
+    }
+    Some(create)
+}
+
+fn same_token_life_replacement_token(
+    default_create: &crate::effects::CreateTokenEffect,
+    replacement_create: &crate::effects::CreateTokenEffect,
+) -> bool {
+    describe_token_blueprint(&default_create.token)
+        == describe_token_blueprint(&replacement_create.token)
+        && default_create.enters_tapped == replacement_create.enters_tapped
+}
+
+fn describe_token_life_clause(effects: &[Effect], refer_to_prior_token: bool) -> Option<String> {
+    let [create_effect, gain_effect] = effects else {
+        return None;
+    };
+    let create = unwrap_tagged_effect(create_effect)
+        .downcast_ref::<crate::effects::CreateTokenEffect>()?;
+    let gain = unwrap_tagged_effect(gain_effect).downcast_ref::<crate::effects::GainLifeEffect>()?;
+    let created = if refer_to_prior_token {
+        format!("{} of those tokens", describe_value(&create.count))
+    } else {
+        describe_create_token_amount(create)
+    };
+    Some(format!(
+        "create {created} and you gain {} life",
+        describe_value(&gain.amount)
+    ))
+}
+
+fn describe_create_token_amount(create: &crate::effects::CreateTokenEffect) -> String {
+    let mut token = describe_token_blueprint(&create.token);
+    if create.enters_tapped {
+        token = format!("tapped {token}");
+    }
+    match create.count.unhinted() {
+        Value::Fixed(1) => format!("a {}", singular_token_phrase(&token)),
+        Value::Fixed(n) => {
+            let count = number_word(*n).unwrap_or_else(|| n.to_string());
+            format!("{count} {}", plural_token_phrase(&token))
+        }
+        _ => format!(
+            "{} {}",
+            describe_value(&create.count),
+            plural_token_phrase(&token)
+        ),
+    }
+}
+
+fn singular_token_phrase(token: &str) -> String {
+    if token.ends_with(" token") {
+        token.to_string()
+    } else {
+        format!("{token} token")
+    }
+}
+
+fn plural_token_phrase(token: &str) -> String {
+    if let Some(stem) = token.strip_suffix(" token") {
+        format!("{stem} tokens")
+    } else {
+        format!("{token} tokens")
+    }
 }
 
 fn unwrap_tagged_effect(mut effect: &Effect) -> &Effect {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -248,6 +248,123 @@ fn ox_tokens_controlled_by(game: &GameState, player: PlayerId) -> Vec<ObjectId> 
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn from_under_the_floorboards_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_210), "From Under the Floorboards")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Madness {X}{B}{B}\n\
+             Create three tapped 2/2 black Zombie creature tokens and you gain 3 life. If this spell's madness cost was paid, instead create X of those tokens and you gain X life.",
+        )
+        .expect("From Under the Floorboards should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn zombie_tokens_controlled_by(game: &GameState, player: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|&id| {
+            game.object(id).is_some_and(|object| {
+                game.controller_of(object) == player
+                    && object.kind == ObjectKind::Token
+                    && object.name == "Zombie"
+                    && object.card_types.contains(&CardType::Creature)
+                    && object.subtypes.contains(&Subtype::Zombie)
+                    && game.current_power(id) == Some(2)
+                    && game.current_toughness(id) == Some(2)
+                    && game.current_colors(id) == Some(crate::color::ColorSet::BLACK)
+            })
+        })
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_from_under_the_floorboards_on_stack(
+    game: &mut GameState,
+    player: PlayerId,
+    paid_madness: bool,
+    x_value: Option<u32>,
+) {
+    let def = from_under_the_floorboards_definition();
+    assert!(
+        def.alternative_casts.iter().any(|method| matches!(
+            method,
+            crate::alternative_cast::AlternativeCastingMethod::Madness { cost }
+                if cost.to_oracle() == "{X}{B}{B}"
+        )),
+        "From Under the Floorboards should expose its madness alternative cost"
+    );
+    let spell_id = game.create_object_from_definition(&def, player, Zone::Stack);
+    if let Some(spell) = game.object_mut(spell_id) {
+        spell.x_value = x_value;
+        if paid_madness {
+            spell.optional_costs_paid.mark_label_paid("Madness");
+        }
+    }
+    let stable_id = game.object(spell_id).expect("spell on stack").stable_id;
+    let mut entry = StackEntry::new(spell_id, player)
+        .with_source_info(stable_id, "From Under the Floorboards".to_string());
+    if let Some(x) = x_value {
+        entry = entry.with_x(x);
+    }
+    game.push_to_stack(entry);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn from_under_the_floorboards_without_madness_uses_default_token_and_life_branch() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    put_from_under_the_floorboards_on_stack(&mut game, alice, false, Some(2));
+    resolve_stack_entry(&mut game).expect("From Under the Floorboards should resolve normally");
+
+    let zombies = zombie_tokens_controlled_by(&game, alice);
+    assert_eq!(zombies.len(), 3, "normal branch should create three Zombies");
+    assert!(
+        zombies.iter().all(|id| game.is_tapped(*id)),
+        "normal branch Zombies should enter tapped"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        23,
+        "normal branch should gain 3 life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn from_under_the_floorboards_paid_madness_uses_x_token_and_life_branch() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    put_from_under_the_floorboards_on_stack(&mut game, alice, true, Some(2));
+    resolve_stack_entry(&mut game)
+        .expect("From Under the Floorboards should resolve with madness paid");
+
+    let zombies = zombie_tokens_controlled_by(&game, alice);
+    assert_eq!(
+        zombies.len(),
+        2,
+        "paid madness branch should replace the default with X Zombies"
+    );
+    assert!(
+        zombies.iter().all(|id| game.is_tapped(*id)),
+        "paid madness branch Zombies should also enter tapped"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        22,
+        "paid madness branch should gain X life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn put_test_cards_in_zone(game: &mut GameState, player: PlayerId, zone: Zone, count: u32) {
     for index in 0..count {
         let card = CardBuilder::new(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: From Under the Floorboards
Initial parse error:
```
missing compile-effect dispatch route for effect variant: SelfReplacement { predicate: ThisSpellPaidLabel("Madness"), if_true: [SubjectVerb(SubjectVerb { subject: SubjectVerbSubject { role: Actor, player: Implicit }, action: CreateTokenWithMods { name: "of those", count: X, player: Implicit } }), SubjectVerb(SubjectVerb { subject: SubjectVerbSubject { role: AffectedPlayer, player: You }, action: GainLife(X) })], if_false: [SubjectVerb(SubjectVerb { subject: SubjectVerbSubject { role: AffectedPlayer, player: You }, action: GainLife(Fixed(3)) })] }; oracle-only fallback also failed: missing compile-effect dispatch route for effect variant: SelfReplacement { predicate: ThisSpellPaidLabel("Madness"), if_true: [SubjectVerb(SubjectVerb { subject: SubjectVerbSubject { role: Actor, player: Implicit }, action: CreateTokenWithMods { name: "of those", count: X, player: Implicit } }), SubjectVerb(SubjectVerb { subject: SubjectVerbSubject { role: AffectedPlayer, player: You }, action: GainLife(X) })], if_false: [SubjectVerb(SubjectVerb { subject: SubjectVerbSubject { role: AffectedPlayer, player: You }, action: GainLife(Fixed(3)) })] }
```

Current worker: i-08f4a87684a3860b0
Branch: codex/aws-card-fix-from-under-the-floorboards
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0015
