### PR TITLE
Fix Ironsmith parse failure: Oath of Scholars

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -368,6 +368,10 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 filter: resolved,
             }
         }
+        PredicateAst::AnOpponentHasMoreCardsInHandThanPlayer { player } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::AnOpponentHasMoreCardsInHandThanPlayer { player }
+        }
         PredicateAst::PlayerLifeAtMostHalfStartingLifeTotal { player } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerLifeAtMostHalfStartingLifeTotal { player }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -915,10 +915,22 @@ pub(crate) fn lower_special_rewrite_triggered_chunk(
             "at the beginning of each player's upkeep",
             line.info.line_index,
         )?;
-        let effects = parse_effect_sentences_from_text(
+        let mut effects = parse_effect_sentences_from_text(
             format!("that player may {effect_text}.").as_str(),
             line.info.line_index,
         )?;
+        let target = TargetAst::Player(
+            PlayerFilter::CardsInHandAtLeastMoreThanYou {
+                base: Box::new(PlayerFilter::Opponent),
+                count: 1,
+            },
+            Some(crate::cards::builders::TextSpan {
+                line: line.info.line_index,
+                start: 0,
+                end: 0,
+            }),
+        );
+        effects.push(EffectAst::subject_verb_target_only(target));
         return Ok(Some(LineAst::Ability(rewrite_parsed_triggered_ability(
             trigger.clone(),
             vec![EffectAst::Conditional {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -907,6 +907,35 @@ pub(crate) fn lower_special_rewrite_triggered_chunk(
 ) -> Result<Option<LineAst>, CardTextError> {
     let normalized = line.full_text.trim_end_matches('.');
 
+    if let Some(effect_text) = str_strip_prefix(
+        normalized,
+        "at the beginning of each player's upkeep, that player chooses target player who has more cards in hand than they do and is their opponent. the first player may ",
+    ) {
+        let trigger = parse_trigger_clause_from_text(
+            "at the beginning of each player's upkeep",
+            line.info.line_index,
+        )?;
+        let effects = parse_effect_sentences_from_text(
+            format!("that player may {effect_text}.").as_str(),
+            line.info.line_index,
+        )?;
+        return Ok(Some(LineAst::Ability(rewrite_parsed_triggered_ability(
+            trigger.clone(),
+            vec![EffectAst::Conditional {
+                predicate: PredicateAst::AnOpponentHasMoreCardsInHandThanPlayer {
+                    player: PlayerAst::That,
+                },
+                if_true: effects,
+                if_false: Vec::new(),
+            }],
+            infer_rewrite_triggered_functional_zones(&trigger, &line.info.raw_line),
+            Some(line.info.raw_line.clone()),
+            None,
+            None,
+            ReferenceImports::default(),
+        ))));
+    }
+
     if normalized
         == "when the names of three or more nonland permanents begin with the same letter, sacrifice this creature. if you do, it deals 2 damage to each creature and each player"
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -423,6 +423,9 @@ pub(crate) enum PredicateAst {
         player: PlayerAst,
         filter: ObjectFilter,
     },
+    AnOpponentHasMoreCardsInHandThanPlayer {
+        player: PlayerAst,
+    },
     PlayerControlsMoreThanYou {
         player: PlayerAst,
         filter: ObjectFilter,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -625,6 +625,9 @@ pub enum Condition {
         player: PlayerFilter,
         filter: ObjectFilter,
     },
+    AnOpponentHasMoreCardsInHandThanPlayer {
+        player: PlayerFilter,
+    },
     PlayerLifeAtMostHalfStartingLifeTotal {
         player: PlayerFilter,
     },

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46328,6 +46328,32 @@ fn parse_oath_of_druids_maps_to_upkeep_consult_effects() {
     );
 }
 
+#[test]
+fn oath_of_scholars_strict_oracle_regression_keeps_hand_size_gate() {
+    let def = parse_oracle_card_definition("Oath of Scholars");
+    let raw = format!("{:?}", def.abilities);
+    assert!(
+        raw.contains("BeginningOfUpkeepTrigger")
+            && raw.contains("player: Any")
+            && raw.contains("AnOpponentHasMoreCardsInHandThanPlayer")
+            && raw.contains("MayEffect")
+            && raw.contains("DiscardHandEffect")
+            && raw.contains("DrawCardsEffect"),
+        "expected Oath of Scholars to keep its upkeep hand-size gate and optional discard/draw effects, got {raw}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("each player's upkeep")
+            && rendered.contains("more cards in hand than they do")
+            && rendered.contains("the first player may discard their hand")
+            && rendered.contains("draw three cards"),
+        "expected Oath of Scholars compiled text to keep the hand-size condition and discard/draw rider, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_mind_funeral_tracks_passive_consult_count_and_graveyard_followup() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46336,10 +46336,12 @@ fn oath_of_scholars_strict_oracle_regression_keeps_hand_size_gate() {
         raw.contains("BeginningOfUpkeepTrigger")
             && raw.contains("player: Any")
             && raw.contains("AnOpponentHasMoreCardsInHandThanPlayer")
+            && raw.contains("CardsInHandAtLeastMoreThanYou")
+            && raw.contains("TargetOnlyEffect")
             && raw.contains("MayEffect")
             && raw.contains("DiscardHandEffect")
             && raw.contains("DrawCardsEffect"),
-        "expected Oath of Scholars to keep its upkeep hand-size gate and optional discard/draw effects, got {raw}"
+        "expected Oath of Scholars to keep its upkeep target, hand-size gate, and optional discard/draw effects, got {raw}"
     );
 
     let rendered = unprocessed_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10967,6 +10967,14 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 format!("an opponent controls more {subject} than {compared_player} does")
             }
         }
+        Condition::AnOpponentHasMoreCardsInHandThanPlayer { player } => {
+            let compared_player = describe_player_filter(player);
+            if compared_player == "you" {
+                "an opponent has more cards in hand than you do".to_string()
+            } else {
+                format!("an opponent has more cards in hand than {compared_player} does")
+            }
+        }
         Condition::PlayerLifeAtMostHalfStartingLifeTotal { player } => {
             let subject = if *player == PlayerFilter::You {
                 "your".to_string()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1038,6 +1038,35 @@ fn describe_each_player_may_discard_hand_draw_commander_value(
     })
 }
 
+fn describe_may_discard_hand_draw_cards(may: &crate::effects::MayEffect) -> Option<String> {
+    let [discard_effect, draw_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let discard = discard_effect.downcast_ref::<crate::effects::DiscardHandEffect>()?;
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if discard.player != draw.player {
+        return None;
+    }
+    if may
+        .decider
+        .as_ref()
+        .is_some_and(|decider| decider != &discard.player)
+    {
+        return None;
+    }
+
+    let player = describe_player_filter(may.decider.as_ref().unwrap_or(&discard.player));
+    let hand = if player == "you" {
+        "your hand"
+    } else {
+        "their hand"
+    };
+    Some(format!(
+        "{player} may discard {hand} and draw {}",
+        describe_card_count(&draw.count)
+    ))
+}
+
 #[derive(Clone, Copy)]
 pub(super) struct SacrificeView<'a> {
     filter: &'a ObjectFilter,
@@ -14604,11 +14633,40 @@ fn rewrite_damaged_player_reference_for_combat_damage_trigger(
         .replace("The damaged player", "That player")
 }
 
+fn describe_each_upkeep_hand_advantage_oath(
+    triggered: &crate::ability::TriggeredAbility,
+) -> Option<String> {
+    let upkeep = triggered
+        .trigger
+        .downcast_ref::<crate::triggers::BeginningOfUpkeepTrigger>()?;
+    if upkeep.player != PlayerFilter::Any {
+        return None;
+    }
+    let Some(Condition::AnOpponentHasMoreCardsInHandThanPlayer { player }) =
+        triggered.intervening_if.as_ref()
+    else {
+        return None;
+    };
+    if *player != PlayerFilter::Active {
+        return None;
+    }
+    let effects = describe_triggered_resolution_text(triggered, "this enchantment", true)?;
+    let rest = effects
+        .strip_prefix("that player may ")
+        .or_else(|| effects.strip_prefix("the active player may "))?;
+    Some(format!(
+        "At the beginning of each player's upkeep, that player chooses target player who has more cards in hand than they do and is their opponent. The first player may {rest}"
+    ))
+}
+
 fn describe_triggered_inline_ability(
     triggered: &crate::ability::TriggeredAbility,
     self_subject: &str,
 ) -> String {
     if let Some(rendered) = describe_backup_keyword(triggered) {
+        return rendered;
+    }
+    if let Some(rendered) = describe_each_upkeep_hand_advantage_oath(triggered) {
         return rendered;
     }
 
@@ -30092,6 +30150,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(compact) = describe_may_choose_reveal_and_move_to_hand(may) {
             return compact;
         }
+        if let Some(compact) = describe_may_discard_hand_draw_cards(may) {
+            return compact;
+        }
         if let Some(compact) = describe_may_search_library_and_or_nonlibrary(may) {
             return compact;
         }
@@ -36311,6 +36372,9 @@ pub(super) fn describe_ability(
         }
         AbilityKind::Triggered(triggered) => {
             if let Some(rendered) = describe_backup_keyword(triggered) {
+                return vec![format!("Triggered ability {index}: {rendered}")];
+            }
+            if let Some(rendered) = describe_each_upkeep_hand_advantage_oath(triggered) {
                 return vec![format!("Triggered ability {index}: {rendered}")];
             }
             if let Some(rendered) = describe_annihilator_keyword(triggered) {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14650,13 +14650,41 @@ fn describe_each_upkeep_hand_advantage_may_discard_draw(
     if *player != PlayerFilter::Active {
         return None;
     }
+    if !triggered
+        .choices
+        .iter()
+        .any(is_more_cards_than_chooser_opponent_target)
+    {
+        return None;
+    }
     let effects = describe_triggered_resolution_text(triggered, "this enchantment", true)?;
     let rest = effects
         .strip_prefix("that player may ")
         .or_else(|| effects.strip_prefix("the active player may "))?;
+    let rest = rest
+        .strip_suffix(
+            ". Choose target opponent who has at least one more cards in hand than you do as you activate this ability",
+        )
+        .unwrap_or(rest);
     Some(format!(
         "At the beginning of each player's upkeep, that player chooses target player who has more cards in hand than they do and is their opponent. The first player may {rest}"
     ))
+}
+
+fn is_more_cards_than_chooser_opponent_target(spec: &crate::target::ChooseSpec) -> bool {
+    match spec {
+        crate::target::ChooseSpec::SurfaceHinted { spec, .. }
+        | crate::target::ChooseSpec::Target(spec)
+        | crate::target::ChooseSpec::WithCount(spec, _)
+        | crate::target::ChooseSpec::WithCountValue(spec, _, _) => {
+            is_more_cards_than_chooser_opponent_target(spec)
+        }
+        crate::target::ChooseSpec::Player(PlayerFilter::CardsInHandAtLeastMoreThanYou {
+            base,
+            count,
+        }) => *count == 1 && matches!(base.as_ref(), PlayerFilter::Opponent),
+        _ => false,
+    }
 }
 
 fn describe_triggered_inline_ability(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14633,7 +14633,7 @@ fn rewrite_damaged_player_reference_for_combat_damage_trigger(
         .replace("The damaged player", "That player")
 }
 
-fn describe_each_upkeep_hand_advantage_oath(
+fn describe_each_upkeep_hand_advantage_may_discard_draw(
     triggered: &crate::ability::TriggeredAbility,
 ) -> Option<String> {
     let upkeep = triggered
@@ -14666,7 +14666,7 @@ fn describe_triggered_inline_ability(
     if let Some(rendered) = describe_backup_keyword(triggered) {
         return rendered;
     }
-    if let Some(rendered) = describe_each_upkeep_hand_advantage_oath(triggered) {
+    if let Some(rendered) = describe_each_upkeep_hand_advantage_may_discard_draw(triggered) {
         return rendered;
     }
 
@@ -36374,7 +36374,7 @@ pub(super) fn describe_ability(
             if let Some(rendered) = describe_backup_keyword(triggered) {
                 return vec![format!("Triggered ability {index}: {rendered}")];
             }
-            if let Some(rendered) = describe_each_upkeep_hand_advantage_oath(triggered) {
+            if let Some(rendered) = describe_each_upkeep_hand_advantage_may_discard_draw(triggered) {
                 return vec![format!("Triggered ability {index}: {rendered}")];
             }
             if let Some(rendered) = describe_annihilator_keyword(triggered) {

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -526,6 +526,16 @@ fn any_opponent_controls_more_than_player(
         })
 }
 
+fn any_opponent_has_more_cards_in_hand_than_player(game: &GameState, player_id: PlayerId) -> bool {
+    let Some(player_hand) = game.player(player_id).map(|player| player.hand.len()) else {
+        return false;
+    };
+    game.players
+        .iter()
+        .filter(|player| player.id != player_id && player.is_in_game())
+        .any(|opponent| opponent.hand.len() > player_hand)
+}
+
 fn player_has_more_life_than_each_other_player(game: &GameState, player_id: PlayerId) -> bool {
     let Some(life) = game.player(player_id).map(|p| p.life) else {
         return false;
@@ -940,6 +950,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::PlayerControlsMost { .. } => {}
         Condition::PlayerControlsMoreThanYou { .. } => {}
         Condition::AnOpponentControlsMoreThanPlayer { .. } => {}
+        Condition::AnOpponentHasMoreCardsInHandThanPlayer { .. } => {}
         Condition::PlayerLifeAtMostHalfStartingLifeTotal { .. } => {}
         Condition::PlayerLifeLessThanHalfStartingLifeTotal { .. } => {}
         Condition::LifeTotalOrLess(..) => {}
@@ -1589,6 +1600,11 @@ pub fn evaluate_condition_external(
                         game, ctx.source, player, player_id, filter,
                     )
                 })
+        }
+        Condition::AnOpponentHasMoreCardsInHandThanPlayer { player } => {
+            matching_condition_players_external(game, ctx, player)
+                .into_iter()
+                .any(|player_id| any_opponent_has_more_cards_in_hand_than_player(game, player_id))
         }
         Condition::PlayerOwnsCardNamedInZones {
             player,
@@ -2294,6 +2310,11 @@ fn evaluate_condition_simple(
                     any_opponent_controls_more_than_player(game, source, player, player_id, filter)
                 })
         }
+        Condition::AnOpponentHasMoreCardsInHandThanPlayer { player } => {
+            matching_condition_players_simple(game, controller, player)
+                .into_iter()
+                .any(|player_id| any_opponent_has_more_cards_in_hand_than_player(game, player_id))
+        }
         Condition::PlayerLifeAtMostHalfStartingLifeTotal { player } => {
             matching_condition_players_simple(game, controller, player)
                 .into_iter()
@@ -2966,6 +2987,11 @@ fn evaluate_condition(
                         game, ctx.source, player, player_id, filter,
                     )
                 }))
+        }
+        Condition::AnOpponentHasMoreCardsInHandThanPlayer { player } => {
+            Ok(matching_condition_players_exec(game, ctx, player)?
+                .into_iter()
+                .any(|player_id| any_opponent_has_more_cards_in_hand_than_player(game, player_id)))
         }
         Condition::PlayerLifeAtMostHalfStartingLifeTotal { player } => {
             Ok(matching_condition_players_exec(game, ctx, player)?

--- a/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
+++ b/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
@@ -817,10 +817,11 @@ fn target_requirements_from_explicit_choices(
                 target_spec,
                 entry.triggering_event.as_ref(),
             );
+            let chooser = target_chooser_for_trigger_spec(game, trigger, &resolved_target_spec);
             let legal_targets = compute_legal_targets_with_tagged_objects_combat_context_and_view(
                 game,
                 &resolved_target_spec,
-                trigger.controller,
+                chooser,
                 Some(trigger.source),
                 None,
                 tagged_objects_ref,
@@ -838,6 +839,41 @@ fn target_requirements_from_explicit_choices(
             }
         })
         .collect()
+}
+
+fn target_chooser_for_trigger_spec(
+    game: &GameState,
+    trigger: &TriggeredAbilityEntry,
+    spec: &ChooseSpec,
+) -> PlayerId {
+    if trigger
+        .ability
+        .trigger
+        .downcast_ref::<crate::triggers::BeginningOfUpkeepTrigger>()
+        .is_some_and(|upkeep| upkeep.player == crate::target::PlayerFilter::Any)
+        && target_spec_is_opponent_with_more_cards_than_chooser(spec)
+    {
+        return game.turn.active_player;
+    }
+    trigger.controller
+}
+
+fn target_spec_is_opponent_with_more_cards_than_chooser(spec: &ChooseSpec) -> bool {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::Target(spec)
+        | ChooseSpec::WithCount(spec, _)
+        | ChooseSpec::WithCountValue(spec, _, _) => {
+            target_spec_is_opponent_with_more_cards_than_chooser(spec)
+        }
+        ChooseSpec::Player(crate::target::PlayerFilter::CardsInHandAtLeastMoreThanYou {
+            base,
+            count,
+        }) => {
+            *count == 1 && matches!(base.as_ref(), crate::target::PlayerFilter::Opponent)
+        }
+        _ => false,
+    }
 }
 
 fn target_requirements_overlap(left: &TargetRequirement, right: &TargetRequirement) -> bool {
@@ -890,11 +926,12 @@ fn refresh_trigger_program_target_requirements(
             &requirement.spec,
             entry.triggering_event.as_ref(),
         );
+        let chooser = target_chooser_for_trigger_spec(game, trigger, &spec);
         requirement.legal_targets =
             compute_legal_targets_with_tagged_objects_combat_context_and_view(
                 game,
                 &spec,
-                trigger.controller,
+                chooser,
                 Some(trigger.source),
                 entry.source_snapshot.as_ref(),
                 tagged_objects,
@@ -941,6 +978,12 @@ fn choose_trigger_targets(
         return Some((Vec::new(), Vec::new()));
     }
 
+    let chooser = requirements
+        .iter()
+        .map(|requirement| target_chooser_for_trigger_spec(game, trigger, &requirement.spec))
+        .find(|chooser| *chooser != trigger.controller)
+        .unwrap_or(trigger.controller);
+
     if requirements
         .iter()
         .any(|requirement| requirement.legal_targets.len() < requirement.min_targets)
@@ -950,7 +993,7 @@ fn choose_trigger_targets(
 
     let requirement_contexts = trigger_target_requirement_contexts(requirements);
     let ctx = crate::decisions::context::TargetsContext::new(
-        trigger.controller,
+        chooser,
         trigger.source,
         format!("{}'s triggered ability", trigger.source_name),
         requirement_contexts.clone(),

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -2261,6 +2261,47 @@ fn choose_spec_for_resolution_target_validation(
     }
 }
 
+fn target_validation_controller_for_spec(
+    game: &GameState,
+    entry: &StackEntry,
+    spec: &crate::target::ChooseSpec,
+) -> PlayerId {
+    if target_validation_uses_active_player_for_spec(entry, spec) {
+        return game.turn.active_player;
+    }
+    entry.controller
+}
+
+fn target_validation_uses_active_player_for_spec(
+    entry: &StackEntry,
+    spec: &crate::target::ChooseSpec,
+) -> bool {
+    entry
+        .triggering_event
+        .as_ref()
+        .is_some_and(|event| event.kind() == crate::events::EventKind::BeginningOfUpkeep)
+        && target_spec_is_opponent_with_more_cards_than_active_player(spec)
+}
+
+fn target_spec_is_opponent_with_more_cards_than_active_player(
+    spec: &crate::target::ChooseSpec,
+) -> bool {
+    use crate::target::ChooseSpec;
+
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::Target(spec)
+        | ChooseSpec::WithCount(spec, _)
+        | ChooseSpec::WithCountValue(spec, _, _) => {
+            target_spec_is_opponent_with_more_cards_than_active_player(spec)
+        }
+        ChooseSpec::Player(PlayerFilter::CardsInHandAtLeastMoreThanYou { base, count }) => {
+            *count == 1 && matches!(base.as_ref(), PlayerFilter::Opponent)
+        }
+        _ => false,
+    }
+}
+
 pub(super) fn validate_stack_entry_targets_with_view(
     game: &GameState,
     entry: &StackEntry,
@@ -2285,11 +2326,19 @@ pub(super) fn validate_stack_entry_targets_with_view(
                 &assignment.spec,
                 entry.triggering_event.as_ref(),
             );
-            let resolved_spec = choose_spec_for_resolution_target_validation(&resolved_spec);
+            let preserve_hand_size_target_gate =
+                target_validation_uses_active_player_for_spec(entry, &resolved_spec);
+            let validation_controller =
+                target_validation_controller_for_spec(game, entry, &resolved_spec);
+            let resolved_spec = if preserve_hand_size_target_gate {
+                resolved_spec
+            } else {
+                choose_spec_for_resolution_target_validation(&resolved_spec)
+            };
             let legal_targets = compute_legal_targets_with_source_snapshot_and_view(
                 game,
                 &resolved_spec,
-                entry.controller,
+                validation_controller,
                 Some(entry.object_id),
                 entry.source_snapshot.as_ref(),
                 if entry.tagged_objects.is_empty() {
@@ -2303,7 +2352,7 @@ pub(super) fn validate_stack_entry_targets_with_view(
                 compute_legal_targets_with_tagged_objects_combat_context_and_view(
                     game,
                     &resolved_spec,
-                    entry.controller,
+                    validation_controller,
                     Some(entry.object_id),
                     entry.source_snapshot.as_ref(),
                     if entry.tagged_objects.is_empty() {
@@ -2350,12 +2399,20 @@ pub(super) fn validate_stack_entry_targets_with_view(
         .map(|spec| {
             let resolved_spec =
                 choose_spec_with_damaged_player_from_event(spec, entry.triggering_event.as_ref());
-            let resolved_spec = choose_spec_for_resolution_target_validation(&resolved_spec);
+            let preserve_hand_size_target_gate =
+                target_validation_uses_active_player_for_spec(entry, &resolved_spec);
+            let validation_controller =
+                target_validation_controller_for_spec(game, entry, &resolved_spec);
+            let resolved_spec = if preserve_hand_size_target_gate {
+                resolved_spec
+            } else {
+                choose_spec_for_resolution_target_validation(&resolved_spec)
+            };
             if entry.defending_player.is_some() {
                 return compute_legal_targets_with_tagged_objects_combat_context_and_view(
                     game,
                     &resolved_spec,
-                    entry.controller,
+                    validation_controller,
                     Some(entry.object_id),
                     entry.source_snapshot.as_ref(),
                     None,
@@ -2367,7 +2424,7 @@ pub(super) fn validate_stack_entry_targets_with_view(
             compute_legal_targets_with_source_snapshot_and_view(
                 game,
                 &resolved_spec,
-                entry.controller,
+                validation_controller,
                 Some(entry.object_id),
                 entry.source_snapshot.as_ref(),
                 None,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -5262,6 +5262,45 @@ fn oath_of_scholars_upkeep_does_nothing_without_opponent_hand_advantage() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oath_of_scholars_upkeep_does_nothing_if_hand_advantage_disappears_before_resolution() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    add_named_card_to_zone(&mut game, 99_230, "Alice Filler A", alice, Zone::Hand);
+    add_named_card_to_zone(&mut game, 99_231, "Alice Filler B", alice, Zone::Hand);
+    let kept = add_named_card_to_zone(&mut game, 99_232, "Bob Original Hand", bob, Zone::Hand);
+    for (offset, name) in ["Bob Library A", "Bob Library B", "Bob Library C"]
+        .into_iter()
+        .enumerate()
+    {
+        add_named_card_to_zone(&mut game, 99_233 + offset as u32, name, bob, Zone::Library);
+    }
+
+    put_oath_of_scholars_trigger_on_stack(&mut game, &mut trigger_queue);
+    let caught_up =
+        add_named_card_to_zone(&mut game, 99_236, "Bob Catch Up Card", bob, Zone::Hand);
+
+    let mut dm = OathOfScholarsDecisionMaker { accept_may: true };
+    resolve_stack_entry_with(&mut game, &mut dm).expect(
+        "Oath of Scholars trigger should resolve cleanly when its hand-size gate becomes false",
+    );
+
+    let bob_state = game.player(bob).expect("Bob exists");
+    assert_eq!(
+        bob_state.hand,
+        vec![kept, caught_up],
+        "if no opponent still has more cards in hand, Bob should keep his hand and draw nothing"
+    );
+    assert!(
+        bob_state.graveyard.is_empty(),
+        "the discard branch should not run after the hand-size gate becomes false"
+    );
+}
+
 fn dream_tides_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(99_120), "Dream Tides")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -5084,6 +5084,184 @@ fn oath_of_druids_upkeep_trigger_puts_revealed_creature_onto_battlefield() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn oath_of_scholars_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(99_200), "Oath of Scholars")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "At the beginning of each player's upkeep, that player chooses target player who has more cards in hand than they do and is their opponent. The first player may discard their hand and draw three cards.",
+        )
+        .expect("Oath of Scholars should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct OathOfScholarsDecisionMaker {
+    accept_may: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for OathOfScholarsDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept_may
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_named_card_to_zone(
+    game: &mut GameState,
+    id: u32,
+    name: &str,
+    owner: PlayerId,
+    zone: Zone,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::from_raw(id), name).build();
+    game.create_object_from_card(&card, owner, zone)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_oath_of_scholars_trigger_on_stack(game: &mut GameState, trigger_queue: &mut TriggerQueue) {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let oath = oath_of_scholars_definition();
+    game.create_object_from_definition(&oath, alice, Zone::Battlefield);
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+
+    generate_and_queue_step_triggers(game, trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Oath of Scholars should trigger at the beginning of each player's upkeep"
+    );
+    put_triggers_on_stack(game, trigger_queue)
+        .expect("Oath of Scholars upkeep trigger should go on the stack");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_oath_of_scholars_on_battlefield_for_bob_upkeep(game: &mut GameState) {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let oath = oath_of_scholars_definition();
+    game.create_object_from_definition(&oath, alice, Zone::Battlefield);
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oath_of_scholars_upkeep_discards_hand_and_draws_when_accepted() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    add_named_card_to_zone(&mut game, 99_201, "Alice Filler A", alice, Zone::Hand);
+    add_named_card_to_zone(&mut game, 99_202, "Alice Filler B", alice, Zone::Hand);
+    add_named_card_to_zone(&mut game, 99_203, "Bob Old Hand", bob, Zone::Hand);
+    for (offset, name) in ["Bob Draw One", "Bob Draw Two", "Bob Draw Three"]
+        .into_iter()
+        .enumerate()
+    {
+        add_named_card_to_zone(&mut game, 99_204 + offset as u32, name, bob, Zone::Library);
+    }
+
+    put_oath_of_scholars_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = OathOfScholarsDecisionMaker { accept_may: true };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Oath of Scholars upkeep trigger should resolve when accepted");
+
+    let bob_state = game.player(bob).expect("Bob exists");
+    assert_eq!(
+        bob_state.hand.len(),
+        3,
+        "Bob should discard his old hand and draw three cards"
+    );
+    assert!(
+        bob_state.graveyard.iter().any(|&id| {
+            game.object(id)
+                .is_some_and(|object| object.name == "Bob Old Hand" && object.owner == bob)
+        }),
+        "Bob's previous hand should be discarded"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oath_of_scholars_upkeep_does_nothing_when_declined() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    add_named_card_to_zone(&mut game, 99_210, "Alice Filler A", alice, Zone::Hand);
+    add_named_card_to_zone(&mut game, 99_211, "Alice Filler B", alice, Zone::Hand);
+    let kept = add_named_card_to_zone(&mut game, 99_212, "Bob Kept Hand", bob, Zone::Hand);
+    for (offset, name) in ["Bob Library A", "Bob Library B", "Bob Library C"]
+        .into_iter()
+        .enumerate()
+    {
+        add_named_card_to_zone(&mut game, 99_213 + offset as u32, name, bob, Zone::Library);
+    }
+
+    put_oath_of_scholars_trigger_on_stack(&mut game, &mut trigger_queue);
+
+    let mut dm = OathOfScholarsDecisionMaker { accept_may: false };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Oath of Scholars upkeep trigger should resolve when declined");
+
+    let bob_state = game.player(bob).expect("Bob exists");
+    assert_eq!(bob_state.hand, vec![kept]);
+    assert!(
+        bob_state.graveyard.is_empty(),
+        "declining should not discard Bob's hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oath_of_scholars_upkeep_does_nothing_without_opponent_hand_advantage() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    add_named_card_to_zone(&mut game, 99_220, "Alice Filler", alice, Zone::Hand);
+    let kept = add_named_card_to_zone(&mut game, 99_221, "Bob Equal Hand", bob, Zone::Hand);
+    for (offset, name) in ["Bob Library A", "Bob Library B", "Bob Library C"]
+        .into_iter()
+        .enumerate()
+    {
+        add_named_card_to_zone(&mut game, 99_222 + offset as u32, name, bob, Zone::Library);
+    }
+
+    put_oath_of_scholars_on_battlefield_for_bob_upkeep(&mut game);
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+
+    assert_eq!(
+        trigger_queue.entries.len(),
+        0,
+        "Oath of Scholars should not trigger without an opponent ahead on cards"
+    );
+
+    let bob_state = game.player(bob).expect("Bob exists");
+    assert_eq!(bob_state.hand, vec![kept]);
+    assert!(
+        bob_state.graveyard.is_empty(),
+        "without an opponent ahead on cards, the discard/draw branch should not happen"
+    );
+}
+
 fn dream_tides_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(99_120), "Dream Tides")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -5097,6 +5097,10 @@ fn oath_of_scholars_definition() -> crate::cards::CardDefinition {
 #[cfg(ironsmith_runtime_parser_tests)]
 struct OathOfScholarsDecisionMaker {
     accept_may: bool,
+    target_to_choose: Option<PlayerId>,
+    expected_target_chooser: Option<PlayerId>,
+    expected_legal_targets: Option<Vec<crate::game_state::Target>>,
+    target_calls: usize,
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
@@ -5107,6 +5111,25 @@ impl DecisionMaker for OathOfScholarsDecisionMaker {
         _ctx: &crate::decisions::context::BooleanContext,
     ) -> bool {
         self.accept_may
+    }
+
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<crate::game_state::Target> {
+        self.target_calls += 1;
+        if let Some(expected) = self.expected_target_chooser {
+            assert_eq!(ctx.player, expected, "Oath target chooser should be the active player");
+        }
+        if let Some(expected) = &self.expected_legal_targets {
+            assert_eq!(ctx.requirements.len(), 1);
+            assert_eq!(&ctx.requirements[0].legal_targets, expected);
+        }
+        self.target_to_choose
+            .map(crate::game_state::Target::Player)
+            .into_iter()
+            .collect()
     }
 }
 
@@ -5124,6 +5147,16 @@ fn add_named_card_to_zone(
 
 #[cfg(ironsmith_runtime_parser_tests)]
 fn put_oath_of_scholars_trigger_on_stack(game: &mut GameState, trigger_queue: &mut TriggerQueue) {
+    let mut dm = AutoPassDecisionMaker;
+    put_oath_of_scholars_trigger_on_stack_with_dm(game, trigger_queue, &mut dm);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_oath_of_scholars_trigger_on_stack_with_dm(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    decision_maker: &mut dyn DecisionMaker,
+) {
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
     let oath = oath_of_scholars_definition();
@@ -5140,7 +5173,7 @@ fn put_oath_of_scholars_trigger_on_stack(game: &mut GameState, trigger_queue: &m
         1,
         "Oath of Scholars should trigger at the beginning of each player's upkeep"
     );
-    put_triggers_on_stack(game, trigger_queue)
+    put_triggers_on_stack_with_dm(game, trigger_queue, decision_maker)
         .expect("Oath of Scholars upkeep trigger should go on the stack");
 }
 
@@ -5177,7 +5210,13 @@ fn oath_of_scholars_upkeep_discards_hand_and_draws_when_accepted() {
 
     put_oath_of_scholars_trigger_on_stack(&mut game, &mut trigger_queue);
 
-    let mut dm = OathOfScholarsDecisionMaker { accept_may: true };
+    let mut dm = OathOfScholarsDecisionMaker {
+        accept_may: true,
+        target_to_choose: None,
+        expected_target_chooser: None,
+        expected_legal_targets: None,
+        target_calls: 0,
+    };
     resolve_stack_entry_with(&mut game, &mut dm)
         .expect("Oath of Scholars upkeep trigger should resolve when accepted");
 
@@ -5194,6 +5233,33 @@ fn oath_of_scholars_upkeep_discards_hand_and_draws_when_accepted() {
         }),
         "Bob's previous hand should be discarded"
     );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn oath_of_scholars_upkeep_target_is_chosen_by_active_player() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    add_named_card_to_zone(&mut game, 99_240, "Alice Filler A", alice, Zone::Hand);
+    add_named_card_to_zone(&mut game, 99_241, "Alice Filler B", alice, Zone::Hand);
+    add_named_card_to_zone(&mut game, 99_242, "Bob Old Hand", bob, Zone::Hand);
+
+    let mut dm = OathOfScholarsDecisionMaker {
+        accept_may: true,
+        target_to_choose: Some(alice),
+        expected_target_chooser: Some(bob),
+        expected_legal_targets: Some(vec![crate::game_state::Target::Player(alice)]),
+        target_calls: 0,
+    };
+    put_oath_of_scholars_trigger_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm);
+
+    assert_eq!(dm.target_calls, 1, "Oath should ask for exactly one target");
+    let entry = game.stack.last().expect("Oath trigger should be on the stack");
+    assert_eq!(entry.targets, vec![crate::game_state::Target::Player(alice)]);
+    assert_eq!(entry.target_assignments.len(), 1);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
@@ -5216,7 +5282,13 @@ fn oath_of_scholars_upkeep_does_nothing_when_declined() {
 
     put_oath_of_scholars_trigger_on_stack(&mut game, &mut trigger_queue);
 
-    let mut dm = OathOfScholarsDecisionMaker { accept_may: false };
+    let mut dm = OathOfScholarsDecisionMaker {
+        accept_may: false,
+        target_to_choose: None,
+        expected_target_chooser: None,
+        expected_legal_targets: None,
+        target_calls: 0,
+    };
     resolve_stack_entry_with(&mut game, &mut dm)
         .expect("Oath of Scholars upkeep trigger should resolve when declined");
 
@@ -5284,7 +5356,13 @@ fn oath_of_scholars_upkeep_does_nothing_if_hand_advantage_disappears_before_reso
     let caught_up =
         add_named_card_to_zone(&mut game, 99_236, "Bob Catch Up Card", bob, Zone::Hand);
 
-    let mut dm = OathOfScholarsDecisionMaker { accept_may: true };
+    let mut dm = OathOfScholarsDecisionMaker {
+        accept_may: true,
+        target_to_choose: None,
+        expected_target_chooser: None,
+        expected_legal_targets: None,
+        target_calls: 0,
+    };
     resolve_stack_entry_with(&mut game, &mut dm).expect(
         "Oath of Scholars trigger should resolve cleanly when its hand-size gate becomes false",
     );


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Oath of Scholars
Initial parse error:
```
compiled text dropped required semantic marker: more-cards-in-hand-than
```

Current worker: i-0626d6a471e9365b2
Branch: codex/aws-card-fix-oath-of-scholars
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0018
