### PR TITLE
Fix Ironsmith parse failure: King Darien XLVIII

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1264,6 +1264,9 @@ fn source_name_aliases_for_builder(builder: &CardDefinitionBuilder) -> Vec<Strin
         if let Some(stripped) = strip_leading_digital_variant_marker(full_name.as_str()) {
             push_unique_source_name_alias(&mut full_names, stripped);
         }
+        if let Some(stripped) = strip_trailing_roman_numeral(full_name.as_str()) {
+            push_unique_source_name_alias(&mut full_names, stripped);
+        }
     }
 
     for full_name in &full_names {
@@ -1302,6 +1305,22 @@ fn strip_leading_digital_variant_marker(name: &str) -> Option<&str> {
         }
     }
     None
+}
+
+fn strip_trailing_roman_numeral(name: &str) -> Option<&str> {
+    let trimmed = name.trim();
+    let (prefix, suffix) = trimmed.rsplit_once(char::is_whitespace)?;
+    let suffix = suffix.trim_matches(|ch: char| !ch.is_ascii_alphabetic());
+    if suffix.len() < 2 || !suffix.bytes().all(|byte| {
+        matches!(
+            byte.to_ascii_uppercase(),
+            b'I' | b'V' | b'X' | b'L' | b'C' | b'D' | b'M'
+        )
+    }) {
+        return None;
+    }
+    let prefix = prefix.trim();
+    (!prefix.is_empty()).then_some(prefix)
 }
 
 fn strip_non_keyword_label_prefix(text: &str) -> &str {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -30,6 +30,7 @@ use super::token_primitives::{
     find_index as find_token_index, str_ends_with, str_starts_with, str_strip_prefix,
     str_strip_suffix,
 };
+use super::util::is_source_reference_words;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ActivationCostCst {
@@ -617,6 +618,9 @@ fn parse_sacrifice_segment_tokens(
             &["this", "card"],
         ],
     ) {
+        return Ok(ActivationCostSegmentCst::SacrificeSelf);
+    }
+    if is_source_reference_words(tail) {
         return Ok(ActivationCostSegmentCst::SacrificeSelf);
     }
     if word_slice_eq(tail, &["a", "creature"]) {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -143,6 +143,9 @@ fn source_reference_aliases_for_name(name: &str) -> Vec<SourceReferenceAlias> {
         if let Some(stripped) = strip_leading_digital_variant_marker(full_name.as_str()) {
             push_unique_source_name_alias(&mut full_names, stripped);
         }
+        if let Some(stripped) = strip_trailing_roman_numeral(full_name.as_str()) {
+            push_unique_source_name_alias(&mut full_names, stripped);
+        }
     }
 
     for full_name in &full_names {
@@ -213,6 +216,22 @@ fn strip_leading_digital_variant_marker(name: &str) -> Option<&str> {
         }
     }
     None
+}
+
+fn strip_trailing_roman_numeral(name: &str) -> Option<&str> {
+    let trimmed = name.trim();
+    let (prefix, suffix) = trimmed.rsplit_once(char::is_whitespace)?;
+    let suffix = suffix.trim_matches(|ch: char| !ch.is_ascii_alphabetic());
+    if suffix.len() < 2 || !suffix.bytes().all(|byte| {
+        matches!(
+            byte.to_ascii_uppercase(),
+            b'I' | b'V' | b'X' | b'L' | b'C' | b'D' | b'M'
+        )
+    }) {
+        return None;
+    }
+    let prefix = prefix.trim();
+    (!prefix.is_empty()).then_some(prefix)
 }
 
 fn source_reference_words_from_text(text: &str) -> Vec<String> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -159,6 +159,219 @@ fn thundermane_dragon_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn king_darien_xlviii_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("King Darien XLVIII");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(
+        def.abilities.len(),
+        3,
+        "King Darien XLVIII should parse its static ability and two activated abilities, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("Anthem")
+            && ability_debug.contains("PutCountersEffect")
+            && ability_debug.contains("SourceReference")
+            && ability_debug.contains("CreateTokenEffect")
+            && ability_debug.contains("SacrificeTargetEffect")
+            && ability_debug.contains("Hexproof")
+            && ability_debug.contains("Indestructible"),
+        "King Darien XLVIII should structurally model all three abilities, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("Other creatures you control get +1/+1."),
+        "expected anthem text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "{3}{G}{W}: Put a +1/+1 counter on King Darien and create a 1/1 white Soldier creature token."
+        ),
+        "expected self-counter plus Soldier creation text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Sacrifice this creature: Creature tokens you control gain hexproof and indestructible until end of turn."
+        ),
+        "expected token keyword grant text, got {rendered}"
+    );
+}
+
+#[test]
+fn king_darien_xlviii_anthem_buffs_only_your_other_creatures_runtime() {
+    let def = parse_oracle_card_definition("King Darien XLVIII");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let alice_creature = CardDefinitionBuilder::new(CardId::from_raw(92_010), "Alice Recruit")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let bob_creature = CardDefinitionBuilder::new(CardId::from_raw(92_011), "Bob Recruit")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let alice_id = game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+    let bob_id = game.create_object_from_definition(&bob_creature, bob, Zone::Battlefield);
+
+    let alice_chars = game
+        .calculated_characteristics(alice_id)
+        .expect("Alice creature should have characteristics");
+    assert_eq!(
+        (alice_chars.power, alice_chars.toughness),
+        (Some(2), Some(2)),
+        "King Darien XLVIII should give other creatures you control +1/+1"
+    );
+
+    let bob_chars = game
+        .calculated_characteristics(bob_id)
+        .expect("Bob creature should have characteristics");
+    assert_eq!(
+        (bob_chars.power, bob_chars.toughness),
+        (Some(1), Some(1)),
+        "King Darien XLVIII should not buff opponents' creatures"
+    );
+}
+
+#[test]
+fn king_darien_xlviii_mana_ability_puts_counter_on_self_and_creates_soldier_runtime() {
+    let def = parse_oracle_card_definition("King Darien XLVIII");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            format!("{:?}", activated.effects)
+                .contains("CreateTokenEffect")
+                .then_some(activated)
+        })
+        .expect("King Darien XLVIII should have its mana activated ability");
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let king_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(king_id, alice, &mut dm);
+    for effect in activated.effects.flattened_default_effects() {
+        effect
+            .0
+            .execute(&mut game, &mut ctx)
+            .expect("King Darien XLVIII mana ability effect should resolve");
+    }
+
+    assert_eq!(
+        game.object(king_id).and_then(|object| object
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied()),
+        Some(1),
+        "the mana ability should put a +1/+1 counter on King Darien XLVIII"
+    );
+    assert!(
+        game.battlefield.iter().any(|id| {
+            game.object(*id).is_some_and(|object| {
+                object.name == "Soldier" && object.kind == crate::object::ObjectKind::Token
+            })
+        }),
+        "the mana ability should create a Soldier creature token"
+    );
+}
+
+#[test]
+fn king_darien_xlviii_sacrifice_ability_grants_keywords_only_to_your_tokens_runtime() {
+    let def = parse_oracle_card_definition("King Darien XLVIII");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            format!("{:?}", activated.effects)
+                .contains("ApplyContinuousEffect")
+                .then_some(activated)
+        })
+        .expect("King Darien XLVIII should have its sacrifice activated ability");
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let king_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let token_def = CardDefinitionBuilder::new(CardId::from_raw(92_012), "Alice Token")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let alice_token = game.create_object_from_definition(&token_def, alice, Zone::Battlefield);
+    game.object_mut(alice_token)
+        .expect("Alice token should exist")
+        .kind = crate::object::ObjectKind::Token;
+    let bob_token = game.create_object_from_definition(&token_def, bob, Zone::Battlefield);
+    game.object_mut(bob_token)
+        .expect("Bob token should exist")
+        .kind = crate::object::ObjectKind::Token;
+    let nontoken_def = CardDefinitionBuilder::new(CardId::from_raw(92_013), "Alice Nontoken")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let alice_nontoken =
+        game.create_object_from_definition(&nontoken_def, alice, Zone::Battlefield);
+
+    let sacrifice_cost = activated
+        .mana_cost
+        .costs()
+        .first()
+        .expect("sacrifice ability should have a sacrifice cost");
+    let mut cost_dm = crate::decision::AutoPassDecisionMaker;
+    let mut cost_ctx = crate::costs::CostContext::new(king_id, alice, &mut cost_dm);
+    sacrifice_cost
+        .pay(&mut game, &mut cost_ctx)
+        .expect("King Darien XLVIII sacrifice cost should be payable");
+    assert!(
+        !game.battlefield.contains(&king_id)
+            && game.player(alice).is_some_and(|player| {
+                player.graveyard.iter().any(|id| {
+                    game.object(*id)
+                        .is_some_and(|object| object.name == "King Darien XLVIII")
+                })
+            }),
+        "paying the sacrifice cost should move King Darien XLVIII from the battlefield to the graveyard"
+    );
+
+    let mut effect_dm = crate::decision::AutoPassDecisionMaker;
+    let mut effect_ctx = crate::effects::ExecutionContext::new(king_id, alice, &mut effect_dm);
+    for effect in activated.effects.flattened_default_effects() {
+        effect
+            .0
+            .execute(&mut game, &mut effect_ctx)
+            .expect("King Darien XLVIII sacrifice ability effect should resolve");
+    }
+
+    assert!(
+        game.object_has_static_ability_id(alice_token, StaticAbilityId::Hexproof)
+            && game.object_has_static_ability_id(alice_token, StaticAbilityId::Indestructible),
+        "your creature token should gain hexproof and indestructible"
+    );
+    assert!(
+        !game.object_has_static_ability_id(alice_nontoken, StaticAbilityId::Hexproof)
+            && !game.object_has_static_ability_id(alice_nontoken, StaticAbilityId::Indestructible),
+        "your nontoken creature should not gain the token-only keywords"
+    );
+    assert!(
+        !game.object_has_static_ability_id(bob_token, StaticAbilityId::Hexproof)
+            && !game.object_has_static_ability_id(bob_token, StaticAbilityId::Indestructible),
+        "opponents' creature tokens should not gain the keywords"
+    );
+}
+
+#[test]
 fn vampire_socialite_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Vampire Socialite");
     let rendered = unprocessed_compiled_lines(&def).join("\n");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9002,6 +9002,20 @@ pub(super) fn describe_apply_continuous_clauses(
         }
     }
 
+    if clauses.len() > 1 {
+        let shared_gain_prefix = if plural_target { "gain " } else { "gains " };
+        if clauses
+            .iter()
+            .all(|clause| clause.starts_with(shared_gain_prefix))
+        {
+            let gained = clauses
+                .iter()
+                .map(|clause| clause[shared_gain_prefix.len()..].to_string())
+                .collect::<Vec<_>>();
+            return vec![format!("{shared_gain_prefix}{}", join_with_and(&gained))];
+        }
+    }
+
     clauses
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4674,6 +4674,34 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         })
         .collect::<Vec<_>>();
 
+    fn describe_source_counter_and_create(effects: &[&Effect]) -> Option<String> {
+        let [counter_effect, create_effect] = effects else {
+            return None;
+        };
+        let put = counter_effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+        if put.counter_type != CounterType::PlusOnePlusOne
+            || put.amount != Value::Fixed(1)
+            || !matches!(put.target.base(), ChooseSpec::Source)
+            || put.target_count.is_some()
+            || put.distributed
+        {
+            return None;
+        }
+        create_effect.downcast_ref::<crate::effects::CreateTokenEffect>()?;
+
+        let counter_text = describe_effect(counter_effect);
+        let create_text = lowercase_first(&describe_effect(create_effect));
+        Some(format!(
+            "{} and {}",
+            counter_text.trim_end_matches('.'),
+            create_text.trim_end_matches('.')
+        ))
+    }
+
+    if let Some(compact) = describe_source_counter_and_create(&filtered) {
+        return compact;
+    }
+
     if let Some(compact) = describe_reveal_hand_choose_move(&filtered) {
         return compact;
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: King Darien XLVIII
Initial parse error:
```
unsupported target phrase (clause: 'king darien'); oracle-only fallback also failed: unsupported target phrase (clause: 'king darien')
```

Current worker: i-01a43d52bed528e3f
Branch: codex/aws-card-fix-king-darien-xlviii
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0030
