### PR TITLE
Fix Ironsmith parse failure: Karn, Silver Golem

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -19,6 +19,23 @@ fn describe_value_for_mode(value: &Value) -> String {
     }
 }
 
+fn retarget_it_mana_value_to_spec(value: &Value, spec: &ChooseSpec) -> Value {
+    match value {
+        Value::SurfaceHinted { value, hints } => Value::SurfaceHinted {
+            value: Box::new(retarget_it_mana_value_to_spec(value, spec)),
+            hints: hints.clone(),
+        },
+        Value::ManaValueOf(target) => {
+            if matches!(target.as_ref(), ChooseSpec::Tagged(tag) if tag.as_str() == IT_TAG) {
+                Value::ManaValueOf(Box::new(spec.clone()))
+            } else {
+                value.clone()
+            }
+        }
+        _ => value.clone(),
+    }
+}
+
 fn resolve_tagged_top_library_condition(
     condition: &crate::ConditionExpr,
     ctx: &EffectLoweringContext,
@@ -2569,14 +2586,16 @@ fn compile_subject_verb_effect(
             let granted_modifications =
                 lower_granted_ability_grant_modifications(granted_abilities)?;
             compile_tagged_effect_for_target(target, ctx, "animated_creature", |spec| {
+                let power = retarget_it_mana_value_to_spec(power, &spec);
+                let toughness = retarget_it_mana_value_to_spec(toughness, &spec);
                 let mut apply = crate::effects::ApplyContinuousEffect::with_spec(
                     spec,
                     crate::continuous::Modification::AddCardTypes(card_types.clone()),
                     duration.clone(),
                 )
                 .with_additional_modification(crate::continuous::Modification::SetPowerToughness {
-                    power: power.clone(),
-                    toughness: toughness.clone(),
+                    power,
+                    toughness,
                     sublayer: crate::continuous::PtSublayer::Setting,
                 })
                 .resolve_set_pt_values_at_resolution();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/helpers.rs
@@ -171,6 +171,28 @@ pub(super) fn parse_become_base_pt_tail<'a>(
         return Ok(None);
     };
     let tail = &become_words[with_idx + 1..];
+    let tagged_object_mana_value = || {
+        Value::ManaValueOf(Box::new(crate::target::ChooseSpec::Tagged(
+            TagKey::from(crate::host::IT_TAG),
+        )))
+    };
+    if tail == ["power", "and", "toughness", "each", "equal", "to", "its", "mana", "value"]
+        || tail == [
+            "base",
+            "power",
+            "and",
+            "toughness",
+            "each",
+            "equal",
+            "to",
+            "its",
+            "mana",
+            "value",
+        ]
+    {
+        let value = tagged_object_mana_value();
+        return Ok(Some((&become_words[..with_idx], value.clone(), value)));
+    }
     if tail.len() != 5
         || !crate::runtime_backend::lexer::word_slice_eq(
             &tail[..4],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -21755,6 +21755,38 @@ fn parse_loses_all_abilities_and_becomes_static_fails_instead_of_partial_parse()
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_karn_silver_golem_mana_value_animation_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(21287), "Karn, Silver Golem")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Golem])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Whenever Karn blocks or becomes blocked, it gets -4/+4 until end of turn.\n\
+             {1}: Target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value until end of turn.",
+        )
+        .expect("Karn, Silver Golem should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains(
+            "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value until end of turn"
+        ),
+        "expected Karn's mana-value animation clause in compiled text, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("AddCardTypes")
+            && debug.contains("SetPowerToughness")
+            && debug.contains("ManaValueOf"),
+        "expected structural artifact-creature animation using target mana value, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_each_player_exile_sacrifice_return_this_way_fails_instead_of_partial_parse() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Living Death Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9106,6 +9106,22 @@ fn plural_non_target_land_animation_target(
     Some(format!("all {}", pluralize_noun_phrase(rest)))
 }
 
+fn value_is_mana_value(value: &Value) -> bool {
+    match value {
+        Value::SurfaceHinted { value, .. } => value_is_mana_value(value),
+        Value::ManaValueOf(_) => true,
+        _ => false,
+    }
+}
+
+fn value_is_target_mana_value(value: &Value) -> bool {
+    match value {
+        Value::SurfaceHinted { value, .. } => value_is_target_mana_value(value),
+        Value::ManaValueOf(spec) => matches!(spec.as_ref(), ChooseSpec::Target(_)),
+        _ => false,
+    }
+}
+
 pub(super) fn describe_apply_continuous_animation_effect(
     effect: &crate::effects::ApplyContinuousEffect,
     target: &str,
@@ -9211,28 +9227,56 @@ pub(super) fn describe_apply_continuous_animation_effect(
     } else {
         false
     };
+    let mana_value_equal_pt = if let (Some(power), Some(toughness)) = (power, toughness) {
+        power == toughness && value_is_mana_value(power)
+    } else {
+        false
+    };
     let pt_where_clause = if let (Some(power), _) = (power, toughness) {
-        (dynamic_equal_pt && !matches!(power, Value::X)).then(|| describe_value(power))
+        (dynamic_equal_pt && !mana_value_equal_pt && !matches!(power, Value::X))
+            .then(|| describe_value(power))
     } else {
         None
     };
 
     let mut text = if let (Some(power), Some(toughness)) = (power, toughness) {
-        let pt = if dynamic_equal_pt {
-            "X/X".to_string()
+        if mana_value_equal_pt {
+            let value_text = if value_is_target_mana_value(power) && !plural_target {
+                "its mana value".to_string()
+            } else {
+                describe_value(power)
+            };
+            let pt_noun_phrase = format!(
+                "{noun_phrase} with power and toughness each equal to {}",
+                value_text
+            );
+            if returned_permanent_animation {
+                format!("{target_text} are {pt_noun_phrase}")
+            } else if plural_target {
+                format!("{target_text} become {pt_noun_phrase}")
+            } else {
+                format!(
+                    "{target_text} becomes {}",
+                    with_indefinite_article(&pt_noun_phrase)
+                )
+            }
         } else {
-            format!("{}/{}", describe_value(power), describe_value(toughness))
-        };
-        let pt_noun_phrase = format!("{pt} {noun_phrase}");
-        if returned_permanent_animation {
-            format!("{target_text} are {pt_noun_phrase}")
-        } else if plural_target {
-            format!("{target_text} become {pt_noun_phrase}")
-        } else {
-            format!(
-                "{target_text} becomes {}",
-                with_indefinite_article(&pt_noun_phrase)
-            )
+            let pt = if dynamic_equal_pt {
+                "X/X".to_string()
+            } else {
+                format!("{}/{}", describe_value(power), describe_value(toughness))
+            };
+            let pt_noun_phrase = format!("{pt} {noun_phrase}");
+            if returned_permanent_animation {
+                format!("{target_text} are {pt_noun_phrase}")
+            } else if plural_target {
+                format!("{target_text} become {pt_noun_phrase}")
+            } else {
+                format!(
+                    "{target_text} becomes {}",
+                    with_indefinite_article(&pt_noun_phrase)
+                )
+            }
         }
     } else if power.is_none() && toughness.is_none() {
         if plural_target {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1291,6 +1291,234 @@ fn vastwood_animist_activation_animates_only_your_land_using_ally_count_until_en
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn karn_silver_golem_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(21_287), "Karn, Silver Golem")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Golem])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Whenever Karn blocks or becomes blocked, it gets -4/+4 until end of turn.\n\
+             {1}: Target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value until end of turn.",
+        )
+        .expect("Karn, Silver Golem should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_artifact_with_mana_value(
+    game: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+    mana_value: u8,
+    creature: bool,
+) -> ObjectId {
+    let mut builder = CardBuilder::new(CardId::new(), name).mana_cost(ManaCost::from_pips(vec![
+        vec![ManaSymbol::Generic(mana_value)],
+    ]));
+    builder = if creature {
+        builder
+            .card_types(vec![CardType::Artifact, CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+    } else {
+        builder.card_types(vec![CardType::Artifact])
+    };
+    let card = builder.build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn karn_silver_golem_activation_animates_noncreature_artifact_by_mana_value_until_cleanup() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let karn_def = karn_silver_golem_definition();
+    let karn_id = game.create_object_from_definition(&karn_def, alice, Zone::Battlefield);
+    let artifact_creature = create_artifact_with_mana_value(
+        &mut game,
+        "Artifact Creature Target Probe",
+        alice,
+        2,
+        true,
+    );
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. }
+                    if source == karn_id
+            )),
+        "Karn should not be activatable while only artifact creatures are available as targets"
+    );
+    assert!(game.current_is_creature(artifact_creature));
+
+    let target_id =
+        create_artifact_with_mana_value(&mut game, "Karn Animation Target", alice, 3, false);
+    assert!(!game.current_is_creature(target_id));
+    assert_eq!(game.current_power(target_id), None);
+
+    let ability_index = game
+        .object(karn_id)
+        .expect("Karn should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Karn should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == karn_id && *idx == ability_index
+            )
+        })
+        .expect("Karn activation should be legal with a noncreature artifact target and mana");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Karn activation should start and pay the generic cost");
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Karn activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("choosing a noncreature artifact should complete Karn activation");
+    assert_eq!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .mana_pool
+            .total(),
+        0,
+        "Karn activation should spend one generic mana"
+    );
+
+    resolve_stack_entry(&mut game).expect("Karn activation should resolve");
+    assert!(game.current_is_creature(target_id));
+    assert!(
+        game.current_card_types(target_id).is_some_and(|types| {
+            types.contains(&CardType::Artifact) && types.contains(&CardType::Creature)
+        }),
+        "animated target should be both artifact and creature"
+    );
+    assert_eq!(game.calculated_power(target_id), Some(3));
+    assert_eq!(game.calculated_toughness(target_id), Some(3));
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+
+    assert!(!game.current_is_creature(target_id));
+    assert_eq!(game.current_power(target_id), None);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_karn_block_trigger(
+    game: &mut GameState,
+    combat: &mut CombatState,
+    declarations: &[BlockerDeclaration],
+    defending_player: PlayerId,
+) {
+    let mut trigger_queue = TriggerQueue::new();
+    apply_blocker_declarations(game, combat, &mut trigger_queue, declarations, defending_player)
+        .expect("Karn block declaration should be legal");
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Karn should trigger exactly once for this block event"
+    );
+    put_triggers_on_stack(game, &mut trigger_queue).expect("Karn block trigger should go on stack");
+    resolve_stack_entry(game).expect("Karn block trigger should resolve");
+    game.refresh_continuous_state();
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn karn_silver_golem_trigger_applies_when_it_becomes_blocked() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let karn_def = karn_silver_golem_definition();
+    let karn_id = game.create_object_from_definition(&karn_def, alice, Zone::Battlefield);
+    let blocker = create_creature(&mut game, "Karn Blocker", bob, 2, 2);
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: karn_id,
+        target: AttackTarget::Player(bob),
+    });
+
+    resolve_karn_block_trigger(
+        &mut game,
+        &mut combat,
+        &[BlockerDeclaration {
+            blocker,
+            blocking: karn_id,
+        }],
+        bob,
+    );
+
+    assert_eq!(game.calculated_power(karn_id), Some(0));
+    assert_eq!(game.calculated_toughness(karn_id), Some(8));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn karn_silver_golem_trigger_applies_when_it_blocks() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let karn_def = karn_silver_golem_definition();
+    let karn_id = game.create_object_from_definition(&karn_def, alice, Zone::Battlefield);
+    let attacker = create_creature(&mut game, "Attacker Into Karn", bob, 2, 2);
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: AttackTarget::Player(alice),
+    });
+
+    resolve_karn_block_trigger(
+        &mut game,
+        &mut combat,
+        &[BlockerDeclaration {
+            blocker: karn_id,
+            blocking: attacker,
+        }],
+        alice,
+    );
+
+    assert_eq!(game.calculated_power(karn_id), Some(0));
+    assert_eq!(game.calculated_toughness(karn_id), Some(8));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn cho_arrim_alchemist_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(19647), "Cho-Arrim Alchemist")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Karn, Silver Golem
Initial parse error:
```
unsupported become clause (clause: 'an artifact creature with power and toughness each equal to its mana value until end of turn'); oracle-only fallback also failed: unsupported become clause (clause: 'an artifact creature with power and toughness each equal to its mana value until end of turn')
```

Current worker: i-0d972f4ac5b2e77fb
Branch: codex/aws-card-fix-karn-silver-golem
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0027
