### PR TITLE
Fix Ironsmith parse failure: Jadar, Ghoulcaller of Nephalia

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -548,6 +548,9 @@ impl CardDefinitionBuilder {
 
     pub fn decayed(self) -> Self {
         self.with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::keyword_marker("decayed"),
+        ))
+        .with_ability(crate::ability::Ability::static_ability(
             crate::static_abilities::StaticAbility::cant_block(),
         ))
         .with_ability(crate::runtime_backend::static_ability_helpers::decayed_triggered_ability())

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -283,6 +283,7 @@ pub(crate) fn decayed_triggered_ability() -> Ability {
 
 pub(crate) fn decayed_object_abilities() -> Vec<Ability> {
     vec![
+        Ability::static_ability(StaticAbility::keyword_marker("decayed")),
         Ability::static_ability(StaticAbility::cant_block()),
         decayed_triggered_ability(),
     ]

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -218,6 +218,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_object_filter_lexed_handles_with_decayed_keyword_marker() {
+        let tokens = lex_line("creatures with decayed", 0).unwrap();
+
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.card_types, vec![CardType::Creature]);
+        assert_eq!(filter.ability_markers, vec!["decayed".to_string()]);
+        assert!(filter.static_abilities.is_empty(), "{filter:?}");
+    }
+
+    #[test]
     fn parse_object_filter_lexed_handles_without_keyword_clause() {
         let tokens = lex_line("creatures without flying", 0).unwrap();
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1495,6 +1495,10 @@ pub(crate) enum FilterKeywordConstraint {
 fn keyword_action_to_filter_constraint(action: KeywordAction) -> Option<FilterKeywordConstraint> {
     use FilterKeywordConstraint::{Marker, Static};
 
+    if matches!(action, KeywordAction::Decayed) {
+        return Some(Marker("decayed"));
+    }
+
     if let KeywordAction::Landwalk(kind) = action {
         let constraint = match kind {
             crate::static_abilities::LandwalkKind::Subtype {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -1738,6 +1738,9 @@ fn lower_granted_ability_grant_modifications(
             }
             GrantedAbilityAst::KeywordAction(crate::KeywordAction::Decayed) => {
                 modifications.push(crate::continuous::Modification::AddAbility(
+                    StaticAbility::keyword_marker("decayed"),
+                ));
+                modifications.push(crate::continuous::Modification::AddAbility(
                     StaticAbility::cant_block(),
                 ));
                 modifications.push(crate::continuous::Modification::AddAbilityGeneric(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -538,6 +538,196 @@ fn vampire_socialite_static_replacement_requires_opponent_life_loss() {
 }
 
 #[test]
+fn jadar_ghoulcaller_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Jadar, Ghoulcaller of Nephalia");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Triggered(triggered) = &ability.kind else {
+                return None;
+            };
+            format!("{:?}", triggered.effects)
+                .contains("CreateTokenEffect")
+                .then_some(triggered)
+        })
+        .expect("Jadar should have a token-creating end-step trigger");
+    let condition_debug = format!("{:?}", triggered.intervening_if);
+
+    assert!(
+        condition_debug.contains("PlayerControls")
+            && condition_debug.contains("Not")
+            && condition_debug.contains("decayed"),
+        "Jadar should structurally keep the no-creatures-with-decayed gate, got {condition_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "At the beginning of your end step, if you control no creatures with decayed, create a 2/2 black Zombie creature token with decayed."
+        ),
+        "expected Jadar compiled text to preserve the full condition and decayed token creation, got {rendered}"
+    );
+}
+
+fn jadar_end_step_event(player: PlayerId) -> crate::triggers::TriggerEvent {
+    crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(player),
+        crate::provenance::ProvNodeId::default(),
+    )
+}
+
+fn jadar_decayed_creature_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(92_003), "Decayed Zombie")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::keyword_marker("decayed"),
+        ))
+        .with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::cant_block(),
+        ))
+        .build()
+}
+
+#[test]
+fn jadar_end_step_creates_decayed_zombie_when_you_control_none() {
+    let def = parse_oracle_card_definition("Jadar, Ghoulcaller of Nephalia");
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let jadar_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.turn.active_player = alice;
+
+    let event = jadar_end_step_event(alice);
+    let triggers = crate::triggers::check_triggers(&game, &event);
+    assert_eq!(
+        triggers
+            .iter()
+            .filter(|entry| entry.source == jadar_id)
+            .count(),
+        1,
+        "Jadar should trigger when you control no creatures with decayed"
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in triggers {
+        trigger_queue.add(trigger);
+    }
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Jadar trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game).expect("Jadar trigger should resolve");
+
+    let zombie_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| (id, object)))
+        .filter(|(_, object)| {
+            matches!(object.kind, crate::object::ObjectKind::Token)
+                && object.subtypes.contains(&Subtype::Zombie)
+                && game.controller_of(object) == alice
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(zombie_tokens.len(), 1, "Jadar should create one Zombie token");
+
+    let (token_id, token) = zombie_tokens[0];
+    assert_eq!(game.current_power(token_id), Some(2));
+    assert_eq!(game.current_toughness(token_id), Some(2));
+    assert_eq!(token.colors(), ColorSet::from(Color::Black));
+    assert!(
+        game.object_has_static_ability_id(token_id, StaticAbilityId::CantBlock),
+        "Jadar's token should have decayed's can't-block ability"
+    );
+    let token_abilities = format!("{:?}", token.abilities);
+    assert!(
+        token_abilities.contains("KeywordMarker") && token_abilities.contains("decayed"),
+        "Jadar's token should carry a decayed marker for future no-decayed checks, got {token_abilities}"
+    );
+    assert!(
+        token
+            .abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Jadar's token should have decayed's sacrifice trigger"
+    );
+}
+
+#[test]
+fn jadar_end_step_does_not_trigger_while_you_control_decayed_creature() {
+    let def = parse_oracle_card_definition("Jadar, Ghoulcaller of Nephalia");
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let jadar_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.create_object_from_definition(
+        &jadar_decayed_creature_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.turn.active_player = alice;
+
+    let event = jadar_end_step_event(alice);
+    let triggers = crate::triggers::check_triggers(&game, &event);
+    assert_eq!(
+        triggers
+            .iter()
+            .filter(|entry| entry.source == jadar_id)
+            .count(),
+        0,
+        "Jadar should not queue its intervening-if trigger while you control a decayed creature"
+    );
+}
+
+#[test]
+fn jadar_end_step_trigger_does_not_create_token_if_condition_fails_on_resolution() {
+    let def = parse_oracle_card_definition("Jadar, Ghoulcaller of Nephalia");
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let jadar_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.turn.active_player = alice;
+
+    let event = jadar_end_step_event(alice);
+    let triggers = crate::triggers::check_triggers(&game, &event);
+    assert_eq!(
+        triggers
+            .iter()
+            .filter(|entry| entry.source == jadar_id)
+            .count(),
+        1,
+        "Jadar should initially queue when you control no decayed creatures"
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in triggers {
+        trigger_queue.add(trigger);
+    }
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Jadar trigger should go on the stack");
+    game.create_object_from_definition(
+        &jadar_decayed_creature_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    crate::game_loop::resolve_stack_entry(&mut game).expect("Jadar trigger should resolve");
+
+    let jadar_created_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .filter(|object| {
+            matches!(object.kind, crate::object::ObjectKind::Token)
+                && object.subtypes.contains(&Subtype::Zombie)
+                && game.controller_of(object) == alice
+        })
+        .count();
+    assert_eq!(
+        jadar_created_tokens, 0,
+        "Jadar should not create a token if the decayed-creature condition is false on resolution"
+    );
+}
+
+#[test]
 fn party_dude_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Party Dude");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -602,10 +602,22 @@ pub(super) fn describe_token_blueprint(token: &CardDefinition) -> String {
     let mut keyword_texts = Vec::new();
     let mut extra_ability_texts = Vec::new();
     let has_non_toxic_poison_trigger = token_has_non_toxic_poison_trigger(token);
+    let has_decayed_marker = token_has_decayed_marker(token);
     for ability in &token.abilities {
         match &ability.kind {
             AbilityKind::Static(static_ability) => {
                 if static_ability.id() == crate::static_abilities::StaticAbilityId::MakeColorless {
+                    continue;
+                }
+                if static_ability.id() == crate::static_abilities::StaticAbilityId::KeywordMarker
+                    && static_ability.display().eq_ignore_ascii_case("decayed")
+                {
+                    keyword_texts.push("decayed".to_string());
+                    continue;
+                }
+                if has_decayed_marker
+                    && static_ability.id() == crate::static_abilities::StaticAbilityId::CantBlock
+                {
                     continue;
                 }
                 if static_ability.is_keyword() {
@@ -624,6 +636,9 @@ pub(super) fn describe_token_blueprint(token: &CardDefinition) -> String {
                 ));
             }
             AbilityKind::Triggered(triggered) => {
+                if has_decayed_marker && is_decayed_sacrifice_trigger(triggered) {
+                    continue;
+                }
                 if !has_non_toxic_poison_trigger
                     && let Some(keyword) = describe_structural_toxic_keyword(triggered)
                 {
@@ -667,6 +682,55 @@ pub(super) fn describe_token_blueprint(token: &CardDefinition) -> String {
     }
 
     text
+}
+
+fn token_has_decayed_marker(token: &CardDefinition) -> bool {
+    token.abilities.iter().any(|ability| {
+        matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == crate::static_abilities::StaticAbilityId::KeywordMarker
+                    && static_ability.display().eq_ignore_ascii_case("decayed")
+        )
+    })
+}
+
+fn is_decayed_sacrifice_trigger(triggered: &crate::ability::TriggeredAbility) -> bool {
+    if triggered.intervening_if.is_some()
+        || !triggered.choices.is_empty()
+        || triggered
+            .trigger
+            .downcast_ref::<crate::triggers::combat::ThisAttacksTrigger>()
+            .is_none()
+    {
+        return false;
+    }
+
+    let effects = triggered.effects.flattened_default_effects();
+    if effects.len() != 1 {
+        return false;
+    }
+    let effect = &effects[0];
+    let Some(schedule) = effect.downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()
+    else {
+        return false;
+    };
+    if !schedule.one_shot
+        || schedule
+            .trigger
+            .downcast_ref::<crate::triggers::EndOfCombatTrigger>()
+            .is_none()
+    {
+        return false;
+    }
+
+    if schedule.effects.len() != 1 {
+        return false;
+    }
+    let delayed_effect = &schedule.effects[0];
+    delayed_effect
+        .downcast_ref::<crate::effects::SacrificeTargetEffect>()
+        .is_some_and(|sacrifice| sacrifice.target == ChooseSpec::Source)
 }
 
 fn token_extra_abilities_prefer_with_clause(abilities: &[String]) -> bool {
@@ -12250,6 +12314,8 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                     // "You control no other permanents" is substantially closer to oracle text than
                     // the ungrammatical "You control no another permanent".
                     object_text = format!("other {}", pluralize_noun_phrase(rest));
+                } else {
+                    object_text = pluralize_noun_phrase(&object_text);
                 }
                 let references_tagged_object =
                     described_filter.tagged_constraints.iter().any(|constraint| {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jadar, Ghoulcaller of Nephalia
Initial parse error:
```
compiled text dropped required semantic marker: no-creatures-with-decayed
```

Current worker: i-0bb1191e51474e0d7
Branch: codex/aws-card-fix-jadar-ghoulcaller-of-nephalia
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0032
