### PR TITLE
Fix Ironsmith parse failure: Grievous Wound

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
@@ -263,6 +263,14 @@ pub(crate) fn parse_trigger_subject_player_filter(subject: &[&str]) -> Option<Pl
     ) {
         return Some(PlayerFilter::ChosenPlayer);
     }
+    if word_slice_eq_any(
+        subject,
+        &[&["enchanted", "player"], &["the", "enchanted", "player"]],
+    ) {
+        return Some(PlayerFilter::TaggedPlayer(crate::tag::TagKey::from(
+            "enchanted",
+        )));
+    }
     if word_slice_starts_with_any(
         subject,
         &[

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -1064,6 +1064,16 @@ fn bind_relative_iterated_player_in_value_to_player_filter(
                 *player = player_filter.clone();
             }
         }
+        Value::HalfLifeTotalRoundedUp(player)
+        | Value::HalfLifeTotalRoundedDown(player)
+        | Value::HalfStartingLifeTotalRoundedUp(player)
+        | Value::HalfStartingLifeTotalRoundedDown(player) => {
+            if matches!(player, PlayerFilter::IteratedPlayer)
+                && !matches!(player_filter, PlayerFilter::IteratedPlayer)
+            {
+                *player = player_filter.clone();
+            }
+        }
         Value::PowerOf(spec)
         | Value::ToughnessOf(spec)
         | Value::ManaValueOf(spec)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -469,6 +469,7 @@ fn trigger_binds_iterated_player(trigger: &TriggerSpec) -> bool {
         | TriggerSpec::PlayerTapsForMana { .. }
         | TriggerSpec::PlayerSacrifices { .. }
         | TriggerSpec::ThisDealsDamageToPlayer { .. }
+        | TriggerSpec::DealsDamageToPlayer { .. }
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
         | TriggerSpec::ThisDealsCombatDamageToPlayer
         | TriggerSpec::DealsCombatDamageToPlayer { .. }
@@ -537,6 +538,7 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         TriggerSpec::AbilityActivated { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::PlayerSacrifices { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::ThisDealsDamageToPlayer { .. }
+        | TriggerSpec::DealsDamageToPlayer { .. }
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
         | TriggerSpec::ThisDealsCombatDamageToPlayer
         | TriggerSpec::DealsCombatDamageToPlayer { .. } => Some(PlayerFilter::DamagedPlayer),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -48915,6 +48915,39 @@ fn parse_enchant_player_upkeep_trigger_uses_attached_player_filter() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_grievous_wound_oracle_tracks_enchanted_player_damage_trigger() {
+    let def = parse_oracle_card_definition("Grievous Wound");
+
+    assert_eq!(
+        def.aura_attach_filter,
+        Some(AuraAttachmentFilter::Player(PlayerFilter::Any))
+    );
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("DealsDamageTrigger")
+            && abilities_debug.contains("TaggedPlayer")
+            && abilities_debug.contains("enchanted")
+            && abilities_debug.contains("DamagedPlayer")
+            && abilities_debug.contains("HalfLifeTotalRoundedUp"),
+        "expected Grievous Wound to bind enchanted-player damage to the damaged player, got {abilities_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join("\n")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("enchant player")
+            && rendered.contains("enchanted player can't gain life")
+            && rendered.contains(
+                "whenever enchanted player is dealt damage, that player loses half their life, rounded up"
+            ),
+        "expected Grievous Wound compiled text to preserve the enchant-player damage trigger, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_megatron_life_lost_turn_mana_clause() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Megatron Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1871,6 +1871,43 @@ fn describe_life_amount_phrase(amount: &Value) -> String {
     format!("{} life", describe_value(amount))
 }
 
+fn describe_half_life_amount_for_same_player(
+    amount: &Value,
+    player_filter: &PlayerFilter,
+) -> Option<&'static str> {
+    match amount {
+        Value::HalfLifeTotalRoundedUp(filter) if filter == player_filter => {
+            Some(if matches!(player_filter, PlayerFilter::You) {
+                "half your life, rounded up"
+            } else {
+                "half their life, rounded up"
+            })
+        }
+        Value::HalfLifeTotalRoundedDown(filter) if filter == player_filter => {
+            Some(if matches!(player_filter, PlayerFilter::You) {
+                "half your life, rounded down"
+            } else {
+                "half their life, rounded down"
+            })
+        }
+        Value::HalfStartingLifeTotalRoundedUp(filter) if filter == player_filter => {
+            Some(if matches!(player_filter, PlayerFilter::You) {
+                "half your starting life total, rounded up"
+            } else {
+                "half their starting life total, rounded up"
+            })
+        }
+        Value::HalfStartingLifeTotalRoundedDown(filter) if filter == player_filter => {
+            Some(if matches!(player_filter, PlayerFilter::You) {
+                "half your starting life total, rounded down"
+            } else {
+                "half their starting life total, rounded down"
+            })
+        }
+        _ => None,
+    }
+}
+
 fn describe_for_players_simple_iterated_action(
     for_players: &crate::effects::ForPlayersEffect,
 ) -> Option<String> {
@@ -14850,7 +14887,7 @@ fn describe_triggered_resolution_text(
     }
 
     let effects = super::ast_render::describe_resolution_program(&triggered.effects);
-    let effects = rewrite_damaged_player_reference_for_combat_damage_trigger(triggered, effects);
+    let effects = rewrite_damaged_player_reference_for_damage_trigger(triggered, effects);
     Some(rewrite_damage_phrases_for_permanent_abilities(
         &effects,
         subject,
@@ -14858,15 +14895,20 @@ fn describe_triggered_resolution_text(
     ))
 }
 
-fn rewrite_damaged_player_reference_for_combat_damage_trigger(
+fn rewrite_damaged_player_reference_for_damage_trigger(
     triggered: &crate::ability::TriggeredAbility,
     effects: String,
 ) -> String {
-    if triggered
+    let references_damaged_player = triggered
         .trigger
         .downcast_ref::<crate::triggers::ThisDealsCombatDamageToPlayerTrigger>()
-        .is_none()
-    {
+        .is_some()
+        || triggered
+            .trigger
+            .downcast_ref::<crate::triggers::combat::DealsDamageTrigger>()
+            .is_some_and(|trigger| trigger.damaged_player.is_some());
+
+    if !references_damaged_player {
         return effects;
     }
     effects
@@ -29221,6 +29263,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(lose) = effect.downcast_ref::<crate::effects::LoseLifeEffect>() {
         let player = describe_choose_spec(&lose.player);
+        if let ChooseSpec::Player(player_filter) = &lose.player
+            && let Some(amount) =
+                describe_half_life_amount_for_same_player(&lose.amount, player_filter)
+        {
+            return format!(
+                "{} {} {amount}",
+                player,
+                player_verb(&player, "lose", "loses")
+            );
+        }
         if let Value::CountersOn(spec, Some(counter_type)) = &lose.amount {
             return format!(
                 "{} {} 1 life for each {} counter on {}",

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -29996,6 +29996,117 @@ fn test_curse_aura_attaches_to_player_and_triggers_on_enchanted_players_upkeep()
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn grievous_wound_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Grievous Wound")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![crate::types::Subtype::Aura])
+        .parse_text(
+            "Enchant player\nEnchanted player can't gain life.\nWhenever enchanted player is dealt damage, they lose half their life, rounded up.",
+        )
+        .expect("Grievous Wound should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_grievous_wound_stops_enchanted_player_life_gain_and_triggers_on_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let grievous_wound = grievous_wound_definition();
+    let wound_id = game.create_object_from_definition(&grievous_wound, alice, Zone::Battlefield);
+    game.object_mut(wound_id)
+        .expect("Grievous Wound should exist")
+        .attached_to = Some(crate::object::AttachmentTarget::Player(bob));
+    game.player_mut(bob)
+        .expect("bob should exist")
+        .attachments
+        .push(wound_id);
+    game.refresh_continuous_state();
+
+    assert!(
+        game.can_gain_life(alice),
+        "Grievous Wound should not stop other players from gaining life"
+    );
+    assert!(
+        !game.can_gain_life(bob),
+        "Grievous Wound should stop the enchanted player from gaining life"
+    );
+
+    game.player_mut(bob).expect("bob should exist").life = 17;
+    let mut gain_ctx = crate::effects::ExecutionContext::new_default(wound_id, alice);
+    crate::effects::execute_effect(
+        &mut game,
+        &Effect::gain_life_player(3, crate::target::ChooseSpec::SpecificPlayer(bob)),
+        &mut gain_ctx,
+    )
+    .expect("life gain prevention should still let the effect resolve");
+    assert_eq!(
+        game.player(bob).expect("bob should exist").life,
+        17,
+        "the enchanted player should not gain life"
+    );
+
+    let alice_life_before = game.player(alice).expect("alice should exist").life;
+    let mut gain_ctx = crate::effects::ExecutionContext::new_default(wound_id, alice);
+    crate::effects::execute_effect(
+        &mut game,
+        &Effect::gain_life_player(3, crate::target::ChooseSpec::SpecificPlayer(alice)),
+        &mut gain_ctx,
+    )
+    .expect("other players should still gain life");
+    assert_eq!(
+        game.player(alice).expect("alice should exist").life,
+        alice_life_before + 3,
+        "non-enchanted players should still gain life"
+    );
+
+    let alice_damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            wound_id,
+            crate::events::DamageTarget::Player(alice),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        check_triggers(&game, &alice_damage_event).is_empty(),
+        "Grievous Wound should not trigger when a non-enchanted player is dealt damage"
+    );
+
+    let bob_damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            wound_id,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in check_triggers(&game, &bob_damage_event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Grievous Wound should trigger when the enchanted player is dealt damage"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Grievous Wound trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Grievous Wound trigger should resolve");
+    assert_eq!(
+        game.player(bob).expect("bob should exist").life,
+        8,
+        "the enchanted player should lose half their life rounded up from 17"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_kitsune_mystic_requires_two_attached_auras_for_end_step_trigger() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Grievous Wound
Initial parse error:
```
triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(LoseLifeEffect { amount: HalfLifeTotalRoundedUp(IteratedPlayer), player: IteratedPlayer }); oracle-only fallback also failed: triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(LoseLifeEffect { amount: HalfLifeTotalRoundedUp(IteratedPlayer), player: IteratedPlayer })
```

Current worker: i-0aa93cefab5a29b3f
Branch: codex/aws-card-fix-grievous-wound
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0031
