### PR TITLE
Fix Ironsmith parse failure: Paladin Elizabeth Taggerdy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3420,6 +3420,36 @@ pub(crate) fn parse_trigger_clause_lexed(
                 .token_index_for_word_index(attack_word_idx)
                 .unwrap_or(tokens.len());
             let subject_tokens = &tokens[..attack_token_idx];
+            if let Some(and_idx) = find_index(subject_tokens, |token| token.is_word("and")) {
+                let left = trim_edge_punctuation(&subject_tokens[..and_idx]);
+                let right = trim_edge_punctuation(&subject_tokens[and_idx + 1..]);
+                if !left.is_empty()
+                    && token_slice_at_is(&right, 0, "at")
+                    && token_slice_at_is(&right, 1, "least")
+                    && let Some((other_count, used)) = parse_number(&right[2..])
+                    && right
+                        .get(2 + used)
+                        .is_some_and(|token| token.is_word("other"))
+                    && right.get(3 + used).is_some_and(|token| {
+                        token.is_word("creature") || token.is_word("creatures")
+                    })
+                {
+                    let rendered_subject =
+                        crate::runtime_backend::lexer::render_token_slice(&left)
+                            .trim()
+                            .to_string();
+                    let display_subject = if rendered_subject == "this" {
+                        current_source_reference_name()
+                    } else {
+                        Some(rendered_subject)
+                    }
+                    .filter(|subject| !subject.is_empty());
+                    return Ok(TriggerSpec::ThisAttacksWithNOthers {
+                        other_count,
+                        display_subject,
+                    });
+                }
+            }
             let player_subject = trigger_subject_player_selector_lexed(subject_tokens).is_some();
             let one_or_more = ActivationRestrictionCompatWords::new(subject_tokens)
                 .slice_eq(0, &["one", "or", "more"])

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2275,6 +2275,7 @@ fn compile_subject_verb_effect(
             to_top,
             battlefield_controller,
             battlefield_tapped,
+            battlefield_attacking,
             attached_to,
         } => {
             let (mut spec, mut choices) =
@@ -2335,6 +2336,11 @@ fn compile_subject_verb_effect(
                 } else {
                     move_effect
                 };
+                let move_effect = if *zone == Zone::Battlefield && *battlefield_attacking {
+                    move_effect.attacking()
+                } else {
+                    move_effect
+                };
                 let move_effect = match battlefield_controller {
                     ReturnControllerAst::Preserve => move_effect,
                     ReturnControllerAst::Owner => move_effect.under_owner_control(),
@@ -2386,6 +2392,11 @@ fn compile_subject_verb_effect(
             let move_effect = crate::effects::MoveToZoneEffect::new(spec.clone(), *zone, *to_top);
             let move_effect = if *zone == Zone::Battlefield && *battlefield_tapped {
                 move_effect.tapped()
+            } else {
+                move_effect
+            };
+            let move_effect = if *zone == Zone::Battlefield && *battlefield_attacking {
+                move_effect.attacking()
             } else {
                 move_effect
             };

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -12,6 +12,13 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
     match trigger {
         TriggerSpec::StateBased { display, .. } => Trigger::state_based(display),
         TriggerSpec::ThisAttacks => Trigger::this_attacks(),
+        TriggerSpec::ThisAttacksWithNOthers {
+            other_count,
+            display_subject,
+        } => Trigger::this_attacks_with_n_others_display_subject(
+            other_count as usize,
+            display_subject,
+        ),
         TriggerSpec::ThisAttacksWithExactlyNOthers(other_count) => {
             Trigger::this_attacks_with_exact_n_others(other_count as usize)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -102,6 +102,10 @@ pub(crate) enum TriggerSpec {
         display: String,
     },
     ThisAttacks,
+    ThisAttacksWithNOthers {
+        other_count: u32,
+        display_subject: Option<String>,
+    },
     ThisAttacksWithExactlyNOthers(u32),
     ThisAttacksAndIsntBlocked,
     ThisAttacksWhileSaddled,
@@ -1091,6 +1095,7 @@ pub(crate) enum SubjectVerbActionAst {
         to_top: bool,
         battlefield_controller: ReturnControllerAst,
         battlefield_tapped: bool,
+        battlefield_attacking: bool,
         attached_to: Option<TargetAst>,
     },
     MoveToLibraryTopOrBottomChoice {
@@ -2324,6 +2329,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 to_top,
                 battlefield_controller,
                 battlefield_tapped,
+                battlefield_attacking,
                 attached_to,
             } => f
                 .debug_struct("MoveToZone")
@@ -2332,6 +2338,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("to_top", to_top)
                 .field("battlefield_controller", battlefield_controller)
                 .field("battlefield_tapped", battlefield_tapped)
+                .field("battlefield_attacking", battlefield_attacking)
                 .field("attached_to", attached_to)
                 .finish(),
             Self::MoveToLibraryTopOrBottomChoice { target } => f
@@ -3844,6 +3851,26 @@ impl EffectAst {
         battlefield_tapped: bool,
         attached_to: Option<TargetAst>,
     ) -> Self {
+        Self::subject_verb_move_to_zone_with_attacking(
+            target,
+            zone,
+            to_top,
+            battlefield_controller,
+            battlefield_tapped,
+            false,
+            attached_to,
+        )
+    }
+
+    pub(crate) fn subject_verb_move_to_zone_with_attacking(
+        target: TargetAst,
+        zone: Zone,
+        to_top: bool,
+        battlefield_controller: ReturnControllerAst,
+        battlefield_tapped: bool,
+        battlefield_attacking: bool,
+        attached_to: Option<TargetAst>,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
@@ -3853,6 +3880,7 @@ impl EffectAst {
                 to_top,
                 battlefield_controller,
                 battlefield_tapped,
+                battlefield_attacking,
                 attached_to,
             },
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2179,6 +2179,23 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
         Ok(())
     }
 
+    fn replace_in_target(
+        target: &mut TargetAst,
+        replacement: &Value,
+        clause: &str,
+    ) -> Result<(), CardTextError> {
+        match target {
+            TargetAst::Object(filter, _, _) => replace_in_filter(filter, replacement, clause)?,
+            TargetAst::WithCount(inner, _) => replace_in_target(inner, replacement, clause)?,
+            TargetAst::WithCountValue(inner, _, value) => {
+                replace_in_target(inner, replacement, clause)?;
+                replace_value(value, replacement, clause)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     fn replace_value(
         value: &mut Value,
         replacement: &Value,
@@ -2492,7 +2509,6 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::ReturnToBattlefield { .. }
             | SubjectVerbActionAst::ReturnAllToBattlefield { .. }
             | SubjectVerbActionAst::ExileUntilSourceLeaves { .. }
-            | SubjectVerbActionAst::MoveToZone { .. }
             | SubjectVerbActionAst::MoveToLibraryTopOrBottomChoice { .. }
             | SubjectVerbActionAst::TargetOnly { .. }
             | SubjectVerbActionAst::TagMatchingObjects { .. }
@@ -2535,6 +2551,16 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
                 }
                 if let Some(position) = library_position_from_top.as_mut() {
                     replace_value(position, replacement, clause)?;
+                }
+            }
+            SubjectVerbActionAst::MoveToZone {
+                target,
+                attached_to,
+                ..
+            } => {
+                replace_in_target(target, replacement, clause)?;
+                if let Some(attached_to) = attached_to {
+                    replace_in_target(attached_to, replacement, clause)?;
                 }
             }
             SubjectVerbActionAst::CreateTokenCopy { count, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -1170,12 +1170,6 @@ pub(crate) fn parse_put_into_hand(
         destination_tail.retain(|token| !token.is_word("and"));
         destination_tail.retain(|token| !token.is_word("tapped"));
         destination_tail.retain(|token| !token.is_word("attacking"));
-        if battlefield_attacking {
-            return Err(CardTextError::ParseError(format!(
-                "unsupported put destination after 'onto' (clause: '{}')",
-                clause_words.join(" ")
-            )));
-        }
 
         let mut attached_to_target: Option<TargetAst> = None;
         if destination_tail
@@ -1286,12 +1280,13 @@ pub(crate) fn parse_put_into_hand(
             apply_source_zone_constraint(&mut target, Zone::Command);
         }
 
-        return Ok(EffectAst::subject_verb_move_to_zone(
+        return Ok(EffectAst::subject_verb_move_to_zone_with_attacking(
             target,
             Zone::Battlefield,
             false,
             battlefield_controller,
             battlefield_tapped,
+            battlefield_attacking,
             attached_to_target,
         ));
     }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1353,6 +1353,7 @@ pub struct MoveToZoneEffect {
     pub to_top: bool,
     pub battlefield_controller: BattlefieldController,
     pub enters_tapped: bool,
+    pub enters_attacking: bool,
     pub transfer_exiled_with_source_links: bool,
 }
 
@@ -1364,6 +1365,7 @@ impl MoveToZoneEffect {
             to_top,
             battlefield_controller: BattlefieldController::Preserve,
             enters_tapped: false,
+            enters_attacking: false,
             transfer_exiled_with_source_links: false,
         }
     }
@@ -1401,6 +1403,11 @@ impl MoveToZoneEffect {
 
     pub fn tapped(mut self) -> Self {
         self.enters_tapped = true;
+        self
+    }
+
+    pub fn attacking(mut self) -> Self {
+        self.enters_attacking = true;
         self
     }
 }

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -24,6 +24,10 @@ pub enum TriggerKind {
     ThisAttacks,
     ThisAttacksPlayerWithMostLife,
     ThisAttacksWithGreaterPower,
+    ThisAttacksWithNOthers {
+        count: usize,
+        display_subject: Option<String>,
+    },
     ThisAttacksWithExactNOthers {
         count: usize,
     },
@@ -361,6 +365,18 @@ impl Trigger {
         Self::typed(
             "this_attacks_with_greater_power",
             TriggerKind::ThisAttacksWithGreaterPower,
+        )
+    }
+    pub fn this_attacks_with_n_others_display_subject(
+        count: usize,
+        display_subject: Option<String>,
+    ) -> Self {
+        Self::typed(
+            "this_attacks_with_n_others",
+            TriggerKind::ThisAttacksWithNOthers {
+                count,
+                display_subject,
+            },
         )
     }
     pub fn this_attacks_with_exact_n_others(count: usize) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35102,13 +35102,7 @@ fn parse_fallen_shinobi_uses_top_library_exile_and_plural_play_permission() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_paladin_elizabeth_taggerdy_battalion_puts_hand_creature_tapped_and_attacking() {
-    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Paladin Elizabeth Taggerdy")
-        .card_types(vec![CardType::Creature])
-        .power_toughness(PowerToughness::fixed(3, 2))
-        .parse_text(
-            "Battalion — Whenever Paladin Elizabeth Taggerdy and at least two other creatures attack, draw a card, then you may put a creature card with mana value X or less from your hand onto the battlefield tapped and attacking, where X is Paladin Elizabeth Taggerdy's power.",
-        )
-        .expect("Paladin Elizabeth Taggerdy should parse strictly");
+    let def = parse_oracle_card_definition("Paladin Elizabeth Taggerdy");
 
     let debug = format!("{def:#?}").to_ascii_lowercase();
     assert!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35101,6 +35101,48 @@ fn parse_fallen_shinobi_uses_top_library_exile_and_plural_play_permission() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_paladin_elizabeth_taggerdy_battalion_puts_hand_creature_tapped_and_attacking() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Paladin Elizabeth Taggerdy")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Battalion — Whenever Paladin Elizabeth Taggerdy and at least two other creatures attack, draw a card, then you may put a creature card with mana value X or less from your hand onto the battlefield tapped and attacking, where X is Paladin Elizabeth Taggerdy's power.",
+        )
+        .expect("Paladin Elizabeth Taggerdy should parse strictly");
+
+    let debug = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        debug.contains("thisattackswithnotherstrigger") && debug.contains("other_count: 2"),
+        "expected battalion-style source-plus-two-others trigger, got {debug}"
+    );
+    assert!(
+        debug.contains("lessthanorequalexpr")
+            && debug.contains("wherexis")
+            && debug.contains("paladin elizabeth taggerdy"),
+        "expected mana-value X gate to keep the named source-power binding, got {debug}"
+    );
+    assert!(
+        debug.contains("enters_attacking: true"),
+        "expected battlefield move to enter attacking, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("paladin elizabeth taggerdy and at least")
+            && rendered.contains("other creatures attack"),
+        "expected named battalion trigger wording, got {rendered}"
+    );
+    assert!(
+        rendered.contains("mana value x or less from your hand onto the battlefield tapped and attacking")
+            && rendered.contains("where x is paladin elizabeth taggerdy"),
+        "expected tapped-and-attacking hand put with source-power X binding, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_necropotence_style_face_down_exile_with_delayed_return() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Necropotence Variant")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -18834,8 +18834,13 @@ fn describe_for_players_choose_then_move_to_battlefield(
     } else {
         ""
     };
+    let attacking = if move_to_zone.enters_attacking {
+        " and attacking"
+    } else {
+        ""
+    };
     Some(format!(
-        "{subject} chooses {chosen} {choice_location}. Put those cards onto the battlefield{tapped} under your control"
+        "{subject} chooses {chosen} {choice_location}. Put those cards onto the battlefield{tapped}{attacking} under your control"
     ))
 }
 
@@ -20603,6 +20608,7 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
     if let Some(rest) = card_desc.strip_suffix(" hands") {
         card_desc = format!("{rest} hand");
     }
+    let where_x_suffix = apply_mana_value_where_x_surface(&mut card_desc, &choose.filter);
     if card_desc == "with different names" {
         card_desc = "card with different names".to_string();
     } else if card_desc == "with different powers" {
@@ -20646,18 +20652,46 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
     };
 
     if choose.count.is_single() {
-        return with_indefinite_article(&card_desc);
+        return format!("{}{}", with_indefinite_article(&card_desc), where_x_suffix);
     }
     if let Some(runtime_count) = describe_runtime_choice_count(choose) {
         let mut selection = describe_plural_selection(runtime_count, &card_desc);
         selection.push_str(&describe_runtime_choice_where_clause(choose).unwrap_or_default());
+        selection.push_str(&where_x_suffix);
         return selection;
     }
     if let Some(exact) = choose_exact_count(choose) {
         let count_text = number_word(exact as i32).unwrap_or_else(|| exact.to_string());
-        return describe_plural_selection(count_text, &card_desc);
+        let mut selection = describe_plural_selection(count_text, &card_desc);
+        selection.push_str(&where_x_suffix);
+        return selection;
     }
-    describe_plural_selection(describe_choice_count(&choose.count), &card_desc)
+    let mut selection = describe_plural_selection(describe_choice_count(&choose.count), &card_desc);
+    selection.push_str(&where_x_suffix);
+    selection
+}
+
+fn apply_mana_value_where_x_surface(card_desc: &mut String, filter: &ObjectFilter) -> String {
+    let Some(crate::filter::Comparison::LessThanOrEqualExpr(value)) = filter.mana_value.as_ref()
+    else {
+        return String::new();
+    };
+    if !value_prefers_where_x(value) {
+        return String::new();
+    }
+
+    let basis = describe_value(value);
+    let needle = format!("mana value {basis} or less");
+    if card_desc.contains(&needle) {
+        *card_desc = card_desc.replace(&needle, "mana value X or less");
+    } else if let Some(start) = card_desc.find("mana value ") {
+        let tail_start = start + "mana value ".len();
+        if let Some(rel_end) = card_desc[tail_start..].find(" or less") {
+            let end = tail_start + rel_end + " or less".len();
+            card_desc.replace_range(start..end, "mana value X or less");
+        }
+    }
+    format!(", where X is {basis}")
 }
 
 fn describe_stack_spell_choice(choose: &crate::effects::ChooseObjectsEffect) -> Option<String> {
@@ -21047,9 +21081,21 @@ pub(super) fn describe_choose_then_move_to_battlefield(
     };
 
     let chooser = describe_player_filter(&choose.chooser);
-    let chosen = describe_choose_selection(choose);
+    let mut chosen = describe_choose_selection(choose);
+    let where_x_clause = if let Some((head, tail)) = chosen.split_once(", where X is ") {
+        let tail = tail.to_string();
+        chosen = head.to_string();
+        format!(", where X is {tail}")
+    } else {
+        String::new()
+    };
     let tapped = if move_to_zone.enters_tapped {
         " tapped"
+    } else {
+        ""
+    };
+    let attacking = if move_to_zone.enters_attacking {
+        " and attacking"
     } else {
         ""
     };
@@ -21081,14 +21127,14 @@ pub(super) fn describe_choose_then_move_to_battlefield(
             "those cards"
         };
         return Some(format!(
-            "{} {choose_verb} {chosen} {choice_location}. Put {moved} onto the battlefield{tapped}{control_suffix}",
+            "{} {choose_verb} {chosen} {choice_location}. Put {moved} onto the battlefield{tapped}{attacking}{control_suffix}{where_x_clause}",
             capitalize_first(&chooser)
         ));
     }
 
     let put_verb = player_verb(&chooser, "put", "puts");
     Some(format!(
-        "{chooser} {put_verb} {chosen} {origin} onto the battlefield{tapped}{control_suffix}"
+        "{chooser} {put_verb} {chosen} {origin} onto the battlefield{tapped}{attacking}{control_suffix}{where_x_clause}"
     ))
 }
 
@@ -27606,6 +27652,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 } else {
                     ""
                 };
+                let attacking_suffix = if move_to_zone.enters_attacking {
+                    " and attacking"
+                } else {
+                    ""
+                };
                 let controller_suffix = match move_to_zone.battlefield_controller {
                     crate::effects::BattlefieldController::Preserve => "",
                     crate::effects::BattlefieldController::Owner => owner_control_suffix,
@@ -27616,9 +27667,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                         || tag.as_str().starts_with("exiled_")
                         || crate::cards::is_sentence_helper_tag(tag.as_str(), "exiled"))
                 {
-                    format!("Return {target} to the battlefield{tapped_suffix}{controller_suffix}")
+                    format!("Return {target} to the battlefield{tapped_suffix}{attacking_suffix}{controller_suffix}")
                 } else {
-                    format!("Put {target} onto the battlefield{tapped_suffix}{controller_suffix}")
+                    format!("Put {target} onto the battlefield{tapped_suffix}{attacking_suffix}{controller_suffix}")
                 }
             }
             Zone::Stack => format!("Put {target} on the stack"),

--- a/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
@@ -1,6 +1,7 @@
 //! Move to zone effect implementation.
 
 use crate::effect::{EffectOutcome, OutcomeObjectMemory};
+use crate::combat_state::{AttackerInfo, get_attack_target};
 use crate::effects::helpers::{resolve_objects_for_effect, resolve_tagged_object_id};
 use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
 use crate::effects::{ExecutionContext, ExecutionError};
@@ -165,6 +166,15 @@ impl EffectExecutor for MoveToZoneEffect {
                         };
                         match move_to_battlefield_with_options(game, ctx, object_id, options) {
                             BattlefieldEntryOutcome::Moved(new_id) => {
+                                if self.enters_attacking
+                                    && let Some(combat) = game.combat.as_mut()
+                                    && let Some(target) = get_attack_target(combat, ctx.source).cloned()
+                                {
+                                    combat.attackers.push(AttackerInfo {
+                                        creature: new_id,
+                                        target,
+                                    });
+                                }
                                 ctx.refresh_target_snapshot(target_lki_before_move.clone());
                                 affected_memory.push(OutcomeObjectMemory::from_snapshot(
                                     &target_lki_before_move,
@@ -329,6 +339,7 @@ impl CostExecutableEffect for MoveToZoneEffect {
 mod tests {
     use super::*;
     use crate::card::CardBuilder;
+    use crate::combat_state::{AttackTarget, AttackerInfo, CombatState};
     use crate::effect::Effect;
     use crate::effects::ExecutionContext;
     use crate::events::zones::matchers::WouldGoToGraveyardMatcher;
@@ -353,6 +364,108 @@ mod tests {
             .build();
         game.add_object(Object::from_card(id, &card, owner, Zone::Battlefield));
         id
+    }
+
+    fn create_named_creature_in_zone(
+        game: &mut GameState,
+        owner: PlayerId,
+        name: &str,
+        zone: Zone,
+    ) -> crate::ids::ObjectId {
+        let id = game.new_object_id();
+        let card = CardBuilder::new(CardId::from_raw(id.0 as u32), name)
+            .mana_cost(ManaCost::from_pips(vec![
+                vec![ManaSymbol::Generic(1)],
+                vec![ManaSymbol::White],
+            ]))
+            .card_types(vec![CardType::Creature])
+            .build();
+        game.add_object(Object::from_card(id, &card, owner, zone));
+        id
+    }
+
+    #[test]
+    fn paladin_elizabeth_taggerdy_move_enters_tapped_and_attacking_same_defender() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let paladin = create_named_creature_in_zone(
+            &mut game,
+            alice,
+            "Paladin Elizabeth Taggerdy",
+            Zone::Battlefield,
+        );
+        let vault_dweller =
+            create_named_creature_in_zone(&mut game, alice, "Vault Dweller", Zone::Hand);
+        game.combat = Some(CombatState {
+            attackers: vec![AttackerInfo {
+                creature: paladin,
+                target: AttackTarget::Player(bob),
+            }],
+            ..CombatState::default()
+        });
+
+        let mut ctx = ExecutionContext::new_default(paladin, alice);
+        let outcome = MoveToZoneEffect::new(
+            ChooseSpec::SpecificObject(vault_dweller),
+            Zone::Battlefield,
+            false,
+        )
+        .tapped()
+        .attacking()
+        .execute(&mut game, &mut ctx)
+        .expect("Paladin Elizabeth Taggerdy move should resolve");
+
+        let moved = outcome
+            .affected_objects()
+            .and_then(|ids| ids.first().copied())
+            .or_else(|| match outcome.value {
+                crate::effect::OutcomeValue::Objects(ref ids) => ids.first().copied(),
+                _ => None,
+            })
+            .expect("moved creature id should be reported");
+        assert!(game.battlefield.contains(&moved));
+        assert!(game.is_tapped(moved), "moved creature should enter tapped");
+        let combat = game.combat.as_ref().expect("combat should remain active");
+        let moved_attacker = combat
+            .attackers
+            .iter()
+            .find(|info| info.creature == moved)
+            .expect("moved creature should enter attacking");
+        assert_eq!(moved_attacker.target, AttackTarget::Player(bob));
+    }
+
+    #[test]
+    fn paladin_elizabeth_taggerdy_move_without_active_combat_does_not_attack() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let paladin = create_named_creature_in_zone(
+            &mut game,
+            alice,
+            "Paladin Elizabeth Taggerdy",
+            Zone::Battlefield,
+        );
+        let vault_dweller =
+            create_named_creature_in_zone(&mut game, alice, "Vault Dweller", Zone::Hand);
+
+        let mut ctx = ExecutionContext::new_default(paladin, alice);
+        let outcome = MoveToZoneEffect::new(
+            ChooseSpec::SpecificObject(vault_dweller),
+            Zone::Battlefield,
+            false,
+        )
+        .tapped()
+        .attacking()
+        .execute(&mut game, &mut ctx)
+        .expect("Paladin Elizabeth Taggerdy move should resolve outside combat");
+
+        let moved = match outcome.value {
+            crate::effect::OutcomeValue::Objects(ids) => ids[0],
+            _ => panic!("expected moved object id"),
+        };
+        assert!(game.battlefield.contains(&moved));
+        assert!(game.is_tapped(moved), "moved creature should still enter tapped");
+        assert!(game.combat.is_none(), "no attacker should be added without combat");
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
@@ -1,7 +1,7 @@
 //! Move to zone effect implementation.
 
 use crate::effect::{EffectOutcome, OutcomeObjectMemory};
-use crate::combat_state::{AttackerInfo, get_attack_target};
+use crate::combat_state::{AttackTarget, AttackerInfo, CombatState};
 use crate::effects::helpers::{resolve_objects_for_effect, resolve_tagged_object_id};
 use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
 use crate::effects::{ExecutionContext, ExecutionError};
@@ -75,6 +75,95 @@ fn matching_cost_candidate_count(
                 .is_some_and(|obj| filter.matches(obj, &filter_ctx, game))
         })
         .count()
+}
+
+fn enters_attacking_targets(game: &GameState, combat: &CombatState) -> Vec<AttackTarget> {
+    let mut defending_players = Vec::new();
+    for attacker in &combat.attackers {
+        let defending_player = match attacker.target {
+            AttackTarget::Player(player) => Some(player),
+            AttackTarget::Planeswalker(planeswalker) => game
+                .object(planeswalker)
+                .map(|object| game.controller_of(object)),
+        };
+        if let Some(player) = defending_player
+            && !defending_players.contains(&player)
+        {
+            defending_players.push(player);
+        }
+    }
+
+    let all_effects = game.all_continuous_effects();
+    let mut targets = Vec::new();
+    for defender in defending_players {
+        targets.push(AttackTarget::Player(defender));
+        for &object_id in &game.battlefield {
+            let Some(object) = game.object(object_id) else {
+                continue;
+            };
+            if game.controller_of(object) == defender
+                && object.zone == Zone::Battlefield
+                && game.object_has_card_type_with_effects(
+                    object_id,
+                    crate::types::CardType::Planeswalker,
+                    &all_effects,
+                )
+            {
+                targets.push(AttackTarget::Planeswalker(object_id));
+            }
+        }
+    }
+    targets
+}
+
+fn attack_target_description(game: &GameState, target: &AttackTarget) -> String {
+    match target {
+        AttackTarget::Player(player) => game
+            .player(*player)
+            .map(|player| player.name.clone())
+            .unwrap_or_else(|| format!("player {}", player.0)),
+        AttackTarget::Planeswalker(object_id) => game
+            .object(*object_id)
+            .map(|object| object.name.clone())
+            .unwrap_or_else(|| format!("planeswalker #{}", object_id.0)),
+    }
+}
+
+fn choose_enters_attacking_target(
+    game: &GameState,
+    ctx: &mut ExecutionContext<'_>,
+    moved_id: crate::ids::ObjectId,
+) -> Option<AttackTarget> {
+    let combat = game.combat.as_ref()?;
+    let targets = enters_attacking_targets(game, combat);
+    if targets.len() <= 1 {
+        return targets.first().cloned();
+    }
+
+    let options = targets
+        .iter()
+        .enumerate()
+        .map(|(index, target)| {
+            crate::decisions::DisplayOption::new(index, attack_target_description(game, target))
+        })
+        .collect();
+    let chooser = game
+        .object(moved_id)
+        .map(|object| game.controller_of(object))
+        .unwrap_or(ctx.controller);
+    let source = ctx.source;
+    let selected = crate::decisions::make_decision(
+        game,
+        &mut *ctx.decision_maker,
+        chooser,
+        Some(source),
+        crate::decisions::ChoiceSpec::single(source, options),
+    );
+    let selected_index = selected.into_iter().next().unwrap_or(0);
+    targets
+        .get(selected_index)
+        .cloned()
+        .or_else(|| targets.first().cloned())
 }
 
 impl EffectExecutor for MoveToZoneEffect {
@@ -167,8 +256,9 @@ impl EffectExecutor for MoveToZoneEffect {
                         match move_to_battlefield_with_options(game, ctx, object_id, options) {
                             BattlefieldEntryOutcome::Moved(new_id) => {
                                 if self.enters_attacking
+                                    && let Some(target) =
+                                        choose_enters_attacking_target(game, ctx, new_id)
                                     && let Some(combat) = game.combat.as_mut()
-                                    && let Some(target) = get_attack_target(combat, ctx.source).cloned()
                                 {
                                     combat.attackers.push(AttackerInfo {
                                         creature: new_id,
@@ -384,28 +474,58 @@ mod tests {
         id
     }
 
+    struct ChooseLastOptionDecisionMaker;
+
+    impl crate::decision::DecisionMaker for ChooseLastOptionDecisionMaker {
+        fn decide_options(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .last()
+                .map(|option| vec![option.index])
+                .unwrap_or_default()
+        }
+    }
+
     #[test]
-    fn paladin_elizabeth_taggerdy_move_enters_tapped_and_attacking_same_defender() {
-        let mut game = setup_game();
+    fn paladin_elizabeth_taggerdy_move_enters_tapped_and_attacking_chosen_defender() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Cara".to_string()],
+            20,
+        );
         let alice = PlayerId::from_index(0);
         let bob = PlayerId::from_index(1);
+        let cara = PlayerId::from_index(2);
         let paladin = create_named_creature_in_zone(
             &mut game,
             alice,
             "Paladin Elizabeth Taggerdy",
             Zone::Battlefield,
         );
+        let other_attacker =
+            create_named_creature_in_zone(&mut game, alice, "Wasteland Raider", Zone::Battlefield);
         let vault_dweller =
             create_named_creature_in_zone(&mut game, alice, "Vault Dweller", Zone::Hand);
         game.combat = Some(CombatState {
-            attackers: vec![AttackerInfo {
-                creature: paladin,
-                target: AttackTarget::Player(bob),
-            }],
+            attackers: vec![
+                AttackerInfo {
+                    creature: paladin,
+                    target: AttackTarget::Player(bob),
+                },
+                AttackerInfo {
+                    creature: other_attacker,
+                    target: AttackTarget::Player(cara),
+                },
+            ],
             ..CombatState::default()
         });
 
-        let mut ctx = ExecutionContext::new_default(paladin, alice);
+        let mut decision_maker = ChooseLastOptionDecisionMaker;
+        let mut ctx = ExecutionContext::new(paladin, alice, &mut decision_maker);
         let outcome = MoveToZoneEffect::new(
             ChooseSpec::SpecificObject(vault_dweller),
             Zone::Battlefield,
@@ -432,7 +552,7 @@ mod tests {
             .iter()
             .find(|info| info.creature == moved)
             .expect("moved creature should enter attacking");
-        assert_eq!(moved_attacker.target, AttackTarget::Player(bob));
+        assert_eq!(moved_attacker.target, AttackTarget::Player(cara));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -256,6 +256,14 @@ impl TriggerMatcher for AttacksTrigger {
 
         if self.one_or_more {
             if self.min_total_attackers > 1 {
+                if display_filter.source {
+                    let other_count = self.min_total_attackers.saturating_sub(1) as u32;
+                    let other_text = ironsmith_core::cardinal_word(other_count)
+                        .unwrap_or_else(|| other_count.to_string());
+                    return format!(
+                        "Whenever this creature and at least {other_text} other creatures attack{target_tail}"
+                    );
+                }
                 let min_total = ironsmith_core::cardinal_word(self.min_total_attackers as u32)
                     .unwrap_or_else(|| self.min_total_attackers.to_string());
                 if let Some(controlled_subject) = subject.strip_suffix(" you control") {

--- a/crates/ironsmith-runtime/src/triggers/combat/this_attacks_with_n_others.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/this_attacks_with_n_others.rs
@@ -15,6 +15,8 @@ pub struct ThisAttacksWithNOthersTrigger {
     pub other_count: usize,
     /// Whether the trigger requires exactly that many other attackers.
     pub exact: bool,
+    /// Optional rendered subject, used when the parser saw a named source.
+    pub display_subject: Option<String>,
 }
 
 impl ThisAttacksWithNOthersTrigger {
@@ -22,6 +24,15 @@ impl ThisAttacksWithNOthersTrigger {
         Self {
             other_count,
             exact: false,
+            display_subject: None,
+        }
+    }
+
+    pub fn with_display_subject(other_count: usize, display_subject: Option<String>) -> Self {
+        Self {
+            other_count,
+            exact: false,
+            display_subject,
         }
     }
 
@@ -29,6 +40,7 @@ impl ThisAttacksWithNOthersTrigger {
         Self {
             other_count,
             exact: true,
+            display_subject: None,
         }
     }
 }
@@ -67,8 +79,9 @@ impl TriggerMatcher for ThisAttacksWithNOthersTrigger {
                 "Whenever this creature attacks, if you attacked with exactly {count} other {noun} this combat"
             )
         } else {
+            let subject = self.display_subject.as_deref().unwrap_or("this creature");
             format!(
-                "Whenever this creature and at least {} other {} attack",
+                "Whenever {subject} and at least {} other {} attack",
                 self.other_count, noun
             )
         }
@@ -175,5 +188,18 @@ mod tests {
             crate::provenance::ProvNodeId::default(),
         );
         assert!(!trigger.matches(&too_many_event, &ctx));
+    }
+
+    #[test]
+    fn paladin_elizabeth_taggerdy_named_battalion_display_keeps_threshold_subject() {
+        let trigger = ThisAttacksWithNOthersTrigger::with_display_subject(
+            2,
+            Some("Paladin Elizabeth Taggerdy".to_string()),
+        );
+
+        assert_eq!(
+            trigger.display(),
+            "Whenever Paladin Elizabeth Taggerdy and at least 2 other creatures attack"
+        );
     }
 }

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -430,6 +430,16 @@ impl Trigger {
         Self::new(ThisAttacksWithNOthersTrigger::new(other_count))
     }
 
+    pub fn this_attacks_with_n_others_display_subject(
+        other_count: usize,
+        display_subject: Option<String>,
+    ) -> Self {
+        Self::new(ThisAttacksWithNOthersTrigger::with_display_subject(
+            other_count,
+            display_subject,
+        ))
+    }
+
     /// Create a "when this creature and exactly N other creatures attack" trigger.
     pub fn this_attacks_with_exact_n_others(other_count: usize) -> Self {
         Self::new(ThisAttacksWithNOthersTrigger::exact(other_count))

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -102,6 +102,13 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::ThisAttacksWithGreaterPower => {
             crate::triggers::Trigger::this_attacks_with_greater_power()
         }
+        TriggerKind::ThisAttacksWithNOthers {
+            count,
+            display_subject,
+        } => crate::triggers::Trigger::this_attacks_with_n_others_display_subject(
+            count,
+            display_subject,
+        ),
         TriggerKind::ThisAttacksWithExactNOthers { count } => {
             crate::triggers::Trigger::this_attacks_with_exact_n_others(count)
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Paladin Elizabeth Taggerdy
Initial parse error:
```
unsupported put destination after 'onto' (clause: 'a creature card with mana value x or less from your hand onto the battlefield tapped and attacking'); oracle-only fallback also failed: unsupported put destination after 'onto' (clause: 'a creature card with mana value x or less from your hand onto the battlefield tapped and attacking')
```

Current worker: i-098a1e962c63799bd
Branch: codex/aws-card-fix-paladin-elizabeth-taggerdy
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0019
