### PR TITLE
Fix Ironsmith parse failure: Interface Ace

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -202,6 +202,8 @@ fn supported_keyword_marker_text(text: &str) -> bool {
         || text.starts_with("splice onto ")
         || is_ticket_sticker_marker_line(&text)
         || text == "this creature crews vehicles using its toughness rather than its power."
+        || text
+            == "this creature saddles mounts and crews vehicles using its toughness rather than its power."
         || is_power_greater_marker("this creature crews vehicles as though its power were ")
         || is_power_greater_marker(
             "this creature saddles mounts and crews vehicles as though its power were ",
@@ -1001,6 +1003,24 @@ fn parse_static_ability_ast_line_early_lexed(
         [
             "this",
             "creature",
+            "crews",
+            "vehicles",
+            "using",
+            "its",
+            "toughness",
+            "rather",
+            "than",
+            "its",
+            "power"
+        ]
+    ) || matches!(
+        words.as_slice(),
+        [
+            "this",
+            "creature",
+            "saddles",
+            "mounts",
+            "and",
             "crews",
             "vehicles",
             "using",

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/line_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/line_lowering.rs
@@ -1743,15 +1743,26 @@ fn lower_triggered_chunk(
         &trigger,
         info.normalized.normalized.as_str(),
     );
+    let mut intervening_if = crate::runtime_backend::trigger_frequency_condition(
+        Some(info.raw_line.as_str()),
+        max_triggers_per_turn,
+    );
+    let lower_source =
+        format!("{} {}", info.raw_line, info.normalized.original).to_ascii_lowercase();
+    if lower_source.contains("becomes tapped during your turn") {
+        let condition = crate::ConditionExpr::YourTurn;
+        intervening_if = Some(match intervening_if {
+            Some(existing) => crate::ConditionExpr::And(Box::new(condition), Box::new(existing)),
+            None => condition,
+        });
+    }
+
     let parsed = super::rewrite_parsed_triggered_ability(
         trigger.clone(),
         prepared.prepared.effects.clone(),
         functional_zones,
         Some(info.raw_line.clone()),
-        crate::runtime_backend::trigger_frequency_condition(
-            Some(info.raw_line.as_str()),
-            max_triggers_per_turn,
-        ),
+        intervening_if,
         None,
         prepared.prepared.imports.clone(),
     );

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
@@ -417,6 +417,10 @@ pub(super) fn apply_chosen_option_to_triggered_chunk(
     chosen_option_label: Option<&str>,
     presentation_label: Option<&str>,
 ) -> Result<LineAst, CardTextError> {
+    let during_your_turn_condition = full_text
+        .to_ascii_lowercase()
+        .contains("becomes tapped during your turn")
+        .then_some(crate::ConditionExpr::YourTurn);
     let max_condition =
         crate::runtime_backend::trigger_frequency_condition(Some(full_text), max_triggers_per_turn);
     let combined_condition = match (chosen_option_label, max_condition.clone()) {
@@ -452,6 +456,14 @@ pub(super) fn apply_chosen_option_to_triggered_chunk(
                 (None, Some(max)) => Some(max),
                 (None, None) => None,
             };
+            let merged_condition = match (during_your_turn_condition.clone(), merged_condition) {
+                (Some(condition), Some(existing)) => Some(crate::ConditionExpr::And(
+                    Box::new(condition),
+                    Box::new(existing),
+                )),
+                (Some(condition), None) => Some(condition),
+                (None, existing) => existing,
+            };
             Ok(LineAst::Ability(rewrite_parsed_triggered_ability(
                 trigger.clone(),
                 effects,
@@ -472,6 +484,16 @@ pub(super) fn apply_chosen_option_to_triggered_chunk(
                 triggered.intervening_if = Some(match triggered.intervening_if.take() {
                     Some(existing) => {
                         crate::ConditionExpr::And(Box::new(existing), Box::new(condition))
+                    }
+                    None => condition,
+                });
+            }
+            if let AbilityKind::Triggered(triggered) = parsed.kind_mut()
+                && let Some(condition) = during_your_turn_condition
+            {
+                triggered.intervening_if = Some(match triggered.intervening_if.take() {
+                    Some(existing) => {
+                        crate::ConditionExpr::And(Box::new(condition), Box::new(existing))
                     }
                     None => condition,
                 });

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41075,6 +41075,106 @@ fn wild_roads_pilot_token_power_bonus_applies_to_saddle_and_crew_costs() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_interface_ace_strict_regression() {
+    assert_oracle_card_parses_strict("Interface Ace");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn interface_ace_compiled_text_keeps_saddle_and_crew_toughness_clause() {
+    let def = parse_oracle_card_definition("Interface Ace");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains(
+            "saddles mounts and crews vehicles using its toughness rather than its power"
+        ),
+        "expected Interface Ace compiled text to preserve toughness-based saddle/crew clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("whenever this creature becomes tapped during your turn")
+            && rendered.contains("untap it")
+            && rendered.contains("this ability triggers only once each turn"),
+        "expected Interface Ace compiled text to preserve tap trigger and once-per-turn cap, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn interface_ace_uses_toughness_for_saddle_and_crew_costs() {
+    let alice = PlayerId::from_index(0);
+    let def = CardDefinitionBuilder::new(CardId::new(), "Interface Ace")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Robot, Subtype::Pilot])
+        .power_toughness(PowerToughness::fixed(0, 4))
+        .parse_text(
+            "This creature saddles Mounts and crews Vehicles using its toughness rather than its power.\n\
+             Whenever this creature becomes tapped during your turn, untap it. This ability triggers only once each turn.",
+        )
+        .expect("Interface Ace should parse for runtime cost test");
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let vehicle = CardDefinitionBuilder::new(CardId::new(), "Vehicle Probe")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Vehicle])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let vehicle_id = game.create_object_from_definition(&vehicle, alice, Zone::Battlefield);
+    let crew_cost = crate::effects::CrewCostEffect { required_power: 4 };
+    crate::effects::CostExecutableEffect::can_execute_as_cost(&crew_cost, &game, vehicle_id, alice)
+        .expect("Interface Ace should crew 4 using its toughness rather than 0 power");
+
+    let mount = CardDefinitionBuilder::new(CardId::new(), "Mount Probe")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Mount])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let mount_id = game.create_object_from_definition(&mount, alice, Zone::Battlefield);
+    let saddle_cost = crate::effects::SaddleCostEffect::new(4);
+    crate::effects::CostExecutableEffect::can_execute_as_cost(&saddle_cost, &game, mount_id, alice)
+        .expect("Interface Ace should saddle 4 using its toughness rather than 0 power");
+
+    let vanilla = CardDefinitionBuilder::new(CardId::new(), "Vanilla 0/4")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(0, 4))
+        .build();
+    let mut baseline_crew = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    baseline_crew.create_object_from_definition(&vanilla, alice, Zone::Battlefield);
+    let baseline_vehicle =
+        baseline_crew.create_object_from_definition(&vehicle, alice, Zone::Battlefield);
+    assert!(
+        crate::effects::CostExecutableEffect::can_execute_as_cost(
+            &crew_cost,
+            &baseline_crew,
+            baseline_vehicle,
+            alice,
+        )
+        .is_err(),
+        "baseline 0/4 without Interface Ace marker should not satisfy crew 4"
+    );
+
+    let mut baseline_saddle = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    baseline_saddle.create_object_from_definition(&vanilla, alice, Zone::Battlefield);
+    let baseline_mount =
+        baseline_saddle.create_object_from_definition(&mount, alice, Zone::Battlefield);
+    assert!(
+        crate::effects::CostExecutableEffect::can_execute_as_cost(
+            &saddle_cost,
+            &baseline_saddle,
+            baseline_mount,
+            alice,
+        )
+        .is_err(),
+        "baseline 0/4 without Interface Ace marker should not satisfy saddle 4"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_brambleback_brute_strict_regression() {
     assert_oracle_card_parses_strict("Brambleback Brute");
 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14689,12 +14689,18 @@ fn describe_triggered_inline_ability(
         .as_ref()
         .map(split_trigger_intervening_if)
         .unwrap_or((None, None));
-    let intervening_condition = if trigger_is_state_based(&triggered.trigger) {
+    let mut intervening_condition = if trigger_is_state_based(&triggered.trigger) {
         None
     } else {
         intervening_condition
     };
     let mut line = describe_trigger_surface_with_frequency(triggered, trigger_frequency);
+    if matches!(intervening_condition, Some(Condition::YourTurn))
+        && line.to_ascii_lowercase().ends_with("becomes tapped")
+    {
+        line.push_str(" during your turn");
+        intervening_condition = None;
+    }
     if let Some(condition) = intervening_condition {
         line.push_str(", if ");
         line.push_str(&describe_trigger_intervening_condition(
@@ -36628,15 +36634,23 @@ pub(super) fn describe_ability(
                 .as_ref()
                 .map(split_trigger_intervening_if)
                 .unwrap_or((None, None));
-            let intervening_condition = if trigger_is_state_based(&triggered.trigger) {
+            let mut intervening_condition = if trigger_is_state_based(&triggered.trigger) {
                 None
             } else {
                 intervening_condition
             };
-            let trigger_surface = apply_triggered_presentation_label(
+            let mut trigger_surface = apply_triggered_presentation_label(
                 triggered,
                 describe_trigger_surface_with_frequency(triggered, trigger_frequency),
             );
+            if matches!(intervening_condition, Some(Condition::YourTurn))
+                && trigger_surface
+                    .to_ascii_lowercase()
+                    .ends_with("becomes tapped")
+            {
+                trigger_surface.push_str(" during your turn");
+                intervening_condition = None;
+            }
             let mut line = format!("Triggered ability {index}: {trigger_surface}");
             if let Some(condition) = intervening_condition {
                 line.push_str(", if ");

--- a/crates/ironsmith-runtime/src/effects/permanents/crew.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/crew.rs
@@ -92,7 +92,10 @@ fn crew_power_bonus_from_marker(marker: &str) -> Option<i32> {
 fn crew_value(game: &GameState, object_id: ObjectId) -> i32 {
     let markers = keyword_marker_texts(game, object_id);
     let use_toughness = markers.iter().any(|marker| {
-        marker == "this creature crews vehicles using its toughness rather than its power."
+        let marker = marker.trim_end_matches('.');
+        marker == "this creature crews vehicles using its toughness rather than its power"
+            || marker
+                == "this creature saddles mounts and crews vehicles using its toughness rather than its power"
     });
     let base = if use_toughness {
         object_toughness(game, object_id)

--- a/crates/ironsmith-runtime/src/effects/permanents/saddle.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/saddle.rs
@@ -64,6 +64,13 @@ impl SaddleCostEffect {
             .unwrap_or(0)
     }
 
+    fn object_toughness(game: &GameState, object_id: ObjectId) -> i32 {
+        game.calculated_characteristics(object_id)
+            .and_then(|calc| calc.toughness)
+            .or_else(|| game.object(object_id).and_then(|obj| obj.toughness()))
+            .unwrap_or(0)
+    }
+
     fn keyword_marker_texts(game: &GameState, object_id: ObjectId) -> Vec<String> {
         let abilities = game.current_abilities(object_id).unwrap_or_else(|| {
             game.object(object_id)
@@ -97,8 +104,18 @@ impl SaddleCostEffect {
     }
 
     fn saddle_value(game: &GameState, object_id: ObjectId) -> i32 {
-        let base = Self::object_power(game, object_id);
-        let bonus: i32 = Self::keyword_marker_texts(game, object_id)
+        let markers = Self::keyword_marker_texts(game, object_id);
+        let use_toughness = markers.iter().any(|marker| {
+            let marker = marker.trim_end_matches('.');
+            marker
+                == "this creature saddles mounts and crews vehicles using its toughness rather than its power"
+        });
+        let base = if use_toughness {
+            Self::object_toughness(game, object_id)
+        } else {
+            Self::object_power(game, object_id)
+        };
+        let bonus: i32 = markers
             .iter()
             .filter_map(|marker| Self::saddle_power_bonus_from_marker(marker))
             .sum();
@@ -128,8 +145,8 @@ impl EffectExecutor for SaddleCostEffect {
         let min = if self.required_power == 0 { 0 } else { 1 };
         let max = Some(candidates.len());
         let chosen = {
-            // Prefer higher-power candidates in fallback selection.
-            candidates.sort_by_key(|id| -Self::object_power(game, *id));
+            // Prefer the actual saddle contribution, including marker-based modifications.
+            candidates.sort_by_key(|id| -Self::saddle_value(game, *id));
             let spec = ChooseObjectsSpec::new(
                 source,
                 "Choose other creatures to saddle",

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -988,6 +988,23 @@ fn tom_bombadil_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn interface_ace_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_925), "Interface Ace")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Robot, Subtype::Pilot])
+        .power_toughness(PowerToughness::fixed(0, 4))
+        .from_text_with_metadata(
+            "This creature saddles Mounts and crews Vehicles using its toughness rather than its power.\n\
+             Whenever this creature becomes tapped during your turn, untap it. This ability triggers only once each turn.",
+        )
+        .expect("Interface Ace should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn merfolk_cave_diver_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_930), "Merfolk Cave-Diver")
         .mana_cost(ManaCost::from_pips(vec![
@@ -39033,6 +39050,81 @@ fn tom_bombadil_strict_parser_and_compiled_text_regression() {
         triggered.intervening_if,
         Some(crate::ConditionExpr::MaxTimesEachTurn(1))
     ));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn interface_ace_tap_trigger_untaps_once_and_only_during_your_turn() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let ace_id =
+        game.create_object_from_definition(&interface_ace_definition(), alice, Zone::Battlefield);
+    game.turn.active_player = alice;
+
+    game.tap(ace_id);
+    let first_tap = TriggerEvent::new_with_provenance(
+        crate::events::PermanentTappedEvent::new(ace_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, first_tap, false);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Interface Ace should trigger when tapped during its controller's turn");
+    assert_eq!(game.stack.len(), 1, "first tap during your turn should trigger");
+    resolve_stack_entry(&mut game).expect("Interface Ace untap trigger should resolve");
+    assert!(
+        !game.is_tapped(ace_id),
+        "Interface Ace trigger should untap it after the first tap"
+    );
+
+    game.tap(ace_id);
+    let second_tap = TriggerEvent::new_with_provenance(
+        crate::events::PermanentTappedEvent::new(ace_id),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, second_tap, false);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("second same-turn Interface Ace tap should be processed cleanly");
+    assert!(
+        game.stack.is_empty(),
+        "Interface Ace should not trigger a second time in the same turn"
+    );
+    assert!(
+        game.is_tapped(ace_id),
+        "second same-turn tap should remain tapped because the once-per-turn trigger is capped"
+    );
+
+    let mut opponent_turn_game = setup_game();
+    let mut opponent_turn_queue = TriggerQueue::new();
+    let opponent_turn_ace = opponent_turn_game.create_object_from_definition(
+        &interface_ace_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    opponent_turn_game.turn.active_player = bob;
+    opponent_turn_game.tap(opponent_turn_ace);
+    let opponent_turn_tap = TriggerEvent::new_with_provenance(
+        crate::events::PermanentTappedEvent::new(opponent_turn_ace),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(
+        &mut opponent_turn_game,
+        &mut opponent_turn_queue,
+        opponent_turn_tap,
+        false,
+    );
+    put_triggers_on_stack(&mut opponent_turn_game, &mut opponent_turn_queue)
+        .expect("opponent-turn Interface Ace tap should be processed cleanly");
+    assert!(
+        opponent_turn_game.stack.is_empty(),
+        "Interface Ace should not trigger when tapped during an opponent's turn"
+    );
+    assert!(
+        opponent_turn_game.is_tapped(opponent_turn_ace),
+        "opponent-turn tap should stay tapped because the trigger condition is not met"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Interface Ace
Initial parse error:
```
parser does not yet support line family: 'This creature saddles Mounts and crews Vehicles using its toughness rather than its power.'; oracle-only fallback also failed: parser does not yet support line family: 'This creature saddles Mounts and crews Vehicles using its toughness rather than its power.'
```

Current worker: i-012465cd1eb8ab4bf
Branch: codex/aws-card-fix-interface-ace
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0027
