### PR TITLE
Fix Ironsmith parse failure: Three Dog, Galaxy News DJ

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -2345,6 +2345,7 @@ impl CardDefinitionBuilder {
 }
 
 pub const IT_TAG: &str = crate::host::IT_TAG;
+pub const PREVIOUS_OBJECT_TAG: &str = crate::host::PREVIOUS_OBJECT_TAG;
 pub const COPIED_STACK_OBJECT_TAG: &str = crate::host::COPIED_STACK_OBJECT_TAG;
 
 fn parse_standalone_bolster_marker(text: &str) -> Option<u32> {

--- a/crates/ironsmith-compiler/src/host.rs
+++ b/crates/ironsmith-compiler/src/host.rs
@@ -13,4 +13,5 @@ pub use crate::payload::{IfResultPredicate, KeywordAction};
 pub use ironsmith_core::TagKey;
 
 pub const IT_TAG: &str = "__it__";
+pub const PREVIOUS_OBJECT_TAG: &str = "__previous_object__";
 pub const COPIED_STACK_OBJECT_TAG: &str = "__copied_stack_object__";

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -2236,25 +2236,16 @@ mod tests {
         let landwalk = single_preprocessed_line(
             "Creatures with islandwalk can be blocked as though they didn’t have islandwalk.",
         );
-        let aura_copy = single_preprocessed_line(
-            "Create a token that’s a copy of that Aura attached to that creature.",
-        );
         let face_down = single_preprocessed_line("Target face-down creature can block this turn.");
 
         let landwalk_error = diagnose_known_unsupported_rewrite_line(&landwalk.tokens)
             .expect("expected landwalk override diagnostic");
-        let aura_copy_error = diagnose_known_unsupported_rewrite_line(&aura_copy.tokens)
-            .expect("expected aura-copy diagnostic");
         let face_down_error = diagnose_known_unsupported_rewrite_line(&face_down.tokens)
             .expect("expected face-down diagnostic");
 
         assert_eq!(
             landwalk_error.to_string(),
             "unsupported landwalk override clause"
-        );
-        assert_eq!(
-            aura_copy_error.to_string(),
-            "unsupported aura-copy attachment fanout clause"
         );
         assert_eq!(face_down_error.to_string(), "unsupported face-down clause");
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
@@ -89,13 +89,6 @@ const UNSUPPORTED_CONTAINS_RULES: &[UnsupportedWordRule] = &[
         message: "unsupported if-you-sacrifice-an-island-this-way clause",
     },
     UnsupportedWordRule {
-        phrase: &[
-            "create", "a", "token", "thats", "a", "copy", "of", "that", "aura", "attached", "to",
-            "that", "creature",
-        ],
-        message: "unsupported aura-copy attachment fanout clause",
-    },
-    UnsupportedWordRule {
         phrase: &["target", "face", "down", "creature"],
         message: "unsupported face-down clause",
     },

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -198,6 +198,7 @@ pub(super) fn parse_mana_symbol_word(word: &str) -> Option<ManaSymbol> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime_backend::front_end::shared::util::with_source_reference_context;
     use crate::runtime_backend::lexer::lex_line;
     use crate::static_abilities::StaticAbilityId;
 
@@ -539,6 +540,32 @@ mod tests {
                     relation: TaggedOpbjectRelation::AttachedToTaggedObject,
                 }
         }));
+    }
+
+    #[test]
+    fn parse_object_filter_lexed_handles_attached_to_source_reference() {
+        let tokens = lex_line("Aura attached to this creature", 0).unwrap();
+
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.subtypes, vec![Subtype::Aura]);
+        assert!(
+            filter.attached_to_source,
+            "attached to this creature should bind to the source object"
+        );
+    }
+
+    #[test]
+    fn parse_object_filter_lexed_handles_attached_to_source_name_reference() {
+        let tokens = lex_line("Aura attached to Three Dog", 0).unwrap();
+
+        let filter = with_source_reference_context("Three Dog, Galaxy News DJ", || {
+            parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap()
+        });
+        assert_eq!(filter.subtypes, vec![Subtype::Aura]);
+        assert!(
+            filter.attached_to_source,
+            "attached to a source-name alias should bind to the source object"
+        );
     }
 
     #[test]

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
@@ -843,6 +843,29 @@ pub(super) fn apply_reference_and_tag_stage(
                 &["that", "aura"],
             ],
         );
+        let references_source = word_slice_starts_with_any(
+            attached_to_words,
+            &[
+                &["this", "creature"],
+                &["this", "permanent"],
+                &["this", "source"],
+                &["this", "object"],
+            ],
+        ) || (1..=attached_to_words.len())
+            .rev()
+            .any(|end| is_source_reference_words(&attached_to_words[..end]));
+        if references_source {
+            let trim_start = if attached_idx >= 2
+                && all_words[attached_idx - 2] == "that"
+                && matches!(all_words[attached_idx - 1], "were" | "was" | "is" | "are")
+            {
+                attached_idx - 2
+            } else {
+                attached_idx
+            };
+            all_words.truncate(trim_start);
+            filter.attached_to_source = true;
+        }
         if references_it {
             let trim_start = if attached_idx >= 2
                 && all_words[attached_idx - 2] == "that"

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -480,6 +480,9 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
                 | ["that"]
                 | ["card"]
                 | ["a", "card"]
+                | ["a", "aura"]
+                | ["an", "aura"]
+                | ["aura"]
                 | ["a", "creature", "card"]
                 | ["creature", "card"]
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/parser_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/parser_support.rs
@@ -56,6 +56,7 @@ pub(crate) fn looks_like_spell_resolution_followup_intro_lexed(tokens: &[OwnedLe
 pub(crate) fn looks_like_reflexive_followup_intro_lexed(tokens: &[OwnedLexToken]) -> bool {
     looks_like_when_one_or_more_this_way_followup_lexed(tokens)
         || looks_like_when_it_connives_this_way_followup_lexed(tokens)
+        || looks_like_when_you_action_this_way_followup_lexed(tokens)
         || looks_like_when_you_do_followup_lexed(tokens)
         || looks_like_otherwise_followup_lexed(tokens)
 }
@@ -214,6 +215,25 @@ fn looks_like_when_it_connives_this_way_followup_lexed(tokens: &[OwnedLexToken])
         0,
         parse_when_it_connives_this_way_followup_intro_inner,
     )
+}
+
+fn parse_when_you_action_this_way_followup_intro_inner<'a>(
+    input: &mut LexStream<'a>,
+) -> Result<(), ErrMode<ContextError>> {
+    (
+        alt((grammar::kw("when"), grammar::kw("whenever"))),
+        grammar::kw("you"),
+    )
+        .void()
+        .parse_next(input)
+}
+
+fn looks_like_when_you_action_this_way_followup_lexed(tokens: &[OwnedLexToken]) -> bool {
+    let this_way_in_prefix = grammar::split_lexed_once_on_delimiter(tokens, TokenKind::Comma)
+        .map(|(before, _after)| contains_token_word_sequence(before, &["this", "way"]))
+        .unwrap_or_else(|| contains_token_word_sequence(tokens, &["this", "way"]));
+    starts_with_lexed_parser(tokens, 0, parse_when_you_action_this_way_followup_intro_inner)
+        && this_way_in_prefix
 }
 
 fn parse_when_you_do_followup_intro_inner<'a>(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2952,7 +2952,10 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
             target_count,
         ));
     }
-    if word_slice_eq_any(&all_words, &[&["that", "permanent"], &["that", "creature"]]) {
+    if word_slice_eq_any(
+        &all_words,
+        &[&["that", "permanent"], &["that", "creature"]],
+    ) {
         return Ok(wrap_target_count(
             TargetAst::Tagged(TagKey::from(IT_TAG), span),
             target_count,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -29,6 +29,46 @@ fn bind_explicit_tag_to_player_tagged_predicate(
     bound
 }
 
+fn bind_previous_object_tag_in_target(target: &mut TargetAst, tag: &TagKey) {
+    match target {
+        TargetAst::Tagged(found, _) if found.as_str() == crate::cards::builders::PREVIOUS_OBJECT_TAG => {
+            *found = tag.clone();
+        }
+        TargetAst::WithCount(inner, _) | TargetAst::WithCountValue(inner, _, _) => {
+            bind_previous_object_tag_in_target(inner, tag);
+        }
+        _ => {}
+    }
+}
+
+fn bind_previous_object_tag_in_effect(effect: &mut EffectAst, tag: &TagKey) {
+    if let EffectAst::SubjectVerb(subject_verb) = effect
+        && let SubjectVerbActionAst::CreateTokenCopyFromSource {
+            source,
+            attached_to,
+            ..
+        } = &mut subject_verb.action
+    {
+        bind_previous_object_tag_in_target(source, tag);
+        if let Some(target) = attached_to.as_mut() {
+            bind_previous_object_tag_in_target(target, tag);
+        }
+    }
+    for_each_nested_effects_mut(effect, true, |nested| {
+        for inner in nested {
+            bind_previous_object_tag_in_effect(inner, tag);
+        }
+    });
+}
+
+fn bind_previous_object_tag_in_effects(effects: &[EffectAst], tag: &TagKey) -> Vec<EffectAst> {
+    let mut effects = effects.to_vec();
+    for effect in &mut effects {
+        bind_previous_object_tag_in_effect(effect, tag);
+    }
+    effects
+}
+
 pub(crate) fn compile_if_do_with_opponent_doesnt(
     first: &EffectAst,
     second: &EffectAst,
@@ -775,6 +815,13 @@ pub(crate) fn compile_effects_in_iterated_object_context(
     ctx: &mut EffectLoweringContext,
 ) -> Result<(Vec<Effect>, Vec<ChooseSpec>), CardTextError> {
     let saved_frame = ctx.lowering_frame();
+    let bound_effects;
+    let effects_to_compile = if let Some(tag) = saved_frame.last_object_tag.as_ref() {
+        bound_effects = bind_previous_object_tag_in_effects(effects, &TagKey::from(tag.as_str()));
+        bound_effects.as_slice()
+    } else {
+        effects
+    };
     let mut iterated_frame = saved_frame.clone();
     iterated_frame.iterated_player = true;
     iterated_frame.last_effect_id = None;
@@ -783,7 +830,7 @@ pub(crate) fn compile_effects_in_iterated_object_context(
 
     let mut id_gen = ctx.id_gen_context();
     let (compiled, choices, _frame_out) =
-        compile_effects_with_explicit_frame(effects, &mut id_gen, iterated_frame)?;
+        compile_effects_with_explicit_frame(effects_to_compile, &mut id_gen, iterated_frame)?;
     let choices = choices
         .into_iter()
         .filter(|choice| !format!("{choice:?}").contains("IteratedPlayer"))

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -3452,6 +3452,7 @@ fn compile_subject_verb_effect(
             source,
             count,
             player: action_player,
+            attached_to,
             enters_tapped,
             enters_attacking,
             attack_target_player_or_planeswalker_controlled_by,
@@ -3477,6 +3478,15 @@ fn compile_subject_verb_effect(
                 resolve_target_spec_with_choices(source, &current_reference_env(ctx))?;
             for choice in source_choices {
                 push_choice(&mut choices, choice);
+            }
+            let resolved_attached_to = attached_to
+                .as_ref()
+                .map(|target| resolve_target_spec_with_choices(target, &current_reference_env(ctx)))
+                .transpose()?;
+            if let Some((_, target_choices)) = &resolved_attached_to {
+                for choice in target_choices {
+                    push_choice(&mut choices, choice.clone());
+                }
             }
             if let Some(last_tag) = ctx.last_object_tag.as_deref()
                 && str_starts_with(last_tag, "exile_cost_")
@@ -3542,14 +3552,37 @@ fn compile_subject_verb_effect(
             for ability in granted_abilities {
                 effect = effect.grant_static_ability(ability.clone());
             }
+            if attached_to.is_some() {
+                effect = effect.suppress_aura_attachment_choice();
+            }
 
             let mut effect = Effect::new(effect);
-            if ctx.auto_tag_object_targets {
+            let needs_created_tag = ctx.auto_tag_object_targets || attached_to.is_some();
+            let mut created_tag = None;
+            if needs_created_tag {
                 let tag = ctx.next_tag("created");
                 ctx.last_object_tag = Some(tag.clone());
-                effect = effect.tag(tag);
+                effect = effect.tag(tag.clone());
+                created_tag = Some(tag);
             }
-            Ok((vec![effect], choices))
+            let mut compiled = vec![effect];
+            if let Some((target_spec, _)) = resolved_attached_to {
+                let Some(created_tag) = created_tag else {
+                    return Err(CardTextError::InvariantViolation(
+                        "attached token-copy creation requires created token tag to be present"
+                            .to_string(),
+                    ));
+                };
+                let objects = ChooseSpec::All(ObjectFilter::tagged(created_tag));
+                let mut attach_effect = Effect::attach_objects(objects, target_spec);
+                if ctx.auto_tag_object_targets {
+                    let tag = ctx.next_tag("attachment_target");
+                    attach_effect = attach_effect.tag(tag.clone());
+                    ctx.last_object_tag = Some(tag);
+                }
+                compiled.push(attach_effect);
+            }
+            Ok((compiled, choices))
         }
         SubjectVerbActionAst::Meld {
             result_name,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1311,6 +1311,7 @@ pub(crate) enum SubjectVerbActionAst {
         source: TargetAst,
         count: Value,
         player: PlayerAst,
+        attached_to: Option<TargetAst>,
         enters_tapped: bool,
         enters_attacking: bool,
         attack_target_player_or_planeswalker_controlled_by: Option<PlayerAst>,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -887,11 +887,23 @@ fn advance_reference_frame_for_effect(
                         frame.last_object_tag = Some(next_reference_tag(id_gen, "searched"));
                     }
                 }
-                SubjectVerbActionAst::CreateTokenCopy { player, .. }
-                | SubjectVerbActionAst::CreateTokenCopyFromSource { player, .. } => {
+                SubjectVerbActionAst::CreateTokenCopy { player, .. } => {
                     track_effect_player(*player, frame, true, true)?;
                     if frame.auto_tag_object_targets {
                         frame.last_object_tag = Some(next_reference_tag(id_gen, "created"));
+                    }
+                }
+                SubjectVerbActionAst::CreateTokenCopyFromSource {
+                    player,
+                    attached_to,
+                    ..
+                } => {
+                    track_effect_player(*player, frame, true, true)?;
+                    if frame.auto_tag_object_targets || attached_to.is_some() {
+                        frame.last_object_tag = Some(next_reference_tag(id_gen, "created"));
+                    }
+                    if frame.auto_tag_object_targets && attached_to.is_some() {
+                        frame.last_object_tag = Some(next_reference_tag(id_gen, "attachment_target"));
                     }
                 }
                 SubjectVerbActionAst::CreateTokenWithMods {
@@ -2932,9 +2944,18 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 bind_unresolved_it_in_object_ref_ast(object, seed_tag)
                     + bind_unresolved_it_in_value(count, seed_tag)
             }
-            SubjectVerbActionAst::CreateTokenCopyFromSource { source, count, .. } => {
-                bind_unresolved_it_in_target(source, seed_tag)
-                    + bind_unresolved_it_in_value(count, seed_tag)
+            SubjectVerbActionAst::CreateTokenCopyFromSource {
+                source,
+                count,
+                attached_to,
+                ..
+            } => {
+                let mut replacements = bind_unresolved_it_in_target(source, seed_tag)
+                    + bind_unresolved_it_in_value(count, seed_tag);
+                if let Some(target) = attached_to.as_mut() {
+                    replacements += bind_unresolved_it_in_target(target, seed_tag);
+                }
+                replacements
             }
             SubjectVerbActionAst::CreateTokenWithMods {
                 count,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1,7 +1,7 @@
 use crate::cards::builders::{
     CardTextError, EffectAst, GrantedAbilityAst, IT_TAG, KeywordAction, ObjectRefAst,
-    OwnedLexToken, PlayerAst, PredicateAst, SubjectAst, SubjectVerbActionAst, SubjectVerbRoleAst,
-    TagKey, TargetAst,
+    OwnedLexToken, PREVIOUS_OBJECT_TAG, PlayerAst, PredicateAst, SubjectAst,
+    SubjectVerbActionAst, SubjectVerbRoleAst, TagKey, TargetAst,
 };
 use crate::color::ColorSet;
 use crate::effect::{EventValueSpec, Value};
@@ -17,7 +17,7 @@ use super::super::keyword_static::parse_value_binding_clause;
 use super::super::lexer::{
     LexedClause, render_token_slice, token_slice_at_is, token_slice_first_is, token_word_refs,
     word_slice_contains_any_phrase, word_slice_contains_phrase, word_slice_contains_word,
-    word_slice_eq_any, word_slice_find_any_phrase_start, word_slice_find_phrase_start,
+    word_slice_eq, word_slice_eq_any, word_slice_find_any_phrase_start, word_slice_find_phrase_start,
     word_slice_find_word, word_slice_find_word_where, word_slice_first_is, word_slice_first_is_any,
     word_slice_rfind_word_where, word_slice_starts_with, word_slice_starts_with_any,
 };
@@ -655,16 +655,6 @@ pub(crate) fn parse_create(
         tail_tokens.truncate(attached_token_idx);
     }
     let tail_words = token_word_refs(&tail_tokens);
-    if attached_to_target.is_some()
-        && tail_words
-            .iter()
-            .any(|word| matches!(*word, "copy" | "copies"))
-    {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported aura-copy attachment fanout clause (clause: '{}')",
-            clause_words.join(" ")
-        )));
-    }
     let with_idx = word_slice_find_word_where(&tail_words, |word| word == "with");
     let raw_for_each_idx = word_slice_find_phrase_start(&tail_words, &["for", "each"]);
     let for_each_idx = raw_for_each_idx.filter(|idx| {
@@ -886,8 +876,18 @@ pub(crate) fn parse_create(
                 enters_attacking = tail_attacking || inline_attacking;
                 attack_target_player_or_planeswalker_controlled_by = inline_attack_target_player;
                 if !source_tokens.is_empty() {
-                    let source = parse_target_phrase(&source_tokens)?;
-                    let references_iterated_object = target_references_it(&source);
+                    let source_words = token_word_refs(&source_tokens);
+                    let source = if word_slice_eq(&source_words, &["that", "aura"]) {
+                        TargetAst::Tagged(TagKey::from(PREVIOUS_OBJECT_TAG), None)
+                    } else {
+                        parse_target_phrase(&source_tokens)?
+                    };
+                    let source_references_iterated_object = target_references_it(&source);
+                    let attach_references_iterated_object = attached_to_target
+                        .as_ref()
+                        .is_some_and(target_references_it);
+                    let references_iterated_object =
+                        source_references_iterated_object || attach_references_iterated_object;
                     let create = EffectAst::subject_verb(
                         SubjectVerbRoleAst::Actor,
                         player,
@@ -895,6 +895,7 @@ pub(crate) fn parse_create(
                             source,
                             count: resolve_create_count(references_iterated_object),
                             player,
+                            attached_to: attached_to_target.clone(),
                             enters_tapped,
                             enters_attacking,
                             attack_target_player_or_planeswalker_controlled_by,

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -2344,6 +2344,7 @@ pub struct CreateTokenCopyEffect<A> {
     pub set_card_types: Option<Vec<CardType>>,
     pub set_subtypes: Option<Vec<Subtype>>,
     pub granted_static_abilities: Vec<A>,
+    pub suppress_aura_attachment_choice: bool,
 }
 
 impl<A> CreateTokenCopyEffect<A> {
@@ -2369,6 +2370,7 @@ impl<A> CreateTokenCopyEffect<A> {
             set_card_types: None,
             set_subtypes: None,
             granted_static_abilities: Vec::new(),
+            suppress_aura_attachment_choice: false,
         }
     }
 
@@ -2495,6 +2497,11 @@ impl<A> CreateTokenCopyEffect<A> {
 
     pub fn grant_static_ability(mut self, ability: A) -> Self {
         self.granted_static_abilities.push(ability);
+        self
+    }
+
+    pub fn suppress_aura_attachment_choice(mut self) -> Self {
+        self.suppress_aura_attachment_choice = true;
         self
     }
 }

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -403,6 +403,7 @@ pub struct ObjectFilter {
     pub attacked_this_turn: bool,
     pub attacking_player_or_planeswalker_controlled_by: Option<PlayerFilter>,
     pub attached_to_player: Option<PlayerFilter>,
+    pub attached_to_source: bool,
     pub nonattacking: bool,
     pub enlist_eligible: bool,
     pub blocking: bool,
@@ -497,6 +498,7 @@ impl ObjectFilter {
             || self.modified
             || self.enlist_eligible
             || self.attached_to_player.is_some()
+            || self.attached_to_source
             || self.drawn_this_turn
             || self.mana_value.is_some()
             || self.mana_value_parity.is_some()
@@ -1575,6 +1577,9 @@ impl ObjectFilter {
         }
         if self.in_combat_with_source {
             post_noun_qualifiers.push("blocking or blocked by this creature".to_string());
+        }
+        if self.attached_to_source {
+            post_noun_qualifiers.push("attached to this creature".to_string());
         }
         if self.nonattacking && self.nonblocking {
             parts.push("nonattacking, nonblocking".to_string());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -29294,19 +29294,271 @@ fn parse_combat_damage_tap_then_doesnt_untap_sentence() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn parse_rejects_three_dog_aura_copy_attachment_clause() {
-    let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Three Dog Variant")
-        .parse_text(
-            "Whenever you attack, you may pay {2} and sacrifice an Aura attached to this creature. When you sacrifice an Aura this way, for each other attacking creature you control, create a token that's a copy of that Aura attached to that creature.",
-        )
-        .expect_err("unsupported aura-copy attachment fanout should not partially parse");
+fn three_dog_galaxy_news_dj_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Three Dog, Galaxy News DJ");
+    let debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
 
-    let message = format!("{err:?}").to_ascii_lowercase();
     assert!(
-        message.contains("unsupported parser line")
-            || message.contains("unsupported known partial parse pattern")
-            || message.contains("unsupported aura-copy attachment fanout clause"),
-        "expected explicit unsupported rejection, got {message}"
+        debug.contains("attached_to_source: true"),
+        "Three Dog should restrict the sacrificed Aura to one attached to itself, got {debug}"
+    );
+    assert!(
+        debug.contains("ReflexiveTriggerEffect")
+            && debug.contains("ForEachObject")
+            && debug.contains("CreateTokenCopyEffect")
+            && debug.contains("AttachObjectsEffect")
+            && debug.contains("attacking: true")
+            && debug.contains("other: true"),
+        "Three Dog should structurally copy the sacrificed Aura onto each other attacking creature, got {debug}"
+    );
+    assert!(
+        rendered_lower.contains("sacrifice an aura attached to this creature")
+            && rendered_lower.contains("for each other attacking creature you control")
+            && rendered_lower.contains(
+                "create a token that's a copy of that aura attached to that creature"
+            ),
+        "expected Three Dog compiled text to preserve the source-attached Aura and fanout attachment clauses, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn three_dog_test_creature_definition(name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn three_dog_test_aura_definition(name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .enchants(crate::target::ObjectFilter::creature())
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn three_dog_galaxy_news_dj_sacrifices_only_aura_attached_to_source_and_copies_it() {
+    let three_dog = parse_oracle_card_definition("Three Dog, Galaxy News DJ");
+    let creature = three_dog_test_creature_definition("Attack Helper");
+    let source_aura = three_dog_test_aura_definition("Source Aura");
+    let other_aura = three_dog_test_aura_definition("Other Aura");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+
+    let three_dog_id = game.create_object_from_definition(&three_dog, alice, Zone::Battlefield);
+    let first_attacker = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let second_attacker = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let other_aura_id = game.create_object_from_definition(&other_aura, alice, Zone::Battlefield);
+    let source_aura_id =
+        game.create_object_from_definition(&source_aura, alice, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        other_aura_id,
+        crate::object::AttachmentTarget::Object(first_attacker),
+    ));
+    assert!(game.attach_object_to_target(
+        source_aura_id,
+        crate::object::AttachmentTarget::Object(three_dog_id),
+    ));
+    let source_aura_stable_id = game
+        .object(source_aura_id)
+        .expect("source aura exists before sacrifice")
+        .stable_id;
+    for attacker in [three_dog_id, first_attacker, second_attacker] {
+        game.remove_summoning_sickness(attacker);
+    }
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[
+            crate::decision::AttackerDeclaration {
+                creature: three_dog_id,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            },
+            crate::decision::AttackerDeclaration {
+                creature: first_attacker,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            },
+            crate::decision::AttackerDeclaration {
+                creature: second_attacker,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            },
+        ],
+    )
+    .expect("attack declaration should succeed");
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Three Dog should trigger once when one or more creatures attack"
+    );
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Three Dog attack trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Three Dog payment and sacrifice trigger should resolve");
+
+    let sacrificed_source_aura = game
+        .find_object_by_stable_id(source_aura_stable_id)
+        .expect("source aura should still be tracked after sacrifice");
+    assert_eq!(
+        game.object(sacrificed_source_aura)
+            .expect("source aura exists")
+            .zone,
+        Zone::Graveyard,
+        "the Aura attached to Three Dog should be sacrificed"
+    );
+    assert_eq!(
+        game.object(other_aura_id).expect("other aura exists").zone,
+        Zone::Battlefield,
+        "an Aura attached to another creature must not satisfy the source-attached sacrifice filter"
+    );
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "sacrificing the Aura this way should create the reflexive copy trigger"
+    );
+
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Three Dog reflexive copy trigger should resolve");
+    let copied_auras: Vec<_> = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| (*id, object)))
+        .filter(|(_, object)| {
+            object.kind == crate::object::ObjectKind::Token && object.name == "Source Aura"
+        })
+        .map(|(id, object)| (id, object.name.clone(), object.attached_to))
+        .collect();
+    let copied_aura_attachments: Vec<_> = copied_auras
+        .iter()
+        .map(|(_, _, attachment)| *attachment)
+        .collect();
+    assert_eq!(
+        copied_aura_attachments.len(),
+        2,
+        "Three Dog should create one Aura copy for each other attacking creature, got {copied_auras:?}"
+    );
+    assert!(
+        copied_aura_attachments.contains(&Some(crate::object::AttachmentTarget::Object(
+            first_attacker,
+        ))),
+        "expected a copied Aura attached to the first other attacker, got {copied_auras:?}"
+    );
+    assert!(
+        copied_aura_attachments.contains(&Some(crate::object::AttachmentTarget::Object(
+            second_attacker,
+        ))),
+        "expected a copied Aura attached to the second other attacker, got {copied_auras:?}"
+    );
+    assert!(
+        !copied_aura_attachments.contains(&Some(crate::object::AttachmentTarget::Object(
+            three_dog_id,
+        ))),
+        "Three Dog itself is not an other attacking creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn three_dog_galaxy_news_dj_declining_payment_creates_no_aura_copies() {
+    let three_dog = parse_oracle_card_definition("Three Dog, Galaxy News DJ");
+    let creature = three_dog_test_creature_definition("Attack Helper");
+    let aura = three_dog_test_aura_definition("Source Aura");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+
+    let three_dog_id = game.create_object_from_definition(&three_dog, alice, Zone::Battlefield);
+    let other_attacker = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let aura_id = game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+    assert!(game.attach_object_to_target(
+        aura_id,
+        crate::object::AttachmentTarget::Object(three_dog_id),
+    ));
+    for attacker in [three_dog_id, other_attacker] {
+        game.remove_summoning_sickness(attacker);
+    }
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[
+            crate::decision::AttackerDeclaration {
+                creature: three_dog_id,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            },
+            crate::decision::AttackerDeclaration {
+                creature: other_attacker,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            },
+        ],
+    )
+    .expect("attack declaration should succeed");
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Three Dog attack trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::AutoPassDecisionMaker,
+    )
+    .expect("declining Three Dog's may payment should resolve cleanly");
+
+    assert_eq!(
+        game.object(aura_id).expect("source aura exists").zone,
+        Zone::Battlefield,
+        "declining the payment should leave the attached Aura on the battlefield"
+    );
+    assert!(
+        game.stack.is_empty(),
+        "declining the payment should not create the reflexive copy trigger"
+    );
+    let copied_aura_count = game
+        .battlefield
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .filter(|object| {
+            object.kind == crate::object::ObjectKind::Token && object.name == "Source Aura"
+        })
+        .count();
+    assert_eq!(
+        copied_aura_count, 0,
+        "declining the payment should not create Aura copies"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1071,6 +1071,88 @@ fn sacrifice_view_unwrapped(effect: &Effect) -> Option<SacrificeView<'_>> {
     }
 }
 
+fn describe_may_pay_mana_and_sacrifice(may: &crate::effects::MayEffect) -> Option<String> {
+    let [pay_effect, choose_effect, sacrifice_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    if !matches!(may.decider.as_ref(), Some(PlayerFilter::You)) {
+        return None;
+    }
+    let pay = pay_effect.downcast_ref::<crate::effects::PayManaEffect>()?;
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let sacrifice = sacrifice_view_unwrapped(sacrifice_effect)?;
+    if pay.player != ChooseSpec::Player(PlayerFilter::You)
+        || choose.chooser != PlayerFilter::You
+        || !choose.count.is_single()
+        || sacrifice.player != &PlayerFilter::You
+        || sacrifice.count != &Value::Fixed(1)
+        || sacrifice.filter != &ObjectFilter::tagged(choose.tag.clone())
+    {
+        return None;
+    }
+
+    let mut object_filter = choose.filter.clone();
+    if object_filter.attached_to_source {
+        object_filter.controller = None;
+    }
+    let object = with_indefinite_article(&object_filter.description());
+    Some(format!(
+        "you may pay {} and sacrifice {object}",
+        pay.cost.to_oracle()
+    ))
+}
+
+fn describe_may_sacrifice_reflexive_condition(
+    may: &crate::effects::MayEffect,
+    predicate: EffectPredicate,
+) -> Option<String> {
+    if predicate != EffectPredicate::Happened
+        || !matches!(may.decider.as_ref(), Some(PlayerFilter::You))
+    {
+        return None;
+    }
+    let [_pay_effect, choose_effect, sacrifice_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let sacrifice = sacrifice_view_unwrapped(sacrifice_effect)?;
+    if !choose.count.is_single()
+        || sacrifice.player != &PlayerFilter::You
+        || sacrifice.count != &Value::Fixed(1)
+        || sacrifice.filter != &ObjectFilter::tagged(choose.tag.clone())
+    {
+        return None;
+    }
+
+    let mut object_filter = ObjectFilter::default();
+    object_filter.card_types = choose.filter.card_types.clone();
+    object_filter.subtypes = choose.filter.subtypes.clone();
+    let object = with_indefinite_article(&object_filter.description());
+    Some(format!("When you sacrifice {object} this way"))
+}
+
+fn sacrificed_object_noun_for_may(may: &crate::effects::MayEffect) -> Option<String> {
+    let [_pay_effect, choose_effect, sacrifice_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let sacrifice = sacrifice_view_unwrapped(sacrifice_effect)?;
+    if !choose.count.is_single()
+        || sacrifice.player != &PlayerFilter::You
+        || sacrifice.count != &Value::Fixed(1)
+        || sacrifice.filter != &ObjectFilter::tagged(choose.tag.clone())
+    {
+        return None;
+    }
+    if choose.filter.subtypes.len() == 1 {
+        return Some(choose.filter.subtypes[0].to_string());
+    }
+    if choose.filter.card_types.len() == 1 {
+        return Some(choose.filter.card_types[0].to_string().to_ascii_lowercase());
+    }
+    None
+}
+
 fn tagged_target_only_effect(
     effect: &Effect,
 ) -> Option<(&crate::TagKey, &crate::effects::TargetOnlyEffect)> {
@@ -24872,8 +24954,16 @@ pub(super) fn describe_with_id_then_reflexive_trigger(
     }
 
     let setup = describe_effect(&with_id.effect);
-    let triggered = lowercase_first(&describe_effect_list(&reflexive.effects));
+    let mut triggered = lowercase_first(&describe_effect_list(&reflexive.effects));
     let condition = if let Some(may) = with_id.effect.downcast_ref::<crate::effects::MayEffect>() {
+        if let Some(noun) = sacrificed_object_noun_for_may(may) {
+            triggered = triggered.replace("copy of it", &format!("copy of that {noun}"));
+        }
+        if let Some(condition) =
+            describe_may_sacrifice_reflexive_condition(may, reflexive.predicate.clone())
+        {
+            return Some(format!("{setup}. {condition}, {triggered}"));
+        }
         let who = may
             .decider
             .as_ref()
@@ -26657,6 +26747,18 @@ fn created_token_effect(effect: &Effect) -> Option<&crate::effects::CreateTokenE
     unwrap_for_each_attachment_wrappers(effect).downcast_ref::<crate::effects::CreateTokenEffect>()
 }
 
+fn tagged_create_token_copy_effect(
+    effect: &Effect,
+) -> Option<(&TagKey, &crate::effects::CreateTokenCopyEffect)> {
+    if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+        return tagged_create_token_copy_effect(&with_id.effect);
+    }
+    let tagged = effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let create_token = unwrap_for_each_attachment_wrappers(&tagged.effect)
+        .downcast_ref::<crate::effects::CreateTokenCopyEffect>()?;
+    Some((&tagged.tag, create_token))
+}
+
 fn choose_spec_references_exact_tag(spec: &ChooseSpec, tag: &TagKey) -> bool {
     match spec {
         ChooseSpec::Tagged(candidate) => candidate == tag,
@@ -26745,6 +26847,47 @@ fn describe_for_each_created_token_attachment(
     let target_noun = describe_iterated_object_reference_noun(&for_each.filter);
     Some(format!(
         "For each {subject}, create {token} attached to that {target_noun}"
+    ))
+}
+
+fn describe_for_each_created_token_copy_attachment(
+    for_each: &crate::effects::ForEachObject,
+) -> Option<String> {
+    let [create_effect, attach_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let (created_tag, create_token) = tagged_create_token_copy_effect(create_effect)?;
+    let attach = unwrap_for_each_attachment_wrappers(attach_effect)
+        .downcast_ref::<crate::effects::AttachObjectsEffect>()?;
+    if !matches!(attach.target, ChooseSpec::Iterated)
+        || !choose_spec_references_exact_tag(&attach.objects, created_tag)
+        || create_token.count != Value::Fixed(1)
+        || !matches!(&create_token.controller, PlayerFilter::You)
+        || create_token.enters_tapped
+        || create_token.enters_attacking
+        || create_token.attack_target_mode.is_some()
+        || create_token.exile_at_end_of_combat
+        || create_token.sacrifice_at_next_end_step
+        || create_token.exile_at_next_end_step
+        || create_token.pt_adjustment.is_some()
+        || create_token.clear_mana_cost
+        || !create_token.added_card_types.is_empty()
+        || !create_token.added_subtypes.is_empty()
+        || !create_token.removed_supertypes.is_empty()
+        || create_token.set_base_power_toughness.is_some()
+        || create_token.set_colors.is_some()
+        || create_token.set_card_types.is_some()
+        || create_token.set_subtypes.is_some()
+        || !create_token.granted_static_abilities.is_empty()
+    {
+        return None;
+    }
+
+    let subject = describe_for_each_object_filter_subject(&for_each.filter);
+    let target = describe_choose_spec(&create_token.target);
+    let target_noun = describe_iterated_object_reference_noun(&for_each.filter);
+    Some(format!(
+        "For each {subject}, create a token that's a copy of {target} attached to that {target_noun}"
     ))
 }
 
@@ -26957,6 +27100,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_for_each_created_token_attachment(for_each) {
+            return compact;
+        }
+        if let Some(compact) = describe_for_each_created_token_copy_attachment(for_each) {
             return compact;
         }
         if let Some(compact) = describe_for_each_devotion_damage(for_each) {
@@ -30106,6 +30252,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return text;
     }
     if let Some(may) = effect.downcast_ref::<crate::effects::MayEffect>() {
+        if let Some(compact) = describe_may_pay_mana_and_sacrifice(may) {
+            return compact;
+        }
         if let Some(compact) = describe_may_enlist(may) {
             return compact;
         }

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -405,6 +405,7 @@ where
                 .cloned()
                 .map(|ability| hooks.runtime_static_ability_hook(ability))
                 .collect::<Result<Vec<_>, _>>()?,
+            suppress_aura_attachment_choice: payload.suppress_aura_attachment_choice,
         }));
     }
     if let Some(payload) =

--- a/crates/ironsmith-runtime/src/effects/tokens/create_token_copy.rs
+++ b/crates/ironsmith-runtime/src/effects/tokens/create_token_copy.rs
@@ -34,6 +34,7 @@ use super::lifecycle::{
 /// * `enters_attacking` - Whether the copy enters attacking
 /// * `attack_target_mode` - Optional custom attack-target selection when attacking
 /// * `exile_at_end_of_combat` - Whether to exile at end of combat
+/// * `suppress_aura_attachment_choice` - Whether Aura attachment is handled by a later effect
 ///
 /// # Example
 ///
@@ -301,11 +302,20 @@ impl EffectExecutor for CreateTokenCopyEffect {
             let token_is_creature = token.is_creature();
 
             game.add_object(token);
-            let Some(entry_result) = game.move_object_with_etb_processing_with_dm(
-                id,
-                Zone::Battlefield,
-                &mut ctx.decision_maker,
-            ) else {
+            let entry_result = if self.suppress_aura_attachment_choice {
+                game.move_object_with_etb_processing_without_aura_attachment_choice(
+                    id,
+                    Zone::Battlefield,
+                    &mut ctx.decision_maker,
+                )
+            } else {
+                game.move_object_with_etb_processing_with_dm(
+                    id,
+                    Zone::Battlefield,
+                    &mut ctx.decision_maker,
+                )
+            };
+            let Some(entry_result) = entry_result else {
                 game.remove_object(id);
                 continue;
             };

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -12,7 +12,7 @@
 use crate::color::{Color, ColorSet};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId, StableId};
-use crate::object::{CounterType, Object, ObjectKind};
+use crate::object::{AttachmentTarget, CounterType, Object, ObjectKind};
 use crate::snapshot::ObjectSnapshot;
 use crate::static_abilities::StaticAbilityId;
 use crate::tag::TagKey;
@@ -1652,6 +1652,14 @@ impl ObjectFilterExt for ObjectFilter {
             return false;
         }
 
+        if self.attached_to_source
+            && ctx.source.is_none_or(|source_id| {
+                object.attached_to != Some(AttachmentTarget::Object(source_id))
+            })
+        {
+            return false;
+        }
+
         if let Some(targetability) = &self.could_be_targeted_by
             && !object_could_be_targeted_by(object.id, targetability, ctx, game)
         {
@@ -2489,6 +2497,14 @@ impl ObjectFilterExt for ObjectFilter {
             && ctx
                 .source
                 .is_none_or(|source_id| snapshot.object_id != source_id)
+        {
+            return false;
+        }
+
+        if self.attached_to_source
+            && ctx.source.is_none_or(|source_id| {
+                snapshot.attached_to != Some(AttachmentTarget::Object(source_id))
+            })
         {
             return false;
         }

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -266,6 +266,11 @@ impl TriggerMatcher for AttacksTrigger {
                 }
                 return format!("Whenever {min_total} or more {subject} attack{target_tail}");
             }
+            if target_tail.is_empty()
+                && matches!(subject.as_str(), "creature you control" | "creatures you control")
+            {
+                return "Whenever you attack".to_string();
+            }
             return format!("Whenever one or more {subject} attack{target_tail}");
         }
         if self.min_total_attackers > 1 {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Three Dog, Galaxy News DJ
Initial parse error:
```
unsupported aura-copy attachment fanout clause; oracle-only fallback also failed: unsupported aura-copy attachment fanout clause
```

Current worker: i-0a07b94b1fd4c7ebf
Branch: codex/aws-card-fix-three-dog-galaxy-news-dj
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0020
