### PR TITLE
Fix Ironsmith parse failure: Vampire Socialite

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2148,6 +2148,25 @@ pub(crate) fn parse_static_condition_clause(
     if word_slice_eq_any(
         &clause_words,
         &[
+            &["an", "opponent", "lost", "life", "this", "turn"],
+            &[
+                "one",
+                "or",
+                "more",
+                "opponents",
+                "lost",
+                "life",
+                "this",
+                "turn",
+            ],
+        ],
+    ) {
+        return Ok(crate::ConditionExpr::OpponentLostLifeThisTurn);
+    }
+
+    if word_slice_eq_any(
+        &clause_words,
+        &[
             &["there", "are", "no", "cards", "in", "your", "library"],
             &["your", "library", "has", "no", "cards", "in", "it"],
         ],

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -2516,6 +2516,20 @@ pub(crate) fn parse_enters_with_additional_counter_for_filter_line(
         return parse_enters_with_additional_counter_for_filter_line(&tokens[comma_idx + 1..]);
     }
 
+    if clause_words.len() > 6
+        && word_slice_starts_with(&clause_words, &["as", "long", "as"])
+        && let Some(comma_idx) = find_token_kind(tokens, TokenKind::Comma)
+    {
+        let condition_tokens = trim_edge_punctuation(&tokens[3..comma_idx]);
+        let condition = parse_static_condition_clause(&condition_tokens)?;
+        let Some(ability) =
+            parse_enters_with_additional_counter_for_filter_line(&tokens[comma_idx + 1..])?
+        else {
+            return Ok(None);
+        };
+        return Ok(Some(ability.with_condition(condition)));
+    }
+
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     let enter_word_idx = word_slice_find_word_where(&clause_words, |word| matches!(word, "enter" | "enters"));
     let Some(enter_word_idx) = enter_word_idx else {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -2217,6 +2217,23 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::CreatureDiedThisTurn);
     }
 
+    if matches!(
+        filtered.as_slice(),
+        ["opponent", "lost", "life", "this", "turn"]
+            | [
+                "one",
+                "or",
+                "more",
+                "opponents",
+                "lost",
+                "life",
+                "this",
+                "turn",
+            ]
+    ) {
+        return Ok(PredicateAst::OpponentLostLifeThisTurn);
+    }
+
     if filtered.len() == 7
         && let Some(count) = parse_named_number(filtered[0])
         && word_slice_eq(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -159,6 +159,172 @@ fn thundermane_dragon_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn vampire_socialite_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Vampire Socialite");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        ability_debug.contains("OpponentLostLifeThisTurn")
+            && ability_debug.contains("EnterWithCountersForFilter")
+            && ability_debug.contains("intervening_if: Some"),
+        "Vampire Socialite should structurally keep both opponent-life-loss gates, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("When this creature enters, if an opponent lost life this turn, put a +1/+1 counter on each other Vampire you control."),
+        "expected Vampire Socialite ETB intervening-if text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("As long as an opponent lost life this turn, each other Vampire you control enters with an additional +1/+1 counter on it."),
+        "expected Vampire Socialite static conditional ETB-counter text, got {rendered}"
+    );
+}
+
+fn stage_vampire_socialite_opponent_life_loss(game: &mut crate::game_state::GameState) {
+    let bob = PlayerId::from_index(1);
+    let life_loss = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::life::LifeLossEvent::from_effect(bob, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.stage_turn_history_event(&life_loss);
+}
+
+#[test]
+fn vampire_socialite_etb_trigger_condition_and_counter_effect_runtime() {
+    let def = parse_oracle_card_definition("Vampire Socialite");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Triggered(triggered) = &ability.kind else {
+                return None;
+            };
+            format!("{:?}", triggered.effects)
+                .contains("PutCountersEffect")
+                .then_some(triggered)
+        })
+        .expect("Vampire Socialite should have a counter-placing ETB trigger");
+
+    assert_eq!(
+        triggered.intervening_if,
+        Some(crate::effect::Condition::OpponentLostLifeThisTurn),
+        "Vampire Socialite ETB trigger should be gated by opponent life loss"
+    );
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let socialite_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let other_vampire = CardDefinitionBuilder::new(CardId::from_raw(92_001), "Bloodhall Trainee")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Vampire])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let other_id = game.create_object_from_definition(&other_vampire, alice, Zone::Battlefield);
+
+    assert!(
+        !crate::condition_eval::evaluate_condition_cast_time(
+            &game,
+            &crate::effect::Condition::OpponentLostLifeThisTurn,
+            alice,
+            socialite_id,
+        ),
+        "Vampire Socialite ETB condition should be false before an opponent loses life"
+    );
+    stage_vampire_socialite_opponent_life_loss(&mut game);
+    assert!(
+        crate::condition_eval::evaluate_condition_cast_time(
+            &game,
+            &crate::effect::Condition::OpponentLostLifeThisTurn,
+            alice,
+            socialite_id,
+        ),
+        "Vampire Socialite ETB condition should be true after an opponent loses life"
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(socialite_id, alice, &mut dm);
+    for effect in triggered.effects.flattened_default_effects() {
+        effect
+            .0
+            .execute(&mut game, &mut ctx)
+            .expect("Vampire Socialite ETB counter effect should resolve");
+    }
+
+    assert_eq!(
+        game.object(other_id).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()),
+        Some(1),
+        "Vampire Socialite ETB trigger should put a +1/+1 counter on another Vampire"
+    );
+    assert_eq!(
+        game.object(socialite_id).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()),
+        None,
+        "Vampire Socialite ETB trigger should not put a counter on itself"
+    );
+}
+
+#[test]
+fn vampire_socialite_static_replacement_requires_opponent_life_loss() {
+    fn entering_vampire_definition() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::from_raw(92_002), "Falkenrath Recruit")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Vampire])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build()
+    }
+
+    let def = parse_oracle_card_definition("Vampire Socialite");
+    let alice = PlayerId::from_index(0);
+
+    let mut inactive_game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    inactive_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let inactive_entering = inactive_game.create_object_from_definition(
+        &entering_vampire_definition(),
+        alice,
+        Zone::Hand,
+    );
+    let inactive_result = inactive_game
+        .move_object_with_etb_processing(inactive_entering, Zone::Battlefield)
+        .expect("inactive Vampire should enter");
+    assert_eq!(
+        inactive_game.object(inactive_result.new_id).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()),
+        None,
+        "Vampire Socialite static replacement should not add a counter before opponent life loss"
+    );
+
+    let mut active_game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    active_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    stage_vampire_socialite_opponent_life_loss(&mut active_game);
+    let active_entering = active_game.create_object_from_definition(
+        &entering_vampire_definition(),
+        alice,
+        Zone::Hand,
+    );
+    let active_result = active_game
+        .move_object_with_etb_processing(active_entering, Zone::Battlefield)
+        .expect("active Vampire should enter");
+    assert_eq!(
+        active_game.object(active_result.new_id).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()),
+        Some(1),
+        "Vampire Socialite static replacement should add a counter after opponent life loss"
+    );
+}
+
+#[test]
 fn party_dude_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Party Dude");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11227,9 +11227,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             )
         }
         Condition::AttackedThisTurn => "you attacked this turn".to_string(),
-        Condition::OpponentLostLifeThisTurn => {
-            "an opponent was dealt damage this turn".to_string()
-        }
+        Condition::OpponentLostLifeThisTurn => "an opponent lost life this turn".to_string(),
         Condition::PermanentLeftBattlefieldThisTurn => {
             "a permanent left the battlefield this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -963,6 +963,9 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::SourceAttackedThisTurn => {
             "as long as this creature attacked this turn".to_string()
         }
+        crate::ConditionExpr::OpponentLostLifeThisTurn => {
+            "as long as an opponent lost life this turn".to_string()
+        }
         crate::ConditionExpr::SourceCameUnderYourControlThisTurn => {
             "as long as this creature came under your control this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -8,7 +8,7 @@ use super::{
     ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
     ConditionalSpellKeywordSpec, EnterAsCopyAsEntersSpec, GraveyardCountMetric, StaticAbilityId,
-    StaticAbilityKind, ThisSpellCastRestrictionKind, TriggerDuplicationSpec,
+    StaticAbility, StaticAbilityKind, ThisSpellCastRestrictionKind, TriggerDuplicationSpec,
     TriggerSuppressionSpec,
     text_utils::{capitalize_first, join_with_and, number_word_u32},
 };
@@ -2405,6 +2405,7 @@ pub struct EnterWithCountersForFilter {
     pub counter_type: CounterType,
     pub count: Value,
     pub added_subtypes: Vec<Subtype>,
+    pub condition: Option<crate::ConditionExpr>,
 }
 
 impl EnterWithCountersForFilter {
@@ -2414,11 +2415,17 @@ impl EnterWithCountersForFilter {
             counter_type,
             count,
             added_subtypes: Vec::new(),
+            condition: None,
         }
     }
 
     pub fn with_added_subtypes(mut self, subtypes: Vec<Subtype>) -> Self {
         self.added_subtypes = subtypes;
+        self
+    }
+
+    pub fn with_condition(mut self, condition: crate::ConditionExpr) -> Self {
+        self.condition = Some(condition);
         self
     }
 }
@@ -2489,7 +2496,24 @@ impl StaticAbilityKind for EnterWithCountersForFilter {
             )
         };
 
-        format!("{subject} {enters} {counter_clause}{subtype_clause}")
+        let text = format!("{subject} {enters} {counter_clause}{subtype_clause}");
+        let Some(condition) = &self.condition else {
+            return text;
+        };
+        let condition = super::describe_static_condition(condition);
+        if let Some(rest) = condition.strip_prefix("as long as ") {
+            let mut chars = text.chars();
+            let lowered = match chars.next() {
+                Some(first) => format!("{}{}", first.to_ascii_lowercase(), chars.as_str()),
+                None => String::new(),
+            };
+            return format!("As long as {rest}, {lowered}");
+        }
+        format!("{text} {condition}")
+    }
+
+    fn with_static_condition(&self, condition: crate::ConditionExpr) -> Option<StaticAbility> {
+        Some(StaticAbility::new(self.clone().with_condition(condition)))
     }
 
     fn generate_replacement_effect(
@@ -2500,7 +2524,10 @@ impl StaticAbilityKind for EnterWithCountersForFilter {
         Some(ReplacementEffect::with_matcher(
             source,
             controller,
-            WouldEnterBattlefieldMatcher::new(self.filter.clone()),
+            ConditionalWouldEnterBattlefieldMatcher {
+                enter_matcher: WouldEnterBattlefieldMatcher::new(self.filter.clone()),
+                condition: self.condition.clone(),
+            },
             ReplacementAction::EnterWithCounters {
                 counter_type: self.counter_type,
                 count: self.count.clone(),
@@ -2508,6 +2535,49 @@ impl StaticAbilityKind for EnterWithCountersForFilter {
                 added_abilities: Vec::new(),
             },
         ))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ConditionalWouldEnterBattlefieldMatcher {
+    enter_matcher: WouldEnterBattlefieldMatcher,
+    condition: Option<crate::ConditionExpr>,
+}
+
+impl ConditionalWouldEnterBattlefieldMatcher {
+    fn condition_matches(&self, ctx: &crate::events::context::EventContext<'_>) -> bool {
+        let Some(condition) = &self.condition else {
+            return true;
+        };
+        let Some(source) = ctx.source else {
+            return false;
+        };
+        let eval_ctx = crate::condition_eval::ExternalEvaluationContext {
+            controller: ctx.controller,
+            source,
+            defending_player: None,
+            attacking_player: None,
+            filter_source: Some(source),
+            triggering_event: None,
+            trigger_identity: None,
+            ability_index: None,
+            options: Default::default(),
+        };
+        crate::condition_eval::evaluate_condition_external(ctx.game, condition, &eval_ctx)
+    }
+}
+
+impl ReplacementMatcher for ConditionalWouldEnterBattlefieldMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        self.enter_matcher.matches_event(event, ctx) && self.condition_matches(ctx)
+    }
+
+    fn priority(&self) -> ReplacementPriority {
+        self.enter_matcher.priority()
+    }
+
+    fn display(&self) -> String {
+        self.enter_matcher.display()
     }
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vampire Socialite
Initial parse error:
```
unsupported static condition clause (clause: 'an opponent lost life this turn'); oracle-only fallback also failed: unsupported static condition clause (clause: 'an opponent lost life this turn')
```

Current worker: i-0230384e64a9d27e9
Branch: codex/aws-card-fix-vampire-socialite
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0026
