### PR TITLE
Fix Ironsmith parse failure: Wheel of Potential

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -52,6 +52,7 @@ pub(crate) enum PermissionClauseSpec {
         as_copy: bool,
         without_paying_mana_cost: bool,
         lifetime: PermissionLifetime,
+        object_filter: Option<ObjectFilter>,
     },
     GrantBySpec {
         player: PlayerAst,
@@ -861,6 +862,32 @@ pub(crate) fn parse_permission_clause_spec_lexed(
     let player = lead.player;
     let allow_land = lead.allow_land;
 
+    let rest_words = token_word_refs(rest_tokens);
+    if word_slice_starts_with(
+        &rest_words,
+        &["cards", "you", "own", "exiled", "this", "way"],
+    ) {
+        let tail_start = token_index_for_word_index(rest_tokens, 6).unwrap_or(rest_tokens.len());
+        let tail_tokens = &rest_tokens[tail_start..];
+        let default_lifetime = prefixed_lifetime.unwrap_or(PermissionLifetime::Immediate);
+        let Some((lifetime, without_paying_mana_cost)) =
+            parse_permission_tail_tokens(tail_tokens, default_lifetime)
+        else {
+            return Ok(None);
+        };
+        let mut object_filter = ObjectFilter::default();
+        object_filter.owner = Some(crate::target::PlayerFilter::You);
+        return Ok(Some(PermissionClauseSpec::Tagged {
+            tag: TagKey::from(IT_TAG),
+            player,
+            allow_land,
+            as_copy: false,
+            without_paying_mana_cost,
+            lifetime,
+            object_filter: Some(object_filter),
+        }));
+    }
+
     if let Some((target_ref, tagged_tail_tokens)) =
         parse_tagged_cast_or_play_target_tokens(rest_tokens)
     {
@@ -960,6 +987,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
             as_copy: target_ref.as_copy,
             without_paying_mana_cost,
             lifetime,
+            object_filter: None,
         }));
     }
 
@@ -1276,14 +1304,31 @@ pub(crate) fn parse_until_end_of_turn_may_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::UntilEndOfTurn,
+            object_filter,
         }) if player == PlayerAst::You => Ok(Some(
-            EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
-                tag,
-                player,
-                allow_land,
-                without_paying_mana_cost,
-                false,
-            ),
+            if let Some(object_filter) = object_filter {
+                EffectAst::subject_verb(
+                    crate::cards::builders::SubjectVerbRoleAst::Actor,
+                    PlayerAst::Implicit,
+                    crate::cards::builders::SubjectVerbActionAst::GrantPlayTaggedUntilEndOfTurn {
+                        tag,
+                        player,
+                        allow_land,
+                        without_paying_mana_cost,
+                        allow_any_color_for_cast: false,
+                        while_on_top_of_library: false,
+                        object_filter: Some(object_filter),
+                    },
+                )
+            } else {
+                EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
+                    tag,
+                    player,
+                    allow_land,
+                    without_paying_mana_cost,
+                    false,
+                )
+            },
         )),
         _ => Ok(None),
     }
@@ -1292,6 +1337,39 @@ pub(crate) fn parse_until_end_of_turn_may_play_tagged_clause(
 pub(crate) fn parse_until_your_next_turn_may_play_tagged_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
+    let trimmed = trim_lexed_commas(tokens);
+    if let Some((lead, rest_tokens)) = parse_permission_lead_tokens(trimmed) {
+        let rest_words = token_word_refs(rest_tokens);
+        let cards_you_own_exiled_this_way = rest_words.len() >= 6
+            && matches!(rest_words[0], "card" | "cards")
+            && rest_words[1] == "you"
+            && rest_words[2] == "own"
+            && rest_words[3].starts_with("exil")
+            && rest_words[4] == "this"
+            && rest_words[5] == "way";
+        if matches!(lead.player, PlayerAst::Implicit | PlayerAst::You)
+            && lead.allow_land
+            && cards_you_own_exiled_this_way
+        {
+            let tail_start = token_index_for_word_index(rest_tokens, 6).unwrap_or(rest_tokens.len());
+            let tail_tokens = &rest_tokens[tail_start..];
+            if let Some((PermissionLifetime::UntilYourNextTurn, false)) =
+                parse_permission_tail_tokens(tail_tokens, PermissionLifetime::Immediate)
+            {
+                let mut object_filter = ObjectFilter::default();
+                object_filter.owner = Some(crate::target::PlayerFilter::You);
+                return Ok(Some(
+                    EffectAst::subject_verb_grant_play_tagged_until_your_next_turn_matching(
+                        TagKey::from(IT_TAG),
+                        PlayerAst::You,
+                        true,
+                        false,
+                        object_filter,
+                    ),
+                ));
+            }
+        }
+    }
     match parse_permission_clause_spec(tokens)? {
         Some(PermissionClauseSpec::Tagged {
             tag,
@@ -1300,13 +1378,24 @@ pub(crate) fn parse_until_your_next_turn_may_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::UntilYourNextTurn,
+            object_filter,
         }) if matches!(player, PlayerAst::You | PlayerAst::Implicit) => Ok(Some(
-            EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
-                tag,
-                PlayerAst::You,
-                true,
-                false,
-            ),
+            if let Some(object_filter) = object_filter {
+                EffectAst::subject_verb_grant_play_tagged_until_your_next_turn_matching(
+                    tag,
+                    PlayerAst::You,
+                    true,
+                    false,
+                    object_filter,
+                )
+            } else {
+                EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
+                    tag,
+                    PlayerAst::You,
+                    true,
+                    false,
+                )
+            },
         )),
         _ => Ok(None),
     }
@@ -1611,6 +1700,38 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
         return Ok(Some(effect));
     }
 
+    if let Some((lead, rest_tokens)) = parse_permission_lead_tokens(&trimmed) {
+        let rest_words = token_word_refs(rest_tokens);
+        let cards_you_own_exiled_this_way = rest_words.len() >= 6
+            && matches!(rest_words[0], "card" | "cards")
+            && rest_words[1] == "you"
+            && rest_words[2] == "own"
+            && rest_words[3].starts_with("exil")
+            && rest_words[4] == "this"
+            && rest_words[5] == "way";
+        if matches!(lead.player, PlayerAst::Implicit | PlayerAst::You)
+            && cards_you_own_exiled_this_way
+        {
+            let tail_start = token_index_for_word_index(rest_tokens, 6).unwrap_or(rest_tokens.len());
+            let tail_tokens = &rest_tokens[tail_start..];
+            if let Some((PermissionLifetime::UntilYourNextTurn, false)) =
+                parse_permission_tail_tokens(tail_tokens, PermissionLifetime::Immediate)
+            {
+                let mut object_filter = ObjectFilter::default();
+                object_filter.owner = Some(crate::target::PlayerFilter::You);
+                return Ok(Some(
+                    EffectAst::subject_verb_grant_play_tagged_until_your_next_turn_matching(
+                        TagKey::from(IT_TAG),
+                        PlayerAst::Implicit,
+                        lead.allow_land,
+                        allow_any_color_for_cast,
+                        object_filter,
+                    ),
+                ));
+            }
+        }
+    }
+
     let conditional_tagged_permission = parse_permission_lead_tokens(&trimmed)
         .filter(|(lead, _)| lead.player == PlayerAst::Implicit)
         .and_then(|(lead, rest_tokens)| {
@@ -1680,6 +1801,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::Immediate,
+            object_filter: _,
         }) => {
             let cast = EffectAst::subject_verb_cast_tagged(
                 tag,
@@ -1705,6 +1827,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::ThisTurn | PermissionLifetime::UntilEndOfTurn,
+            object_filter: _,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 tag,
@@ -1721,13 +1844,24 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::UntilYourNextTurn,
+            object_filter,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
-            EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
-                tag,
-                PlayerAst::Implicit,
-                allow_land,
-                allow_any_color_for_cast,
-            ),
+            if let Some(object_filter) = object_filter {
+                EffectAst::subject_verb_grant_play_tagged_until_your_next_turn_matching(
+                    tag,
+                    PlayerAst::Implicit,
+                    allow_land,
+                    allow_any_color_for_cast,
+                    object_filter,
+                )
+            } else {
+                EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
+                    tag,
+                    PlayerAst::Implicit,
+                    allow_land,
+                    allow_any_color_for_cast,
+                )
+            },
         )),
         Some(PermissionClauseSpec::GrantBySpec {
             player,
@@ -1769,6 +1903,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::ForAsLongAsExiled,
+            object_filter: _,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
                 tag,
@@ -1784,6 +1919,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::ForAsLongAsYouControlSource,
+            object_filter: _,
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_for_as_long_as_you_control_source(
                 tag,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -807,6 +807,24 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     if filtered.len() >= 2 && filtered[0] == "it" && filtered[1] == "s" {
         filtered.remove(1);
     }
+    if filtered.len() >= 6
+        && filtered[1] == "or"
+        && filtered[2] == "more"
+        && word_slice_ends_with(&filtered, &["was", "paid", "this", "way"])
+        && let Some(amount) = filtered[0]
+            .parse::<i32>()
+            .ok()
+            .or_else(|| parse_named_number(filtered[0]).map(|n| n as i32))
+    {
+        return Ok(PredicateAst::ValueComparison {
+            left: Value::PendingEffectMetric {
+                source: ironsmith_core::EffectMetricSource::Outcome,
+                metric: ironsmith_core::EffectMetric::Count,
+            },
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: Value::Fixed(amount),
+        });
+    }
     if let Some(instead_idx) = word_slice_find_word(&filtered, "instead")
         && instead_idx > 0
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -312,7 +312,13 @@ pub(crate) fn classify_statement_line_family_lexed(
 
     let starts_with_each_player_statement =
         word_slice_strip_prefix(&word_refs, &["each", "player"])
-            .and_then(|rest| rest.first())
+            .and_then(|rest| {
+                if rest.first().copied() == Some("may") {
+                    rest.get(1)
+                } else {
+                    rest.first()
+                }
+            })
             .is_some_and(|word| is_statement_verb_word(word));
     let starts_with_each_other_player_statement =
         word_slice_strip_prefix(&word_refs, &["each", "other", "player"])
@@ -538,6 +544,19 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
             .and_then(|value| i32::try_from(value).ok())
     {
         return Some(IfResultPredicate::Value(Comparison::Equal(value)));
+    }
+    if words.len() >= 6
+        && words[1] == "or"
+        && words[2] == "more"
+        && words[words.len() - 2] == "this"
+        && words[words.len() - 1] == "way"
+        && words.iter().any(|word| matches!(*word, "paid" | "spent"))
+        && let Some(value) = ironsmith_core::parse_cardinal_word(words[0])
+            .and_then(|value| i32::try_from(value).ok())
+    {
+        return Some(IfResultPredicate::Value(Comparison::GreaterThanOrEqual(
+            value,
+        )));
     }
     if words.len() >= 3
         && words[0] == "you"

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -167,6 +167,72 @@ pub(crate) use trigger_support::{
     trigger_binds_player_reference_context, trigger_supports_event_value,
 };
 
+fn resolve_condition_result_value_refs(
+    value: &Value,
+    ctx: &EffectLoweringContext,
+) -> Result<Value, CardTextError> {
+    let mut resolved = value.clone();
+    match &mut resolved {
+        Value::Add(left, right) | Value::Min(left, right) => {
+            *left = Box::new(resolve_condition_result_value_refs(left, ctx)?);
+            *right = Box::new(resolve_condition_result_value_refs(right, ctx)?);
+        }
+        Value::Scaled(inner, _) | Value::HalfRoundedDown(inner) => {
+            *inner = Box::new(resolve_condition_result_value_refs(inner, ctx)?);
+        }
+        Value::SurfaceHinted { value, .. } => {
+            *value = Box::new(resolve_condition_result_value_refs(value, ctx)?);
+        }
+        Value::PendingEffectMetric { source, metric } => {
+            let id = ctx.last_effect_id.ok_or_else(|| {
+                CardTextError::ParseError(
+                    "pending predicate metric requires a prior memory-producing effect".to_string(),
+                )
+            })?;
+            resolved = Value::EffectMetric {
+                effect_id: id,
+                source: *source,
+                metric: *metric,
+            };
+        }
+        Value::PendingEffectMetricOffset {
+            source,
+            metric,
+            offset,
+        } => {
+            let id = ctx.last_effect_id.ok_or_else(|| {
+                CardTextError::ParseError(
+                    "pending predicate metric requires a prior memory-producing effect".to_string(),
+                )
+            })?;
+            resolved = Value::EffectMetricOffset {
+                effect_id: id,
+                source: *source,
+                metric: *metric,
+                offset: *offset,
+            };
+        }
+        Value::EventValue(EventValueSpec::Amount) => {
+            let id = ctx.last_effect_id.ok_or_else(|| {
+                CardTextError::ParseError(
+                    "event predicate amount requires a prior memory-producing effect".to_string(),
+                )
+            })?;
+            resolved = Value::EffectValue(id);
+        }
+        Value::EventValueOffset(EventValueSpec::Amount, offset) => {
+            let id = ctx.last_effect_id.ok_or_else(|| {
+                CardTextError::ParseError(
+                    "event predicate amount requires a prior memory-producing effect".to_string(),
+                )
+            })?;
+            resolved = Value::EffectValueOffset(id, *offset);
+        }
+        _ => {}
+    }
+    Ok(resolved)
+}
+
 pub(crate) fn compile_condition_from_predicate_ast(
     predicate: &PredicateAst,
     ctx: &mut EffectLoweringContext,
@@ -647,10 +713,12 @@ pub(crate) fn compile_condition_from_predicate_ast(
             {
                 Condition::XValueAtLeast(*amount as u32)
             } else {
+                let left = resolve_condition_result_value_refs(left, ctx)?;
+                let right = resolve_condition_result_value_refs(right, ctx)?;
                 Condition::ValueComparison {
-                    left: resolve_value_it_tag(left, &refs)?,
+                    left: resolve_value_it_tag(&left, &refs)?,
                     operator: *operator,
-                    right: resolve_value_it_tag(right, &refs)?,
+                    right: resolve_value_it_tag(&right, &refs)?,
                 }
             }
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -743,7 +743,9 @@ pub(crate) fn compile_effects_in_iterated_player_context(
     let saved_frame = ctx.lowering_frame();
     let mut iterated_frame = saved_frame.clone();
     iterated_frame.iterated_player = true;
-    iterated_frame.last_effect_id = None;
+    if !effects_reference_prior_effect_result(effects) {
+        iterated_frame.last_effect_id = None;
+    }
     iterated_frame.last_player_filter = Some(PlayerFilter::IteratedPlayer);
     if tagged_object.is_some() {
         iterated_frame.last_object_tag = Some(IT_TAG.to_string());
@@ -768,6 +770,50 @@ pub(crate) fn compile_effects_in_iterated_player_context(
         ctx.last_object_tag = Some(tag);
     }
     Ok((compiled, choices))
+}
+
+fn effects_reference_prior_effect_result(effects: &[EffectAst]) -> bool {
+    effects.iter().any(effect_references_prior_effect_result)
+}
+
+fn effect_references_prior_effect_result(effect: &EffectAst) -> bool {
+    match effect {
+        EffectAst::SubjectVerb(subject_verb) => match &subject_verb.action {
+            SubjectVerbActionAst::Draw { count } => value_references_prior_effect_result(count),
+            _ => false,
+        },
+        EffectAst::Sequence { effects }
+        | EffectAst::May { effects }
+        | EffectAst::MayByPlayer { effects, .. }
+        | EffectAst::ForEachPlayer { effects }
+        | EffectAst::ForEachOpponent { effects }
+        | EffectAst::ForEachPlayersFiltered { effects, .. }
+        | EffectAst::ForEachTargetPlayers { effects, .. } => {
+            effects_reference_prior_effect_result(effects)
+        }
+        _ => false,
+    }
+}
+
+fn value_references_prior_effect_result(value: &Value) -> bool {
+    match value {
+        Value::EventValue(_)
+        | Value::EventValueOffset(_, _)
+        | Value::EffectValue(_)
+        | Value::EffectValueOffset(_, _)
+        | Value::EffectMetric { .. }
+        | Value::EffectMetricOffset { .. }
+        | Value::PendingEffectMetric { .. }
+        | Value::PendingEffectMetricOffset { .. } => true,
+        Value::Add(left, right) | Value::Min(left, right) => {
+            value_references_prior_effect_result(left) || value_references_prior_effect_result(right)
+        }
+        Value::Scaled(inner, _) | Value::HalfRoundedDown(inner) => {
+            value_references_prior_effect_result(inner)
+        }
+        Value::SurfaceHinted { value, .. } => value_references_prior_effect_result(value),
+        _ => false,
+    }
 }
 
 pub(crate) fn compile_effects_in_iterated_object_context(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1963,6 +1963,7 @@ fn compile_subject_verb_effect(
             without_paying_mana_cost,
             allow_any_color_for_cast,
             while_on_top_of_library,
+            object_filter,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -1995,6 +1996,9 @@ fn compile_subject_verb_effect(
                 *allow_land,
                 *allow_any_color_for_cast,
             );
+            if let Some(filter) = object_filter {
+                grant_play = grant_play.matching(resolve_it_tag(filter, &current_reference_env(ctx))?);
+            }
             if *while_on_top_of_library {
                 grant_play = grant_play.while_on_top_of_library();
             }
@@ -2051,6 +2055,7 @@ fn compile_subject_verb_effect(
             player,
             allow_land,
             allow_any_color_for_cast,
+            object_filter,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -2070,22 +2075,24 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            Ok((
-                vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
-                    resolved_tag,
-                    player_filter,
-                    crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd,
-                    *allow_land,
-                    *allow_any_color_for_cast,
-                ))],
-                Vec::new(),
-            ))
+            let mut grant_play = crate::effects::GrantPlayTaggedEffect::new(
+                resolved_tag,
+                player_filter,
+                crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd,
+                *allow_land,
+                *allow_any_color_for_cast,
+            );
+            if let Some(filter) = object_filter {
+                grant_play = grant_play.matching(resolve_it_tag(filter, &current_reference_env(ctx))?);
+            }
+            Ok((vec![Effect::new(grant_play)], Vec::new()))
         }
         SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled {
             tag,
             player,
             allow_land,
             allow_any_color_for_cast,
+            object_filter,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -2105,22 +2112,24 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            Ok((
-                vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
-                    resolved_tag,
-                    player_filter,
-                    crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled,
-                    *allow_land,
-                    *allow_any_color_for_cast,
-                ))],
-                Vec::new(),
-            ))
+            let mut grant_play = crate::effects::GrantPlayTaggedEffect::new(
+                resolved_tag,
+                player_filter,
+                crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled,
+                *allow_land,
+                *allow_any_color_for_cast,
+            );
+            if let Some(filter) = object_filter {
+                grant_play = grant_play.matching(resolve_it_tag(filter, &current_reference_env(ctx))?);
+            }
+            Ok((vec![Effect::new(grant_play)], Vec::new()))
         }
         SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource {
             tag,
             player,
             allow_land,
             allow_any_color_for_cast,
+            object_filter,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -2140,16 +2149,17 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            Ok((
-                vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
-                    resolved_tag,
-                    player_filter,
-                    crate::effects::GrantPlayTaggedDuration::ForAsLongAsYouControlSource,
-                    *allow_land,
-                    *allow_any_color_for_cast,
-                ))],
-                Vec::new(),
-            ))
+            let mut grant_play = crate::effects::GrantPlayTaggedEffect::new(
+                resolved_tag,
+                player_filter,
+                crate::effects::GrantPlayTaggedDuration::ForAsLongAsYouControlSource,
+                *allow_land,
+                *allow_any_color_for_cast,
+            );
+            if let Some(filter) = object_filter {
+                grant_play = grant_play.matching(resolve_it_tag(filter, &current_reference_env(ctx))?);
+            }
+            Ok((vec![Effect::new(grant_play)], Vec::new()))
         }
         SubjectVerbActionAst::ExileUntilSourceLeaves { target, face_down } => {
             let (spec, choices) =

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
@@ -1,7 +1,7 @@
 use crate::cards::builders::{
     CardTextError, EffectAst, EffectLoweringContext, IT_TAG, PredicateAst, TagKey,
 };
-use crate::effect::{Condition, Effect, EffectPredicate};
+use crate::effect::{Condition, Effect, EffectId, EffectPredicate};
 use crate::target::{ChooseSpec, ObjectFilter};
 
 use super::{
@@ -48,6 +48,11 @@ pub(crate) fn materialize_prepared_statement_effects(
     let compiled = normalize_random_destroy_across_target_groups(compiled);
     let compiled = fold_local_zone_rewrite_self_replacements(compiled);
     let final_env = ctx.reference_env();
+    let compiled = materialize_exported_last_effect_id(
+        compiled,
+        prepared.initial_env.known_last_effect_id(),
+        final_env.known_last_effect_id(),
+    );
     Ok(LoweredEffects {
         effects: crate::resolution::ResolutionProgram::from_effects(prepend_effect_prelude(
             compiled,
@@ -74,6 +79,11 @@ pub(crate) fn materialize_prepared_effects_with_trigger_context(
     let compiled = normalize_random_destroy_across_target_groups(compiled);
     let compiled = fold_local_zone_rewrite_self_replacements(compiled);
     let final_env = ctx.reference_env();
+    let compiled = materialize_exported_last_effect_id(
+        compiled,
+        prepared.initial_env.known_last_effect_id(),
+        final_env.known_last_effect_id(),
+    );
     Ok(LoweredEffects {
         effects: crate::resolution::ResolutionProgram::from_effects(prepend_effect_prelude(
             compiled,
@@ -82,6 +92,30 @@ pub(crate) fn materialize_prepared_effects_with_trigger_context(
         choices,
         exports: ReferenceExports::from_env(&final_env),
     })
+}
+
+fn effect_contains_id(effect: &Effect, id: EffectId) -> bool {
+    if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+        return with_id.id == id || effect_contains_id(&with_id.effect, id);
+    }
+    false
+}
+
+fn materialize_exported_last_effect_id(
+    mut effects: Vec<Effect>,
+    initial_id: Option<EffectId>,
+    final_id: Option<EffectId>,
+) -> Vec<Effect> {
+    let Some(id) = final_id else {
+        return effects;
+    };
+    if initial_id == Some(id) || effects.iter().any(|effect| effect_contains_id(effect, id)) {
+        return effects;
+    }
+    if let Some(last) = effects.pop() {
+        effects.push(Effect::with_id(id.0, last));
+    }
+    effects
 }
 
 fn materialize_trailing_self_replacement(

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1049,6 +1049,7 @@ pub(crate) enum SubjectVerbActionAst {
         without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
         while_on_top_of_library: bool,
+        object_filter: Option<ObjectFilter>,
     },
     GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn {
         tag: TagKey,
@@ -1059,18 +1060,21 @@ pub(crate) enum SubjectVerbActionAst {
         player: PlayerAst,
         allow_land: bool,
         allow_any_color_for_cast: bool,
+        object_filter: Option<ObjectFilter>,
     },
     GrantPlayTaggedForAsLongAsExiled {
         tag: TagKey,
         player: PlayerAst,
         allow_land: bool,
         allow_any_color_for_cast: bool,
+        object_filter: Option<ObjectFilter>,
     },
     GrantPlayTaggedForAsLongAsYouControlSource {
         tag: TagKey,
         player: PlayerAst,
         allow_land: bool,
         allow_any_color_for_cast: bool,
+        object_filter: Option<ObjectFilter>,
     },
     ReturnToBattlefield {
         target: TargetAst,
@@ -2248,6 +2252,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
                 while_on_top_of_library,
+                object_filter,
             } => f
                 .debug_struct("GrantPlayTaggedUntilEndOfTurn")
                 .field("tag", tag)
@@ -2256,6 +2261,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("without_paying_mana_cost", without_paying_mana_cost)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
                 .field("while_on_top_of_library", while_on_top_of_library)
+                .field("object_filter", object_filter)
                 .finish(),
             Self::GrantTaggedSpellAlternativeCostPayLifeByManaValueUntilEndOfTurn {
                 tag,
@@ -2270,36 +2276,42 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 player,
                 allow_land,
                 allow_any_color_for_cast,
+                object_filter,
             } => f
                 .debug_struct("GrantPlayTaggedUntilYourNextTurn")
                 .field("tag", tag)
                 .field("player", player)
                 .field("allow_land", allow_land)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .field("object_filter", object_filter)
                 .finish(),
             Self::GrantPlayTaggedForAsLongAsExiled {
                 tag,
                 player,
                 allow_land,
                 allow_any_color_for_cast,
+                object_filter,
             } => f
                 .debug_struct("GrantPlayTaggedForAsLongAsExiled")
                 .field("tag", tag)
                 .field("player", player)
                 .field("allow_land", allow_land)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .field("object_filter", object_filter)
                 .finish(),
             Self::GrantPlayTaggedForAsLongAsYouControlSource {
                 tag,
                 player,
                 allow_land,
                 allow_any_color_for_cast,
+                object_filter,
             } => f
                 .debug_struct("GrantPlayTaggedForAsLongAsYouControlSource")
                 .field("tag", tag)
                 .field("player", player)
                 .field("allow_land", allow_land)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .field("object_filter", object_filter)
                 .finish(),
             Self::ReturnToBattlefield {
                 target,
@@ -3750,6 +3762,27 @@ impl EffectAst {
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
                 while_on_top_of_library: false,
+                object_filter: None,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_grant_play_tagged_until_your_next_turn_matching(
+        tag: TagKey,
+        player: PlayerAst,
+        allow_land: bool,
+        allow_any_color_for_cast: bool,
+        object_filter: ObjectFilter,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::GrantPlayTaggedUntilYourNextTurn {
+                tag,
+                player,
+                allow_land,
+                allow_any_color_for_cast,
+                object_filter: Some(object_filter),
             },
         )
     }
@@ -3771,6 +3804,7 @@ impl EffectAst {
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
                 while_on_top_of_library: true,
+                object_filter: None,
             },
         )
     }
@@ -3803,6 +3837,7 @@ impl EffectAst {
                 player,
                 allow_land,
                 allow_any_color_for_cast,
+                object_filter: None,
             },
         )
     }
@@ -3821,6 +3856,7 @@ impl EffectAst {
                 player,
                 allow_land,
                 allow_any_color_for_cast,
+                object_filter: None,
             },
         )
     }
@@ -3839,6 +3875,7 @@ impl EffectAst {
                 player,
                 allow_land,
                 allow_any_color_for_cast,
+                object_filter: None,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -346,6 +346,19 @@ fn advance_reference_frames(
     Ok(())
 }
 
+fn optional_payment_effects_produce_memory(effects: &[EffectAst]) -> bool {
+    matches!(
+        effects,
+        [EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action:
+                SubjectVerbActionAst::PayAnyEnergy { .. }
+                | SubjectVerbActionAst::PayEnergy { .. }
+                | SubjectVerbActionAst::PayMana { .. },
+            ..
+        })]
+    )
+}
+
 fn advance_reference_frame_for_effect(
     effect: &EffectAst,
     id_gen: &mut IdGenContext,
@@ -1033,8 +1046,14 @@ fn advance_reference_frame_for_effect(
             frame.last_object_tag = Some(chosen_tag);
         }
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}
-        EffectAst::May { effects }
-        | EffectAst::DelayedUntilNextEndStep { effects, .. }
+        EffectAst::May { effects } => {
+            advance_effects_preserving_last_effect(&effects, id_gen, frame)?;
+            if optional_payment_effects_produce_memory(effects) {
+                frame.last_effect_id = Some(EffectId(id_gen.next_effect_id));
+                id_gen.next_effect_id += 1;
+            }
+        }
+        EffectAst::DelayedUntilNextEndStep { effects, .. }
         | EffectAst::DelayedUntilEndOfCombat { effects }
         | EffectAst::DelayedTriggerThisTurn { effects, .. }
         | EffectAst::DelayedWhenLastObjectDiesThisTurn { effects, .. } => {
@@ -1042,6 +1061,10 @@ fn advance_reference_frame_for_effect(
         }
         EffectAst::MayByPlayer { player, effects } => {
             advance_effects_preserving_last_effect(&effects, id_gen, frame)?;
+            if optional_payment_effects_produce_memory(effects) {
+                frame.last_effect_id = Some(EffectId(id_gen.next_effect_id));
+                id_gen.next_effect_id += 1;
+            }
             track_effect_player(player.clone(), frame, true, true)?;
         }
         EffectAst::DelayedUntilNextUpkeep { player, effects }
@@ -1196,8 +1219,13 @@ fn annotate_effect_sequence_with_env_internal(
                 || effects_reference_its_controller(remaining)
                 || effects_reference_tag(remaining, "damaged_0")
         };
-        let assigned_effect_id =
-            maybe_assign_effect_result_id(effects, idx, id_gen, in_env.allow_life_event_value);
+        let assigned_effect_id = maybe_assign_effect_result_id(
+            effects,
+            idx,
+            id_gen,
+            in_env.allow_life_event_value,
+            in_env.known_last_effect_id(),
+        );
 
         let mut out_env = advance_reference_env_for_effect(
             &effect,
@@ -1271,6 +1299,7 @@ fn maybe_assign_effect_result_id(
     idx: usize,
     id_gen: &mut IdGenContext,
     _allow_life_event_value: bool,
+    current_last_effect_id: Option<EffectId>,
 ) -> Option<EffectId> {
     let next_is_result_gate = idx + 1 < effects.len()
         && matches!(
@@ -1309,6 +1338,15 @@ fn maybe_assign_effect_result_id(
                 )
         );
 
+    if idx + 1 < effects.len()
+        && effect_can_supply_prior_effect_memory(&effects[idx])
+        && let Some(id) = first_explicit_effect_result_reference(&effects[idx + 1])
+        && Some(id) != current_last_effect_id
+        && id == EffectId(id_gen.next_effect_id)
+    {
+        return Some(id);
+    }
+
     if !(next_is_if_result_with_opponent_doesnt
         || next_is_if_result_with_player_doesnt
         || next_is_if_result_with_opponent_did
@@ -1324,6 +1362,23 @@ fn maybe_assign_effect_result_id(
     let id = EffectId(id_gen.next_effect_id);
     id_gen.next_effect_id += 1;
     Some(id)
+}
+
+fn first_explicit_effect_result_reference(effect: &EffectAst) -> Option<EffectId> {
+    let mut found = None;
+    visit_effect_values(effect, &mut |value| {
+        if found.is_some() {
+            return;
+        }
+        found = match value {
+            Value::EffectValue(id)
+            | Value::EffectValueOffset(id, _)
+            | Value::EffectMetric { effect_id: id, .. }
+            | Value::EffectMetricOffset { effect_id: id, .. } => Some(*id),
+            _ => None,
+        };
+    });
+    found
 }
 
 fn effect_can_supply_prior_effect_memory(effect: &EffectAst) -> bool {
@@ -1680,8 +1735,13 @@ fn resolve_effect_sequence_references_with_state(
             &[]
         };
         let _ = effects_reference_it_tag(remaining) || effects_reference_its_controller(remaining);
-        let assigned_effect_id =
-            maybe_assign_effect_result_id(effects, idx, id_gen, state.allow_life_event_value);
+        let assigned_effect_id = maybe_assign_effect_result_id(
+            effects,
+            idx,
+            id_gen,
+            state.allow_life_event_value,
+            state.last_effect_id,
+        );
         state.last_effect_id = if matches!(
             effect,
             EffectAst::ResolvedIfResult { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -376,6 +376,21 @@ pub(crate) fn parse_effect_chain_lexed(
     let starts_with_each_player =
         grammar::words_match_any_prefix(tokens, EACH_PLAYER_PREFIXES).is_some();
 
+    if starts_with_each_player
+        && let Some(stripped) = grammar::strip_lexed_prefix_phrase(tokens, &["each", "player", "may"])
+            .or_else(|| grammar::strip_lexed_prefix_phrase(tokens, &["each", "players", "may"]))
+    {
+        let mut subject_tokens = vec![synthetic_lexed_word("they")];
+        subject_tokens.extend_from_slice(stripped);
+        let effects = parse_effect_chain_lexed(&subject_tokens)?;
+        return Ok(vec![EffectAst::ForEachPlayer {
+            effects: vec![EffectAst::MayByPlayer {
+                player: PlayerAst::That,
+                effects,
+            }],
+        }]);
+    }
+
     if let Some(player) = parse_leading_player_may_lexed(tokens) {
         let mut stripped = remove_through_first_word(tokens, "may");
         if stripped

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -37,6 +37,24 @@ pub(crate) fn parse_exile(
     )? {
         return Ok(effect);
     }
+    if word_slice_starts_with_any(&clause_words, &[&["their", "hand"], &["your", "hand"]])
+        && clause_words.len() == 2
+    {
+        let mut filter = ObjectFilter::default().in_zone(Zone::Hand);
+        filter.owner = if clause_words[0] == "your" {
+            Some(PlayerFilter::You)
+        } else {
+            exile_subject_owner_filter(subject).or(Some(PlayerFilter::IteratedPlayer))
+        };
+        return Ok(if until_source_leaves {
+            EffectAst::subject_verb_exile_until_source_leaves(
+                TargetAst::Object(filter, None, None),
+                face_down,
+            )
+        } else {
+            EffectAst::subject_verb_exile_all(filter, face_down)
+        });
+    }
     if word_slice_first_is_any(&clause_words, &["all", "each"]) {
         let filter_tokens = &tokens[1..];
         let mut filter = parse_object_filter_lexed(filter_tokens, false)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
@@ -89,6 +89,19 @@ pub(crate) fn parse_draw(
         } else if let Some(value) = parse_draw_as_many_cards_value(tokens) {
             consumed_embedded_card_keyword = true;
             (value, tokens.len())
+        } else if word_slice_starts_with(
+            &clause_words,
+            &["a", "number", "of", "cards", "equal", "to"],
+        ) {
+            let value_tokens = &tokens[token_index_for_word_index(tokens, 4).unwrap_or(tokens.len())..];
+            let value = parse_draw_equal_to_value(value_tokens)?.ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unsupported draw count (clause: '{}')",
+                    clause_words.join(" ")
+                ))
+            })?;
+            consumed_embedded_card_keyword = true;
+            (value, tokens.len())
         } else if token_slice_first_is(tokens, "another")
             && token_slice_at_is_any(tokens, 1, &["card", "cards"])
         {
@@ -615,6 +628,14 @@ pub(crate) fn parse_draw_equal_to_value(
         .or_else(|| parse_equal_to_number_of_filter_value(tokens))
     {
         return Ok(Some(value));
+    }
+    if word_slice_starts_with(&token_words, &["equal", "to", "the", "amount", "of"])
+        && word_slice_contains_phrase(&token_words, &["paid", "this", "way"])
+    {
+        return Ok(Some(Value::PendingEffectMetric {
+            source: ironsmith_core::EffectMetricSource::Outcome,
+            metric: ironsmith_core::EffectMetric::Count,
+        }));
     }
     if grammar::words_find_phrase(tokens, &["this", "way"]).is_some() {
         return Ok(Some(Value::EventValue(EventValueSpec::Amount)));

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3504,6 +3504,7 @@ pub struct GrantPlayTaggedEffect {
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
     pub while_on_top_of_library: bool,
+    pub object_filter: Option<ObjectFilter>,
 }
 
 impl GrantPlayTaggedEffect {
@@ -3521,7 +3522,13 @@ impl GrantPlayTaggedEffect {
             allow_land,
             allow_any_color_for_cast,
             while_on_top_of_library: false,
+            object_filter: None,
         }
+    }
+
+    pub fn matching(mut self, filter: ObjectFilter) -> Self {
+        self.object_filter = Some(filter);
+        self
     }
 
     pub fn while_on_top_of_library(mut self) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -142,6 +142,94 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn wheel_of_potential_strict_parser_text_and_paid_energy_regression() {
+    let def = parse_oracle_card_definition("Wheel of Potential");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Wheel of Potential should have a spell effect")
+        .flattened_default_effects();
+
+    assert_eq!(
+        rendered,
+        "You get {E}{E}{E}, then you may pay any amount of {E}. Each player may exile their hand and draw a number of cards equal to the amount of {E} paid this way. If seven or more {E} was paid this way, you may play cards you own exiled this way until the end of your next turn."
+    );
+    assert_eq!(effects.len(), 4, "expected two Wheel resolution segments flattened to four effects, got {effects:#?}");
+
+    let pay_with_id = effects[1]
+        .downcast_ref::<crate::effects::WithIdEffect>()
+        .expect("optional energy payment should be materialized with an effect id");
+    let may_pay = pay_with_id
+        .effect
+        .downcast_ref::<crate::effects::MayEffect>()
+        .expect("payment id should wrap the optional payment");
+    assert!(
+        may_pay.effects[0]
+            .downcast_ref::<crate::effects::PayAnyEnergyEffect>()
+            .is_some(),
+        "expected optional pay-any-energy effect, got {may_pay:#?}"
+    );
+
+    let for_players = effects[2]
+        .downcast_ref::<crate::effects::ForPlayersEffect>()
+        .expect("second segment should iterate each player");
+    let per_player_may = for_players.effects[0]
+        .downcast_ref::<crate::effects::MayEffect>()
+        .expect("each player should choose whether to exile their hand");
+    let draw = per_player_may.effects[1]
+        .downcast_ref::<crate::effects::DrawCardsEffect>()
+        .expect("hand exile should be followed by a draw");
+    assert!(
+        matches!(
+            &draw.count,
+            Value::EffectMetric {
+                effect_id,
+                source: crate::effect::EffectMetricSource::Outcome,
+                metric: crate::effect::EffectMetric::Count,
+            } if *effect_id == pay_with_id.id
+        ),
+        "draw count should use the amount of energy paid, not cards exiled, got {:?}",
+        draw.count
+    );
+
+    let conditional = effects[3]
+        .downcast_ref::<crate::effects::ConditionalEffect>()
+        .expect("seven-or-more branch should be a value comparison conditional");
+    assert!(
+        matches!(
+            &conditional.condition,
+            Condition::ValueComparison {
+                left: Value::EffectMetric {
+                    effect_id,
+                    source: crate::effect::EffectMetricSource::Outcome,
+                    metric: crate::effect::EffectMetric::Count,
+                },
+                operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                right: Value::Fixed(7),
+            } if *effect_id == pay_with_id.id
+        ),
+        "seven-or-more branch should check the paid energy amount, got {:?}",
+        conditional.condition
+    );
+    assert!(
+        conditional.if_false.is_empty(),
+        "below seven energy paid should not grant play permission"
+    );
+    let grant = conditional.if_true[0]
+        .downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+        .expect("seven or more energy paid should grant play permission");
+    assert_eq!(
+        grant
+            .object_filter
+            .as_ref()
+            .and_then(|filter| filter.owner.clone()),
+        Some(PlayerFilter::You),
+        "play permission should be restricted to cards you own exiled this way"
+    );
+}
+
+#[test]
 fn thundermane_dragon_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Thundermane Dragon");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -230,6 +230,174 @@ fn wheel_of_potential_strict_parser_text_and_paid_energy_regression() {
 }
 
 #[test]
+fn wheel_of_potential_runtime_paid_energy_and_owner_restricted_permission() {
+    fn filler_definition(card_id: u32, name: &str) -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::from_raw(card_id), name)
+            .card_types(vec![CardType::Sorcery])
+            .build()
+    }
+
+    fn add_cards(
+        game: &mut crate::game_state::GameState,
+        owner: PlayerId,
+        zone: Zone,
+        count: usize,
+        card_id_base: u32,
+        name_prefix: &str,
+    ) -> Vec<crate::ids::StableId> {
+        (0..count)
+            .map(|idx| {
+                let def = filler_definition(
+                    card_id_base + idx as u32,
+                    &format!("{name_prefix} {}", idx + 1),
+                );
+                let object_id = game.create_object_from_definition(&def, owner, zone);
+                game.object(object_id)
+                    .expect("created card should exist")
+                    .stable_id
+            })
+            .collect()
+    }
+
+    fn current_id(
+        game: &crate::game_state::GameState,
+        stable_id: crate::ids::StableId,
+    ) -> ObjectId {
+        game.find_object_by_stable_id(stable_id)
+            .expect("stable card should still exist")
+    }
+
+    fn run_wheel_with_starting_energy(
+        starting_energy: u32,
+    ) -> (
+        crate::game_state::GameState,
+        PlayerId,
+        PlayerId,
+        Vec<crate::ids::StableId>,
+        Vec<crate::ids::StableId>,
+    ) {
+        let def = parse_oracle_card_definition("Wheel of Potential");
+        let mut game =
+            crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.player_mut(alice)
+            .expect("Alice should exist")
+            .energy_counters = starting_energy;
+
+        let alice_hand = add_cards(&mut game, alice, Zone::Hand, 2, 93_000, "Alice Hand");
+        let bob_hand = add_cards(&mut game, bob, Zone::Hand, 2, 94_000, "Bob Hand");
+        add_cards(&mut game, alice, Zone::Library, 8, 95_000, "Alice Library");
+        add_cards(&mut game, bob, Zone::Library, 8, 96_000, "Bob Library");
+
+        let source_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+        let mut dm = crate::decision::SelectFirstDecisionMaker;
+        let mut ctx = crate::effects::ExecutionContext::new(source_id, alice, &mut dm);
+        for effect in def
+            .spell_effect
+            .as_ref()
+            .expect("Wheel of Potential should have a spell effect")
+            .flattened_default_effects()
+        {
+            effect
+                .0
+                .execute(&mut game, &mut ctx)
+                .expect("Wheel of Potential effect should resolve");
+        }
+
+        (game, alice, bob, alice_hand, bob_hand)
+    }
+
+    let (below_game, below_alice, below_bob, below_alice_hand, below_bob_hand) =
+        run_wheel_with_starting_energy(3);
+    assert_eq!(
+        below_game
+            .player(below_alice)
+            .expect("Alice should exist")
+            .hand
+            .len(),
+        6,
+        "below-seven payment should make Alice draw the amount of energy paid"
+    );
+    assert_eq!(
+        below_game
+            .player(below_bob)
+            .expect("Bob should exist")
+            .hand
+            .len(),
+        6,
+        "below-seven payment should make Bob draw the amount of energy paid"
+    );
+    for stable_id in below_alice_hand.iter().chain(below_bob_hand.iter()) {
+        let object_id = current_id(&below_game, *stable_id);
+        assert_eq!(
+            below_game.object(object_id).expect("card should exist").zone,
+            Zone::Exile,
+            "each player should exile their previous hand"
+        );
+        assert!(
+            !below_game.effect_store.grant_registry.card_can_play_from_zone(
+                &below_game,
+                object_id,
+                Zone::Exile,
+                below_alice
+            ),
+            "below-seven payment should not grant play permission"
+        );
+    }
+
+    let (above_game, above_alice, above_bob, above_alice_hand, above_bob_hand) =
+        run_wheel_with_starting_energy(4);
+    assert_eq!(
+        above_game
+            .player(above_alice)
+            .expect("Alice should exist")
+            .hand
+            .len(),
+        7,
+        "seven-or-more payment should make Alice draw the amount of energy paid"
+    );
+    assert_eq!(
+        above_game
+            .player(above_bob)
+            .expect("Bob should exist")
+            .hand
+            .len(),
+        7,
+        "seven-or-more payment should make Bob draw the amount of energy paid"
+    );
+    let alice_exiled = current_id(&above_game, above_alice_hand[0]);
+    let bob_exiled = current_id(&above_game, above_bob_hand[0]);
+    assert!(
+        above_game.effect_store.grant_registry.card_can_play_from_zone(
+            &above_game,
+            alice_exiled,
+            Zone::Exile,
+            above_alice
+        ),
+        "seven-or-more payment should let the caster play cards they own exiled this way"
+    );
+    assert!(
+        !above_game.effect_store.grant_registry.card_can_play_from_zone(
+            &above_game,
+            bob_exiled,
+            Zone::Exile,
+            above_alice
+        ),
+        "play permission should not include opponents' cards exiled this way"
+    );
+    assert!(
+        !above_game.effect_store.grant_registry.card_can_play_from_zone(
+            &above_game,
+            alice_exiled,
+            Zone::Exile,
+            above_bob
+        ),
+        "the grant should belong to the caster, not each card's owner"
+    );
+}
+
+#[test]
 fn thundermane_dragon_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Thundermane Dragon");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -349,6 +349,14 @@ pub(super) fn describe_resolution_program(
     if let Some(rendered) = describe_spell_mastery_reanimation_program(program) {
         return rendered;
     }
+    if program.segments.len() == 2 {
+        let rendered = describe_effect_list(program.flattened_default_effects());
+        if rendered.contains("Each player may exile their hand")
+            && rendered.contains("seven or more {E} was paid this way")
+        {
+            return rendered;
+        }
+    }
 
     let mut rendered_segments = Vec::new();
     for segment in &program.segments {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3999,6 +3999,105 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
+    fn describe_energy_pay_each_player_hand_exile_draw_permission(
+        effects: &[&Effect],
+    ) -> Option<String> {
+        let [energy_effect, may_effect, for_players_effect, conditional_effect] = effects else {
+            return None;
+        };
+        let energy = unwrap_wrapped_effect(energy_effect)
+            .downcast_ref::<crate::effects::EnergyCountersEffect>()?;
+        if energy.player != PlayerFilter::You {
+            return None;
+        }
+        let may_with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+        let may = may_with_id
+            .effect
+            .downcast_ref::<crate::effects::MayEffect>()?;
+        if !matches!(may.decider, None | Some(PlayerFilter::You)) || may.effects.len() != 1 {
+            return None;
+        }
+        let pay_any = unwrap_wrapped_effect(&may.effects[0])
+            .downcast_ref::<crate::effects::PayAnyEnergyEffect>()?;
+        if !matches!(pay_any.player, ChooseSpec::Player(PlayerFilter::You)) {
+            return None;
+        }
+
+        let for_players = for_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()?;
+        if for_players.filter != PlayerFilter::Any || for_players.effects.len() != 1 {
+            return None;
+        }
+        let per_player_may = for_players.effects[0].downcast_ref::<crate::effects::MayEffect>()?;
+        if per_player_may.decider != Some(PlayerFilter::IteratedPlayer)
+            || per_player_may.effects.len() != 2
+        {
+            return None;
+        }
+        let tagged = per_player_may.effects[0].downcast_ref::<crate::effects::TaggedEffect>()?;
+        let exile = tagged
+            .effect
+            .downcast_ref::<crate::effects::ExileEffect>()?;
+        let ChooseSpec::All(hand_filter) = &exile.spec else {
+            return None;
+        };
+        if hand_filter.zone != Some(Zone::Hand)
+            || hand_filter.owner != Some(PlayerFilter::IteratedPlayer)
+        {
+            return None;
+        }
+        let draw = per_player_may.effects[1].downcast_ref::<crate::effects::DrawCardsEffect>()?;
+        if draw.player != PlayerFilter::IteratedPlayer
+            || !matches!(
+                &draw.count,
+                Value::EffectMetric {
+                    effect_id,
+                    source: crate::effect::EffectMetricSource::Outcome,
+                    metric: crate::effect::EffectMetric::Count,
+                } if *effect_id == may_with_id.id
+            )
+        {
+            return None;
+        }
+
+        let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        let Condition::ValueComparison {
+            left,
+            operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+            right: Value::Fixed(7),
+        } = &conditional.condition
+        else {
+            return None;
+        };
+        if !matches!(
+            left,
+            Value::EffectMetric {
+                effect_id,
+                source: crate::effect::EffectMetricSource::Outcome,
+                metric: crate::effect::EffectMetric::Count,
+            } if *effect_id == may_with_id.id
+        ) || !conditional.if_false.is_empty() || conditional.if_true.len() != 1
+        {
+            return None;
+        }
+        let grant = conditional.if_true[0].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()?;
+        if grant.tag != tagged.tag
+            || grant.player != PlayerFilter::You
+            || grant.duration != crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd
+            || !grant.allow_land
+        {
+            return None;
+        }
+        let payment = describe_pay_any_energy_amount(pay_any)?;
+        Some(format!(
+            "{}, then you may pay {payment}. Each player may exile their hand and draw a number of cards equal to the amount of {{E}} paid this way. If seven or more {{E}} was paid this way, you may play cards you own exiled this way until the end of your next turn",
+            describe_effect(energy_effect)
+        ))
+    }
+
+    if let Some(compact) = describe_energy_pay_each_player_hand_exile_draw_permission(&raw_effects) {
+        return compact;
+    }
+
     fn describe_energy_then_pay_any_then_put_paid_counters(effects: &[&Effect]) -> Option<String> {
         let [energy_effect, may_effect, if_effect] = effects else {
             return None;
@@ -33181,7 +33280,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "looked")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "chosen")
             || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "searched");
-        let object_text = if grant_play_tagged.tag.as_str().starts_with("targeted_")
+        let object_text = if grant_play_tagged
+            .object_filter
+            .as_ref()
+            .is_some_and(|filter| filter.owner == Some(PlayerFilter::You))
+            && helper_tag
+        {
+            "cards you own exiled this way".to_string()
+        } else if grant_play_tagged.tag.as_str().starts_with("targeted_")
             || grant_play_tagged.tag.as_str().starts_with("__source_")
             || grant_play_tagged.tag.as_str() == "__it__"
             || matches!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4084,6 +4084,10 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             || grant.player != PlayerFilter::You
             || grant.duration != crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd
             || !grant.allow_land
+            || !grant
+                .object_filter
+                .as_ref()
+                .is_some_and(|filter| filter.owner == Some(PlayerFilter::You))
         {
             return None;
         }

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1040,14 +1040,18 @@ where
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::GrantPlayTaggedEffect>(&effect) {
-        return Ok(Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+        let mut grant_play = crate::effects::GrantPlayTaggedEffect::new(
             payload.tag.clone(),
             payload.player.clone(),
             payload.duration,
             payload.allow_land,
             payload.allow_any_color_for_cast,
         )
-        .while_on_top_of_library_if(payload.while_on_top_of_library)));
+        .while_on_top_of_library_if(payload.while_on_top_of_library);
+        if let Some(filter) = &payload.object_filter {
+            grant_play = grant_play.matching(filter.clone());
+        }
+        return Ok(Effect::new(grant_play));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::LocalRewriteEffect<M::Effect>>(&effect)
     {

--- a/crates/ironsmith-runtime/src/effects/composition/for_players.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/for_players.rs
@@ -6,7 +6,10 @@ use crate::effects::{ExecutionContext, ExecutionError, execute_effect};
 use crate::filter::PlayerFilterExt;
 use crate::game_state::GameState;
 use crate::ids::PlayerId;
+use crate::snapshot::ObjectSnapshot;
+use crate::tag::TagKey;
 use crate::target::PlayerFilter;
+use std::collections::HashMap;
 
 /// Effect that applies effects once for each player matching a filter.
 ///
@@ -82,9 +85,12 @@ impl EffectExecutor for ForPlayersEffect {
         let mut outcomes = Vec::new();
         let mut player_counts = Vec::new();
         let mut player_affected_memory = Vec::new();
+        let base_tagged_objects = ctx.tagged_objects.clone();
+        let mut accumulated_tagged_objects: HashMap<TagKey, Vec<ObjectSnapshot>> = HashMap::new();
 
         for player_id in players {
-            ctx.with_temp_iterated_player(Some(player_id), |ctx| {
+            ctx.tagged_objects = base_tagged_objects.clone();
+            let iteration_result = ctx.with_temp_iterated_player(Some(player_id), |ctx| {
                 let start = outcomes.len();
                 // Execute all inner effects for this player
                 for effect in &self.effects {
@@ -103,13 +109,67 @@ impl EffectExecutor for ForPlayersEffect {
                     player_affected_memory.push((player_id, memory.to_vec()));
                 }
                 Ok::<(), ExecutionError>(())
-            })?;
+            });
+
+            accumulate_iteration_tags(
+                &base_tagged_objects,
+                &ctx.tagged_objects,
+                &mut accumulated_tagged_objects,
+            );
+            ctx.tagged_objects = base_tagged_objects.clone();
+            iteration_result?;
+        }
+
+        ctx.tagged_objects = base_tagged_objects;
+        for (tag, snapshots) in accumulated_tagged_objects {
+            ctx.tag_objects_unique(tag, snapshots);
         }
 
         Ok(EffectOutcome::aggregate_summing_counts(outcomes)
             .with_player_counts(player_counts)
             .with_player_affected_object_memory(player_affected_memory))
     }
+}
+
+fn accumulate_iteration_tags(
+    base: &HashMap<TagKey, Vec<ObjectSnapshot>>,
+    current: &HashMap<TagKey, Vec<ObjectSnapshot>>,
+    accumulated: &mut HashMap<TagKey, Vec<ObjectSnapshot>>,
+) {
+    for (tag, snapshots) in current {
+        if base
+            .get(tag)
+            .is_some_and(|base_snapshots| same_snapshots(base_snapshots, snapshots))
+        {
+            continue;
+        }
+        let entry = accumulated.entry(tag.clone()).or_default();
+        for snapshot in snapshots {
+            let existed_before = base
+                .get(tag)
+                .is_some_and(|base_snapshots| contains_snapshot(base_snapshots, snapshot));
+            let already_accumulated = contains_snapshot(entry, snapshot);
+            if !existed_before && !already_accumulated {
+                entry.push(snapshot.clone());
+            }
+        }
+    }
+}
+
+fn same_snapshots(left: &[ObjectSnapshot], right: &[ObjectSnapshot]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right.iter())
+            .all(|(left, right)| {
+                left.object_id == right.object_id && left.stable_id == right.stable_id
+            })
+}
+
+fn contains_snapshot(snapshots: &[ObjectSnapshot], needle: &ObjectSnapshot) -> bool {
+    snapshots.iter().any(|snapshot| {
+        snapshot.object_id == needle.object_id && snapshot.stable_id == needle.stable_id
+    })
 }
 
 #[cfg(test)]

--- a/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
@@ -4,11 +4,12 @@ use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_player_filter;
 use crate::effects::{ExecutionContext, ExecutionError};
+use crate::filter::ObjectFilterExt;
 use crate::game_state::GameState;
 use crate::grant::Grantable;
 use crate::grant_registry::GrantSource;
 use crate::tag::TagKey;
-use crate::target::PlayerFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 pub use ironsmith_core::GrantPlayTaggedDuration;
 
 /// Grant temporary permission to cast or play cards tagged in the current context.
@@ -20,6 +21,7 @@ pub struct GrantPlayTaggedEffect {
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
     pub while_on_top_of_library: bool,
+    pub object_filter: Option<ObjectFilter>,
 }
 
 impl GrantPlayTaggedEffect {
@@ -37,7 +39,13 @@ impl GrantPlayTaggedEffect {
             allow_land,
             allow_any_color_for_cast,
             while_on_top_of_library: false,
+            object_filter: None,
         }
+    }
+
+    pub fn matching(mut self, filter: ObjectFilter) -> Self {
+        self.object_filter = Some(filter);
+        self
     }
 
     pub fn while_on_top_of_library(mut self) -> Self {
@@ -183,6 +191,12 @@ impl EffectExecutor for GrantPlayTaggedEffect {
             let Some(object) = game.object(object_id) else {
                 continue;
             };
+            if let Some(filter) = &self.object_filter {
+                let filter_ctx = game.filter_context_for(player_id, Some(ctx.source));
+                if !filter.matches(object, &filter_ctx, game) {
+                    continue;
+                }
+            }
             if (!self.allow_land && object.is_land()) || !seen.insert(object_id) {
                 continue;
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wheel of Potential
Initial parse error:
```
parser does not yet support line family: 'Each player may exile their hand and draw a number of cards equal to the amount of {E} paid this way. If seven or more {E} was paid this way, you may play cards you own exiled this way until the end of your next turn.'; oracle-only fallback also failed: parser does not yet support line family: 'Each player may exile their hand and draw a number of cards equal to the amount of {E} paid this way. If seven or more {E} was paid this way, you may play cards you own exiled this way until the end of your next turn.'
```

Current worker: i-09d27649098d9fef5
Branch: codex/aws-card-fix-wheel-of-potential
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0030
