### PR TITLE
Fix Ironsmith parse failure: Kjeldoran Elite Guard

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -40,6 +40,9 @@ fn compile_delayed_trigger_spec(
             },
         ),
         TriggerSpec::ThisDies => Ok(ironsmith_core::DelayedTriggerSpec::ThisDies),
+        TriggerSpec::ThisLeavesBattlefield => {
+            Ok(ironsmith_core::DelayedTriggerSpec::ThisLeavesBattlefield)
+        }
         TriggerSpec::ThisAttacksAndIsntBlocked => {
             Ok(ironsmith_core::DelayedTriggerSpec::ThisAttacksAndIsntBlocked)
         }
@@ -55,6 +58,9 @@ fn compile_delayed_trigger_spec(
         TriggerSpec::Blocks(filter) => {
             Ok(ironsmith_core::DelayedTriggerSpec::Blocks(filter.clone()))
         }
+        TriggerSpec::LeavesBattlefield(filter) => Ok(
+            ironsmith_core::DelayedTriggerSpec::LeavesBattlefield(filter.clone()),
+        ),
         TriggerSpec::Dies(filter) | TriggerSpec::DiesOneOrMore(filter) => {
             Ok(ironsmith_core::DelayedTriggerSpec::Dies(filter.clone()))
         }
@@ -377,6 +383,50 @@ pub(super) fn try_compile_timing_and_control_effect(
                         let effect = Effect::new(
                             crate::effects::ScheduleDelayedTriggerEffect::new(
                                 ironsmith_core::DelayedTriggerSpec::Dies(resolved_filter),
+                                delayed_effects,
+                                *one_shot,
+                                Vec::new(),
+                                PlayerFilter::You,
+                            )
+                            .until_end_of_turn(),
+                        );
+                        (vec![effect], choices)
+                    }
+                }
+                TriggerSpec::LeavesBattlefield(filter) => {
+                    let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+                    let watched_tag = watch_tag_from_filter(&resolved_filter).or_else(|| {
+                        filter_references_tag(filter, IT_TAG)
+                            .then(|| TagKey::from("targeted_0"))
+                    });
+                    if let Some(watched_tag) = watched_tag {
+                        let lowered = compile_trigger_effects_with_imports(
+                            Some(trigger),
+                            effects,
+                            &ReferenceImports {
+                                last_object_tag: Some(watched_tag.clone()),
+                                ..Default::default()
+                            },
+                        )?;
+                        let delayed_effects = lowered.effects.to_vec();
+                        let delayed = crate::effects::ScheduleDelayedTriggerEffect::from_tag(
+                            watched_tag.clone().into(),
+                            ironsmith_core::DelayedTriggerSpec::ThisLeavesBattlefield,
+                            delayed_effects,
+                            *one_shot,
+                            Vec::new(),
+                            PlayerFilter::You,
+                        );
+                        let delayed = delayed
+                            .with_target_filter(resolved_filter)
+                            .until_end_of_turn();
+                        (vec![Effect::new(delayed)], choices)
+                    } else {
+                        let effect = Effect::new(
+                            crate::effects::ScheduleDelayedTriggerEffect::new(
+                                ironsmith_core::DelayedTriggerSpec::LeavesBattlefield(
+                                    resolved_filter,
+                                ),
                                 delayed_effects,
                                 *one_shot,
                                 Vec::new(),

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -138,11 +138,13 @@ pub enum DelayedTriggerSpec {
     BeginningOfEndStep(PlayerFilter),
     EndOfCombat,
     ThisDies,
+    ThisLeavesBattlefield,
     ThisAttacksAndIsntBlocked,
     Attacks(ObjectFilter),
     AttacksAndIsntBlocked(ObjectFilter),
     AttacksOneOrMore(ObjectFilter),
     Blocks(ObjectFilter),
+    LeavesBattlefield(ObjectFilter),
     Dies(ObjectFilter),
     DealsCombatDamageToPlayer {
         source: ObjectFilter,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39796,6 +39796,38 @@ fn alena_kessig_trapper_strict_parser_and_text_regression() {
 }
 
 #[test]
+fn kjeldoran_elite_guard_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Kjeldoran Elite Guard");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains("target creature gets +2/+2 until end of turn"),
+        "expected Kjeldoran Elite Guard to render the target pump, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("when that creature leaves the battlefield this turn, sacrifice this creature"),
+        "expected the delayed target leaves-battlefield clause to render, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("activate only during combat"),
+        "expected the combat-only activation restriction to render, got {rendered}"
+    );
+
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("ScheduleDelayedTriggerEffect")
+            && ability_debug.contains("target_tag: Some")
+            && ability_debug.contains("targeted_0")
+            && ability_debug.contains("from: Specific(")
+            && ability_debug.contains("Battlefield")
+            && ability_debug.contains("to: Any")
+            && ability_debug.contains("this_object: true"),
+        "expected delayed trigger to watch the targeted creature leaving, got {ability_debug}"
+    );
+}
+
+#[test]
 fn alena_kessig_trapper_mana_runtime_uses_only_your_creatures_that_entered_this_turn() {
     fn record_entered_this_turn(game: &mut crate::game_state::GameState, id: ObjectId) {
         let snapshot = crate::snapshot::ObjectSnapshot::from_object(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32776,6 +32776,28 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             }
             return format!("When that creature dies this turn, {delayed_text}");
         }
+        if schedule.target_tag.is_some()
+            && trigger_lower.contains("leaves the battlefield")
+        {
+            let subject = schedule
+                .target_filter
+                .as_ref()
+                .map(|filter| {
+                    let mut base = filter.clone();
+                    base.tagged_constraints.retain(|constraint| {
+                        !(constraint.relation
+                            == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                            && schedule.target_tag.as_ref().is_some_and(|tag| {
+                                constraint.tag.as_str() == tag.as_str()
+                                    || constraint.tag.as_str() == "__it__"
+                            }))
+                    });
+                    let desc = base.description();
+                    format!("that {}", strip_leading_article(&desc))
+                })
+                .unwrap_or_else(|| "that permanent".to_string());
+            return format!("When {subject} leaves the battlefield this turn, {delayed_text}");
+        }
         if trigger_lower.starts_with("when ")
             || trigger_lower.starts_with("whenever ")
             || trigger_lower.starts_with("if ")

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -16620,6 +16620,145 @@ fn test_goddric_celebration_granted_ability_buffs_only_dragons() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn kjeldoran_elite_guard_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Kjeldoran Elite Guard")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "{T}: Target creature gets +2/+2 until end of turn. When that creature leaves the battlefield this turn, sacrifice this creature. Activate only during combat.",
+        )
+        .expect("Kjeldoran Elite Guard should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn zone_contains_named(game: &GameState, zone: Zone, name: &str) -> bool {
+    game.objects_in_zone(zone).into_iter().any(|id| {
+        game.object(id)
+            .is_some_and(|object| object.name.eq_ignore_ascii_case(name))
+    })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kjeldoran_elite_guard_delayed_trigger_tracks_only_targeted_creature() {
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::BeginCombat);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let guard = kjeldoran_elite_guard_definition();
+    let guard_id = game.create_object_from_definition(&guard, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(guard_id);
+
+    let target = CardBuilder::new(CardId::new(), "Chosen Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let decoy = CardBuilder::new(CardId::new(), "Decoy Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_card(&target, bob, Zone::Battlefield);
+    let decoy_id = game.create_object_from_card(&decoy, bob, Zone::Battlefield);
+
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, .. } if *source == guard_id
+            )
+        })
+        .expect("Kjeldoran Elite Guard should be activatable during combat");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = ChooseSpecificObjectDecisionMaker::new(target_id);
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Kjeldoran Elite Guard activation should choose the target and go on the stack");
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("Kjeldoran Elite Guard target choice should complete activation");
+
+    if !game.stack.is_empty() {
+        resolve_stack_entry(&mut game).expect("Kjeldoran Elite Guard activation should resolve");
+    }
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.calculated_power(target_id),
+        Some(4),
+        "the chosen target should get +2/+2 until end of turn"
+    );
+    assert_eq!(
+        game.calculated_power(decoy_id),
+        Some(2),
+        "an untargeted creature should not get the pump"
+    );
+
+    game.move_object(
+        decoy_id,
+        Zone::Graveyard,
+        crate::events::cause::EventCause::effect(),
+    )
+    .expect("decoy should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "a nontarget creature leaving should not trigger the delayed sacrifice"
+    );
+    assert!(
+        zone_contains_named(&game, Zone::Battlefield, "Kjeldoran Elite Guard"),
+        "Kjeldoran Elite Guard should remain after the decoy leaves"
+    );
+
+    game.move_object(
+        target_id,
+        Zone::Graveyard,
+        crate::events::cause::EventCause::effect(),
+    )
+    .expect("target should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "the targeted creature leaving should trigger the delayed sacrifice"
+    );
+
+    let mut trigger_dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut trigger_dm)
+        .expect("delayed sacrifice trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("delayed sacrifice trigger should resolve");
+
+    assert!(
+        zone_contains_named(&game, Zone::Graveyard, "Kjeldoran Elite Guard"),
+        "Kjeldoran Elite Guard should be sacrificed when the targeted creature leaves"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_root_greevil_activation_reaches_stack_and_resolves_with_color_choice() {
     use crate::decision::{LegalAction, compute_legal_actions};

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -479,6 +479,9 @@ impl super::Trigger {
             }
             ironsmith_core::DelayedTriggerSpec::EndOfCombat => Self::end_of_combat(),
             ironsmith_core::DelayedTriggerSpec::ThisDies => Self::this_dies(),
+            ironsmith_core::DelayedTriggerSpec::ThisLeavesBattlefield => {
+                Self::this_leaves_battlefield()
+            }
             ironsmith_core::DelayedTriggerSpec::ThisAttacksAndIsntBlocked => {
                 Self::this_attacks_and_isnt_blocked()
             }
@@ -490,6 +493,9 @@ impl super::Trigger {
                 Self::attacks_one_or_more(filter)
             }
             ironsmith_core::DelayedTriggerSpec::Blocks(filter) => Self::blocks(filter),
+            ironsmith_core::DelayedTriggerSpec::LeavesBattlefield(filter) => {
+                Self::leaves_battlefield(filter)
+            }
             ironsmith_core::DelayedTriggerSpec::Dies(filter) => Self::dies(filter),
             ironsmith_core::DelayedTriggerSpec::DealsCombatDamageToPlayer { source, player } => {
                 Self::deals_combat_damage_to_player(source, player)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kjeldoran Elite Guard
Initial parse error:
```
unsupported delayed trigger spec: LeavesBattlefield(ObjectFilter { zone: Some(Battlefield), controller: None, cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [TaggedObjectConstraint { tag: TagKey("__it__"), relation: IsTaggedObject }], specific: None, any_of: [], source: false }); oracle-only fallback also failed: unsupported delayed trigger spec: LeavesBattlefield(ObjectFilter { zone: Some(Battlefield), controller: None, cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [TaggedObjectConstraint { tag: TagKey("__it__"), relation: IsTaggedObject }], specific: None, any_of: [], source: false })
```

Current worker: i-0cc964d8d55ae3b89
Branch: codex/aws-card-fix-kjeldoran-elite-guard
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0034
