### PR TITLE
Fix Ironsmith parse failure: Valley Rotcaller

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -903,8 +903,21 @@ fn parse_effect_sentence_with_where_x_lexed(
     };
     let where_tokens = &tokens[where_token_idx..];
     let where_segments = split_lexed_slices_on_commas_or_semicolons(where_tokens);
-    let primary_where_tokens = where_segments.first().copied().unwrap_or(where_tokens);
-    let trailing_after_where = if where_segments.len() > 1 {
+    let comma_tail_has_effect_clause = where_segments.iter().skip(1).any(|segment| {
+        let words = crate::runtime_backend::token_word_refs(segment);
+        words.iter().any(|word| *word == "then") || super::find_verb(segment).is_some()
+    });
+    let full_where_is_count_value = !comma_tail_has_effect_clause
+        && crate::runtime_backend::families::keyword_static::parse_where_x_is_number_of_filter_value(
+            where_tokens,
+        )
+        .is_some();
+    let primary_where_tokens = if full_where_is_count_value {
+        where_tokens
+    } else {
+        where_segments.first().copied().unwrap_or(where_tokens)
+    };
+    let trailing_after_where = if !full_where_is_count_value && where_segments.len() > 1 {
         let mut tail = Vec::new();
         for (idx, segment) in where_segments.iter().enumerate().skip(1) {
             if idx > 1 {

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -450,6 +450,7 @@ impl Subtype {
             Subtype::Avatar,
             Subtype::Barbarian,
             Subtype::Bard,
+            Subtype::Bat,
             Subtype::Bear,
             Subtype::Beast,
             Subtype::Berserker,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46819,6 +46819,157 @@ fn valley_floodcaller_compiled_lines_meet_strict_semantic_threshold() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn valley_rotcaller_strict_oracle_parses_and_renders_type_count() {
+    assert_oracle_card_parses_strict("Valley Rotcaller");
+
+    let oracle = oracle_text_by_name()
+        .get("Valley Rotcaller")
+        .expect("missing Valley Rotcaller oracle text")
+        .clone();
+    let def = parse_oracle_card_definition("Valley Rotcaller");
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("each opponent loses x life and you gain x life"),
+        "expected Valley Rotcaller to render its life-drain attack trigger, got {rendered}"
+    );
+    assert!(
+        rendered.contains("where x is the number of other")
+            && rendered.contains("squirrels")
+            && rendered.contains("bats")
+            && rendered.contains("lizards")
+            && rendered.contains("rats")
+            && rendered.contains("you control"),
+        "expected Valley Rotcaller to preserve the comma-separated creature-type count, got {rendered}"
+    );
+
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            &oracle,
+            &compiled,
+            Some(crate::semantic_compare::EmbeddingConfig {
+                dims: 384,
+                mismatch_threshold: 0.99,
+            }),
+        );
+    assert!(
+        similarity >= 0.99,
+        "expected Valley Rotcaller to clear strict semantic threshold, got score={similarity}, lines={compiled:?}"
+    );
+    assert!(
+        !mismatch,
+        "expected Valley Rotcaller to avoid semantic mismatch, got lines={compiled:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn valley_rotcaller_creature(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    name: &str,
+    subtype: Subtype,
+) -> ObjectId {
+    let def = CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![subtype])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_definition(&def, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_valley_rotcaller_attack(game: &mut crate::game_state::GameState, rotcaller: ObjectId) {
+    let bob = PlayerId::from_index(1);
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::new(
+            rotcaller,
+            crate::triggers::AttackEventTarget::Player(bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(game, &event)
+        .into_iter()
+        .filter(|entry| entry.source == rotcaller)
+    {
+        trigger_queue.add(entry);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Valley Rotcaller should trigger when it attacks"
+    );
+    crate::game_loop::put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Valley Rotcaller trigger should go on the stack");
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    crate::game_loop::resolve_stack_entry_with(game, &mut dm)
+        .expect("Valley Rotcaller trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn valley_rotcaller_attack_trigger_counts_other_supported_types_only() {
+    let def = parse_oracle_card_definition("Valley Rotcaller");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let rotcaller = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.object_mut(rotcaller)
+        .expect("Valley Rotcaller should exist")
+        .subtypes
+        .push(Subtype::Squirrel);
+
+    valley_rotcaller_creature(&mut game, alice, "Squirrel Ally", Subtype::Squirrel);
+    valley_rotcaller_creature(&mut game, alice, "Bat Ally", Subtype::Bat);
+    valley_rotcaller_creature(&mut game, alice, "Lizard Ally", Subtype::Lizard);
+    valley_rotcaller_creature(&mut game, alice, "Rat Ally", Subtype::Rat);
+    valley_rotcaller_creature(&mut game, alice, "Wizard Ally", Subtype::Wizard);
+    valley_rotcaller_creature(&mut game, bob, "Opponent Rat", Subtype::Rat);
+
+    resolve_valley_rotcaller_attack(&mut game, rotcaller);
+
+    assert_eq!(
+        game.life_total(bob),
+        16,
+        "Bob should lose 4 life for Alice's other Squirrel, Bat, Lizard, and Rat"
+    );
+    assert_eq!(
+        game.life_total(alice),
+        24,
+        "Alice should gain 4 life from Valley Rotcaller's trigger"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn valley_rotcaller_attack_trigger_ignores_itself_when_no_other_type_matches() {
+    let def = parse_oracle_card_definition("Valley Rotcaller");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let rotcaller = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.object_mut(rotcaller)
+        .expect("Valley Rotcaller should exist")
+        .subtypes
+        .push(Subtype::Squirrel);
+
+    resolve_valley_rotcaller_attack(&mut game, rotcaller);
+
+    assert_eq!(
+        game.life_total(bob),
+        20,
+        "Valley Rotcaller should not count itself as another matching creature"
+    );
+    assert_eq!(
+        game.life_total(alice),
+        20,
+        "Alice should not gain life when X is 0"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_zealous_display_non_turn_conditional_untap_clause() {
     let oracle = "Creatures you control get +2/+0 until end of turn. If it's not your turn, untap those creatures.";
     let def = CardDefinitionBuilder::new(CardId::new(), "Zealous Display")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Valley Rotcaller
Initial parse error:
```
could not find verb in effect clause (clause: 'bats lizards and rats you control'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'bats lizards and rats you control'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0915ed65fd8b4ea7d
Branch: codex/aws-card-fix-valley-rotcaller
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0015
