### PR TITLE
Fix Ironsmith parse failure: Loxodon Smiter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -20,6 +20,7 @@ use super::grammar::abilities::{
     is_draw_replacement_skip_empty_library_line_lexed,
     is_during_your_turn_prevent_all_damage_to_source_line_lexed,
     is_effect_discard_to_library_replacement_line_lexed,
+    is_opponent_effect_discard_this_to_battlefield_replacement_line_lexed,
     is_enchanted_land_is_chosen_type_line_lexed,
     is_if_source_you_control_with_mana_value_double_instead_marker_line_lexed,
     is_krrik_black_mana_life_payment_line_lexed,
@@ -8862,6 +8863,12 @@ pub(crate) fn parse_effect_discard_to_library_replacement_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     if is_effect_discard_to_library_replacement_line_lexed(tokens) {
         return Ok(Some(StaticAbility::effect_discard_to_library_replacement()));
+    }
+
+    if is_opponent_effect_discard_this_to_battlefield_replacement_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::opponent_effect_discard_this_to_battlefield_replacement(),
+        ));
     }
 
     Ok(None)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -1643,6 +1643,43 @@ pub(crate) fn is_effect_discard_to_library_replacement_line_lexed(
         && contains_token_word(tokens, "graveyard")
 }
 
+pub(crate) fn is_opponent_effect_discard_this_to_battlefield_replacement_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    let words = TokenWordView::new(tokens).word_refs();
+    word_slice_eq(
+        &words,
+        &[
+            "if",
+            "a",
+            "spell",
+            "or",
+            "ability",
+            "an",
+            "opponent",
+            "controls",
+            "causes",
+            "you",
+            "to",
+            "discard",
+            "this",
+            "card",
+            "put",
+            "it",
+            "onto",
+            "the",
+            "battlefield",
+            "instead",
+            "of",
+            "putting",
+            "it",
+            "into",
+            "your",
+            "graveyard",
+        ],
+    )
+}
+
 pub(crate) fn is_shuffle_into_library_from_graveyard_line_lexed(tokens: &[OwnedLexToken]) -> bool {
     contains_token_word_sequence(tokens, &["would", "be", "put"])
         && contains_token_word(tokens, "graveyard")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_support.rs
@@ -18,6 +18,11 @@ pub(super) fn infer_static_ability_functional_zones(normalized_line: &str) -> Op
     {
         return Some(vec![Zone::Exile]);
     }
+    if str_contains(normalized.as_str(), "causes you to discard this card")
+        && str_contains(normalized.as_str(), "instead of putting it into your graveyard")
+    {
+        return Some(vec![Zone::Hand]);
+    }
 
     let mut zones = Vec::new();
     for (needles, zone) in [

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
@@ -72,6 +72,7 @@ pub(crate) fn uses_spell_only_functional_zones(static_ability: &StaticAbility) -
     matches!(
         static_ability.id(),
         crate::static_abilities::StaticAbilityId::ConditionalSpellKeyword
+            | crate::static_abilities::StaticAbilityId::CantBeCountered
             | crate::static_abilities::StaticAbilityId::ThisSpellCastRestriction
             | crate::static_abilities::StaticAbilityId::ThisSpellXMaximum
             | crate::static_abilities::StaticAbilityId::ThisSpellCostReduction

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -221,6 +221,7 @@ pub enum StaticAbilityId {
     OpponentSearchExileFoundCards,
     CastThisCardFromLibraryWhileSearching,
     EffectDiscardToLibraryReplacement,
+    OpponentEffectDiscardThisToBattlefieldReplacement,
     DrawReplacementExileTopFaceDown,
     DrawReplacementExileTopAndPlay,
     DrawReplacementDouble,
@@ -477,6 +478,7 @@ impl StaticAbilityId {
             | OpponentSearchExileFoundCards
             | CastThisCardFromLibraryWhileSearching
             | EffectDiscardToLibraryReplacement
+            | OpponentEffectDiscardThisToBattlefieldReplacement
             | DrawReplacementExileTopFaceDown
             | DrawReplacementExileTopAndPlay
             | DrawReplacementDouble

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3431,6 +3431,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn opponent_effect_discard_this_to_battlefield_replacement() -> Self {
+        Self {
+            id: Some(StaticAbilityId::OpponentEffectDiscardThisToBattlefieldReplacement),
+            label: "opponent effect discard this to battlefield replacement".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn draw_replacement_exile_top_face_down() -> Self {
         Self {
             id: Some(StaticAbilityId::DrawReplacementExileTopFaceDown),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3616,6 +3616,42 @@ fn vexing_shusher_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn loxodon_smiter_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Loxodon Smiter");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("This spell can't be countered."),
+        "expected Loxodon Smiter to render its uncounterable spell line, got {rendered}"
+    );
+    assert!(
+        rendered.contains("If a spell or ability an opponent controls causes you to discard this card, put it onto the battlefield instead of putting it into your graveyard"),
+        "expected Loxodon Smiter to render its opponent-caused discard replacement, got {rendered}"
+    );
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::CantBeCountered
+                    && ability.functions_in(&Zone::Stack)
+        )),
+        "Loxodon Smiter's uncounterable ability should function on the stack"
+    );
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id()
+                    == StaticAbilityId::OpponentEffectDiscardThisToBattlefieldReplacement
+                    && ability.functions_in(&Zone::Hand)
+        )),
+        "Loxodon Smiter's discard replacement should function from hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_spells_cant_be_countered_as_rule_restriction() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Global No Counter")
         .parse_text("Spells can't be countered.")

--- a/crates/ironsmith-runtime/src/events/cards/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/cards/matchers.rs
@@ -3,8 +3,8 @@
 use crate::events::cause::{CauseFilter, CauseFilterRuntimeExt as _};
 use crate::events::context::EventContext;
 use crate::events::traits::{EventKind, GameEventType, ReplacementMatcher, downcast_event};
-use crate::filter::PlayerFilterExt;
-use crate::target::PlayerFilter;
+use crate::filter::{ObjectFilterExt as _, PlayerFilterExt};
+use crate::target::{ObjectFilter, PlayerFilter};
 
 use super::{DiscardEvent, DrawEvent};
 
@@ -158,6 +158,8 @@ pub struct WouldDiscardMatcher {
     pub player_filter: PlayerFilter,
     /// Filter on what caused the discard.
     pub cause_filter: CauseFilter,
+    /// Optional filter for the card being discarded.
+    pub card_filter: Option<ObjectFilter>,
 }
 
 impl WouldDiscardMatcher {
@@ -166,6 +168,7 @@ impl WouldDiscardMatcher {
         Self {
             player_filter,
             cause_filter,
+            card_filter: None,
         }
     }
 
@@ -178,6 +181,16 @@ impl WouldDiscardMatcher {
     /// This is what Library of Leng uses.
     pub fn you_from_effect() -> Self {
         Self::new(PlayerFilter::You, CauseFilter::effect_like())
+    }
+
+    /// Matches when you would discard this replacement source from an opponent's effect.
+    pub fn source_from_opponent_effect() -> Self {
+        Self::new(
+            PlayerFilter::You,
+            CauseFilter::effect_like()
+                .with_controller(crate::events::cause::ControllerFilter::Opponent),
+        )
+        .with_card_filter(ObjectFilter::source())
     }
 
     /// Matches when any player would discard a card.
@@ -193,6 +206,12 @@ impl WouldDiscardMatcher {
     /// Add a cause filter to this matcher.
     pub fn with_cause_filter(mut self, cause_filter: CauseFilter) -> Self {
         self.cause_filter = cause_filter;
+        self
+    }
+
+    /// Add a filter for the card being discarded.
+    pub fn with_card_filter(mut self, card_filter: ObjectFilter) -> Self {
+        self.card_filter = Some(card_filter);
         self
     }
 }
@@ -223,10 +242,33 @@ impl ReplacementMatcher for WouldDiscardMatcher {
             return false;
         }
 
+        if let Some(card_filter) = &self.card_filter {
+            let Some(card) = ctx.game.object(discard.card) else {
+                return false;
+            };
+            if !card_filter.matches(card, &ctx.filter_ctx, ctx.game) {
+                return false;
+            }
+        }
+
         true
     }
 
     fn display(&self) -> String {
+        if self.card_filter.as_ref().is_some_and(|filter| filter.source)
+            && matches!(self.player_filter, PlayerFilter::You)
+            && matches!(
+                self.cause_filter.cause_type,
+                Some(crate::events::cause::CauseTypeFilter::EffectLike)
+            )
+            && matches!(
+                self.cause_filter.controller_filter,
+                Some(crate::events::cause::ControllerFilter::Opponent)
+            )
+        {
+            return "When a spell or ability an opponent controls causes you to discard this card"
+                .to_string();
+        }
         match (&self.player_filter, &self.cause_filter.cause_type) {
             (PlayerFilter::You, Some(crate::events::cause::CauseTypeFilter::EffectLike)) => {
                 "When an effect causes you to discard a card".to_string()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12894,6 +12894,205 @@ fn vexing_shusher_activation_targets_spell_and_stops_countering_it() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn loxodon_smiter_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(290_543), "Loxodon Smiter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elephant, Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "This spell can't be countered.\nIf a spell or ability an opponent controls causes you to discard this card, put it onto the battlefield instead of putting it into your graveyard.",
+        )
+        .expect("Loxodon Smiter should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_smiter_spell_cant_be_countered_runtime() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let loxodon = loxodon_smiter_definition();
+    let smiter_spell = game.create_object_from_definition(&loxodon, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(smiter_spell, alice));
+
+    game.update_cant_effects();
+    assert!(
+        !game.can_be_countered(smiter_spell),
+        "Loxodon Smiter should be uncounterable while it is a spell on the stack"
+    );
+
+    let counter_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Counter Source")
+            .card_types(vec![CardType::Instant])
+            .build(),
+        bob,
+        Zone::Stack,
+    );
+    let mut dm = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(counter_source, bob, &mut dm);
+    let outcome = crate::effects::execute_effect(
+        &mut game,
+        &Effect::counter(crate::target::ChooseSpec::SpecificObject(smiter_spell)),
+        &mut ctx,
+    )
+    .expect("counter attempt should resolve as protected");
+
+    assert_eq!(outcome.status, crate::effect::OutcomeStatus::Protected);
+    assert!(
+        game.stack.iter().any(|entry| entry.object_id == smiter_spell),
+        "Loxodon Smiter should remain on the stack after a counter attempt"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_smiter_opponent_effect_discard_replacement_moves_to_battlefield() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let loxodon = loxodon_smiter_definition();
+    let smiter = game.create_object_from_definition(&loxodon, alice, Zone::Hand);
+    let discard_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Opponent Discard Spell")
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        bob,
+        Zone::Stack,
+    );
+    let mut dm = SelectFirstDecisionMaker;
+
+    let result = crate::events::processing::execute_discard(
+        &mut game,
+        smiter,
+        alice,
+        crate::events::cause::EventCause::from_effect(discard_source, bob),
+        false,
+        crate::provenance::ProvNodeId::default(),
+        &mut dm,
+    );
+
+    assert_eq!(result.final_zone, Zone::Battlefield);
+    let moved = result
+        .new_id
+        .expect("Loxodon Smiter should have moved to the battlefield");
+    assert!(
+        game.object(moved).is_some_and(|object| object.name == "Loxodon Smiter"
+            && object.zone == Zone::Battlefield),
+        "opponent-controlled discard effect should put Loxodon Smiter onto the battlefield"
+    );
+    assert!(
+        !game
+            .player(alice)
+            .expect("Alice exists")
+            .graveyard
+            .iter()
+            .any(|&id| game
+                .object(id)
+                .is_some_and(|object| object.name == "Loxodon Smiter")),
+        "Loxodon Smiter should not be put into Alice's graveyard when the replacement applies"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_smiter_discard_replacement_ignores_own_effects_and_costs() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let loxodon = loxodon_smiter_definition();
+
+    for (source_controller, cause_kind) in [(alice, "own effect"), (bob, "opponent cost")] {
+        let mut game = setup_game();
+        let smiter = game.create_object_from_definition(&loxodon, alice, Zone::Hand);
+        let discard_source = game.create_object_from_card(
+            &CardBuilder::new(CardId::new(), "Discard Source")
+                .card_types(vec![CardType::Sorcery])
+                .build(),
+            source_controller,
+            Zone::Stack,
+        );
+        let cause = if cause_kind == "own effect" {
+            crate::events::cause::EventCause::from_effect(discard_source, source_controller)
+        } else {
+            crate::events::cause::EventCause::from_cost(discard_source, source_controller)
+        };
+        let mut dm = SelectFirstDecisionMaker;
+
+        let result = crate::events::processing::execute_discard(
+            &mut game,
+            smiter,
+            alice,
+            cause,
+            false,
+            crate::provenance::ProvNodeId::default(),
+            &mut dm,
+        );
+
+        assert_eq!(
+            result.final_zone,
+            Zone::Graveyard,
+            "Loxodon Smiter should go to the graveyard for {cause_kind}"
+        );
+        assert!(
+            game.player(alice)
+                .expect("Alice exists")
+                .graveyard
+                .iter()
+                .any(|&id| game
+                    .object(id)
+                    .is_some_and(|object| object.name == "Loxodon Smiter")),
+            "Loxodon Smiter should be in Alice's graveyard for {cause_kind}"
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn loxodon_smiter_discard_replacement_only_applies_to_itself() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let loxodon = loxodon_smiter_definition();
+    let smiter = game.create_object_from_definition(&loxodon, alice, Zone::Hand);
+    let other_card = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Other Discarded Card")
+            .card_types(vec![CardType::Creature])
+            .build(),
+        alice,
+        Zone::Hand,
+    );
+    let discard_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Opponent Discard Spell")
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        bob,
+        Zone::Stack,
+    );
+    let mut dm = SelectFirstDecisionMaker;
+
+    let result = crate::events::processing::execute_discard(
+        &mut game,
+        other_card,
+        alice,
+        crate::events::cause::EventCause::from_effect(discard_source, bob),
+        false,
+        crate::provenance::ProvNodeId::default(),
+        &mut dm,
+    );
+
+    assert_eq!(result.final_zone, Zone::Graveyard);
+    assert!(
+        game.object(smiter)
+            .is_some_and(|object| object.zone == Zone::Hand),
+        "Loxodon Smiter's replacement should not apply to another discarded card"
+    );
+}
+
 #[test]
 fn magma_mine_activated_ability_sacrifices_source_and_deals_counter_scaled_damage_to_player() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -209,6 +209,9 @@ impl StaticAbility {
             Some(StaticAbilityId::EffectDiscardToLibraryReplacement) => {
                 Self::effect_discard_to_library_replacement()
             }
+            Some(StaticAbilityId::OpponentEffectDiscardThisToBattlefieldReplacement) => {
+                Self::opponent_effect_discard_this_to_battlefield_replacement()
+            }
             Some(StaticAbilityId::DrawReplacementExileTopFaceDown) => {
                 Self::draw_replacement_exile_top_face_down()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -4072,6 +4072,38 @@ impl StaticAbilityKind for EffectDiscardToLibraryReplacement {
     }
 }
 
+/// Replacement for opponent-controlled effects causing this card to be discarded.
+///
+/// "If a spell or ability an opponent controls causes you to discard this card,
+/// put it onto the battlefield instead of putting it into your graveyard."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct OpponentEffectDiscardThisToBattlefieldReplacement;
+
+impl StaticAbilityKind for OpponentEffectDiscardThisToBattlefieldReplacement {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::OpponentEffectDiscardThisToBattlefieldReplacement
+    }
+
+    fn display(&self) -> String {
+        "If a spell or ability an opponent controls causes you to discard this card, put it onto \
+         the battlefield instead of putting it into your graveyard"
+            .to_string()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            WouldDiscardMatcher::source_from_opponent_effect(),
+            ReplacementAction::ChangeDestination(Zone::Battlefield),
+        ))
+    }
+}
+
 /// "If you would draw a card, exile the top card of your library face down instead."
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct DrawReplacementExileTopFaceDown;

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2847,6 +2847,10 @@ impl StaticAbility {
         Self::new(EffectDiscardToLibraryReplacement)
     }
 
+    pub fn opponent_effect_discard_this_to_battlefield_replacement() -> Self {
+        Self::new(OpponentEffectDiscardThisToBattlefieldReplacement)
+    }
+
     pub fn duplicate_matching_triggered_abilities(
         source_filter: Option<crate::target::ObjectFilter>,
         event_matcher: Option<crate::triggers::Trigger>,

--- a/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
@@ -479,6 +479,18 @@ impl StaticAbilityKind for CantBeCountered {
         .with_condition(condition)
     }
 
+    fn apply_restrictions(&self, game: &mut GameState, source: ObjectId, controller: PlayerId) {
+        let mut tracker = CantEffectTracker::default();
+        Restriction::be_countered(ObjectFilter::source()).apply(
+            game,
+            &mut tracker,
+            controller,
+            Some(source),
+            None,
+        );
+        game.effect_store.cant_effects.merge(tracker);
+    }
+
     fn cant_be_countered(&self) -> bool {
         true
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Loxodon Smiter
Initial parse error:
```
unsupported predicate (predicate: 'spell'); oracle-only fallback also failed: unsupported predicate (predicate: 'spell')
```

Current worker: i-01a8881674179693e
Branch: codex/aws-card-fix-loxodon-smiter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0035
