### PR TITLE
Fix Ironsmith parse failure: Vastwood Animist

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
@@ -1,5 +1,5 @@
 use super::super::super::keyword_static::{
-    keyword_action_to_static_ability, parse_ability_line, parse_pt_modifier,
+    keyword_action_to_static_ability, parse_ability_line, parse_pt_modifier_values,
 };
 use super::super::super::lexer::{
     LexedClause, OwnedLexToken, word_slice_eq, word_slice_eq_any, word_slice_starts_with,
@@ -284,12 +284,12 @@ pub(crate) fn parse_become_clause(
     }
 
     if let Some(pt_word) = become_words.first().copied()
-        && let Ok((power, toughness)) = parse_pt_modifier(pt_word)
+        && let Ok((power, toughness)) = parse_pt_modifier_values(pt_word)
     {
         if subject_targets_base_pt || become_words.len() == 1 {
             return Ok(EffectAst::subject_verb_set_base_power_toughness(
-                Value::Fixed(power),
-                Value::Fixed(toughness),
+                power,
+                toughness,
                 target,
                 duration,
             ));
@@ -374,8 +374,8 @@ pub(crate) fn parse_become_clause(
             };
             if !all_prefix_words_supported || !suffix_supported {
                 return Ok(EffectAst::subject_verb_become_base_pt_creature(
-                    Value::Fixed(power),
-                    Value::Fixed(toughness),
+                    power,
+                    toughness,
                     target,
                     vec![CardType::Creature],
                     Vec::new(),
@@ -386,8 +386,8 @@ pub(crate) fn parse_become_clause(
                 ));
             }
             return Ok(EffectAst::subject_verb_become_base_pt_creature(
-                Value::Fixed(power),
-                Value::Fixed(toughness),
+                power,
+                toughness,
                 target,
                 card_types,
                 subtypes,
@@ -404,8 +404,8 @@ pub(crate) fn parse_become_clause(
             parse_become_creature_descriptor_words(descriptor_words)
     {
         return Ok(EffectAst::subject_verb_become_base_pt_creature(
-            Value::Fixed(power),
-            Value::Fixed(toughness),
+            power,
+            toughness,
             target,
             card_types,
             subtypes,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/helpers.rs
@@ -166,7 +166,7 @@ pub(super) fn strip_base_power_toughness_subject_tokens<'a>(
 
 pub(super) fn parse_become_base_pt_tail<'a>(
     become_words: &'a [&'a str],
-) -> Result<Option<(&'a [&'a str], i32, i32)>, CardTextError> {
+) -> Result<Option<(&'a [&'a str], Value, Value)>, CardTextError> {
     let Some(with_idx) = word_slice_find_word(become_words, "with") else {
         return Ok(None);
     };
@@ -179,7 +179,7 @@ pub(super) fn parse_become_base_pt_tail<'a>(
     {
         return Ok(None);
     }
-    let (power, toughness) = parse_pt_modifier(tail[4])?;
+    let (power, toughness) = parse_pt_modifier_values(tail[4])?;
     Ok(Some((&become_words[..with_idx], power, toughness)))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2315,6 +2315,9 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::SetBasePowerToughness {
                 power, toughness, ..
             }
+            | SubjectVerbActionAst::BecomeBasePtCreature {
+                power, toughness, ..
+            }
             | SubjectVerbActionAst::PumpAll {
                 power, toughness, ..
             } => {
@@ -2493,7 +2496,6 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::MoveToLibraryTopOrBottomChoice { .. }
             | SubjectVerbActionAst::TargetOnly { .. }
             | SubjectVerbActionAst::TagMatchingObjects { .. }
-            | SubjectVerbActionAst::BecomeBasePtCreature { .. }
             | SubjectVerbActionAst::PumpByLastEffect { .. }
             | SubjectVerbActionAst::AddCardTypes { .. }
             | SubjectVerbActionAst::RemoveCardTypes { .. }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40254,6 +40254,22 @@ fn xanthic_statue_activation_sets_base_pt_and_trample_on_source_artifact() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn vastwood_animist_strict_parse_and_compiled_text_include_dynamic_land_animation() {
+    let def = parse_oracle_card_definition("Vastwood Animist");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower
+            .contains("target land you control becomes an x/x elemental creature until end of turn")
+            && rendered_lower.contains("where x is the number of allies you control")
+            && rendered_lower.contains("it's still a land"),
+        "expected Vastwood Animist compiled text to preserve dynamic X/X land animation, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_oran_rief_the_vastwood_strict_regression() {
     assert_oracle_card_parses_strict("Oran-Rief, the Vastwood");
 }

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9124,8 +9124,23 @@ pub(super) fn describe_apply_continuous_animation_effect(
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
         .join(" ");
+    let dynamic_equal_pt = if let (Some(power), Some(toughness)) = (power, toughness) {
+        power == toughness && !matches!(power, Value::Fixed(_))
+    } else {
+        false
+    };
+    let pt_where_clause = if let (Some(power), _) = (power, toughness) {
+        (dynamic_equal_pt && !matches!(power, Value::X)).then(|| describe_value(power))
+    } else {
+        None
+    };
+
     let mut text = if let (Some(power), Some(toughness)) = (power, toughness) {
-        let pt = format!("{}/{}", describe_value(power), describe_value(toughness));
+        let pt = if dynamic_equal_pt {
+            "X/X".to_string()
+        } else {
+            format!("{}/{}", describe_value(power), describe_value(toughness))
+        };
         let pt_noun_phrase = format!("{pt} {noun_phrase}");
         if plural_target {
             format!("{target_text} become {pt_noun_phrase}")
@@ -9193,6 +9208,10 @@ pub(super) fn describe_apply_continuous_animation_effect(
             text.push_str(" that's still a land");
         }
         None => {}
+    }
+    if let Some(where_clause) = pt_where_clause {
+        text.push_str(", where X is ");
+        text.push_str(&where_clause);
     }
     if preserves_land_types && !render_as_addition_to_other_types && !inline_still_land {
         if plural_target {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -776,6 +776,148 @@ fn create_vanilla_creature(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn vastwood_animist_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_956), "Vastwood Animist")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf, Subtype::Shaman, Subtype::Ally])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "{T}: Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.",
+        )
+        .expect("Vastwood Animist should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_test_land(game: &mut GameState, name: &str, controller: PlayerId) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Land])
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn vastwood_animist_activation_animates_only_your_land_using_ally_count_until_end_of_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let animist_def = vastwood_animist_definition();
+    let animist_id = game.create_object_from_definition(&animist_def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(animist_id);
+    let other_ally = CardBuilder::new(CardId::new(), "Ally Helper")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Ally])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&other_ally, alice, Zone::Battlefield);
+    let _opponent_land_id = create_test_land(&mut game, "Bob's Forest", bob);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. }
+                    if source == animist_id
+            )),
+        "Vastwood Animist should not be activatable without a land you control to target"
+    );
+
+    let land_id = create_test_land(&mut game, "Alice's Forest", alice);
+    assert!(!game.current_is_creature(land_id));
+
+    let ability_index = game
+        .object(animist_id)
+        .expect("Vastwood Animist should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Vastwood Animist should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == animist_id && *idx == ability_index
+            )
+        })
+        .expect("Vastwood Animist activation should be legal with a land you control");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Vastwood Animist activation should start and pay the tap cost");
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Vastwood Animist, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(land_id)]),
+        &mut dm,
+    )
+    .expect("choosing a land you control should complete Vastwood Animist activation");
+    assert!(
+        game.is_tapped(animist_id),
+        "activation should tap Vastwood Animist"
+    );
+    resolve_stack_entry(&mut game).expect("Vastwood Animist ability should resolve");
+
+    assert!(game.current_is_creature(land_id));
+    assert!(
+        game.current_card_types(land_id).is_some_and(|types| {
+            types.contains(&CardType::Land) && types.contains(&CardType::Creature)
+        }),
+        "animated land should remain a land and gain creature"
+    );
+    assert!(
+        game.current_has_subtype(land_id, Subtype::Elemental),
+        "animated land should become an Elemental"
+    );
+    assert_eq!(
+        game.current_power(land_id),
+        Some(2),
+        "X should be the number of Allies Alice controls at resolution"
+    );
+    assert_eq!(game.current_toughness(land_id), Some(2));
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+
+    assert!(!game.current_is_creature(land_id));
+    assert_eq!(game.current_power(land_id), None);
+    assert!(
+        game.current_card_types(land_id)
+            .is_some_and(|types| types.contains(&CardType::Land)
+                && !types.contains(&CardType::Creature)),
+        "animation should expire at end of turn while leaving the permanent a land"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn cho_arrim_alchemist_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(19647), "Cho-Arrim Alchemist")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vastwood Animist
Initial parse error:
```
unsupported become clause (clause: 'an x/x elemental creature until end of turn'); oracle-only fallback also failed: unsupported become clause (clause: 'an x/x elemental creature until end of turn')
```

Current worker: i-0b4ea632dfa5c7aa5
Branch: codex/aws-card-fix-vastwood-animist
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0016
