### PR TITLE
Fix Ironsmith parse failure: Commander Liara Portyr

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -866,6 +866,10 @@ pub(crate) fn parse_value_binding_clause(tokens: &[OwnedLexToken]) -> Option<Val
         | Some(["number", "of", "opponents"]) => {
             return Some(Value::CountPlayers(PlayerFilter::Opponent));
         }
+        Some(["the", "number", "of", "players", "being", "attacked"])
+        | Some(["number", "of", "players", "being", "attacked"]) => {
+            return Some(Value::PlayersBeingAttacked);
+        }
         Some(["target", "players", "life", "total"])
         | Some(["target", "player", "life", "total"]) => {
             return Some(Value::LifeTotal(PlayerFilter::target_player()));

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -109,12 +109,14 @@ fn parse_tagged_cast_or_play_target_inner<'a>(
 ) -> Result<TaggedPermissionTarget, ErrMode<ContextError>> {
     alt((
         alt((
-            grammar::phrase(&["spells", "from", "among", "those", "cards"]).value(
-                TaggedPermissionTarget {
-                    tag: TagKey::from(IT_TAG),
-                    as_copy: false,
-                },
-            ),
+            alt((
+                grammar::phrase(&["spells", "from", "among", "those", "cards"]),
+                grammar::phrase(&["spells", "from", "among", "those", "exiled", "cards"]),
+            ))
+            .value(TaggedPermissionTarget {
+                tag: TagKey::from(IT_TAG),
+                as_copy: false,
+            }),
             grammar::phrase(&["spells", "from", "among", "them"]).value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5379,6 +5379,28 @@ fn compile_subject_verb_effect(
                 Vec::new(),
             ))
         }
+        SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { filter, reduction } => {
+            let subject = resolve_subject_verb_subject(role, player, ctx, false, false, true)?;
+            let mut player_filter = subject.into_player_filter();
+            let mut resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            if let Some(last_player_filter) = ctx.last_player_filter.clone() {
+                bind_relative_iterated_player_to_last_player_filter(
+                    &mut player_filter,
+                    &mut resolved_filter,
+                    &last_player_filter,
+                );
+            }
+            Ok((
+                vec![Effect::new(
+                    crate::effects::GrantNextSpellCostReductionEffect::all_matching_this_turn(
+                        player_filter,
+                        resolved_filter,
+                        reduction.clone(),
+                    ),
+                )],
+                Vec::new(),
+            ))
+        }
         SubjectVerbActionAst::GrantNextSpellAbilityThisTurn { filter, ability } => {
             let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
             let mut player_filter = subject.clone_player_filter();

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -617,6 +617,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::PlayFromGraveyardUntilEot
         | SubjectVerbActionAst::ControlPlayer { .. }
         | SubjectVerbActionAst::ReduceNextSpellCostThisTurn { .. }
+        | SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { .. }
         | SubjectVerbActionAst::GrantNextSpellAbilityThisTurn { .. }
         | SubjectVerbActionAst::RingTemptsYou
         | SubjectVerbActionAst::VentureIntoDungeon { .. }
@@ -990,7 +991,8 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
             } => value_references_tag(count, IT_TAG) || filter_references_tag(filter, IT_TAG),
             SubjectVerbActionAst::RearrangeLookedCardsInLibrary { tag, .. }
             | SubjectVerbActionAst::ReorderTopOfLibrary { tag } => tag.as_str() == IT_TAG,
-            SubjectVerbActionAst::ReduceNextSpellCostThisTurn { filter, .. } => {
+            SubjectVerbActionAst::ReduceNextSpellCostThisTurn { filter, .. }
+            | SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { filter, .. } => {
                 filter_references_tag(filter, IT_TAG)
             }
             SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1641,6 +1641,10 @@ pub(crate) enum SubjectVerbActionAst {
         filter: ObjectFilter,
         reduction: ManaCost,
     },
+    ReduceMatchingSpellCostThisTurn {
+        filter: ObjectFilter,
+        reduction: Value,
+    },
     GrantNextSpellAbilityThisTurn {
         filter: ObjectFilter,
         ability: GrantedAbilityAst,
@@ -3135,6 +3139,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .finish(),
             Self::ReduceNextSpellCostThisTurn { filter, reduction } => f
                 .debug_struct("ReduceNextSpellCostThisTurn")
+                .field("filter", filter)
+                .field("reduction", reduction)
+                .finish(),
+            Self::ReduceMatchingSpellCostThisTurn { filter, reduction } => f
+                .debug_struct("ReduceMatchingSpellCostThisTurn")
                 .field("filter", filter)
                 .field("reduction", reduction)
                 .finish(),
@@ -5418,6 +5427,18 @@ impl EffectAst {
             SubjectVerbRoleAst::AffectedPlayer,
             player,
             SubjectVerbActionAst::ReduceNextSpellCostThisTurn { filter, reduction },
+        )
+    }
+
+    pub(crate) fn subject_verb_reduce_matching_spell_cost_this_turn(
+        player: PlayerAst,
+        filter: ObjectFilter,
+        reduction: Value,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::AffectedPlayer,
+            player,
+            SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { filter, reduction },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -358,6 +358,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::PlayFromGraveyardUntilEot
             | SubjectVerbActionAst::ControlPlayer { .. }
             | SubjectVerbActionAst::ReduceNextSpellCostThisTurn { .. }
+            | SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { .. }
             | SubjectVerbActionAst::GrantNextSpellAbilityThisTurn { .. }
             | SubjectVerbActionAst::RingTemptsYou
             | SubjectVerbActionAst::VentureIntoDungeon { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1919,6 +1919,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::PlayFromGraveyardUntilEot
             | SubjectVerbActionAst::ControlPlayer { .. }
             | SubjectVerbActionAst::ReduceNextSpellCostThisTurn { .. }
+            | SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { .. }
             | SubjectVerbActionAst::GrantNextSpellAbilityThisTurn { .. }
             | SubjectVerbActionAst::RingTemptsYou
             | SubjectVerbActionAst::VentureIntoDungeon { .. }
@@ -2657,7 +2658,8 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             SubjectVerbActionAst::ControlPlayer { player, .. } => {
                 bind_unresolved_it_in_player_filter(player, seed_tag)
             }
-            SubjectVerbActionAst::ReduceNextSpellCostThisTurn { filter, .. } => {
+            SubjectVerbActionAst::ReduceNextSpellCostThisTurn { filter, .. }
+            | SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { filter, .. } => {
                 bind_unresolved_it_in_filter(filter, seed_tag)
             }
             SubjectVerbActionAst::GrantNextSpellAbilityThisTurn { filter, .. } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -907,6 +907,17 @@ pub(super) fn parse_if_you_dont_sentence(
 fn parse_effect_sentences_from_sentence_inputs(
     sentences: Vec<SentenceInput>,
 ) -> Result<Vec<EffectAst>, CardTextError> {
+    fn where_x_value_from_tokens(tokens: &[OwnedLexToken]) -> Option<Value> {
+        let word_view = TokenWordView::new(tokens);
+        let words = word_view.word_refs();
+        let where_idx = words
+            .windows(3)
+            .position(|window| window == ["where", "x", "is"])?;
+        let where_token_idx = token_index_for_word_index(tokens, where_idx)?;
+        parse_value_binding_clause(&tokens[where_token_idx..])
+            .map(|value| value.with_surface_hint(ValueSurfaceHint::WhereXIs))
+    }
+
     if let Some(effects) = try_parse_divvy_sentence_sequence(&sentences)? {
         return Ok(effects);
     }
@@ -914,6 +925,7 @@ fn parse_effect_sentences_from_sentence_inputs(
     let mut effects = Vec::new();
     let mut sentence_idx = 0usize;
     let mut carried_context: Option<CarryContext> = None;
+    let mut carried_where_x: Option<Value> = None;
 
     while sentence_idx < sentences.len() {
         let sentence = sentences[sentence_idx].lowered();
@@ -1036,6 +1048,7 @@ fn parse_effect_sentences_from_sentence_inputs(
             }
         };
         parser_trace("parse_effect_sentences:sentence", &parse_plan.tokens);
+        let sentence_where_x = where_x_value_from_tokens(&parse_plan.tokens);
 
         let mut sentence_effects = if let Some(direct_effects) = parse_plan.direct_effects.take() {
             parse_trace::event(format!(
@@ -1054,6 +1067,15 @@ fn parse_effect_sentences_from_sentence_inputs(
                 effects: sentence_effects,
             }];
             carried_context = None;
+        }
+        if sentence_where_x.is_none()
+            && let Some(where_value) = carried_where_x.as_ref()
+        {
+            replace_unbound_x_in_effects_anywhere(
+                &mut sentence_effects,
+                where_value,
+                &crate::runtime_backend::token_word_refs(&parse_plan.tokens).join(" "),
+            )?;
         }
         maybe_append_trailing_that_much_life_loss(&mut sentence_effects, &parse_plan.tokens);
         let previous_damage_target = effects.last().and_then(primary_damage_target_from_effect);
@@ -1138,6 +1160,9 @@ fn parse_effect_sentences_from_sentence_inputs(
         }
 
         parse_trace::event(format!("effects: {}", summarize_effects(&sentence_effects)));
+        if let Some(where_value) = sentence_where_x {
+            carried_where_x = Some(where_value);
+        }
         effects.extend(sentence_effects);
         sentence_idx += parse_plan.consumed_sentences;
     }
@@ -2345,6 +2370,9 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             }
             SubjectVerbActionAst::SetBasePower { power, .. } => {
                 replace_value(power, replacement, clause)?;
+            }
+            SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { reduction, .. } => {
+                replace_value(reduction, replacement, clause)?;
             }
             SubjectVerbActionAst::PumpForEach { count, .. } => {
                 replace_value(count, replacement, clause)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
@@ -53,6 +53,9 @@ pub(crate) fn parse_effect_sentence_inner_lexed(
     if let Some(effects) = parse_next_spell_grant_sentence_lexed(tokens)? {
         return Ok(effects);
     }
+    if let Some(effect) = parse_matching_spell_cost_reduction_this_turn_sentence_lexed(tokens) {
+        return Ok(vec![effect]);
+    }
     if word_slice_first_is_any(&sentence_words, &["prevent", "take", "monstrosity"])
         && let Some(mut effects) = parse_subject_verb_extension_sentence(tokens)?
     {
@@ -371,6 +374,55 @@ pub(crate) fn parse_effect_sentence_inner_lexed(
 
     let (_, effects) = super::sentence_registry::run_sentence_parse_rules_lexed(tokens)?;
     Ok(effects)
+}
+
+fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    let words = TokenWordView::new(tokens);
+    let clause_words = words.to_word_refs();
+    let spell_idx = word_slice_find_word(clause_words.as_slice(), "spells")
+        .or_else(|| word_slice_find_word(clause_words.as_slice(), "spell"))?;
+    let cost_idx = word_slice_find_word(clause_words.as_slice(), "cost")
+        .or_else(|| word_slice_find_word(clause_words.as_slice(), "costs"))?;
+    let less_idx = word_slice_find_word(clause_words.as_slice(), "less")?;
+
+    if cost_idx <= spell_idx
+        || less_idx <= cost_idx
+        || !word_slice_contains_phrase(&clause_words, &["you", "cast"])
+        || !word_slice_contains_phrase(&clause_words, &["this", "turn"])
+        || clause_words.get(less_idx + 1).copied() != Some("to")
+        || clause_words.get(less_idx + 2).copied() != Some("cast")
+    {
+        return None;
+    }
+
+    let spell_token_idx = words.token_index_for_word_index(spell_idx)?;
+    let cost_token_idx = words.token_index_for_word_index(cost_idx)?;
+    let less_token_idx = words.token_index_for_word_index(less_idx)?;
+    let subject_tokens = trim_edge_punctuation(&tokens[..=spell_token_idx]);
+    let reduction_tokens = trim_edge_punctuation(&tokens[cost_token_idx + 1..less_token_idx]);
+    let (reduction, used) = parse_value(reduction_tokens)?;
+    if used != reduction_tokens.len() {
+        return None;
+    }
+
+    let mut filter = crate::runtime_backend::parse_spell_filter_lexed(subject_tokens);
+    filter.cast_by = Some(PlayerFilter::You);
+
+    let between_words = &clause_words[spell_idx + 1..cost_idx];
+    if word_slice_contains_phrase(between_words, &["from", "exile"]) {
+        filter.zone = Some(Zone::Exile);
+    } else if word_slice_contains_phrase(between_words, &["from", "your", "graveyard"]) {
+        filter.zone = Some(Zone::Graveyard);
+        filter.owner = Some(PlayerFilter::You);
+    }
+
+    Some(EffectAst::subject_verb_reduce_matching_spell_cost_this_turn(
+        PlayerAst::You,
+        filter,
+        reduction,
+    ))
 }
 
 fn parse_exile_replacement_subject_verb_sentence(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
@@ -402,12 +402,20 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
     let less_token_idx = words.token_index_for_word_index(less_idx)?;
     let subject_tokens = trim_edge_punctuation(&tokens[..=spell_token_idx]);
     let reduction_tokens = trim_edge_punctuation(&tokens[cost_token_idx + 1..less_token_idx]);
-    let (reduction, used) = parse_value(reduction_tokens)?;
+    let (mut reduction, used) = parse_value(&reduction_tokens)?;
     if used != reduction_tokens.len() {
         return None;
     }
+    if matches!(reduction, Value::X)
+        && clause_words.get(less_idx + 3).copied() == Some("where")
+    {
+        let where_token_idx = words.token_index_for_word_index(less_idx + 3)?;
+        if let Some(where_value) = parse_value_binding_clause(&tokens[where_token_idx..]) {
+            reduction = where_value;
+        }
+    }
 
-    let mut filter = crate::runtime_backend::parse_spell_filter_lexed(subject_tokens);
+    let mut filter = crate::runtime_backend::parse_spell_filter_lexed(&subject_tokens);
     filter.cast_by = Some(PlayerFilter::You);
 
     let between_words = &clause_words[spell_idx + 1..cost_idx];

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1836,6 +1836,8 @@ pub struct GrantNextSpellCostReductionEffect {
     pub player: PlayerFilter,
     pub filter: ObjectFilter,
     pub reduction: crate::mana::ManaCost,
+    pub generic_reduction: Option<Value>,
+    pub applies_to_all_matching_this_turn: bool,
 }
 
 impl GrantNextSpellCostReductionEffect {
@@ -1848,6 +1850,22 @@ impl GrantNextSpellCostReductionEffect {
             player,
             filter,
             reduction,
+            generic_reduction: None,
+            applies_to_all_matching_this_turn: false,
+        }
+    }
+
+    pub fn all_matching_this_turn(
+        player: PlayerFilter,
+        filter: ObjectFilter,
+        generic_reduction: impl Into<Value>,
+    ) -> Self {
+        Self {
+            player,
+            filter,
+            reduction: crate::mana::ManaCost::new(),
+            generic_reduction: Some(generic_reduction.into()),
+            applies_to_all_matching_this_turn: true,
         }
     }
 }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -73,6 +73,7 @@ pub enum Value {
     DistinctPowers(ObjectFilter),
     CreaturesDiedThisTurn,
     CreaturesDiedThisTurnControlledBy(PlayerFilter),
+    PlayersBeingAttacked,
     CountPlayers(PlayerFilter),
     PlayersWhoControlMoreThanYou(ObjectFilter),
     PartySize(PlayerFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -142,6 +142,30 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Commander Liara Portyr");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Commander Liara Portyr should parse its attack trigger strictly"
+    );
+    assert!(
+        ability_debug.contains("PlayersBeingAttacked")
+            && ability_debug.contains("applies_to_all_matching_this_turn: true")
+            && ability_debug.contains("GrantPlayTaggedEffect"),
+        "expected Commander Liara Portyr to lower the dynamic exile-spell reduction and cast permission structurally, got {ability_debug}"
+    );
+    assert_eq!(
+        rendered,
+        "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards."
+    );
+}
+
+#[test]
 fn thundermane_dragon_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Thundermane Dragon");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8130,6 +8130,7 @@ pub(crate) fn describe_value(value: &Value) -> String {
             "the number of creatures that died under {} control this turn",
             describe_possessive_player_filter(filter)
         ),
+        Value::PlayersBeingAttacked => "the number of players being attacked".to_string(),
         Value::CountPlayers(filter) => match filter {
             PlayerFilter::Any => "the number of players".to_string(),
             PlayerFilter::Opponent => "the number of opponents".to_string(),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -12872,7 +12872,15 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                 filtered[idx].downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()
             && let Some(grant_play) =
                 filtered[idx + 1].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
-            && let Some(compact) = describe_exile_top_then_play(exile_top, grant_play)
+            && let Some(compact) = describe_exile_top_then_play(
+                exile_top,
+                grant_play,
+                idx.checked_sub(1)
+                    .and_then(|previous_idx| filtered[previous_idx]
+                        .downcast_ref::<crate::effects::GrantNextSpellCostReductionEffect>())
+                    .and_then(|reduction| reduction.generic_reduction.as_ref())
+                    .is_some_and(|reduction| reduction == &exile_top.count),
+            )
         {
             parts.push(compact);
             idx += 2;
@@ -21927,6 +21935,7 @@ fn describe_exile_top_then_play_without_paying_mana(
 fn describe_exile_top_then_play(
     exile_top: &crate::effects::ExileTopOfLibraryEffect,
     grant_play: &crate::effects::GrantPlayTaggedEffect,
+    suppress_count_where_clause: bool,
 ) -> Option<String> {
     let Some(first_tag) = exile_top.moved_tags.first() else {
         return None;
@@ -21950,7 +21959,10 @@ fn describe_exile_top_then_play(
         _ => {
             let owner = describe_possessive_player_filter(&exile_top.player);
             let value_text = describe_value(&exile_top.count);
-            if value_text == "X" {
+            if value_text == "X"
+                || (suppress_count_where_clause
+                    && value_has_surface_hint(&exile_top.count, ValueSurfaceHint::WhereXIs))
+            {
                 format!("Exile the top X cards of {owner} library")
             } else {
                 format!("Exile the top X cards of {owner} library, where X is {value_text}")
@@ -21967,6 +21979,11 @@ fn describe_exile_top_then_play(
     } else {
         "cast"
     };
+    if !grant_play.allow_land && !singular_count {
+        return Some(format!(
+            "{exile_clause}. Until end of turn, you may cast spells from among those exiled cards"
+        ));
+    }
     Some(format!(
         "{exile_clause}. You may {verb} {cards_text} this turn"
     ))
@@ -33446,6 +33463,20 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_player_filter(&grant_play_tagged.player),
             );
         }
+        if helper_tag
+            && !grant_play_tagged.allow_land
+            && grant_play_tagged.duration == crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+            && matches!(grant_play_tagged.player, PlayerFilter::You)
+        {
+            let cards_text = if grant_play_tagged.tag.as_str() == "exiled"
+                || crate::cards::is_sentence_helper_tag(grant_play_tagged.tag.as_str(), "exiled")
+            {
+                "those exiled cards"
+            } else {
+                "those cards"
+            };
+            return format!("Until end of turn, you may cast spells from among {cards_text}");
+        }
         return format!(
             "{} may {verb} {object_text} {timing}",
             describe_player_filter(&grant_play_tagged.player),
@@ -33659,6 +33690,44 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         let spell_text = spell_text
             .strip_suffix(player_suffix.as_str())
             .unwrap_or(spell_text.as_str());
+        if grant_next_spell_cost_reduction.applies_to_all_matching_this_turn {
+            let (reduction, where_suffix) = grant_next_spell_cost_reduction
+                .generic_reduction
+                .as_ref()
+                .map(|value| match value {
+                    Value::Fixed(amount) => (amount.to_string(), String::new()),
+                    Value::X => ("{X}".to_string(), String::new()),
+                    _ => ("{X}".to_string(), format!(", where X is {}", describe_value(value))),
+                })
+                .unwrap_or_else(|| {
+                    (
+                        grant_next_spell_cost_reduction.reduction.to_oracle(),
+                        String::new(),
+                    )
+                });
+            let plural_spell_text = if grant_next_spell_cost_reduction.filter.zone == Some(Zone::Exile)
+                && grant_next_spell_cost_reduction
+                    .filter
+                    .cast_by
+                    .as_ref()
+                    .is_some_and(|cast_by| cast_by == &grant_next_spell_cost_reduction.player)
+                && grant_next_spell_cost_reduction.filter.card_types.is_empty()
+            {
+                format!("spells {player_text} cast from exile")
+            } else if spell_text.contains("spells") {
+                spell_text.to_string()
+            } else if let Some(rest) = spell_text.strip_prefix("spell") {
+                format!("spells{rest}")
+            } else {
+                format!("{spell_text} spells")
+            };
+            return format!(
+                "{} this turn cost {} less to cast{}",
+                plural_spell_text,
+                reduction,
+                where_suffix,
+            );
+        }
         return format!(
             "The next {} {} cast this turn costs {} less to cast",
             spell_text,

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4333,6 +4333,7 @@ fn resolve_value_with_context(
         // For these, we'd need more complex resolution (game state, execution context)
         // Return 0 as fallback (these are rare in continuous effects anyway)
         Value::XTimes(_)
+        | Value::PlayersBeingAttacked
         | Value::CountPlayers(_)
         | Value::PlayersWhoControlMoreThanYou(_)
         | Value::PartySize(_)

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -2978,6 +2978,12 @@ pub(crate) fn apply_spell_cost_modifiers(
             continue;
         }
         if spell_matches_filter(game, spell, player, &effect.filter, &ctx, casting_method) {
+            if let Some(generic_reduction) = &effect.generic_reduction {
+                let amount = resolve_cost_modifier_value(game, player, spell, generic_reduction);
+                if amount > 0 {
+                    total_reduction = total_reduction.saturating_add(amount);
+                }
+            }
             reduction_pips.extend(effect.reduction.pips().iter().cloned());
         }
     }

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1336,6 +1336,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::DistinctPowers(_)
         | Value::CreaturesDiedThisTurn
         | Value::CreaturesDiedThisTurnControlledBy(_)
+        | Value::PlayersBeingAttacked
         | Value::CountPlayers(_)
         | Value::PlayersWhoControlMoreThanYou(_)
         | Value::PartySize(_)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -825,6 +825,12 @@ pub fn resolve_value(
             }
             Ok(total)
         }
+        Value::PlayersBeingAttacked => Ok(game
+            .combat
+            .as_ref()
+            .map(crate::combat_state::defending_players)
+            .map(|players| players.len() as i32)
+            .unwrap_or(0)),
 
         Value::CountPlayers(player_filter) => {
             let filter_ctx = ctx.filter_context(game);

--- a/crates/ironsmith-runtime/src/effects/player/grant_next_spell_cost_reduction.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_next_spell_cost_reduction.rs
@@ -2,7 +2,7 @@
 
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
-use crate::effects::helpers::resolve_player_filter;
+use crate::effects::helpers::{resolve_player_filter, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 
@@ -15,13 +15,29 @@ impl EffectExecutor for GrantNextSpellCostReductionEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let player = resolve_player_filter(game, &self.player, ctx)?;
-        game.add_temporary_spell_cost_reduction(
-            player,
-            ctx.source,
-            self.filter.clone(),
-            self.reduction.clone(),
-            1,
-        );
+        if self.applies_to_all_matching_this_turn {
+            let amount = self
+                .generic_reduction
+                .as_ref()
+                .map(|value| resolve_value(game, value, ctx))
+                .transpose()?
+                .unwrap_or(0)
+                .max(0);
+            game.add_temporary_matching_spell_cost_reduction_this_turn(
+                player,
+                ctx.source,
+                self.filter.clone(),
+                crate::effect::Value::Fixed(amount),
+            );
+        } else {
+            game.add_temporary_spell_cost_reduction(
+                player,
+                ctx.source,
+                self.filter.clone(),
+                self.reduction.clone(),
+                1,
+            );
+        }
         Ok(EffectOutcome::resolved())
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3936,6 +3936,7 @@ pub(super) fn finalize_spell_cast(
                 .temporary_spell_cost_reductions
                 .get_mut(idx)
                 && effect.remaining_uses > 0
+                && !effect.applies_to_all_matching_this_turn
             {
                 effect.remaining_uses -= 1;
             }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -29448,6 +29448,219 @@ fn test_next_matching_spell_cost_reduction_is_consumed_by_first_match_only() {
 }
 
 #[test]
+fn commander_liara_portyr_runtime_reduces_each_exiled_spell_by_attacked_players() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: game.new_object_id(),
+        target: AttackTarget::Player(bob),
+    });
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: game.new_object_id(),
+        target: AttackTarget::Player(charlie),
+    });
+    game.combat = Some(combat);
+
+    let source = game.new_object_id();
+    let grant_reduction = Effect::new(
+        crate::effects::GrantNextSpellCostReductionEffect::all_matching_this_turn(
+            PlayerFilter::You,
+            crate::target::ObjectFilter::default()
+                .in_zone(Zone::Exile)
+                .cast_by_you(),
+            Value::PlayersBeingAttacked,
+        ),
+    );
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    execute_effect(&mut game, &grant_reduction, &mut ctx)
+        .expect("Commander Liara Portyr reduction grant should resolve");
+    game.combat = None;
+
+    let first_exiled =
+        CardDefinitionBuilder::new(CardId::new(), "Commander Liara Portyr Exiled Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Sorcery])
+            .with_spell_effect(vec![Effect::draw(1)])
+            .build();
+    let second_exiled = CardDefinitionBuilder::new(
+        CardId::new(),
+        "Commander Liara Portyr Second Exiled Probe",
+    )
+    .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+    .card_types(vec![CardType::Sorcery])
+    .with_spell_effect(vec![Effect::draw(1)])
+    .build();
+    let hand_spell = CardDefinitionBuilder::new(CardId::new(), "Commander Liara Portyr Hand Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Sorcery])
+        .with_spell_effect(vec![Effect::draw(1)])
+        .build();
+
+    let first_id = game.create_object_from_definition(&first_exiled, alice, Zone::Exile);
+    let second_id = game.create_object_from_definition(&second_exiled, alice, Zone::Exile);
+    let hand_id = game.create_object_from_definition(&hand_spell, alice, Zone::Hand);
+    let play_from_exile = CastingMethod::PlayFrom {
+        source,
+        zone: Zone::Exile,
+        use_alternative: None,
+    };
+
+    let first = game.object(first_id).expect("first exiled spell exists");
+    let first_cost = crate::decision::calculate_effective_mana_cost_for_casting_method(
+        &game,
+        alice,
+        first,
+        first.mana_cost.as_ref().expect("first spell mana cost"),
+        &play_from_exile,
+    );
+    assert_eq!(
+        first_cost.to_oracle(),
+        "{2}",
+        "two defending players should reduce the first exiled spell by two generic mana"
+    );
+
+    let second = game.object(second_id).expect("second exiled spell exists");
+    let second_cost = crate::decision::calculate_effective_mana_cost_for_casting_method(
+        &game,
+        alice,
+        second,
+        second.mana_cost.as_ref().expect("second spell mana cost"),
+        &play_from_exile,
+    );
+    assert_eq!(
+        second_cost.to_oracle(),
+        "{3}",
+        "Commander Liara Portyr's reduction applies to every matching exiled spell this turn"
+    );
+
+    let hand = game.object(hand_id).expect("hand spell exists");
+    let hand_cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        alice,
+        hand,
+        hand.mana_cost.as_ref().expect("hand spell mana cost"),
+    );
+    assert_eq!(
+        hand_cost.to_oracle(),
+        "{4}",
+        "Commander Liara Portyr should not reduce spells cast from hand"
+    );
+
+    for idx in 0..3 {
+        let library_card = CardDefinitionBuilder::new(
+            CardId::new(),
+            format!("Commander Liara Portyr Library Probe {idx}"),
+        )
+        .card_types(vec![CardType::Sorcery])
+        .with_spell_effect(vec![Effect::draw(1)])
+        .build();
+        game.create_object_from_definition(&library_card, alice, Zone::Library);
+    }
+    let library_before = game.player(alice).expect("alice exists").library.len();
+    let exile_before = game.exile.len();
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: game.new_object_id(),
+        target: AttackTarget::Player(bob),
+    });
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: game.new_object_id(),
+        target: AttackTarget::Player(charlie),
+    });
+    game.combat = Some(combat);
+    let exile_top =
+        Effect::exile_top_of_library_player(Value::PlayersBeingAttacked, PlayerFilter::You);
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    execute_effect(&mut game, &exile_top, &mut ctx)
+        .expect("Commander Liara Portyr exile-top effect should resolve");
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        library_before - 2,
+        "two attacked players should make Commander Liara Portyr exile the top two cards"
+    );
+    assert_eq!(
+        game.exile.len(),
+        exile_before + 2,
+        "Commander Liara Portyr should exile one top card per attacked player"
+    );
+}
+
+#[test]
+fn commander_liara_portyr_runtime_has_no_reduction_without_attacked_players() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let source = game.new_object_id();
+    let grant_reduction = Effect::new(
+        crate::effects::GrantNextSpellCostReductionEffect::all_matching_this_turn(
+            PlayerFilter::You,
+            crate::target::ObjectFilter::default()
+                .in_zone(Zone::Exile)
+                .cast_by_you(),
+            Value::PlayersBeingAttacked,
+        ),
+    );
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    execute_effect(&mut game, &grant_reduction, &mut ctx)
+        .expect("Commander Liara Portyr zero-count reduction grant should resolve");
+
+    let exiled_spell =
+        CardDefinitionBuilder::new(CardId::new(), "Commander Liara Portyr No Attack Probe")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![CardType::Sorcery])
+            .with_spell_effect(vec![Effect::draw(1)])
+            .build();
+    let spell_id = game.create_object_from_definition(&exiled_spell, alice, Zone::Exile);
+    let spell = game.object(spell_id).expect("exiled spell exists");
+    let cost = crate::decision::calculate_effective_mana_cost_for_casting_method(
+        &game,
+        alice,
+        spell,
+        spell.mana_cost.as_ref().expect("spell mana cost"),
+        &CastingMethod::PlayFrom {
+            source,
+            zone: Zone::Exile,
+            use_alternative: None,
+        },
+    );
+
+    assert_eq!(
+        cost.to_oracle(),
+        "{4}",
+        "without current attacked players, Commander Liara Portyr's dynamic reduction is zero"
+    );
+
+    let library_card = CardDefinitionBuilder::new(
+        CardId::new(),
+        "Commander Liara Portyr No Attack Library Probe",
+    )
+    .card_types(vec![CardType::Sorcery])
+    .with_spell_effect(vec![Effect::draw(1)])
+    .build();
+    game.create_object_from_definition(&library_card, alice, Zone::Library);
+    let library_before = game.player(alice).expect("alice exists").library.len();
+    let exile_before = game.exile.len();
+    let exile_top =
+        Effect::exile_top_of_library_player(Value::PlayersBeingAttacked, PlayerFilter::You);
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    execute_effect(&mut game, &exile_top, &mut ctx)
+        .expect("Commander Liara Portyr zero-count exile-top effect should resolve");
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        library_before,
+        "without attacked players, Commander Liara Portyr should exile no library cards"
+    );
+    assert_eq!(
+        game.exile.len(),
+        exile_before,
+        "without attacked players, Commander Liara Portyr should leave exile unchanged"
+    );
+}
+
+#[test]
 fn test_face_down_cast_matches_panoptic_filter_and_enters_battlefield_face_down() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -787,6 +787,8 @@ pub struct TemporarySpellCostReductionEffectInstance {
     pub source: ObjectId,
     pub filter: crate::target::ObjectFilter,
     pub reduction: crate::mana::ManaCost,
+    pub generic_reduction: Option<crate::effect::Value>,
+    pub applies_to_all_matching_this_turn: bool,
     pub remaining_uses: u32,
     pub expires_end_of_turn: u32,
 }
@@ -2781,7 +2783,30 @@ impl GameState {
                 source,
                 filter,
                 reduction,
+                generic_reduction: None,
+                applies_to_all_matching_this_turn: false,
                 remaining_uses,
+                expires_end_of_turn: self.turn.turn_number,
+            },
+        );
+    }
+
+    pub fn add_temporary_matching_spell_cost_reduction_this_turn(
+        &mut self,
+        player: PlayerId,
+        source: ObjectId,
+        filter: crate::target::ObjectFilter,
+        generic_reduction: crate::effect::Value,
+    ) {
+        self.effect_store.temporary_spell_cost_reductions.push(
+            TemporarySpellCostReductionEffectInstance {
+                player,
+                source,
+                filter,
+                reduction: crate::mana::ManaCost::new(),
+                generic_reduction: Some(generic_reduction),
+                applies_to_all_matching_this_turn: true,
+                remaining_uses: u32::MAX,
                 expires_end_of_turn: self.turn.turn_number,
             },
         );

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -274,6 +274,9 @@ impl TriggerMatcher for AttacksTrigger {
                 }
                 return format!("Whenever {min_total} or more {subject} attack{target_tail}");
             }
+            if subject == "creature you control" && target_tail.is_empty() {
+                return "Whenever you attack".to_string();
+            }
             return format!("Whenever one or more {subject} attack{target_tail}");
         }
         if self.min_total_attackers > 1 {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Commander Liara Portyr
Initial parse error:
```
unsupported where-x clause (clause: 'spells you cast from exile this turn cost x less to cast where x is the number of players being attacked'); oracle-only fallback also failed: unsupported where-x clause (clause: 'spells you cast from exile this turn cost x less to cast where x is the number of players being attacked')
```

Current worker: i-086cd36a364f0b766
Branch: codex/aws-card-fix-commander-liara-portyr
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0036
