### PR TITLE
Fix Ironsmith parse failure: Spell Contortion

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -5913,6 +5913,15 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
     if word_slice_starts_with_any(
         &filter_words,
         &[
+            &["time", "this", "was", "kicked"],
+            &["time", "this", "spell", "was", "kicked"],
+        ],
+    ) {
+        return Ok(Some(Value::KickCount));
+    }
+    if word_slice_starts_with_any(
+        &filter_words,
+        &[
             &["creature", "that", "died", "this", "turn"],
             &["creatures", "that", "died", "this", "turn"],
         ],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3,7 +3,7 @@ use crate::ability::AbilityKind;
 use crate::cards::CardDefinitionRuntimeExt;
 use crate::color::Color;
 use crate::compiled_text::{
-    canonical_compiled_lines, debug_compiled_lines, unprocessed_compiled_lines,
+    canonical_compiled_lines, compiled_text_lines, debug_compiled_lines, unprocessed_compiled_lines,
 };
 use crate::effects::{
     AddManaEffect, ChooseModeEffect, ChooseObjectsEffect, ConsultTopOfLibraryEffect,
@@ -7972,6 +7972,57 @@ fn parse_strength_of_the_tajuru_strict_and_renders_kicked_targets() {
     assert!(
         !rendered.contains("each target permanent"),
         "Strength of the Tajuru should keep the counter effect tied to the chosen creatures, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_spell_contortion_strict_and_renders_kicked_draw_count() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Spell Contortion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\n\
+             Counter target spell unless its controller pays {2}. Draw a card for each time Spell Contortion was kicked.",
+        )
+        .expect("Spell Contortion should parse strictly");
+
+    assert_eq!(def.optional_costs.len(), 1);
+    assert_eq!(def.optional_costs[0].label, "Multikicker");
+    assert!(
+        def.optional_costs[0].repeatable,
+        "Spell Contortion's multikicker should be repeatable"
+    );
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("UnlessPaysEffect")
+            && debug.contains("DrawCardsEffect")
+            && debug.contains("KickCount"),
+        "expected Spell Contortion to model counter-unless and draw per kick count, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Counter target spell unless its controller pays {2}"),
+        "expected Spell Contortion compiled text to preserve counter-unless clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Counter target spell unless its controller pays {2}. Draw a card for each time this spell was kicked"
+        ),
+        "expected Spell Contortion compiled text to preserve kicked draw count, got {rendered}"
+    );
+
+    let scored = compiled_text_lines(&def).join("\n");
+    assert!(
+        scored.contains(
+            "Counter target spell unless its controller pays {2}. Draw a card for each time Spell Contortion was kicked"
+        ),
+        "expected Spell Contortion scored text to use the source name for kicked draw count, got {scored}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -43,6 +43,7 @@ pub fn compiled_text_lines(def: &CardDefinition) -> Vec<String> {
     normalize_ast_surface_lines(debug_compiled_lines(def))
         .into_iter()
         .map(|line| substitute_legendary_source_reference(&line, &def.card, ""))
+        .map(|line| substitute_kicked_draw_source_reference(&line, def))
         .map(normalize_scored_compiled_line)
         .collect()
 }
@@ -86,6 +87,30 @@ fn normalize_scored_compiled_line(line: String) -> String {
         );
     }
     line
+}
+
+fn substitute_kicked_draw_source_reference(line: &str, def: &CardDefinition) -> String {
+    let has_repeatable_kicker = def.optional_costs.iter().any(|cost| {
+        cost.repeatable
+            && (cost.label.eq_ignore_ascii_case("kicker")
+                || cost.label.eq_ignore_ascii_case("multikicker"))
+    });
+    if !has_repeatable_kicker
+        || def.card.name.contains(" // ")
+        || !line
+            .to_ascii_lowercase()
+            .contains("draw a card for each time this spell was kicked")
+    {
+        return line.to_string();
+    }
+
+    let source_name = def.card.name.split(',').next().unwrap_or(&def.card.name).trim();
+    if source_name.is_empty() {
+        return line.to_string();
+    }
+
+    line.replace("this spell was kicked", &format!("{source_name} was kicked"))
+        .replace("This spell was kicked", &format!("{source_name} was kicked"))
 }
 
 fn normalize_unprocessed_compiled_line(line: String) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2755,6 +2755,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         }
     }
 
+    if let Some(compact) = describe_counter_unless_then_kick_count_draw(effects) {
+        return Some(compact);
+    }
+
     if let Some(compact) = describe_return_to_hand_then_owner_discards(effects) {
         return Some(compact);
     }
@@ -2765,6 +2769,32 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_counter_unless_then_kick_count_draw(effects: &[Effect]) -> Option<String> {
+    let [unless_effect, draw_effect] = effects else {
+        return None;
+    };
+    let unless_pays = unwrap_structural_effect_tag(unless_effect)
+        .downcast_ref::<crate::effects::UnlessPaysEffect>()?;
+    let [_counter] = unless_pays.effects.as_slice() else {
+        return None;
+    };
+    unless_pays.effects[0].downcast_ref::<crate::effects::CounterEffect>()?;
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if draw.count != Value::KickCount {
+        return None;
+    }
+
+    let counter_text = describe_effect(unless_effect)
+        .trim_end_matches('.')
+        .to_string();
+    let draw_text = if draw.player == PlayerFilter::You {
+        "Draw a card for each time this spell was kicked".to_string()
+    } else {
+        describe_draw_for_each(draw)?.trim_end_matches('.').to_string()
+    };
+    Some(format!("{counter_text}. {draw_text}"))
 }
 
 fn describe_return_to_hand_then_owner_discards(effects: &[Effect]) -> Option<String> {
@@ -20450,6 +20480,9 @@ pub(super) fn describe_draw_for_each(draw: &crate::effects::DrawCardsEffect) -> 
         Value::SpellsCastThisTurn(spell_caster) => Some(format!(
             "{player} {verb} a card for each {}",
             describe_spells_cast_this_turn_each(spell_caster)
+        )),
+        Value::KickCount => Some(format!(
+            "{player} {verb} a card for each time this spell was kicked"
         )),
         Value::SpellsCastThisTurnMatching {
             player: spell_caster,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -32826,6 +32826,49 @@ fn strength_of_the_tajuru_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn spell_contortion_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(76_301), "Spell Contortion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Multikicker {1}{U} (You may pay an additional {1}{U} any number of times as you cast this spell.)\n\
+             Counter target spell unless its controller pays {2}. Draw a card for each time Spell Contortion was kicked.",
+        )
+        .expect("Spell Contortion should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn stack_spell_probe_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(76_302), "Stack Spell Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Instant])
+        .parse_text("Draw a card.")
+        .expect("stack spell probe should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_spell_contortion_on_stack(
+    game: &mut GameState,
+    controller: PlayerId,
+    target_spell: ObjectId,
+    kicks: u32,
+) -> ObjectId {
+    let def = spell_contortion_definition();
+    let source = game.create_object_from_definition(&def, controller, Zone::Stack);
+    let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+    paid.pay_times(0, kicks);
+    game.push_to_stack(
+        StackEntry::new(source, controller)
+            .with_targets(vec![Target::Object(target_spell)])
+            .with_optional_costs_paid(paid),
+    );
+    source
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_strength_of_the_tajuru_no_kicks_requires_one_creature_target() {
     let def = strength_of_the_tajuru_definition();
@@ -32977,6 +33020,138 @@ fn test_strength_of_the_tajuru_puts_x_counters_on_each_kicked_target() {
     assert_eq!(
         untargeted_counters, 0,
         "Strength of the Tajuru should affect only its chosen targets"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn spell_contortion_no_kicks_counters_unpaid_target_and_draws_no_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 3);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let spell_contortion = put_spell_contortion_on_stack(&mut game, alice, target_spell, 0);
+
+    let alice_hand_before = game.player(alice).expect("alice exists").hand.len();
+    resolve_stack_entry(&mut game).expect("Spell Contortion should resolve");
+
+    let countered_target = game
+        .current_object_id_after_zone_change(target_spell)
+        .expect("target spell should still be tracked after zone change");
+    assert_eq!(
+        game.object(countered_target)
+            .expect("target spell exists")
+            .zone,
+        Zone::Graveyard,
+        "the target spell should be countered when its controller cannot pay {{2}}"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == spell_contortion)
+            && game.objects_in_zone(Zone::Graveyard).iter().any(|id| {
+                game.object(*id)
+                    .is_some_and(|obj| obj.name == "Spell Contortion")
+            }),
+        "Spell Contortion should leave the stack and go to its owner's graveyard after resolving"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        alice_hand_before,
+        "Spell Contortion with zero kicks should draw no cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn spell_contortion_two_kicks_counters_unpaid_target_and_still_draws_two_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 3);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let spell_contortion = put_spell_contortion_on_stack(&mut game, alice, target_spell, 2);
+
+    let alice_hand_before = game.player(alice).expect("alice exists").hand.len();
+    resolve_stack_entry(&mut game).expect("Spell Contortion should resolve");
+
+    let countered_target = game
+        .current_object_id_after_zone_change(target_spell)
+        .expect("target spell should still be tracked after zone change");
+    assert_eq!(
+        game.object(countered_target)
+            .expect("target spell exists")
+            .zone,
+        Zone::Graveyard,
+        "the target spell should be countered when its controller cannot pay {{2}}"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == spell_contortion)
+            && game.objects_in_zone(Zone::Graveyard).iter().any(|id| {
+                game.object(*id)
+                    .is_some_and(|obj| obj.name == "Spell Contortion")
+            }),
+        "Spell Contortion should leave the stack and go to its owner's graveyard after resolving"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        alice_hand_before + 2,
+        "Spell Contortion kicked twice should draw two cards even when the target spell is countered"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn spell_contortion_two_kicks_draws_two_cards_when_target_controller_pays() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 3);
+    game.player_mut(bob)
+        .expect("bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let spell_contortion = put_spell_contortion_on_stack(&mut game, alice, target_spell, 2);
+
+    let alice_hand_before = game.player(alice).expect("alice exists").hand.len();
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Spell Contortion should resolve");
+
+    assert_eq!(
+        game.object(target_spell).expect("target spell exists").zone,
+        Zone::Stack,
+        "the target spell should remain on the stack when its controller pays {{2}}"
+    );
+    assert!(
+        game.stack.iter().any(|entry| entry.object_id == target_spell),
+        "the paid-for target spell should still have a stack entry"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").mana_pool.total(),
+        0,
+        "the target spell's controller should spend {{2}} to prevent the counter effect"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == spell_contortion)
+            && game.objects_in_zone(Zone::Graveyard).iter().any(|id| {
+                game.object(*id)
+                    .is_some_and(|obj| obj.name == "Spell Contortion")
+            }),
+        "Spell Contortion should leave the stack and go to its owner's graveyard after resolving"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        alice_hand_before + 2,
+        "Spell Contortion kicked twice should draw two cards"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Spell Contortion
Initial parse error:
```
unsupported draw for-each clause (clause: 'a card for each time this was kicked'); oracle-only fallback also failed: unsupported draw for-each clause (clause: 'a card for each time this was kicked')
```

Current worker: i-0bb9bea2069c23a50
Branch: codex/aws-card-fix-spell-contortion
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0032
