### PR TITLE
Fix Ironsmith parse failure: Infernal Kirin

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -44,6 +44,28 @@ fn wrap_unless_escaped(effect: EffectAst, unless_escaped: bool) -> EffectAst {
     }
 }
 
+fn parse_trailing_discard_same_mana_value_filter(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !word_slice_eq_any(
+        &words,
+        &[
+            &["with", "that", "spells", "mana", "value"],
+            &["with", "that", "spell's", "mana", "value"],
+            &["with", "the", "same", "mana", "value", "as", "that", "spell"],
+            &["with", "same", "mana", "value", "as", "that", "spell"],
+        ],
+    ) {
+        return None;
+    }
+
+    let mut filter = ObjectFilter::default();
+    filter.tagged_constraints.push(crate::target::TaggedObjectConstraint {
+        tag: crate::TagKey::from("triggering"),
+        relation: crate::target::TaggedOpbjectRelation::SameManaValueAsTagged,
+    });
+    Some(filter)
+}
+
 fn parse_unless_mana_spent_to_cast_predicate(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
     let [mana_token, rest @ ..] = tokens else {
         return None;
@@ -464,6 +486,8 @@ pub(crate) fn parse_discard(
             filter.name = Some("{chosen name}".to_string());
             Some(filter)
         } else if let Some(filter) = parse_discard_chosen_color_qualifier_filter(trailing_tokens) {
+            Some(filter)
+        } else if let Some(filter) = parse_trailing_discard_same_mana_value_filter(trailing_tokens) {
             Some(filter)
         } else if let Some(filter) = parse_discard_color_qualifier_filter(trailing_tokens) {
             Some(filter)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31678,6 +31678,39 @@ fn parse_dinrova_horror_strict_oracle_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_infernal_kirin_strict_oracle_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(74_377), "Infernal Kirin")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Kirin, Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Flying\nWhenever you cast a Spirit or Arcane spell, target player reveals their hand and discards all cards with that spell's mana value.",
+        )
+        .expect("Infernal Kirin should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+    assert!(rendered.contains("Flying"), "expected Flying, got {rendered}");
+    assert!(
+        rendered.contains(
+            "Whenever you cast a Spirit or Arcane spell, target player reveals their hand and discards all cards with that spell's mana value."
+        ),
+        "expected Infernal Kirin trigger text to preserve the mana-value discard clause, got {rendered}"
+    );
+    assert!(debug.contains("LookAtHandEffect"), "{debug}");
+    assert!(debug.contains("DiscardEffect"), "{debug}");
+    assert!(debug.contains("SameManaValueAsTagged"), "{debug}");
+    assert!(debug.contains("triggering"), "{debug}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_comma_then_return_source_to_hand_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Cyclopean Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6009,6 +6009,27 @@ pub(super) fn describe_discard_count(value: &Value, filter: Option<&ObjectFilter
         };
     }
 
+    if filter_is_only_same_mana_value_as_triggering_spell(filter) {
+        return match value {
+            Value::Fixed(1) => "a card with that spell's mana value".to_string(),
+            Value::Fixed(n) if *n >= 0 => {
+                let plural = "cards with that spell's mana value";
+                small_number_word(*n as u32)
+                    .map(|word| format!("{word} {plural}"))
+                    .unwrap_or_else(|| format!("{n} {plural}"))
+            }
+            Value::Count(count_filter)
+                if filter_is_only_same_mana_value_as_triggering_spell(count_filter) =>
+            {
+                "all cards with that spell's mana value".to_string()
+            }
+            _ => format!(
+                "{} cards with that spell's mana value",
+                describe_value(value)
+            ),
+        };
+    }
+
     if !filter.tagged_constraints.is_empty() {
         return match value {
             Value::Fixed(1) => "that card".to_string(),
@@ -6042,6 +6063,21 @@ pub(super) fn describe_discard_count(value: &Value, filter: Option<&ObjectFilter
             }
         }
     }
+}
+
+fn filter_is_only_same_mana_value_as_triggering_spell(filter: &ObjectFilter) -> bool {
+    let mut bare = filter.clone();
+    bare.zone = None;
+    bare.owner = None;
+    bare.controller = None;
+
+    let tagged_constraints_before = bare.tagged_constraints.len();
+    bare.tagged_constraints.retain(|constraint| {
+        !(constraint.tag.as_str() == "triggering"
+            && constraint.relation == crate::filter::TaggedOpbjectRelation::SameManaValueAsTagged)
+    });
+
+    tagged_constraints_before != bare.tagged_constraints.len() && bare == ObjectFilter::default()
 }
 
 pub(super) fn describe_discard_card_phrase(filter: &ObjectFilter) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4172,6 +4172,36 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         ))
     }
 
+    fn describe_reveal_hand_then_discard(effects: &[&Effect]) -> Option<String> {
+        let [look_effect, discard_effect] = effects else {
+            return None;
+        };
+        let look = look_effect.downcast_ref::<crate::effects::LookAtHandEffect>()?;
+        let discard = discard_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+        if !look.reveal || discard.random || discard.any_number {
+            return None;
+        }
+
+        let revealer = describe_choose_spec(&look.target);
+        if describe_player_filter(&discard.player) != revealer {
+            return None;
+        }
+
+        let reveal_verb = player_verb(&revealer, "reveal", "reveals");
+        let discard_verb = player_verb(&revealer, "discard", "discards");
+        let hand = if revealer == "you" {
+            "your hand"
+        } else {
+            "their hand"
+        };
+        Some(format!(
+            "{} {} {hand} and {discard_verb} {}",
+            capitalize_first(&revealer),
+            reveal_verb,
+            describe_discard_count(&discard.count, discard.card_filter.as_ref())
+        ))
+    }
+
     fn downcast_move_to_library_nth<'a>(
         effect: &'a Effect,
     ) -> Option<&'a crate::effects::MoveToLibraryNthFromTopEffect> {
@@ -4513,6 +4543,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         .collect::<Vec<_>>();
 
     if let Some(compact) = describe_reveal_hand_choose_move(&filtered) {
+        return compact;
+    }
+    if let Some(compact) = describe_reveal_hand_then_discard(&filtered) {
         return compact;
     }
     if let Some(compact) = describe_exile_graveyard_reflexive_copy_artifact(&filtered) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7619,6 +7619,226 @@ fn emrakul_cast_trigger_prompt_does_not_autofill_or_stack_before_choice() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn infernal_kirin_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_377), "Infernal Kirin")
+        .mana_cost(ManaCost::from_symbols(vec![
+            ManaSymbol::Generic(2),
+            ManaSymbol::Black,
+            ManaSymbol::Black,
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Kirin, Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Flying\nWhenever you cast a Spirit or Arcane spell, target player reveals their hand and discards all cards with that spell's mana value.",
+        )
+        .expect("Infernal Kirin should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn test_card_with_mana_value(
+    name: &str,
+    mana: Vec<ManaSymbol>,
+    card_types: Vec<CardType>,
+) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_symbols(mana))
+        .card_types(card_types)
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn infernal_kirin_discards_only_cards_matching_triggering_spell_mana_value() {
+    struct ChooseBobAndAllDiscardCards {
+        bob: PlayerId,
+        reveal_calls: Vec<(PlayerId, PlayerId, bool, Vec<ObjectId>)>,
+    }
+
+    impl DecisionMaker for ChooseBobAndAllDiscardCards {
+        fn decide_targets(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<Target> {
+            vec![Target::Player(self.bob)]
+        }
+
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .collect()
+        }
+
+        fn view_cards(
+            &mut self,
+            _game: &GameState,
+            viewer: PlayerId,
+            cards: &[ObjectId],
+            ctx: &crate::decisions::context::ViewCardsContext,
+        ) {
+            self.reveal_calls
+                .push((viewer, ctx.subject, ctx.public, cards.to_vec()));
+        }
+    }
+
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.create_object_from_definition(&infernal_kirin_definition(), alice, Zone::Battlefield);
+
+    let matching_one = game.create_object_from_card(
+        &test_card_with_mana_value(
+            "Bob Matching One",
+            vec![ManaSymbol::Generic(1), ManaSymbol::Blue],
+            vec![CardType::Instant],
+        ),
+        bob,
+        Zone::Hand,
+    );
+    let matching_two = game.create_object_from_card(
+        &test_card_with_mana_value(
+            "Bob Matching Two",
+            vec![ManaSymbol::Black, ManaSymbol::Black],
+            vec![CardType::Sorcery],
+        ),
+        bob,
+        Zone::Hand,
+    );
+    let nonmatching = game.create_object_from_card(
+        &test_card_with_mana_value(
+            "Bob Nonmatching",
+            vec![ManaSymbol::Generic(2), ManaSymbol::Green],
+            vec![CardType::Instant],
+        ),
+        bob,
+        Zone::Hand,
+    );
+    let alice_matching = game.create_object_from_card(
+        &test_card_with_mana_value(
+            "Alice Matching",
+            vec![ManaSymbol::Generic(1), ManaSymbol::Red],
+            vec![CardType::Instant],
+        ),
+        alice,
+        Zone::Hand,
+    );
+
+    let triggering_spell = CardBuilder::new(CardId::new(), "Triggering Spirit")
+        .mana_cost(ManaCost::from_symbols(vec![
+            ManaSymbol::Generic(1),
+            ManaSymbol::White,
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .build();
+    let spell_id = game.create_object_from_card(&triggering_spell, alice, Zone::Stack);
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Infernal Kirin should trigger from a Spirit spell"
+    );
+
+    let mut dm = ChooseBobAndAllDiscardCards {
+        bob,
+        reveal_calls: Vec::new(),
+    };
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Infernal Kirin trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Infernal Kirin trigger should resolve");
+
+    assert_eq!(
+        dm.reveal_calls.len(),
+        game.players.len(),
+        "revealing a hand should show it publicly to every player"
+    );
+    for (_viewer, subject, public, cards) in &dm.reveal_calls {
+        assert_eq!(*subject, bob);
+        assert!(*public, "Infernal Kirin should reveal the targeted player's hand");
+        assert!(cards.contains(&matching_one));
+        assert!(cards.contains(&matching_two));
+        assert!(cards.contains(&nonmatching));
+    }
+
+    let bob_hand = &game.player(bob).expect("bob exists").hand;
+    assert!(!bob_hand.contains(&matching_one));
+    assert!(!bob_hand.contains(&matching_two));
+    assert!(bob_hand.contains(&nonmatching));
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .contains(&alice_matching),
+        "Infernal Kirin should only discard from the targeted player's hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn infernal_kirin_triggers_for_arcane_spell() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    game.create_object_from_definition(&infernal_kirin_definition(), alice, Zone::Battlefield);
+
+    let arcane_spell = CardBuilder::new(CardId::new(), "Arcane Probe")
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Red]))
+        .card_types(vec![CardType::Instant])
+        .subtypes(vec![Subtype::Arcane])
+        .build();
+    let spell_id = game.create_object_from_card(&arcane_spell, alice, Zone::Stack);
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Infernal Kirin should trigger from an Arcane spell"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn infernal_kirin_does_not_trigger_for_non_spirit_non_arcane_spell() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    game.create_object_from_definition(&infernal_kirin_definition(), alice, Zone::Battlefield);
+
+    let ordinary_spell = CardBuilder::new(CardId::new(), "Ordinary Instant")
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Blue]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let spell_id = game.create_object_from_card(&ordinary_spell, alice, Zone::Stack);
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Infernal Kirin should not trigger from a spell that is neither Spirit nor Arcane"
+    );
+}
+
 #[test]
 fn put_triggers_on_stack_uses_controller_selected_order_for_simultaneous_triggers() {
     use crate::ability::TriggeredAbility;

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
@@ -245,6 +245,20 @@ fn indefinite_article_for(text: &str) -> &'static str {
     }
 }
 
+fn join_with_or(parts: &[String]) -> String {
+    match parts.len() {
+        0 => String::new(),
+        1 => parts[0].clone(),
+        2 => format!("{} or {}", parts[0], parts[1]),
+        _ => {
+            let mut text = parts[..parts.len() - 1].join(", ");
+            text.push_str(", or ");
+            text.push_str(parts.last().map(String::as_str).unwrap_or_default());
+            text
+        }
+    }
+}
+
 fn describe_spell_filter(filter: &ObjectFilter) -> String {
     if filter.targets_player.is_some() || filter.targets_object.is_some() {
         let mut base_filter = filter.clone();
@@ -357,6 +371,19 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
             .contains(&crate::types::CardType::Land)
     {
         return "a noncreature spell".to_string();
+    }
+    let mut subtype_only_spell_filter = ObjectFilter::default();
+    subtype_only_spell_filter.zone = Some(Zone::Stack);
+    subtype_only_spell_filter.subtypes = filter.subtypes.clone();
+    subtype_only_spell_filter.has_mana_cost = filter.has_mana_cost;
+    if !filter.subtypes.is_empty() && *filter == subtype_only_spell_filter {
+        let subtypes = filter
+            .subtypes
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let subtype_text = join_with_or(&subtypes);
+        return format!("{} {subtype_text} spell", indefinite_article_for(&subtype_text));
     }
 
     let fallback = filter.description();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Infernal Kirin
Initial parse error:
```
unsupported trailing discard clause (clause: 'all cards with that spell's mana value'); oracle-only fallback also failed: unsupported trailing discard clause (clause: 'all cards with that spell's mana value')
```

Current worker: i-071a92dfd12ebb254
Branch: codex/aws-card-fix-infernal-kirin
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0027
