### PR TITLE
Fix Ironsmith parse failure: Assaultron Dominator

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4686,6 +4686,41 @@ fn compile_subject_verb_effect(
             };
             Ok((vec![effect], choices))
         }
+        SubjectVerbActionAst::PutCounterChoice {
+            counter_types,
+            count,
+            mode_texts,
+            target,
+            target_count,
+        } => {
+            use crate::effect::EffectMode;
+
+            let (base_spec, _) =
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let mut spec = base_spec;
+            if let Some(target_count) = target_count {
+                spec = spec.with_count(*target_count);
+            }
+
+            let modes = counter_types
+                .iter()
+                .enumerate()
+                .map(|(idx, counter_type)| EffectMode {
+                    description: mode_texts.get(idx).cloned().unwrap_or_else(|| {
+                        format!("Put a {} counter", counter_type.description())
+                    }),
+                    effects: vec![Effect::put_counters(*counter_type, count.clone(), spec.clone())],
+                })
+                .collect();
+
+            let effect = tag_object_target_effect(Effect::choose_one(modes), &spec, ctx, "counters");
+            let choices = if spec.is_target() {
+                vec![spec.clone()]
+            } else {
+                Vec::new()
+            };
+            Ok((vec![effect], choices))
+        }
         SubjectVerbActionAst::PutCountersAll {
             counter_type,
             count,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -60,6 +60,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::Counter { target }
             | SubjectVerbActionAst::CounterUnlessPays { target, .. }
             | SubjectVerbActionAst::PutCounters { target, .. }
+            | SubjectVerbActionAst::PutCounterChoice { target, .. }
             | SubjectVerbActionAst::PutOrRemoveCounters { target, .. }
             | SubjectVerbActionAst::CopySpell { target, .. }
             | SubjectVerbActionAst::CopySpellForEachTarget { target, .. }
@@ -529,6 +530,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::PreventDamageEach { amount, .. }
         | SubjectVerbActionAst::CopySpell { count: amount, .. }
         | SubjectVerbActionAst::PutCounters { count: amount, .. }
+        | SubjectVerbActionAst::PutCounterChoice { count: amount, .. }
         | SubjectVerbActionAst::PutCountersAll { count: amount, .. }
         | SubjectVerbActionAst::RemoveUpToAnyCounters { amount, .. }
         | SubjectVerbActionAst::RemoveCountersAll { amount, .. }
@@ -1004,6 +1006,9 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
                 remove_count,
                 ..
             } => value_references_tag(put_count, IT_TAG) || value_references_tag(remove_count, IT_TAG),
+            SubjectVerbActionAst::PutCounterChoice { count, .. } => {
+                value_references_tag(count, IT_TAG)
+            }
             SubjectVerbActionAst::CopySpellForEachTarget { object_filter, .. } => object_filter
                 .as_ref()
                 .is_some_and(|filter| filter_references_tag(filter, IT_TAG)),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -97,6 +97,7 @@ fn retarget_bare_it_effect_targets_to_source(effect: &mut EffectAst) {
     match effect {
         EffectAst::SubjectVerb(subject_verb) => match &mut subject_verb.action {
             SubjectVerbActionAst::PutCounters { target, .. }
+            | SubjectVerbActionAst::PutCounterChoice { target, .. }
             | SubjectVerbActionAst::PutOrRemoveCounters { target, .. }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { target, .. }
             | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1503,6 +1503,13 @@ pub(crate) enum SubjectVerbActionAst {
         target_count: Option<ChoiceCount>,
         distributed: bool,
     },
+    PutCounterChoice {
+        counter_types: Vec<CounterType>,
+        count: Value,
+        mode_texts: Vec<String>,
+        target: TargetAst,
+        target_count: Option<ChoiceCount>,
+    },
     PutOrRemoveCounters {
         put_counter_type: CounterType,
         put_count: Value,
@@ -2927,6 +2934,20 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("target", target)
                 .field("target_count", target_count)
                 .field("distributed", distributed)
+                .finish(),
+            Self::PutCounterChoice {
+                counter_types,
+                count,
+                mode_texts,
+                target,
+                target_count,
+            } => f
+                .debug_struct("PutCounterChoice")
+                .field("counter_types", counter_types)
+                .field("count", count)
+                .field("mode_texts", mode_texts)
+                .field("target", target)
+                .field("target_count", target_count)
                 .finish(),
             Self::PutOrRemoveCounters {
                 put_counter_type,
@@ -5809,6 +5830,26 @@ impl EffectAst {
                 target,
                 target_count,
                 distributed,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_put_counter_choice(
+        counter_types: Vec<CounterType>,
+        count: Value,
+        mode_texts: Vec<String>,
+        target: TargetAst,
+        target_count: Option<ChoiceCount>,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::PutCounterChoice {
+                counter_types,
+                count,
+                mode_texts,
+                target,
+                target_count,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -235,6 +235,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::PreventDamageEach { amount, .. }
             | SubjectVerbActionAst::CopySpell { count: amount, .. }
             | SubjectVerbActionAst::PutCounters { count: amount, .. }
+            | SubjectVerbActionAst::PutCounterChoice { count: amount, .. }
             | SubjectVerbActionAst::PutCountersAll { count: amount, .. }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { amount, .. }
             | SubjectVerbActionAst::RemoveCountersAll { amount, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -511,7 +511,8 @@ fn advance_reference_frame_for_effect(
                 | SubjectVerbActionAst::CounterUnlessPays { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "countered")?;
                 }
-                SubjectVerbActionAst::PutCounters { target, .. } => {
+                SubjectVerbActionAst::PutCounters { target, .. }
+                | SubjectVerbActionAst::PutCounterChoice { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "counters")?;
                 }
                 SubjectVerbActionAst::RemoveUpToAnyCounters { target, .. }
@@ -1475,6 +1476,7 @@ fn visit_subject_verb_action_values(action: &SubjectVerbActionAst, visit: &mut i
         | SubjectVerbActionAst::PreventDamageEach { amount: count, .. }
         | SubjectVerbActionAst::CopySpell { count, .. }
         | SubjectVerbActionAst::PutCounters { count, .. }
+        | SubjectVerbActionAst::PutCounterChoice { count, .. }
         | SubjectVerbActionAst::PutCountersAll { count, .. }
         | SubjectVerbActionAst::RemoveUpToAnyCounters { amount: count, .. }
         | SubjectVerbActionAst::RemoveCountersAll { amount: count, .. }
@@ -1814,6 +1816,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::PreventDamageEach { amount, .. }
             | SubjectVerbActionAst::CopySpell { count: amount, .. }
             | SubjectVerbActionAst::PutCounters { count: amount, .. }
+            | SubjectVerbActionAst::PutCounterChoice { count: amount, .. }
             | SubjectVerbActionAst::PutCountersAll { count: amount, .. }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { amount, .. }
             | SubjectVerbActionAst::RemoveCountersAll { amount, .. }
@@ -2538,7 +2541,8 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::ReorderTopOfLibrary { tag } => {
                 bind_unresolved_it_in_tag(tag, seed_tag)
             }
-            SubjectVerbActionAst::PutCounters { count, target, .. } => {
+            SubjectVerbActionAst::PutCounters { count, target, .. }
+            | SubjectVerbActionAst::PutCounterChoice { count, target, .. } => {
                 bind_unresolved_it_in_value(count, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -1964,6 +1964,7 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::Counter { target }
             | SubjectVerbActionAst::CounterUnlessPays { target, .. }
             | SubjectVerbActionAst::PutCounters { target, .. }
+            | SubjectVerbActionAst::PutCounterChoice { target, .. }
             | SubjectVerbActionAst::ReturnToHand { target, .. }
             | SubjectVerbActionAst::Detain { target }
             | SubjectVerbActionAst::Goad { target }
@@ -2265,6 +2266,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::PreventDamageEach { amount, .. }
             | SubjectVerbActionAst::CopySpell { count: amount, .. }
             | SubjectVerbActionAst::PutCounters { count: amount, .. }
+            | SubjectVerbActionAst::PutCounterChoice { count: amount, .. }
             | SubjectVerbActionAst::PutCountersAll { count: amount, .. }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { amount, .. }
             | SubjectVerbActionAst::RemoveCountersAll { amount, .. }
@@ -2672,6 +2674,10 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
                 ..
             }
             | SubjectVerbActionAst::PutCounters {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::PutCounterChoice {
                 target: effect_target,
                 ..
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -162,10 +162,97 @@ fn subject_verb_put_counters_target(effect: &EffectAst) -> Option<TargetAst> {
     match effect {
         EffectAst::SubjectVerb(subject_verb) => match &subject_verb.action {
             SubjectVerbActionAst::PutCounters { target, .. } => Some(target.clone()),
+            SubjectVerbActionAst::PutCounterChoice { target, .. } => Some(target.clone()),
             _ => None,
         },
         _ => None,
     }
+}
+
+fn counter_type_from_choice_segment(
+    segment: SubjectVerbPrimitiveClause<'_>,
+) -> Option<crate::object::CounterType> {
+    let mut words = segment.word_refs();
+    while words
+        .first()
+        .is_some_and(|word| matches!(*word, "and" | "or" | "a" | "an" | "one"))
+    {
+        words.remove(0);
+    }
+    while words
+        .last()
+        .is_some_and(|word| matches!(*word, "counter" | "counters"))
+    {
+        words.pop();
+    }
+
+    match words.as_slice() {
+        ["first", "strike"] => Some(crate::object::CounterType::FirstStrike),
+        ["double", "strike"] => Some(crate::object::CounterType::DoubleStrike),
+        [word] => crate::runtime_backend::util::parse_counter_type_word(word),
+        _ => None,
+    }
+}
+
+fn parse_put_counter_choice_sequence(
+    clause: SubjectVerbPrimitiveClause<'_>,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some((descriptor_clause, target_clause)) = clause.split_once_on_word("on") else {
+        return Ok(None);
+    };
+    let descriptor_clause = descriptor_clause.from(1).trimmed();
+    let target_clause = target_clause.trimmed();
+    if descriptor_clause.is_empty()
+        || target_clause.is_empty()
+        || !descriptor_clause.contains_phrase(&["your", "choice", "of"])
+        || descriptor_clause.contains_no_words(&["counter", "counters"])
+    {
+        return Ok(None);
+    }
+
+    let Some(choice_clause) = descriptor_clause.strip_prefix_clause(&["your", "choice", "of"])
+    else {
+        return Ok(None);
+    };
+
+    let mut counter_types = Vec::new();
+    for segment in choice_clause.trimmed_comma_segments() {
+        let segment = segment.trimmed();
+        if segment.is_empty() {
+            continue;
+        }
+        let Some(counter_type) = counter_type_from_choice_segment(segment) else {
+            return Ok(None);
+        };
+        counter_types.push(counter_type);
+    }
+
+    if counter_types.len() < 2 {
+        return Ok(None);
+    }
+
+    let target = parse_target_phrase(target_clause.tokens())?;
+    let target_phrase = target_clause.word_refs().join(" ");
+    let mode_texts = counter_types
+        .iter()
+        .map(|counter_type| {
+            format!(
+                "Put {} on {target_phrase}",
+                super::super::zone_counter_helpers::describe_counter_phrase_for_mode(
+                    1,
+                    *counter_type,
+                )
+            )
+        })
+        .collect();
+
+    Ok(Some(vec![EffectAst::subject_verb_put_counter_choice(
+        counter_types,
+        Value::Fixed(1),
+        mode_texts,
+        target,
+        None,
+    )]))
 }
 
 pub(crate) fn parse_sentence_sacrifice_at_end_of_combat(
@@ -360,6 +447,10 @@ pub(crate) fn parse_sentence_put_counter_sequence_matched(
     }
 
     if let Some(effects) = parse_put_counter_ladder_segments(clause)? {
+        return Ok(Some(effects));
+    }
+
+    if let Some(effects) = parse_put_counter_choice_sequence(clause)? {
         return Ok(Some(effects));
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -24857,6 +24857,43 @@ fn parse_gain_choice_of_three_keywords_clause_compiles_to_mode_choice() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn assaultron_dominator_parses_counter_choice_attack_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Assaultron Dominator")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Robot])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "When this creature enters, you get {E}{E} (two energy counters).\n\
+             Whenever an artifact creature you control attacks, you may pay {E}. If you do, put your choice of a +1/+1, first strike, or trample counter on that creature.",
+        )
+        .expect("Assaultron Dominator should parse strictly");
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("ChooseModeEffect")
+            && ability_debug.contains("PlusOnePlusOne")
+            && ability_debug.contains("FirstStrike")
+            && ability_debug.contains("Trample"),
+        "expected modal counter choice in Assaultron Dominator, got {ability_debug}"
+    );
+
+    let joined = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains(
+            "put your choice of a +1/+1, first strike, or trample counter on that creature"
+        ),
+        "expected compact counter-choice text for Assaultron Dominator, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_gain_choice_of_keywords_preserves_protection_qualifier() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Jodah Choice Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -26421,6 +26421,59 @@ pub(super) fn describe_tap_or_untap_mode(
     None
 }
 
+pub(super) fn describe_put_counter_choice_mode(
+    choose_mode: &crate::effects::ChooseModeEffect,
+) -> Option<String> {
+    if choose_mode.modes.len() < 2
+        || choose_mode.choose_count != Value::Fixed(1)
+        || choose_mode.min_choose_count != Value::Fixed(1)
+        || choose_mode.allow_repeated_modes
+    {
+        return None;
+    }
+
+    let mut counter_names = Vec::new();
+    let mut shared_target: Option<String> = None;
+    for mode in &choose_mode.modes {
+        let [effect] = mode.effects.as_slice() else {
+            return None;
+        };
+        let put = effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+        if !matches!(put.amount, Value::Fixed(1))
+            || put.target_count.is_some()
+            || put.distributed
+        {
+            return None;
+        }
+        let target = mode
+            .description
+            .trim()
+            .trim_end_matches('.')
+            .rsplit_once(" counter on ")
+            .map(|(_, target)| target.to_string())
+            .unwrap_or_else(|| describe_choose_spec(&put.target));
+        if let Some(existing) = &shared_target {
+            if existing != &target {
+                return None;
+            }
+        } else {
+            shared_target = Some(target);
+        }
+        counter_names.push(put.counter_type.description().into_owned());
+    }
+
+    let target = shared_target?;
+    let first = counter_names.first()?.clone();
+    let first = with_indefinite_article(&first);
+    let mut options = Vec::with_capacity(counter_names.len());
+    options.push(first);
+    options.extend(counter_names.into_iter().skip(1));
+    Some(format!(
+        "Put your choice of {} counter on {target}",
+        join_with_or(&options)
+    ))
+}
+
 pub(super) fn describe_put_or_remove_counter_mode(
     choose_mode: &crate::effects::ChooseModeEffect,
 ) -> Option<String> {
@@ -30225,6 +30278,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_tap_or_untap_mode(choose_mode) {
+            return compact;
+        }
+        if let Some(compact) = describe_put_counter_choice_mode(choose_mode) {
             return compact;
         }
         if let Some(compact) = describe_put_or_remove_counter_mode(choose_mode) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -347,6 +347,55 @@ fn assaultron_dominator_attack_trigger_pays_energy_and_chooses_each_counter_mode
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn assaultron_dominator_attack_trigger_puts_counter_on_that_attacking_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let assaultron = assaultron_dominator_definition();
+    let assaultron_id = game.create_object_from_definition(&assaultron, alice, Zone::Battlefield);
+    let attacker = CardBuilder::new(CardId::from_raw(74_261), "Artifact Attacker")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let attacker_id = game.create_object_from_card(&attacker, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .energy_counters = 1;
+
+    let mut trigger_queue = attack_with_assaultron_creature(&mut game, attacker_id);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Assaultron Dominator should trigger when another artifact creature attacks"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Assaultron Dominator attack trigger should go on the stack");
+
+    let mut dm = AssaultronDecisionMaker {
+        pay_energy: true,
+        mode_index: 1,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Assaultron Dominator attack trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        0,
+        "Assaultron Dominator should spend one energy when the payment is accepted"
+    );
+    assert_eq!(
+        game.counter_count(attacker_id, crate::object::CounterType::FirstStrike),
+        1,
+        "the selected counter should be put on the attacking artifact creature"
+    );
+    assert_eq!(
+        game.counter_count(assaultron_id, crate::object::CounterType::FirstStrike),
+        0,
+        "the selected counter should not default to Assaultron Dominator"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn assaultron_dominator_declining_energy_payment_adds_no_counter() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -192,6 +192,170 @@ fn rampaging_aetherhood_declining_payment_gets_energy_without_counters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn assaultron_dominator_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_260), "Assaultron Dominator")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Robot])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "When this creature enters, you get {E}{E} (two energy counters).\n\
+             Whenever an artifact creature you control attacks, you may pay {E}. If you do, put your choice of a +1/+1, first strike, or trample counter on that creature.",
+        )
+        .expect("Assaultron Dominator should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct AssaultronDecisionMaker {
+    pay_energy: bool,
+    mode_index: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for AssaultronDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.pay_energy
+    }
+
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        vec![self.mode_index.min(ctx.options.len().saturating_sub(1))]
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn attack_with_assaultron_creature(game: &mut GameState, attacker_id: ObjectId) -> TriggerQueue {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.remove_summoning_sickness(attacker_id);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("Assaultron attacker should be legal");
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn assaultron_dominator_attack_trigger_pays_energy_and_chooses_each_counter_mode() {
+    for (mode_index, counter_type) in [
+        (0, crate::object::CounterType::PlusOnePlusOne),
+        (1, crate::object::CounterType::FirstStrike),
+        (2, crate::object::CounterType::Trample),
+    ] {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let assaultron = assaultron_dominator_definition();
+        let assaultron_id = game.create_object_from_definition(&assaultron, alice, Zone::Battlefield);
+        game.player_mut(alice)
+            .expect("alice exists")
+            .energy_counters = 1;
+
+        let mut trigger_queue = attack_with_assaultron_creature(&mut game, assaultron_id);
+        assert_eq!(
+            trigger_queue.entries.len(),
+            1,
+            "Assaultron Dominator should trigger when it attacks as an artifact creature"
+        );
+        put_triggers_on_stack(&mut game, &mut trigger_queue)
+            .expect("Assaultron Dominator attack trigger should go on the stack");
+
+        let mut dm = AssaultronDecisionMaker {
+            pay_energy: true,
+            mode_index,
+        };
+        resolve_stack_entry_with(&mut game, &mut dm)
+            .expect("Assaultron Dominator attack trigger should resolve");
+
+        assert_eq!(
+            game.player(alice).expect("alice exists").energy_counters,
+            0,
+            "Assaultron Dominator should spend one energy when the payment is accepted"
+        );
+        assert_eq!(
+            game.counter_count(assaultron_id, counter_type),
+            1,
+            "Assaultron Dominator should receive the selected counter mode"
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn assaultron_dominator_declining_energy_payment_adds_no_counter() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let assaultron = assaultron_dominator_definition();
+    let assaultron_id = game.create_object_from_definition(&assaultron, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .energy_counters = 1;
+
+    let mut trigger_queue = attack_with_assaultron_creature(&mut game, assaultron_id);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Assaultron Dominator attack trigger should go on the stack");
+
+    let mut dm = AssaultronDecisionMaker {
+        pay_energy: false,
+        mode_index: 0,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Assaultron Dominator attack trigger should resolve when payment is declined");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        1,
+        "declining the optional payment should leave the energy unspent"
+    );
+    assert_eq!(
+        game.counter_count(assaultron_id, crate::object::CounterType::PlusOnePlusOne)
+            + game.counter_count(assaultron_id, crate::object::CounterType::FirstStrike)
+            + game.counter_count(assaultron_id, crate::object::CounterType::Trample),
+        0,
+        "declining the optional payment should add no counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn assaultron_dominator_ignores_nonartifact_attackers() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let assaultron = assaultron_dominator_definition();
+    game.create_object_from_definition(&assaultron, alice, Zone::Battlefield);
+    let nonartifact = create_creature(&mut game, "Nonartifact Attacker", alice, 2, 2);
+
+    let trigger_queue = attack_with_assaultron_creature(&mut game, nonartifact);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        0,
+        "Assaultron Dominator should not trigger for a nonartifact creature attacking"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_950), "Twenty-Toed Toad")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -259,6 +259,49 @@ fn attack_with_assaultron_creature(game: &mut GameState, attacker_id: ObjectId) 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn assaultron_dominator_enters_trigger_gets_two_energy() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let assaultron = assaultron_dominator_definition();
+    let assaultron_id = game.create_object_from_definition(&assaultron, alice, Zone::Battlefield);
+    let event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            assaultron_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        if trigger.source == assaultron_id {
+            trigger_queue.add(trigger);
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Assaultron Dominator should trigger when it enters"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Assaultron Dominator enters trigger should go on the stack");
+
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Assaultron Dominator enters trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        2,
+        "Assaultron Dominator should give two energy when it enters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn assaultron_dominator_attack_trigger_pays_energy_and_chooses_each_counter_mode() {
     for (mode_index, counter_type) in [
         (0, crate::object::CounterType::PlusOnePlusOne),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Assaultron Dominator
Initial parse error:
```
missing counter amount (clause: 'your choice of a +1/+1'); oracle-only fallback also failed: missing counter amount (clause: 'your choice of a +1/+1')
```

Current worker: i-0b909224292e273ca
Branch: codex/aws-card-fix-assaultron-dominator
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0021
