### PR TITLE
Fix Ironsmith parse failure: Selvala, Eager Trailblazer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
@@ -156,6 +156,29 @@ pub(crate) fn parse_add_mana(
     }
     if word_slice_starts_with(
         &clause_words,
+        &["one", "mana", "of", "that", "color"],
+    ) {
+        let tail_start = clause_word_view.token_index_after_words(5).unwrap_or(tokens.len());
+        let tail_tokens = trim_leading_commas(&tokens[tail_start..]);
+        if tail_tokens.is_empty() || is_mana_pool_tail_tokens(tail_tokens) {
+            return Ok(EffectAst::subject_verb_add_mana_chosen_color(
+                player,
+                Value::Fixed(1),
+                None,
+            ));
+        }
+        if let Some(amount) = parse_dynamic_cost_modifier_value(tail_tokens)? {
+            return Ok(EffectAst::subject_verb_add_mana_chosen_color(
+                player, amount, None,
+            ));
+        }
+        return Err(CardTextError::ParseError(format!(
+            "unsupported dynamic chosen-color mana amount (clause: '{}')",
+            clause_words.join(" ")
+        )));
+    }
+    if word_slice_starts_with(
+        &clause_words,
         &["an", "amount", "of", "mana", "of", "that", "color"],
     ) {
         let amount = parse_devotion_value_from_add_clause(tokens)?

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6146,6 +6146,35 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
             return Ok(Some(Value::CardTypesAmong(filter)));
         }
     }
+    if word_slice_starts_with_any(
+        &filter_words,
+        &[
+            &["different", "powers", "among"],
+            &["different", "power", "values", "among"],
+            &["different", "power", "among"],
+        ],
+    ) {
+        let scope_start_word_idx = if word_slice_at_is(&filter_words, 2, "among") {
+            3
+        } else {
+            4
+        };
+        let Some(scope_start_token_idx) =
+            token_index_for_word_index(filter_tokens, scope_start_word_idx)
+        else {
+            return Ok(None);
+        };
+        let mut end_token_idx = filter_tokens.len();
+        if let Some(period_idx) =
+            find_token_kind(&filter_tokens[scope_start_token_idx..], TokenKind::Period)
+        {
+            end_token_idx = scope_start_token_idx + period_idx;
+        }
+        let scope_tokens = trim_commas(&filter_tokens[scope_start_token_idx..end_token_idx]);
+        if let Ok(filter) = parse_object_filter(&scope_tokens, false) {
+            return Ok(Some(Value::DistinctPowers(filter)));
+        }
+    }
 
     let has_card_type_among = word_slice_contains_any_phrase(
         &filter_words,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
@@ -118,6 +118,28 @@ pub(crate) fn parse_add_mana(
             }
         }
     }
+    if let Some(tail_tokens) = grammar::words_match_prefix(
+        tokens,
+        &["one", "mana", "of", "that", "color"],
+    ) {
+        let tail_tokens = trim_leading_commas(tail_tokens);
+        if tail_tokens.is_empty() || is_mana_pool_tail_tokens(tail_tokens) {
+            return Ok(EffectAst::subject_verb_add_mana_chosen_color(
+                player,
+                Value::Fixed(1),
+                None,
+            ));
+        }
+        if let Some(amount) = parse_dynamic_cost_modifier_value(tail_tokens)? {
+            return Ok(EffectAst::subject_verb_add_mana_chosen_color(
+                player, amount, None,
+            ));
+        }
+        return Err(CardTextError::ParseError(format!(
+            "unsupported dynamic chosen-color mana amount (clause: '{}')",
+            clause_words.join(" ")
+        )));
+    }
     if grammar::words_match_prefix(
         tokens,
         &["an", "amount", "of", "mana", "of", "that", "color"],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17731,6 +17731,30 @@ fn parse_add_mana_chosen_color_tail() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_chosen_color_mana_for_each_different_power() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Selvala Mana Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "{T}: Choose a color. Add one mana of that color for each different power among creatures you control.",
+        )
+        .expect("chosen-color mana scaled by distinct powers should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "Choose a color. Add one mana of that color for each different power among creatures you control"
+        ),
+        "expected distinct-power chosen-color mana render, got {rendered}"
+    );
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("AddManaOfChosenColorEffect") && debug.contains("DistinctPowers"),
+        "expected chosen-color mana effect scaled by distinct powers, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_urzas_tower_conditional_mana_output() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Urza's Tower Variant")
         .card_types(vec![CardType::Land])
@@ -39377,6 +39401,190 @@ fn alena_kessig_trapper_mana_runtime_uses_only_your_creatures_that_entered_this_
 
     assert_eq!(result.value, crate::effect::OutcomeValue::ManaAdded(vec![]));
     assert_eq!(game.player(alice).expect("alice").mana_pool.red, 0);
+}
+
+#[test]
+fn selvala_eager_trailblazer_strict_parser_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Selvala, Eager Trailblazer");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Vigilance")
+            && rendered.contains("Whenever you cast a creature spell")
+            && rendered.contains(
+                "Choose a color. Add one mana of that color for each different power among creatures you control"
+            ),
+        "expected Selvala's keyword, token trigger, and distinct-power mana clause to render, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("ChooseColorEffect")
+            && ability_debug.contains("AddManaOfChosenColorEffect")
+            && ability_debug.contains("DistinctPowers"),
+        "expected Selvala's mana ability to choose a color and scale by distinct powers, got {ability_debug}"
+    );
+}
+
+#[test]
+fn selvala_eager_trailblazer_mana_runtime_counts_distinct_controlled_powers() {
+    fn selvala_definition() -> CardDefinition {
+        let oracle = oracle_text_by_name()
+            .get("Selvala, Eager Trailblazer")
+            .expect("Selvala oracle text should be present")
+            .clone();
+        CardDefinitionBuilder::new(CardId::new(), "Selvala, Eager Trailblazer")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 5))
+            .parse_text(oracle)
+            .expect("Selvala should parse for runtime regression")
+    }
+
+    fn create_creature(
+        game: &mut crate::game_state::GameState,
+        controller: PlayerId,
+        name: &str,
+        power: i32,
+    ) {
+        let def = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(power, 1))
+            .build();
+        game.create_object_from_definition(&def, controller, Zone::Battlefield);
+    }
+
+    let def = selvala_definition();
+    let add_chosen = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.is_mana_ability() => activated
+                .effects
+                .iter()
+                .find_map(|effect| {
+                    effect.downcast_ref::<crate::effects::AddManaOfChosenColorEffect>()
+                }),
+            _ => None,
+        })
+        .expect("Selvala should have a chosen-color mana effect");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let selvala_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    create_creature(&mut game, alice, "One-Power Scout", 1);
+    create_creature(&mut game, alice, "Duplicate-Power Ally", 4);
+    create_creature(&mut game, bob, "Opposing Giant", 7);
+    game.set_chosen_color(selvala_id, Color::Blue);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(selvala_id, alice, &mut dm);
+    let result = add_chosen
+        .execute(&mut game, &mut ctx)
+        .expect("Selvala's mana effect should resolve");
+
+    assert_eq!(
+        result.value,
+        crate::effect::OutcomeValue::Count(2),
+        "Selvala should add one mana for each distinct controlled power, ignoring duplicates and opponents"
+    );
+    assert_eq!(game.player(alice).expect("alice").mana_pool.blue, 2);
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let selvala_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.set_chosen_color(selvala_id, Color::Red);
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(selvala_id, alice, &mut dm);
+    let result = add_chosen
+        .execute(&mut game, &mut ctx)
+        .expect("Selvala's mana effect should count Selvala herself");
+
+    assert_eq!(
+        result.value,
+        crate::effect::OutcomeValue::Count(1),
+        "Selvala should count her own power when she is the only creature you control"
+    );
+    assert_eq!(game.player(alice).expect("alice").mana_pool.red, 1);
+}
+
+#[test]
+fn selvala_eager_trailblazer_creature_spell_trigger_creates_mercenary_token() {
+    fn spell_def(name: &str, card_types: Vec<CardType>) -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(card_types)
+            .build()
+    }
+
+    fn spell_cast_event(spell: ObjectId, caster: PlayerId) -> crate::triggers::TriggerEvent {
+        crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::spells::SpellCastEvent::new(spell, caster, Zone::Hand),
+            crate::provenance::ProvNodeId::default(),
+        )
+    }
+
+    let def = parse_oracle_card_definition("Selvala, Eager Trailblazer");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let selvala_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let instant = spell_def("Not a Creature", vec![CardType::Instant]);
+    let instant_id = game.create_object_from_definition(&instant, alice, Zone::Stack);
+    let instant_event = spell_cast_event(instant_id, alice);
+    assert!(
+        crate::triggers::check_triggers(&game, &instant_event).is_empty(),
+        "Selvala should not trigger from your noncreature spell"
+    );
+
+    let opponent_creature = spell_def("Opponent Creature", vec![CardType::Creature]);
+    let opponent_creature_id =
+        game.create_object_from_definition(&opponent_creature, bob, Zone::Stack);
+    let opponent_event = spell_cast_event(opponent_creature_id, bob);
+    assert!(
+        crate::triggers::check_triggers(&game, &opponent_event).is_empty(),
+        "Selvala should not trigger from an opponent's creature spell"
+    );
+
+    let creature = spell_def("Your Creature", vec![CardType::Creature]);
+    let creature_id = game.create_object_from_definition(&creature, alice, Zone::Stack);
+    let creature_event = spell_cast_event(creature_id, alice);
+    let triggered = crate::triggers::check_triggers(&game, &creature_event);
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Selvala should trigger once from your creature spell"
+    );
+
+    let entry = &triggered[0];
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(selvala_id, alice, &mut dm)
+        .with_triggering_event(entry.triggering_event.clone());
+    for effect in &entry.ability.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Selvala's token trigger should resolve");
+    }
+
+    let mercenaries = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter(|&id| id != selvala_id)
+        .filter_map(|id| game.object(id))
+        .filter(|object| {
+            object.card_types == [CardType::Creature]
+                && object.subtypes == [Subtype::Mercenary]
+                && object.color_override == Some(crate::color::ColorSet::RED)
+                && object.base_power == Some(crate::card::PtValue::Fixed(1))
+                && object.base_toughness == Some(crate::card::PtValue::Fixed(1))
+                && game.controller_of(object) == alice
+                && object.abilities.iter().any(|ability| {
+                    matches!(ability.kind, AbilityKind::Activated(_))
+                })
+        })
+        .count();
+    assert_eq!(
+        mercenaries, 1,
+        "Selvala should create one 1/1 red Mercenary token with an activated ability"
+    );
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -675,6 +675,9 @@ fn token_extra_abilities_prefer_with_clause(abilities: &[String]) -> bool {
             if ability == "\"This token can't block.\"" {
                 return true;
             }
+            if ability.starts_with("\"{") {
+                return true;
+            }
             ability.to_ascii_lowercase().starts_with(
                 "\"this token saddles mounts and crews vehicles as though its power were ",
             )
@@ -708,7 +711,10 @@ pub(super) fn quote_token_granted_ability_text(text: &str) -> String {
     } else {
         trimmed
     };
-    let normalized = normalize_quoted_token_ability_surface(unquoted);
+    let mut normalized = normalize_quoted_token_ability_surface(unquoted);
+    if token_quoted_ability_needs_terminal_period(&normalized) {
+        normalized.push('.');
+    }
     format!("\"{normalized}\"")
 }
 
@@ -776,7 +782,8 @@ fn token_quoted_ability_needs_terminal_period(text: &str) -> bool {
     !trimmed.ends_with('.')
         && !trimmed.ends_with('!')
         && !trimmed.ends_with('?')
-        && (trimmed.contains("Sacrifice this token:")
+        && (trimmed.starts_with('{')
+            || trimmed.contains("Sacrifice this token:")
             || trimmed.starts_with("When this token ")
             || trimmed.starts_with("Whenever this token "))
 }
@@ -12643,11 +12650,11 @@ mod tests {
     fn quoted_token_abilities_use_token_self_reference_for_activation_costs() {
         assert_eq!(
             quote_token_granted_ability_text("Sacrifice this creature, add {c}"),
-            "\"Sacrifice this token: Add {C}\""
+            "\"Sacrifice this token: Add {C}.\""
         );
         assert_eq!(
             quote_token_granted_ability_text("{t}, Sacrifice this artifact, add {r} or {g}"),
-            "\"{T}, Sacrifice this token: Add {R} or {G}\""
+            "\"{T}, Sacrifice this token: Add {R} or {G}.\""
         );
         assert_eq!(
             normalize_common_semantic_phrasing(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3296,12 +3296,36 @@ fn describe_each_creature_and_player_damage_cant_regenerate_structural(
     ))
 }
 
+fn describe_choose_color_then_chosen_color_mana(effects: &[&Effect]) -> Option<String> {
+    let [choose_effect, mana_effect] = effects else {
+        return None;
+    };
+    let choose_color = choose_effect.downcast_ref::<crate::effects::ChooseColorEffect>()?;
+    let add_mana = mana_effect.downcast_ref::<crate::effects::AddManaOfChosenColorEffect>()?;
+    if choose_color.chooser != PlayerFilter::You
+        || add_mana.player != PlayerFilter::You
+        || add_mana.fixed_option.is_some()
+    {
+        return None;
+    }
+    if let Value::DistinctPowers(filter) = &add_mana.amount {
+        return Some(format!(
+            "Choose a color. Add one mana of that color for each different power among {}",
+            pluralize_noun_phrase(&describe_for_each_count_filter(filter))
+        ));
+    }
+    None
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
     }
 
     let raw_effects = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_choose_color_then_chosen_color_mana(&raw_effects) {
+        return compact;
+    }
     if let Some(compact) = describe_kicked_additional_targets_put_counters(&raw_effects) {
         return compact;
     }
@@ -13415,6 +13439,11 @@ fn normalize_haunting_echoes_text(text: &str) -> Option<String> {
 pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> {
     if effects.len() < 2 {
         return None;
+    }
+
+    let effect_refs = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_choose_color_then_chosen_color_mana(&effect_refs) {
+        return Some(compact);
     }
 
     if effects.len() >= 3
@@ -31803,6 +31832,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         }
         if matches!(add_chosen.amount, Value::Fixed(1)) {
             return format!("Add one mana of the chosen color{}", destination);
+        }
+        if let Value::DistinctPowers(filter) = &add_chosen.amount {
+            return format!(
+                "Add one mana of the chosen color for each different power among {}{}",
+                pluralize_noun_phrase(&describe_for_each_count_filter(filter)),
+                destination
+            );
         }
         if !matches!(&add_chosen.amount, Value::Fixed(_) | Value::X) {
             return format!(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Selvala, Eager Trailblazer
Initial parse error:
```
missing mana symbols (clause: 'one mana of that color for each different power among creatures you control'); oracle-only fallback also failed: missing mana symbols (clause: 'one mana of that color for each different power among creatures you control')
```

Current worker: i-0b8906868dac206d0
Branch: codex/aws-card-fix-selvala-eager-trailblazer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0026
