### PR TITLE
Fix Ironsmith parse failure: Haakon, Stromgald Scourge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2227,6 +2227,17 @@ pub(crate) fn parse_static_condition_clause(
     if word_slice_eq_any(
         &clause_words,
         &[
+            &["this", "is", "on", "the", "battlefield"],
+            &["this", "card", "is", "on", "the", "battlefield"],
+            &["this", "creature", "is", "on", "the", "battlefield"],
+            &["this", "permanent", "is", "on", "the", "battlefield"],
+        ],
+    ) {
+        return Ok(crate::ConditionExpr::SourceIsInZone(Zone::Battlefield));
+    }
+    if word_slice_eq_any(
+        &clause_words,
+        &[
             &["this", "creature", "is", "equipped"],
             &["this", "is", "equipped"],
             &["it", "is", "equipped"],

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -779,6 +779,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         multi_static_ability_ast_rule!(parse_surveilled_graveyard_play_life_cost_line),
         single_static_ability_ast_rule!(parse_play_from_permission_with_haste_this_way_line),
         single_static_ability_ast_rule!(parse_you_may_static_grant_line),
+        single_static_ability_ast_rule!(parse_cast_this_spell_only_line_lexed),
         single_static_ability_ast_rule!(parse_grant_flash_to_noncreature_spells_line),
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
         single_static_ability_ast_rule!(parse_during_your_turn_prevent_all_damage_to_source_line),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static_helpers.rs
@@ -18,9 +18,9 @@ pub(crate) use super::permission_helpers::parse_permission_clause_spec;
 pub(crate) use super::static_ability_helpers::static_ability_for_keyword_action;
 pub(crate) use super::util::{
     contains_until_end_of_turn, intern_counter_name, is_article, non_article_word_refs_except,
-    parse_mana_symbol, parse_number, parse_number_word_i32, parser_trace, parser_trace_stack,
-    replace_unbound_x_with_value, starts_with_until_end_of_turn, value_contains_unbound_x,
-    word_refs_at_is_article,
+    parse_cast_this_spell_only_line_lexed, parse_mana_symbol, parse_number, parse_number_word_i32,
+    parser_trace, parser_trace_stack, replace_unbound_x_with_value, starts_with_until_end_of_turn,
+    value_contains_unbound_x, word_refs_at_is_article,
 };
 pub(crate) use super::value_helpers::{
     parse_equal_to_aggregate_filter_value, parse_equal_to_number_of_counters_on_reference_value,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -1,5 +1,6 @@
 use super::super::grammar::structure;
 use super::*;
+use crate::runtime_backend::util::parse_cast_this_spell_only_line_lexed;
 use crate::parse_trace;
 
 pub(super) fn parse_triggered_line_cst(
@@ -274,6 +275,10 @@ pub(super) fn parse_static_line_cst(
     }
 
     if split_compound_buff_and_unblockable_sentence(&lexed).is_some() {
+        return Ok(Some(make_static(None)));
+    }
+
+    if parse_cast_this_spell_only_line_lexed(&lexed)?.is_some() {
         return Ok(Some(make_static(None)));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_dispatch.rs
@@ -204,7 +204,7 @@ const LINE_FAMILY_RULES: [LineFamilyRuleDef; 31] = [
     LineFamilyRuleDef {
         id: "graveyard-or-exile-cast",
         priority: 76,
-        heads: &["you"],
+        heads: &["you", "as"],
         run: run_graveyard_or_exile_cast_line_family,
     },
     LineFamilyRuleDef {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -419,9 +419,63 @@ pub(super) fn run_graveyard_or_exile_cast_line_family(
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     let raw = ctx.line.info.raw_line.trim();
     let raw_no_period = raw.trim_end_matches('.');
-    if raw_no_period.to_ascii_lowercase()
-        != "you may cast this card from your graveyard or from exile"
+    let lower = raw_no_period.to_ascii_lowercase();
+
+    if str_starts_with(lower.as_str(), "as long as ")
+        && let Some((condition_text, permission_text)) = str_split_once(raw_no_period, ",")
+        && is_source_battlefield_condition(ctx, condition_text)
+        && str_starts_with(permission_text.trim_start().to_ascii_lowercase().as_str(), "you may ")
+        && str_ends_with(
+            permission_text.trim().to_ascii_lowercase().as_str(),
+            " from your graveyard",
+        )
     {
+        let permission_line = rewrite_line_normalized(
+            ctx.line,
+            format!("{}.", permission_text.trim()).as_str(),
+        )?;
+        let Some(static_cst) = parse_static_line_cst(&permission_line)? else {
+            return Err(CardTextError::ParseError(format!(
+                "parser could not lower battlefield-source graveyard permission line: '{}'",
+                ctx.line.info.raw_line
+            )));
+        };
+
+        return Ok(Some(LineDispatchResult::single(
+            RewriteLineCst::Static(static_cst),
+            ctx.idx + 1,
+        )));
+    }
+
+    if lower == "you may cast this card from your graveyard, but not from anywhere else" {
+        let graveyard_line =
+            rewrite_line_normalized(ctx.line, "You may cast this card from your graveyard.")?;
+        let restriction_line =
+            rewrite_line_normalized(ctx.line, "Cast this spell only from your graveyard.")?;
+
+        let Some(graveyard_static) = parse_static_line_cst(&graveyard_line)? else {
+            return Err(CardTextError::ParseError(format!(
+                "parser could not lower graveyard-only cast line permission half: '{}'",
+                ctx.line.info.raw_line
+            )));
+        };
+        let Some(restriction_static) = parse_static_line_cst(&restriction_line)? else {
+            return Err(CardTextError::ParseError(format!(
+                "parser could not lower graveyard-only cast line restriction half: '{}'",
+                ctx.line.info.raw_line
+            )));
+        };
+
+        return Ok(Some(LineDispatchResult {
+            lines: vec![
+                RewriteLineCst::Static(graveyard_static),
+                RewriteLineCst::Static(restriction_static),
+            ],
+            next_idx: ctx.idx + 1,
+        }));
+    }
+
+    if lower != "you may cast this card from your graveyard or from exile" {
         return Ok(None);
     }
 
@@ -449,6 +503,28 @@ pub(super) fn run_graveyard_or_exile_cast_line_family(
         ],
         next_idx: ctx.idx + 1,
     }))
+}
+
+fn is_source_battlefield_condition(ctx: &LineDispatchContext<'_>, condition_text: &str) -> bool {
+    let lower = condition_text.trim().to_ascii_lowercase();
+    let Some(condition_body) = str_strip_prefix(lower.as_str(), "as long as ") else {
+        return false;
+    };
+
+    let is_source_battlefield_phrase = |text: &str| {
+        [
+            "this is on the battlefield",
+            "this card is on the battlefield",
+            "this creature is on the battlefield",
+            "this permanent is on the battlefield",
+        ]
+        .iter()
+        .any(|candidate| *candidate == text)
+    };
+
+    is_source_battlefield_phrase(condition_body)
+        || normalize_named_source_sentence_for_builder(&ctx.preprocessed.builder, condition_body)
+            .is_some_and(|normalized| is_source_battlefield_phrase(normalized.as_str()))
 }
 
 pub(super) fn run_champion_line_family(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -870,6 +870,22 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     for (phrase, zone) in [
+        (
+            ["this", "is", "on", "the", "battlefield"].as_slice(),
+            Zone::Battlefield,
+        ),
+        (
+            ["this", "card", "is", "on", "the", "battlefield"].as_slice(),
+            Zone::Battlefield,
+        ),
+        (
+            ["this", "creature", "is", "on", "the", "battlefield"].as_slice(),
+            Zone::Battlefield,
+        ),
+        (
+            ["this", "permanent", "is", "on", "the", "battlefield"].as_slice(),
+            Zone::Battlefield,
+        ),
         (["this", "is", "in", "your", "hand"].as_slice(), Zone::Hand),
         (
             ["this", "card", "is", "in", "your", "hand"].as_slice(),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -5365,7 +5365,12 @@ pub(crate) fn parse_cast_this_spell_only_line(
         ],
     ];
 
-    let restriction = if declare_attackers_tails
+    let restriction = if word_slice_eq(tail, &["from", "your", "graveyard"]) {
+        Some((
+            crate::static_abilities::ThisSpellCastRestrictionKind::from_zone(Zone::Graveyard),
+            "Cast this spell only from your graveyard.",
+        ))
+    } else if declare_attackers_tails
         .iter()
         .any(|candidate| *candidate == tail)
     {

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -738,6 +738,15 @@ where
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Graveyard
+            && (!filter_can_include_lands(&self.filter) || !self.filter.subtypes.is_empty())
+        {
+            return format!(
+                "{may_prefix} cast {} from your graveyard",
+                castable_filter_description(&self.filter)
+            ) + &cast_this_way_suffix();
+        }
+        if matches!(self.grantable, Grantable::PlayFrom)
+            && self.zone == Zone::Graveyard
             && self.filter.surveilled_this_turn
         {
             return format!(

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -145,6 +145,10 @@ impl ThisSpellCastRestrictionKind {
     pub fn if_you_control_subtype_or_more(subtype: Subtype, count: u32) -> Self {
         Self::named(format!("if you control {count}+ {subtype}"))
     }
+
+    pub fn from_zone(zone: Zone) -> Self {
+        Self::named(format!("from {zone}"))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2916,6 +2916,43 @@ fn parse_oracle_squee_the_immortal_graveyard_or_exile_cast_permission() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_haakon_graveyard_only_and_knight_permission_text_regression() {
+    assert_oracle_card_parses_strict("Haakon, Stromgald Scourge");
+    let info = oracle_card_info_by_name()
+        .get("Haakon, Stromgald Scourge")
+        .expect("Haakon oracle entry should be present");
+    let def = CardDefinitionBuilder::new(CardId::from_raw(92_300), "Haakon, Stromgald Scourge")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Knight])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(info.oracle_text.clone())
+        .expect("Haakon, Stromgald Scourge should parse strictly");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+
+    assert_eq!(
+        rendered,
+        "You may cast this card from your graveyard, but not from anywhere else.\n\
+As long as Haakon is on the battlefield, you may cast Knight spells from your graveyard.\n\
+When Haakon dies, you lose 2 life."
+    );
+    assert!(
+        debug.contains("grantable: PlayFrom")
+            && debug.contains("ThisSpellCastRestriction")
+            && debug.contains("zone: Some(Graveyard)")
+            && debug.contains("subtypes: [Knight]"),
+        "expected Haakon to lower to graveyard PlayFrom grants, a graveyard-only cast restriction, and a Knight subtype filter, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_max_speed_draw_replacement_static_ability() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Vnwxt Parse Test")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -869,6 +869,8 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(": as long as "))
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
     let uses_named_source_surface = lower.starts_with("this creature gets ")
+        || lower.starts_with("as long as this creature is on the battlefield")
+        || lower.starts_with("when this creature dies")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
         || lower.starts_with("whenever this creature deals combat damage to a player")
@@ -1477,6 +1479,68 @@ fn describe_structural_graveyard_or_exile_cast_pair(
         }
         _ => None,
     }
+}
+
+fn describe_structural_cast_from_zone_only_pair(
+    first: &Ability,
+    second: &Ability,
+) -> Option<String> {
+    fn play_from_source_zone(ability: &Ability) -> Option<Zone> {
+        let AbilityKind::Static(static_ability) = &ability.kind else {
+            return None;
+        };
+        let spec = static_ability.grant_spec()?;
+        (matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+            && spec.filter == crate::target::ObjectFilter::source()
+            && matches!(spec.beneficiary, PlayerFilter::You))
+        .then_some(spec.zone)
+    }
+
+    fn cast_restriction_zone(ability: &Ability) -> Option<Zone> {
+        let AbilityKind::Static(static_ability) = &ability.kind else {
+            return None;
+        };
+        let kind = static_ability.this_spell_cast_restriction_kind()?;
+        (kind.timing.is_none() && kind.condition.is_none()).then_some(kind.zone?)
+    }
+
+    let zone = play_from_source_zone(first)?;
+    if cast_restriction_zone(second)? != zone {
+        return None;
+    }
+    let zone_text = match zone {
+        Zone::Graveyard => "your graveyard",
+        Zone::Exile => "exile",
+        _ => return None,
+    };
+    Some(format!(
+        "You may cast this card from {zone_text}, but not from anywhere else"
+    ))
+}
+
+fn describe_structural_battlefield_play_from_grant(
+    ability: &Ability,
+    subject: &str,
+) -> Option<String> {
+    let AbilityKind::Static(static_ability) = &ability.kind else {
+        return None;
+    };
+    let spec = static_ability.grant_spec()?;
+    if !matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+        || !matches!(spec.beneficiary, PlayerFilter::You)
+        || spec.filter == crate::target::ObjectFilter::source()
+        || ability.functional_zones.as_slice() != [Zone::Battlefield]
+    {
+        return None;
+    }
+    let permission = spec.display();
+    if permission.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "As long as {subject} is on the battlefield, {}",
+        lowercase_first(&permission)
+    ))
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2307,6 +2371,16 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                 continue;
             }
             if ability_idx + 1 < def.abilities.len()
+                && let Some(permission) = describe_structural_cast_from_zone_only_pair(
+                    ability,
+                    &def.abilities[ability_idx + 1],
+                )
+            {
+                output.push(format!("Static ability {}: {permission}", ability_idx + 1));
+                ability_idx += 2;
+                continue;
+            }
+            if ability_idx + 1 < def.abilities.len()
                 && let Some(permission) = describe_structural_graveyard_or_exile_cast_pair(
                     ability,
                     &def.abilities[ability_idx + 1],
@@ -2314,6 +2388,13 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
             {
                 output.push(format!("Static ability {}: {permission}", ability_idx + 1));
                 ability_idx += 2;
+                continue;
+            }
+            if let Some(permission) =
+                describe_structural_battlefield_play_from_grant(ability, subject)
+            {
+                output.push(format!("Static ability {}: {permission}", ability_idx + 1));
+                ability_idx += 1;
                 continue;
             }
             if let Some((keyword, consumed)) =

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -732,8 +732,13 @@ pub(crate) fn player_was_attacked_this_step(game: &GameState, player: PlayerId) 
 pub(crate) fn this_spell_cast_restriction_allows(
     game: &GameState,
     player: PlayerId,
+    spell: &crate::object::Object,
     kind: &crate::static_abilities::ThisSpellCastRestrictionKind,
 ) -> bool {
+    if kind.zone.is_some_and(|zone| spell.zone != zone) {
+        return false;
+    }
+
     let timing_allows = kind
         .timing
         .is_none_or(|timing| this_spell_cast_timing_allows(game, player, timing));
@@ -936,7 +941,7 @@ pub(crate) fn spell_cast_restrictions_allow(
         let Some(kind) = static_ability.this_spell_cast_restriction_kind() else {
             return true;
         };
-        this_spell_cast_restriction_allows(game, player, &kind)
+        this_spell_cast_restriction_allows(game, player, spell, &kind)
     })
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -31977,6 +31977,208 @@ fn test_library_play_from_grant_offers_top_creature_card() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn haakon_stromgald_scourge_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(92_300), "Haakon, Stromgald Scourge")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Knight])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "You may cast this card from your graveyard, but not from anywhere else.\n\
+             As long as Haakon is on the battlefield, you may cast Knight spells from your graveyard.\n\
+             When Haakon dies, you lose 2 life.",
+        )
+        .expect("Haakon, Stromgald Scourge should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_haakon_mana(game: &mut GameState, player: PlayerId) {
+    let mana_pool = &mut game.player_mut(player).expect("player exists").mana_pool;
+    mana_pool.add(ManaSymbol::Colorless, 1);
+    mana_pool.add(ManaSymbol::Black, 2);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn has_haakon_self_cast_action(
+    game: &GameState,
+    player: PlayerId,
+    card_id: ObjectId,
+    zone: Zone,
+) -> bool {
+    crate::decision::compute_legal_actions(game, player)
+        .iter()
+        .any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone,
+                casting_method: CastingMethod::PlayFrom {
+                    zone: Zone::Graveyard,
+                    use_alternative: None,
+                    ..
+                },
+            } if *spell_id == card_id && *from_zone == zone
+        ))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn haakon_can_be_cast_from_graveyard_but_not_hand_or_exile() {
+    let alice = PlayerId::from_index(0);
+
+    let mut graveyard_game = setup_game();
+    graveyard_game.turn.phase = Phase::FirstMain;
+    graveyard_game.turn.step = None;
+    graveyard_game.turn.active_player = alice;
+    graveyard_game.turn.priority_player = Some(alice);
+    add_haakon_mana(&mut graveyard_game, alice);
+    let graveyard_haakon = graveyard_game.create_object_from_definition(
+        &haakon_stromgald_scourge_definition(),
+        alice,
+        Zone::Graveyard,
+    );
+    assert!(
+        has_haakon_self_cast_action(&graveyard_game, alice, graveyard_haakon, Zone::Graveyard),
+        "Haakon should be castable from its controller's graveyard"
+    );
+
+    let mut hand_game = setup_game();
+    hand_game.turn.phase = Phase::FirstMain;
+    hand_game.turn.step = None;
+    hand_game.turn.active_player = alice;
+    hand_game.turn.priority_player = Some(alice);
+    add_haakon_mana(&mut hand_game, alice);
+    let hand_haakon = hand_game.create_object_from_definition(
+        &haakon_stromgald_scourge_definition(),
+        alice,
+        Zone::Hand,
+    );
+    let hand_actions = crate::decision::compute_legal_actions(&hand_game, alice);
+    assert!(
+        !hand_actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, .. } if *spell_id == hand_haakon
+        )),
+        "Haakon should not be castable from hand; got {hand_actions:?}"
+    );
+
+    let mut exile_game = setup_game();
+    exile_game.turn.phase = Phase::FirstMain;
+    exile_game.turn.step = None;
+    exile_game.turn.active_player = alice;
+    exile_game.turn.priority_player = Some(alice);
+    add_haakon_mana(&mut exile_game, alice);
+    let exile_haakon = exile_game.create_object_from_definition(
+        &haakon_stromgald_scourge_definition(),
+        alice,
+        Zone::Exile,
+    );
+    let exile_actions = crate::decision::compute_legal_actions(&exile_game, alice);
+    assert!(
+        !exile_actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, .. } if *spell_id == exile_haakon
+        )),
+        "Haakon should not be castable from exile; got {exile_actions:?}"
+    );
+
+    let mut exile_grant_game = setup_game();
+    exile_grant_game.turn.phase = Phase::FirstMain;
+    exile_grant_game.turn.step = None;
+    exile_grant_game.turn.active_player = alice;
+    exile_grant_game.turn.priority_player = Some(alice);
+    add_haakon_mana(&mut exile_grant_game, alice);
+    let exile_grant_haakon = exile_grant_game.create_object_from_definition(
+        &haakon_stromgald_scourge_definition(),
+        alice,
+        Zone::Exile,
+    );
+    add_test_play_from_grant_source(
+        &mut exile_grant_game,
+        alice,
+        crate::filter::ObjectFilter::default().with_type(CardType::Creature),
+        Zone::Exile,
+    );
+    let exile_grant_actions = crate::decision::compute_legal_actions(&exile_grant_game, alice);
+    assert!(
+        !exile_grant_actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell { spell_id, .. } if *spell_id == exile_grant_haakon
+        )),
+        "Haakon's graveyard-only restriction should override another exile-cast permission; got {exile_grant_actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn haakon_grants_knight_graveyard_casts_only_while_on_battlefield() {
+    let alice = PlayerId::from_index(0);
+    let knight = CardBuilder::new(CardId::from_raw(92_301), "Graveyard Test Knight")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Knight])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let mut game = setup_game();
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    let haakon_id = game.create_object_from_definition(
+        &haakon_stromgald_scourge_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let knight_id = game.create_object_from_card(&knight, alice, Zone::Graveyard);
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom {
+                    source,
+                    zone: Zone::Graveyard,
+                    use_alternative: None,
+                },
+            } if *spell_id == knight_id && *source == haakon_id
+        )),
+        "Haakon should let Alice cast Knight spells from her graveyard; got {actions:?}"
+    );
+
+    let mut absent_game = setup_game();
+    absent_game.turn.phase = Phase::FirstMain;
+    absent_game.turn.step = None;
+    absent_game.turn.active_player = alice;
+    absent_game.turn.priority_player = Some(alice);
+    absent_game.create_object_from_definition(
+        &haakon_stromgald_scourge_definition(),
+        alice,
+        Zone::Graveyard,
+    );
+    let absent_knight_id = absent_game.create_object_from_card(&knight, alice, Zone::Graveyard);
+    let absent_actions = crate::decision::compute_legal_actions(&absent_game, alice);
+    assert!(
+        !absent_actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id,
+                from_zone: Zone::Graveyard,
+                casting_method: CastingMethod::PlayFrom { .. },
+            } if *spell_id == absent_knight_id
+        )),
+        "Haakon should not grant Knight graveyard casts unless it is on the battlefield; got {absent_actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn thundermane_dragon_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), "Thundermane Dragon")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -112,6 +112,7 @@ pub enum ThisSpellCastCondition {
 pub struct ThisSpellCastRestrictionKind {
     pub timing: Option<ThisSpellCastTiming>,
     pub condition: Option<ThisSpellCastCondition>,
+    pub zone: Option<crate::zone::Zone>,
 }
 
 impl ThisSpellCastRestrictionKind {
@@ -119,6 +120,7 @@ impl ThisSpellCastRestrictionKind {
         Self {
             timing: Some(timing),
             condition: None,
+            zone: None,
         }
     }
 
@@ -129,6 +131,7 @@ impl ThisSpellCastRestrictionKind {
         Self {
             timing: Some(timing),
             condition: Some(condition),
+            zone: None,
         }
     }
 
@@ -136,6 +139,15 @@ impl ThisSpellCastRestrictionKind {
         Self {
             timing: None,
             condition: Some(condition),
+            zone: None,
+        }
+    }
+
+    pub fn from_zone(zone: crate::zone::Zone) -> Self {
+        Self {
+            timing: None,
+            condition: None,
+            zone: Some(zone),
         }
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -768,6 +768,10 @@ impl StaticAbilityModelInterpreter {
                 super::ThisSpellCastRestrictionKind::during_opponents_turn_after_upkeep()
             }
             "during your end step" => super::ThisSpellCastRestrictionKind::during_your_end_step(),
+            "from graveyard" => {
+                super::ThisSpellCastRestrictionKind::from_zone(crate::zone::Zone::Graveyard)
+            }
+            "from exile" => super::ThisSpellCastRestrictionKind::from_zone(crate::zone::Zone::Exile),
             "if you cast another spell this turn" => {
                 super::ThisSpellCastRestrictionKind::if_you_cast_another_spell_this_turn()
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Haakon, Stromgald Scourge
Initial parse error:
```
parser does not yet support line family: 'You may cast this card from your graveyard, but not from anywhere else.'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast this card from your graveyard, but not from anywhere else.'
```

Current worker: i-038037c71b9b3bd3c
Branch: codex/aws-card-fix-haakon-stromgald-scourge
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0033
