### PR TITLE
Fix Ironsmith parse failure: Nemesis Trap

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2340,6 +2340,24 @@ pub(crate) fn parse_static_condition_clause(
         return Ok(crate::ConditionExpr::EquippedCreatureAttacking);
     }
     if clause_words.len() >= 4
+        && word_slice_ends_with(&clause_words, &["is", "attacking"])
+        && !is_source_reference_words(&clause_words[..clause_words.len() - 2])
+    {
+        let subject_end = token_index_for_word_index(&tokens, clause_words.len() - 2).ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "unable to map attacking condition subject (clause: '{}')",
+                clause_words.join(" ")
+            ))
+        })?;
+        let mut filter = parse_object_filter(&tokens[..subject_end], false)?;
+        filter.attacking = true;
+        return Ok(crate::ConditionExpr::CountComparison {
+            count: AnthemCountExpression::MatchingFilter(filter),
+            comparison: crate::effect::Comparison::GreaterThanOrEqual(1),
+            display: Some(clause_words.join(" ")),
+        });
+    }
+    if clause_words.len() >= 4
         && clause_words[2] == "is"
         && matches!(
             &clause_words[..2],

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5470,6 +5470,25 @@ fn rewrite_static_condition_parses_multicolor_devotion_comparison() {
 }
 
 #[test]
+fn rewrite_static_condition_parses_attacking_filter_subject() {
+    let tokens = lex_line("a white creature is attacking", 0)
+        .expect("rewrite lexer should classify attacking-filter condition clause");
+
+    let parsed = super::keyword_static::parse_static_condition_clause(&tokens)
+        .expect("attacking-filter condition clause should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("CountComparison"), "{debug}");
+    assert!(debug.contains("MatchingFilter"), "{debug}");
+    assert!(debug.contains("card_types"), "{debug}");
+    assert!(debug.contains("Creature"), "{debug}");
+    assert!(debug.contains("colors: Some"), "{debug}");
+    assert!(debug.contains("attacking: true"), "{debug}");
+    assert!(debug.contains("GreaterThanOrEqual"), "{debug}");
+    assert!(debug.contains("a white creature is attacking"), "{debug}");
+}
+
+#[test]
 fn rewrite_anthem_subject_parses_enchanted_player_controls() {
     let tokens = lex_line("Creatures enchanted player controls", 0)
         .expect("rewrite lexer should classify enchanted-player-controls subject");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -168,6 +168,53 @@ fn party_dude_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn nemesis_trap_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_146), "Nemesis Trap")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .subtypes(vec![Subtype::Trap])
+        .parse_text(
+            "If a white creature is attacking, you may pay {B}{B} rather than pay this spell's mana cost.\n\
+             Exile target attacking creature. Create a token that's a copy of that creature. Exile it at the beginning of the next end step.",
+        )
+        .expect("Nemesis Trap should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nemesis_trap_strict_parser_and_compiled_text_regression() {
+    let def = nemesis_trap_definition();
+    let alternative_debug = format!("{:#?}", def.alternative_casts);
+    let lines = crate::compiled_text::compiled_text_lines(&def);
+    let rendered = lines.join("\n");
+
+    assert!(
+        alternative_debug.contains("ConditionExpr")
+            && alternative_debug.contains("MatchingFilter")
+            && alternative_debug.contains("Creature")
+            && alternative_debug.contains("colors: Some")
+            && alternative_debug.contains("attacking: true")
+            && alternative_debug.contains("GreaterThanOrEqual"),
+        "Nemesis Trap should structurally preserve the conditional white-attacker alternative cost, got {alternative_debug}"
+    );
+    assert_eq!(
+        lines.first().map(String::as_str),
+        Some("If a white creature is attacking, you may pay {B}{B} rather than pay this spell's mana cost."),
+        "Nemesis Trap's conditional alternative cost should render before the spell effect, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Exile target attacking creature")
+            && rendered.contains("Create a token that's a copy of that creature")
+            && rendered.contains("Exile it at the beginning of the next end step"),
+        "Nemesis Trap compiled text should cover exile, copy-token, and delayed-exile clauses, got {rendered}"
+    );
+}
+
 #[test]
 fn rootpath_purifier_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Rootpath Purifier");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -2190,7 +2190,8 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
         if matches!(
             method,
             AlternativeCastingMethod::FlashWithAdditionalCost { .. }
-        ) {
+        ) || (method.is_composed_cost() && method.cast_condition().is_some())
+        {
             leading_alternative_cast_lines.push(line);
         } else {
             alternative_cast_lines.push(line);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2651,7 +2651,8 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return Some(compact);
     }
 
-    describe_roll_choose_destroy_create_structural(effects)
+    describe_exile_then_create_token_copy_structural(effects)
+        .or_else(|| describe_roll_choose_destroy_create_structural(effects))
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
@@ -2701,6 +2702,52 @@ fn unwrap_structural_effect_tag(effect: &Effect) -> &Effect {
         return unwrap_structural_effect_tag(&tag_all.effect);
     }
     effect
+}
+
+fn describe_exile_then_create_token_copy_structural(effects: &[Effect]) -> Option<String> {
+    let [move_effect, create_effect] = effects else {
+        return None;
+    };
+    let tag = structural_effect_tag(move_effect)?;
+    let move_to = unwrap_structural_effect_tag(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to.zone != Zone::Exile {
+        return None;
+    }
+    let create = unwrap_structural_effect_tag(create_effect)
+        .downcast_ref::<crate::effects::CreateTokenCopyEffect>()?;
+    if !matches!(&create.target, ChooseSpec::Tagged(create_tag) if create_tag == tag)
+        || create.count != Value::Fixed(1)
+        || create.controller != PlayerFilter::You
+        || create.enters_tapped
+        || create.has_haste
+        || create.enters_attacking
+        || create.exile_at_end_of_combat
+        || create.pt_adjustment.is_some()
+        || create.set_base_power_toughness.is_some()
+        || create.set_colors.is_some()
+        || create.set_card_types.is_some()
+        || create.set_subtypes.is_some()
+        || !create.added_card_types.is_empty()
+        || !create.added_subtypes.is_empty()
+        || !create.removed_supertypes.is_empty()
+        || !create.granted_static_abilities.is_empty()
+    {
+        return None;
+    }
+
+    let referent = describe_prevention_follow_up_target(&move_to.target);
+    let mut text = format!(
+        "{}. Create a token that's a copy of {referent}",
+        describe_effect(move_effect).trim_end_matches('.')
+    );
+    if create.sacrifice_at_next_end_step {
+        text.push_str(". Sacrifice it at the beginning of the next end step");
+    }
+    if create.exile_at_next_end_step {
+        text.push_str(". Exile it at the beginning of the next end step");
+    }
+    Some(text)
 }
 
 fn describe_roll_choose_destroy_create_structural(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26507,6 +26507,281 @@ fn test_flashback_not_available_from_hand() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn nemesis_trap_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_617), "Nemesis Trap")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .subtypes(vec![Subtype::Trap])
+        .parse_text(
+            "If a white creature is attacking, you may pay {B}{B} rather than pay this spell's mana cost.\n\
+             Exile target attacking creature. Create a token that's a copy of that creature. Exile it at the beginning of the next end step.",
+        )
+        .expect("Nemesis Trap should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_mana_colored_creature(
+    game: &mut GameState,
+    name: &str,
+    owner: PlayerId,
+    mana_symbol: ManaSymbol,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![mana_symbol]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn declare_bob_attacker_at_alice(game: &mut GameState, attacker: ObjectId) {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = bob;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    game.turn.priority_player = Some(alice);
+    game.remove_summoning_sickness(attacker);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("attacker declaration should be legal");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nemesis_trap_alternative_cost_requires_white_attacker() {
+    use crate::decision::compute_legal_actions;
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let mut game = setup_game();
+    let trap = nemesis_trap_definition();
+    let trap_id = game.create_object_from_definition(&trap, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 2);
+    let black_attacker =
+        create_mana_colored_creature(&mut game, "Black Attacker", bob, ManaSymbol::Black);
+    declare_bob_attacker_at_alice(&mut game, black_attacker);
+
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::Alternative(0),
+            } if *spell_id == trap_id
+        )),
+        "Nemesis Trap should not expose its alternative cost without a white attacking creature; actions={actions:?}"
+    );
+
+    let mut game = setup_game();
+    let trap = nemesis_trap_definition();
+    let trap_id = game.create_object_from_definition(&trap, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 2);
+    let white_attacker =
+        create_mana_colored_creature(&mut game, "White Attacker", bob, ManaSymbol::White);
+    declare_bob_attacker_at_alice(&mut game, white_attacker);
+
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::Alternative(0),
+            } if *spell_id == trap_id
+        )),
+        "Nemesis Trap should expose its {{B}}{{B}} alternative cost while a white creature is attacking; actions={actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nemesis_trap_rejects_nonattacking_target() {
+    use crate::decision::compute_legal_actions;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let trap = nemesis_trap_definition();
+    let trap_id = game.create_object_from_definition(&trap, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 2);
+    let white_attacker =
+        create_mana_colored_creature(&mut game, "White Attacker", bob, ManaSymbol::White);
+    let nonattacking_creature =
+        create_mana_colored_creature(&mut game, "Home Creature", bob, ManaSymbol::White);
+    declare_bob_attacker_at_alice(&mut game, white_attacker);
+
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::Alternative(0),
+            } if *spell_id == trap_id
+        ))
+        .expect("Nemesis Trap alternative cast should be legal");
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut trigger_queue = TriggerQueue::new();
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+    )
+    .expect("Nemesis Trap alternative cast should start");
+
+    let result = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(nonattacking_creature)]),
+    );
+    assert!(
+        result.is_err(),
+        "Nemesis Trap should reject a nonattacking creature target"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nemesis_trap_exiles_attacker_copies_it_and_exiles_copy_next_end_step() {
+    use crate::decision::compute_legal_actions;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let trap = nemesis_trap_definition();
+    let trap_id = game.create_object_from_definition(&trap, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Black, 2);
+    let white_attacker =
+        create_mana_colored_creature(&mut game, "White Attacker", bob, ManaSymbol::White);
+    let attacker_stable_id = game
+        .object(white_attacker)
+        .expect("white attacker exists")
+        .stable_id;
+    declare_bob_attacker_at_alice(&mut game, white_attacker);
+
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::Alternative(0),
+            } if *spell_id == trap_id
+        ))
+        .expect("Nemesis Trap alternative cast should be legal");
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut trigger_queue = TriggerQueue::new();
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+    )
+    .expect("Nemesis Trap alternative cast should start");
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(white_attacker)]),
+    )
+    .expect("attacking creature target should be legal");
+
+    assert_eq!(game.stack.len(), 1, "Nemesis Trap should be on the stack");
+    assert_eq!(
+        game.stack[0].casting_method,
+        CastingMethod::Alternative(0),
+        "Nemesis Trap should remember that its alternative cost was paid"
+    );
+    resolve_stack_entry(&mut game).expect("Nemesis Trap should resolve");
+
+    assert!(
+        !game.battlefield.contains(&white_attacker),
+        "Nemesis Trap should exile the targeted attacking creature"
+    );
+    assert!(
+        game.exile.iter().any(|&id| game.object(id).is_some_and(
+            |object| object.stable_id == attacker_stable_id && object.name == "White Attacker"
+        )),
+        "the targeted attacking creature should be in exile"
+    );
+    let token_id = *game
+        .battlefield
+        .iter()
+        .find(|&&id| {
+            game.object(id).is_some_and(|object| {
+                object.name == "White Attacker"
+                    && game.controller_of(object) == alice
+                    && object.kind == ObjectKind::Token
+            })
+        })
+        .expect("Nemesis Trap should create a token copy under the caster's control");
+    let token_stable_id = game
+        .object(token_id)
+        .expect("token copy should exist")
+        .stable_id;
+
+    let end_step_event = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(game.turn.active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(&mut game, &end_step_event) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Nemesis Trap delayed exile trigger should go on the stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("Nemesis Trap delayed exile trigger should resolve");
+    }
+
+    assert!(
+        !game.battlefield.contains(&token_id),
+        "Nemesis Trap's token copy should leave the battlefield at the next end step"
+    );
+    assert!(
+        game.exile.iter().any(|&id| game.object(id).is_some_and(
+            |object| object.stable_id == token_stable_id && object.name == "White Attacker"
+        )),
+        "Nemesis Trap's token copy should be exiled at the next end step"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_flashback_exiles_after_resolution() {
     use crate::cards::definitions::think_twice;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nemesis Trap
Initial parse error:
```
unsupported this-spell cost condition (clause: 'if a white creature is attacking you may pay b b rather than pay this spells mana cost'); oracle-only fallback also failed: unsupported this-spell cost condition (clause: 'if a white creature is attacking you may pay b b rather than pay this spells mana cost')
```

Current worker: i-08c1a4f9baabfa5b3
Branch: codex/aws-card-fix-nemesis-trap
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0022
