### PR TITLE
Fix Ironsmith parse failure: Necromantic Summons

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -78,6 +78,18 @@ pub(crate) const IF_ENTERS_WITH_ADDITIONAL_COUNTER_PATTERN_ATOMS: &[LexPatternAt
         LexCaptureKind::OneOrMoreWords,
     ),
 ];
+const TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PREFIXES: &[&[&str]] = &[
+    &["that", "card", "enters", "with"],
+    &["that", "creature", "enters", "with"],
+    &["that", "object", "enters", "with"],
+    &["that", "permanent", "enters", "with"],
+    &["it", "enters", "with"],
+];
+pub(crate) const TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PATTERN_ATOMS: &[LexPatternAtom<'static>] =
+    &[
+        LexPattern::any_phrase(TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PREFIXES),
+        LexPattern::role_capture("counter", LexCaptureRole::Amount, LexCaptureKind::Rest),
+    ];
 pub(crate) const PUT_ONTO_BATTLEFIELD_WITH_ADDITIONAL_COUNTERS_PATTERN_ATOMS: &[LexPatternAtom<
     'static,
 >] = &[
@@ -1181,6 +1193,40 @@ pub(crate) fn parse_if_enters_with_additional_counter_sentence_matched(
         predicate: IfResultPredicate::Did,
         effects: vec![apply_only_if_creature],
     }]))
+}
+
+pub(crate) fn parse_tagged_enters_with_additional_counter_sentence(
+    clause: SubjectVerbPrimitiveClause<'_>,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let pattern = LexPattern::new(TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PATTERN_ATOMS);
+    let Some(matched) = clause.match_pattern(pattern) else {
+        return Ok(None);
+    };
+    parse_tagged_enters_with_additional_counter_sentence_matched(clause, &matched)
+}
+
+pub(crate) fn parse_tagged_enters_with_additional_counter_sentence_matched(
+    clause: SubjectVerbPrimitiveClause<'_>,
+    _matched: &LexPatternMatch<'_>,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some((_, counter_clause)) =
+        clause.strip_any_prefix_clause(TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PREFIXES)
+    else {
+        return Ok(None);
+    };
+    let Some((count, counter_type)) =
+        parse_additional_counter_descriptor_on_target(counter_clause, &[&["it"]])?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(vec![EffectAst::subject_verb_put_counters(
+        counter_type,
+        Value::Fixed(count as i32),
+        TargetAst::Tagged(TagKey::from(IT_TAG), clause.span()),
+        None,
+        false,
+    )]))
 }
 
 pub(crate) fn parse_put_onto_battlefield_with_additional_counters_sentence(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/mechanic_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/mechanic_marker_family.rs
@@ -301,6 +301,18 @@ pub(crate) const PRE_CONDITIONAL_SUBJECT_VERB_PRIMITIVES: &[SubjectVerbPrimitive
         parse_if_enters_with_additional_counter_sentence,
         parse_if_enters_with_additional_counter_sentence_matched
     ),
+    primitive_with_pattern_parser!(
+        "tagged-enters-with-additional-counter",
+        52,
+        PreDiagnostic,
+        &[
+            LexRuleHeadHint::Single("it"),
+            LexRuleHeadHint::Single("that"),
+        ],
+        TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PATTERN_ATOMS,
+        parse_tagged_enters_with_additional_counter_sentence,
+        parse_tagged_enters_with_additional_counter_sentence_matched
+    ),
     primitive_with_pattern!(
         "if-any-tagged-cards-share-card-type-with-triggering-spell",
         55,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45355,6 +45355,88 @@ fn parse_rise_from_the_grave_color_and_subtype_followup_sentence() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_necromantic_summons_spell_mastery_counter_followup() {
+    let def = parse_oracle_card_definition("Necromantic Summons");
+    assert!(
+        def.card.card_types.contains(&CardType::Sorcery),
+        "Necromantic Summons should parse as a sorcery"
+    );
+
+    let spell_effect = def.spell_effect.as_ref().expect("expected spell effect");
+    assert_eq!(
+        spell_effect.segments.len(),
+        2,
+        "expected reanimation effect plus spell-mastery follow-up"
+    );
+    let move_effects = &spell_effect.segments[0].default_effects;
+    assert_eq!(move_effects.len(), 1);
+    let moved = move_effects[0]
+        .downcast_ref::<TaggedEffect>()
+        .expect("returned creature should be tagged");
+    let move_to_battlefield = moved
+        .effect
+        .downcast_ref::<MoveToZoneEffect>()
+        .expect("first effect should return a creature card");
+    assert_eq!(move_to_battlefield.zone, Zone::Battlefield);
+    match move_to_battlefield.target.base() {
+        ChooseSpec::Object(filter) => {
+            assert_eq!(filter.zone, Some(Zone::Graveyard));
+            assert!(filter.card_types.contains(&CardType::Creature));
+        }
+        other => panic!(
+            "Necromantic Summons should target a creature card in a graveyard, got {other:?}"
+        ),
+    }
+
+    assert_eq!(spell_effect.segments[1].default_effects.len(), 1);
+    let conditional = spell_effect.segments[1].default_effects[0]
+        .downcast_ref::<crate::effects::ConditionalEffect>()
+        .expect("spell mastery should lower to a conditional counter effect");
+    match &conditional.condition {
+        crate::effect::Condition::ValueComparison {
+            left: crate::effect::Value::Count(filter),
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: crate::effect::Value::Fixed(2),
+        } => {
+            assert_eq!(filter.zone, Some(Zone::Graveyard));
+            assert_eq!(filter.owner, Some(PlayerFilter::You));
+            assert_eq!(filter.card_types, vec![CardType::Instant, CardType::Sorcery]);
+        }
+        other => panic!("expected spell mastery graveyard count condition, got {other:?}"),
+    }
+    assert!(
+        conditional.if_false.is_empty(),
+        "spell mastery should have no false branch"
+    );
+    assert_eq!(conditional.if_true.len(), 1);
+    let put_counters = conditional.if_true[0]
+        .downcast_ref::<TaggedEffect>()
+        .and_then(|tagged| tagged.effect.downcast_ref::<crate::effects::PutCountersEffect>())
+        .expect("spell mastery condition should put counters on the returned creature");
+    assert_eq!(
+        put_counters.counter_type,
+        crate::object::CounterType::PlusOnePlusOne
+    );
+    assert_eq!(put_counters.amount, crate::effect::Value::Fixed(2));
+    assert!(matches!(
+        &put_counters.target,
+        ChooseSpec::Tagged(tag) if tag == &moved.tag
+    ));
+
+    let expected_compiled = concat!(
+        "Put target creature card from a graveyard onto the battlefield under your control. ",
+        "Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, ",
+        "that creature enters with two additional +1/+1 counters on it."
+    );
+    assert_eq!(
+        crate::compiled_text::compiled_text_lines(&def),
+        vec![expected_compiled.to_string()],
+        "compiled text should preserve reanimation plus spell mastery counter clause"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_ghost_vacuum_base_pt_and_subtype_followup_sentence() {
     CardDefinitionBuilder::new(CardId::new(), "Ghost Vacuum Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -346,6 +346,10 @@ fn join_english_list(items: &[String]) -> String {
 pub(super) fn describe_resolution_program(
     program: &crate::resolution::ResolutionProgram,
 ) -> String {
+    if let Some(rendered) = describe_spell_mastery_reanimation_program(program) {
+        return rendered;
+    }
+
     let mut rendered_segments = Vec::new();
     for segment in &program.segments {
         if segment.self_replacements.len() == 1 {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -177,6 +177,114 @@ pub fn compile_effect_list(effects: &[Effect]) -> String {
     normalize_compile_effect_list_surface(&describe_effect_list(effects))
 }
 
+pub(super) fn describe_spell_mastery_reanimation_program(
+    program: &crate::resolution::ResolutionProgram,
+) -> Option<String> {
+    if program
+        .segments
+        .iter()
+        .any(|segment| !segment.self_replacements.is_empty())
+    {
+        return None;
+    }
+    let effects = program
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .collect::<Vec<_>>();
+    describe_spell_mastery_reanimation_effects(&effects)
+}
+
+fn unwrap_basic_tag_wrappers(effect: &Effect) -> &Effect {
+    if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        return unwrap_basic_tag_wrappers(&tag_all.effect);
+    }
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return unwrap_basic_tag_wrappers(&tagged.effect);
+    }
+    effect
+}
+
+fn direct_wrapped_effect_tag(effect: &Effect) -> Option<&crate::TagKey> {
+    effect
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .map(|tagged| &tagged.tag)
+}
+
+fn describe_spell_mastery_reanimation_effects(effects: &[&Effect]) -> Option<String> {
+    let [move_effect, conditional_effect] = effects else {
+        return None;
+    };
+
+    let move_tag = direct_wrapped_effect_tag(move_effect)?;
+    let move_to_zone = unwrap_basic_tag_wrappers(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Battlefield
+        || move_to_zone.battlefield_controller != crate::effects::BattlefieldController::You
+        || move_to_zone.enters_tapped
+    {
+        return None;
+    }
+    let target_filter = match move_to_zone.target.base() {
+        ChooseSpec::Object(filter) => filter,
+        ChooseSpec::WithCount(inner, count) if count.is_single() => {
+            let ChooseSpec::Object(filter) = inner.base() else {
+                return None;
+            };
+            filter
+        }
+        _ => return None,
+    };
+    if target_filter.zone != Some(Zone::Graveyard)
+        || !target_filter.card_types.contains(&CardType::Creature)
+    {
+        return None;
+    }
+
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+        return None;
+    }
+    let Condition::ValueComparison {
+        left: Value::Count(condition_filter),
+        operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+        right: Value::Fixed(2),
+    } = &conditional.condition
+    else {
+        return None;
+    };
+    if condition_filter.zone != Some(Zone::Graveyard)
+        || condition_filter.owner != Some(PlayerFilter::You)
+        || condition_filter.card_types != vec![CardType::Instant, CardType::Sorcery]
+    {
+        return None;
+    }
+
+    let put_counters = unwrap_basic_tag_wrappers(&conditional.if_true[0])
+        .downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put_counters.distributed
+        || put_counters.target_count.is_some()
+        || !matches!(&put_counters.target, ChooseSpec::Tagged(tag) if tag == move_tag)
+    {
+        return None;
+    }
+
+    let move_text = describe_effect(move_effect).replace(" in a graveyard", " from a graveyard");
+    let counter_type = describe_counter_type(put_counters.counter_type);
+    let counter_suffix = match &put_counters.amount {
+        Value::Fixed(1) => format!("an additional {counter_type} counter"),
+        Value::Fixed(amount) => {
+            let count_text = number_word(*amount).unwrap_or_else(|| amount.to_string());
+            format!("{count_text} additional {counter_type} counters")
+        }
+        _ => return None,
+    };
+    Some(format!(
+        "{move_text}. Spell mastery — If there are two or more instant and/or sorcery cards in \
+         your graveyard, that creature enters with {counter_suffix} on it"
+    ))
+}
+
 fn normalize_compile_effect_list_surface(line: &str) -> String {
     let lower = line.to_ascii_lowercase();
     if lower
@@ -5411,6 +5519,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_sacrifice_source_then_return_with_counters(&visible_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_spell_mastery_reanimation_effects(&visible_effects) {
         return compact;
     }
     if let Some(compact) = describe_choose_then_put_counter_on_each(&visible_effects) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1018,6 +1018,21 @@ fn rise_from_the_grave_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn necromantic_summons_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_945), "Necromantic Summons")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Put target creature card from a graveyard onto the battlefield under your control.\n\
+             Spell mastery — If there are two or more instant and/or sorcery cards in your graveyard, that creature enters with two additional +1/+1 counters on it.",
+        )
+        .expect("Necromantic Summons should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn keeper_of_the_flame_activation_requires_higher_life_opponent_and_damages_that_player() {
     let mut game = setup_game();
@@ -2456,6 +2471,135 @@ fn rise_from_the_grave_targets_only_creature_cards_in_graveyards() {
         requirements.len(),
         1,
         "Rise should have one target requirement"
+    );
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(graveyard_creature)),
+        "creature cards in graveyards should be legal targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(graveyard_artifact)),
+        "noncreature cards in graveyards should not be legal targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(battlefield_creature)),
+        "battlefield creatures should not be legal targets, got {legal_targets:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necromantic_summons_returns_creature_without_counters_below_spell_mastery() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let spell = necromantic_summons_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    let target_card = CardBuilder::new(CardId::from_raw(72_946), "Graveyard Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_card(&target_card, bob, Zone::Graveyard);
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
+
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice).with_targets(vec![Target::Object(target_id)]),
+    );
+    resolve_stack_entry(&mut game).expect("Necromantic Summons should resolve");
+
+    let returned_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("returned creature should still exist");
+    let returned = game.object(returned_id).expect("returned creature exists");
+    assert_eq!(returned.zone, Zone::Battlefield);
+    assert_eq!(game.controller_of(returned), alice);
+    assert_eq!(
+        returned
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "without spell mastery the returned creature should not get +1/+1 counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necromantic_summons_spell_mastery_returns_creature_with_two_counters() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let spell = necromantic_summons_definition();
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    for (idx, card_type) in [CardType::Instant, CardType::Sorcery].into_iter().enumerate() {
+        let card = CardBuilder::new(CardId::from_raw(72_947 + idx as u32), "Spell Mastery Fuel")
+            .card_types(vec![card_type])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Graveyard);
+    }
+    let target_card = CardBuilder::new(CardId::from_raw(72_949), "Mastered Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_card(&target_card, bob, Zone::Graveyard);
+    let target_stable = game.object(target_id).expect("target exists").stable_id;
+
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice).with_targets(vec![Target::Object(target_id)]),
+    );
+    resolve_stack_entry(&mut game).expect("Necromantic Summons should resolve");
+
+    let returned_id = game
+        .find_object_by_stable_id(target_stable)
+        .expect("returned creature should still exist");
+    let returned = game.object(returned_id).expect("returned creature exists");
+    assert_eq!(returned.zone, Zone::Battlefield);
+    assert_eq!(game.controller_of(returned), alice);
+    assert_eq!(
+        returned
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or(0),
+        2,
+        "with spell mastery the returned creature should get two +1/+1 counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necromantic_summons_targets_only_creature_cards_in_graveyards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell = necromantic_summons_definition();
+    let effects = spell.spell_effect.as_ref().expect("expected spell effects");
+
+    let graveyard_creature = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(72_950), "Graveyard Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Graveyard,
+    );
+    let graveyard_artifact = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(72_951), "Graveyard Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Graveyard,
+    );
+    let battlefield_creature = create_creature(&mut game, "Battlefield Creature", bob, 2, 2);
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(
+        requirements.len(),
+        1,
+        "Necromantic Summons should have one target requirement"
     );
     let legal_targets = &requirements[0].legal_targets;
     assert!(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Necromantic Summons
Initial parse error:
```
could not find verb in effect clause (clause: 'that creature enters with two additional +1/+1 counters on it'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'that creature enters with two additional +1/+1 counters on it'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-03c1aaa3a5b952ddc
Branch: codex/aws-card-fix-necromantic-summons
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0028
