### PR TITLE
Fix Ironsmith parse failure: Howl of the Horde

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -565,6 +565,41 @@ fn should_prefer_statement_before_static_for_nonpermanent_spell(
                 && contains_token_word_sequence(tokens, &["instead"])))
 }
 
+fn should_parse_next_cast_trigger_line_as_spell_effect(
+    preprocessed: &PreprocessedDocument,
+    tokens: &[OwnedLexToken],
+) -> bool {
+    let builder_has_nonpermanent_spell_type = preprocessed
+        .builder
+        .card_builder
+        .card_types_ref()
+        .iter()
+        .any(|card_type| {
+            matches!(
+                card_type,
+                crate::types::CardType::Instant | crate::types::CardType::Sorcery
+            )
+        });
+    let metadata_has_nonpermanent_spell_type = preprocessed.items.iter().any(|item| {
+        matches!(
+            item,
+            PreprocessedItem::Metadata(metadata)
+                if matches!(
+                    metadata.value,
+                    crate::cards::builders::MetadataLine::TypeLine(ref raw)
+                        if raw
+                            .split(|ch: char| !ch.is_alphabetic())
+                            .any(|part| matches!(part, "Instant" | "Sorcery"))
+                )
+        )
+    });
+
+    (builder_has_nonpermanent_spell_type || metadata_has_nonpermanent_spell_type)
+        && token_slice_starts_with_any(tokens, &[&["when"], &["whenever"]])
+        && contains_token_word_sequence(tokens, &["next", "cast"])
+        && contains_token_word_sequence(tokens, &["this", "turn"])
+}
+
 fn looks_like_activation_cost_prefix(raw: &str) -> bool {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -2789,6 +2824,15 @@ fn try_parse_triggered_line_dispatch(
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     if !line_starts_with_trigger_intro_tokens(&line.tokens) {
         return Ok(None);
+    }
+
+    if should_parse_next_cast_trigger_line_as_spell_effect(preprocessed, &line.tokens)
+        && let Some(statement_line) = parse_statement_line_cst(line)?
+    {
+        return Ok(Some(LineDispatchResult::single(
+            RewriteLineCst::Statement(statement_line),
+            idx + 1,
+        )));
     }
 
     let trigger_chunks = split_trigger_sentence_chunks_rewrite_lexed(&line.tokens);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1334,7 +1334,10 @@ pub(crate) fn split_if_clause_lexed(
             } else {
                 true
             };
-            if comma_fragment_looks_like_effect
+            let comma_fragment_looks_like_delayed_trigger = effect_tokens
+                .first()
+                .is_some_and(|token| token.is_word("when") || token.is_word("whenever"));
+            if (comma_fragment_looks_like_effect || comma_fragment_looks_like_delayed_trigger)
                 && let Ok(effects) =
                     parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -268,7 +268,11 @@ pub(super) fn try_compile_timing_and_control_effect(
             ));
             (vec![effect], choices)
         }
-        EffectAst::DelayedTriggerThisTurn { trigger, effects } => {
+        EffectAst::DelayedTriggerThisTurn {
+            trigger,
+            effects,
+            one_shot,
+        } => {
             let (delayed_effects, _delayed_choices) =
                 compile_trigger_effects(Some(trigger), effects)?;
             let choices = Vec::new();
@@ -280,7 +284,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             watched_tag.clone().into(),
                             ironsmith_core::DelayedTriggerSpec::IsDealtDamage(ChooseSpec::Source),
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         );
@@ -295,7 +299,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                                     ChooseSpec::Object(resolved_filter),
                                 ),
                                 delayed_effects,
-                                false,
+                                *one_shot,
                                 Vec::new(),
                                 PlayerFilter::You,
                             )
@@ -321,7 +325,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             watched_tag.clone().into(),
                             ironsmith_core::DelayedTriggerSpec::ThisDies,
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         );
@@ -336,7 +340,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                                     resolved_filter,
                                 ),
                                 delayed_effects,
-                                false,
+                                *one_shot,
                                 Vec::new(),
                                 PlayerFilter::You,
                             )
@@ -361,7 +365,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             watched_tag.clone().into(),
                             ironsmith_core::DelayedTriggerSpec::ThisDies,
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         );
@@ -374,7 +378,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             crate::effects::ScheduleDelayedTriggerEffect::new(
                                 ironsmith_core::DelayedTriggerSpec::Dies(resolved_filter),
                                 delayed_effects,
-                                false,
+                                *one_shot,
                                 Vec::new(),
                                 PlayerFilter::You,
                             )
@@ -397,7 +401,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                                 one_or_more: *one_or_more,
                             },
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         )
@@ -411,7 +415,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             target_tag.clone().into(),
                             ironsmith_core::DelayedTriggerSpec::ThisAttacksAndIsntBlocked,
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         )
@@ -422,7 +426,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             crate::effects::ScheduleDelayedTriggerEffect::new(
                                 ironsmith_core::DelayedTriggerSpec::ThisAttacksAndIsntBlocked,
                                 delayed_effects,
-                                false,
+                                *one_shot,
                                 Vec::new(),
                                 PlayerFilter::You,
                             )
@@ -438,7 +442,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                             watched_tag.clone().into(),
                             ironsmith_core::DelayedTriggerSpec::ThisAttacksAndIsntBlocked,
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         )
@@ -452,7 +456,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                                     resolved_filter,
                                 ),
                                 delayed_effects,
-                                false,
+                                *one_shot,
                                 Vec::new(),
                                 PlayerFilter::You,
                             )
@@ -466,7 +470,7 @@ pub(super) fn try_compile_timing_and_control_effect(
                         crate::effects::ScheduleDelayedTriggerEffect::new(
                             compile_delayed_trigger_spec(trigger)?,
                             delayed_effects,
-                            false,
+                            *one_shot,
                             Vec::new(),
                             PlayerFilter::You,
                         )

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -3222,6 +3222,7 @@ pub(crate) enum EffectAst {
     DelayedTriggerThisTurn {
         trigger: TriggerSpec,
         effects: Vec<EffectAst>,
+        one_shot: bool,
     },
     DelayedWhenLastObjectDiesThisTurn {
         filter: Option<ObjectFilter>,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1642,7 +1642,10 @@ fn resolve_effect_references_in_effect(
         ));
     }
 
-    if let EffectAst::DelayedTriggerThisTurn { trigger, effects } = &mut effect {
+    if let EffectAst::DelayedTriggerThisTurn {
+        trigger, effects, ..
+    } = &mut effect
+    {
         let nested_state = EffectReferenceResolutionState {
             last_effect_id: state.last_effect_id,
             allow_life_event_value: trigger_supports_event_amount(trigger),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -954,6 +954,60 @@ fn post_rule_delayed_trigger_result_followup(
     }))
 }
 
+fn effects_are_copy_retarget_followup(effects: &[EffectAst]) -> bool {
+    fn contains_retarget(effect: &EffectAst) -> bool {
+        match effect {
+            EffectAst::SubjectVerb(subject_verb) => matches!(
+                subject_verb.action,
+                SubjectVerbActionAst::RetargetStackObject { .. }
+            ),
+            EffectAst::May { effects } | EffectAst::MayByPlayer { effects, .. } => {
+                effects.iter().any(contains_retarget)
+            }
+            _ => false,
+        }
+    }
+
+    effects.iter().any(contains_retarget)
+}
+
+fn trailing_delayed_trigger_effects_mut(effect: &mut EffectAst) -> Option<&mut Vec<EffectAst>> {
+    match effect {
+        EffectAst::DelayedTriggerThisTurn { effects, .. } => Some(effects),
+        EffectAst::Conditional { if_true, .. } => if_true.iter_mut().rev().find_map(|effect| {
+            if let EffectAst::DelayedTriggerThisTurn { effects, .. } = effect {
+                Some(effects)
+            } else {
+                None
+            }
+        }),
+        _ => None,
+    }
+}
+
+fn post_rule_delayed_trigger_copy_retarget_followup(
+    state: &mut SentenceDispatchState<'_>,
+    _sentences: &[SentenceInput],
+    _sentence_idx: usize,
+    _sentence_tokens: &[OwnedLexToken],
+    sentence_effects: &mut Vec<EffectAst>,
+) -> Result<Option<PostParseFollowupResult>, CardTextError> {
+    if !effects_are_copy_retarget_followup(sentence_effects) {
+        return Ok(None);
+    }
+    let Some(previous) = state.effects.last_mut() else {
+        return Ok(None);
+    };
+    let Some(delayed_effects) = trailing_delayed_trigger_effects_mut(previous) else {
+        return Ok(None);
+    };
+
+    delayed_effects.extend(sentence_effects.drain(..));
+    Ok(Some(PostParseFollowupResult::Handled {
+        consumed_sentences: 1,
+    }))
+}
+
 const PRE_PARSE_SUBJECT_VERB_FOLLOWUP_RULES: &[SubjectVerbFollowupRuleDef] = &[
     SubjectVerbFollowupRuleDef {
         id: "library-shuffle",
@@ -1053,5 +1107,11 @@ const POST_PARSE_SUBJECT_VERB_FOLLOWUP_RULES: &[SubjectVerbPostParseRuleDef] = &
         priority: 30,
         heads: &["if", "when"],
         run: post_rule_delayed_trigger_result_followup,
+    },
+    SubjectVerbPostParseRuleDef {
+        id: "delayed-trigger-copy-retarget-followup",
+        priority: 31,
+        heads: &["you"],
+        run: post_rule_delayed_trigger_copy_retarget_followup,
     },
 ];

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
@@ -118,6 +118,27 @@ pub(crate) fn parse_delayed_until_next_end_step_sentence(
     }
 }
 
+fn retarget_source_copy_spell_to_delayed_triggering_object(effects: &mut [EffectAst]) {
+    fn visit(effect: &mut EffectAst) {
+        if let EffectAst::SubjectVerb(subject_verb) = effect
+            && let SubjectVerbActionAst::CopySpell { target, .. } = &mut subject_verb.action
+            && matches!(target, TargetAst::Source(_))
+        {
+            *target = TargetAst::Tagged(TagKey::from("triggering"), None);
+        }
+
+        crate::runtime_backend::effect_ast_traversal::for_each_nested_effects_mut(
+            effect,
+            true,
+            |nested| retarget_source_copy_spell_to_delayed_triggering_object(nested),
+        );
+    }
+
+    for effect in effects {
+        visit(effect);
+    }
+}
+
 pub(crate) fn parse_sentence_delayed_trigger_this_turn(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
@@ -160,7 +181,7 @@ pub(crate) fn parse_sentence_delayed_trigger_this_turn(
             )));
         }
 
-        let delayed_effects = parse_effect_chain(&trim_commas(effect_part))?;
+        let mut delayed_effects = parse_effect_chain(&trim_commas(effect_part))?;
         if delayed_effects.is_empty() {
             return Err(CardTextError::ParseError(format!(
                 "missing delayed trigger effect clause (clause: '{}')",
@@ -212,14 +233,20 @@ pub(crate) fn parse_sentence_delayed_trigger_this_turn(
                 EffectAst::DelayedTriggerThisTurn {
                     trigger: TriggerSpec::AttacksAndIsntBlocked(trigger_filter),
                     effects: delayed_effects,
+                    one_shot: true,
                 },
             ]));
         }
 
         let trigger = parse_trigger_clause_lexed(&trigger_tokens)?;
+        let one_shot = trigger_words.contains(&"next");
+        if matches!(trigger, TriggerSpec::SpellCast { .. }) {
+            retarget_source_copy_spell_to_delayed_triggering_object(&mut delayed_effects);
+        }
         return Ok(Some(vec![EffectAst::DelayedTriggerThisTurn {
             trigger,
             effects: delayed_effects,
+            one_shot,
         }]));
     }
 
@@ -301,17 +328,22 @@ pub(crate) fn parse_sentence_delayed_trigger_this_turn(
         )));
     }
 
-    let delayed_effects = parse_effect_chain(&remainder)?;
+    let mut delayed_effects = parse_effect_chain(&remainder)?;
     if delayed_effects.is_empty() {
         return Err(CardTextError::ParseError(format!(
             "missing delayed trigger effect clause (clause: '{}')",
             crate::runtime_backend::token_word_refs(tokens).join(" ")
         )));
     }
+    if matches!(trigger, TriggerSpec::SpellCast { .. }) {
+        retarget_source_copy_spell_to_delayed_triggering_object(&mut delayed_effects);
+    }
 
+    let one_shot = trigger_words.contains(&"next");
     Ok(Some(vec![EffectAst::DelayedTriggerThisTurn {
         trigger,
         effects: delayed_effects,
+        one_shot,
     }]))
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10656,6 +10656,60 @@ fn test_parse_raid_conditional_with_attacked_this_turn_without_fallback() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+const HOWL_OF_THE_HORDE_TEXT: &str = "When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nRaid — If you attacked this turn, when you next cast an instant or sorcery spell this turn, copy that spell an additional time. You may choose new targets for the copy.";
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn howl_of_the_horde_parses_as_spell_effect_delayed_triggers() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Howl of the Horde")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(HOWL_OF_THE_HORDE_TEXT)
+        .expect("Howl of the Horde should parse strictly");
+
+    assert!(
+        def.abilities.is_empty(),
+        "Howl's next-cast clauses should be spell effects, not battlefield triggers: {:?}",
+        def.abilities
+    );
+    let spell_debug = format!("{:#?}", def.spell_effect.as_ref().expect("spell effects"));
+    assert!(
+        spell_debug.matches("ScheduleDelayedTriggerEffect").count() >= 2
+            && spell_debug.contains("one_shot: true")
+            && spell_debug.contains("until_end_of_turn: true")
+            && spell_debug.contains("AttackedThisTurn")
+            && spell_debug.contains("CopySpellEffect")
+            && spell_debug.contains("RetargetStackObjectEffect"),
+        "expected unconditional and raid-gated one-shot delayed copy triggers, got {spell_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn howl_of_the_horde_compiled_text_preserves_raid_next_cast_copy_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Howl of the Horde")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(HOWL_OF_THE_HORDE_TEXT)
+        .expect("Howl of the Horde should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("When you next cast an instant or sorcery spell this turn, copy that spell")
+            && rendered.contains("Raid — If you attacked this turn")
+            && rendered.contains("copy that spell an additional time")
+            && rendered.contains("You may choose new targets for the copy"),
+        "expected Howl's next-cast raid copy text to render structurally, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_x_target_lands_clause_without_fallback() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "X Untap Probe")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14888,6 +14888,42 @@ fn describe_delayed_coin_flip_result(
     ))
 }
 
+fn describe_next_spell_delayed_trigger(
+    schedule: &crate::effects::ScheduleDelayedTriggerEffect,
+    additional: bool,
+) -> Option<String> {
+    if !schedule.one_shot || !schedule.until_end_of_turn || schedule.start_next_turn {
+        return None;
+    }
+    let trigger_display = cleanup_decompiled_text(
+        schedule
+            .trigger
+            .display()
+            .trim()
+            .trim_end_matches('.'),
+    );
+    let trigger_lower = trigger_display.to_ascii_lowercase();
+    let spell_tail = trigger_lower.strip_prefix("whenever you cast ")?;
+    let spell_text = spell_tail
+        .strip_suffix(" this turn")
+        .unwrap_or(spell_tail)
+        .to_string();
+    let mut delayed_text = lowercase_first(&describe_effect_list(&schedule.effects));
+    if let Some(rest) = delayed_text.strip_prefix("copy it") {
+        delayed_text = format!("copy that spell{rest}");
+    }
+    if additional {
+        delayed_text = delayed_text.replacen(
+            "copy that spell",
+            "copy that spell an additional time",
+            1,
+        );
+    }
+    Some(format!(
+        "When you next cast {spell_text} this turn, {delayed_text}"
+    ))
+}
+
 fn normalize_modal_named_source_etb_surface(
     line: String,
     triggered: &crate::ability::TriggeredAbility,
@@ -30215,6 +30251,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(compact) = describe_no_more_counters_move_then_each_player_return(conditional) {
             return compact;
         }
+        if conditional.if_false.is_empty()
+            && matches!(conditional.condition, crate::effect::Condition::AttackedThisTurn)
+            && let [single] = conditional.if_true.as_slice()
+            && let Some(schedule) = single.downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()
+            && let Some(compact) = describe_next_spell_delayed_trigger(schedule, true)
+        {
+            return format!("Raid — If you attacked this turn, {}", lowercase_first(&compact));
+        }
         let true_branch = describe_effect_clause_list(&conditional.if_true)
             .unwrap_or_else(|| describe_effect_list(&conditional.if_true));
         let false_branch = describe_effect_clause_list(&conditional.if_false)
@@ -32224,6 +32268,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(schedule) = effect.downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>() {
         if let Some(text) = describe_delayed_coin_flip_result(schedule) {
+            return text;
+        }
+        if let Some(text) = describe_next_spell_delayed_trigger(schedule, false) {
             return text;
         }
         let trigger_display = schedule.trigger.display();

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -27898,6 +27898,137 @@ fn test_copied_blitz_creature_spell_schedules_blitz_delayed_triggers() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn howl_of_the_horde_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(435_001), "Howl of the Horde")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.\nRaid — If you attacked this turn, when you next cast an instant or sorcery spell this turn, copy that spell an additional time. You may choose new targets for the copy.",
+        )
+        .expect("Howl of the Horde should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_howl_of_the_horde_spell_effect(game: &mut GameState, attacked: bool) {
+    let alice = PlayerId::from_index(0);
+    let howl = howl_of_the_horde_definition();
+    let howl_id = game.create_object_from_definition(&howl, alice, Zone::Stack);
+    if attacked {
+        game.turn_store
+            .turn_history
+            .players_attacked_this_turn
+            .insert(alice);
+    }
+    let mut ctx = crate::effects::ExecutionContext::new_default(howl_id, alice);
+    execute_resolution_program(
+        game,
+        &mut ctx,
+        alice,
+        howl_id,
+        howl.spell_effect.as_ref().expect("Howl spell effects"),
+        None,
+        &[],
+    )
+    .expect("Howl spell effect should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_howl_target_spell_on_stack(game: &mut GameState) -> ObjectId {
+    let alice = PlayerId::from_index(0);
+    let bolt = CardBuilder::new(CardId::from_raw(435_002), "Runtime Bolt")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let spell_id = game.create_object_from_card(&bolt, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice));
+    spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn howl_of_the_horde_without_raid_schedules_one_one_shot_copy_trigger() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    execute_howl_of_the_horde_spell_effect(&mut game, false);
+    assert_eq!(
+        game.effect_store.delayed_triggers.len(),
+        1,
+        "Howl should schedule only the base next-spell trigger without raid"
+    );
+    assert!(
+        game.effect_store.delayed_triggers[0].one_shot,
+        "Howl's next-spell trigger should be one-shot"
+    );
+
+    let spell_id = create_howl_target_spell_on_stack(&mut game);
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(&mut game, &event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(trigger_queue.entries.len(), 1, "base Howl trigger should fire once");
+    assert!(
+        game.effect_store.delayed_triggers.is_empty(),
+        "one-shot Howl trigger should be consumed after the next cast"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("put Howl trigger on stack");
+    resolve_stack_entry(&mut game).expect("resolve Howl delayed copy trigger");
+    assert_eq!(
+        game.stack.len(),
+        2,
+        "resolving the base Howl trigger should leave the original spell plus one copy on the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn howl_of_the_horde_with_raid_schedules_two_one_shot_copy_triggers() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    execute_howl_of_the_horde_spell_effect(&mut game, true);
+    assert_eq!(
+        game.effect_store.delayed_triggers.len(),
+        2,
+        "Howl should schedule the base and raid next-spell triggers after attacking"
+    );
+    assert!(
+        game.effect_store
+            .delayed_triggers
+            .iter()
+            .all(|trigger| trigger.one_shot),
+        "both Howl delayed triggers should be one-shot"
+    );
+
+    let spell_id = create_howl_target_spell_on_stack(&mut game);
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(&mut game, &event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        2,
+        "base and raid Howl triggers should both fire on the next instant or sorcery"
+    );
+    assert!(
+        game.effect_store.delayed_triggers.is_empty(),
+        "both one-shot Howl triggers should be consumed after the next cast"
+    );
+}
+
 #[test]
 fn test_prototyped_spell_on_stack_snapshots_with_prototype_mana_value() {
     use crate::snapshot::ObjectSnapshot;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Howl of the Horde
Initial parse error:
```
unsupported predicate (predicate: 'you attacked this turn when you next cast instant'); oracle-only fallback also failed: unsupported predicate (predicate: 'you attacked this turn when you next cast instant')
```

Current worker: i-096ffdcd8fd84e355
Branch: codex/aws-card-fix-howl-of-the-horde
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0026
