### PR TITLE
Fix Ironsmith parse failure: Rashmi and Ragavan

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
@@ -866,6 +866,8 @@ pub(crate) fn has_first_spell_each_turn_pattern(words: &[&str]) -> bool {
             &["during", "each", "opponents", "turn"],
             &["during", "each", "opponent's", "turn"],
             &["during", "each", "opponent", "s", "turn"],
+            &["during", "each", "of", "your", "turns"],
+            &["during", "each", "your", "turns"],
         ],
     );
     if !has_turn_context {
@@ -936,7 +938,15 @@ pub(crate) fn parse_spell_activity_trigger(
         ],
     );
     let mut during_turn =
-        if word_slice_contains_phrase_or_empty(&clause_words, &["during", "your", "turn"]) {
+        if word_slice_contains_phrase_or_empty(&clause_words, &["during", "your", "turn"])
+            || word_slice_contains_any_phrase_or_empty(
+                &clause_words,
+                &[
+                    &["during", "each", "of", "your", "turns"],
+                    &["during", "each", "your", "turns"],
+                ],
+            )
+        {
             Some(PlayerFilter::You)
         } else if word_slice_contains_any_phrase_or_empty(
             &clause_words,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -221,6 +221,7 @@ fn parse_tagged_permission_mana_value_condition_prefix_inner<'a>(
 ) -> Result<(), ErrMode<ContextError>> {
     alt((
         grammar::phrase(&["if", "it's", "a", "spell", "with", "mana", "value"]),
+        grammar::phrase(&["if", "its", "a", "spell", "with", "mana", "value"]),
         grammar::phrase(&["if", "it", "is", "a", "spell", "with", "mana", "value"]),
         grammar::phrase(&["if", "the", "spell's", "mana", "value"]),
         grammar::phrase(&["if", "the", "spells", "mana", "value"]),
@@ -440,9 +441,15 @@ fn parse_tagged_permission_mana_value_condition_tokens(
         parse_tagged_permission_mana_value_condition_prefix_inner,
     )?;
     let (operator, operand_tokens) = parse_value_comparison_tokens(after_prefix)?;
-    let (value, trailing) = parse_lexed_prefix(operand_tokens, parse_i32_word_token)?;
-    if trailing.is_empty() {
+    if let Some((value, trailing)) = parse_lexed_prefix(operand_tokens, parse_i32_word_token)
+        && trailing.is_empty()
+    {
         return Some((operator, Value::Fixed(value)));
+    }
+
+    let (value, used) = parse_value_from_lexed(operand_tokens)?;
+    if used == operand_tokens.len() {
+        return Some((operator, value));
     }
 
     None
@@ -1612,7 +1619,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
     }
 
     let conditional_tagged_permission = parse_permission_lead_tokens(&trimmed)
-        .filter(|(lead, _)| lead.player == PlayerAst::Implicit)
+        .filter(|(lead, _)| matches!(lead.player, PlayerAst::Implicit | PlayerAst::You))
         .and_then(|(lead, rest_tokens)| {
             parse_tagged_cast_or_play_target_tokens(rest_tokens).and_then(
                 |(target_ref, tail_tokens)| {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -459,6 +459,8 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
                 | "discarded"
                 | "exile"
                 | "exiled"
+                | "cast"
+                | "casted"
                 | "mill"
                 | "milled"
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -3339,16 +3339,7 @@ fn compile_subject_verb_effect(
                 .extend(lower_granted_abilities_ast_to_object_abilities(granted_abilities)?);
             let subject = LoweredSubject::resolve_actor(*action_player, ctx, true, true, true)?;
             let count = subject.resolve_object_refs_and_bind_player_refs_in_value(count, ctx)?;
-            let mut player_filter = subject.clone_player_filter();
-            if name.eq_ignore_ascii_case("Treasure")
-                && matches!(
-                    &player_filter,
-                    PlayerFilter::OwnerOf(ObjectRef::Tagged(tag))
-                        if tag.as_str() == crate::tag::SOURCE_EXILED_TAG
-                )
-            {
-                player_filter = PlayerFilter::You;
-            }
+            let player_filter = subject.clone_player_filter();
             let count = per_player_partition_value_for_filter(count, &player_filter);
             let mut choices = subject.into_choices();
             let mut effect = if matches!(player_filter, PlayerFilter::You) {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -3339,7 +3339,16 @@ fn compile_subject_verb_effect(
                 .extend(lower_granted_abilities_ast_to_object_abilities(granted_abilities)?);
             let subject = LoweredSubject::resolve_actor(*action_player, ctx, true, true, true)?;
             let count = subject.resolve_object_refs_and_bind_player_refs_in_value(count, ctx)?;
-            let player_filter = subject.clone_player_filter();
+            let mut player_filter = subject.clone_player_filter();
+            if name.eq_ignore_ascii_case("Treasure")
+                && matches!(
+                    &player_filter,
+                    PlayerFilter::OwnerOf(ObjectRef::Tagged(tag))
+                        if tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+                )
+            {
+                player_filter = PlayerFilter::You;
+            }
             let count = per_player_partition_value_for_filter(count, &player_filter);
             let mut choices = subject.into_choices();
             let mut effect = if matches!(player_filter, PlayerFilter::You) {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -530,8 +530,18 @@ pub(super) fn try_compile_stack_and_condition_effect(
             predicate,
             effects,
         } => {
-            let (inner_effects, inner_choices) =
-                with_preserved_lowering_context(ctx, |_| {}, |ctx| compile_effects(effects, ctx))?;
+            let exiled_tag = ctx.last_exiled_collection_tag.clone();
+            let (inner_effects, inner_choices) = with_preserved_lowering_context(
+                ctx,
+                |ctx| {
+                    if matches!(predicate, IfResultPredicate::DidNot)
+                        && let Some(tag) = exiled_tag
+                    {
+                        ctx.last_object_tag = Some(tag);
+                    }
+                },
+                |ctx| compile_effects(effects, ctx),
+            )?;
             let predicate = effect_predicate_from_if_result(*predicate);
             let effect = Effect::if_then(*condition, predicate, inner_effects);
             (vec![effect], inner_choices)
@@ -600,7 +610,15 @@ pub(super) fn try_compile_stack_and_condition_effect(
                 None
             };
 
-            let mut condition_reference_tag = saved_last_tag.clone();
+            let conditional_cast_tag = if let [EffectAst::SubjectVerb(subject_verb)] = if_true.as_slice()
+                && let SubjectVerbActionAst::CastTagged { tag, .. } = &subject_verb.action
+                && tag.as_str() != IT_TAG
+            {
+                Some(tag.as_str().to_string())
+            } else {
+                None
+            };
+            let mut condition_reference_tag = conditional_cast_tag.or(saved_last_tag.clone());
             let mut prelude = Vec::new();
             if condition_reference_tag.is_none()
                 && let Some(choice) = antecedent_choice.clone()

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -273,8 +273,17 @@ pub(crate) fn resolve_it_tag(
     refs: &ReferenceEnv,
 ) -> Result<ObjectFilter, CardTextError> {
     let mut resolved = resolve_object_filter_player_refs(filter, refs)?;
+    if let Some(tag) = refs.known_last_exiled_collection_tag() {
+        for constraint in &mut resolved.tagged_constraints {
+            if constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
+                constraint.tag = tag.clone();
+            }
+        }
+    }
     if let Some(tag) = refs.known_last_object_tag()
         && tag.as_str() != crate::tag::SOURCE_EXILED_TAG
+        && (tag.as_str().starts_with("exiled_")
+            || tag.as_str().starts_with("__sentence_helper_exiled"))
     {
         for constraint in &mut resolved.tagged_constraints {
             if constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
@@ -547,6 +556,13 @@ pub(crate) fn resolve_choose_spec_it_tag(
                 return Ok(ChooseSpec::Object(filter));
             }
             Ok(ChooseSpec::Source)
+        }
+        ChooseSpec::Tagged(tag) if tag.as_str() == crate::tag::SOURCE_EXILED_TAG => {
+            if let Some(resolved) = refs.known_last_exiled_collection_tag() {
+                Ok(ChooseSpec::Tagged(resolved.clone()))
+            } else {
+                Ok(ChooseSpec::Tagged(tag.clone()))
+            }
         }
         ChooseSpec::Tagged(tag) => Ok(ChooseSpec::Tagged(tag.clone())),
         ChooseSpec::Object(filter) => {

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_model.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_model.rs
@@ -16,6 +16,7 @@ pub(crate) enum RefState<T> {
 pub(crate) struct ReferenceFrame {
     pub(crate) last_effect_id: Option<EffectId>,
     pub(crate) last_object_tag: Option<String>,
+    pub(crate) last_exiled_collection_tag: Option<String>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: Option<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -32,6 +33,7 @@ impl ReferenceFrame {
         Self {
             last_effect_id: frame.last_effect_id,
             last_object_tag: frame.last_object_tag.clone(),
+            last_exiled_collection_tag: frame.last_exiled_collection_tag.clone(),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: frame.last_player_filter.clone(),
             source_object_antecedent: frame.source_object_antecedent,
@@ -48,9 +50,9 @@ impl ReferenceFrame {
         LoweringFrame {
             last_effect_id: self.last_effect_id,
             last_object_tag: self.last_object_tag.clone(),
+            last_exiled_collection_tag: self.last_exiled_collection_tag.clone(),
             last_it_choice_is_set: self.last_it_choice_is_set,
             last_revealed_tag: None,
-            last_exiled_collection_tag: None,
             last_player_filter: self.last_player_filter.clone(),
             source_object_antecedent: self.source_object_antecedent,
             recent_player_choice_tags: self.recent_player_choice_tags.clone(),
@@ -92,6 +94,7 @@ impl<T: Clone + PartialEq> RefState<T> {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub(crate) struct ReferenceImports {
     pub(crate) last_object_tag: Option<TagKey>,
+    pub(crate) last_exiled_collection_tag: Option<TagKey>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: Option<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -101,6 +104,7 @@ pub(crate) struct ReferenceImports {
 impl ReferenceImports {
     pub(crate) fn is_empty(&self) -> bool {
         self.last_object_tag.is_none()
+            && self.last_exiled_collection_tag.is_none()
             && !self.last_it_choice_is_set
             && self.last_player_filter.is_none()
             && !self.source_object_antecedent
@@ -110,6 +114,7 @@ impl ReferenceImports {
     pub(crate) fn with_last_object_tag(tag: impl Into<TagKey>) -> Self {
         Self {
             last_object_tag: Some(tag.into()),
+            last_exiled_collection_tag: None,
             last_it_choice_is_set: false,
             ..Default::default()
         }
@@ -118,6 +123,7 @@ impl ReferenceImports {
     pub(crate) fn from_frame(frame: &ReferenceFrame) -> Self {
         Self {
             last_object_tag: frame.last_object_tag.as_ref().map(TagKey::from),
+            last_exiled_collection_tag: frame.last_exiled_collection_tag.as_ref().map(TagKey::from),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: frame.last_player_filter.clone(),
             source_object_antecedent: frame.source_object_antecedent,
@@ -133,6 +139,7 @@ impl ReferenceImports {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ReferenceEnv {
     pub(crate) last_object_tag: RefState<TagKey>,
+    pub(crate) last_exiled_collection_tag: RefState<TagKey>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: RefState<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -146,6 +153,7 @@ impl Default for ReferenceEnv {
     fn default() -> Self {
         Self {
             last_object_tag: RefState::Unknown,
+            last_exiled_collection_tag: RefState::Unknown,
             last_it_choice_is_set: false,
             last_player_filter: RefState::Unknown,
             source_object_antecedent: false,
@@ -167,6 +175,9 @@ impl ReferenceEnv {
     ) -> Self {
         Self {
             last_object_tag: RefState::from_option(imports.last_object_tag.clone()),
+            last_exiled_collection_tag: RefState::from_option(
+                imports.last_exiled_collection_tag.clone(),
+            ),
             last_it_choice_is_set: imports.last_it_choice_is_set,
             last_player_filter: RefState::from_option(imports.last_player_filter.clone()),
             source_object_antecedent: imports.source_object_antecedent,
@@ -183,6 +194,9 @@ impl ReferenceEnv {
         Self {
             last_object_tag: RefState::from_option(
                 frame.last_object_tag.as_ref().map(TagKey::from),
+            ),
+            last_exiled_collection_tag: RefState::from_option(
+                frame.last_exiled_collection_tag.as_ref().map(TagKey::from),
             ),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: RefState::from_option(frame.last_player_filter.clone()),
@@ -207,6 +221,11 @@ impl ReferenceEnv {
             last_effect_id: self.last_effect_id.clone().into_option(),
             last_object_tag: self
                 .last_object_tag
+                .clone()
+                .into_option()
+                .map(|tag| tag.as_str().to_string()),
+            last_exiled_collection_tag: self
+                .last_exiled_collection_tag
                 .clone()
                 .into_option()
                 .map(|tag| tag.as_str().to_string()),
@@ -238,6 +257,13 @@ impl ReferenceEnv {
         }
     }
 
+    pub(crate) fn known_last_exiled_collection_tag(&self) -> Option<&TagKey> {
+        match &self.last_exiled_collection_tag {
+            RefState::Known(tag) => Some(tag),
+            RefState::Unknown | RefState::Ambiguous => None,
+        }
+    }
+
     pub(crate) fn known_last_player_filter(&self) -> Option<&PlayerFilter> {
         match &self.last_player_filter {
             RefState::Known(filter) => Some(filter),
@@ -260,6 +286,7 @@ impl ReferenceEnv {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ReferenceExports {
     pub(crate) last_object_tag: RefState<TagKey>,
+    pub(crate) last_exiled_collection_tag: RefState<TagKey>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: RefState<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -271,6 +298,7 @@ impl Default for ReferenceExports {
     fn default() -> Self {
         Self {
             last_object_tag: RefState::Unknown,
+            last_exiled_collection_tag: RefState::Unknown,
             last_it_choice_is_set: false,
             last_player_filter: RefState::Unknown,
             source_object_antecedent: false,
@@ -284,6 +312,7 @@ impl ReferenceExports {
     pub(crate) fn from_env(env: &ReferenceEnv) -> Self {
         Self {
             last_object_tag: env.last_object_tag.clone(),
+            last_exiled_collection_tag: env.last_exiled_collection_tag.clone(),
             last_it_choice_is_set: env.last_it_choice_is_set,
             last_player_filter: env.last_player_filter.clone(),
             source_object_antecedent: env.source_object_antecedent,
@@ -295,6 +324,10 @@ impl ReferenceExports {
     pub(crate) fn join(left: &Self, right: &Self) -> Self {
         Self {
             last_object_tag: RefState::join(&left.last_object_tag, &right.last_object_tag),
+            last_exiled_collection_tag: RefState::join(
+                &left.last_exiled_collection_tag,
+                &right.last_exiled_collection_tag,
+            ),
             last_it_choice_is_set: left.last_it_choice_is_set && right.last_it_choice_is_set,
             last_player_filter: RefState::join(&left.last_player_filter, &right.last_player_filter),
             source_object_antecedent: left.source_object_antecedent
@@ -307,6 +340,7 @@ impl ReferenceExports {
     pub(crate) fn to_imports(&self) -> ReferenceImports {
         ReferenceImports {
             last_object_tag: self.last_object_tag.clone().into_option(),
+            last_exiled_collection_tag: self.last_exiled_collection_tag.clone().into_option(),
             last_it_choice_is_set: self.last_it_choice_is_set,
             last_player_filter: self.last_player_filter.clone().into_option(),
             source_object_antecedent: self.source_object_antecedent,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1,6 +1,6 @@
 use crate::cards::builders::{
-    CardTextError, EffectAst, IT_TAG, IdGenContext, PlayerAst, PredicateAst, SubjectVerbActionAst,
-    SubjectVerbEffectAst, SubjectVerbRoleAst, TargetAst, TriggerSpec,
+    CardTextError, EffectAst, IT_TAG, IdGenContext, IfResultPredicate, PlayerAst, PredicateAst,
+    SubjectVerbActionAst, SubjectVerbEffectAst, SubjectVerbRoleAst, TargetAst, TriggerSpec,
 };
 use crate::effect::{EffectId, EventValueSpec};
 use crate::filter::{Comparison, TaggedOpbjectRelation};
@@ -123,6 +123,12 @@ fn next_reference_tag(id_gen: &mut IdGenContext, prefix: &str) -> String {
     };
     id_gen.next_tag_id += 1;
     tag
+}
+
+fn tag_is_exiled_collection(tag: &str) -> bool {
+    tag == crate::tag::SOURCE_EXILED_TAG
+        || tag.starts_with("exiled_")
+        || tag.starts_with("__sentence_helper_exiled")
 }
 
 fn generated_object_result_tag_prefix(effect: &EffectAst) -> Option<&'static str> {
@@ -481,15 +487,20 @@ fn advance_reference_frame_for_effect(
                     if matches!(spec.base(), ChooseSpec::Source) {
                         frame.source_object_antecedent = true;
                     }
+                    if let ChooseSpec::Tagged(tag) = spec.base() {
+                        frame.last_exiled_collection_tag = Some(tag.as_str().to_string());
+                    }
                     if frame.auto_tag_object_targets {
                         if spec.is_target() {
                             if let Some(tag) =
                                 propagated_or_generated_object_tag(&spec, id_gen, "exiled")
                             {
                                 frame.last_object_tag = Some(tag);
+                                frame.last_exiled_collection_tag = frame.last_object_tag.clone();
                             }
                         } else if choose_spec_targets_object(&spec) {
                             frame.last_object_tag = Some(crate::tag::SOURCE_EXILED_TAG.to_string());
+                            frame.last_exiled_collection_tag = frame.last_object_tag.clone();
                         }
                     }
                     track_target_player(target, frame);
@@ -501,6 +512,7 @@ fn advance_reference_frame_for_effect(
                         });
                     if frame.auto_tag_object_targets && !keep_last_object_tag {
                         frame.last_object_tag = Some(next_reference_tag(id_gen, "exiled"));
+                        frame.last_exiled_collection_tag = frame.last_object_tag.clone();
                     }
                     track_player_from_object_filter(filter, frame);
                 }
@@ -775,6 +787,7 @@ fn advance_reference_frame_for_effect(
                         } else {
                             tag.as_str().to_string()
                         });
+                        frame.last_exiled_collection_tag = frame.last_object_tag.clone();
                     }
                 }
                 SubjectVerbActionAst::RevealCardsFromHand { tag, .. } => {
@@ -975,6 +988,9 @@ fn advance_reference_frame_for_effect(
                 )));
             }
             frame.last_object_tag = Some(chosen_tag);
+            if tag_is_exiled_collection(tag.as_str()) {
+                frame.last_exiled_collection_tag = frame.last_object_tag.clone();
+            }
         }
         EffectAst::ChooseObjectsAcrossZones {
             filter,
@@ -1031,6 +1047,9 @@ fn advance_reference_frame_for_effect(
                 )));
             }
             frame.last_object_tag = Some(chosen_tag);
+            if tag_is_exiled_collection(tag.as_str()) {
+                frame.last_exiled_collection_tag = frame.last_object_tag.clone();
+            }
         }
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}
         EffectAst::May { effects }
@@ -1081,13 +1100,25 @@ fn advance_reference_frame_for_effect(
             }
         }
         EffectAst::ResolvedIfResult {
-            condition, effects, ..
+            condition,
+            predicate,
+            effects,
         } => {
             let saved_last_effect = frame.last_effect_id;
             let saved_bind = frame.bind_unbound_x_to_last_effect;
             frame.last_effect_id = Some(*condition);
             frame.bind_unbound_x_to_last_effect = true;
+            let saved_last_object = frame.last_object_tag.clone();
+            if matches!(predicate, IfResultPredicate::DidNot)
+                && let Some(tag) = frame.last_exiled_collection_tag.clone()
+            {
+                frame.last_object_tag = Some(tag);
+            }
             advance_reference_frames(&effects, id_gen, frame)?;
+            if matches!(predicate, IfResultPredicate::DidNot) && frame.last_object_tag == saved_last_object
+            {
+                frame.last_object_tag = saved_last_object;
+            }
             frame.last_effect_id = saved_last_effect;
             frame.bind_unbound_x_to_last_effect = saved_bind;
         }
@@ -1740,6 +1771,10 @@ fn advance_reference_env_for_effect(
                 last_object_tag: RefState::join(
                     &true_sequence.final_env.last_object_tag,
                     &false_sequence.final_env.last_object_tag,
+                ),
+                last_exiled_collection_tag: RefState::join(
+                    &true_sequence.final_env.last_exiled_collection_tag,
+                    &false_sequence.final_env.last_exiled_collection_tag,
                 ),
                 last_it_choice_is_set: true_sequence.final_env.last_it_choice_is_set
                     && false_sequence.final_env.last_it_choice_is_set,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2024,6 +2024,7 @@ fn expand_gain_lose_followup_segment_lexed(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CarryContext {
     Player(PlayerAst),
+    ObjectOwner(PlayerAst),
     ForEachPlayer,
     ForEachTargetPlayers(ChoiceCount),
     ForEachOpponent,
@@ -2103,7 +2104,7 @@ pub(crate) fn explicit_player_for_carry(effect: &EffectAst) -> Option<CarryConte
         && let SubjectVerbActionAst::Exile { target, .. } = &subject_verb.action
         && let Some(player) = player_owner_filter_from_target_for_carry(target)
     {
-        return Some(CarryContext::Player(player));
+        return Some(CarryContext::ObjectOwner(player));
     }
     if let EffectAst::SubjectVerb(SubjectVerbEffectAst {
         action: SubjectVerbActionAst::ExileUntilSourceLeaves { target, .. },
@@ -2111,7 +2112,7 @@ pub(crate) fn explicit_player_for_carry(effect: &EffectAst) -> Option<CarryConte
     }) = effect
         && let Some(player) = player_owner_filter_from_target_for_carry(target)
     {
-        return Some(CarryContext::Player(player));
+        return Some(CarryContext::ObjectOwner(player));
     }
     if let EffectAst::SubjectVerb(SubjectVerbEffectAst {
         action: SubjectVerbActionAst::ExileAll { filter, .. },
@@ -2120,7 +2121,7 @@ pub(crate) fn explicit_player_for_carry(effect: &EffectAst) -> Option<CarryConte
         && let Some(owner) = filter.owner.as_ref()
         && let Some(player) = player_ast_from_filter_for_carry(owner)
     {
-        return Some(CarryContext::Player(player));
+        return Some(CarryContext::ObjectOwner(player));
     }
     if matches!(
         effect,
@@ -2328,7 +2329,7 @@ fn subject_verb_player_action_player(effect: &EffectAst) -> Option<PlayerAst> {
 
 pub(crate) fn maybe_apply_carried_player(effect: &mut EffectAst, carried_context: CarryContext) {
     match carried_context {
-        CarryContext::Player(carried_player) => {
+        CarryContext::Player(carried_player) | CarryContext::ObjectOwner(carried_player) => {
             // When carrying an explicit target player/opponent into an implicit clause,
             // bind to the previously selected target ("that player") instead of creating
             // a fresh explicit target. This preserves shared-target semantics for chains
@@ -2353,9 +2354,11 @@ pub(crate) fn maybe_apply_carried_player(effect: &mut EffectAst, carried_context
                     }
                 }
                 EffectAst::SubjectVerb(SubjectVerbEffectAst {
-                    action: SubjectVerbActionAst::CreateTokenWithMods { .. },
+                    action: SubjectVerbActionAst::CreateTokenWithMods { player, .. },
                     ..
-                }) if matches!(carried_player, PlayerAst::ItsOwner | PlayerAst::ItsController) => {}
+                }) if matches!(carried_context, CarryContext::ObjectOwner(_))
+                    || (matches!(carried_player, PlayerAst::ItsOwner | PlayerAst::ItsController)
+                        && matches!(*player, PlayerAst::Implicit)) => {}
                 EffectAst::SubjectVerb(_) => {
                     if let Some(player) = subject_verb_player_action_player_mut(effect)
                         && *player == PlayerAst::Implicit
@@ -2411,7 +2414,7 @@ pub(crate) fn maybe_apply_carried_player_with_clause_lexed(
 ) {
     let clause_words = clause_words_for_carry_lexed(clause_tokens);
     let should_skip = match carried_context {
-        CarryContext::Player(_) => {
+        CarryContext::Player(_) | CarryContext::ObjectOwner(_) => {
             matches!(
                 effect,
                 EffectAst::SubjectVerb(SubjectVerbEffectAst {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2352,6 +2352,10 @@ pub(crate) fn maybe_apply_carried_player(effect: &mut EffectAst, carried_context
                         *player = carried_player;
                     }
                 }
+                EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                    action: SubjectVerbActionAst::CreateTokenWithMods { .. },
+                    ..
+                }) if matches!(carried_player, PlayerAst::ItsOwner | PlayerAst::ItsController) => {}
                 EffectAst::SubjectVerb(_) => {
                     if let Some(player) = subject_verb_player_action_player_mut(effect)
                         && *player == PlayerAst::Implicit

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1112,6 +1112,8 @@ fn rewrite_structure_if_result_predicate_parser_preserves_contractions() {
     let didnt_tokens = lex_line("you don't", 0).expect("rewrite lexer should classify predicate");
     let dies_tokens = lex_line("that creature dies this way", 0)
         .expect("rewrite lexer should classify dies-this-way predicate");
+    let cast_tokens = lex_line("you don't cast it this way", 0)
+        .expect("rewrite lexer should classify cast-this-way predicate");
 
     assert_eq!(
         super::grammar::structure::parse_if_result_predicate(&didnt_tokens),
@@ -1120,6 +1122,10 @@ fn rewrite_structure_if_result_predicate_parser_preserves_contractions() {
     assert_eq!(
         super::grammar::structure::parse_if_result_predicate(&dies_tokens),
         Some(crate::cards::builders::IfResultPredicate::DiesThisWay)
+    );
+    assert_eq!(
+        super::grammar::structure::parse_if_result_predicate(&cast_tokens),
+        Some(crate::cards::builders::IfResultPredicate::DidNot)
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33406,6 +33406,48 @@ fn rashmi_and_ragavan_lowers_trigger_treasure_and_cast_branches() {
     );
 }
 
+#[test]
+fn explicit_exiled_object_owner_or_controller_treasure_creator_is_preserved() {
+    fn treasure_controller_for(text: &str) -> PlayerFilter {
+        let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Explicit Creator Variant")
+            .card_types(vec![CardType::Instant])
+            .parse_text(text)
+            .expect("explicit exiled-object token creator should parse");
+        let spell = def.spell_effect.as_ref().expect("spell effect");
+
+        for effect in spell {
+            if let Some(create) = effect.downcast_ref::<CreateTokenEffect>() {
+                if create.token.card.name == "Treasure" {
+                    return create.controller.clone();
+                }
+            }
+            if let Some(tagged) = effect.downcast_ref::<TaggedEffect>()
+                && let Some(create) = tagged.effect.downcast_ref::<CreateTokenEffect>()
+                && create.token.card.name == "Treasure"
+            {
+                return create.controller.clone();
+            }
+        }
+
+        panic!("expected Treasure creation in spell effect, got {spell:#?}");
+    }
+
+    assert!(
+        matches!(
+            treasure_controller_for("Exile target creature. Its owner creates a Treasure token."),
+            PlayerFilter::OwnerOf(ObjectRef::Tagged(_))
+        ),
+        "explicit owner-created Treasure must stay tied to the exiled object's owner"
+    );
+    assert!(
+        matches!(
+            treasure_controller_for("Exile target creature. Its controller creates a Treasure token."),
+            PlayerFilter::ControllerOf(ObjectRef::Tagged(_))
+        ),
+        "explicit controller-created Treasure must stay tied to the exiled object's controller"
+    );
+}
+
 fn resolve_rashmi_and_ragavan_runtime(
     accept_free_cast: bool,
     starting_artifacts: usize,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33293,6 +33293,288 @@ fn parse_trigger_with_and_or_subtype_list_keeps_effect_split_on_trigger_delimite
     );
 }
 
+#[test]
+fn rashmi_and_ragavan_parses_and_preserves_cast_fallback_branch() {
+    let def = parse_oracle_card_definition("Rashmi and Ragavan");
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join(" ");
+    let oracle = oracle_text_by_name()
+        .get("Rashmi and Ragavan")
+        .expect("Rashmi and Ragavan oracle text")
+        .clone();
+    assert!(
+        rendered.contains("Whenever you cast your first spell during each of your turns"),
+        "expected Rashmi and Ragavan's first-spell trigger to parse, got {rendered}"
+    );
+    assert!(
+        rendered.contains("without paying its mana cost")
+            && rendered.contains("If you don't cast it this way, you may cast it this turn"),
+        "expected Rashmi and Ragavan to render the free-cast condition and fallback cast permission, got {rendered}"
+    );
+    assert_eq!(rendered, oracle);
+}
+
+#[test]
+fn rashmi_and_ragavan_lowers_trigger_treasure_and_cast_branches() {
+    let def = parse_oracle_card_definition("Rashmi and Ragavan");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Rashmi and Ragavan should have a triggered ability");
+
+    assert_eq!(
+        triggered.trigger.display(),
+        "Whenever you cast your first spell during each of your turns"
+    );
+    assert_eq!(triggered.choices.len(), 1, "expected target opponent choice");
+    assert!(
+        matches!(&triggered.choices[0], ChooseSpec::Target(inner) if matches!(inner.as_ref(), ChooseSpec::Player(PlayerFilter::Opponent))),
+        "expected target opponent choice, got {:?}",
+        triggered.choices
+    );
+
+    let effects = triggered.effects.flattened_default_effects();
+    let choose = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<ChooseObjectsEffect>())
+        .expect("Rashmi and Ragavan should choose the top library card");
+    assert_eq!(choose.filter.zone, Some(Zone::Library));
+    assert!(choose.top_only, "expected top-card library choice");
+    assert_eq!(choose.filter.owner, Some(PlayerFilter::Target(Box::new(PlayerFilter::Opponent))));
+
+    let exile = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::ExileEffect>())
+        .expect("Rashmi and Ragavan should exile the chosen card");
+    assert!(
+        matches!(&exile.spec, ChooseSpec::Tagged(tag) if tag == &choose.tag),
+        "expected exile to use the chosen top-card tag, got {:?}",
+        exile.spec
+    );
+
+    let create = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<TaggedEffect>())
+        .and_then(|tagged| tagged.effect.downcast_ref::<CreateTokenEffect>())
+        .expect("Rashmi and Ragavan should create a Treasure token");
+    assert_eq!(create.token.card.name, "Treasure");
+    assert_eq!(create.controller, PlayerFilter::You);
+
+    let may = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::WithIdEffect>())
+        .and_then(|with_id| with_id.effect.downcast_ref::<crate::effects::MayEffect>())
+        .expect("Rashmi and Ragavan should make the immediate free cast optional");
+    let conditional = may.effects[0]
+        .downcast_ref::<crate::effects::ConditionalEffect>()
+        .expect("free cast should be gated by the exiled card's mana value");
+    assert!(
+        matches!(conditional.condition, crate::effect::Condition::ValueComparison { .. }),
+        "free-cast gate should compare the exiled card's mana value to the artifact count, got {:#?}",
+        conditional.condition,
+    );
+    let cast = conditional.if_true[0]
+        .downcast_ref::<crate::effects::CastTaggedEffect>()
+        .expect("true branch should cast the exiled card");
+    assert!(cast.without_paying_mana_cost);
+    assert!(!cast.allow_land);
+    assert!(
+        cast.tag == choose.tag || cast.tag.as_str() == crate::tag::SOURCE_EXILED_TAG,
+        "free-cast branch should reference the exiled card tag, got {:?} for chosen tag {:?}",
+        cast.tag,
+        choose.tag,
+    );
+
+    let fallback = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::IfEffect>())
+        .expect("Rashmi and Ragavan should branch when the free cast was not taken");
+    assert_eq!(fallback.predicate, crate::effect::EffectPredicate::DidNotHappen);
+    assert!(fallback.else_.is_empty());
+    let grant = fallback.then[0]
+        .downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+        .expect("fallback should grant a this-turn cast permission for the exiled card");
+    assert!(
+        grant.tag == choose.tag || grant.tag.as_str() == crate::tag::SOURCE_EXILED_TAG,
+        "fallback branch should reference the exiled card tag, got {:?} for chosen tag {:?}",
+        grant.tag,
+        choose.tag,
+    );
+}
+
+fn resolve_rashmi_and_ragavan_runtime(
+    accept_free_cast: bool,
+    starting_artifacts: usize,
+) -> (crate::game_state::GameState, PlayerId, crate::ids::StableId) {
+    use crate::card::CardBuilder;
+    use crate::decision::DecisionMaker;
+    use crate::mana::{ManaCost, ManaSymbol};
+
+    struct MayDecision(bool);
+    impl DecisionMaker for MayDecision {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            self.0
+        }
+    }
+
+    let def = parse_oracle_card_definition("Rashmi and Ragavan");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Rashmi and Ragavan should have a triggered ability");
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let triggering_spell = CardBuilder::new(CardId::new(), "Triggering Spell")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let triggering_spell_id = game.create_object_from_card(&triggering_spell, alice, Zone::Stack);
+    let triggering_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(triggering_spell_id)
+            .expect("triggering spell should exist"),
+        &game,
+    );
+    let triggering_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::spells::SpellCastEvent::new_with_snapshot(
+            triggering_spell_id,
+            alice,
+            Zone::Hand,
+            triggering_snapshot,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    for index in 0..starting_artifacts {
+        let artifact = CardBuilder::new(CardId::new(), &format!("Alice Artifact {index}"))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        game.create_object_from_card(&artifact, alice, Zone::Battlefield);
+    }
+
+    let borrowed_spell = CardBuilder::new(CardId::new(), "Borrowed Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let borrowed_id = game.create_object_from_card(&borrowed_spell, bob, Zone::Library);
+    let borrowed_stable_id = game
+        .object(borrowed_id)
+        .expect("borrowed spell should exist")
+        .stable_id;
+
+    let mut dm = MayDecision(accept_free_cast);
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_triggering_event(triggering_event)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Rashmi and Ragavan trigger should resolve");
+
+    (game, alice, borrowed_stable_id)
+}
+
+#[test]
+fn rashmi_and_ragavan_runtime_cast_gate_and_fallback_permission() {
+    let (accepted_game, alice, borrowed_stable_id) = resolve_rashmi_and_ragavan_runtime(true, 1);
+    let borrowed_id = accepted_game
+        .find_object_by_stable_id(borrowed_stable_id)
+        .expect("accepted free-cast branch should preserve the borrowed spell object");
+    assert!(
+        accepted_game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == borrowed_id),
+        "accepted free-cast branch should put the exiled spell on the stack; borrowed zone={:?}, stack={:?}",
+        accepted_game.object(borrowed_id).map(|object| object.zone),
+        accepted_game.stack,
+    );
+    assert!(
+        !accepted_game.effect_store.grant_registry.card_can_play_from_zone(
+            &accepted_game,
+            borrowed_id,
+            Zone::Exile,
+            alice,
+        ),
+        "accepted free-cast branch should not also grant the this-turn fallback permission"
+    );
+    assert!(
+        accepted_game
+            .objects_in_zone(Zone::Battlefield)
+            .into_iter()
+            .filter_map(|id| accepted_game.object(id))
+            .any(|object| object.name == "Treasure" && accepted_game.controller_of(object) == alice),
+        "Rashmi and Ragavan should create a Treasure token for you before the cast gate"
+    );
+
+    let (declined_game, alice, borrowed_stable_id) = resolve_rashmi_and_ragavan_runtime(false, 1);
+    let borrowed_id = declined_game
+        .find_object_by_stable_id(borrowed_stable_id)
+        .expect("declined free-cast branch should preserve the borrowed spell object");
+    assert!(
+        declined_game
+            .object(borrowed_id)
+            .is_some_and(|object| object.zone == Zone::Exile),
+        "declined free-cast branch should leave the exiled spell in exile"
+    );
+    assert!(
+        declined_game.effect_store.grant_registry.card_can_play_from_zone(
+            &declined_game,
+            borrowed_id,
+            Zone::Exile,
+            alice,
+        ),
+        "declining the immediate cast should grant this-turn cast permission for the exiled card"
+    );
+    assert!(
+        declined_game
+            .effect_store
+            .grant_registry
+            .granted_alternative_casts_for_card(&declined_game, borrowed_id, Zone::Exile, alice)
+            .is_empty(),
+        "the fallback permission should not also be a free-cast permission"
+    );
+
+    let (failed_gate_game, alice, borrowed_stable_id) = resolve_rashmi_and_ragavan_runtime(true, 0);
+    let borrowed_id = failed_gate_game
+        .find_object_by_stable_id(borrowed_stable_id)
+        .expect("failed gate branch should preserve the borrowed spell object");
+    assert!(
+        failed_gate_game
+            .object(borrowed_id)
+            .is_some_and(|object| object.zone == Zone::Exile),
+        "mana-value gate should prevent the free cast when the exiled spell is not cheap enough"
+    );
+    assert!(
+        failed_gate_game.effect_store.grant_registry.card_can_play_from_zone(
+            &failed_gate_game,
+            borrowed_id,
+            Zone::Exile,
+            alice,
+        ),
+        "failing the free-cast gate should still grant this-turn cast permission"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_other_mice_anthem_renders_irregular_plural() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -25,6 +25,127 @@ fn describe_pay_any_energy_amount(
     }
 }
 
+fn describe_simple_count_value(value: &Value) -> String {
+    if let Value::Count(filter) = value
+        && filter.zone == Some(Zone::Battlefield)
+        && filter.controller == Some(PlayerFilter::You)
+        && filter.card_types.len() == 1
+        && filter.card_types[0] == CardType::Artifact
+        && filter.subtypes.is_empty()
+    {
+        return "the number of artifacts you control".to_string();
+    }
+    describe_value(value)
+}
+
+fn describe_may_conditional_cast_tagged(may: &crate::effects::MayEffect) -> Option<String> {
+    let [conditional_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+        return None;
+    }
+    let cast = conditional.if_true[0].downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    let (operator_text, right) = match &conditional.condition {
+        Condition::ValueComparison {
+            left: Value::ManaValueOf(spec),
+            operator,
+            right,
+        } => {
+            if !matches!(spec.as_ref(), ChooseSpec::Tagged(tag) if tag == &cast.tag) {
+                return None;
+            }
+            let operator_text = match operator {
+                crate::effect::ValueComparisonOperator::LessThan => "less than",
+                crate::effect::ValueComparisonOperator::LessThanOrEqual => "less than or equal to",
+                crate::effect::ValueComparisonOperator::Equal => "equal to",
+                crate::effect::ValueComparisonOperator::GreaterThan => "greater than",
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual => {
+                    "greater than or equal to"
+                }
+                crate::effect::ValueComparisonOperator::NotEqual => "not equal to",
+            };
+            (operator_text, right)
+        }
+        Condition::TaggedObjectMatches(tag, filter) if tag == &cast.tag => {
+            let comparison = filter.mana_value.as_ref()?;
+            match comparison {
+                crate::filter::Comparison::LessThanExpr(value) => ("less than", value.as_ref()),
+                crate::filter::Comparison::LessThanOrEqualExpr(value) => {
+                    ("less than or equal to", value.as_ref())
+                }
+                crate::filter::Comparison::EqualExpr(value) => ("equal to", value.as_ref()),
+                crate::filter::Comparison::GreaterThanExpr(value) => ("greater than", value.as_ref()),
+                crate::filter::Comparison::GreaterThanOrEqualExpr(value) => {
+                    ("greater than or equal to", value.as_ref())
+                }
+                crate::filter::Comparison::NotEqualExpr(value) => ("not equal to", value.as_ref()),
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+
+    let target = if cast.tag.as_str().starts_with("__sentence_helper_exiled")
+        || cast.tag.as_str().starts_with("exiled_")
+    {
+        "the exiled card".to_string()
+    } else {
+        describe_choose_spec(&ChooseSpec::Tagged(cast.tag.clone()))
+    };
+    let mut text = format!(
+        "You may cast {target} if it's a spell with mana value {operator_text} {}",
+        describe_simple_count_value(right)
+    );
+    if cast.without_paying_mana_cost {
+        text = format!(
+            "You may cast {target} without paying its mana cost if it's a spell with mana value {operator_text} {}",
+            describe_simple_count_value(right)
+        );
+    }
+    Some(text)
+}
+
+fn describe_target_opponent_top_exile_treasure_sequence(effects: &[Effect]) -> Option<String> {
+    if effects.len() < 5 {
+        return None;
+    }
+    effects[0].downcast_ref::<crate::effects::TagTriggeringObjectEffect>()?;
+    let target = effects[1].downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+    if !matches!(&target.target, ChooseSpec::Target(inner) if matches!(inner.as_ref(), ChooseSpec::Player(PlayerFilter::Opponent))) {
+        return None;
+    }
+    let choose = effects[2].downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if choose.filter.zone != Some(Zone::Library)
+        || choose.filter.owner != Some(PlayerFilter::Target(Box::new(PlayerFilter::Opponent)))
+        || !choose.top_only
+        || choose.count.min != 1
+        || choose.count.max != Some(1)
+    {
+        return None;
+    }
+    let exile = effects[3].downcast_ref::<crate::effects::ExileEffect>()?;
+    if !matches!(&exile.spec, ChooseSpec::Tagged(tag) if tag == &choose.tag) {
+        return None;
+    }
+    let create = effects[4].downcast_ref::<crate::effects::TaggedEffect>()?;
+    let create = create.effect.downcast_ref::<crate::effects::CreateTokenEffect>()?;
+    if create.token.card.name != "Treasure" || create.controller != PlayerFilter::You {
+        return None;
+    }
+
+    let mut text = "Exile the top card of target opponent's library and create a Treasure token".to_string();
+    if effects.len() > 5 {
+        let rest = describe_effect_list(&effects[5..]);
+        if !rest.trim().is_empty() {
+            text.push_str(". Then ");
+            text.push_str(&lowercase_first(rest.trim()));
+        }
+    }
+    Some(text)
+}
+
 fn describe_discard_hand_add_mana_draw_sequence(effects: &[&Effect]) -> Option<String> {
     let [discard_effect, mana_effect, draw_effect] = effects else {
         return None;
@@ -3426,6 +3547,9 @@ fn describe_choose_color_then_chosen_color_mana(effects: &[&Effect]) -> Option<S
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_target_opponent_top_exile_treasure_sequence(effects) {
+        return compact;
+    }
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
     }
@@ -25022,6 +25146,21 @@ fn describe_with_id_if_clause(
     let then_text = describe_effect_list(&if_effect.then);
     let else_text = describe_effect_list(&if_effect.else_);
 
+    if with_id
+        .effect
+        .downcast_ref::<crate::effects::MayEffect>()
+        .is_some()
+        && if_effect.predicate == EffectPredicate::DidNotHappen
+        && if_effect.else_.is_empty()
+        && if_effect.then.len() == 1
+        && let Some(grant) = if_effect.then[0].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+        && grant.player == PlayerFilter::You
+        && matches!(grant.duration, crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn)
+        && !grant.allow_land
+    {
+        return Some("If you don't cast it this way, you may cast it this turn".to_string());
+    }
+
     let condition = if with_id
         .effect
         .downcast_ref::<crate::effects::ForPlayersEffect>()
@@ -30607,6 +30746,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(if_effect) = effect.downcast_ref::<crate::effects::IfEffect>() {
+        if if_effect.predicate == EffectPredicate::DidNotHappen
+            && if_effect.else_.is_empty()
+            && if_effect.then.len() == 1
+            && let Some(grant) = if_effect.then[0]
+                .downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && grant.player == PlayerFilter::You
+            && matches!(grant.duration, crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn)
+            && !grant.allow_land
+            && !grant.allow_any_color_for_cast
+            && (grant.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+                || grant.tag.as_str().starts_with("__sentence_helper_exiled")
+                || grant.tag.as_str().starts_with("exiled_"))
+        {
+            return "If you don't cast it this way, you may cast it this turn".to_string();
+        }
         let then_text = describe_effect_list(&if_effect.then);
         let else_text = describe_effect_list(&if_effect.else_);
         if then_text.trim().is_empty() && else_text.trim().is_empty() {
@@ -30704,6 +30858,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_may_search_library_and_or_nonlibrary(may) {
+            return compact;
+        }
+        if let Some(compact) = describe_may_conditional_cast_tagged(may) {
             return compact;
         }
         if may.effects.len() == 1

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -38,7 +38,12 @@ fn describe_simple_count_value(value: &Value) -> String {
     describe_value(value)
 }
 
-fn describe_may_conditional_cast_tagged(may: &crate::effects::MayEffect) -> Option<String> {
+fn simple_may_conditional_cast_tagged(
+    may: &crate::effects::MayEffect,
+) -> Option<(
+    &crate::effects::CastTaggedEffect,
+    &crate::effects::ConditionalEffect,
+)> {
     let [conditional_effect] = may.effects.as_slice() else {
         return None;
     };
@@ -47,6 +52,18 @@ fn describe_may_conditional_cast_tagged(may: &crate::effects::MayEffect) -> Opti
         return None;
     }
     let cast = conditional.if_true[0].downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    if cast.player != PlayerFilter::You
+        || cast.allow_land
+        || cast.as_copy
+        || cast.cost_reduction.is_some()
+    {
+        return None;
+    }
+    Some((cast, conditional))
+}
+
+fn describe_may_conditional_cast_tagged(may: &crate::effects::MayEffect) -> Option<String> {
+    let (cast, conditional) = simple_may_conditional_cast_tagged(may)?;
     let (operator_text, right) = match &conditional.condition {
         Condition::ValueComparison {
             left: Value::ManaValueOf(spec),
@@ -25146,17 +25163,17 @@ fn describe_with_id_if_clause(
     let then_text = describe_effect_list(&if_effect.then);
     let else_text = describe_effect_list(&if_effect.else_);
 
-    if with_id
-        .effect
-        .downcast_ref::<crate::effects::MayEffect>()
-        .is_some()
+    if let Some(may) = with_id.effect.downcast_ref::<crate::effects::MayEffect>()
+        && let Some((cast, _)) = simple_may_conditional_cast_tagged(may)
         && if_effect.predicate == EffectPredicate::DidNotHappen
         && if_effect.else_.is_empty()
         && if_effect.then.len() == 1
         && let Some(grant) = if_effect.then[0].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+        && grant.tag == cast.tag
         && grant.player == PlayerFilter::You
         && matches!(grant.duration, crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn)
         && !grant.allow_land
+        && !grant.allow_any_color_for_cast
     {
         return Some("If you don't cast it this way, you may cast it this turn".to_string());
     }
@@ -30746,21 +30763,6 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(if_effect) = effect.downcast_ref::<crate::effects::IfEffect>() {
-        if if_effect.predicate == EffectPredicate::DidNotHappen
-            && if_effect.else_.is_empty()
-            && if_effect.then.len() == 1
-            && let Some(grant) = if_effect.then[0]
-                .downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
-            && grant.player == PlayerFilter::You
-            && matches!(grant.duration, crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn)
-            && !grant.allow_land
-            && !grant.allow_any_color_for_cast
-            && (grant.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
-                || grant.tag.as_str().starts_with("__sentence_helper_exiled")
-                || grant.tag.as_str().starts_with("exiled_"))
-        {
-            return "If you don't cast it this way, you may cast it this turn".to_string();
-        }
         let then_text = describe_effect_list(&if_effect.then);
         let else_text = describe_effect_list(&if_effect.else_);
         if then_text.trim().is_empty() && else_text.trim().is_empty() {

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -3356,7 +3356,8 @@ fn evaluate_condition(
         }
         Condition::TaggedObjectMatches(tag, filter) => {
             let filter_ctx = ctx.filter_context(game);
-            if let Some(tagged) = ctx.get_tagged_all(tag.as_str()) {
+            let tagged = ctx.get_tagged_all(tag.as_str());
+            if let Some(tagged) = tagged {
                 return Ok(tagged.iter().any(|snapshot| {
                     let current_id = game
                         .object(snapshot.object_id)
@@ -3369,6 +3370,25 @@ fn evaluate_condition(
                     }
                     filter.matches_snapshot(snapshot, &filter_ctx, game)
                 }));
+            }
+            if tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
+                return Ok(ctx
+                    .tagged_objects
+                    .iter()
+                    .filter(|(tag, _)| tag.as_str().starts_with("__sentence_helper_exiled"))
+                    .flat_map(|(_, snapshots)| snapshots)
+                    .any(|snapshot| {
+                        let current_id = game
+                            .object(snapshot.object_id)
+                            .map(|object| object.id)
+                            .or_else(|| game.find_object_by_stable_id(snapshot.stable_id));
+                        if let Some(current_id) = current_id
+                            && let Some(object) = game.object(current_id)
+                        {
+                            return filter.matches(object, &filter_ctx, game);
+                        }
+                        filter.matches_snapshot(snapshot, &filter_ctx, game)
+                    }));
             }
 
             // Some compile-time conditional lowering paths synthesize a branch-local tag

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2472,6 +2472,25 @@ fn resolve_primary_object_from_value_spec(
         .ok_or(ExecutionError::InvalidTarget)
 }
 
+fn tagged_snapshots_for_spec<'a>(
+    ctx: &'a ExecutionContext,
+    tag: &crate::tag::TagKey,
+) -> Vec<&'a crate::snapshot::ObjectSnapshot> {
+    let mut snapshots = ctx
+        .get_tagged_all(tag)
+        .map(|snapshots| snapshots.iter().collect::<Vec<_>>())
+        .unwrap_or_default();
+    if snapshots.is_empty() && tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
+        snapshots.extend(
+            ctx.tagged_objects
+                .iter()
+                .filter(|(tag, _)| tag.as_str().starts_with("__sentence_helper_exiled"))
+                .flat_map(|(_, snapshots)| snapshots.iter()),
+        );
+    }
+    snapshots
+}
+
 /// Result shaping policy for applying operations to selected objects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObjectApplyResultPolicy {
@@ -2818,11 +2837,12 @@ pub fn resolve_objects_from_spec(
                         .ok_or(ExecutionError::InvalidTarget);
                 }
                 ChooseSpec::Tagged(tag) => {
-                    let tagged = ctx
-                        .get_tagged_all(tag)
-                        .ok_or_else(|| ExecutionError::TagNotFound(tag.to_string()))?;
+                    let tagged = tagged_snapshots_for_spec(ctx, tag);
+                    if tagged.is_empty() {
+                        return Err(ExecutionError::TagNotFound(tag.to_string()));
+                    }
                     let objects: Vec<ObjectId> = tagged
-                        .iter()
+                        .into_iter()
                         .filter_map(|snapshot| resolve_tagged_object_id(game, snapshot))
                         .collect();
                     if objects.is_empty() {
@@ -2971,11 +2991,9 @@ pub fn resolve_objects_from_spec(
 
         // Tagged objects
         ChooseSpec::Tagged(tag) => {
-            let Some(tagged) = ctx.get_tagged_all(tag) else {
-                return Ok(Vec::new());
-            };
+            let tagged = tagged_snapshots_for_spec(ctx, tag);
             Ok(tagged
-                .iter()
+                .into_iter()
                 .filter_map(|snapshot| resolve_tagged_object_id(game, snapshot))
                 .collect())
         }

--- a/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
@@ -177,6 +177,21 @@ fn choose_and_pay_optional_costs_for_cast_tagged_spell(
     Ok(Some(paid))
 }
 
+fn tagged_snapshot_for_cast_tagged(
+    ctx: &ExecutionContext,
+    tag: &crate::tag::TagKey,
+) -> Option<crate::snapshot::ObjectSnapshot> {
+    ctx.get_tagged(tag.as_str()).cloned().or_else(|| {
+        (tag.as_str() == crate::tag::SOURCE_EXILED_TAG).then(|| {
+            ctx.tagged_objects
+                .iter()
+                .filter(|(tag, _)| tag.as_str().starts_with("__sentence_helper_exiled"))
+                .flat_map(|(_, snapshots)| snapshots.iter().cloned())
+                .next()
+        })?
+    })
+}
+
 fn pay_total_cost_for_cast_tagged_spell(
     game: &mut GameState,
     ctx: &mut ExecutionContext,
@@ -331,7 +346,7 @@ impl EffectExecutor for CastTaggedEffect {
         use crate::alternative_cast::CastingMethod;
         use crate::effects::helpers::resolve_player_filter;
 
-        let Some(snapshot) = ctx.get_tagged(self.tag.as_str()) else {
+        let Some(snapshot) = tagged_snapshot_for_cast_tagged(ctx, &self.tag) else {
             return Ok(EffectOutcome::target_invalid());
         };
 

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
@@ -171,6 +171,9 @@ impl TriggerMatcher for SpellCastTrigger {
                 ironsmith_core::ordinal_word(exact_spells).unwrap_or_else(|| "nth".to_string());
             if spell_text == "a spell" || spell_text == "spell" {
                 spell_text = match &self.caster {
+                    PlayerFilter::You if self.during_turn == Some(PlayerFilter::You) => {
+                        format!("your {ordinal} spell during each of your turns")
+                    }
                     PlayerFilter::You => format!("your {ordinal} spell each turn"),
                     PlayerFilter::Any => format!("their {ordinal} spell each turn"),
                     PlayerFilter::Active => format!("their {ordinal} spell each turn"),
@@ -183,6 +186,9 @@ impl TriggerMatcher for SpellCastTrigger {
             } else {
                 let base_spell_text = strip_leading_spell_article(&spell_text);
                 spell_text = match &self.caster {
+                    PlayerFilter::You if self.during_turn == Some(PlayerFilter::You) => {
+                        format!("your {ordinal} {base_spell_text} during each of your turns")
+                    }
                     PlayerFilter::You => format!("your {ordinal} {base_spell_text} each turn"),
                     PlayerFilter::Any | PlayerFilter::Active => {
                         format!("their {ordinal} {base_spell_text} each turn")
@@ -222,7 +228,11 @@ impl TriggerMatcher for SpellCastTrigger {
                 PlayerFilter::Specific(_) => " during that player's turn",
                 _ => "",
             };
-            if !suppress_turn_suffix {
+            if !suppress_turn_suffix
+                && !(self.exact_spells_this_turn.is_some()
+                    && self.caster == PlayerFilter::You
+                    && *turn_filter == PlayerFilter::You)
+            {
                 suffix.push_str(turn_text);
             }
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rashmi and Ragavan
Initial parse error:
```
unsupported predicate (predicate: 'you dont cast it this way'); oracle-only fallback also failed: unsupported predicate (predicate: 'you dont cast it this way')
```

Current worker: i-0a42c461f04173ba9
Branch: codex/aws-card-fix-rashmi-and-ragavan
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0032
