### PR TITLE
Fix Ironsmith parse failure: Thundermane Dragon

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -770,6 +770,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         multi_static_ability_ast_rule!(
             parse_you_may_cast_exile_counter_cards_with_mana_permission_line
         ),
+        single_static_ability_ast_rule!(parse_play_from_permission_with_haste_this_way_line),
         single_static_ability_ast_rule!(parse_you_may_static_grant_line),
         single_static_ability_ast_rule!(parse_grant_flash_to_noncreature_spells_line),
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
@@ -7953,6 +7954,44 @@ pub(crate) fn parse_you_may_static_grant_line(
             }
             Ok(static_grant_beneficiary(player)
                 .map(|beneficiary| StaticAbility::grants(spec.with_beneficiary(beneficiary))))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub(crate) fn parse_play_from_permission_with_haste_this_way_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let sentences = split_lexed_sentences(tokens);
+    let [permission_sentence, haste_sentence] = sentences.as_slice() else {
+        return Ok(None);
+    };
+
+    let haste_words = parser_token_word_refs(haste_sentence);
+    if !word_slice_starts_with(&haste_words, &["if", "you", "cast"])
+        || !word_slice_ends_with(
+            &haste_words,
+            &[
+                "spell", "this", "way", "it", "gains", "haste", "until", "end", "of",
+                "turn",
+            ],
+        )
+    {
+        return Ok(None);
+    }
+
+    match parse_permission_clause_spec(permission_sentence)? {
+        Some(crate::cards::builders::PermissionClauseSpec::GrantBySpec {
+            player,
+            spec,
+            lifetime: crate::cards::builders::PermissionLifetime::Static,
+        }) if matches!(spec.grantable, crate::grant::Grantable::PlayFrom) => {
+            Ok(static_grant_beneficiary(player).map(|beneficiary| {
+                StaticAbility::grants(
+                    spec.with_beneficiary(beneficiary)
+                        .with_cast_this_way_grant(StaticAbility::haste()),
+                )
+            }))
         }
         _ => Ok(None),
     }

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -281,6 +281,8 @@ pub struct GrantSpec<SA, E, C, Cond> {
     pub zone: Zone,
     /// Which player may use the grant when rendered or applied statically.
     pub beneficiary: PlayerFilter,
+    /// Static abilities granted to a spell as it is cast using this permission.
+    pub cast_this_way_grants: Vec<SA>,
 }
 
 impl<SA, E, C, Cond> GrantSpec<SA, E, C, Cond> {
@@ -291,12 +293,18 @@ impl<SA, E, C, Cond> GrantSpec<SA, E, C, Cond> {
             filter,
             zone,
             beneficiary: PlayerFilter::You,
+            cast_this_way_grants: Vec::new(),
         }
     }
 
     /// Return a copy of this grant specification with an explicit beneficiary.
     pub fn with_beneficiary(mut self, beneficiary: PlayerFilter) -> Self {
         self.beneficiary = beneficiary;
+        self
+    }
+
+    pub fn with_cast_this_way_grant(mut self, ability: SA) -> Self {
+        self.cast_this_way_grants.push(ability);
         self
     }
 
@@ -335,6 +343,7 @@ where
             filter,
             zone: Zone::Hand,
             beneficiary: PlayerFilter::You,
+            cast_this_way_grants: Vec::new(),
         }
     }
 
@@ -391,6 +400,7 @@ where
             filter: ObjectFilter::nonland(),
             zone: Zone::Graveyard,
             beneficiary: PlayerFilter::You,
+            cast_this_way_grants: Vec::new(),
         }
     }
 }
@@ -467,6 +477,16 @@ where
         }
 
         fn castable_filter_description(filter: &ObjectFilter) -> String {
+            if filter.card_types.as_slice() == [CardType::Creature]
+                && let Some(crate::filter_model::Comparison::GreaterThanOrEqual(power)) = filter.power
+            {
+                let mut normalized = filter.clone();
+                normalized.card_types.clear();
+                normalized.power = None;
+                if normalized == ObjectFilter::default() {
+                    return format!("creature spells with power {power} or greater");
+                }
+            }
             if let Some(merged) = merged_simple_any_of_card_type_filter(filter) {
                 return castable_filter_description(&merged);
             }
@@ -498,8 +518,10 @@ where
             let description = filter.description();
             if description.contains("permanent") {
                 description.replace("permanent", "spell")
-            } else if description.contains("spell") || description.contains("card") {
+            } else if description.contains("spell") {
                 description
+            } else if description.contains(" card") {
+                description.replace(" card", " spell")
             } else {
                 format!("{description} spells")
             }
@@ -612,6 +634,32 @@ where
         filter.zone.get_or_insert(self.zone);
         let filter_desc = filter.description();
         let may_prefix = beneficiary_may_prefix(&self.beneficiary);
+        let cast_this_way_suffix = || {
+            if self.cast_this_way_grants.is_empty() {
+                return String::new();
+            }
+            let grants = self
+                .cast_this_way_grants
+                .iter()
+                .map(GrantStaticAbility::grant_display)
+                .collect::<Vec<_>>();
+            if grants.len() == 1 && grants[0].eq_ignore_ascii_case("haste") {
+                let cast_desc = castable_filter_description(&self.filter);
+                let spell_text = if let Some(base) = cast_desc.strip_suffix(" spells") {
+                    format!("a {base} spell")
+                } else if let Some((base, tail)) = cast_desc.split_once(" spells ") {
+                    format!("a {base} spell {tail}")
+                } else if cast_desc.starts_with("a ") {
+                    cast_desc
+                } else {
+                    "a spell".to_string()
+                };
+                return format!(
+                    ". If you cast {spell_text} this way, it gains haste until end of turn"
+                );
+            }
+            format!(". Spells cast this way gain {}", grants.join(" and "))
+        };
 
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Graveyard
@@ -674,9 +722,9 @@ where
         }
         if matches!(self.grantable, Grantable::PlayFrom) && self.zone == Zone::Library {
             return format!(
-                "{may_prefix} play {} from the top of your library",
-                filter_desc
-            );
+                "{may_prefix} cast {} from the top of your library",
+                castable_filter_description(&self.filter)
+            ) + &cast_this_way_suffix();
         }
         if let Grantable::AlternativeCast(method) = &self.grantable
             && self.zone == Zone::Hand

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -527,6 +527,25 @@ where
             }
         }
 
+        fn cast_this_way_spell_subject(filter: &ObjectFilter) -> String {
+            let cast_desc = castable_filter_description(filter);
+            if let Some(base) = cast_desc.strip_suffix(" spells") {
+                return format!("a {base} spell");
+            }
+            for pt_clause in [" spells with power ", " spells with toughness "] {
+                if let Some((base, _)) = cast_desc.split_once(pt_clause) {
+                    return format!("a {base} spell");
+                }
+            }
+            if let Some((base, tail)) = cast_desc.split_once(" spells ") {
+                return format!("a {base} spell {tail}");
+            }
+            if cast_desc.starts_with("a ") || cast_desc.starts_with("an ") {
+                return cast_desc;
+            }
+            "a spell".to_string()
+        }
+
         fn sacrifice_cost_filter_description(filter: &ObjectFilter) -> Option<String> {
             let mut normalized = filter.clone();
             normalized.controller = None;
@@ -644,16 +663,7 @@ where
                 .map(GrantStaticAbility::grant_display)
                 .collect::<Vec<_>>();
             if grants.len() == 1 && grants[0].eq_ignore_ascii_case("haste") {
-                let cast_desc = castable_filter_description(&self.filter);
-                let spell_text = if let Some(base) = cast_desc.strip_suffix(" spells") {
-                    format!("a {base} spell")
-                } else if let Some((base, tail)) = cast_desc.split_once(" spells ") {
-                    format!("a {base} spell {tail}")
-                } else if cast_desc.starts_with("a ") {
-                    cast_desc
-                } else {
-                    "a spell".to_string()
-                };
+                let spell_text = cast_this_way_spell_subject(&self.filter);
                 return format!(
                     ". If you cast {spell_text} this way, it gains haste until end of turn"
                 );

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -749,6 +749,11 @@ where
                 filter: spec.filter,
                 zone: spec.zone,
                 beneficiary: spec.beneficiary,
+                cast_this_way_grants: spec
+                    .cast_this_way_grants
+                    .into_iter()
+                    .map(|ability| map_static_ability(ability, map_trigger, map_effect, map_cost))
+                    .collect::<Result<Vec<_>, _>>()?,
             })
         }
 

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -204,6 +204,11 @@ impl ironsmith::effect_model_interpreter::EffectModelInterpreterHooks<CompilerEf
             filter: spec.filter,
             zone: spec.zone,
             beneficiary: spec.beneficiary,
+            cast_this_way_grants: spec
+                .cast_this_way_grants
+                .into_iter()
+                .map(|ability| self.runtime_static_ability_hook(ability))
+                .collect::<Result<Vec<_>, _>>()?,
         })
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -142,6 +142,23 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn thundermane_dragon_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Thundermane Dragon");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        ability_debug.contains("PlayFrom") && ability_debug.contains("cast_this_way_grants"),
+        "Thundermane Dragon should structurally grant top-library casting with a cast-this-way ability, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("from the top of your library")
+            && rendered.contains("If you cast a creature spell this way, it gains haste until end of turn"),
+        "Thundermane Dragon compiled text should preserve the top-library cast and haste clause, got {rendered}"
+    );
+}
+
+#[test]
 fn party_dude_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Party Dude");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3246,6 +3246,7 @@ pub(crate) fn propose_spell_cast(
     caster: PlayerId,
     casting_method: &CastingMethod,
 ) -> Result<ObjectId, GameLoopError> {
+    let cast_origin_object = game.object(spell_id).cloned();
     let selected_method = game.object(spell_id).and_then(|obj| match casting_method {
         CastingMethod::Alternative(idx) => obj.alternative_casts.get(*idx).cloned(),
         CastingMethod::PlayFrom {
@@ -3412,7 +3413,51 @@ pub(crate) fn propose_spell_cast(
         game.set_face_down(new_id);
     }
 
+    if let Some(origin) = cast_origin_object.as_ref() {
+        apply_play_from_cast_this_way_grants(game, new_id, origin, caster, casting_method);
+    }
+
     Ok(new_id)
+}
+
+fn apply_play_from_cast_this_way_grants(
+    game: &mut GameState,
+    stack_id: ObjectId,
+    origin: &crate::object::Object,
+    caster: PlayerId,
+    casting_method: &CastingMethod,
+) {
+    let (source_id, zone) = match casting_method {
+        CastingMethod::PlayFrom { source, zone, .. }
+        | CastingMethod::SplitOtherHalfPlayFrom { source, zone, .. } => (*source, *zone),
+        _ => return,
+    };
+    let Some(source) = game.object(source_id) else {
+        return;
+    };
+    let ctx = game.filter_context_for(caster, Some(source_id));
+    let mut granted = Vec::new();
+    for ability in &source.abilities {
+        let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
+            continue;
+        };
+        if !static_ability.is_active(game, source_id) {
+            continue;
+        }
+        let Some(spec) = static_ability.grant_spec() else {
+            continue;
+        };
+        if spec.zone == zone
+            && matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+            && !spec.cast_this_way_grants.is_empty()
+            && spec.filter.matches(origin, &ctx, game)
+        {
+            granted.extend(spec.cast_this_way_grants.iter().cloned());
+        }
+    }
+    for ability in granted {
+        game.grant_temporary_static_ability_to_object_until_end_of_turn(stack_id, ability.id());
+    }
 }
 
 /// Revert a spell cast that failed during the casting process.

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30941,6 +30941,116 @@ fn test_library_play_from_grant_offers_top_creature_card() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn thundermane_dragon_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Thundermane Dragon")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dragon])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .parse_text(
+            "Flying\nYou may cast creature spells with power 4 or greater from the top of your library. If you cast a creature spell this way, it gains haste until end of turn.",
+        )
+        .expect("Thundermane Dragon should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thundermane_dragon_casts_top_power_four_creature_and_grants_haste_until_eot() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let thundermane = thundermane_dragon_definition();
+    let source_id = game.create_object_from_definition(&thundermane, alice, Zone::Battlefield);
+    let top_creature = CardBuilder::new(CardId::new(), "Top Power Four")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let top_id = game.create_object_from_card(&top_creature, alice, Zone::Library);
+
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    let casting_method = actions
+        .iter()
+        .find_map(|action| match action {
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Library,
+                casting_method: method @ CastingMethod::PlayFrom {
+                        source,
+                        zone: Zone::Library,
+                        ..
+                    },
+            } if *spell_id == top_id && *source == source_id => Some(method.clone()),
+            _ => None,
+        })
+        .expect("Thundermane Dragon should let Alice cast the top power-4 creature");
+
+    let stack_id = super::priority_mana::propose_spell_cast(
+        &mut game,
+        top_id,
+        Zone::Library,
+        alice,
+        &casting_method,
+    )
+    .expect("top creature should move to the stack");
+    let battlefield_id = game
+        .move_object_by_effect(stack_id, Zone::Battlefield)
+        .expect("creature spell should resolve to the battlefield");
+    game.refresh_continuous_state();
+
+    assert!(
+        game.object_has_static_ability_id(battlefield_id, crate::static_abilities::StaticAbilityId::Haste),
+        "creature cast from the top with Thundermane Dragon should gain haste"
+    );
+
+    crate::turn::execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+    assert!(
+        !game.object_has_static_ability_id(battlefield_id, crate::static_abilities::StaticAbilityId::Haste),
+        "Thundermane Dragon's haste grant should expire at end of turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thundermane_dragon_does_not_cast_top_creature_below_power_four() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let thundermane = thundermane_dragon_definition();
+    game.create_object_from_definition(&thundermane, alice, Zone::Battlefield);
+    let small_creature = CardBuilder::new(CardId::new(), "Top Power Three")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let small_id = game.create_object_from_card(&small_creature, alice, Zone::Library);
+
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Library,
+                casting_method: CastingMethod::PlayFrom { .. },
+            } if *spell_id == small_id
+        )),
+        "Thundermane Dragon should not let Alice cast a top creature with power below 4"
+    );
+}
+
 #[test]
 fn test_library_play_from_grant_offers_adventure_half_when_linked_face_matches() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -405,6 +405,12 @@ impl StaticAbilityModelInterpreter {
             filter: spec.filter.clone(),
             zone: spec.zone,
             beneficiary: spec.beneficiary.clone(),
+            cast_this_way_grants: spec
+                .cast_this_way_grants
+                .iter()
+                .cloned()
+                .map(StaticAbility::from_model)
+                .collect(),
         }
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thundermane Dragon
Initial parse error:
```
parser does not yet support line family: 'You may cast creature spells with power 4 or greater from the top of your library. If you cast a creature spell this way, it gains haste until end of turn.'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast creature spells with power 4 or greater from the top of your library. If you cast a creature spell this way, it gains haste until end of turn.'
```

Current worker: i-03f6ec242b0cf3595
Branch: codex/aws-card-fix-thundermane-dragon
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0020
