### PR TITLE
Fix Ironsmith parse failure: Careful Consideration

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -1,3 +1,4 @@
+use crate::cards::builders::SubjectVerbSubjectAst;
 use crate::runtime_backend::grammar::structure::parse_trailing_if_predicate_lexed;
 
 use super::*;
@@ -907,6 +908,11 @@ fn post_rule_future_zone_and_self_replacement(
             mut if_false,
         }) = sentence_effects.pop()
         {
+            let (default_effects, carried_player) =
+                default_effects_for_self_replacement(state.effects, previous);
+            if let Some(player) = carried_player {
+                bind_that_player_subjects_in_effects(&mut if_true, player);
+            }
             if let Some(target) = previous_target {
                 replace_it_target_in_effects(&mut if_true, &target);
             }
@@ -914,7 +920,9 @@ fn post_rule_future_zone_and_self_replacement(
                 replace_it_damage_target_in_effects(&mut if_true, &target);
                 replace_placeholder_damage_target_in_effects(&mut if_true, &target);
             }
-            if_false.insert(0, previous);
+            for effect in default_effects.into_iter().rev() {
+                if_false.insert(0, effect);
+            }
             state.effects.push(EffectAst::SelfReplacement {
                 predicate,
                 if_true,
@@ -926,6 +934,86 @@ fn post_rule_future_zone_and_self_replacement(
         }
     }
     Ok(None)
+}
+
+fn carried_player_from_effect(effect: &EffectAst) -> Option<PlayerAst> {
+    let Some(CarryContext::Player(player)) = explicit_player_for_carry(effect) else {
+        return None;
+    };
+    if matches!(player, PlayerAst::That | PlayerAst::Implicit) {
+        None
+    } else {
+        Some(player)
+    }
+}
+
+fn effect_has_that_player_subject(effect: &EffectAst) -> bool {
+    if matches!(
+        effect,
+        EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            subject: SubjectVerbSubjectAst {
+                player: PlayerAst::That,
+                ..
+            },
+            ..
+        })
+    ) {
+        return true;
+    }
+
+    let mut found = false;
+    for_each_nested_effects(effect, true, |nested| {
+        if !found {
+            found = nested.iter().any(effect_has_that_player_subject);
+        }
+    });
+    found
+}
+
+fn bind_that_player_subjects(effect: &mut EffectAst, player: PlayerAst) {
+    if let EffectAst::SubjectVerb(SubjectVerbEffectAst { subject, .. }) = effect
+        && subject.player == PlayerAst::That
+    {
+        subject.player = player;
+    }
+
+    for_each_nested_effects_mut(effect, true, |nested| {
+        for nested_effect in nested {
+            bind_that_player_subjects(nested_effect, player);
+        }
+    });
+}
+
+fn bind_that_player_subjects_in_effects(effects: &mut [EffectAst], player: PlayerAst) {
+    for effect in effects {
+        bind_that_player_subjects(effect, player);
+    }
+}
+
+fn default_effects_for_self_replacement(
+    prior_effects: &mut Vec<EffectAst>,
+    previous: EffectAst,
+) -> (Vec<EffectAst>, Option<PlayerAst>) {
+    let mut default_effects = vec![previous];
+    let mut carried_player = default_effects.iter().rev().find_map(carried_player_from_effect);
+
+    if carried_player.is_none()
+        && default_effects.iter().any(effect_has_that_player_subject)
+        && let Some(anchor_idx) = prior_effects
+            .iter()
+            .rposition(|effect| carried_player_from_effect(effect).is_some())
+    {
+        carried_player = carried_player_from_effect(&prior_effects[anchor_idx]);
+        let mut anchored_default_effects = prior_effects.split_off(anchor_idx);
+        anchored_default_effects.append(&mut default_effects);
+        default_effects = anchored_default_effects;
+    }
+
+    if let Some(player) = carried_player {
+        bind_that_player_subjects_in_effects(&mut default_effects, player);
+    }
+
+    (default_effects, carried_player)
 }
 
 fn post_rule_delayed_trigger_result_followup(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -44568,6 +44568,40 @@ fn return_to_dust_main_phase_paid_label_condition_branches() {
     );
 }
 
+#[test]
+fn parse_oracle_careful_consideration_strictly_parses_and_renders_main_phase_replacement() {
+    let def = parse_oracle_card_definition("Careful Consideration");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        !lower.contains("unsupported") && !lower.contains("unimplemented"),
+        "expected Careful Consideration to parse without unsupported placeholders, got {rendered}"
+    );
+    assert!(
+        lower.contains("target player draws four cards, then discards three cards"),
+        "expected default draw/discard clause to render, got {rendered}"
+    );
+    assert!(
+        lower.contains(
+            "if you cast this spell during your main phase, instead that player draws four cards, then discards two cards"
+        ),
+        "expected main-phase replacement clause to render with that-player binding, got {rendered}"
+    );
+
+    let raw = format!("{:#?}", def.spell_effect);
+    let compact_raw: String = raw.chars().filter(|ch| !ch.is_whitespace()).collect();
+    assert!(
+        raw.contains("SelfReplacementBranch")
+            && raw.contains("CastDuringYourMainPhase")
+            && raw.contains("DiscardEffect")
+            && compact_raw.contains("Fixed(3,")
+            && compact_raw.contains("Fixed(2,")
+            && !raw.contains("IteratedPlayer"),
+        "expected Careful Consideration to lower as a target-player self-replacement without unbound that-player refs, got {raw}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn undercellar_sweep_attack_trigger_creates_tokens_when_you_have_initiative() {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -470,6 +470,13 @@ fn describe_single_self_replacement_segment(
     ) {
         return Some(count_override_text);
     }
+    if let Some(draw_discard_text) = describe_target_player_draw_discard_self_replacement(
+        &segment.default_effects,
+        &branch.replacement_effects,
+        &condition_text,
+    ) {
+        return Some(draw_discard_text);
+    }
     if let Some(damage_text) =
         describe_rendered_damage_self_replacement(&default_text, &replacement_text, &condition_text)
     {
@@ -740,6 +747,67 @@ fn describe_rendered_count_override_self_replacement(
     Some(format!(
         "{default_intro}. {default_choice}. If {condition_text}, {} instead. {default_rest}",
         super::normalize_common::lowercase_first(replacement_choice)
+    ))
+}
+
+fn target_player_draw_discard_counts(effects: &[Effect]) -> Option<(&Value, &Value)> {
+    let [target_effect, draw_effect, discard_effect] = effects else {
+        return None;
+    };
+    let target = target_effect.downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+    if target.target != target_any_player_spec() {
+        return None;
+    }
+
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    let discard = discard_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+    if draw.player != target_any_player_filter()
+        || discard.player != target_any_player_filter()
+        || discard.random
+        || discard.any_number
+        || discard.card_filter.is_some()
+    {
+        return None;
+    }
+    Some((&draw.count, &discard.count))
+}
+
+fn card_count_noun(count: &Value) -> &'static str {
+    if matches!(count.unhinted(), Value::Fixed(1)) {
+        "card"
+    } else {
+        "cards"
+    }
+}
+
+fn card_count_text(count: &Value) -> String {
+    match count.unhinted() {
+        Value::Fixed(n) => number_word(*n).unwrap_or_else(|| n.to_string()),
+        _ => describe_value(count),
+    }
+}
+
+fn describe_target_player_draw_discard_self_replacement(
+    default_effects: &[Effect],
+    replacement_effects: &[Effect],
+    condition_text: &str,
+) -> Option<String> {
+    let (default_draw, default_discard) = target_player_draw_discard_counts(default_effects)?;
+    let (replacement_draw, replacement_discard) =
+        target_player_draw_discard_counts(replacement_effects)?;
+    if default_draw != replacement_draw {
+        return None;
+    }
+
+    let draw_count = card_count_text(default_draw);
+    let default_discard_count = card_count_text(default_discard);
+    let replacement_discard_count = card_count_text(replacement_discard);
+    Some(format!(
+        "Target player draws {draw_count} {}, then discards {default_discard_count} {}. If {condition_text}, instead that player draws {draw_count} {}, then discards {replacement_discard_count} {}",
+        card_count_noun(default_draw),
+        card_count_noun(default_discard),
+        card_count_noun(replacement_draw),
+        card_count_noun(replacement_discard),
     ))
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -38798,6 +38798,95 @@ fn voices_from_the_void_discards_one_card_per_basic_land_type() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn careful_consideration_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Careful Consideration")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Target player draws four cards, then discards three cards. If you cast this spell during your main phase, instead that player draws four cards, then discards two cards.",
+        )
+        .expect("Careful Consideration should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_careful_consideration_targeting_bob(main_phase: bool) -> GameState {
+    use crate::cost::OptionalCostsPaid;
+    use crate::game_loop::resolve_stack_entry_with_dm_and_triggers;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let def = careful_consideration_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    put_test_cards_in_zone(&mut game, bob, Zone::Library, 4);
+    put_test_cards_in_zone(&mut game, bob, Zone::Hand, 3);
+
+    let mut entry = StackEntry::new(spell_id, alice).with_targets(vec![Target::Player(bob)]);
+    if main_phase {
+        let mut paid = OptionalCostsPaid::default();
+        paid.mark_label_paid("CastDuringYourMainPhase");
+        game.object_mut(spell_id)
+            .expect("Careful Consideration spell should exist")
+            .optional_costs_paid = paid.clone();
+        entry = entry.with_optional_costs_paid(paid);
+    }
+    game.push_to_stack(entry);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Careful Consideration should resolve");
+    game
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn careful_consideration_non_main_phase_target_draws_four_discards_three() {
+    let game = resolve_careful_consideration_targeting_bob(false);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    assert_eq!(
+        game.player(bob).expect("bob exists").hand.len(),
+        4,
+        "Bob should net one card after drawing four and discarding three"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").graveyard.len(),
+        3,
+        "Bob should discard three cards outside Alice's main phase"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        0,
+        "Careful Consideration should affect the targeted player, not its controller"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn careful_consideration_main_phase_replacement_discards_two_instead() {
+    let game = resolve_careful_consideration_targeting_bob(true);
+    let bob = PlayerId::from_index(1);
+
+    assert_eq!(
+        game.player(bob).expect("bob exists").hand.len(),
+        5,
+        "Bob should net two cards when the main-phase replacement applies"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").graveyard.len(),
+        2,
+        "the main-phase branch should discard two cards instead of three"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn tromp_the_domains_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), "Tromp the Domains")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Careful Consideration
Initial parse error:
```
spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Fixed(3), player: IteratedPlayer, random: false, any_number: false, card_filter: None, tag: Some(TagKey("discarded_0")) }); oracle-only fallback also failed: spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Fixed(3), player: IteratedPlayer, random: false, any_number: false, card_filter: None, tag: Some(TagKey("discarded_0")) })
```

Current worker: i-070efc5baef709b76
Branch: codex/aws-card-fix-careful-consideration
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0029
