### PR TITLE
Fix Ironsmith parse failure: Temporal Aperture

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -556,7 +556,7 @@ fn parse_revealed_top_library_permission_clause(
             if tag.as_str() == IT_TAG {
                 tag = TagKey::from("__last_revealed__");
             }
-            EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
+            EffectAst::subject_verb_grant_play_tagged_until_end_of_turn_while_on_top_of_library(
                 tag,
                 player,
                 allow_land,
@@ -574,12 +574,16 @@ fn parse_revealed_top_library_permission_clause(
 
     Ok(Some(EffectAst::Sequence {
         effects: vec![
-            EffectAst::subject_verb_grant_abilities_to_target(
+            EffectAst::subject_verb_grant_abilities_to_target_with_condition(
                 TargetAst::Source(None),
                 vec![GrantedAbilityAst::StaticAbility(
                     StaticAbility::all_players_look_at_your_top_library_card(),
                 )],
                 crate::effect::Until::EndOfTurn,
+                crate::ConditionExpr::TaggedObjectIsTopOfLibrary {
+                    tag: TagKey::from("__last_revealed__"),
+                    player: crate::target::PlayerFilter::You,
+                },
             ),
             permission,
         ],

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1,5 +1,7 @@
 use crate::effect::{Until, Value, ValueComparisonOperator};
-use crate::host::{CardTextError, EffectAst, IT_TAG, PlayerAst, PredicateAst, TagKey};
+use crate::host::{CardTextError, EffectAst, IT_TAG, PlayerAst, PredicateAst, TagKey, TargetAst};
+use crate::runtime_backend::GrantedAbilityAst;
+use crate::static_abilities::StaticAbility;
 use crate::target::ObjectFilter;
 use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
@@ -499,6 +501,89 @@ fn parse_permission_tail_tokens(
     }
 
     None
+}
+
+fn parse_revealed_top_library_permission_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let tokens = trim_lexed_commas(tokens);
+    let words = token_word_refs(tokens);
+    const PREFIX: &[&str] = &[
+        "until", "end", "of", "turn", "for", "as", "long", "as",
+    ];
+    const REMAINS_TOP: &[&str] = &[
+        "remains", "on", "top", "of", "your", "library", "play", "with", "the", "top", "card",
+        "of", "your", "library", "revealed", "and",
+    ];
+
+    if !word_slice_starts_with(&words, PREFIX) {
+        return Ok(None);
+    }
+
+    let Some(after_prefix) = words.get(PREFIX.len()..) else {
+        return Ok(None);
+    };
+    let referenced_card_len = if word_slice_starts_with(after_prefix, &["that", "card"]) {
+        2
+    } else if word_slice_starts_with(after_prefix, &["that", "revealed", "card"])
+        || word_slice_starts_with(after_prefix, &["the", "revealed", "card"])
+    {
+        3
+    } else {
+        return Ok(None);
+    };
+
+    let after_card = &after_prefix[referenced_card_len..];
+    if !word_slice_starts_with(after_card, REMAINS_TOP) {
+        return Ok(None);
+    }
+
+    let permission_start_word = PREFIX.len() + referenced_card_len + REMAINS_TOP.len();
+    let Some(permission_start_token) = token_index_for_word_index(tokens, permission_start_word)
+    else {
+        return Ok(None);
+    };
+    let permission_tokens = trim_lexed_commas(&tokens[permission_start_token..]);
+    let permission = match parse_permission_clause_spec(permission_tokens)? {
+        Some(PermissionClauseSpec::Tagged {
+            mut tag,
+            player,
+            allow_land,
+            as_copy: false,
+            without_paying_mana_cost,
+            ..
+        }) if matches!(player, PlayerAst::You | PlayerAst::Implicit) => {
+            if tag.as_str() == IT_TAG {
+                tag = TagKey::from("__last_revealed__");
+            }
+            EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
+                tag,
+                player,
+                allow_land,
+                without_paying_mana_cost,
+                false,
+            )
+        }
+        _ => {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported revealed top-library play permission clause (clause: '{}')",
+                words.join(" ")
+            )));
+        }
+    };
+
+    Ok(Some(EffectAst::Sequence {
+        effects: vec![
+            EffectAst::subject_verb_grant_abilities_to_target(
+                TargetAst::Source(None),
+                vec![GrantedAbilityAst::StaticAbility(
+                    StaticAbility::all_players_look_at_your_top_library_card(),
+                )],
+                crate::effect::Until::EndOfTurn,
+            ),
+            permission,
+        ],
+    }))
 }
 
 fn normalize_permission_subject_filter(mut filter: ObjectFilter) -> ObjectFilter {
@@ -1492,6 +1577,10 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
 ) -> Result<Option<EffectAst>, CardTextError> {
     let trimmed_tokens = trim_commas(tokens);
     let mut trimmed = strip_leading_token_words_any(&trimmed_tokens, &["then", "and"]).to_vec();
+
+    if let Some(effect) = parse_revealed_top_library_permission_clause(&trimmed)? {
+        return Ok(Some(effect));
+    }
 
     let mut allow_any_color_for_cast = false;
     if let Some(stripped) = strip_allow_any_color_for_cast_suffix_tokens(&trimmed) {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -19,6 +19,47 @@ fn describe_value_for_mode(value: &Value) -> String {
     }
 }
 
+fn resolve_tagged_top_library_condition(
+    condition: &crate::ConditionExpr,
+    ctx: &EffectLoweringContext,
+) -> Result<crate::ConditionExpr, CardTextError> {
+    match condition {
+        crate::ConditionExpr::TaggedObjectIsTopOfLibrary { tag, player } => {
+            let resolved_tag = if tag.as_str() == "__last_revealed__" {
+                TagKey::from(ctx.last_revealed_tag.clone().ok_or_else(|| {
+                    CardTextError::ParseError(
+                        "unable to resolve last revealed card without prior reveal".to_string(),
+                    )
+                })?)
+            } else if tag.as_str() == IT_TAG {
+                TagKey::from(ctx.last_object_tag.clone().ok_or_else(|| {
+                    CardTextError::ParseError(
+                        "unable to resolve 'it' without prior reference".to_string(),
+                    )
+                })?)
+            } else {
+                tag.clone()
+            };
+            Ok(crate::ConditionExpr::TaggedObjectIsTopOfLibrary {
+                tag: resolved_tag,
+                player: player.clone(),
+            })
+        }
+        crate::ConditionExpr::Not(inner) => Ok(crate::ConditionExpr::Not(Box::new(
+            resolve_tagged_top_library_condition(inner, ctx)?,
+        ))),
+        crate::ConditionExpr::And(left, right) => Ok(crate::ConditionExpr::And(
+            Box::new(resolve_tagged_top_library_condition(left, ctx)?),
+            Box::new(resolve_tagged_top_library_condition(right, ctx)?),
+        )),
+        crate::ConditionExpr::Or(left, right) => Ok(crate::ConditionExpr::Or(
+            Box::new(resolve_tagged_top_library_condition(left, ctx)?),
+            Box::new(resolve_tagged_top_library_condition(right, ctx)?),
+        )),
+        _ => Ok(condition.clone()),
+    }
+}
+
 const EFFECT_COMPILE_HANDLERS: [EffectCompileHandlerDef; 14] = [
     EffectCompileHandlerDef {
         run: effect_combat_resource_handlers::try_compile_combat_and_damage_effect,
@@ -1921,6 +1962,7 @@ fn compile_subject_verb_effect(
             allow_land,
             without_paying_mana_cost,
             allow_any_color_for_cast,
+            while_on_top_of_library,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -1946,20 +1988,27 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            let mut effects = vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+            let mut grant_play = crate::effects::GrantPlayTaggedEffect::new(
                 resolved_tag.clone(),
                 player_filter.clone(),
                 crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn,
                 *allow_land,
                 *allow_any_color_for_cast,
-            ))];
+            );
+            if *while_on_top_of_library {
+                grant_play = grant_play.while_on_top_of_library();
+            }
+            let mut effects = vec![Effect::new(grant_play)];
             if *without_paying_mana_cost {
-                effects.push(Effect::new(
+                let mut grant_free_cast =
                     crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect::new(
                         resolved_tag,
                         player_filter,
-                    ),
-                ));
+                    );
+                if *while_on_top_of_library {
+                    grant_free_cast = grant_free_cast.while_on_top_of_library();
+                }
+                effects.push(Effect::new(grant_free_cast));
             }
             Ok((effects, Vec::new()))
         }
@@ -2913,6 +2962,7 @@ fn compile_subject_verb_effect(
             target,
             abilities,
             duration,
+            condition,
         } => {
             let modifications = lower_granted_ability_grant_modifications(abilities)?;
             let Some(first_modification) = modifications.first() else {
@@ -2920,6 +2970,10 @@ fn compile_subject_verb_effect(
                     Effect::new(crate::effects::TargetOnlyEffect::new(spec))
                 });
             };
+            let resolved_condition = condition
+                .as_ref()
+                .map(|condition| resolve_tagged_top_library_condition(condition, ctx))
+                .transpose()?;
 
             compile_tagged_effect_for_target(target, ctx, "granted", |spec| {
                 let mut apply = crate::effects::ApplyContinuousEffect::with_spec(
@@ -2930,6 +2984,9 @@ fn compile_subject_verb_effect(
 
                 for modification in modifications.iter().skip(1) {
                     apply = apply.with_additional_modification(modification.clone());
+                }
+                if let Some(condition) = &resolved_condition {
+                    apply = apply.with_condition(condition.clone());
                 }
 
                 Effect::new(apply)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1044,6 +1044,7 @@ pub(crate) enum SubjectVerbActionAst {
         allow_land: bool,
         without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
+        while_on_top_of_library: bool,
     },
     GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn {
         tag: TagKey,
@@ -1239,6 +1240,7 @@ pub(crate) enum SubjectVerbActionAst {
         target: TargetAst,
         abilities: Vec<GrantedAbilityAst>,
         duration: Until,
+        condition: Option<crate::ConditionExpr>,
     },
     GrantToTarget {
         target: TargetAst,
@@ -2233,6 +2235,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                while_on_top_of_library,
             } => f
                 .debug_struct("GrantPlayTaggedUntilEndOfTurn")
                 .field("tag", tag)
@@ -2240,6 +2243,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("allow_land", allow_land)
                 .field("without_paying_mana_cost", without_paying_mana_cost)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .field("while_on_top_of_library", while_on_top_of_library)
                 .finish(),
             Self::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn {
                 tag,
@@ -2602,11 +2606,13 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 target,
                 abilities,
                 duration,
+                condition,
             } => f
                 .debug_struct("GrantAbilitiesToTarget")
                 .field("target", target)
                 .field("abilities", abilities)
                 .field("duration", duration)
+                .field("condition", condition)
                 .finish(),
             Self::GrantToTarget {
                 target,
@@ -3714,6 +3720,28 @@ impl EffectAst {
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                while_on_top_of_library: false,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_grant_play_tagged_until_end_of_turn_while_on_top_of_library(
+        tag: TagKey,
+        player: PlayerAst,
+        allow_land: bool,
+        without_paying_mana_cost: bool,
+        allow_any_color_for_cast: bool,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::GrantPlayTaggedUntilEndOfTurn {
+                tag,
+                player,
+                allow_land,
+                without_paying_mana_cost,
+                allow_any_color_for_cast,
+                while_on_top_of_library: true,
             },
         )
     }
@@ -4290,6 +4318,25 @@ impl EffectAst {
                 target,
                 abilities,
                 duration,
+                condition: None,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_grant_abilities_to_target_with_condition(
+        target: TargetAst,
+        abilities: Vec<GrantedAbilityAst>,
+        duration: Until,
+        condition: crate::ConditionExpr,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::GrantAbilitiesToTarget {
+                target,
+                abilities,
+                duration,
+                condition: Some(condition),
             },
         )
     }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -2963,6 +2963,7 @@ impl<E> VoteEffect<E> {
 pub struct GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
     pub tag: crate::tag::TagKey,
     pub player: PlayerFilter,
+    pub while_on_top_of_library: bool,
 }
 
 impl GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
@@ -2970,7 +2971,13 @@ impl GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
         Self {
             tag: tag.into(),
             player,
+            while_on_top_of_library: false,
         }
+    }
+
+    pub fn while_on_top_of_library(mut self) -> Self {
+        self.while_on_top_of_library = true;
+        self
     }
 }
 
@@ -3482,6 +3489,7 @@ pub struct GrantPlayTaggedEffect {
     pub duration: GrantPlayTaggedDuration,
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
+    pub while_on_top_of_library: bool,
 }
 
 impl GrantPlayTaggedEffect {
@@ -3498,7 +3506,13 @@ impl GrantPlayTaggedEffect {
             duration,
             allow_land,
             allow_any_color_for_cast,
+            while_on_top_of_library: false,
         }
+    }
+
+    pub fn while_on_top_of_library(mut self) -> Self {
+        self.while_on_top_of_library = true;
+        self
     }
 }
 

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -1,6 +1,7 @@
 use crate::{
     ActivationTiming, AnthemCountExpression, Comparison, CounterType, EffectId, EventValueSpec,
-    ManaSymbol, ObjectFilter, PlayerFilter, StableId, TagKey, ValueComparisonOperator, Zone,
+    ManaSymbol, ObjectFilter, PlayerFilter, PlayerId, StableId, TagKey, ValueComparisonOperator,
+    Zone,
 };
 use crate::{ChooseSpec, Color, ColorSet};
 
@@ -765,6 +766,12 @@ pub enum Condition {
     ColorsOfManaSpentToCastThisSpellOrMore(u32),
     YouControlCommander,
     TaggedObjectMatches(TagKey, ObjectFilter),
+    TaggedObjectIsTopOfLibrary { tag: TagKey, player: PlayerFilter },
+    StableObjectIsTopOfLibrary {
+        stable_id: StableId,
+        player: PlayerId,
+        library_top_revision: u64,
+    },
     TaggedObjectWasCast(TagKey),
     TaggedObjectIsSoulbondPaired(TagKey),
     EnchantedPermanentAttackedThisTurn,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35486,6 +35486,13 @@ fn temporal_aperture_runtime_grants_free_cast_only_while_revealed_card_is_top_li
             .is_empty(),
         "Temporal Aperture should grant a no-mana alternative cast from library"
     );
+    assert!(
+        game.current_has_static_ability_id(
+            temporal_id,
+            crate::static_abilities::StaticAbilityId::AllPlayersLookAtYourTopLibraryCard,
+        ),
+        "Temporal Aperture should reveal the top card while the tagged card remains on top"
+    );
 
     let actions = compute_legal_actions(&game, alice);
     assert!(
@@ -35503,7 +35510,48 @@ fn temporal_aperture_runtime_grants_free_cast_only_while_revealed_card_is_top_li
     let blocker = CardBuilder::new(CardId::from_raw(77_002), "New Top Card")
         .card_types(vec![CardType::Artifact])
         .build();
-    game.create_object_from_card(&blocker, alice, Zone::Library);
+    let blocker_id = game.create_object_from_card(&blocker, alice, Zone::Library);
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            spell_id,
+            Zone::Library,
+            alice
+        ),
+        "Temporal Aperture's play-from-library grant should stop applying after the tagged card leaves the top"
+    );
+    assert!(
+        game
+            .effect_store
+            .grant_registry
+            .granted_alternative_casts_for_card(&game, spell_id, Zone::Library, alice)
+            .is_empty(),
+        "Temporal Aperture's free-cast grant should stop applying after the tagged card leaves the top"
+    );
+    assert!(
+        !game.current_has_static_ability_id(
+            temporal_id,
+            crate::static_abilities::StaticAbilityId::AllPlayersLookAtYourTopLibraryCard,
+        ),
+        "Temporal Aperture should stop revealing the top card after the tagged card leaves the top"
+    );
+    let _drawn_blocker = game.move_object_by_game_rule(blocker_id, Zone::Hand);
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            spell_id,
+            Zone::Library,
+            alice
+        ),
+        "Temporal Aperture's play grant should not resume if the tagged card later becomes top again"
+    );
+    assert!(
+        !game.current_has_static_ability_id(
+            temporal_id,
+            crate::static_abilities::StaticAbilityId::AllPlayersLookAtYourTopLibraryCard,
+        ),
+        "Temporal Aperture's reveal permission should not resume if the tagged card later becomes top again"
+    );
     let actions_after_top_changed = compute_legal_actions(&game, alice);
     assert!(
         !actions_after_top_changed.iter().any(|action| matches!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35410,7 +35410,8 @@ fn temporal_aperture_oracle_parses_and_renders_top_library_permission() {
     let rendered = unprocessed_compiled_lines(&def).join(" ");
     let rendered_lower = rendered.to_ascii_lowercase();
     assert!(
-        rendered_lower.contains("for as long as that card remains on top of your library")
+        rendered_lower.contains("shuffle your library, then reveal the top card")
+            && rendered_lower.contains("for as long as that card remains on top of your library")
             && rendered_lower.contains("play with the top card of your library revealed")
             && rendered_lower.contains("you may play that card without paying its mana cost"),
         "expected Temporal Aperture compiled text to preserve the revealed-top-card permission, got {rendered}"

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35383,6 +35383,140 @@ fn parse_until_end_of_turn_you_may_play_that_card_without_paying_mana_cost() {
     );
 }
 
+#[test]
+fn temporal_aperture_oracle_parses_and_renders_top_library_permission() {
+    let def = parse_oracle_card_definition("Temporal Aperture");
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("RevealTop"),
+        "expected Temporal Aperture to reveal and tag the top card, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("AllPlayersLookAtYourTopLibraryCard"),
+        "expected Temporal Aperture to grant temporary top-library reveal permission, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("GrantPlayTaggedEffect")
+            || abilities_debug.contains("GrantPlayTaggedUntilEndOfTurn"),
+        "expected Temporal Aperture to grant play permission for the revealed card, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("GrantTaggedSpellFreeCastUntilEndOfTurnEffect")
+            || abilities_debug.contains("without_paying_mana_cost: true"),
+        "expected Temporal Aperture to grant a free-cast permission for the revealed card, got {abilities_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("for as long as that card remains on top of your library")
+            && rendered_lower.contains("play with the top card of your library revealed")
+            && rendered_lower.contains("you may play that card without paying its mana cost"),
+        "expected Temporal Aperture compiled text to preserve the revealed-top-card permission, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("unsupported") && !rendered_lower.contains("unimplemented"),
+        "Temporal Aperture should compile without fallback markers, got {rendered}"
+    );
+}
+
+#[test]
+fn temporal_aperture_runtime_grants_free_cast_only_while_revealed_card_is_top_library_card() {
+    use crate::card::CardBuilder;
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    let def = parse_oracle_card_definition("Temporal Aperture");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Temporal Aperture should have an activated ability");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let temporal_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let expensive_spell = CardBuilder::new(CardId::from_raw(77_001), "Expensive Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let spell_id = game.create_object_from_card(&expensive_spell, alice, Zone::Library);
+
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            spell_id,
+            Zone::Library,
+            alice
+        ),
+        "Temporal Aperture should not grant play permission before its ability resolves"
+    );
+
+    let mut ctx = ExecutionContext::new_default(temporal_id, alice);
+    for effect in activated.effects.flattened_default_effects() {
+        execute_effect(&mut game, effect, &mut ctx)
+            .expect("Temporal Aperture activated effect should resolve");
+    }
+
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            spell_id,
+            Zone::Library,
+            alice
+        ),
+        "Temporal Aperture should grant play-from-library permission to the revealed card"
+    );
+    assert!(
+        !game
+            .effect_store
+            .grant_registry
+            .granted_alternative_casts_for_card(&game, spell_id, Zone::Library, alice)
+            .is_empty(),
+        "Temporal Aperture should grant a no-mana alternative cast from library"
+    );
+
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: action_spell_id,
+                from_zone: Zone::Library,
+                casting_method: CastingMethod::PlayFrom { use_alternative: Some(_), .. },
+            } if *action_spell_id == spell_id
+        )),
+        "revealed top spell should be castable from library without paying its mana cost, got {actions:?}"
+    );
+
+    let blocker = CardBuilder::new(CardId::from_raw(77_002), "New Top Card")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&blocker, alice, Zone::Library);
+    let actions_after_top_changed = compute_legal_actions(&game, alice);
+    assert!(
+        !actions_after_top_changed.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: action_spell_id,
+                from_zone: Zone::Library,
+                ..
+            } if *action_spell_id == spell_id
+        )),
+        "Temporal Aperture should not offer the revealed spell once it is no longer the top library card, got {actions_after_top_changed:?}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_your_opponents_cant_cast_spells_this_turn() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11761,6 +11761,19 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 }
                 format!("the tagged object '{}' matches {desc}", tag.as_str())
             }
+        Condition::TaggedObjectIsTopOfLibrary { tag, .. } => {
+            if is_implicit_reference_tag(tag.as_str()) {
+                "it remains on top of its owner's library".to_string()
+            } else {
+                format!(
+                    "the tagged object '{}' remains on top of its owner's library",
+                    tag.as_str()
+                )
+            }
+        }
+        Condition::StableObjectIsTopOfLibrary { .. } => {
+            "that card remains on top of its owner's library".to_string()
+        }
         Condition::TaggedObjectWasCast(tag) => {
             if is_implicit_reference_tag(tag.as_str()) {
                 "it was cast".to_string()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -21368,6 +21368,13 @@ fn describe_reveal_top_then_temporarily_play_revealed_top_card(
         || grant_play.player != PlayerFilter::You
         || grant_play.duration != crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
         || !grant_play.allow_land
+        || !grant_play.while_on_top_of_library
+        || !grant_free_cast.while_on_top_of_library
+        || !matches!(
+            reveal_permission.condition,
+            Some(crate::ConditionExpr::TaggedObjectIsTopOfLibrary { .. })
+                | Some(crate::ConditionExpr::StableObjectIsTopOfLibrary { .. })
+        )
     {
         return None;
     }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12455,6 +12455,25 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 3;
             continue;
         }
+        if idx + 3 < filtered.len()
+            && let Some(reveal_top) = filtered[idx].downcast_ref::<crate::effects::RevealTopEffect>()
+            && let Some(reveal_permission) = unwrap_tag_wrappers(filtered[idx + 1])
+                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+            && let Some(grant_play) =
+                filtered[idx + 2].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(grant_free_cast) = filtered[idx + 3]
+                .downcast_ref::<crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect>()
+            && let Some(compact) = describe_reveal_top_then_temporarily_play_revealed_top_card(
+                reveal_top,
+                reveal_permission,
+                grant_play,
+                grant_free_cast,
+            )
+        {
+            parts.push(compact);
+            idx += 4;
+            continue;
+        }
         if idx + 1 < filtered.len()
             && let Some(exile_top) =
                 filtered[idx].downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()
@@ -21303,6 +21322,33 @@ fn tagged_move_to_zone(
     move_to_zone.zone == zone
         && move_to_zone.to_top == to_top
         && matches!(move_to_zone.target.base(), ChooseSpec::Tagged(move_tag) if move_tag == tag)
+}
+
+fn describe_reveal_top_then_temporarily_play_revealed_top_card(
+    reveal_top: &crate::effects::RevealTopEffect,
+    reveal_permission: &crate::effects::ApplyContinuousEffect,
+    grant_play: &crate::effects::GrantPlayTaggedEffect,
+    grant_free_cast: &crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect,
+) -> Option<String> {
+    let tag = reveal_top.tag.as_ref()?;
+    if reveal_top.player != PlayerFilter::You
+        || !matches!(reveal_permission.target, crate::continuous::EffectTarget::Source)
+        || reveal_permission.until != Until::EndOfTurn
+        || !apply_continuous_adds_static_ability(
+            reveal_permission,
+            crate::static_abilities::StaticAbilityId::AllPlayersLookAtYourTopLibraryCard,
+        )
+        || grant_play.tag != *tag
+        || grant_free_cast.tag != *tag
+        || grant_play.player != grant_free_cast.player
+        || grant_play.player != PlayerFilter::You
+        || grant_play.duration != crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+        || !grant_play.allow_land
+    {
+        return None;
+    }
+
+    Some("Reveal the top card of your library. Until end of turn, for as long as that card remains on top of your library, play with the top card of your library revealed and you may play that card without paying its mana cost".to_string())
 }
 
 fn describe_exile_top_then_play_without_paying_mana(
@@ -32679,10 +32725,52 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(grant_tagged_spell_free_cast) =
         effect.downcast_ref::<crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect>()
     {
-        return format!(
-            "{} may cast {} from exile this turn without paying their mana costs",
-            describe_player_filter(&grant_tagged_spell_free_cast.player),
+        let helper_tag = grant_tagged_spell_free_cast
+            .tag
+            .as_str()
+            .starts_with("targeted_")
+            || grant_tagged_spell_free_cast
+                .tag
+                .as_str()
+                .starts_with("__source_")
+            || grant_tagged_spell_free_cast.tag.as_str() == "__it__"
+            || matches!(
+                grant_tagged_spell_free_cast.tag.as_str(),
+                "exiled" | "revealed" | "looked" | "chosen" | "searched"
+            )
+            || crate::cards::is_sentence_helper_tag(
+                grant_tagged_spell_free_cast.tag.as_str(),
+                "exiled",
+            )
+            || crate::cards::is_sentence_helper_tag(
+                grant_tagged_spell_free_cast.tag.as_str(),
+                "revealed",
+            )
+            || crate::cards::is_sentence_helper_tag(
+                grant_tagged_spell_free_cast.tag.as_str(),
+                "looked",
+            )
+            || crate::cards::is_sentence_helper_tag(
+                grant_tagged_spell_free_cast.tag.as_str(),
+                "chosen",
+            )
+            || crate::cards::is_sentence_helper_tag(
+                grant_tagged_spell_free_cast.tag.as_str(),
+                "searched",
+            );
+        let object_text = if helper_tag {
+            "that card"
+        } else {
             "those spells"
+        };
+        let cost_text = if helper_tag {
+            "its mana cost"
+        } else {
+            "their mana costs"
+        };
+        return format!(
+            "{} may cast {object_text} this turn without paying {cost_text}",
+            describe_player_filter(&grant_tagged_spell_free_cast.player),
         );
     }
     if let Some(may_cast_matching) =

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12455,6 +12455,30 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 3;
             continue;
         }
+        if idx + 4 < filtered.len()
+            && let Some(shuffle) =
+                filtered[idx].downcast_ref::<crate::effects::ShuffleLibraryEffect>()
+            && let Some(reveal_top) =
+                filtered[idx + 1].downcast_ref::<crate::effects::RevealTopEffect>()
+            && let Some(reveal_permission) = unwrap_tag_wrappers(filtered[idx + 2])
+                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+            && let Some(grant_play) =
+                filtered[idx + 3].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(grant_free_cast) = filtered[idx + 4]
+                .downcast_ref::<crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect>()
+            && let Some(compact) =
+                describe_shuffle_then_reveal_top_then_temporarily_play_revealed_top_card(
+                    shuffle,
+                    reveal_top,
+                    reveal_permission,
+                    grant_play,
+                    grant_free_cast,
+                )
+        {
+            parts.push(compact);
+            idx += 5;
+            continue;
+        }
         if idx + 3 < filtered.len()
             && let Some(reveal_top) = filtered[idx].downcast_ref::<crate::effects::RevealTopEffect>()
             && let Some(reveal_permission) = unwrap_tag_wrappers(filtered[idx + 1])
@@ -21348,7 +21372,44 @@ fn describe_reveal_top_then_temporarily_play_revealed_top_card(
         return None;
     }
 
-    Some("Reveal the top card of your library. Until end of turn, for as long as that card remains on top of your library, play with the top card of your library revealed and you may play that card without paying its mana cost".to_string())
+    Some(
+        concat!(
+            "Reveal the top card of your library. Until end of turn, ",
+            "for as long as that card remains on top of your library, ",
+            "play with the top card of your library revealed and you may play ",
+            "that card without paying its mana cost"
+        )
+        .to_string(),
+    )
+}
+
+fn describe_shuffle_then_reveal_top_then_temporarily_play_revealed_top_card(
+    shuffle: &crate::effects::ShuffleLibraryEffect,
+    reveal_top: &crate::effects::RevealTopEffect,
+    reveal_permission: &crate::effects::ApplyContinuousEffect,
+    grant_play: &crate::effects::GrantPlayTaggedEffect,
+    grant_free_cast: &crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect,
+) -> Option<String> {
+    if shuffle.player != PlayerFilter::You {
+        return None;
+    }
+
+    describe_reveal_top_then_temporarily_play_revealed_top_card(
+        reveal_top,
+        reveal_permission,
+        grant_play,
+        grant_free_cast,
+    )?;
+
+    Some(
+        concat!(
+            "Shuffle your library, then reveal the top card. Until end of turn, ",
+            "for as long as that card remains on top of your library, ",
+            "play with the top card of your library revealed and you may play ",
+            "that card without paying its mana cost"
+        )
+        .to_string(),
+    )
 }
 
 fn describe_exile_top_then_play_without_paying_mana(

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -996,6 +996,8 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::ColorsOfManaSpentToCastThisSpellOrMore(..) => {}
         Condition::YouControlCommander => {}
         Condition::TaggedObjectMatches(..) => {}
+        Condition::TaggedObjectIsTopOfLibrary { .. } => {}
+        Condition::StableObjectIsTopOfLibrary { .. } => {}
         Condition::TaggedObjectWasCast(..) => {}
         Condition::TaggedObjectIsSoulbondPaired(..) => {}
         Condition::EnchantedPermanentAttackedThisTurn => {}
@@ -1800,9 +1802,22 @@ pub fn evaluate_condition_external(
             .as_ref()
             .is_some_and(|combat| crate::combat_state::is_blocking(combat, ctx.source)),
         Condition::SourceIsSoulbondPaired => game.is_soulbond_paired(ctx.source),
+        Condition::StableObjectIsTopOfLibrary {
+            stable_id,
+            player,
+            library_top_revision,
+        } => {
+            crate::grant_registry::stable_card_is_top_of_library_at_revision(
+                game,
+                *stable_id,
+                *player,
+                *library_top_revision,
+            )
+        }
 
         // Conditions requiring targets / effect execution context are not evaluable here.
         Condition::TaggedObjectMatches(_, _)
+        | Condition::TaggedObjectIsTopOfLibrary { .. }
         | Condition::TaggedObjectWasCast(_)
         | Condition::TaggedObjectIsSoulbondPaired(_)
         | Condition::EnchantedPermanentAttackedThisTurn
@@ -2502,7 +2517,21 @@ fn evaluate_condition_simple(
         | Condition::VoteOptionGetsMoreVotes(_)
         | Condition::VoteOptionGetsMoreVotesOrTied(_)
         | Condition::XValueAtLeast(_) => false,
-        Condition::TaggedObjectMatches(_, _) | Condition::TaggedObjectWasCast(_) => false,
+        Condition::TaggedObjectMatches(_, _)
+        | Condition::TaggedObjectIsTopOfLibrary { .. }
+        | Condition::TaggedObjectWasCast(_) => false,
+        Condition::StableObjectIsTopOfLibrary {
+            stable_id,
+            player,
+            library_top_revision,
+        } => {
+            crate::grant_registry::stable_card_is_top_of_library_at_revision(
+                game,
+                *stable_id,
+                *player,
+                *library_top_revision,
+            )
+        }
         Condition::TaggedObjectIsSoulbondPaired(_) => false,
         Condition::EnchantedPermanentAttackedThisTurn => false,
         Condition::TargetMatches(_) => false,
@@ -3363,6 +3392,29 @@ fn evaluate_condition(
             }
             Ok(false)
         }
+        Condition::TaggedObjectIsTopOfLibrary { tag, player } => {
+            let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
+            let Some(tagged) = ctx.get_tagged_all(tag.as_str()) else {
+                return Ok(false);
+            };
+            Ok(tagged.iter().any(|snapshot| {
+                crate::grant_registry::stable_card_is_top_of_library(
+                    game,
+                    snapshot.stable_id,
+                    player_id,
+                )
+            }))
+        }
+        Condition::StableObjectIsTopOfLibrary {
+            stable_id,
+            player,
+            library_top_revision,
+        } => Ok(crate::grant_registry::stable_card_is_top_of_library_at_revision(
+            game,
+            *stable_id,
+            *player,
+            *library_top_revision,
+        )),
         Condition::TaggedObjectWasCast(tag) => Ok(tagged_object_was_cast(game, tag, ctx)),
         Condition::TaggedObjectIsSoulbondPaired(tag) => {
             let tagged_id = ctx

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1046,7 +1046,8 @@ where
             payload.duration,
             payload.allow_land,
             payload.allow_any_color_for_cast,
-        )));
+        )
+        .while_on_top_of_library_if(payload.while_on_top_of_library)));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::LocalRewriteEffect<M::Effect>>(&effect)
     {

--- a/crates/ironsmith-runtime/src/effects/continuous/apply_continuous.rs
+++ b/crates/ironsmith-runtime/src/effects/continuous/apply_continuous.rs
@@ -384,6 +384,41 @@ fn is_controller_change_cost(effect: &ApplyContinuousEffect) -> bool {
         && runtime_are_controller_changes
 }
 
+fn materialize_runtime_condition(
+    condition: &crate::ConditionExpr,
+    game: &GameState,
+    ctx: &ExecutionContext,
+) -> Result<crate::ConditionExpr, ExecutionError> {
+    match condition {
+        crate::ConditionExpr::TaggedObjectIsTopOfLibrary { tag, player } => {
+            let player_id = resolve_player_filter(game, player, ctx)?;
+            let Some(snapshot) = ctx.get_tagged_all(tag.as_str()).and_then(|items| items.first())
+            else {
+                return Ok(crate::ConditionExpr::Custom(
+                    "unresolved tagged top-library condition",
+                ));
+            };
+            Ok(crate::ConditionExpr::StableObjectIsTopOfLibrary {
+                stable_id: snapshot.stable_id,
+                player: player_id,
+                library_top_revision: game.library_top_revision(player_id),
+            })
+        }
+        crate::ConditionExpr::Not(inner) => Ok(crate::ConditionExpr::Not(Box::new(
+            materialize_runtime_condition(inner, game, ctx)?,
+        ))),
+        crate::ConditionExpr::And(left, right) => Ok(crate::ConditionExpr::And(
+            Box::new(materialize_runtime_condition(left, game, ctx)?),
+            Box::new(materialize_runtime_condition(right, game, ctx)?),
+        )),
+        crate::ConditionExpr::Or(left, right) => Ok(crate::ConditionExpr::Or(
+            Box::new(materialize_runtime_condition(left, game, ctx)?),
+            Box::new(materialize_runtime_condition(right, game, ctx)?),
+        )),
+        _ => Ok(condition.clone()),
+    }
+}
+
 impl EffectExecutor for ApplyContinuousEffect {
     fn as_cost_executable(&self) -> Option<&dyn CostExecutableEffect> {
         is_controller_change_cost(self).then_some(self)
@@ -488,7 +523,7 @@ impl EffectExecutor for ApplyContinuousEffect {
                 effect = effect.with_source_type(source_type.clone());
             }
             if let Some(condition) = &self.condition {
-                effect = effect.with_condition(condition.clone());
+                effect = effect.with_condition(materialize_runtime_condition(condition, game, ctx)?);
             }
             if let Some(group) = effect_group {
                 effect = effect.with_group(group);

--- a/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
@@ -19,6 +19,7 @@ pub struct GrantPlayTaggedEffect {
     pub duration: GrantPlayTaggedDuration,
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
+    pub while_on_top_of_library: bool,
 }
 
 impl GrantPlayTaggedEffect {
@@ -35,7 +36,18 @@ impl GrantPlayTaggedEffect {
             duration,
             allow_land,
             allow_any_color_for_cast,
+            while_on_top_of_library: false,
         }
+    }
+
+    pub fn while_on_top_of_library(mut self) -> Self {
+        self.while_on_top_of_library = true;
+        self
+    }
+
+    pub fn while_on_top_of_library_if(mut self, enabled: bool) -> Self {
+        self.while_on_top_of_library = enabled;
+        self
     }
 
     pub fn until_your_next_turn(tag: impl Into<TagKey>, player: PlayerFilter) -> Self {
@@ -179,7 +191,15 @@ impl EffectExecutor for GrantPlayTaggedEffect {
                 mana_permission_stable_ids.push(object.stable_id);
             }
 
-            let source = if self.duration == GrantPlayTaggedDuration::ForAsLongAsYouControlSource {
+            let source = if self.while_on_top_of_library {
+                GrantSource::EffectWhileStableCardOnTopOfLibrary {
+                    source_id: ctx.source,
+                    expires_end_of_turn,
+                    stable_id: object.stable_id,
+                    player: object.owner,
+                    library_top_revision: game.library_top_revision(object.owner),
+                }
+            } else if self.duration == GrantPlayTaggedDuration::ForAsLongAsYouControlSource {
                 GrantSource::EffectWhileControlled {
                     source_id: ctx.source,
                     controller: player_id,

--- a/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
@@ -1,4 +1,4 @@
-//! Grant temporary "cast this tagged exiled spell without paying its mana cost"
+//! Grant temporary "cast this tagged spell without paying its mana cost"
 //! permissions.
 
 use crate::alternative_cast::AlternativeCastingMethod;
@@ -8,9 +8,8 @@ use crate::effects::helpers::resolve_player_filter;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 use crate::grant_registry::GrantSource;
-use crate::zone::Zone;
 
-/// Grants a temporary zero-mana alternative casting method to tagged exiled spells.
+/// Grants a temporary zero-mana alternative casting method to tagged spells.
 pub type GrantTaggedSpellFreeCastUntilEndOfTurnEffect =
     ironsmith_core::GrantTaggedSpellFreeCastUntilEndOfTurnEffect;
 
@@ -42,9 +41,10 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
             let Some(object) = game.object(object_id) else {
                 continue;
             };
-            if object.zone != Zone::Exile || object.is_land() || !seen.insert(object_id) {
+            if object.is_land() || !seen.insert(object_id) {
                 continue;
             }
+            let zone = object.zone;
 
             let method = AlternativeCastingMethod::alternative_cost(
                 "Without paying its mana cost",
@@ -55,7 +55,7 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
                 .grant_registry
                 .grant_alternative_cast_to_card(
                     object_id,
-                    Zone::Exile,
+                    zone,
                     player_id,
                     method,
                     GrantSource::Effect {

--- a/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
@@ -45,6 +45,20 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
                 continue;
             }
             let zone = object.zone;
+            let source = if self.while_on_top_of_library {
+                GrantSource::EffectWhileStableCardOnTopOfLibrary {
+                    source_id: ctx.source,
+                    expires_end_of_turn,
+                    stable_id: object.stable_id,
+                    player: object.owner,
+                    library_top_revision: game.library_top_revision(object.owner),
+                }
+            } else {
+                GrantSource::Effect {
+                    source_id: ctx.source,
+                    expires_end_of_turn,
+                }
+            };
 
             let method = AlternativeCastingMethod::alternative_cost(
                 "Without paying its mana cost",
@@ -58,10 +72,7 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
                     zone,
                     player_id,
                     method,
-                    GrantSource::Effect {
-                        source_id: ctx.source,
-                        expires_end_of_turn,
-                    },
+                    source,
                 );
             granted += 1;
         }

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -286,6 +286,8 @@ pub struct EffectStore {
     pub pending_replacement_choice: Option<PendingReplacementChoice>,
     /// Registry for tracking granted alternative casts and abilities.
     pub grant_registry: crate::grant_registry::GrantRegistry,
+    /// Monotonic per-library revision for one-shot "while this remains on top" effects.
+    pub library_top_revisions: HashMap<PlayerId, u64>,
     /// Temporary mana abilities granted to players (e.g., Channel), expiring at end of turn.
     pub granted_mana_abilities: Vec<GrantedManaAbility>,
     /// Temporary spell-cost reductions waiting for the next matching spell this turn.
@@ -312,6 +314,7 @@ impl Default for EffectStore {
             active_state_trigger_conditions: HashSet::new(),
             pending_replacement_choice: None,
             grant_registry: crate::grant_registry::GrantRegistry::new(),
+            library_top_revisions: HashMap::new(),
             granted_mana_abilities: Vec::new(),
             temporary_spell_cost_reductions: Vec::new(),
             temporary_spell_ability_grants: Vec::new(),
@@ -2511,6 +2514,9 @@ impl GameState {
             self.players[index].library.shuffle(&mut rng);
         }
         let after_order = self.players[index].library.clone();
+        if before_order != after_order {
+            self.bump_library_top_revision(player_id);
+        }
         self.push_hidden_info_operation(HiddenInfoOperation::LibraryShuffle {
             player: player_id,
             before_order,
@@ -2572,6 +2578,9 @@ impl GameState {
         }
         if let Some(player_state) = self.player_mut(player) {
             player_state.library = after_order.clone();
+        }
+        if before_order != after_order {
+            self.bump_library_top_revision(player);
         }
         self.record_library_reorder(player, before_order, after_order, reason);
         true
@@ -2678,6 +2687,9 @@ impl GameState {
         } else {
             return false;
         };
+        if before_order != after_order {
+            self.bump_library_top_revision(player);
+        }
         self.record_library_reorder(player, before_order, after_order, reason);
         true
     }
@@ -3366,6 +3378,7 @@ impl GameState {
                 if let Some(player) = self.player_mut(owner) {
                     player.library.push(id);
                 }
+                self.bump_library_top_revision(owner);
             }
             Zone::Hand => {
                 if let Some(player) = self.player_mut(owner) {
@@ -4762,6 +4775,7 @@ impl GameState {
                 if let Some(player) = self.player_mut(owner) {
                     player.library.retain(|&x| x != id);
                 }
+                self.bump_library_top_revision(owner);
             }
             Zone::Hand => {
                 if let Some(player) = self.player_mut(owner) {
@@ -6093,6 +6107,23 @@ impl GameState {
             self.update_replacement_effects();
             self.update_cant_effects();
         }
+    }
+
+    pub fn library_top_revision(&self, player: PlayerId) -> u64 {
+        self.effect_store
+            .library_top_revisions
+            .get(&player)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    fn bump_library_top_revision(&mut self, player: PlayerId) {
+        let revision = self
+            .effect_store
+            .library_top_revisions
+            .entry(player)
+            .or_insert(0);
+        *revision = revision.saturating_add(1);
     }
 
     /// Check if a player may spend mana as though it were mana of any color.

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -34,6 +34,15 @@ pub enum GrantSource {
         source_id: ObjectId,
         controller: PlayerId,
     },
+    /// From a resolving effect that lasts until end of turn only while a
+    /// particular physical card remains on top of a player's library.
+    EffectWhileStableCardOnTopOfLibrary {
+        source_id: ObjectId,
+        expires_end_of_turn: u32,
+        stable_id: StableId,
+        player: PlayerId,
+        library_top_revision: u64,
+    },
     /// From a static ability on a permanent.
     /// The grant exists only while the source is on the battlefield.
     StaticAbility {
@@ -56,6 +65,7 @@ impl GrantSource {
         match self {
             GrantSource::Effect { source_id, .. } => *source_id,
             GrantSource::EffectWhileControlled { source_id, .. } => *source_id,
+            GrantSource::EffectWhileStableCardOnTopOfLibrary { source_id, .. } => *source_id,
             GrantSource::StaticAbility { source_id } => *source_id,
         }
     }
@@ -80,6 +90,19 @@ impl GrantSource {
             } => game.object(*source_id).is_some_and(|source| {
                 source.zone == Zone::Battlefield && game.controller_of(source) == *controller
             }),
+            GrantSource::EffectWhileStableCardOnTopOfLibrary {
+                expires_end_of_turn,
+                stable_id,
+                player,
+                library_top_revision,
+                ..
+            } => game.turn.turn_number <= *expires_end_of_turn
+                && stable_card_is_top_of_library_at_revision(
+                    game,
+                    *stable_id,
+                    *player,
+                    *library_top_revision,
+                ),
         }
     }
 
@@ -98,6 +121,10 @@ impl GrantSource {
                 battlefield.contains(source_id)
             }
             GrantSource::EffectWhileControlled { source_id, .. } => battlefield.contains(source_id),
+            GrantSource::EffectWhileStableCardOnTopOfLibrary {
+                expires_end_of_turn,
+                ..
+            } => turn_number <= *expires_end_of_turn,
         }
     }
 }
@@ -113,6 +140,13 @@ pub enum GrantLifetime {
         source_id: ObjectId,
         controller: PlayerId,
     },
+    WhileStableCardOnTopOfLibrary {
+        source_id: ObjectId,
+        stable_id: StableId,
+        player: PlayerId,
+        turn: u32,
+        library_top_revision: u64,
+    },
 }
 
 impl GrantLifetime {
@@ -121,6 +155,7 @@ impl GrantLifetime {
             GrantLifetime::UntilEndOfTurn { source_id, .. } => *source_id,
             GrantLifetime::WhileSourceOnBattlefield(source_id) => *source_id,
             GrantLifetime::WhileSourceControlledBy { source_id, .. } => *source_id,
+            GrantLifetime::WhileStableCardOnTopOfLibrary { source_id, .. } => *source_id,
         }
     }
 }
@@ -145,8 +180,46 @@ impl GrantSource {
                 source_id: *source_id,
                 controller: *controller,
             },
+            GrantSource::EffectWhileStableCardOnTopOfLibrary {
+                source_id,
+                stable_id,
+                player,
+                expires_end_of_turn,
+                library_top_revision,
+            } => GrantLifetime::WhileStableCardOnTopOfLibrary {
+                source_id: *source_id,
+                stable_id: *stable_id,
+                player: *player,
+                turn: *expires_end_of_turn,
+                library_top_revision: *library_top_revision,
+            },
         }
     }
+}
+
+pub(crate) fn stable_card_is_top_of_library_at_revision(
+    game: &crate::game_state::GameState,
+    stable_id: StableId,
+    player: PlayerId,
+    library_top_revision: u64,
+) -> bool {
+    game.library_top_revision(player) == library_top_revision
+        && stable_card_is_top_of_library(game, stable_id, player)
+}
+
+pub(crate) fn stable_card_is_top_of_library(
+    game: &crate::game_state::GameState,
+    stable_id: StableId,
+    player: PlayerId,
+) -> bool {
+    let Some(player_state) = game.player(player) else {
+        return false;
+    };
+    let Some(top_id) = player_state.library.last().copied() else {
+        return false;
+    };
+    game.object(top_id)
+        .is_some_and(|object| object.stable_id == stable_id)
 }
 
 /// A granted alternative casting method for a specific card.
@@ -509,6 +582,7 @@ impl GrantRegistry {
             !matches!(&grant.source,
                 GrantSource::Effect { source_id: sid, .. } |
                 GrantSource::EffectWhileControlled { source_id: sid, .. } |
+                GrantSource::EffectWhileStableCardOnTopOfLibrary { source_id: sid, .. } |
                 GrantSource::StaticAbility { source_id: sid }
                 if *sid == source_id
             )


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Temporal Aperture
Initial parse error:
```
could not find verb in effect clause (clause: 'until end of turn for as long as that card remains on top of your library play with the top card of your library revealed and you may play that card without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'until end of turn for as long as that card remains on top of your library play with the top card of your library revealed and you may play that card without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0d6b2e088bf5a7e8b
Branch: codex/aws-card-fix-temporal-aperture
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0021
