### PR TITLE
Fix Ironsmith parse failure: Covenant of Minds

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -384,6 +384,9 @@ pub(crate) fn parse_effect_chain_lexed(
         {
             stripped.remove(0);
         }
+        if word_slice_starts_with(&token_word_refs(&stripped), &["choose", "to"]) {
+            stripped = remove_through_first_word_tokens(&stripped, "to");
+        }
         let mut effects = parse_effect_chain_lexed(&stripped)?;
         for effect in &mut effects {
             bind_implicit_player_context(effect, player);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -22730,6 +22730,40 @@ fn parse_terrapact_intimidator_preserves_have_you_create_branch() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_covenant_of_minds_preserves_opponent_choice_and_decline_branch() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(416_862), "Covenant of Minds")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Reveal the top three cards of your library. Target opponent may choose to put those cards into your hand. If they don't, put those cards into your graveyard and draw five cards.",
+        )
+        .expect("Covenant of Minds oracle text should parse strictly");
+
+    let expected = concat!(
+        "Reveal the top three cards of your library. ",
+        "Target opponent may choose to put those cards into your hand. ",
+        "If they don't, put those cards into your graveyard and draw five cards."
+    );
+    assert_eq!(
+        unprocessed_compiled_lines(&def),
+        vec![expected.to_string()],
+        "expected exact Covenant of Minds compiled text"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("LookAtTopCardsEffect")
+            && debug.contains("MayEffect")
+            && debug.contains("IfEffect"),
+        "expected reveal, optional opponent choice, and decline conditional effects, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_trigger_target_opponent_may_draw_card() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Target Opponent May Draw Variant")
         .parse_text("At the beginning of your end step, target opponent may draw a card.")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3492,6 +3492,78 @@ fn describe_choose_color_then_chosen_color_mana(effects: &[&Effect]) -> Option<S
     None
 }
 
+fn describe_revealed_cards_opponent_may_put_or_draw(effects: &[&Effect]) -> Option<String> {
+    let [look_effect, may_effect, fallback_effect] = effects else {
+        return None;
+    };
+    let look = look_effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    if !look.reveal || look.player != PlayerFilter::You {
+        return None;
+    }
+
+    let with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let may = with_id
+        .effect
+        .downcast_ref::<crate::effects::MayEffect>()?;
+    if !matches!(
+        may.decider.as_ref(),
+        Some(PlayerFilter::Target(inner)) if matches!(inner.as_ref(), PlayerFilter::Opponent)
+    ) {
+        return None;
+    }
+    let [target_effect, hand_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let target = target_effect.downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+    if !matches!(target.target.base(), ChooseSpec::Player(PlayerFilter::Opponent)) {
+        return None;
+    }
+    let move_to_hand = hand_effect.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_hand.zone != Zone::Hand
+        || !matches!(move_to_hand.target.base(), ChooseSpec::Tagged(tag) if tag == &look.tag)
+    {
+        return None;
+    }
+
+    let if_effect = fallback_effect.downcast_ref::<crate::effects::IfEffect>()?;
+    if if_effect.condition != with_id.id
+        || if_effect.predicate != EffectPredicate::DidNotHappen
+        || !if_effect.else_.is_empty()
+    {
+        return None;
+    }
+    let [graveyard_effect, draw_effect] = if_effect.then.as_slice() else {
+        return None;
+    };
+    let move_to_graveyard = unwrap_basic_tag_wrappers(graveyard_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_graveyard.zone != Zone::Graveyard
+        || !matches!(move_to_graveyard.target.base(), ChooseSpec::Tagged(tag) if tag == &look.tag)
+    {
+        return None;
+    }
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if draw.player != PlayerFilter::You {
+        return None;
+    }
+
+    let is_single_card = matches!(look.count, Value::Fixed(1));
+    let count_text = if is_single_card {
+        "card".to_string()
+    } else {
+        describe_card_count(&look.count)
+    };
+    let object_text = if is_single_card {
+        "that card"
+    } else {
+        "those cards"
+    };
+    Some(format!(
+        "Reveal the top {count_text} of your library. Target opponent may choose to put {object_text} into your hand. If they don't, put {object_text} into your graveyard and draw {}",
+        describe_card_count(&draw.count)
+    ))
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
@@ -3499,6 +3571,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
 
     let raw_effects = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&raw_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_revealed_cards_opponent_may_put_or_draw(&raw_effects) {
         return compact;
     }
     if let Some(compact) = describe_kicked_additional_targets_put_counters(&raw_effects) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2411,6 +2411,146 @@ fn open_the_way_reveals_x_lands_to_battlefield_tapped_and_bottoms_rest() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn covenant_of_minds_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(416_862), "Covenant of Minds")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Reveal the top three cards of your library. Target opponent may choose to put those cards into your hand. If they don't, put those cards into your graveyard and draw five cards.",
+        )
+        .expect("Covenant of Minds should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct CovenantOfMindsDecisionMaker {
+    accept_opponent_choice: bool,
+    expected_decider: PlayerId,
+    prompts: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for CovenantOfMindsDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.prompts += 1;
+        assert_eq!(
+            ctx.player, self.expected_decider,
+            "Covenant of Minds choice should be made by the targeted opponent"
+        );
+        self.accept_opponent_choice
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_covenant_library_card(game: &mut GameState, owner: PlayerId, name: &str) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Library)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn setup_covenant_of_minds_stack(
+    game: &mut GameState,
+    alice: PlayerId,
+    bob: PlayerId,
+) -> (ObjectId, Vec<crate::ids::StableId>) {
+    let covenant = covenant_of_minds_definition();
+    let spell_id = game.create_object_from_definition(&covenant, alice, Zone::Stack);
+    for idx in 0..5 {
+        create_covenant_library_card(game, alice, &format!("Covenant Draw Filler {idx}"));
+    }
+    let mut revealed = Vec::new();
+    for name in ["Covenant Revealed A", "Covenant Revealed B", "Covenant Revealed C"] {
+        let id = create_covenant_library_card(game, alice, name);
+        revealed.push(game.object(id).expect("revealed card exists").stable_id);
+    }
+
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_targets(vec![Target::Player(bob)]));
+    (spell_id, revealed)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn covenant_of_minds_opponent_accepts_puts_revealed_cards_into_your_hand() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let (_spell_id, revealed) = setup_covenant_of_minds_stack(&mut game, alice, bob);
+
+    let mut dm = CovenantOfMindsDecisionMaker {
+        accept_opponent_choice: true,
+        expected_decider: bob,
+        prompts: 0,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Covenant of Minds should resolve");
+    assert_eq!(dm.prompts, 1, "Covenant should ask exactly one may-choice");
+
+    for stable_id in revealed {
+        let id = game
+            .find_object_by_stable_id(stable_id)
+            .expect("revealed card should still exist");
+        assert!(
+            game.player(alice).expect("alice exists").hand.contains(&id),
+            "accepted opponent choice should put revealed card {id:?} into Alice's hand"
+        );
+    }
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        3,
+        "accepting should not draw the fallback five cards"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        5,
+        "accepting should leave the five unrevealed library cards in place"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn covenant_of_minds_opponent_declines_graveyards_revealed_cards_and_draws_five() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let (_spell_id, revealed) = setup_covenant_of_minds_stack(&mut game, alice, bob);
+
+    let mut dm = CovenantOfMindsDecisionMaker {
+        accept_opponent_choice: false,
+        expected_decider: bob,
+        prompts: 0,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Covenant of Minds should resolve");
+    assert_eq!(dm.prompts, 1, "Covenant should ask exactly one may-choice");
+
+    for stable_id in revealed {
+        let id = game
+            .find_object_by_stable_id(stable_id)
+            .expect("revealed card should still exist");
+        assert!(
+            game.player(alice).expect("alice exists").graveyard.contains(&id),
+            "declining should put revealed card {id:?} into Alice's graveyard"
+        );
+    }
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        5,
+        "declining should draw the remaining five library cards"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        0,
+        "declining should draw the five unrevealed library cards after moving the revealed cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn rise_from_the_grave_returns_creature_under_your_control_black_zombie() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Covenant of Minds
Initial parse error:
```
missing chosen player in choose-player clause (clause: 'choose'); oracle-only fallback also failed: missing chosen player in choose-player clause (clause: 'choose')
```

Current worker: i-0837b2a7a698046c6
Branch: codex/aws-card-fix-covenant-of-minds
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0036
