### PR TITLE
Fix Ironsmith parse failure: Primal Plasma

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -2774,6 +2774,23 @@ pub(crate) fn parse_as_enters_or_turns_face_up_pt_choice_line(
     }
 
     let after_enter = clause_words.get(enter_word_idx + 1..).unwrap_or_default();
+    if word_slice_starts_with(after_enter, &["it", "becomes", "your", "choice", "of"]) {
+        let options = parse_pt_choice_characteristic_options(&after_enter[5..], &clause_words)?;
+        if options.is_empty() {
+            return Ok(None);
+        }
+        let subject = subject_words.join(" ");
+        let display = format!(
+            "As {subject} enters, it becomes your choice of {}",
+            render_pt_choice_characteristic_options(&options)
+        );
+        return Ok(Some(
+            StaticAbility::choose_power_toughness_options_as_enters_or_turns_face_up(
+                options, display,
+            ),
+        ));
+    }
+
     if after_enter.len() != 13
         || !word_slice_starts_with(
             after_enter,
@@ -2813,4 +2830,130 @@ pub(crate) fn parse_as_enters_or_turns_face_up_pt_choice_line(
             display,
         ),
     ))
+}
+
+fn parse_pt_choice_characteristic_options(
+    words: &[&str],
+    clause_words: &[&str],
+) -> Result<Vec<PowerToughnessChoiceOption>, CardTextError> {
+    let mut options = Vec::new();
+    let mut idx = 0usize;
+    while idx < words.len() {
+        if words[idx] == "or" {
+            idx += 1;
+        }
+        if matches!(words.get(idx).copied(), Some("a" | "an")) {
+            idx += 1;
+        }
+        let Some(pt_word) = words.get(idx).copied() else {
+            break;
+        };
+        let (power, toughness) = match parse_pt_modifier(pt_word) {
+            Ok(pt) => pt,
+            Err(_) if options.is_empty() => return Ok(Vec::new()),
+            Err(_) => {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported power/toughness choice '{}' (clause: '{}')",
+                    pt_word,
+                    clause_words.join(" ")
+                )));
+            }
+        };
+        idx += 1;
+
+        if !matches!(
+            words.get(idx).copied(),
+            Some("creature" | "permanent" | "object")
+        ) {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported power/toughness choice descriptor after '{}' (clause: '{}')",
+                pt_word,
+                clause_words.join(" ")
+            )));
+        }
+        idx += 1;
+
+        let mut abilities = Vec::new();
+        if words.get(idx).copied() == Some("with") {
+            idx += 1;
+            let ability_start = idx;
+            while idx < words.len()
+                && words[idx] != "or"
+                && !(matches!(words[idx], "a" | "an")
+                    && words
+                        .get(idx + 1)
+                        .is_some_and(|next| parse_pt_modifier(next).is_ok()))
+            {
+                idx += 1;
+            }
+            abilities =
+                parse_pt_choice_keyword_abilities(&words[ability_start..idx], clause_words)?;
+        }
+
+        options.push(PowerToughnessChoiceOption::with_abilities(
+            power, toughness, abilities,
+        ));
+    }
+
+    Ok(options)
+}
+
+fn parse_pt_choice_keyword_abilities(
+    words: &[&str],
+    clause_words: &[&str],
+) -> Result<Vec<StaticAbility>, CardTextError> {
+    if words.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing keyword ability in power/toughness choice (clause: '{}')",
+            clause_words.join(" ")
+        )));
+    }
+
+    let action = match words {
+        [word] => parse_single_word_keyword_action(word),
+        ["first", "strike"] => Some(KeywordAction::FirstStrike),
+        ["double", "strike"] => Some(KeywordAction::DoubleStrike),
+        _ => None,
+    };
+    let Some(static_ability) = action.and_then(static_ability_for_keyword_action) else {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported keyword ability '{}' in power/toughness choice (clause: '{}')",
+            words.join(" "),
+            clause_words.join(" ")
+        )));
+    };
+
+    Ok(vec![static_ability])
+}
+
+fn render_pt_choice_characteristic_options(options: &[PowerToughnessChoiceOption]) -> String {
+    let rendered = options
+        .iter()
+        .map(|option| {
+            let mut text = format!("a {}/{} creature", option.power, option.toughness);
+            if !option.abilities.is_empty() {
+                let abilities = option
+                    .abilities
+                    .iter()
+                    .map(|ability| ability.display().to_ascii_lowercase())
+                    .collect::<Vec<_>>()
+                    .join(" and ");
+                text.push_str(" with ");
+                text.push_str(&abilities);
+            }
+            text
+        })
+        .collect::<Vec<_>>();
+
+    match rendered.as_slice() {
+        [] => String::new(),
+        [only] => only.clone(),
+        [first, second] => format!("{first} or {second}"),
+        _ => {
+            let mut text = rendered[..rendered.len() - 1].join(", ");
+            text.push_str(", or ");
+            text.push_str(rendered.last().expect("nonempty options"));
+            text
+        }
+    }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2,6 +2,7 @@ use super::activation_and_restrictions::parse_cycling_line;
 use super::activation_and_restrictions::{
     normalize_cant_words, parse_ability_phrase, parse_activated_line, parse_activation_cost,
     parse_choose_land_type_phrase_words, parse_payment_clause_as_total_cost,
+    parse_single_word_keyword_action,
 };
 use super::effect_sentences::parse_granted_abilities_for_gain_clause;
 use super::grammar::abilities::{
@@ -86,7 +87,9 @@ use super::lexer::{
 use super::lowering_support::rewrite_parsed_triggered_ability as parsed_triggered_ability;
 use super::object_filters::{parse_object_filter, parse_object_filter_lexed};
 use super::rule_engine::{LexRuleHeadHint, LexRuleHintIndex, build_lex_rule_hint_index};
-use super::static_ability_helpers::lower_granted_abilities_ast_to_object_abilities;
+use super::static_ability_helpers::{
+    lower_granted_abilities_ast_to_object_abilities, static_ability_for_keyword_action,
+};
 use super::token_primitives::{
     find_index, find_window_by, lexed_head_words, rfind_index, slice_contains, slice_strip_prefix,
     slice_strip_suffix, split_em_dash_label_prefix, str_strip_prefix, str_strip_suffix,
@@ -124,7 +127,8 @@ use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::CounterType;
 #[allow(unused_imports)]
 use crate::static_abilities::{
-    Anthem, AnthemCountExpression, AnthemValue, GrantAbility, StaticAbility,
+    Anthem, AnthemCountExpression, AnthemValue, GrantAbility, PowerToughnessChoiceOption,
+    StaticAbility,
 };
 #[allow(unused_imports)]
 use crate::target::{ChooseSpec, ChooseSpecSurfaceHint, ObjectFilter, PlayerFilter};

--- a/crates/ironsmith-compiler/src/static_abilities.rs
+++ b/crates/ironsmith-compiler/src/static_abilities.rs
@@ -29,6 +29,12 @@ pub type StaticAbilityPayload = ironsmith_core::StaticAbilityPayload<
     crate::costs::Cost,
     ThisSpellCostCondition,
 >;
+pub type PowerToughnessChoiceOption = ironsmith_core::PowerToughnessChoiceOption<
+    crate::triggers::Trigger,
+    crate::effect::Effect,
+    crate::costs::Cost,
+    ThisSpellCostCondition,
+>;
 pub type AttachedAbilityGrant = ironsmith_core::AttachedAbilityGrant<
     crate::triggers::Trigger,
     crate::effect::Effect,

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -169,9 +169,10 @@ pub use static_ability_model::{
     CopyActivatedAbilities, CopyTriggeredAbilities, CostIncrease, CostIncreaseManaCost,
     CostReduction, CostReductionManaCost, DefendingPlayerAttackCondition, EnterAsCopyAsEntersSpec,
     EnterAsCopyLinkedExilePairSpec, GrantAbility, GrantObjectAbilityForFilter,
-    GraveyardCountMetric, LandwalkKind, PregameActionKind, PregameBeginOnBattlefieldSpec,
-    RemoveCardTypesForFilter, SetColorsForFilter, StaticAbility, StaticAbilityPayload,
-    ThisSpellCastRestrictionKind, ThisSpellCostReduction, ThisSpellCostReductionManaCost,
+    GraveyardCountMetric, LandwalkKind, PowerToughnessChoiceOption, PregameActionKind,
+    PregameBeginOnBattlefieldSpec, RemoveCardTypesForFilter, SetColorsForFilter, StaticAbility,
+    StaticAbilityPayload, ThisSpellCastRestrictionKind, ThisSpellCostReduction,
+    ThisSpellCostReductionManaCost,
 };
 pub use tag::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, TagKey};
 pub use target_model::{ChooseSpec, ChooseSpecSurfaceHint, SourceReferenceSurface};

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -154,6 +154,35 @@ pub struct StaticAbility<T, E, C, Cond> {
     pub payload: StaticAbilityPayload<T, E, C, Cond>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct PowerToughnessChoiceOption<T, E, C, Cond> {
+    pub power: i32,
+    pub toughness: i32,
+    pub abilities: Vec<StaticAbility<T, E, C, Cond>>,
+}
+
+impl<T, E, C, Cond> PowerToughnessChoiceOption<T, E, C, Cond> {
+    pub fn new(power: i32, toughness: i32) -> Self {
+        Self {
+            power,
+            toughness,
+            abilities: Vec::new(),
+        }
+    }
+
+    pub fn with_abilities(
+        power: i32,
+        toughness: i32,
+        abilities: Vec<StaticAbility<T, E, C, Cond>>,
+    ) -> Self {
+        Self {
+            power,
+            toughness,
+            abilities,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum StaticAbilityPayload<T, E, C, Cond> {
     #[default]
@@ -358,7 +387,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         display: String,
     },
     ChoosePowerToughnessAsEntersOrTurnsFaceUp {
-        options: Vec<(i32, i32)>,
+        options: Vec<PowerToughnessChoiceOption<T, E, C, Cond>>,
         display: String,
     },
     EnterAsCopyAsEnters {
@@ -1161,7 +1190,22 @@ where
                 options,
                 display,
             } => StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
-                options,
+                options: options
+                    .into_iter()
+                    .map(|option| {
+                        Ok(PowerToughnessChoiceOption {
+                            power: option.power,
+                            toughness: option.toughness,
+                            abilities: option
+                                .abilities
+                                .into_iter()
+                                .map(|ability| {
+                                    map_static_ability(ability, map_trigger, map_effect, map_cost)
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
                 display,
             },
             StaticAbilityPayload::EnterAsCopyAsEnters { spec, display } => {
@@ -3017,6 +3061,17 @@ impl<
 
     pub fn choose_power_toughness_as_enters_or_turns_face_up(
         options: Vec<(i32, i32)>,
+        display: impl Into<String>,
+    ) -> Self {
+        let options = options
+            .into_iter()
+            .map(|(power, toughness)| PowerToughnessChoiceOption::new(power, toughness))
+            .collect();
+        Self::choose_power_toughness_options_as_enters_or_turns_face_up(options, display)
+    }
+
+    pub fn choose_power_toughness_options_as_enters_or_turns_face_up(
+        options: Vec<PowerToughnessChoiceOption<T, E, C, Cond>>,
         display: impl Into<String>,
     ) -> Self {
         let display = display.into();

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -14579,6 +14579,32 @@ fn aquamorph_entity_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn primal_plasma_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Primal Plasma");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("ChoosePowerToughnessAsEntersOrTurnsFaceUp"),
+        "expected structured P/T-choice static ability, got {debug}"
+    );
+    assert!(
+        debug.contains("Flying") && debug.contains("Defender"),
+        "expected keyword-granting P/T choices, got {debug}"
+    );
+
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains(
+            "as this creature enters, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender"
+        ),
+        "expected Primal Plasma choice clause in compiled output, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_this_creature_enters_from_your_graveyard() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Phyrexian Dragon Engine")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -29706,6 +29706,93 @@ fn aquamorph_entity_turns_face_up_with_chosen_power_toughness() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn primal_plasma_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(509445), "Primal Plasma")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elemental, Subtype::Shapeshifter])
+        .power_toughness(PowerToughness::new(PtValue::Star, PtValue::Star))
+        .parse_text(
+            "As this creature enters, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.",
+        )
+        .expect("Primal Plasma should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChoosePrimalPlasmaCharacteristics {
+    option_index: usize,
+    choices_seen: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChoosePrimalPlasmaCharacteristics {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if ctx.options.iter().any(|option| option.description == "3/3")
+            && ctx.options.iter().any(|option| option.description == "2/2")
+            && ctx.options.iter().any(|option| option.description == "1/6")
+        {
+            self.choices_seen += 1;
+            return vec![self.option_index];
+        }
+        ctx.options
+            .iter()
+            .filter(|option| option.legal)
+            .map(|option| option.index)
+            .take(ctx.min)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn primal_plasma_enters_with_each_chosen_characteristic_set() {
+    let cases = [
+        (0, 3, 3, false, false),
+        (1, 2, 2, true, false),
+        (2, 1, 6, false, true),
+    ];
+
+    for (option_index, expected_power, expected_toughness, has_flying, has_defender) in cases {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let primal_plasma = primal_plasma_definition();
+        let hand_id = game.create_object_from_definition(&primal_plasma, alice, Zone::Hand);
+
+        let mut dm = ChoosePrimalPlasmaCharacteristics {
+            option_index,
+            choices_seen: 0,
+        };
+        let result = game
+            .move_object_with_etb_processing_with_dm(hand_id, Zone::Battlefield, &mut dm)
+            .expect("Primal Plasma should enter the battlefield");
+        let object = game
+            .object(result.new_id)
+            .expect("Primal Plasma should exist on the battlefield");
+
+        assert_eq!(object.power(), Some(expected_power));
+        assert_eq!(object.toughness(), Some(expected_toughness));
+        assert_eq!(
+            game.object_has_ability(result.new_id, &StaticAbility::flying()),
+            has_flying,
+            "flying grant should match option {option_index}"
+        );
+        assert_eq!(
+            game.object_has_ability(result.new_id, &StaticAbility::defender()),
+            has_defender,
+            "defender grant should match option {option_index}"
+        );
+        assert_eq!(dm.choices_seen, 1);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_bestow_cast_enters_as_aura_and_reverts_when_unattached() {
     use crate::cards::CardDefinitionBuilder;

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -8836,8 +8836,11 @@ impl GameState {
                 .options
                 .iter()
                 .enumerate()
-                .map(|(idx, (power, toughness))| {
-                    crate::decisions::spec::DisplayOption::new(idx, format!("{power}/{toughness}"))
+                .map(|(idx, option)| {
+                    crate::decisions::spec::DisplayOption::new(
+                        idx,
+                        format!("{}/{}", option.power, option.toughness),
+                    )
                 })
                 .collect::<Vec<_>>();
             let choice_spec =
@@ -8850,10 +8853,16 @@ impl GameState {
                 choice_spec,
             );
             if let Some(chosen_idx) = chosen.pop().filter(|idx| *idx < spec.options.len()) {
-                let (power, toughness) = spec.options[chosen_idx];
+                let option = &spec.options[chosen_idx];
                 if let Some(object) = self.object_mut(permanent_id) {
-                    object.base_power = Some(crate::card::PtValue::Fixed(power));
-                    object.base_toughness = Some(crate::card::PtValue::Fixed(toughness));
+                    object.base_power = Some(crate::card::PtValue::Fixed(option.power));
+                    object.base_toughness = Some(crate::card::PtValue::Fixed(option.toughness));
+                    for granted in &option.abilities {
+                        let ability = crate::ability::Ability::static_ability(granted.clone());
+                        if !object.abilities.contains(&ability) {
+                            object.abilities.push(ability);
+                        }
+                    }
                     self.mark_continuous_state_dirty();
                 }
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -7,9 +7,9 @@ use super::{
     ChooseColorAsEntersSpec, ChooseCreatureTypeAsEntersSpec, ChooseLandTypeAsEntersSpec,
     ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
-    ConditionalSpellKeywordSpec, EnterAsCopyAsEntersSpec, GraveyardCountMetric, StaticAbilityId,
-    StaticAbility, StaticAbilityKind, ThisSpellCastRestrictionKind, TriggerDuplicationSpec,
-    TriggerSuppressionSpec,
+    ConditionalSpellKeywordSpec, EnterAsCopyAsEntersSpec, GraveyardCountMetric,
+    PowerToughnessChoiceOption, StaticAbilityId, StaticAbility, StaticAbilityKind,
+    ThisSpellCastRestrictionKind, TriggerDuplicationSpec, TriggerSuppressionSpec,
     text_utils::{capitalize_first, join_with_and, number_word_u32},
 };
 use crate::ability::{Ability, AbilityKind, LevelAbility};
@@ -1617,12 +1617,20 @@ impl StaticAbilityKind for ChooseNamedOptionAsEnters {
 /// "As this enters or is turned face up, choose a power/toughness."
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChoosePowerToughnessAsEntersOrTurnsFaceUp {
-    pub options: Vec<(i32, i32)>,
+    pub options: Vec<PowerToughnessChoiceOption>,
     pub display: String,
 }
 
 impl ChoosePowerToughnessAsEntersOrTurnsFaceUp {
     pub fn new(options: Vec<(i32, i32)>, display: String) -> Self {
+        let options = options
+            .into_iter()
+            .map(|(power, toughness)| PowerToughnessChoiceOption::new(power, toughness))
+            .collect();
+        Self { options, display }
+    }
+
+    pub fn new_with_options(options: Vec<PowerToughnessChoiceOption>, display: String) -> Self {
         Self { options, display }
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -975,10 +975,36 @@ pub struct ChooseNamedOptionAsEntersSpec {
     pub options: Vec<String>,
 }
 
-/// Spec for "as this enters or is turned face up, choose a P/T" abilities.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// One option for "as this enters or is turned face up, choose characteristics" abilities.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PowerToughnessChoiceOption {
+    pub power: i32,
+    pub toughness: i32,
+    pub abilities: Vec<StaticAbility>,
+}
+
+impl PowerToughnessChoiceOption {
+    pub fn new(power: i32, toughness: i32) -> Self {
+        Self {
+            power,
+            toughness,
+            abilities: Vec::new(),
+        }
+    }
+
+    pub fn with_abilities(power: i32, toughness: i32, abilities: Vec<StaticAbility>) -> Self {
+        Self {
+            power,
+            toughness,
+            abilities,
+        }
+    }
+}
+
+/// Spec for "as this enters or is turned face up, choose characteristics" abilities.
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec {
-    pub options: Vec<(i32, i32)>,
+    pub options: Vec<PowerToughnessChoiceOption>,
 }
 
 /// Spec for "you may have this enter as a copy ..." abilities.
@@ -2643,6 +2669,15 @@ impl StaticAbility {
         display: String,
     ) -> Self {
         Self::new(ChoosePowerToughnessAsEntersOrTurnsFaceUp::new(
+            options, display,
+        ))
+    }
+
+    pub fn choose_power_toughness_options_as_enters_or_turns_face_up(
+        options: Vec<PowerToughnessChoiceOption>,
+        display: String,
+    ) -> Self {
+        Self::new(ChoosePowerToughnessAsEntersOrTurnsFaceUp::new_with_options(
             options, display,
         ))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1176,8 +1176,22 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ChoosePowerToughnessAsEntersOrTurnsFaceUp {
                 options,
                 display,
-            } => StaticAbility::choose_power_toughness_as_enters_or_turns_face_up(
-                options.clone(),
+            } => StaticAbility::choose_power_toughness_options_as_enters_or_turns_face_up(
+                options
+                    .iter()
+                    .map(|option| {
+                        super::PowerToughnessChoiceOption::with_abilities(
+                            option.power,
+                            option.toughness,
+                            option
+                                .abilities
+                                .iter()
+                                .cloned()
+                                .map(StaticAbility::from_model)
+                                .collect(),
+                        )
+                    })
+                    .collect(),
                 display.clone(),
             ),
             ironsmith_core::StaticAbilityPayload::EnterAsCopyAsEnters { spec, display } => {
@@ -1885,7 +1899,21 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
                 options,
                 ..
             } => Some(super::ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec {
-                options: options.clone(),
+                options: options
+                    .iter()
+                    .map(|option| {
+                        super::PowerToughnessChoiceOption::with_abilities(
+                            option.power,
+                            option.toughness,
+                            option
+                                .abilities
+                                .iter()
+                                .cloned()
+                                .map(StaticAbility::from_model)
+                                .collect(),
+                        )
+                    })
+                    .collect(),
             }),
             _ => None,
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Primal Plasma
Initial parse error:
```
parser does not yet support line family: 'As this creature enters, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.'; oracle-only fallback also failed: parser does not yet support line family: 'As this creature enters, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.'
```

Current worker: i-046763ac8d0804698
Branch: codex/aws-card-fix-primal-plasma
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0034
