### PR TITLE
Fix Ironsmith parse failure: Dance of the Manse

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -104,6 +104,64 @@ fn rest_starts_all_abilities_shared_gain(tokens: &[OwnedLexToken]) -> bool {
             .is_some_and(|word| matches!(word, "gain" | "gains"))
 }
 
+fn is_tagged_object_reference(words: &[&str]) -> bool {
+    word_slice_eq_any(
+        words,
+        &[
+            &["it"],
+            &["they"],
+            &["them"],
+            &["that"],
+            &["that", "card"],
+            &["that", "creature"],
+            &["that", "permanent"],
+            &["that", "object"],
+            &["those"],
+            &["those", "cards"],
+            &["those", "creatures"],
+            &["those", "permanents"],
+            &["those", "objects"],
+        ],
+    )
+}
+
+fn parse_copular_base_pt_animation_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let clause = LexedClause::new(tokens).trimmed();
+    let words = clause.word_refs();
+    let Some(copula_idx) = words.iter().position(|word| matches!(*word, "is" | "are")) else {
+        return Ok(None);
+    };
+    if copula_idx == 0 || copula_idx + 1 >= words.len() {
+        return Ok(None);
+    }
+
+    let rest_words = &words[copula_idx + 1..];
+    if parse_pt_modifier(rest_words[0]).is_err()
+        || !rest_words
+            .iter()
+            .any(|word| matches!(*word, "creature" | "creatures"))
+        || !word_slice_contains_phrase(rest_words, &["in", "addition", "to"])
+    {
+        return Ok(None);
+    }
+
+    let Some(subject_clause) = clause.before_word(copula_idx) else {
+        return Ok(None);
+    };
+    let Some(rest_clause) = clause.from_word(copula_idx + 1) else {
+        return Ok(None);
+    };
+    let subject_tokens = subject_clause.trimmed_tokens();
+    let rest_tokens = rest_clause.trimmed_tokens();
+    if subject_tokens.is_empty() || rest_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    parse_become_clause(subject_tokens, rest_tokens).map(Some)
+}
+
 #[derive(Debug, Clone, Copy)]
 struct PlayerObjectClause<'a> {
     subject: SubjectAst,
@@ -716,6 +774,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     }
 
     if let Some(effect) = parse_has_base_power_toughness_clause(tokens)? {
+        return Ok(effect);
+    }
+
+    if let Some(effect) = parse_copular_base_pt_animation_clause(tokens)? {
         return Ok(effect);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
@@ -144,7 +144,7 @@ pub(crate) fn parse_become_clause(
     }
 
     let mut target = if target_subject_words.is_empty()
-        || word_slice_eq_any(&target_subject_words, &[&["it"], &["they"], &["them"]])
+        || super::is_tagged_object_reference(&target_subject_words)
     {
         TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(subject_tokens))
     } else if word_slice_eq_any(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -6139,6 +6139,31 @@ fn life_lost_this_way_lowers_to_prior_effect_metric() {
 }
 
 #[test]
+fn dance_of_the_manse_strict_parser_lowers_returned_permanent_animation() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Dance of the Manse")
+        .mana_cost(crate::mana::ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Return up to X target artifact and/or non-Aura enchantment cards each with mana value X or less from your graveyard to the battlefield. If X is 6 or more, those permanents are 4/4 creatures in addition to their other types.",
+        )
+        .expect("Dance of the Manse should parse strictly");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("ReturnFromGraveyardToBattlefieldEffect")
+            && debug.contains("XValueAtLeast")
+            && debug.contains("ApplyContinuousEffect")
+            && debug.contains("AddCardTypes")
+            && debug.contains("SetPowerToughness"),
+        "expected Dance of the Manse to return cards and conditionally animate returned permanents, got {debug}"
+    );
+}
+
+#[test]
 fn gain_life_equal_to_the_power_of_target_creature_you_control_parses() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Wall of Reverence Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7116,11 +7116,18 @@ pub(super) fn describe_choose_spec_without_graveyard_zone(spec: &ChooseSpec) -> 
                     }
                 };
                 if let Some(stripped) = text.strip_suffix(&suffix) {
-                    return ensure_indefinite_article(stripped);
+                    return ensure_indefinite_article(
+                        &render_artifact_non_aura_enchantment_text(filter, stripped),
+                    );
                 }
-                return ensure_indefinite_article(&text);
+                return ensure_indefinite_article(&render_artifact_non_aura_enchantment_text(
+                    filter, &text,
+                ));
             }
-            ensure_indefinite_article(&filter.description())
+            ensure_indefinite_article(&render_artifact_non_aura_enchantment_text(
+                filter,
+                &filter.description(),
+            ))
         }
         ChooseSpec::PlayerOrPlaneswalker(filter) => match filter {
             PlayerFilter::Opponent => "target opponent or planeswalker".to_string(),
@@ -7164,7 +7171,10 @@ pub(super) fn describe_choose_spec_without_graveyard_zone(spec: &ChooseSpec) -> 
                 if let ChooseSpec::Target(target_inner) = inner.as_ref() {
                     let target_desc = describe_choose_spec_without_graveyard_zone(target_inner);
                     let base = strip_leading_article(&target_desc);
-                    let plural = pluralize_noun_phrase(base);
+                    let plural = render_counted_artifact_non_aura_enchantment_text(
+                        target_inner,
+                        &pluralize_noun_phrase(base),
+                    );
                     let count_text =
                         |n: usize| number_word(n as i32).unwrap_or_else(|| n.to_string());
                     if count.is_up_to_dynamic_x() {
@@ -7242,6 +7252,58 @@ pub(super) fn describe_choose_spec_without_graveyard_zone(spec: &ChooseSpec) -> 
         }
         _ => describe_choose_spec(spec),
     }
+}
+
+fn is_artifact_non_aura_enchantment_mana_value_filter(filter: &ObjectFilter) -> bool {
+    let has_artifact_enchantment_types = filter.card_types.len() == 2
+        && filter.card_types.contains(&CardType::Artifact)
+        && filter.card_types.contains(&CardType::Enchantment);
+    if !has_artifact_enchantment_types
+        || filter.excluded_subtypes != [Subtype::Aura]
+        || filter.mana_value.is_none()
+    {
+        return false;
+    }
+
+    let mut remaining = filter.clone();
+    remaining.zone = None;
+    remaining.owner = None;
+    remaining.single_graveyard = false;
+    remaining.card_types.clear();
+    remaining.excluded_subtypes.clear();
+    remaining.mana_value = None;
+    remaining == ObjectFilter::default()
+}
+
+fn render_artifact_non_aura_enchantment_text(filter: &ObjectFilter, text: &str) -> String {
+    if !is_artifact_non_aura_enchantment_mana_value_filter(filter) {
+        return text.to_string();
+    }
+
+    let Some((_, mana_value_text)) = text.split_once(" with mana value ") else {
+        return text.to_string();
+    };
+    let mana_value_text = mana_value_text.trim();
+    if text.contains("artifacts or enchantment cards with mana value") {
+        format!("artifact and/or non-Aura enchantment cards each with mana value {mana_value_text}")
+    } else if text.contains("artifact or enchantment card with mana value") {
+        format!("artifact and/or non-Aura enchantment card with mana value {mana_value_text}")
+    } else {
+        text.to_string()
+    }
+}
+
+fn render_counted_artifact_non_aura_enchantment_text(spec: &ChooseSpec, text: &str) -> String {
+    let ChooseSpec::Object(filter) = spec else {
+        return text.to_string();
+    };
+    if !is_artifact_non_aura_enchantment_mana_value_filter(filter) {
+        return text.to_string();
+    }
+    text.replace(
+        "artifact and/or non-Aura enchantment cards with mana value",
+        "artifact and/or non-Aura enchantment cards each with mana value",
+    )
 }
 
 pub(super) fn describe_choice_count(count: &ChoiceCount) -> String {
@@ -9077,6 +9139,11 @@ pub(super) fn describe_apply_continuous_animation_effect(
         }
     }
 
+    let returned_permanent_animation = effect.until == Until::Forever
+        && matches!(
+            effect.target_spec.as_ref(),
+            Some(ChooseSpec::Tagged(tag)) if tag.as_str().starts_with("returned_")
+        );
     let preserves_land_types = effect
         .target_spec
         .as_ref()
@@ -9085,6 +9152,8 @@ pub(super) fn describe_apply_continuous_animation_effect(
     let (target_text, plural_target) =
         if let Some(target_text) = plural_non_target_land_animation_target(effect) {
             (target_text, true)
+        } else if returned_permanent_animation {
+            ("those permanents".to_string(), true)
         } else {
             (target.to_string(), plural_target)
         };
@@ -9127,7 +9196,9 @@ pub(super) fn describe_apply_continuous_animation_effect(
     let mut text = if let (Some(power), Some(toughness)) = (power, toughness) {
         let pt = format!("{}/{}", describe_value(power), describe_value(toughness));
         let pt_noun_phrase = format!("{pt} {noun_phrase}");
-        if plural_target {
+        if returned_permanent_animation {
+            format!("{target_text} are {pt_noun_phrase}")
+        } else if plural_target {
             format!("{target_text} become {pt_noun_phrase}")
         } else {
             format!(
@@ -9160,7 +9231,8 @@ pub(super) fn describe_apply_continuous_animation_effect(
         .is_some_and(choose_spec_guarantees_artifact);
     let artifact_type_is_redundant = target_is_guaranteed_artifact && adds_artifact_type;
     let render_as_addition_to_other_types =
-        (!preserves_land_types && !ability_text.is_empty() && !has_generic_ability)
+        returned_permanent_animation
+            || (!preserves_land_types && !ability_text.is_empty() && !has_generic_ability)
             || (preserves_land_types
                 && adds_named_types
                 && effect

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3338,6 +3338,32 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         matches!(apply.target_spec.as_ref(), Some(ChooseSpec::Tagged(candidate)) if candidate == tag)
     }
 
+    fn describe_return_then_conditional_animation(effects: &[Effect]) -> Option<String> {
+        let [return_effect, conditional_effect] = effects else {
+            return None;
+        };
+        let returned_tag = effect_tag(return_effect)?;
+        unwrap_wrapped_effect(return_effect)
+            .downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()?;
+        let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+            return None;
+        }
+        let apply = tagged_apply_continuous(&conditional.if_true[0])?;
+        if !apply_targets_tag(apply, returned_tag) {
+            return None;
+        }
+
+        let return_text = describe_effect(return_effect);
+        let animation_text = describe_effect(&conditional.if_true[0]);
+        Some(format!(
+            "{}. If {}, {}",
+            return_text.trim_end_matches('.'),
+            describe_condition(&conditional.condition),
+            lowercase_first(animation_text.trim_end_matches('.'))
+        ))
+    }
+
     fn filter_is_tagged_object(filter: &ObjectFilter, tag: &crate::TagKey) -> bool {
         filter.tagged_constraints.iter().any(|constraint| {
             constraint.tag == *tag
@@ -3448,6 +3474,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     if let Some(compact) = describe_tagged_pump_then_conditional_keyword(&raw_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_return_then_conditional_animation(effects) {
         return compact;
     }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1957,6 +1957,312 @@ fn rise_from_the_grave_targets_only_creature_cards_in_graveyards() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn dance_of_the_manse_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_960), "Dance of the Manse")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Return up to X target artifact and/or non-Aura enchantment cards each with mana value X or less from your graveyard to the battlefield. If X is 6 or more, those permanents are 4/4 creatures in addition to their other types.",
+        )
+        .expect("Dance of the Manse should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn dance_graveyard_card(
+    id: u32,
+    name: &str,
+    card_types: Vec<CardType>,
+    subtypes: Vec<Subtype>,
+    mana_value: u8,
+) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(id), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(
+            mana_value,
+        )]]))
+        .card_types(card_types)
+        .subtypes(subtypes)
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dance_of_the_manse_compiled_text_matches_oracle_animation_clause() {
+    let def = dance_of_the_manse_definition();
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join(" ");
+
+    assert_eq!(
+        rendered,
+        "Return up to X target artifact and/or non-Aura enchantment cards each with mana value X or less from your graveyard to the battlefield. If X is 6 or more, those permanents are 4/4 creatures in addition to their other types."
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dance_of_the_manse_targets_only_own_graveyard_artifacts_or_non_aura_enchantments() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell = dance_of_the_manse_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    game.object_mut(spell_id).unwrap().x_value = Some(6);
+
+    let artifact = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_961,
+            "Graveyard Relic",
+            vec![CardType::Artifact],
+            Vec::new(),
+            6,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let enchantment = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_962,
+            "Graveyard Sigil",
+            vec![CardType::Enchantment],
+            Vec::new(),
+            6,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let aura = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_963,
+            "Graveyard Aura",
+            vec![CardType::Enchantment],
+            vec![Subtype::Aura],
+            6,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let too_expensive = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_964,
+            "Expensive Relic",
+            vec![CardType::Artifact],
+            Vec::new(),
+            7,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let opponents_artifact = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_969,
+            "Opponent's Relic",
+            vec![CardType::Artifact],
+            Vec::new(),
+            2,
+        ),
+        bob,
+        Zone::Graveyard,
+    );
+    let battlefield_artifact = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_965,
+            "Battlefield Relic",
+            vec![CardType::Artifact],
+            Vec::new(),
+            2,
+        ),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let effects = game
+        .object(spell_id)
+        .and_then(|object| object.spell_effect.as_deref())
+        .expect("Dance of the Manse should have spell effects");
+    let requirements = extract_target_requirements(&game, effects, alice, Some(spell_id));
+    assert_eq!(
+        requirements.len(),
+        1,
+        "Dance should have one target requirement"
+    );
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(artifact)),
+        "artifact should be legal"
+    );
+    assert!(
+        legal_targets.contains(&Target::Object(enchantment)),
+        "non-Aura enchantment should be legal"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(aura)),
+        "Aura enchantment should not be legal"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(too_expensive)),
+        "mana value greater than X should not be legal"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(opponents_artifact)),
+        "artifact in an opponent's graveyard should not be legal"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(battlefield_artifact)),
+        "battlefield artifact should not be legal"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dance_of_the_manse_x_six_returns_and_animates_targets() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let spell = dance_of_the_manse_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    let artifact = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_966,
+            "Animated Relic",
+            vec![CardType::Artifact],
+            Vec::new(),
+            6,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let enchantment = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_967,
+            "Animated Sigil",
+            vec![CardType::Enchantment],
+            Vec::new(),
+            3,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let artifact_stable = game.object(artifact).expect("artifact exists").stable_id;
+    let enchantment_stable = game.object(enchantment).expect("enchantment exists").stable_id;
+    game.object_mut(spell_id).unwrap().x_value = Some(6);
+    let target_assignment = {
+        let effects = game
+            .object(spell_id)
+            .and_then(|object| object.spell_effect.as_deref())
+            .expect("Dance of the Manse should have spell effects");
+        let requirements = extract_target_requirements(&game, effects, alice, Some(spell_id));
+        assert_eq!(requirements.len(), 1, "Dance should have one target requirement");
+        crate::game_state::TargetAssignment {
+            spec: requirements[0].spec.clone(),
+            range: 0..2,
+        }
+    };
+
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice)
+            .with_x(6)
+            .with_targets(vec![Target::Object(artifact), Target::Object(enchantment)])
+            .with_target_assignments(vec![target_assignment]),
+    );
+    resolve_stack_entry(&mut game).expect("Dance of the Manse should resolve");
+
+    for stable_id in [artifact_stable, enchantment_stable] {
+        let returned = game
+            .find_object_by_stable_id(stable_id)
+            .expect("returned object should still exist");
+        assert!(
+            game.battlefield.contains(&returned),
+            "target should return to battlefield"
+        );
+        let card_types = game
+            .current_card_types(returned)
+            .expect("returned permanent should have card types");
+        assert!(
+            card_types.contains(&CardType::Creature),
+            "returned permanent should become a creature, got {card_types:?}"
+        );
+        assert_eq!(game.calculated_power(returned), Some(4));
+        assert_eq!(game.calculated_toughness(returned), Some(4));
+    }
+
+    let artifact_id = game.find_object_by_stable_id(artifact_stable).unwrap();
+    let enchantment_id = game.find_object_by_stable_id(enchantment_stable).unwrap();
+    assert!(
+        game.current_card_types(artifact_id)
+            .unwrap()
+            .contains(&CardType::Artifact),
+        "animated artifact should keep artifact type"
+    );
+    assert!(
+        game.current_card_types(enchantment_id)
+            .unwrap()
+            .contains(&CardType::Enchantment),
+        "animated enchantment should keep enchantment type"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dance_of_the_manse_x_five_returns_without_animation() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let spell = dance_of_the_manse_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    let artifact = game.create_object_from_card(
+        &dance_graveyard_card(
+            72_968,
+            "Small Relic",
+            vec![CardType::Artifact],
+            Vec::new(),
+            5,
+        ),
+        alice,
+        Zone::Graveyard,
+    );
+    let artifact_stable = game.object(artifact).expect("artifact exists").stable_id;
+    game.object_mut(spell_id).unwrap().x_value = Some(5);
+    let target_assignment = {
+        let effects = game
+            .object(spell_id)
+            .and_then(|object| object.spell_effect.as_deref())
+            .expect("Dance of the Manse should have spell effects");
+        let requirements = extract_target_requirements(&game, effects, alice, Some(spell_id));
+        assert_eq!(requirements.len(), 1, "Dance should have one target requirement");
+        crate::game_state::TargetAssignment {
+            spec: requirements[0].spec.clone(),
+            range: 0..1,
+        }
+    };
+
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice)
+            .with_x(5)
+            .with_targets(vec![Target::Object(artifact)])
+            .with_target_assignments(vec![target_assignment]),
+    );
+    resolve_stack_entry(&mut game).expect("Dance of the Manse should resolve");
+
+    let returned = game
+        .find_object_by_stable_id(artifact_stable)
+        .expect("returned artifact should still exist");
+    assert!(
+        game.battlefield.contains(&returned),
+        "target should return to battlefield"
+    );
+    let card_types = game
+        .current_card_types(returned)
+        .expect("returned artifact should have card types");
+    assert!(card_types.contains(&CardType::Artifact));
+    assert!(
+        !card_types.contains(&CardType::Creature),
+        "X less than 6 should not animate the returned artifact, got {card_types:?}"
+    );
+    assert_eq!(game.calculated_power(returned), None);
+    assert_eq!(game.calculated_toughness(returned), None);
+}
+
 #[test]
 fn regeneration_count_tracks_used_shields_until_cleanup() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dance of the Manse
Initial parse error:
```
could not find verb in effect clause (clause: 'those permanents are 4/4 creatures in addition to their other types'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'those permanents are 4/4 creatures in addition to their other types'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-080947a03572d8372
Branch: codex/aws-card-fix-dance-of-the-manse
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0015
