### PR TITLE
Fix Ironsmith parse failure: Pious Kitsune

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -791,6 +791,54 @@ fn parse_card_in_your_graveyard_predicate(words: &[&str]) -> Option<PredicateAst
     })
 }
 
+fn parse_object_on_battlefield_predicate(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<PredicateAst>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let suffix_len = if word_slice_ends_with(&words, &["is", "on", "the", "battlefield"])
+        || word_slice_ends_with(&words, &["are", "on", "the", "battlefield"])
+    {
+        4
+    } else if word_slice_ends_with(&words, &["is", "on", "battlefield"])
+        || word_slice_ends_with(&words, &["are", "on", "battlefield"])
+    {
+        3
+    } else {
+        return Ok(None);
+    };
+    let object_token_end = tokens.len().saturating_sub(suffix_len);
+    if object_token_end == 0 {
+        return Ok(None);
+    }
+
+    let object_tokens = &tokens[..object_token_end];
+    let mut filter = parse_object_filter(object_tokens, false)?;
+    if filter.name.is_some()
+        && let Some(named_idx) = object_tokens.iter().position(|token| token.is_word("named"))
+    {
+        let object_words = object_tokens
+            .iter()
+            .filter_map(OwnedLexToken::as_word)
+            .collect::<Vec<_>>();
+        let name_end = find_name_clause_end(&object_words, named_idx + 1);
+        let name = object_tokens[named_idx + 1..name_end]
+            .iter()
+            .filter_map(OwnedLexToken::as_word)
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !name.is_empty() {
+            filter.name = Some(name);
+        }
+    }
+    filter.zone = Some(Zone::Battlefield);
+
+    Ok(Some(PredicateAst::ValueComparison {
+        left: Value::Count(filter),
+        operator: crate::effect::ValueComparisonOperator::GreaterThan,
+        right: Value::Fixed(0),
+    }))
+}
+
 pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, CardTextError> {
     let raw_words_view = GrammarFilterNormalizedWords::new(tokens);
     let raw_words = raw_words_view.to_word_refs();
@@ -939,6 +987,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_card_in_your_graveyard_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_object_on_battlefield_predicate(tokens)? {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -931,6 +931,16 @@ pub(crate) fn parse_life_amount_from_trailing(
         return Ok(None);
     }
 
+    if let Some(counter_value) = parse_for_each_counter_on_reference_value(trailing)
+        && let Some(multiplier) = match base_amount {
+            Value::Fixed(value) => Some(*value),
+            Value::X => Some(1),
+            _ => None,
+        }
+    {
+        return Ok(Some(scale_value_multiplier(counter_value, multiplier)));
+    }
+
     if let Some(dynamic) = parse_dynamic_cost_modifier_value(trailing)? {
         if let Some(multiplier) = match base_amount {
             Value::Fixed(value) => Some(*value),
@@ -956,6 +966,59 @@ pub(crate) fn parse_life_amount_from_trailing(
     }
 
     Ok(None)
+}
+
+fn parse_for_each_counter_on_reference_value(tokens: &[OwnedLexToken]) -> Option<Value> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !word_slice_starts_with(&words, &["for", "each"]) {
+        return None;
+    }
+    let counter_idx = find_index(words.as_slice(), |word| {
+        *word == "counter" || *word == "counters"
+    })?;
+    if counter_idx <= 2 || !words.get(counter_idx + 1).is_some_and(|word| *word == "on") {
+        return None;
+    }
+
+    let counter_type = crate::runtime_backend::parse_counter_type_from_tokens(
+        &tokens[2..=counter_idx],
+    );
+    let reference = &words[counter_idx + 2..];
+    if word_slice_eq_any(
+        reference,
+        &[
+            &["it"],
+            &["this"],
+            &["this", "creature"],
+            &["this", "permanent"],
+            &["this", "source"],
+        ],
+    ) {
+        return Some(match counter_type {
+            Some(counter_type) => Value::CountersOnSource(counter_type),
+            None => Value::CountersOn(Box::new(ChooseSpec::Source), None),
+        });
+    }
+
+    if word_slice_eq_any(
+        reference,
+        &[
+            &["that"],
+            &["that", "creature"],
+            &["that", "permanent"],
+            &["that", "object"],
+            &["those"],
+            &["those", "creatures"],
+            &["those", "permanents"],
+        ],
+    ) {
+        return Some(Value::CountersOn(
+            Box::new(ChooseSpec::Tagged(TagKey::from(IT_TAG))),
+            counter_type,
+        ));
+    }
+
+    None
 }
 
 pub(crate) fn validate_life_keyword(rest: &[OwnedLexToken]) -> Result<(), CardTextError> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -278,6 +278,174 @@ fn kin_tree_nurturer_endure_effect(def: &CardDefinition) -> &Effect {
     effect
 }
 
+fn pious_kitsune_upkeep_effects(def: &CardDefinition) -> &[Effect] {
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Pious Kitsune should compile an upkeep trigger");
+    triggered.effects.flattened_default_effects()
+}
+
+fn pious_kitsune_life_activated_ability(
+    def: &CardDefinition,
+) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Pious Kitsune should compile a life-gain activated ability")
+}
+
+#[test]
+fn pious_kitsune_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Pious Kitsune");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join("\n");
+    let oracle = oracle_text_by_name()
+        .get("Pious Kitsune")
+        .expect("Pious Kitsune oracle text")
+        .clone();
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            &oracle,
+            &compiled,
+            crate::semantic_compare::report_embedding_config(),
+        );
+
+    assert!(
+        ability_debug.contains("ValueComparison")
+            && ability_debug.contains("eight-and-a-half-tails")
+            && ability_debug.contains("CountersOnSource")
+            && ability_debug.contains("\"devotion\"")
+            && ability_debug.contains("RemoveCountersEffect"),
+        "Pious Kitsune should structurally keep the named-creature condition, devotion-counter life scaling, and activated counter cost, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("if a creature named eight-and-a-half-tails is on the battlefield")
+            && rendered.contains("gain 1 life for each devotion counter on this creature")
+            && rendered.contains("Remove a devotion counter from this creature"),
+        "expected Pious Kitsune compiled text to preserve named-creature condition and devotion counter clauses, got {rendered}"
+    );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Pious Kitsune semantic comparison to clear target, score={similarity}, mismatch={mismatch}, compiled={compiled:?}"
+    );
+}
+
+#[test]
+fn pious_kitsune_upkeep_gains_life_when_named_creature_is_on_battlefield() {
+    let def = parse_oracle_card_definition("Pious Kitsune");
+    let effects = pious_kitsune_upkeep_effects(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.add_counters(source, CounterType::Named("devotion"), 1)
+        .expect("Pious Kitsune should accept devotion counters");
+    let named_creature = CardDefinitionBuilder::new(CardId::new(), "Eight-and-a-Half-Tails")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_definition(&named_creature, bob, Zone::Battlefield);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    for effect in effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Pious Kitsune upkeep effect should resolve");
+    }
+
+    assert_eq!(
+        game.counter_count(source, CounterType::Named("devotion")),
+        2,
+        "upkeep trigger should put a devotion counter on Pious Kitsune first"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        22,
+        "named creature on any battlefield should enable life gain equal to devotion counters"
+    );
+}
+
+#[test]
+fn pious_kitsune_upkeep_skips_life_gain_without_named_creature() {
+    let def = parse_oracle_card_definition("Pious Kitsune");
+    let effects = pious_kitsune_upkeep_effects(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.add_counters(source, CounterType::Named("devotion"), 1)
+        .expect("Pious Kitsune should accept devotion counters");
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    for effect in effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Pious Kitsune upkeep effect should resolve");
+    }
+
+    assert_eq!(
+        game.counter_count(source, CounterType::Named("devotion")),
+        2,
+        "upkeep trigger should put a devotion counter even when condition is false"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        20,
+        "life-gain branch should not happen without Eight-and-a-Half-Tails on the battlefield"
+    );
+}
+
+#[test]
+fn pious_kitsune_activated_ability_removes_devotion_counter_and_gains_life() {
+    let def = parse_oracle_card_definition("Pious Kitsune");
+    let activated = pious_kitsune_life_activated_ability(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(source);
+    game.add_counters(source, CounterType::Named("devotion"), 1)
+        .expect("Pious Kitsune should accept devotion counters");
+
+    crate::cost::can_pay_cost(&game, source, alice, &activated.mana_cost)
+        .expect("Pious Kitsune activation should be payable with an untapped source and a devotion counter");
+    let mut dm = crate::decision::AutoPassDecisionMaker::default();
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        source,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("Pious Kitsune activation cost should be paid");
+
+    assert!(game.is_tapped(source), "activation cost should tap Pious Kitsune");
+    assert_eq!(
+        game.counter_count(source, CounterType::Named("devotion")),
+        0,
+        "activation cost should remove one devotion counter"
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Pious Kitsune activated ability effect should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        21,
+        "activated ability should gain 1 life after its counter-removal cost is paid"
+    );
+}
+
 #[test]
 fn tromp_the_domains_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Tromp the Domains");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12074,6 +12074,26 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 return format!("there are {} or more {} on the battlefield", count_text, noun);
             }
             if let (
+                Value::Count(filter),
+                crate::effect::ValueComparisonOperator::GreaterThan,
+                Value::Fixed(0),
+            ) = (left, operator, right)
+                && filter.zone == Some(Zone::Battlefield)
+            {
+                let mut described_filter = filter.clone();
+                described_filter.zone = None;
+                let object_text = described_filter.description();
+                let object_text = if object_text.starts_with("a ")
+                    || object_text.starts_with("an ")
+                    || object_text.starts_with("the ")
+                {
+                    object_text
+                } else {
+                    with_indefinite_article(&object_text)
+                };
+                return format!("{object_text} is on the battlefield");
+            }
+            if let (
                 Value::SpellsCastThisTurnMatching {
                     player,
                     filter,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pious Kitsune
Initial parse error:
```
unsupported predicate (predicate: 'creature named eight and half tails is on battlefield'); oracle-only fallback also failed: unsupported predicate (predicate: 'creature named eight and half tails is on battlefield')
```

Current worker: i-0867229723527dec2
Branch: codex/aws-card-fix-pious-kitsune
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0023
