### PR TITLE
Fix Ironsmith parse failure: Eye of Duskmantle

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -378,6 +378,10 @@ fn static_ability_rule_head_hints(rule_id: &'static str) -> Vec<StaticAbilityLin
             StaticAbilityLineHeadHint::Single("you"),
             StaticAbilityLineHeadHint::Pair("you", "may"),
         ],
+        "parse_surveilled_graveyard_play_life_cost_line" => vec![
+            StaticAbilityLineHeadHint::Single("you"),
+            StaticAbilityLineHeadHint::Pair("you", "may"),
+        ],
         "parse_fixed_mana_cost_instead_of_mana_cost_grant_line" => vec![
             StaticAbilityLineHeadHint::Single("you"),
             StaticAbilityLineHeadHint::Pair("you", "may"),
@@ -770,6 +774,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         multi_static_ability_ast_rule!(
             parse_you_may_cast_exile_counter_cards_with_mana_permission_line
         ),
+        multi_static_ability_ast_rule!(parse_surveilled_graveyard_play_life_cost_line),
         single_static_ability_ast_rule!(parse_you_may_static_grant_line),
         single_static_ability_ast_rule!(parse_grant_flash_to_noncreature_spells_line),
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
@@ -7896,6 +7901,90 @@ pub(crate) fn parse_you_may_cast_exile_counter_cards_with_mana_permission_line(
         StaticAbility::mana_spend_permission(permission, render_token_slice(tokens));
 
     Ok(Some(vec![grant, mana_permission]))
+}
+
+pub(crate) fn parse_surveilled_graveyard_play_life_cost_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<StaticAbility>>, CardTextError> {
+    let words = parser_token_word_refs(tokens);
+    let normalized = words
+        .iter()
+        .map(|word| word.replace(['\'', '’'], ""))
+        .collect::<Vec<_>>();
+    let refs = normalized.iter().map(String::as_str).collect::<Vec<_>>();
+    if !matches!(
+        refs.as_slice(),
+        [
+            "you",
+            "may",
+            "play",
+            "lands",
+            "and",
+            "cast",
+            "spells",
+            "from",
+            "among",
+            "cards",
+            "in",
+            "your",
+            "graveyard",
+            "youve",
+            "surveilled",
+            "this",
+            "turn",
+            "if",
+            "you",
+            "cast",
+            "a",
+            "spell",
+            "this",
+            "way",
+            "you",
+            "pay",
+            "life",
+            "equal",
+            "to",
+            "its",
+            "mana",
+            "value",
+            "rather",
+            "than",
+            "paying",
+            "its",
+            "mana",
+            "cost"
+        ]
+    ) {
+        return Ok(None);
+    }
+
+    let base_filter = ObjectFilter {
+        zone: Some(Zone::Graveyard),
+        owner: Some(PlayerFilter::You),
+        surveilled_this_turn: true,
+        ..ObjectFilter::default()
+    };
+    let mut spell_filter = base_filter.clone();
+    spell_filter.excluded_card_types.push(CardType::Land);
+
+    Ok(Some(vec![
+        StaticAbility::grants(
+            crate::grant::GrantSpec::new(
+                crate::grant::Grantable::play_from(),
+                base_filter,
+                Zone::Graveyard,
+            )
+            .with_beneficiary(PlayerFilter::You),
+        ),
+        StaticAbility::grants(
+            crate::grant::GrantSpec::new(
+                crate::grant::Grantable::life_equal_mana_value_from_zone(Zone::Graveyard, None),
+                spell_filter,
+                Zone::Graveyard,
+            )
+            .with_beneficiary(PlayerFilter::You),
+        ),
+    ]))
 }
 
 pub(crate) fn parse_you_may_static_grant_line(

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -416,6 +416,7 @@ pub struct ObjectFilter {
     pub entered_battlefield_controller: Option<PlayerFilter>,
     pub entered_graveyard_this_turn: bool,
     pub entered_graveyard_from_battlefield_this_turn: bool,
+    pub surveilled_this_turn: bool,
     pub was_dealt_damage_this_turn: bool,
     pub drawn_this_turn: bool,
     pub power: Option<Comparison>,
@@ -497,6 +498,7 @@ impl ObjectFilter {
             || self.modified
             || self.enlist_eligible
             || self.attached_to_player.is_some()
+            || self.surveilled_this_turn
             || self.drawn_this_turn
             || self.mana_value.is_some()
             || self.mana_value_parity.is_some()
@@ -1988,6 +1990,9 @@ impl ObjectFilter {
             parts.push("that was put there from the battlefield this turn".to_string());
         } else if self.entered_graveyard_this_turn && self.zone == Some(Zone::Graveyard) {
             parts.push("that was put there from anywhere this turn".to_string());
+        }
+        if self.surveilled_this_turn {
+            parts.push("you've surveilled this turn".to_string());
         }
 
         if self.was_dealt_damage_this_turn {

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -30,6 +30,11 @@ pub enum DerivedAlternativeCast<C> {
     LifeEqualManaValueFromHand {
         usage_limit: Option<GrantUsageLimit>,
     },
+    /// Cast from a specified zone by paying life equal to the card's mana value.
+    LifeEqualManaValueFromZone {
+        zone: Zone,
+        usage_limit: Option<GrantUsageLimit>,
+    },
     /// Cast from the graveyard using the card's mana cost plus optional extra cost components.
     GraveyardCastFromCardManaCost {
         additional_costs: Vec<C>,
@@ -50,6 +55,7 @@ impl<C> DerivedAlternativeCast<C> {
             Self::EscapeFromCardManaCost { .. } => "Escape",
             Self::ManaValueAsGenericFromHand => "Pay mana value",
             Self::LifeEqualManaValueFromHand { .. } => "Pay life equal to mana value",
+            Self::LifeEqualManaValueFromZone { .. } => "Pay life equal to mana value",
             Self::GraveyardCastFromCardManaCost { .. } => "Cast from graveyard",
         }
     }
@@ -57,6 +63,7 @@ impl<C> DerivedAlternativeCast<C> {
     pub fn usage_limit(&self) -> Option<GrantUsageLimit> {
         match self {
             Self::LifeEqualManaValueFromHand { usage_limit } => *usage_limit,
+            Self::LifeEqualManaValueFromZone { usage_limit, .. } => *usage_limit,
             Self::GraveyardCastFromCardManaCost { usage_limit, .. } => *usage_limit,
             _ => None,
         }
@@ -116,6 +123,13 @@ impl<C: CostComponent> DerivedAlternativeCast<C> {
 
     pub fn life_equal_mana_value_from_hand(usage_limit: Option<GrantUsageLimit>) -> Self {
         Self::LifeEqualManaValueFromHand { usage_limit }
+    }
+
+    pub fn life_equal_mana_value_from_zone(
+        zone: Zone,
+        usage_limit: Option<GrantUsageLimit>,
+    ) -> Self {
+        Self::LifeEqualManaValueFromZone { zone, usage_limit }
     }
 
     pub fn graveyard_cast_from_cards_mana_cost_with_condition(
@@ -215,6 +229,16 @@ where
     /// the granted card's mana value.
     pub fn life_equal_mana_value_from_hand(usage_limit: Option<GrantUsageLimit>) -> Self {
         Self::DerivedAlternativeCast(DerivedAlternativeCast::life_equal_mana_value_from_hand(
+            usage_limit,
+        ))
+    }
+
+    pub fn life_equal_mana_value_from_zone(
+        zone: Zone,
+        usage_limit: Option<GrantUsageLimit>,
+    ) -> Self {
+        Self::DerivedAlternativeCast(DerivedAlternativeCast::life_equal_mana_value_from_zone(
+            zone,
             usage_limit,
         ))
     }
@@ -638,6 +662,14 @@ where
             return format!("{may_prefix} play lands and cast spells from your graveyard");
         }
         if matches!(self.grantable, Grantable::PlayFrom)
+            && self.zone == Zone::Graveyard
+            && self.filter.surveilled_this_turn
+        {
+            return format!(
+                "{may_prefix} play lands and cast spells from among cards in your graveyard you've surveilled this turn"
+            );
+        }
+        if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Library
             && self.filter == ObjectFilter::default()
         {
@@ -820,6 +852,30 @@ where
                 .unwrap_or(filter_desc);
             return format!(
                 "{prefix}{} cast {singular_filter_desc} by paying life equal to its mana value rather than paying its mana cost",
+                may_prefix.to_ascii_lowercase()
+            );
+        }
+        if let Grantable::DerivedAlternativeCast(
+            DerivedAlternativeCast::LifeEqualManaValueFromZone { zone, usage_limit },
+        ) = &self.grantable
+            && self.zone == *zone
+        {
+            let prefix = if matches!(
+                usage_limit,
+                Some(GrantUsageLimit::OnceDuringEachOfYourTurns)
+            ) {
+                "Once during each of your turns, "
+            } else {
+                ""
+            };
+            if *zone == Zone::Graveyard && self.filter.surveilled_this_turn {
+                return format!(
+                    "{prefix}If you cast a spell this way, you pay life equal to its mana value rather than paying its mana cost"
+                );
+            }
+            let filter_desc = castable_filter_description(&self.filter);
+            return format!(
+                "{prefix}{} cast {filter_desc} by paying life equal to its mana value rather than paying its mana cost",
                 may_prefix.to_ascii_lowercase()
             );
         }

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -679,6 +679,9 @@ where
                 DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit } => {
                     DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit }
                 }
+                DerivedAlternativeCast::LifeEqualManaValueFromZone { zone, usage_limit } => {
+                    DerivedAlternativeCast::LifeEqualManaValueFromZone { zone, usage_limit }
+                }
                 DerivedAlternativeCast::GraveyardCastFromCardManaCost {
                     additional_costs,
                     usage_limit,

--- a/crates/ironsmith-core/src/tag.rs
+++ b/crates/ironsmith-core/src/tag.rs
@@ -15,6 +15,9 @@ pub const EXPLOITED_TAG: &str = "exploited";
 /// Runtime tag for the object whose exploit action sacrificed another object.
 pub const EXPLOITER_TAG: &str = "exploiter";
 
+/// Runtime tag for cards seen by a surveil action this turn.
+pub const SURVEILLED_THIS_TURN_TAG: &str = "__surveilled_this_turn__";
+
 /// Dynamic tag key used by the tagging system.
 ///
 /// Using an owned key instead of `&'static str` enables tags built at runtime

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -344,6 +344,13 @@ fn convert_derived_alternative_cast(
         compiler::grant::DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit } => {
             ironsmith::grant::DerivedAlternativeCast::LifeEqualManaValueFromHand { usage_limit }
         }
+        compiler::grant::DerivedAlternativeCast::LifeEqualManaValueFromZone {
+            zone,
+            usage_limit,
+        } => ironsmith::grant::DerivedAlternativeCast::LifeEqualManaValueFromZone {
+            zone,
+            usage_limit,
+        },
         compiler::grant::DerivedAlternativeCast::GraveyardCastFromCardManaCost {
             additional_costs,
             usage_limit,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20265,6 +20265,69 @@ fn parse_oracle_demon_of_fates_design_life_cost_and_sacrifice_pump_regression() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_eye_of_duskmantle_surveilled_graveyard_permission() {
+    let def = parse_oracle_card_definition("Eye of Duskmantle");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains(
+            "you may play lands and cast spells from among cards in your graveyard you've surveilled this turn"
+        ),
+        "expected Eye of Duskmantle surveilled graveyard play permission, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "if you cast a spell this way, you pay life equal to its mana value rather than paying its mana cost"
+        ),
+        "expected Eye of Duskmantle life-cost replacement wording, got {rendered}"
+    );
+
+    let mut has_play_grant = false;
+    let mut has_life_cost_grant = false;
+    for ability in &def.abilities {
+        let AbilityKind::Static(static_ability) = &ability.kind else {
+            continue;
+        };
+        let Some(spec) = static_ability.grant_spec() else {
+            continue;
+        };
+        if matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+            && spec.zone == Zone::Graveyard
+            && spec.filter.surveilled_this_turn
+            && spec.filter.owner == Some(PlayerFilter::You)
+        {
+            has_play_grant = true;
+        }
+        if matches!(
+            spec.grantable,
+            crate::grant::Grantable::DerivedAlternativeCast(
+                crate::grant::DerivedAlternativeCast::LifeEqualManaValueFromZone {
+                    zone: Zone::Graveyard,
+                    usage_limit: None
+                }
+            )
+        ) && spec.zone == Zone::Graveyard
+            && spec.filter.surveilled_this_turn
+            && spec.filter.excluded_card_types.contains(&CardType::Land)
+        {
+            has_life_cost_grant = true;
+        }
+    }
+
+    assert!(
+        has_play_grant,
+        "expected Eye of Duskmantle to grant play-from-graveyard permission for surveilled cards"
+    );
+    assert!(
+        has_life_cost_grant,
+        "expected Eye of Duskmantle to grant a graveyard life-cost alternative cast"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_creature_spell_emerge_grant_uses_hand_derived_alternative_cast() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Herigast Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -81,18 +81,26 @@ fn append_granted_play_from_actions_for_card(
             }
         }
 
-        let base_alt_idx = card.alternative_casts.len();
-        for (offset, granted_alt) in granted_alternatives.iter().enumerate() {
-            if can_cast_with_alternative_with_view(game, player, card, &granted_alt.method, view) {
-                actions.push(LegalAction::CastSpell {
-                    spell_id: card_id,
-                    from_zone,
-                    casting_method: CastingMethod::PlayFrom {
-                        source: granted_alt.source_id,
-                        zone: from_zone,
-                        use_alternative: Some(base_alt_idx + offset),
-                    },
-                });
+        if source_zone != Zone::Graveyard {
+            let base_alt_idx = card.alternative_casts.len();
+            for (offset, granted_alt) in granted_alternatives.iter().enumerate() {
+                if can_cast_with_alternative_with_view(
+                    game,
+                    player,
+                    card,
+                    &granted_alt.method,
+                    view,
+                ) {
+                    actions.push(LegalAction::CastSpell {
+                        spell_id: card_id,
+                        from_zone,
+                        casting_method: CastingMethod::PlayFrom {
+                            source: granted_alt.source_id,
+                            zone: from_zone,
+                            use_alternative: Some(base_alt_idx + offset),
+                        },
+                    });
+                }
             }
         }
     }

--- a/crates/ironsmith-runtime/src/effects/cards/surveil.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/surveil.rs
@@ -8,9 +8,12 @@ use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::{KeywordActionEvent, KeywordActionKind};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
+use crate::snapshot::ObjectSnapshot;
+use crate::tag::{SURVEILLED_THIS_TURN_TAG, TagKey};
 use crate::target::PlayerFilter;
 use crate::triggers::TriggerEvent;
 use crate::zone::Zone;
+use std::collections::HashMap;
 
 fn normalize_order_response(response: Vec<ObjectId>, original: &[ObjectId]) -> Vec<ObjectId> {
     let mut remaining = original.to_vec();
@@ -124,6 +127,13 @@ impl EffectExecutor for SurveilEffect {
         }
 
         let surveil_count = top_cards_top_to_bottom.len();
+        let surveilled_snapshots = top_cards_top_to_bottom
+            .iter()
+            .filter_map(|card_id| {
+                game.object(*card_id)
+                    .map(|object| ObjectSnapshot::from_object(object, game))
+            })
+            .collect::<Vec<_>>();
 
         let view_ctx = ViewCardsContext::new(
             player_id,
@@ -184,6 +194,12 @@ impl EffectExecutor for SurveilEffect {
             );
         }
 
+        let mut object_tags = HashMap::new();
+        object_tags.insert(
+            TagKey::from(SURVEILLED_THIS_TURN_TAG),
+            surveilled_snapshots,
+        );
+
         Ok(EffectOutcome::count(surveil_count as i32).with_event(
             TriggerEvent::new_with_provenance(
                 KeywordActionEvent::new(
@@ -191,7 +207,8 @@ impl EffectExecutor for SurveilEffect {
                     player_id,
                     ctx.source,
                     surveil_count as u32,
-                ),
+                )
+                .with_object_tags(object_tags),
                 ctx.provenance,
             ),
         ))
@@ -203,6 +220,7 @@ mod tests {
     use super::*;
     use crate::decision::DecisionMaker;
     use crate::effects::ExecutionContext;
+    use crate::filter::ObjectFilterExt as _;
     use crate::ids::CardId;
     use crate::mana::{ManaCost, ManaSymbol};
     use crate::object::Object;
@@ -321,6 +339,71 @@ mod tests {
             graveyard_names_top_to_bottom(&game, alice),
             vec!["C".to_string()]
         );
+    }
+
+    #[test]
+    fn surveil_event_marks_all_seen_cards_for_this_turn_filters() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let a = add_library_card(&mut game, alice, "A");
+        let b = add_library_card(&mut game, alice, "B");
+        let c = add_library_card(&mut game, alice, "C");
+        let source = game.new_object_id();
+        let mut decision_maker = ScriptedSurveilDecisionMaker {
+            partition: vec![c],
+            top_order: vec![b],
+        };
+
+        let outcome = {
+            let mut ctx = ExecutionContext::new(source, alice, &mut decision_maker);
+            SurveilEffect::you(2)
+                .execute(&mut game, &mut ctx)
+                .expect("surveil should resolve")
+        };
+        game.turn_store
+            .turn_history
+            .record_event(&outcome.events[0], None, None);
+
+        let graveyard_card = game
+            .player(alice)
+            .expect("alice")
+            .graveyard
+            .last()
+            .copied()
+            .expect("surveilled card should be in graveyard");
+        let graveyard_filter = crate::target::ObjectFilter {
+            zone: Some(Zone::Graveyard),
+            surveilled_this_turn: true,
+            ..Default::default()
+        };
+        assert!(graveyard_filter.matches(
+            game.object(graveyard_card).unwrap(),
+            &game.filter_context_for(alice, None),
+            &game
+        ));
+
+        let library_filter = crate::target::ObjectFilter {
+            zone: Some(Zone::Library),
+            surveilled_this_turn: true,
+            ..Default::default()
+        };
+        assert!(library_filter.matches(
+            game.object(b).unwrap(),
+            &game.filter_context_for(alice, None),
+            &game
+        ));
+        assert!(!library_filter.matches(
+            game.object(a).unwrap(),
+            &game.filter_context_for(alice, None),
+            &game
+        ));
+
+        game.turn_store.turn_history.clear_for_new_turn();
+        assert!(!graveyard_filter.matches(
+            game.object(graveyard_card).unwrap(),
+            &game.filter_context_for(alice, None),
+            &game
+        ));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1709,6 +1709,15 @@ impl ObjectFilterExt for ObjectFilter {
             return false;
         }
 
+        if self.surveilled_this_turn
+            && !game
+                .turn_store
+                .turn_history
+                .object_was_surveilled_this_turn(object.stable_id)
+        {
+            return false;
+        }
+
         if self.was_dealt_damage_this_turn && !game.creature_was_damaged_this_turn(object.id) {
             return false;
         }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -23809,6 +23809,162 @@ fn demon_of_fates_design_life_cost_casts_only_enchantments_once_during_your_turn
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn eye_of_duskmantle_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(92_210), "Eye of Duskmantle")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 8))
+        .parse_text(
+            "Flying, lifelink\n\
+             You may play lands and cast spells from among cards in your graveyard you've surveilled this turn. If you cast a spell this way, you pay life equal to its mana value rather than paying its mana cost.",
+        )
+        .expect("Eye of Duskmantle should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn eye_of_duskmantle_casts_only_surveilled_graveyard_spells_for_life() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+    use crate::events::{KeywordActionEvent, KeywordActionKind, RawEvent};
+    use crate::provenance::ProvNodeId;
+    use crate::snapshot::ObjectSnapshot;
+    use crate::tag::{SURVEILLED_THIS_TURN_TAG, TagKey};
+    use std::collections::HashMap;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice).expect("Alice exists").life = 20;
+
+    let eye_id = game.create_object_from_definition(
+        &eye_of_duskmantle_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let spell_card = CardBuilder::new(CardId::from_raw(92_211), "Seen Graveyard Spell")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let seen_spell_id = game.create_object_from_card(&spell_card, alice, Zone::Graveyard);
+    let unseen_spell_id = game.create_object_from_card(&spell_card, alice, Zone::Graveyard);
+    let land_card = CardBuilder::new(CardId::from_raw(92_212), "Seen Graveyard Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let seen_land_id = game.create_object_from_card(&land_card, alice, Zone::Graveyard);
+
+    let mut object_tags = HashMap::new();
+    object_tags.insert(
+        TagKey::from(SURVEILLED_THIS_TURN_TAG),
+        vec![
+            ObjectSnapshot::from_object(game.object(seen_spell_id).unwrap(), &game),
+            ObjectSnapshot::from_object(game.object(seen_land_id).unwrap(), &game),
+        ],
+    );
+    let event = RawEvent::new(
+        KeywordActionEvent::new(KeywordActionKind::Surveil, alice, eye_id, 2)
+            .with_object_tags(object_tags),
+        ProvNodeId::default(),
+    );
+    game.turn_store
+        .turn_history
+        .record_event(&event, None, None);
+
+    let actions = compute_legal_actions(&game, alice);
+    let seen_spell_casts = actions
+        .iter()
+        .filter(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Graveyard,
+                    ..
+                } if *spell_id == seen_spell_id
+            )
+        })
+        .count();
+    assert_eq!(
+        seen_spell_casts, 1,
+        "Eye should offer exactly one graveyard cast for a surveilled spell"
+    );
+
+    let cast_action = actions
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Graveyard,
+                    casting_method: CastingMethod::PlayFrom {
+                        source,
+                        zone: Zone::Graveyard,
+                        use_alternative: Some(_),
+                    },
+                } if *spell_id == seen_spell_id && *source == eye_id
+            )
+        })
+        .expect("Eye should offer the surveilled spell with the life alternative");
+
+    assert!(
+        !compute_legal_actions(&game, alice).iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                casting_method: CastingMethod::PlayFrom {
+                    source,
+                    use_alternative: None,
+                    ..
+                },
+                ..
+            } if *spell_id == seen_spell_id && *source == eye_id
+        )),
+        "Eye should not also allow the surveilled spell for its normal mana cost"
+    );
+    assert!(
+        !compute_legal_actions(&game, alice).iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, .. } if *spell_id == unseen_spell_id
+        )),
+        "Eye should not allow non-surveilled graveyard spells"
+    );
+    assert!(
+        compute_legal_actions(&game, alice).iter().any(|action| matches!(
+            action,
+            LegalAction::PlayLand { land_id } if *land_id == seen_land_id
+        )),
+        "Eye should allow surveilled graveyard lands to be played"
+    );
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+    )
+    .expect("Eye life-cost graveyard cast should succeed");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        17,
+        "casting the three-mana-value spell this way should cost 3 life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn demon_of_fates_design_life_cost_requires_enough_life() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/grant.rs
+++ b/crates/ironsmith-runtime/src/grant.rs
@@ -174,6 +174,25 @@ impl DerivedAlternativeCastRuntimeExt for DerivedAlternativeCast {
                     ],
                 ))
             }
+            Self::LifeEqualManaValueFromZone { zone, .. } => {
+                if card.zone != *zone {
+                    return None;
+                }
+                Some(AlternativeCastingMethod::cast_from_zone_with_total_cost(
+                    "Pay life equal to mana value",
+                    *zone,
+                    TotalCost::from_costs(vec![
+                        Cost::try_from_runtime_effect(crate::effect::Effect::new(
+                            crate::effects::LoseLifeEffect::you(crate::effect::Value::ManaValueOf(
+                                Box::new(crate::target::ChooseSpec::Source),
+                            )),
+                        ))
+                        .expect("mana-value life payment should be cost-capable"),
+                    ]),
+                    None,
+                    false,
+                ))
+            }
             Self::GraveyardCastFromCardManaCost {
                 additional_costs,
                 usage_limit,

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -666,10 +666,15 @@ mod tests {
     use crate::ability::Ability;
     use crate::alternative_cast::AlternativeCastingMethod;
     use crate::card::CardBuilder;
+    use crate::events::{KeywordActionEvent, KeywordActionKind, RawEvent};
     use crate::ids::{ObjectId, PlayerId};
     use crate::mana::ManaCost;
+    use crate::provenance::ProvNodeId;
+    use crate::snapshot::ObjectSnapshot;
+    use crate::tag::{SURVEILLED_THIS_TURN_TAG, TagKey};
     use crate::target::PlayerFilter;
     use crate::types::CardType;
+    use std::collections::HashMap;
 
     #[test]
     fn test_grant_registry_creation() {
@@ -878,5 +883,107 @@ mod tests {
             bob,
             &flash,
         ));
+    }
+
+    #[test]
+    fn surveilled_graveyard_static_grants_apply_only_to_surveilled_cards() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+
+        let mut filter = ObjectFilter {
+            zone: Some(Zone::Graveyard),
+            owner: Some(PlayerFilter::You),
+            surveilled_this_turn: true,
+            ..Default::default()
+        };
+        let play_grant = StaticAbility::grants(
+            crate::grant::GrantSpec::new(Grantable::play_from(), filter.clone(), Zone::Graveyard)
+                .with_beneficiary(PlayerFilter::You),
+        );
+        filter.excluded_card_types.push(CardType::Land);
+        let life_grant = StaticAbility::grants(
+            crate::grant::GrantSpec::new(
+                Grantable::life_equal_mana_value_from_zone(Zone::Graveyard, None),
+                filter,
+                Zone::Graveyard,
+            )
+            .with_beneficiary(PlayerFilter::You),
+        );
+        let source_card = CardBuilder::new(crate::ids::CardId::from_raw(91_510), "Eye Stand-In")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let source_id = game.create_object_from_card(&source_card, alice, Zone::Battlefield);
+        game.object_mut(source_id)
+            .expect("source should exist")
+            .abilities
+            .extend([
+                Ability::static_ability(play_grant),
+                Ability::static_ability(life_grant),
+            ]);
+
+        let spell_card = CardBuilder::new(crate::ids::CardId::from_raw(91_511), "Seen Spell")
+            .card_types(vec![CardType::Sorcery])
+            .mana_cost(ManaCost::new())
+            .build();
+        let seen_spell = game.create_object_from_card(&spell_card, alice, Zone::Graveyard);
+        let unseen_spell = game.create_object_from_card(&spell_card, alice, Zone::Graveyard);
+        let land_card = CardBuilder::new(crate::ids::CardId::from_raw(91_512), "Seen Land")
+            .card_types(vec![CardType::Land])
+            .build();
+        let seen_land = game.create_object_from_card(&land_card, alice, Zone::Graveyard);
+
+        let mut object_tags = HashMap::new();
+        object_tags.insert(
+            TagKey::from(SURVEILLED_THIS_TURN_TAG),
+            vec![
+                ObjectSnapshot::from_object(game.object(seen_spell).unwrap(), &game),
+                ObjectSnapshot::from_object(game.object(seen_land).unwrap(), &game),
+            ],
+        );
+        let event = RawEvent::new(
+            KeywordActionEvent::new(KeywordActionKind::Surveil, alice, source_id, 2)
+                .with_object_tags(object_tags),
+            ProvNodeId::default(),
+        );
+        game.turn_store.turn_history.record_event(&event, None, None);
+
+        assert_eq!(
+            game.effect_store
+                .grant_registry
+                .granted_play_from_for_card(&game, seen_spell, Zone::Graveyard, alice)
+                .len(),
+            1,
+            "surveilled graveyard spell should be playable"
+        );
+        assert_eq!(
+            game.effect_store
+                .grant_registry
+                .granted_alternative_casts_for_card(&game, seen_spell, Zone::Graveyard, alice)
+                .len(),
+            1,
+            "surveilled graveyard spell should get the life-cost cast"
+        );
+        assert!(
+            game.effect_store
+                .grant_registry
+                .granted_play_from_for_card(&game, unseen_spell, Zone::Graveyard, alice)
+                .is_empty(),
+            "non-surveilled graveyard spell should not be playable"
+        );
+        assert_eq!(
+            game.effect_store
+                .grant_registry
+                .granted_play_from_for_card(&game, seen_land, Zone::Graveyard, alice)
+                .len(),
+            1,
+            "surveilled graveyard land should be playable"
+        );
+        assert!(
+            game.effect_store
+                .grant_registry
+                .granted_alternative_casts_for_card(&game, seen_land, Zone::Graveyard, alice)
+                .is_empty(),
+            "surveilled graveyard land should not get a spell life-cost alternative"
+        );
     }
 }

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -461,6 +461,22 @@ impl TurnHistory {
         })
     }
 
+    pub fn object_was_surveilled_this_turn(&self, stable_id: StableId) -> bool {
+        self.projected_records()
+            .filter_map(|record| record.event.downcast::<KeywordActionEvent>())
+            .filter(|event| event.action == KeywordActionKind::Surveil)
+            .any(|event| {
+                event
+                    .object_tags
+                    .get(crate::tag::SURVEILLED_THIS_TURN_TAG)
+                    .is_some_and(|snapshots| {
+                        snapshots
+                            .iter()
+                            .any(|snapshot| snapshot.stable_id == stable_id)
+                    })
+            })
+    }
+
     pub fn player_was_dealt_damage_by_creature_this_turn(&self, player: PlayerId) -> bool {
         self.total_creature_damage_to_player(player) > 0
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Eye of Duskmantle
Initial parse error:
```
parser does not yet support line family: 'You may play lands and cast spells from among cards in your graveyard you've surveilled this turn. If you cast a spell this way, you pay life equal to its mana value rather than paying its mana cost.'; oracle-only fallback also failed: parser does not yet support line family: 'You may play lands and cast spells from among cards in your graveyard you've surveilled this turn. If you cast a spell this way, you pay life equal to its mana value rather than paying its mana cost.'
```

Current worker: i-0a38b7ae1c67c79e2
Branch: codex/aws-card-fix-eye-of-duskmantle
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0016
