### PR TITLE
Fix Ironsmith parse failure: Goblin Airbrusher

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2430,15 +2430,33 @@ pub(crate) fn parse_trigger_clause_lexed(
         }
     }
 
-    if let Some(put_word_idx) = find_index(&words, |word| *word == "put" || *word == "puts") {
+    if let Some(put_word_idx) = find_index(&words, |word| {
+        matches!(*word, "put" | "puts" | "place" | "places" | "placed")
+    }) {
         let subject = &words[..put_word_idx];
         if let Some(player) = parse_trigger_subject_player_filter(subject) {
             let tail = &words[put_word_idx + 1..];
-            let has_name_sticker = word_slice_contains_phrase_or_empty(tail, &["name", "sticker"]);
-            let has_on = word_slice_contains_word(tail, "on");
-            if has_name_sticker && has_on {
+            let tail_without_articles = non_article_word_refs(tail);
+            let action = if word_slice_contains_phrase_or_empty(
+                tail,
+                &["power", "and", "toughness", "sticker"],
+            )
+            {
+                Some(crate::events::KeywordActionKind::PowerToughnessSticker)
+            } else if word_slice_contains_phrase_or_empty(tail, &["ability", "sticker"]) {
+                Some(crate::events::KeywordActionKind::AbilitySticker)
+            } else if word_slice_contains_phrase_or_empty(tail, &["name", "sticker"]) {
+                Some(crate::events::KeywordActionKind::NameSticker)
+            } else if word_slice_contains_phrase_or_empty(tail, &["art", "sticker"]) {
+                Some(crate::events::KeywordActionKind::ArtSticker)
+            } else if word_slice_contains_word(&tail_without_articles, "sticker") {
+                Some(crate::events::KeywordActionKind::Sticker)
+            } else {
+                None
+            };
+            if let Some(action) = action {
                 return Ok(TriggerSpec::KeywordAction {
-                    action: crate::events::KeywordActionKind::NameSticker,
+                    action,
                     player,
                     source_filter: None,
                 });

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -791,6 +791,25 @@ fn parse_card_in_your_graveyard_predicate(words: &[&str]) -> Option<PredicateAst
     })
 }
 
+fn parse_triggering_sticker_action_predicate(words: &[&str]) -> Option<PredicateAst> {
+    let tail = match words {
+        ["it", "is", tail @ ..] | ["it", tail @ ..] => tail,
+        _ => return None,
+    };
+
+    let action = match tail {
+        ["art", "sticker"] => crate::events::KeywordActionKind::ArtSticker,
+        ["ability", "sticker"] => crate::events::KeywordActionKind::AbilitySticker,
+        ["name", "sticker"] => crate::events::KeywordActionKind::NameSticker,
+        ["power", "and", "toughness", "sticker"] => {
+            crate::events::KeywordActionKind::PowerToughnessSticker
+        }
+        _ => return None,
+    };
+
+    Some(PredicateAst::TriggeringKeywordAction(action))
+}
+
 pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, CardTextError> {
     let raw_words_view = GrammarFilterNormalizedWords::new(tokens);
     let raw_words = raw_words_view.to_word_refs();
@@ -939,6 +958,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_card_in_your_graveyard_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_triggering_sticker_action_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -539,6 +539,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::SourceIsTapped => Condition::SourceIsTapped,
         PredicateAst::SourceIsSaddled => Condition::SourceIsSaddled,
         PredicateAst::SourceMatches(filter) => Condition::SourceMatches(filter.clone()),
+        PredicateAst::TriggeringKeywordAction(action) => {
+            Condition::TriggeringKeywordAction(*action)
+        }
         PredicateAst::TriggeringObjectHadToAttackThisCombat => {
             Condition::TriggeringObjectHadToAttackThisCombat
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -525,6 +525,7 @@ pub(crate) enum PredicateAst {
     SourceIsTapped,
     SourceIsSaddled,
     SourceMatches(ObjectFilter),
+    TriggeringKeywordAction(crate::events::KeywordActionKind),
     TriggeringObjectHadToAttackThisCombat,
 
     SourceHasNoCounter(CounterType),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -1,7 +1,7 @@
 use crate::{
     ActivationTiming, AnthemCountExpression, Comparison, CounterType, EffectId, EventValueSpec,
-    ManaSymbol, ObjectFilter, PlayerFilter, PlayerId, StableId, TagKey, ValueComparisonOperator,
-    Zone,
+    KeywordActionKind, ManaSymbol, ObjectFilter, PlayerFilter, PlayerId, StableId, TagKey,
+    ValueComparisonOperator, Zone,
 };
 use crate::{ChooseSpec, Color, ColorSet};
 
@@ -796,6 +796,7 @@ pub enum Condition {
     MaxTimesEachTurn(u32),
     DoThisMaxTimesEachTurn(u32),
     TriggeringObjectWasEnchanted,
+    TriggeringKeywordAction(KeywordActionKind),
     TriggeringObjectHadToAttackThisCombat,
     TriggeringObjectHadCounters {
         counter_type: CounterType,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -9672,6 +9672,137 @@ fn costume_shop_keeps_visit_sticker_effect() {
     );
 }
 
+#[test]
+fn goblin_airbrusher_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Goblin Airbrusher");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert_eq!(
+        rendered,
+        "Whenever you place a sticker, create a Treasure token. If it's an art sticker, create two Treasure tokens instead."
+    );
+    assert!(
+        rendered_lower.contains("whenever you place a sticker"),
+        "expected Goblin Airbrusher to render its sticker trigger, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("if it's an art sticker")
+            && rendered_lower.contains("create two treasure tokens instead"),
+        "expected Goblin Airbrusher to render its art-sticker replacement branch, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("unsupported"),
+        "Goblin Airbrusher should parse strictly without unsupported fallback text, got {rendered}"
+    );
+}
+
+#[test]
+fn goblin_airbrusher_structurally_models_art_sticker_self_replacement() {
+    let def = parse_oracle_card_definition("Goblin Airbrusher");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        debug.contains("KeywordAction")
+            && debug.contains("Sticker")
+            && debug.contains("SelfReplacement")
+            && debug.contains("TriggeringKeywordAction")
+            && debug.contains("ArtSticker"),
+        "expected Goblin Airbrusher to lower as a generic sticker trigger with an art-sticker self replacement, got {debug}"
+    );
+}
+
+fn resolve_goblin_airbrusher_sticker_action(
+    action: crate::events::KeywordActionKind,
+    event_player: PlayerId,
+) -> usize {
+    let airbrusher = parse_oracle_card_definition("Goblin Airbrusher");
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let airbrusher_id = game.create_object_from_definition(&airbrusher, alice, Zone::Battlefield);
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::KeywordActionEvent::new(action, event_player, airbrusher_id, 1),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in crate::triggers::check_triggers(&game, &event)
+        .into_iter()
+        .filter(|entry| entry.source == airbrusher_id)
+    {
+        trigger_queue.add(entry);
+    }
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Goblin Airbrusher trigger should be put on the stack");
+    while !game.stack.is_empty() {
+        crate::game_loop::resolve_stack_entry(&mut game)
+            .expect("Goblin Airbrusher trigger should resolve");
+    }
+
+    game.battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id).is_some_and(|object| {
+                object.name == "Treasure" && game.controller_of(object) == alice
+            })
+        })
+        .count()
+}
+
+#[test]
+fn goblin_airbrusher_creates_one_treasure_for_non_art_sticker() {
+    let alice = PlayerId::from_index(0);
+    let treasure_count =
+        resolve_goblin_airbrusher_sticker_action(crate::events::KeywordActionKind::Sticker, alice);
+
+    assert_eq!(
+        treasure_count, 1,
+        "Goblin Airbrusher should create one Treasure for a non-art sticker"
+    );
+}
+
+#[test]
+fn goblin_airbrusher_creates_one_treasure_for_non_art_sticker_subtype() {
+    let alice = PlayerId::from_index(0);
+    let treasure_count = resolve_goblin_airbrusher_sticker_action(
+        crate::events::KeywordActionKind::NameSticker,
+        alice,
+    );
+
+    assert_eq!(
+        treasure_count, 1,
+        "Goblin Airbrusher should trigger for non-art sticker subtypes without taking the art branch"
+    );
+}
+
+#[test]
+fn goblin_airbrusher_creates_two_treasures_for_art_sticker() {
+    let alice = PlayerId::from_index(0);
+    let treasure_count = resolve_goblin_airbrusher_sticker_action(
+        crate::events::KeywordActionKind::ArtSticker,
+        alice,
+    );
+
+    assert_eq!(
+        treasure_count, 2,
+        "Goblin Airbrusher should replace the one-Treasure branch with two Treasures for an art sticker"
+    );
+}
+
+#[test]
+fn goblin_airbrusher_ignores_opponents_stickers() {
+    let bob = PlayerId::from_index(1);
+    let treasure_count = resolve_goblin_airbrusher_sticker_action(
+        crate::events::KeywordActionKind::ArtSticker,
+        bob,
+    );
+
+    assert_eq!(
+        treasure_count, 0,
+        "Goblin Airbrusher should not trigger for an opponent placing an art sticker"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn eldrazi_guacamole_tightrope_ticket_sticker_lines_parse_strictly() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11923,6 +11923,17 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             format!("this effect has been used fewer than {limit} times this turn")
         }
         Condition::TriggeringObjectWasEnchanted => "the triggering object was enchanted".to_string(),
+        Condition::TriggeringKeywordAction(action) => match action {
+            crate::events::KeywordActionKind::ArtSticker => "it's an art sticker".to_string(),
+            crate::events::KeywordActionKind::AbilitySticker => {
+                "it's an ability sticker".to_string()
+            }
+            crate::events::KeywordActionKind::NameSticker => "it's a name sticker".to_string(),
+            crate::events::KeywordActionKind::PowerToughnessSticker => {
+                "it's a power and toughness sticker".to_string()
+            }
+            _ => format!("it was {}", action.infinitive()),
+        },
         Condition::TriggeringObjectHadToAttackThisCombat => {
             "that creature had to attack this combat".to_string()
         }

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -796,6 +796,11 @@ fn evaluate_condition_shared_core(
             object_matching_was_put_into_graveyard_from_battlefield_this_turn(game, ctx, filter),
         ),
         Condition::SourceWasCast => Some(source_was_cast(game, ctx.source, ctx.triggering_event)),
+        Condition::TriggeringKeywordAction(action) => Some(
+            ctx.triggering_event
+                .and_then(|event| event.downcast::<crate::events::KeywordActionEvent>())
+                .is_some_and(|event| event.action == *action),
+        ),
         Condition::TaggedObjectWasCast(_) => None,
         Condition::ThisSpellEscaped => Some(source_escaped(game, ctx.source)),
         Condition::ThisSpellWasCastFromZone(_) => None,
@@ -1011,6 +1016,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::MaxTimesEachTurn(..) => {}
         Condition::DoThisMaxTimesEachTurn(..) => {}
         Condition::TriggeringObjectWasEnchanted => {}
+        Condition::TriggeringKeywordAction(..) => {}
         Condition::TriggeringObjectHadToAttackThisCombat => {}
         Condition::TriggeringObjectHadCounters { .. } => {}
         Condition::ControlCreaturesTotalPowerAtLeast(..) => {}
@@ -1375,6 +1381,10 @@ pub fn evaluate_condition_external(
             .triggering_event
             .and_then(|event| event.snapshot())
             .is_some_and(|snapshot| snapshot.was_enchanted),
+        Condition::TriggeringKeywordAction(action) => ctx
+            .triggering_event
+            .and_then(|event| event.downcast::<crate::events::KeywordActionEvent>())
+            .is_some_and(|event| event.action == *action),
         Condition::TriggeringObjectHadToAttackThisCombat => {
             triggering_object_had_to_attack_this_combat(game, ctx.triggering_event)
         }
@@ -2060,6 +2070,7 @@ fn evaluate_condition_simple(
             .is_some_and(|obj| obj.optional_costs_paid.was_kicked()),
         Condition::ThisSpellEscaped => source_escaped(game, source),
         Condition::ThisSpellWasCastFromZone(_) => false,
+        Condition::TriggeringKeywordAction(_) => false,
         Condition::ThisSpellPaidLabel(label) => game
             .object(source)
             .is_some_and(|obj| obj.optional_costs_paid.was_paid_label(label)),
@@ -2811,6 +2822,7 @@ fn evaluate_condition(
 
     match condition {
         Condition::ItIsNight => Ok(game.is_night),
+        Condition::TriggeringKeywordAction(_) => Ok(false),
         Condition::YouControl(filter) => {
             let filter_ctx = ctx.filter_context(game);
 

--- a/crates/ironsmith-runtime/src/triggers/other/keyword_action.rs
+++ b/crates/ironsmith-runtime/src/triggers/other/keyword_action.rs
@@ -10,6 +10,21 @@ use crate::triggers::TriggerEvent;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
 use crate::types::CardType;
 
+fn keyword_action_matches(
+    trigger_action: KeywordActionKind,
+    event_action: KeywordActionKind,
+) -> bool {
+    trigger_action == event_action
+        || (trigger_action == KeywordActionKind::Sticker
+            && matches!(
+                event_action,
+                KeywordActionKind::ArtSticker
+                    | KeywordActionKind::AbilitySticker
+                    | KeywordActionKind::NameSticker
+                    | KeywordActionKind::PowerToughnessSticker
+            ))
+}
+
 fn is_plain_other_card_filter(filter: &ObjectFilter) -> bool {
     filter.other
         && !filter.source
@@ -128,7 +143,7 @@ impl TriggerMatcher for KeywordActionTrigger {
         let Some(e) = event.downcast::<KeywordActionEvent>() else {
             return false;
         };
-        if e.action != self.action {
+        if !keyword_action_matches(self.action, e.action) {
             return false;
         }
 
@@ -229,6 +244,14 @@ impl TriggerMatcher for KeywordActionTrigger {
                 PlayerFilter::Opponent => "Whenever the Ring tempts an opponent".to_string(),
                 PlayerFilter::Any => "Whenever the Ring tempts a player".to_string(),
                 _ => "Whenever the Ring tempts a player".to_string(),
+            };
+        }
+        if self.action == KeywordActionKind::Sticker {
+            return match &self.player {
+                PlayerFilter::You => "Whenever you place a sticker".to_string(),
+                PlayerFilter::Opponent => "Whenever an opponent places a sticker".to_string(),
+                PlayerFilter::Any => "Whenever a player places a sticker".to_string(),
+                _ => "Whenever a player places a sticker".to_string(),
             };
         }
         if self.action == KeywordActionKind::ChaosEnsues && self.player == PlayerFilter::Any {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Goblin Airbrusher
Initial parse error:
```
unsupported predicate (predicate: 'it art sticker'); oracle-only fallback also failed: unsupported predicate (predicate: 'it art sticker')
```

Current worker: i-0fbbe875cb528001f
Branch: codex/aws-card-fix-goblin-airbrusher
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0029
