### PR TITLE
Fix Ironsmith parse failure: Yidaro, Wandering Monster

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3825,6 +3825,39 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         });
     }
 
+    if word_slice_starts_with(&filtered, &["youve", "cycled", "card", "named"])
+        || word_slice_starts_with(&filtered, &["you", "have", "cycled", "card", "named"])
+    {
+        let name_start = if filtered[0] == "youve" { 4 } else { 5 };
+        if let Some(times_idx) = filtered[name_start..]
+            .iter()
+            .position(|word| *word == "times")
+            .map(|idx| idx + name_start)
+            && times_idx >= name_start + 1
+            && times_idx + 3 == filtered.len()
+            && word_slice_eq(&filtered[times_idx + 1..], &["this", "game"])
+            && let Some(count_start) = times_idx.checked_sub(3)
+            && word_slice_eq(&filtered[count_start + 1..times_idx], &["or", "more"])
+            && let Some(count) = parse_named_number(filtered[count_start])
+        {
+            let card_name = filtered[name_start..count_start]
+                .iter()
+                .map(|word| (*word).to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            if !card_name.is_empty() {
+                return Ok(
+                    PredicateAst::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+                        player: PlayerAst::You,
+                        action: crate::events::KeywordActionKind::Cycle,
+                        card_name,
+                        count,
+                    },
+                );
+            }
+        }
+    }
+
     let negative_spell_cast_prefix =
         if word_slice_starts_with(&filtered, &["that", "player", "didnt", "cast"]) {
             Some((4usize, PlayerFilter::Active))

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -489,6 +489,20 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 count: *count,
             }
         }
+        PredicateAst::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+            player,
+            action,
+            card_name,
+            count,
+        } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+                player,
+                action: *action,
+                card_name: card_name.clone(),
+                count: *count,
+            }
+        }
         PredicateAst::OpponentLostLifeThisTurn => Condition::OpponentLostLifeThisTurn,
         PredicateAst::YouHaveNoCardsInHand => {
             Condition::Not(Box::new(Condition::CardsInHandOrMore(1)))
@@ -4465,6 +4479,24 @@ mod parse_compile_tests {
         assert!(
             choices.is_empty(),
             "self-targeted object filters should not create extra target choices"
+        );
+    }
+
+    #[test]
+    fn resolve_target_spec_preserves_constrained_source_object_filters() {
+        let filter = ObjectFilter::source().in_zone(Zone::Graveyard);
+        let target = TargetAst::Object(filter.clone(), None, None);
+        let (spec, choices) = resolve_target_spec_with_choices(&target, &ReferenceEnv::default())
+            .expect("source object target with zone constraint should resolve cleanly");
+
+        assert_eq!(
+            spec,
+            ChooseSpec::Object(filter),
+            "source object filters with additional constraints must not collapse to unconstrained source"
+        );
+        assert!(
+            choices.is_empty(),
+            "non-targeted constrained source object filters should not create extra target choices"
         );
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
@@ -104,7 +104,7 @@ fn materialize_trailing_self_replacement(
         let default_lowered = compile_statement_effects_with_imports(if_false, &prepared.imports)?;
         let replacement_lowered =
             compile_statement_effects_with_imports(if_true, &prepared.imports)?;
-        let condition = compile_condition_from_predicate_ast_with_env(
+        let mut condition = compile_condition_from_predicate_ast_with_env(
             predicate,
             &prepared.initial_env,
             prepared.imports.last_object_tag.as_ref(),
@@ -131,6 +131,14 @@ fn materialize_trailing_self_replacement(
         } else {
             replacement_effects
         };
+        if default_effects.iter().any(effect_moves_tagged_object_from_graveyard)
+            && replacement_effects.iter().any(effect_moves_tagged_object_to_battlefield)
+        {
+            condition = Condition::And(
+                Box::new(Condition::SourceIsInZone(crate::zone::Zone::Graveyard)),
+                Box::new(condition),
+            );
+        }
 
         let mut choices = prefix_lowered.choices;
         choices.extend(default_lowered.choices);
@@ -150,6 +158,27 @@ fn materialize_trailing_self_replacement(
         }));
     }
     Ok(None)
+}
+
+fn effect_moves_tagged_object_from_graveyard(effect: &Effect) -> bool {
+    let Some(for_each) = effect.downcast_ref::<crate::effects::ForEachObject>() else {
+        return false;
+    };
+    for_each.filter.zone == Some(crate::zone::Zone::Graveyard)
+        && for_each.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::target::TaggedOpbjectRelation::IsTaggedObject
+        })
+}
+
+fn effect_moves_tagged_object_to_battlefield(effect: &Effect) -> bool {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return effect_moves_tagged_object_to_battlefield(&tagged.effect);
+    }
+    let Some(move_to_zone) = effect.downcast_ref::<crate::effects::MoveToZoneEffect>() else {
+        return false;
+    };
+    move_to_zone.zone == crate::zone::Zone::Battlefield
+        && matches!(move_to_zone.target, crate::target::ChooseSpec::Tagged(_))
 }
 
 pub(crate) fn materialize_prepared_triggered_effects(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/line_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/line_lowering.rs
@@ -86,6 +86,23 @@ fn unwrap_matching_conditional_replacement_effects(
     conditional.if_true.clone()
 }
 
+fn add_instead_source_zone_condition(
+    condition: crate::effect::Condition,
+    normalized_line: &str,
+) -> crate::effect::Condition {
+    if normalized_line.contains("from your graveyard instead")
+        || normalized_line.contains("from its owner graveyard instead")
+        || normalized_line.contains("from its owners graveyard instead")
+    {
+        crate::effect::Condition::And(
+            Box::new(crate::effect::Condition::SourceIsInZone(Zone::Graveyard)),
+            Box::new(condition),
+        )
+    } else {
+        condition
+    }
+}
+
 fn rewrite_prior_token_placeholder_effect(
     effect: &mut EffectAst,
     token_info: &(String, PlayerAst),
@@ -1169,7 +1186,7 @@ fn lower_statement_chunk(
         segment
             .self_replacements
             .push(crate::resolution::SelfReplacementBranch::new(
-                replacement.condition,
+                add_instead_source_zone_condition(replacement.condition, &normalized_line),
                 replacement.if_true,
             ));
         builder.spell_effect = Some(spell_effect);
@@ -1201,7 +1218,7 @@ fn lower_statement_chunk(
         segment
             .self_replacements
             .push(crate::resolution::SelfReplacementBranch::new(
-                replacement.condition,
+                add_instead_source_zone_condition(replacement.condition, &normalized_line),
                 replacement.if_true,
             ));
         return Ok(builder);
@@ -1212,6 +1229,7 @@ fn lower_statement_chunk(
         && builder.spell_effect.is_none()
         && let Some(condition) = trailing_instead_if_condition
     {
+        let condition = add_instead_source_zone_condition(condition, &normalized_line);
         let previous = compiled[0].clone();
         let mut replacement_effects = vec![compiled[1].clone()];
         if let Some(previous_target) = super::extract_previous_replacement_target(&previous) {
@@ -1243,6 +1261,7 @@ fn lower_statement_chunk(
         && !existing.is_empty()
         && let Some(condition) = trailing_instead_if_condition
     {
+        let condition = add_instead_source_zone_condition(condition, &normalized_line);
         let mut replacement_effects = vec![compiled[1].clone()];
         if let Some(previous_target) = existing
             .last()
@@ -1275,6 +1294,7 @@ fn lower_statement_chunk(
         && !existing.is_empty()
         && let Some(condition) = trailing_instead_if_condition
     {
+        let condition = add_instead_source_zone_condition(condition, &normalized_line);
         let mut replacement_effects = vec![compiled[0].clone()];
         if let Some(previous_target) = existing
             .last()
@@ -1318,6 +1338,10 @@ fn lower_statement_chunk(
                     .to_string(),
             ));
         };
+        replacement.condition = add_instead_source_zone_condition(
+            replacement.condition,
+            &normalized_line,
+        );
         segment.self_replacements.push(replacement);
         return Ok(builder);
     } else if matches!(
@@ -1384,7 +1408,7 @@ fn lower_statement_chunk(
         segment
             .self_replacements
             .push(crate::resolution::SelfReplacementBranch::new(
-                replacement.condition,
+                add_instead_source_zone_condition(replacement.condition, &normalized_line),
                 replacement.if_true,
             ));
     } else if let Some(ref mut existing) = builder.spell_effect {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -511,6 +511,12 @@ pub(crate) enum PredicateAst {
         player: PlayerAst,
         count: u32,
     },
+    PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+        player: PlayerAst,
+        action: crate::events::KeywordActionKind,
+        card_name: String,
+        count: u32,
+    },
     OpponentLostLifeThisTurn,
     YouHaveNoCardsInHand,
     PlayerWouldDrawCard {

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -750,7 +750,7 @@ pub(crate) fn choose_spec_for_target(target: &TargetAst) -> ChooseSpec {
             }
         }
         TargetAst::Object(filter, explicit_target_span, _) => {
-            if filter.source {
+            if *filter == ObjectFilter::source() {
                 return ChooseSpec::Source;
             }
             if explicit_target_span.is_some() {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -427,6 +427,9 @@ pub(crate) fn parse_put_into_hand(
             TargetAst::Source(span) => {
                 *target = TargetAst::Object(ObjectFilter::source().in_zone(zone), *span, None);
             }
+            TargetAst::Tagged(tag, span) => {
+                *target = TargetAst::Object(ObjectFilter::tagged(tag.clone()).in_zone(zone), *span, None);
+            }
             TargetAst::Object(filter, _, _) => {
                 filter.zone = Some(zone);
             }
@@ -1157,19 +1160,36 @@ pub(crate) fn parse_put_into_hand(
         let mut destination_tail: Vec<OwnedLexToken> = destination_tokens[1..].to_vec();
         let battlefield_attacking = grammar::contains_word(&destination_tail, "attacking");
         let battlefield_tapped = grammar::contains_word(&destination_tail, "tapped");
-        if let Some(from_idx) = find_index(&destination_tail, |token| token.is_word("from"))
-            && destination_tail
-                .get(from_idx + 1)
+        let mut source_zone = None;
+        if let Some(from_idx) = find_index(&destination_tail, |token| token.is_word("from")) {
+            let mut zone_idx = from_idx + 1;
+            if destination_tail
+                .get(zone_idx)
+                .is_some_and(|token| token.is_word("your"))
+            {
+                zone_idx += 1;
+            }
+            if destination_tail
+                .get(zone_idx)
                 .is_some_and(|token| token.is_word("command"))
-            && destination_tail
-                .get(from_idx + 2)
-                .is_some_and(|token| token.is_word("zone"))
-        {
-            destination_tail.drain(from_idx..from_idx + 3);
+                && destination_tail
+                    .get(zone_idx + 1)
+                    .is_some_and(|token| token.is_word("zone"))
+            {
+                source_zone = Some(Zone::Command);
+                destination_tail.drain(from_idx..zone_idx + 2);
+            } else if destination_tail
+                .get(zone_idx)
+                .is_some_and(|token| token.is_word("graveyard"))
+            {
+                source_zone = Some(Zone::Graveyard);
+                destination_tail.drain(from_idx..zone_idx + 1);
+            }
         }
         destination_tail.retain(|token| !token.is_word("and"));
         destination_tail.retain(|token| !token.is_word("tapped"));
         destination_tail.retain(|token| !token.is_word("attacking"));
+        destination_tail.retain(|token| !token.is_word("instead"));
 
         let mut attached_to_target: Option<TargetAst> = None;
         if destination_tail
@@ -1270,7 +1290,9 @@ pub(crate) fn parse_put_into_hand(
         {
             crate::runtime_backend::sentences::effect_sentences::zone_counter_helpers::apply_exile_subject_owner_context(filter, subject);
         }
-        if super::super::grammar::primitives::contains_phrase(
+        if let Some(source_zone) = source_zone {
+            apply_source_zone_constraint(&mut target, source_zone);
+        } else if super::super::grammar::primitives::contains_phrase(
             dest_slice,
             &["from", "the", "command", "zone"],
         ) || super::super::grammar::primitives::contains_phrase(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -675,6 +675,21 @@ pub(crate) fn parse_shuffle(
         )
     }
 
+    fn shuffle_source_zone(words: &[&str]) -> Option<Zone> {
+        matches!(
+            words,
+            ["from", "graveyard"]
+                | ["from", "your", "graveyard"]
+                | ["from", "their", "graveyard"]
+                | ["from", "that", "player", "graveyard"]
+                | ["from", "that", "players", "graveyard"]
+                | ["from", "its", "owner", "graveyard"]
+                | ["from", "its", "owners", "graveyard"]
+                | ["from", "his", "or", "her", "graveyard"]
+        )
+        .then_some(Zone::Graveyard)
+    }
+
     fn is_simple_library_phrase(words: &[&str]) -> bool {
         matches!(
             words,
@@ -715,6 +730,26 @@ pub(crate) fn parse_shuffle(
         {
             let trailing_words = &destination_words[consumed..];
             if is_supported_shuffle_source_tail(trailing_words) {
+                if let Some(source_zone) = shuffle_source_zone(trailing_words) {
+                    return Ok(EffectAst::ForEachObject {
+                        filter: ObjectFilter::tagged(TagKey::from(IT_TAG)).in_zone(source_zone),
+                        effects: vec![
+                            EffectAst::subject_verb_move_to_zone(
+                                TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(tokens)),
+                                Zone::Library,
+                                false,
+                                ReturnControllerAst::Preserve,
+                                false,
+                                None,
+                            ),
+                            subject_verb_player_resource_effect(
+                                SubjectVerbRoleAst::LibraryOwner,
+                                destination_player,
+                                SubjectVerbActionAst::ShuffleLibrary,
+                            ),
+                        ],
+                    });
+                }
                 return Ok(EffectAst::ForEachTagged {
                     tag: TagKey::from(IT_TAG),
                     effects: vec![

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -696,6 +696,12 @@ pub enum Condition {
         player: PlayerFilter,
         count: u32,
     },
+    PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+        player: PlayerFilter,
+        action: crate::KeywordActionKind,
+        card_name: String,
+        count: u32,
+    },
     AttackedThisTurn,
     OpponentLostLifeThisTurn,
     PermanentLeftBattlefieldThisTurn,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -190,6 +190,189 @@ fn stage_vampire_socialite_opponent_life_loss(game: &mut crate::game_state::Game
 }
 
 #[test]
+fn yidaro_wandering_monster_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Yidaro, Wandering Monster");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Cycling {1}{R}"),
+        "Yidaro should preserve its cycling cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains("shuffle it into your library from your graveyard")
+            && rendered.contains("If you've cycled a card named Yidaro Wandering Monster four or more times this game, put it onto the battlefield from your graveyard instead"),
+        "Yidaro compiled text should preserve the graveyard shuffle and battlefield replacement clause, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("KeywordActionTrigger")
+            && ability_debug.contains("SelfReplacementBranch")
+            && ability_debug.contains("PlayerPerformedKeywordActionWithCardNameThisGameOrMore")
+            && ability_debug.contains("ForEachObject")
+            && ability_debug.contains("SourceIsInZone")
+            && ability_debug.contains("zone: Some")
+            && ability_debug.contains("Graveyard")
+            && ability_debug.contains("zone: Battlefield"),
+        "Yidaro should structurally keep its cycling trigger and replacement branch, got {ability_debug}"
+    );
+}
+
+fn yidaro_cycle_trigger_program(
+    def: &CardDefinition,
+) -> crate::resolution::ResolutionProgram {
+    def.abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Triggered(triggered) = &ability.kind else {
+                return None;
+            };
+            format!("{:?}", triggered.trigger)
+                .contains("KeywordActionTrigger")
+                .then(|| triggered.effects.clone())
+        })
+        .expect("Yidaro should have a cycling triggered ability")
+}
+
+fn record_yidaro_cycle_event(
+    game: &mut crate::game_state::GameState,
+    player: PlayerId,
+    yidaro_id: ObjectId,
+) {
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(yidaro_id)
+            .expect("Yidaro object should exist for cycle event"),
+        game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::KeywordActionEvent::new(
+            crate::events::KeywordActionKind::Cycle,
+            player,
+            snapshot.stable_id.object_id(),
+            1,
+        )
+        .with_snapshot(Some(snapshot)),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&event);
+}
+
+fn execute_yidaro_cycle_trigger(
+    game: &mut crate::game_state::GameState,
+    program: &crate::resolution::ResolutionProgram,
+    player: PlayerId,
+    yidaro_id: ObjectId,
+) {
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(yidaro_id)
+            .expect("Yidaro object should exist before trigger resolution"),
+        game,
+    );
+    let mut tagged_objects = HashMap::new();
+    tagged_objects.insert(crate::tag::TagKey::from("triggering"), vec![snapshot]);
+    let mut ctx = crate::effects::ExecutionContext::new_default(yidaro_id, player)
+        .with_tagged_objects(tagged_objects);
+
+    crate::game_loop::execute_resolution_program(
+        game,
+        &mut ctx,
+        player,
+        yidaro_id,
+        program,
+        None,
+        &[],
+    )
+    .expect("Yidaro cycling trigger should resolve");
+}
+
+#[test]
+fn yidaro_wandering_monster_cycle_trigger_shuffles_before_fourth_cycle() {
+    let def = parse_oracle_card_definition("Yidaro, Wandering Monster");
+    let program = yidaro_cycle_trigger_program(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let yidaro_id = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    let stable_id = game.object(yidaro_id).unwrap().stable_id;
+
+    for _ in 0..3 {
+        record_yidaro_cycle_event(&mut game, alice, yidaro_id);
+    }
+    execute_yidaro_cycle_trigger(&mut game, &program, alice, yidaro_id);
+
+    let current_id = game
+        .find_object_by_stable_id(stable_id)
+        .expect("Yidaro should still exist after trigger resolution");
+    assert_eq!(
+        game.object(current_id).unwrap().zone,
+        Zone::Library,
+        "before the fourth cycle, Yidaro should be shuffled into its owner's library"
+    );
+}
+
+#[test]
+fn yidaro_wandering_monster_fourth_cycle_puts_it_onto_battlefield() {
+    let def = parse_oracle_card_definition("Yidaro, Wandering Monster");
+    let program = yidaro_cycle_trigger_program(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let yidaro_id = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    let stable_id = game.object(yidaro_id).unwrap().stable_id;
+
+    for _ in 0..2 {
+        record_yidaro_cycle_event(&mut game, alice, yidaro_id);
+    }
+    game.turn_store.turn_history.clear_for_new_turn();
+    for _ in 0..2 {
+        record_yidaro_cycle_event(&mut game, alice, yidaro_id);
+    }
+    execute_yidaro_cycle_trigger(&mut game, &program, alice, yidaro_id);
+
+    let current_id = game
+        .find_object_by_stable_id(stable_id)
+        .expect("Yidaro should still exist after trigger resolution");
+    assert_eq!(
+        game.object(current_id).unwrap().zone,
+        Zone::Battlefield,
+        "on the fourth cycle, Yidaro should replace the shuffle with entering the battlefield"
+    );
+}
+
+#[test]
+fn yidaro_wandering_monster_cycle_trigger_does_not_move_from_other_zone() {
+    let def = parse_oracle_card_definition("Yidaro, Wandering Monster");
+    let program = yidaro_cycle_trigger_program(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let yidaro_id = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    let stable_id = game.object(yidaro_id).unwrap().stable_id;
+
+    for _ in 0..4 {
+        record_yidaro_cycle_event(&mut game, alice, yidaro_id);
+    }
+    let exiled_id = game
+        .move_object_by_effect(yidaro_id, Zone::Exile)
+        .expect("Yidaro should move out of the graveyard before trigger resolution");
+    execute_yidaro_cycle_trigger(&mut game, &program, alice, exiled_id);
+
+    let current_id = game
+        .find_object_by_stable_id(stable_id)
+        .expect("Yidaro should still exist after trigger resolution");
+    assert_eq!(
+        game.object(current_id).unwrap().zone,
+        Zone::Exile,
+        "Yidaro's trigger should only move it from the graveyard"
+    );
+}
+
+#[test]
 fn vampire_socialite_etb_trigger_condition_and_counter_effect_runtime() {
     let def = parse_oracle_card_definition("Vampire Socialite");
     let triggered = def

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -437,6 +437,71 @@ fn is_hidden_gift_etb_ability(ability: &Ability) -> bool {
     rendered.starts_with("if the gift was promised") || is_standard_gift_render_payload(&rendered)
 }
 
+fn strip_source_graveyard_condition(condition: &Condition) -> &Condition {
+    if let Condition::And(left, right) = condition {
+        if matches!(left.as_ref(), Condition::SourceIsInZone(Zone::Graveyard)) {
+            return right.as_ref();
+        }
+        if matches!(right.as_ref(), Condition::SourceIsInZone(Zone::Graveyard)) {
+            return left.as_ref();
+        }
+    }
+    condition
+}
+
+fn describe_graveyard_shuffle_to_battlefield_self_replacement(
+    segment: &crate::resolution::ResolutionSegment,
+) -> Option<String> {
+    let [default_effect] = segment.default_effects.as_slice() else {
+        return None;
+    };
+    let [branch] = segment.self_replacements.as_slice() else {
+        return None;
+    };
+    let for_each = default_effect.downcast_ref::<crate::effects::ForEachObject>()?;
+    if for_each.filter.zone != Some(Zone::Graveyard)
+        || !for_each.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::target::TaggedOpbjectRelation::IsTaggedObject
+        })
+    {
+        return None;
+    }
+    let [move_to_library_effect, shuffle_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let move_to_library = move_to_library_effect
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_library.zone != Zone::Library
+        || move_to_library.to_top
+        || !matches!(move_to_library.target, ChooseSpec::Iterated)
+    {
+        return None;
+    }
+    let shuffle = shuffle_effect.downcast_ref::<crate::effects::ShuffleLibraryEffect>()?;
+    if !matches!(shuffle.player, PlayerFilter::You) {
+        return None;
+    }
+    let [replacement_effect] = branch.replacement_effects.as_slice() else {
+        return None;
+    };
+    let replacement_effect = replacement_effect
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .map(|tagged| tagged.effect.as_ref())
+        .unwrap_or(replacement_effect);
+    let replacement_move = replacement_effect
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if replacement_move.zone != Zone::Battlefield
+        || !matches!(replacement_move.target, ChooseSpec::Tagged(_))
+    {
+        return None;
+    }
+    let condition = strip_source_graveyard_condition(&branch.condition);
+    let condition_text = super::normalize_common::describe_condition(condition);
+    Some(format!(
+        "Shuffle it into your library from your graveyard. If {condition_text}, put it onto the battlefield from your graveyard instead"
+    ))
+}
+
 fn describe_single_self_replacement_segment(
     segment: &crate::resolution::ResolutionSegment,
 ) -> Option<String> {
@@ -452,6 +517,9 @@ fn describe_single_self_replacement_segment(
     let conditional_text = describe_effect_list(&[conditional]);
     if conditional_text.contains(" damage instead if ") {
         return Some(conditional_text);
+    }
+    if let Some(text) = describe_graveyard_shuffle_to_battlefield_self_replacement(segment) {
+        return Some(text);
     }
     let default_text = describe_effect_list(&segment.default_effects);
     let replacement_text = describe_effect_list(&branch.replacement_effects);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11275,6 +11275,50 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 count_text
             )
         }
+        Condition::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+            player,
+            action,
+            card_name,
+            count,
+        } => {
+            let subject = describe_player_filter(player);
+            let count_text = small_number_word(*count).unwrap_or_else(|| count.to_string());
+            let action_text = match action {
+                crate::events::KeywordActionKind::Cycle => "cycled",
+                _ => action.infinitive(),
+            };
+            let display_name = card_name
+                .split_whitespace()
+                .map(|word| {
+                    let mut chars = word.chars();
+                    match chars.next() {
+                        Some(first) => format!(
+                            "{}{}",
+                            first.to_ascii_uppercase(),
+                            chars.as_str().to_ascii_lowercase()
+                        ),
+                        None => String::new(),
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            if matches!(player, PlayerFilter::You)
+                && matches!(action, crate::events::KeywordActionKind::Cycle)
+            {
+                format!(
+                    "you've {action_text} a card named {display_name} {count_text} or more times this game"
+                )
+            } else {
+                format!(
+                    "{} {} {} a card named {} {} or more times this game",
+                    subject,
+                    player_verb(&subject, "have", "has"),
+                    action_text,
+                    display_name,
+                    count_text
+                )
+            }
+        }
         Condition::AttackedThisTurn => "you attacked this turn".to_string(),
         Condition::OpponentLostLifeThisTurn => "an opponent lost life this turn".to_string(),
         Condition::PermanentLeftBattlefieldThisTurn => {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2375,13 +2375,16 @@ fn describe_for_each_tagged_shuffle_into_owner_library(
         return None;
     }
     let shuffle = for_each.effects[1].downcast_ref::<crate::effects::ShuffleLibraryEffect>()?;
-    if !matches!(
+    if matches!(&shuffle.player, PlayerFilter::You) {
+        return Some("Shuffle it into your library".to_string());
+    }
+    if matches!(
         &shuffle.player,
         PlayerFilter::OwnerOf(crate::filter::ObjectRef::Tagged(tag)) if tag == &for_each.tag
     ) {
-        return None;
+        return Some("Its owner shuffles it into their library".to_string());
     }
-    Some("Its owner shuffles it into their library".to_string())
+    None
 }
 
 fn describe_source_owner_shuffle_then_reveal_named_to_battlefield(

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1043,6 +1043,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::And(..) => {}
         Condition::Or(..) => {}
         Condition::PlayerCastSpellsThisTurnOrMore { .. } => {}
+        Condition::PlayerPerformedKeywordActionWithCardNameThisGameOrMore { .. } => {}
         Condition::PlayerTappedLandForManaThisTurn { .. } => {}
         Condition::PlayerGainedLifeThisTurnOrMore { .. } => {}
         Condition::PlayerHadLandEnterBattlefieldThisTurn { .. } => {}
@@ -1201,6 +1202,17 @@ pub fn evaluate_condition_external(
                 .sum();
             cast_count >= *count
         }
+        Condition::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+            player,
+            action,
+            card_name,
+            count,
+        } => matching_condition_players_external(game, ctx, player)
+            .into_iter()
+            .any(|player_id| {
+                game.keyword_action_card_name_count_this_game(player_id, *action, card_name)
+                    >= *count
+            }),
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
                 return false;
@@ -2451,6 +2463,17 @@ fn evaluate_condition_simple(
                 .sum();
             cast_count >= *count
         }
+        Condition::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+            player,
+            action,
+            card_name,
+            count,
+        } => matching_condition_players_simple(game, controller, player)
+            .into_iter()
+            .any(|player_id| {
+                game.keyword_action_card_name_count_this_game(player_id, *action, card_name)
+                    >= *count
+            }),
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
                 return false;
@@ -3121,6 +3144,17 @@ fn evaluate_condition(
                 .sum();
             Ok(cast_count >= *count)
         }
+        Condition::PlayerPerformedKeywordActionWithCardNameThisGameOrMore {
+            player,
+            action,
+            card_name,
+            count,
+        } => Ok(matching_condition_players_exec(game, ctx, player)?
+            .into_iter()
+            .any(|player_id| {
+                game.keyword_action_card_name_count_this_game(player_id, *action, card_name)
+                    >= *count
+            })),
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
             Ok(game

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -2002,6 +2002,9 @@ pub struct GameState {
     /// Highest pregame draft-note number recorded by a player for a named card.
     pub draft_noted_highest_numbers: HashMap<(PlayerId, String), u32>,
 
+    /// Game-wide keyword action counts by player, action, and normalized source card name.
+    pub keyword_action_card_name_counts: HashMap<(PlayerId, crate::events::KeywordActionKind, String), u32>,
+
     // =========================================================================
     // Battlefield State Extension Maps
     // =========================================================================
@@ -2140,6 +2143,21 @@ fn normalize_draft_note_card_name(name: &str) -> String {
         .to_ascii_lowercase()
 }
 
+fn normalize_keyword_action_card_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch.is_ascii_whitespace() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 impl GameState {
     /// Creates a new game state with the given players.
     pub fn new(player_names: Vec<String>, starting_life: i32) -> Self {
@@ -2191,6 +2209,7 @@ impl GameState {
             combat_damage_player_batch_hits: Vec::new(),
             speed_increase_triggered_this_turn: HashSet::new(),
             draft_noted_highest_numbers: HashMap::new(),
+            keyword_action_card_name_counts: HashMap::new(),
             // Battlefield state extension maps
             tapped_permanents: HashSet::new(),
             summoning_sick: HashSet::new(),
@@ -7581,6 +7600,59 @@ impl GameState {
             .get(&TurnCounterKey::Named(name.to_string()))
     }
 
+    fn keyword_action_source_name(
+        &self,
+        event: &crate::events::KeywordActionEvent,
+        object_snapshot: Option<&ObjectSnapshot>,
+        source_snapshot: Option<&ObjectSnapshot>,
+    ) -> Option<String> {
+        event
+            .snapshot
+            .as_ref()
+            .or(object_snapshot)
+            .or(source_snapshot)
+            .map(|snapshot| snapshot.name.clone())
+            .or_else(|| self.object(event.source).map(|object| object.name.clone()))
+            .or_else(|| {
+                self.find_object_by_stable_id(StableId::from(event.source))
+                    .and_then(|id| self.object(id).map(|object| object.name.clone()))
+            })
+    }
+
+    fn record_keyword_action_card_name_count(
+        &mut self,
+        event: &crate::events::KeywordActionEvent,
+        object_snapshot: Option<&ObjectSnapshot>,
+        source_snapshot: Option<&ObjectSnapshot>,
+    ) {
+        let Some(source_name) =
+            self.keyword_action_source_name(event, object_snapshot, source_snapshot)
+        else {
+            return;
+        };
+        let normalized_name = normalize_keyword_action_card_name(&source_name);
+        if normalized_name.is_empty() {
+            return;
+        }
+        *self
+            .keyword_action_card_name_counts
+            .entry((event.player, event.action, normalized_name))
+            .or_insert(0) += event.amount.max(1);
+    }
+
+    pub fn keyword_action_card_name_count_this_game(
+        &self,
+        player: PlayerId,
+        action: KeywordActionKind,
+        card_name: &str,
+    ) -> u32 {
+        let normalized_name = normalize_keyword_action_card_name(card_name);
+        self.keyword_action_card_name_counts
+            .get(&(player, action, normalized_name))
+            .copied()
+            .unwrap_or(0)
+    }
+
     /// Records that an activated ability was used.
     /// Used for OncePerTurn timing restrictions.
     pub fn record_ability_activation(&mut self, source: ObjectId, ability_index: usize) {
@@ -9127,6 +9199,13 @@ impl GameState {
 
     pub(crate) fn record_turn_history_event(&mut self, event: &crate::triggers::TriggerEvent) {
         let (object_snapshot, source_snapshot) = self.projected_turn_event_snapshots(event);
+        if let Some(keyword_action) = event.downcast::<crate::events::KeywordActionEvent>() {
+            self.record_keyword_action_card_name_count(
+                keyword_action,
+                object_snapshot.as_ref(),
+                source_snapshot.as_ref(),
+            );
+        }
         self.turn_store
             .turn_history
             .record_event(event, object_snapshot, source_snapshot);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Yidaro, Wandering Monster
Initial parse error:
```
unsupported put destination after 'onto' (clause: 'it onto the battlefield from your graveyard instead'); oracle-only fallback also failed: unsupported put destination after 'onto' (clause: 'it onto the battlefield from your graveyard instead')
```

Current worker: i-03915dbdf48256e79
Branch: codex/aws-card-fix-yidaro-wandering-monster
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0029
