### PR TITLE
Fix Ironsmith parse failure: Brain in a Jar

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1440,6 +1440,115 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         })
     }
 
+    fn parse_cast_with_prefixed_mana_value_limit(
+        rest_tokens: &[OwnedLexToken],
+        normalized_words: &[String],
+        player: PlayerAst,
+        from_idx: usize,
+        parse_simple_spell_type_list_filter: fn(&[OwnedLexToken]) -> Option<ObjectFilter>,
+    ) -> Result<Option<EffectAst>, CardTextError> {
+        let Some(without_idx) = normalized_words
+            .iter()
+            .position(|word| word.as_str() == "without")
+        else {
+            return Ok(None);
+        };
+        if from_idx + 3 != without_idx
+            || !normalized_words
+                .get(from_idx + 1)
+                .is_some_and(|word| word == "your")
+            || !normalized_words
+                .get(from_idx + 2)
+                .is_some_and(|word| matches!(word.as_str(), "graveyard" | "hand"))
+        {
+            return Ok(None);
+        }
+
+        let without_tail = normalized_words[without_idx..]
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if !word_slice_eq(&without_tail, &["without", "paying", "its", "mana", "cost"]) {
+            return Ok(None);
+        }
+
+        let Some(with_idx) = normalized_words[..from_idx]
+            .windows(3)
+            .position(|window| window == ["with", "mana", "value"])
+        else {
+            return Ok(None);
+        };
+        if with_idx == 0 {
+            return Ok(None);
+        }
+
+        let Some(comparison_tokens_start) = token_index_for_word_index(rest_tokens, with_idx + 3)
+        else {
+            return Ok(None);
+        };
+        let Some(comparison_tokens_end) = token_index_for_word_index(rest_tokens, from_idx) else {
+            return Ok(None);
+        };
+        let comparison_tokens = &rest_tokens[comparison_tokens_start..comparison_tokens_end];
+        let Some((operator, rhs_tokens)) = parse_value_comparison_tokens(comparison_tokens) else {
+            return Ok(None);
+        };
+
+        let Some(filter_end) = token_index_for_word_index(rest_tokens, with_idx) else {
+            return Ok(None);
+        };
+        let filter_tokens = trim_lexed_commas(&rest_tokens[..filter_end]);
+        let Some(mut filter) = parse_simple_spell_type_list_filter(filter_tokens)
+            .or(parse_permission_subject_filter_tokens_lexed(filter_tokens)?)
+        else {
+            return Ok(None);
+        };
+        filter.owner = Some(crate::target::PlayerFilter::You);
+
+        let Some((rhs_value, used)) = parse_value_from_lexed(rhs_tokens) else {
+            return Ok(None);
+        };
+        if used != rhs_tokens.len() {
+            return Ok(None);
+        }
+        if let (ValueComparisonOperator::Equal, Value::CountersOnSource(counter_type)) =
+            (&operator, &rhs_value)
+        {
+            filter.mana_value_eq_counters_on_source = Some(*counter_type);
+        } else {
+            filter.mana_value = Some(match operator {
+                ValueComparisonOperator::Equal => {
+                    crate::filter::Comparison::EqualExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::NotEqual => {
+                    crate::filter::Comparison::NotEqualExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::LessThan => {
+                    crate::filter::Comparison::LessThanExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::LessThanOrEqual => {
+                    crate::filter::Comparison::LessThanOrEqualExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::GreaterThan => {
+                    crate::filter::Comparison::GreaterThanExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::GreaterThanOrEqual => {
+                    crate::filter::Comparison::GreaterThanOrEqualExpr(Box::new(rhs_value))
+                }
+            });
+        }
+
+        let zone = if normalized_words[from_idx + 2] == "hand" {
+            Zone::Hand
+        } else {
+            Zone::Graveyard
+        };
+
+        Ok(Some(
+            EffectAst::may_cast_matching_spell_without_paying_mana_cost(player, filter, zone),
+        ))
+    }
+
     let Some((lead, rest_tokens)) = parse_permission_lead_tokens(tokens) else {
         return Ok(None);
     };
@@ -1463,6 +1572,16 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
     };
     if from_idx == 0 {
         return Ok(None);
+    }
+
+    if let Some(effect) = parse_cast_with_prefixed_mana_value_limit(
+        rest_tokens,
+        &normalized_words,
+        lead.player,
+        from_idx,
+        parse_simple_spell_type_list_filter,
+    )? {
+        return Ok(Some(effect));
     }
 
     let normalized_tail = &normalized_words[from_idx..];
@@ -1543,26 +1662,32 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         if used != rhs_tokens.len() {
             return Ok(None);
         }
-        filter.mana_value = Some(match operator {
-            ValueComparisonOperator::Equal => {
-                crate::filter::Comparison::EqualExpr(Box::new(rhs_value))
-            }
-            ValueComparisonOperator::NotEqual => {
-                crate::filter::Comparison::NotEqualExpr(Box::new(rhs_value))
-            }
-            ValueComparisonOperator::LessThan => {
-                crate::filter::Comparison::LessThanExpr(Box::new(rhs_value))
-            }
-            ValueComparisonOperator::LessThanOrEqual => {
-                crate::filter::Comparison::LessThanOrEqualExpr(Box::new(rhs_value))
-            }
-            ValueComparisonOperator::GreaterThan => {
-                crate::filter::Comparison::GreaterThanExpr(Box::new(rhs_value))
-            }
-            ValueComparisonOperator::GreaterThanOrEqual => {
-                crate::filter::Comparison::GreaterThanOrEqualExpr(Box::new(rhs_value))
-            }
-        });
+        if let (ValueComparisonOperator::Equal, Value::CountersOnSource(counter_type)) =
+            (&operator, &rhs_value)
+        {
+            filter.mana_value_eq_counters_on_source = Some(*counter_type);
+        } else {
+            filter.mana_value = Some(match operator {
+                ValueComparisonOperator::Equal => {
+                    crate::filter::Comparison::EqualExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::NotEqual => {
+                    crate::filter::Comparison::NotEqualExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::LessThan => {
+                    crate::filter::Comparison::LessThanExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::LessThanOrEqual => {
+                    crate::filter::Comparison::LessThanOrEqualExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::GreaterThan => {
+                    crate::filter::Comparison::GreaterThanExpr(Box::new(rhs_value))
+                }
+                ValueComparisonOperator::GreaterThanOrEqual => {
+                    crate::filter::Comparison::GreaterThanOrEqualExpr(Box::new(rhs_value))
+                }
+            });
+        }
     }
 
     let zone = if normalized_tail[2] == "hand" {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4759,6 +4759,35 @@ fn rewrite_lexed_parse_glamdring_trigger_clause_with_damage_value_gate() {
 }
 
 #[test]
+fn rewrite_lexed_parse_brain_in_a_jar_free_cast_clause_with_counter_value_gate() {
+    let tokens = lex_line(
+        "Cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify Brain in a Jar cast clause");
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("Brain in a Jar cast clause should parse as a supported effect");
+
+    let (filter, zone) = match effects.as_slice() {
+        [crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+            filter,
+            zone,
+            ..
+        }] => (filter, zone),
+        _ => panic!("expected one-shot counter-gated hand free-cast effect, got {effects:#?}"),
+    };
+
+    assert_eq!(*zone, crate::zone::Zone::Hand);
+    assert!(filter.card_types.contains(&crate::types::CardType::Instant));
+    assert!(filter.card_types.contains(&crate::types::CardType::Sorcery));
+    assert_eq!(
+        filter.mana_value_eq_counters_on_source,
+        Some(crate::object::CounterType::Charge)
+    );
+}
+
+#[test]
 fn rewrite_lexed_parse_glamdring_static_clause_keeps_first_strike_and_anthem() {
     let tokens = lex_line(
         "Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your graveyard",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20405,6 +20405,35 @@ fn parse_omniscience_static_free_cast_permission() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_brain_in_a_jar_strictly_and_renders_counter_gated_free_cast() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Brain in a Jar")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{1}, {T}: Put a charge counter on this artifact, then you may cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost.\n{3}, {T}, Remove X charge counters from this artifact: Scry X.",
+        )
+        .expect("Brain in a Jar should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains(
+            "you may cast an instant or sorcery spell from your hand with mana value equal to the number of charge counters on this artifact without paying its mana cost"
+        ) || rendered_lower.contains(
+            "you may cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost"
+        ),
+        "expected counter-gated free-cast clause in compiled output, got {rendered}"
+    );
+
+    let ability_debug = format!("{:?}", def.abilities);
+    assert!(
+        ability_debug.contains("MayCastMatchingSpellWithoutPayingManaCostEffect")
+            && ability_debug.contains("mana_value_eq_counters_on_source: Some(Charge)"),
+        "expected Brain in a Jar to lower to a charge-counter-gated free-cast effect, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_kentaro_static_mana_value_permission() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Kentaro Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33285,7 +33285,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             Zone::OutsideGame => "from outside the game".to_string(),
         };
         let mana_value_limit_text = if has_tagged_mana_value_cap {
-            " with mana value less than or equal to that spell's mana value"
+            " with mana value less than or equal to that spell's mana value".to_string()
+        } else if let Some(counter_type) = may_cast_matching.filter.mana_value_eq_counters_on_source
+        {
+            format!(
+                " with mana value equal to the number of {} counters on this artifact",
+                counter_type.description()
+            )
         } else if matches!(
             may_cast_matching.filter.mana_value,
             Some(crate::filter::Comparison::LessThanOrEqualExpr(ref value))
@@ -33294,9 +33300,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     crate::effect::Value::EventValue(crate::effect::EventValueSpec::Amount)
                 )
         ) {
-            " with mana value less than or equal to that amount"
+            " with mana value less than or equal to that amount".to_string()
+        } else if let Some(crate::filter::Comparison::EqualExpr(value)) =
+            may_cast_matching.filter.mana_value.as_ref()
+        {
+            format!(" with mana value equal to {}", describe_value(value))
         } else {
-            ""
+            String::new()
         };
         match may_cast_matching.payment {
             ironsmith_core::MayCastMatchingSpellPayment::WithoutPayingManaCost => {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -33816,6 +33816,32 @@ fn test_choose_casting_method_flow() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn brain_in_a_jar_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(93_000), "Brain in a Jar")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{1}, {T}: Put a charge counter on this artifact, then you may cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost.\n{3}, {T}, Remove X charge counters from this artifact: Scry X.",
+        )
+        .expect("Brain in a Jar should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn brain_in_a_jar_ability_index(game: &GameState, brain_id: ObjectId, needle: &str) -> usize {
+    game.object(brain_id)
+        .expect("Brain in a Jar should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                format!("{:?}", activated.effects).contains(needle)
+            } else {
+                false
+            }
+        })
+        .unwrap_or_else(|| panic!("Brain in a Jar should have activated ability containing {needle}"))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_omniscience_grants_free_cast_from_hand_without_mana() {
     use crate::cards::definitions::lightning_bolt;
@@ -33971,6 +33997,316 @@ fn test_omniscience_does_not_bypass_sorcery_timing_restrictions() {
         free_cast.is_none(),
         "Omniscience should not let sorceries ignore normal timing restrictions"
     );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_brain_in_a_jar_first_ability_casts_matching_mana_value_spell_for_free() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let brain = brain_in_a_jar_definition();
+    let brain_id = game.create_object_from_definition(&brain, alice, Zone::Battlefield);
+    let matching_spell = CardBuilder::new(CardId::from_raw(93_001), "One-Mana Instant")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(1)]))
+        .build();
+    let nonmatching_spell = CardBuilder::new(CardId::from_raw(93_002), "Two-Mana Instant")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(2)]))
+        .build();
+    game.create_object_from_card(&matching_spell, alice, Zone::Hand);
+    let nonmatching_id = game.create_object_from_card(&nonmatching_spell, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let ability_index = brain_in_a_jar_ability_index(
+        &game,
+        brain_id,
+        "MayCastMatchingSpellWithoutPayingManaCostEffect",
+    );
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == brain_id && *idx == ability_index
+            )
+        })
+        .expect("Brain in a Jar first ability should be legal with one mana and untapped source");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Brain in a Jar activation should be put on the stack");
+
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Brain in a Jar first ability should resolve");
+
+    assert_eq!(
+        game.counter_count(brain_id, crate::object::CounterType::Charge),
+        1,
+        "Brain in a Jar should put a charge counter on itself before checking the free-cast gate"
+    );
+    assert!(
+        game.stack.iter().any(|entry| {
+            game.object(entry.object_id)
+                .is_some_and(|object| object.name == "One-Mana Instant")
+        }),
+        "the one-mana instant should be cast onto the stack without paying its mana cost"
+    );
+    assert_eq!(
+        game.object(nonmatching_id)
+            .expect("nonmatching spell should remain in hand")
+            .zone,
+        Zone::Hand,
+        "the two-mana instant should not match one charge counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_brain_in_a_jar_first_ability_casts_nothing_without_matching_mana_value() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let brain = brain_in_a_jar_definition();
+    let brain_id = game.create_object_from_definition(&brain, alice, Zone::Battlefield);
+    let nonmatching_spell = CardBuilder::new(CardId::from_raw(93_003), "Two-Mana Sorcery")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(2)]))
+        .build();
+    let nonmatching_type = CardBuilder::new(CardId::from_raw(93_004), "One-Mana Creature")
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(1)]))
+        .build();
+    let opponent_spell = CardBuilder::new(CardId::from_raw(93_005), "Opponent One-Mana Instant")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(1)]))
+        .build();
+    let nonmatching_id = game.create_object_from_card(&nonmatching_spell, alice, Zone::Hand);
+    let nonmatching_type_id = game.create_object_from_card(&nonmatching_type, alice, Zone::Hand);
+    let opponent_spell_id = game.create_object_from_card(&opponent_spell, bob, Zone::Hand);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let ability_index = brain_in_a_jar_ability_index(
+        &game,
+        brain_id,
+        "MayCastMatchingSpellWithoutPayingManaCostEffect",
+    );
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == brain_id && *idx == ability_index
+            )
+        })
+        .expect("Brain in a Jar first ability should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Brain in a Jar activation should be put on the stack");
+
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Brain in a Jar first ability should resolve without a matching spell");
+
+    assert_eq!(
+        game.counter_count(brain_id, crate::object::CounterType::Charge),
+        1,
+        "Brain in a Jar should still get its charge counter"
+    );
+    assert_eq!(
+        game.object(nonmatching_id)
+            .expect("nonmatching spell should remain in hand")
+            .zone,
+        Zone::Hand,
+        "a spell with the wrong mana value should not be cast"
+    );
+    assert_eq!(
+        game.object(nonmatching_type_id)
+            .expect("nonmatching card type should remain in hand")
+            .zone,
+        Zone::Hand,
+        "a non-instant, non-sorcery card with matching mana value should not be cast"
+    );
+    assert_eq!(
+        game.object(opponent_spell_id)
+            .expect("opponent's matching spell should remain in hand")
+            .zone,
+        Zone::Hand,
+        "a matching instant in another player's hand should not be cast"
+    );
+    assert!(
+        game.stack.iter().all(|entry| match game.object(entry.object_id) {
+            Some(object) => !matches!(
+                object.name.as_str(),
+                "Two-Mana Sorcery" | "One-Mana Creature" | "Opponent One-Mana Instant"
+            ),
+            None => true,
+        }),
+        "nonmatching or non-owned cards should not be on the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_brain_in_a_jar_second_ability_removes_x_charge_counters_for_scry() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let brain = brain_in_a_jar_definition();
+    let brain_id = game.create_object_from_definition(&brain, alice, Zone::Battlefield);
+    game.add_counters(brain_id, crate::object::CounterType::Charge, 2)
+        .expect("charge counters should be addable to Brain in a Jar");
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 3);
+
+    let ability_index = brain_in_a_jar_ability_index(&game, brain_id, "ScryEffect");
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == brain_id && *idx == ability_index
+            )
+        })
+        .expect("Brain in a Jar scry ability should be legal with three mana and counters");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Brain in a Jar scry activation should ask for X");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Number(ctx),
+        ) => {
+            assert_eq!(ctx.player, alice);
+            assert_eq!(ctx.source, Some(brain_id));
+        }
+        other => panic!("expected X choice for Brain in a Jar scry activation, got {other:?}"),
+    }
+
+    let mut progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::XValue(2),
+        &mut dm,
+    )
+    .expect("choosing X should finish paying Brain in a Jar activation costs");
+
+    for _ in 0..8 {
+        progress = match progress {
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) if ctx.description.starts_with("Choose the next cost to pay") => {
+                let option = ctx
+                    .options
+                    .iter()
+                    .find(|option| {
+                        let description = option.description.to_ascii_lowercase();
+                        option.legal && description.contains("remove")
+                    })
+                    .or_else(|| {
+                        ctx.options.iter().find(|option| {
+                            let description = option.description.to_ascii_lowercase();
+                            option.legal && description.contains("tap")
+                        })
+                    })
+                    .or_else(|| ctx.options.iter().find(|option| option.legal))
+                    .expect("Brain in a Jar should have a legal cost option");
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(option.index),
+                    &mut dm,
+                )
+                .expect("chosen Brain in a Jar cost should be payable")
+            }
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) => {
+                let option = ctx
+                    .options
+                    .iter()
+                    .find(|option| option.legal)
+                    .expect("Brain in a Jar mana payment should have a legal option");
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::ManaPayment(option.index),
+                    &mut dm,
+                )
+                .expect("Brain in a Jar mana payment should succeed")
+            }
+            crate::decision::GameProgress::Continue => break,
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            ) => break,
+            other => panic!("unexpected Brain in a Jar activation progress: {other:?}"),
+        };
+    }
+
+    assert_eq!(
+        game.counter_count(brain_id, crate::object::CounterType::Charge),
+        0,
+        "the X charge counters should be removed as an activation cost"
+    );
+
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Brain in a Jar scry ability should resolve");
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Brain in a Jar
Initial parse error:
```
could not find verb in effect clause (clause: 'cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0da1f7e17850e5d4b
Branch: codex/aws-card-fix-brain-in-a-jar
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0029
