### PR TITLE
Fix Ironsmith parse failure: Expand the Sphere

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3034,6 +3034,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     if filtered.len() >= 7
         && filtered[0] == "you"
         && filtered[1] == "put"
+        && !matches!(filtered.get(2..4), Some(["fewer" | "less", "than"]))
         && word_slice_ends_with(&filtered, &["this", "way"])
         && let Some(onto_idx) = onto_battlefield_idx
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -577,6 +577,20 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
     {
         return Some(IfResultPredicate::Did);
     }
+    if words.len() >= 8
+        && words[0] == "you"
+        && words[1] == "put"
+        && matches!(words[2], "fewer" | "less")
+        && words[3] == "than"
+        && words[words.len() - 2] == "this"
+        && words[words.len() - 1] == "way"
+        && let Some(value) = words[4]
+            .parse::<i32>()
+            .ok()
+            .or_else(|| ironsmith_core::parse_cardinal_word(words[4]).and_then(|n| n.try_into().ok()))
+    {
+        return Some(IfResultPredicate::Value(Comparison::LessThan(value)));
+    }
     if is_unqualified_this_way_result("you") {
         return Some(IfResultPredicate::Did);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -821,6 +821,42 @@ fn assign_effect_result_id(
     id: EffectId,
     error_message: &str,
 ) -> Result<(), CardTextError> {
+    if effects.len() >= 2
+        && effects
+            .last()
+            .is_some_and(|effect| {
+                effect
+                    .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()
+                    .is_some()
+            })
+    {
+        let move_idx = effects.len() - 2;
+        let move_effect_returns_battlefield_count = effects[move_idx]
+            .downcast_ref::<crate::effects::PutOntoBattlefieldEffect>()
+            .is_some()
+            || effects[move_idx]
+                .downcast_ref::<crate::effects::ForEachTaggedEffect<Effect>>()
+                .is_some_and(|for_each| {
+                    for_each.effects.iter().any(|effect| {
+                        effect
+                            .downcast_ref::<crate::effects::PutOntoBattlefieldEffect>()
+                            .is_some()
+                    })
+                });
+        if move_effect_returns_battlefield_count {
+            let move_effect = effects.remove(move_idx);
+            effects.insert(move_idx, Effect::with_id(id.0, move_effect));
+            return Ok(());
+        }
+        if effects[0]
+            .downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            .is_some()
+        {
+            let choose_effect = effects.remove(0);
+            effects.insert(0, Effect::with_id(id.0, choose_effect));
+            return Ok(());
+        }
+    }
     let Some(last) = effects.pop() else {
         return Err(CardTextError::InvariantViolation(error_message.to_string()));
     };

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4104,6 +4104,71 @@ fn compile_subject_verb_effect(
                 choices,
             ))
         }
+        SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary {
+            battlefield_filter,
+            count,
+            tapped,
+            order,
+        } => {
+            use crate::target::{TaggedObjectConstraint, TaggedOpbjectRelation};
+
+            let looked_tag = ctx.last_object_tag.clone().ok_or_else(|| {
+                CardTextError::ParseError(
+                    "unable to resolve looked-at cards without prior reference".to_string(),
+                )
+            })?;
+
+            let subject = LoweredSubject::resolve_chooser(player, ctx, true, true, false)?;
+            let chooser = subject.clone_player_filter();
+
+            let mut choose_filter = subject
+                .resolve_object_refs_and_bind_player_refs_in_filter(battlefield_filter, ctx)?;
+            let choices = subject.into_choices();
+            choose_filter.zone = Some(Zone::Library);
+            choose_filter.tagged_constraints.push(TaggedObjectConstraint {
+                tag: TagKey::from(looked_tag.as_str()),
+                relation: TaggedOpbjectRelation::IsTaggedObject,
+            });
+
+            let chosen_tag = ctx.next_tag("chosen");
+            let chosen_tag_key: TagKey = chosen_tag.as_str().into();
+            let choose = Effect::new(
+                crate::effects::ChooseObjectsEffect::new(
+                    choose_filter,
+                    count.clone(),
+                    chooser.clone(),
+                    chosen_tag_key.clone(),
+                )
+                .in_zone(Zone::Library),
+            );
+
+            let resolved_order = match order {
+                crate::cards::builders::LibraryBottomOrderAst::Random => {
+                    crate::effects::consult_helpers::LibraryBottomOrder::Random
+                }
+                crate::cards::builders::LibraryBottomOrderAst::ChooserChooses => {
+                    crate::effects::consult_helpers::LibraryBottomOrder::ChooserChooses
+                }
+            };
+            let move_rest = Effect::put_tagged_remainder_on_library_bottom(
+                TagKey::from(looked_tag.as_str()),
+                Some(chosen_tag_key.clone()),
+                resolved_order,
+                chooser.clone(),
+            );
+
+            let move_chosen = Effect::for_each_tagged(
+                chosen_tag.clone(),
+                vec![Effect::put_onto_battlefield(
+                    ChooseSpec::Iterated,
+                    *tapped,
+                    chooser.clone(),
+                )],
+            );
+
+            ctx.last_object_tag = Some(chosen_tag);
+            Ok((vec![choose, move_chosen, move_rest], choices))
+        }
         SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary {
             battlefield_filter,
             hand_filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -740,6 +740,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary { .. }
         | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeIntoHandRestOnBottomOfLibrary { .. }
         | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+        | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary { .. }
         | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. }
         | SubjectVerbActionAst::RetargetStackObject { .. }
         | SubjectVerbActionAst::GrantAbilityToSource { .. }
@@ -995,6 +996,7 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
             }
             SubjectVerbActionAst::ChooseFromLookedCardsIntoHandRestIntoGraveyard { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+            | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. } => true,
             SubjectVerbActionAst::PreventDamageToTargetPutCounters {
                 amount: Some(amount),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1406,6 +1406,12 @@ pub(crate) enum SubjectVerbActionAst {
         battlefield_filter: ObjectFilter,
         tapped: bool,
     },
+    ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary {
+        battlefield_filter: ObjectFilter,
+        count: ChoiceCount,
+        tapped: bool,
+        order: LibraryBottomOrderAst,
+    },
     ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary {
         battlefield_filter: ObjectFilter,
         hand_filter: ObjectFilter,
@@ -2832,6 +2838,18 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary")
                 .field("battlefield_filter", battlefield_filter)
                 .field("tapped", tapped)
+                .finish(),
+            Self::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary {
+                battlefield_filter,
+                count,
+                tapped,
+                order,
+            } => f
+                .debug_struct("ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary")
+                .field("battlefield_filter", battlefield_filter)
+                .field("count", count)
+                .field("tapped", tapped)
+                .field("order", order)
                 .finish(),
             Self::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary {
                 battlefield_filter,
@@ -4735,6 +4753,25 @@ impl EffectAst {
             SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary {
                 battlefield_filter,
                 tapped,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_choose_from_looked_cards_onto_battlefield_rest_on_bottom_of_library(
+        player: PlayerAst,
+        battlefield_filter: ObjectFilter,
+        count: ChoiceCount,
+        tapped: bool,
+        order: LibraryBottomOrderAst,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            player,
+            SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary {
+                battlefield_filter,
+                count,
+                tapped,
+                order,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -433,6 +433,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+            | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::RetargetStackObject { .. }
             | SubjectVerbActionAst::GrantAbilityToSource { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1,6 +1,6 @@
 use crate::cards::builders::{
-    CardTextError, EffectAst, IT_TAG, IdGenContext, PlayerAst, PredicateAst, SubjectVerbActionAst,
-    SubjectVerbEffectAst, SubjectVerbRoleAst, TargetAst, TriggerSpec,
+    CardTextError, EffectAst, IT_TAG, IdGenContext, IfResultPredicate, PlayerAst, PredicateAst,
+    SubjectVerbActionAst, SubjectVerbEffectAst, SubjectVerbRoleAst, TargetAst, TriggerSpec,
 };
 use crate::effect::{EffectId, EventValueSpec};
 use crate::filter::{Comparison, TaggedOpbjectRelation};
@@ -402,6 +402,7 @@ fn advance_reference_frame_for_effect(
                 | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary { .. }
                 | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeIntoHandRestOnBottomOfLibrary { .. }
                 | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+                | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary { .. }
                 | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. } => {
                     track_effect_player(subject_verb.subject.player, frame, true, true)?;
                     frame.last_object_tag = Some(next_reference_tag(id_gen, "chosen"));
@@ -1584,6 +1585,10 @@ fn resolve_effect_references_in_effect(
         let condition = state.last_effect_id.ok_or_else(|| {
             CardTextError::ParseError("missing prior effect for if clause".to_string())
         })?;
+        let mut effects = effects;
+        if let IfResultPredicate::Value(crate::effect::Comparison::LessThan(threshold)) = predicate {
+            apply_difference_threshold_to_effects(&mut effects, threshold);
+        }
         let effects = resolve_effect_sequence_references_with_state(
             &effects,
             id_gen,
@@ -1662,6 +1667,56 @@ fn resolve_effect_references_in_effect(
         Ok::<_, CardTextError>(())
     })?;
     Ok(effect)
+}
+
+fn apply_difference_threshold_to_effects(effects: &mut [EffectAst], threshold: i32) {
+    for effect in effects {
+        match effect {
+            EffectAst::SubjectVerb(subject_verb) => {
+                if let SubjectVerbActionAst::Proliferate { count } = &mut subject_verb.action {
+                    apply_difference_threshold_to_value(count, threshold);
+                }
+            }
+            EffectAst::Conditional {
+                if_true, if_false, ..
+            } => {
+                apply_difference_threshold_to_effects(if_true, threshold);
+                apply_difference_threshold_to_effects(if_false, threshold);
+            }
+            EffectAst::IfResult { effects, .. }
+            | EffectAst::WhenResult { effects, .. }
+            | EffectAst::ResolvedIfResult { effects, .. }
+            | EffectAst::ResolvedWhenResult { effects, .. }
+            | EffectAst::ForEachOpponent { effects }
+            | EffectAst::ForEachPlayer { effects }
+            | EffectAst::ForEachTagged { effects, .. }
+            | EffectAst::ForEachOpponentDoesNot { effects, .. }
+            | EffectAst::ForEachPlayerDoesNot { effects, .. }
+            | EffectAst::ForEachOpponentDid { effects, .. }
+            | EffectAst::ForEachPlayerDid { effects, .. }
+            | EffectAst::ForEachTargetPlayers { effects, .. }
+            | EffectAst::ForEachTaggedPlayer { effects, .. }
+            | EffectAst::ForEachPlayersFiltered { effects, .. } => {
+                apply_difference_threshold_to_effects(effects, threshold);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn apply_difference_threshold_to_value(value: &mut Value, threshold: i32) {
+    if let Value::SurfaceHinted { value: inner, hints } = value
+        && hints.contains(&ironsmith_core::ValueSurfaceHint::Difference)
+        && matches!(inner.unhinted(), Value::EventValue(EventValueSpec::Amount))
+    {
+        *value = Value::Add(
+            Box::new(Value::Fixed(threshold)),
+            Box::new(Value::Scaled(
+                Box::new(Value::EventValue(EventValueSpec::Amount)),
+                -1,
+            )),
+        );
+    }
 }
 
 fn resolve_effect_sequence_references_with_state(
@@ -1993,6 +2048,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+            | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::RetargetStackObject { .. }
             | SubjectVerbActionAst::GrantAbilityToSource { .. }
@@ -2695,6 +2751,10 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 ..
             } => 0,
             SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary {
+                battlefield_filter,
+                ..
+            } => bind_unresolved_it_in_filter(battlefield_filter, seed_tag),
+            SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary {
                 battlefield_filter,
                 ..
             } => bind_unresolved_it_in_filter(battlefield_filter, seed_tag),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2485,6 +2485,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeAmongSpellsCastThisTurnIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsForEachCardTypeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldOrIntoHandRestOnBottomOfLibrary { .. }
+            | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::ChooseFromLookedCardsOntoBattlefieldAndIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::RetargetStackObject { .. }
             | SubjectVerbActionAst::GrantAbilityToSource { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -26,7 +26,7 @@ use crate::runtime_backend::lexer::TokenWordView;
 use crate::runtime_backend::object_filters::parse_object_filter_lexed;
 use crate::runtime_backend::permission_helpers::parse_cast_or_play_tagged_clause;
 use crate::runtime_backend::token_primitives::{
-    find_index, parse_leading_may_action_lexed, word_view_has_any_prefix,
+    find_index, parse_count_range_prefix, parse_leading_may_action_lexed, word_view_has_any_prefix,
 };
 use crate::runtime_backend::util::trim_commas;
 use crate::runtime_backend::util::{
@@ -74,6 +74,113 @@ fn strip_leading_if_you_do_sentence(tokens: &[OwnedLexToken]) -> (Vec<OwnedLexTo
     let stripped = crate::runtime_backend::token_primitives::strip_leading_if_you_do_lexed(tokens);
     let was_stripped = stripped.len() != tokens.len();
     (trim_commas(stripped), was_stripped)
+}
+
+fn looked_cards_battlefield_choice_count(
+    tokens: &[OwnedLexToken],
+) -> Option<(ChoiceCount, Vec<OwnedLexToken>)> {
+    let trimmed = trim_commas(tokens);
+    let Some(((min, max), rest)) = parse_count_range_prefix(&trimmed) else {
+        return Some((ChoiceCount::up_to(1), trimmed));
+    };
+    let count = match (min, max) {
+        (Some(Value::Fixed(0)), Some(Value::Fixed(max))) if max >= 0 => {
+            ChoiceCount::up_to(max as usize)
+        }
+        (Some(Value::Fixed(min)), Some(Value::Fixed(max))) if min >= 0 && max >= min => {
+            ChoiceCount {
+                min: min as usize,
+                max: Some(max as usize),
+                dynamic_x: false,
+                up_to_x: false,
+                random: false,
+            }
+        }
+        _ => return None,
+    };
+    Some((count, trim_commas(rest)))
+}
+
+pub(crate) fn parse_look_at_top_then_put_matches_onto_battlefield_rest_bottom(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some((player, count, reveal_top)) =
+        parse_top_cards_view_sentence(sentences[sentence_idx].lowered())
+    else {
+        return Ok(None);
+    };
+
+    let action_tokens = trim_commas(sentences[sentence_idx + 1].lowered());
+    let action_clause = LexedClause::new(&action_tokens).trimmed();
+    if !action_clause.starts_with(&["put"]) {
+        return Ok(None);
+    }
+    let put_tail = action_clause.after_words(1).ok_or_else(|| {
+        CardTextError::ParseError("missing looked-card battlefield choice".to_string())
+    })?;
+    let action_words = put_tail.words();
+    let action_word_refs = action_words.word_refs();
+    let Some((from_among_word_idx, from_among_len)) =
+        find_from_among_looked_cards_phrase(&action_words)
+    else {
+        return Ok(None);
+    };
+
+    let filter_end = action_words
+        .token_index_for_word_index(from_among_word_idx)
+        .unwrap_or(put_tail.len());
+    let filter_tokens = trim_commas(&put_tail.tokens()[..filter_end]);
+    let Some((choice_count, filter_tokens)) = looked_cards_battlefield_choice_count(&filter_tokens)
+    else {
+        return Ok(None);
+    };
+    let mut filter = if let Some(filter) = parse_looked_card_reveal_filter(&filter_tokens) {
+        filter
+    } else {
+        return Ok(None);
+    };
+    effect_sentences::normalize_search_library_filter(&mut filter);
+    filter.zone = None;
+
+    let after_from_words = &action_word_refs[from_among_word_idx + from_among_len..];
+    let battlefield_tapped = word_slice_starts_with_any(
+        after_from_words,
+        &[
+            &[
+                "onto", "the", "battlefield", "tapped", "and", "the", "rest",
+            ],
+            &["onto", "battlefield", "tapped", "and", "the", "rest"],
+        ],
+    );
+    if !battlefield_tapped
+        || !word_slice_contains_all_words(after_from_words, &["rest", "bottom", "library"])
+    {
+        return Ok(None);
+    }
+    let Some(order) = parse_consult_remainder_order(after_from_words) else {
+        return Ok(None);
+    };
+
+    let looked_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "looked");
+    let mut effects = vec![EffectAst::subject_verb_look_at_top_cards(
+        player,
+        count,
+        looked_tag.clone(),
+    )];
+    if reveal_top {
+        effects.push(EffectAst::subject_verb_reveal_tagged(looked_tag.clone()));
+    }
+    effects.push(
+        EffectAst::subject_verb_choose_from_looked_cards_onto_battlefield_rest_on_bottom_of_library(
+            player,
+            filter,
+            choice_count,
+            true,
+            order,
+        ),
+    );
+    Ok(Some(effects))
 }
 
 fn wrap_optional_consult_effects(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -520,6 +520,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         parser: generic_subject_verb_sequences::pairs::parse_look_at_top_then_exile_face_down_then_play_while_exiled,
     },
     SequenceRuleDef {
+        name: "look-at-top-put-matches-battlefield-rest-bottom",
+        feature_tag: Some("looked-cards-battlefield-bottom"),
+        priority: 236,
+        consumed_sentences: 2,
+        predicate: first_head_look_at,
+        parser: generic_subject_verb_sequences::pairs::parse_look_at_top_then_put_matches_onto_battlefield_rest_bottom,
+    },
+    SequenceRuleDef {
         name: "look-at-top-put-one-hand-other-bottom",
         feature_tag: Some("looked-cards-hand-bottom"),
         priority: 236,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -155,6 +155,22 @@ fn parse_proliferate(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextErro
         return Ok(EffectAst::subject_verb_proliferate(Value::Fixed(1)));
     }
 
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if crate::runtime_backend::lexer::word_slice_eq_any(
+        &words,
+        &[
+            &["a", "number", "of", "times", "equal", "to", "the", "difference"],
+            &["a", "number", "of", "times", "equal", "to", "difference"],
+            &["number", "of", "times", "equal", "to", "the", "difference"],
+            &["number", "of", "times", "equal", "to", "difference"],
+        ],
+    ) {
+        return Ok(EffectAst::subject_verb_proliferate(
+            Value::EventValue(crate::effect::EventValueSpec::Amount)
+                .with_surface_hint(ironsmith_core::ValueSurfaceHint::Difference),
+        ));
+    }
+
     let (count, used) = if let Some(first) = tokens.first().and_then(OwnedLexToken::as_word) {
         match first {
             "once" => (Value::Fixed(1), 1),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -42,6 +42,7 @@ pub enum ValueSurfaceHint {
     WhereXIs,
     EqualTo,
     ForEach,
+    Difference,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39480,10 +39480,15 @@ fn parse_oracle_expand_the_sphere_compiles_strictly_and_renders_difference_claus
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
-fn execute_expand_the_sphere_with_library(land_count: usize) -> (usize, u32, u32) {
-    struct ChooseMaximum;
+fn execute_expand_the_sphere_with_library_and_choice(
+    land_count: usize,
+    choice_limit: Option<usize>,
+) -> (usize, u32, u32) {
+    struct ChooseLimited {
+        limit: Option<usize>,
+    }
 
-    impl crate::decision::DecisionMaker for ChooseMaximum {
+    impl crate::decision::DecisionMaker for ChooseLimited {
         fn decide_objects(
             &mut self,
             _game: &crate::game_state::GameState,
@@ -39492,7 +39497,8 @@ fn execute_expand_the_sphere_with_library(land_count: usize) -> (usize, u32, u32
             let count = ctx
                 .max
                 .unwrap_or(ctx.candidates.len())
-                .min(ctx.candidates.len());
+                .min(ctx.candidates.len())
+                .min(self.limit.unwrap_or(usize::MAX));
             ctx.candidates
                 .iter()
                 .take(count)
@@ -39546,7 +39552,9 @@ fn execute_expand_the_sphere_with_library(land_count: usize) -> (usize, u32, u32
         game.create_object_from_definition(&builder.build(), alice, Zone::Library);
     }
 
-    let mut dm = ChooseMaximum;
+    let mut dm = ChooseLimited {
+        limit: choice_limit,
+    };
     let mut ctx = crate::effects::ExecutionContext::new(source_id, alice, &mut dm);
     for effect in def.spell_effect.as_ref().expect("Expand the Sphere spell effects") {
         crate::effects::execute_effect(&mut game, effect, &mut ctx)
@@ -39574,12 +39582,29 @@ fn execute_expand_the_sphere_with_library(land_count: usize) -> (usize, u32, u32
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn execute_expand_the_sphere_with_library(land_count: usize) -> (usize, u32, u32) {
+    execute_expand_the_sphere_with_library_and_choice(land_count, None)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn expand_the_sphere_two_lands_enter_and_do_not_proliferate() {
     let (lands, poison, counters) = execute_expand_the_sphere_with_library(2);
     assert_eq!(lands, 2, "two eligible lands should enter tapped");
     assert_eq!(poison, 1, "putting two lands should not proliferate");
     assert_eq!(counters, 1, "putting two lands should not add permanent counters");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn expand_the_sphere_choosing_fewer_lands_proliferates_for_choice_shortfall() {
+    let (lands, poison, counters) = execute_expand_the_sphere_with_library_and_choice(2, Some(1));
+    assert_eq!(lands, 1, "only the chosen land should enter tapped");
+    assert_eq!(poison, 2, "choosing one fewer land should proliferate once");
+    assert_eq!(
+        counters, 2,
+        "choosing one fewer land should add one permanent counter"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39460,6 +39460,148 @@ fn proud_pack_rhino_proliferate_mode_increases_selected_counters() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_expand_the_sphere_compiles_strictly_and_renders_difference_clause() {
+    let def = parse_oracle_card_definition("Expand the Sphere");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+
+    assert_eq!(
+        rendered,
+        "Look at the top six cards of your library. Put up to two land cards from among them onto the battlefield tapped and the rest on the bottom of your library in a random order. If you put fewer than two lands onto the battlefield this way, proliferate a number of times equal to the difference.",
+        "expected strict compiled text to match Expand the Sphere's oracle text"
+    );
+    assert!(
+        rendered.contains("Put up to two land cards from among them onto the battlefield tapped"),
+        "expected looked-land battlefield choice in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("If you put fewer than two lands onto the battlefield this way, proliferate a number of times equal to the difference"),
+        "expected shortfall proliferate clause in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_expand_the_sphere_with_library(land_count: usize) -> (usize, u32, u32) {
+    struct ChooseMaximum;
+
+    impl crate::decision::DecisionMaker for ChooseMaximum {
+        fn decide_objects(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            let count = ctx
+                .max
+                .unwrap_or(ctx.candidates.len())
+                .min(ctx.candidates.len());
+            ctx.candidates
+                .iter()
+                .take(count)
+                .map(|candidate| candidate.id)
+                .collect()
+        }
+
+        fn decide_proliferate(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::ProliferateContext,
+        ) -> crate::decisions::specs::ProliferateResponse {
+            crate::decisions::specs::ProliferateResponse {
+                permanents: ctx.eligible_permanents.iter().map(|(id, _)| *id).collect(),
+                players: ctx.eligible_players.iter().map(|(id, _)| *id).collect(),
+            }
+        }
+    }
+
+    let def = parse_oracle_card_definition("Expand the Sphere");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let countered_id = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(92_000), "Countered Bear")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.add_counters(countered_id, crate::object::CounterType::PlusOnePlusOne, 1)
+        .expect("countered creature should be on battlefield");
+    game.players[1].poison_counters = 1;
+
+    for idx in 0..6 {
+        let is_land = idx < land_count;
+        let mut builder = CardDefinitionBuilder::new(
+            CardId::from_raw(92_001 + idx as u32),
+            &format!("Library Card {idx}"),
+        );
+        builder = if is_land {
+            builder.card_types(vec![CardType::Land])
+        } else {
+            builder
+                .card_types(vec![CardType::Creature])
+                .power_toughness(PowerToughness::fixed(1, 1))
+        };
+        game.create_object_from_definition(&builder.build(), alice, Zone::Library);
+    }
+
+    let mut dm = ChooseMaximum;
+    let mut ctx = crate::effects::ExecutionContext::new(source_id, alice, &mut dm);
+    for effect in def.spell_effect.as_ref().expect("Expand the Sphere spell effects") {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Expand the Sphere effect should resolve");
+    }
+
+    let battlefield_lands = game
+        .battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id)
+                .is_some_and(|object| object.name.starts_with("Library Card"))
+        })
+        .count();
+    let plus_one_counters = game
+        .object(countered_id)
+        .and_then(|object| {
+            object
+                .counters
+                .get(&crate::object::CounterType::PlusOnePlusOne)
+                .copied()
+        })
+        .unwrap_or(0);
+    (battlefield_lands, game.players[1].poison_counters, plus_one_counters)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn expand_the_sphere_two_lands_enter_and_do_not_proliferate() {
+    let (lands, poison, counters) = execute_expand_the_sphere_with_library(2);
+    assert_eq!(lands, 2, "two eligible lands should enter tapped");
+    assert_eq!(poison, 1, "putting two lands should not proliferate");
+    assert_eq!(counters, 1, "putting two lands should not add permanent counters");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn expand_the_sphere_one_land_proliferates_once() {
+    let (lands, poison, counters) = execute_expand_the_sphere_with_library(1);
+    assert_eq!(lands, 1, "the one eligible land should enter tapped");
+    assert_eq!(poison, 2, "one missing land should proliferate once");
+    assert_eq!(counters, 2, "one missing land should add one permanent counter");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn expand_the_sphere_zero_lands_proliferates_twice() {
+    let (lands, poison, counters) = execute_expand_the_sphere_with_library(0);
+    assert_eq!(lands, 0, "no lands should enter when none are looked at");
+    assert_eq!(poison, 3, "two missing lands should proliferate twice");
+    assert_eq!(counters, 3, "two missing lands should add two permanent counters");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_oracle_tekuthal_inquiry_dominus_compiles_strictly() {
     let def = parse_oracle_card_definition("Tekuthal, Inquiry Dominus");
     let rendered = canonical_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -836,7 +836,11 @@ fn describe_reveal_top_two_optional_picks_rest_bottom(effects: &[&Effect]) -> Op
     else {
         return None;
     };
-    let look = look_effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    let look_unwrapped = look_effect
+        .downcast_ref::<crate::effects::WithIdEffect>()
+        .map(|with_id| with_id.effect.as_ref())
+        .unwrap_or(look_effect);
+    let look = look_unwrapped.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
     let reveal = reveal_effect.downcast_ref::<crate::effects::RevealTaggedEffect>()?;
     let first_choose = first_choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
     let first_tagged = first_move_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
@@ -899,6 +903,114 @@ fn describe_reveal_top_two_optional_picks_rest_bottom(effects: &[&Effect]) -> Op
     let subtype_text = second_choose.filter.subtypes[0].to_string();
     Some(format!(
         "Reveal the top {count_text} cards of your library. You may put up to one land card from among them onto the battlefield tapped and up to one {subtype_text} card from among them into your hand. Put the rest on the bottom of your library in a random order"
+    ))
+}
+
+fn describe_look_top_put_matches_battlefield_rest_bottom_difference(
+    effects: &[&Effect],
+) -> Option<String> {
+    fn unwrap_with_id(effect: &Effect) -> (&Effect, Option<crate::effect::EffectId>) {
+        if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+            (with_id.effect.as_ref(), Some(with_id.id))
+        } else {
+            (effect, None)
+        }
+    }
+
+    let [look_effect, choose_effect, move_effect, rest_effect, if_effect] = effects else {
+        return None;
+    };
+    let (look_effect, _) = unwrap_with_id(look_effect);
+    let look = look_effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    let (choose_effect, _choose_id) = unwrap_with_id(choose_effect);
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let (move_effect, move_id) = unwrap_with_id(move_effect);
+    let move_id = move_id?;
+    let (move_chosen, move_targets_chosen_cards) = if let Some(for_each) =
+        move_effect.downcast_ref::<crate::effects::ForEachTaggedEffect>()
+    {
+        if for_each.tag != choose.tag {
+            return None;
+        }
+        let [inner] = for_each.effects.as_slice() else {
+            return None;
+        };
+        (
+            inner.downcast_ref::<crate::effects::PutOntoBattlefieldEffect>()?,
+            true,
+        )
+    } else {
+        let move_chosen = move_effect.downcast_ref::<crate::effects::PutOntoBattlefieldEffect>()?;
+        let targets_chosen =
+            matches!(&move_chosen.target, ChooseSpec::Tagged(tag) if tag == &choose.tag);
+        (move_chosen, targets_chosen)
+    };
+    let rest = rest_effect
+        .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()?;
+    let if_effect = if_effect.downcast_ref::<crate::effects::IfEffect>()?;
+
+    let max = choose.count.max?;
+    let max_i32 = i32::try_from(max).ok()?;
+    if look.player != PlayerFilter::You
+        || look.reveal
+        || choose.chooser != PlayerFilter::You
+        || choose.count.min != 0
+        || choose_primary_zone(choose) != Some(Zone::Library)
+        || !choose.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag == look.tag
+        })
+        || rest.tag != look.tag
+        || rest.keep_tagged.as_ref() != Some(&choose.tag)
+        || rest.order != LibraryBottomOrder::Random
+        || rest.player != PlayerFilter::You
+        || !move_targets_chosen_cards
+        || !move_chosen.tapped
+        || move_chosen.controller != PlayerFilter::You
+        || if_effect.condition != move_id
+        || if_effect.predicate
+            != crate::effect::EffectPredicate::Value(crate::effect::Comparison::LessThan(max_i32))
+        || if_effect.then.len() != 1
+        || !if_effect.else_.is_empty()
+    {
+        return None;
+    }
+
+    let proliferate_effect = if_effect.then[0]
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .map(|tagged| tagged.effect.as_ref())
+        .unwrap_or(&if_effect.then[0]);
+    let proliferate = proliferate_effect.downcast_ref::<crate::effects::ProliferateEffect>()?;
+    let Value::Add(left, right) = &proliferate.count else {
+        return None;
+    };
+    if !matches!(left.as_ref(), Value::Fixed(n) if *n == max_i32)
+        || !matches!(
+            right.as_ref(),
+            Value::Scaled(inner, -1) if matches!(inner.as_ref(), Value::EffectValue(id) if *id == move_id)
+        )
+    {
+        return None;
+    }
+
+    let (look_count_text, noun, _) = describe_look_count_and_noun(&look.count);
+    let max_text = small_number_word(max as u32).unwrap_or_else(|| max.to_string());
+    let mut display_filter = choose.filter.clone();
+    display_filter.zone = None;
+    display_filter.tagged_constraints.clear();
+    let selection = pluralize_noun_phrase(&describe_search_selection_with_cards(
+        &display_filter.description(),
+    ));
+    let shortfall_selection = if display_filter.card_types == [CardType::Land]
+        && display_filter.subtypes.is_empty()
+        && display_filter.supertypes.is_empty()
+    {
+        "lands".to_string()
+    } else {
+        selection.clone()
+    };
+    Some(format!(
+        "Look at the top {look_count_text} {noun} of your library. Put up to {max_text} {selection} from among them onto the battlefield tapped and the rest on the bottom of your library in a random order. If you put fewer than {max_text} {shortfall_selection} onto the battlefield this way, proliferate a number of times equal to the difference"
     ))
 }
 
@@ -4820,6 +4932,14 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         })
         .collect::<Vec<_>>();
 
+    let unfiltered = effects.iter().collect::<Vec<_>>();
+    if unfiltered.len() == 5
+        && let Some(compact) =
+            describe_look_top_put_matches_battlefield_rest_bottom_difference(&unfiltered)
+    {
+        return compact;
+    }
+
     fn describe_source_counter_and_create(effects: &[&Effect]) -> Option<String> {
         let [counter_effect, create_effect] = effects else {
             return None;
@@ -5645,6 +5765,12 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     {
         return compact;
     }
+    if filtered.len() == 5
+        && let Some(compact) =
+            describe_look_top_put_matches_battlefield_rest_bottom_difference(&filtered)
+    {
+        return compact;
+    }
     if filtered.len() == 4
         && let Some(compact) = describe_hideaway_effects(&filtered)
     {
@@ -5688,6 +5814,13 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                 .is_some_and(|tag| is_implicit_reference_tag(tag.tag.as_str()))
         })
         .collect::<Vec<_>>();
+
+    if visible_effects.len() == 5
+        && let Some(compact) =
+            describe_look_top_put_matches_battlefield_rest_bottom_difference(&visible_effects)
+    {
+        return compact;
+    }
 
     if let Some(compact) = describe_choose_each_basic_land_type_then_destroy(&visible_effects) {
         return compact;

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -610,12 +610,20 @@ impl EffectOutcome {
 
     /// Get the count value, or zero if not a Count result.
     pub fn count_or_zero(&self) -> i32 {
-        self.value.count_or_zero()
+        self.result_count().unwrap_or(0)
     }
 
     /// Get the count value if this is a Count result.
     pub fn as_count(&self) -> Option<i32> {
         self.value.as_count()
+    }
+
+    /// Numeric result for effects whose natural result is a countable object set.
+    pub fn result_count(&self) -> Option<i32> {
+        self.as_count().or_else(|| {
+            let count = self.output_objects().len();
+            (count > 0).then_some(count as i32)
+        })
     }
 
     /// Access explicit object IDs returned by the compatibility summary.
@@ -780,7 +788,7 @@ impl EffectPredicateRuntimeExt for EffectPredicate {
                     && !outcome.has_execution_fact(|fact| matches!(fact, ExecutionFact::Replaced))
                     && outcome.status != OutcomeStatus::Replaced
             }
-            Self::Value(cmp) => outcome.as_count().is_some_and(|n| cmp.evaluate(n)),
+            Self::Value(cmp) => outcome.result_count().is_some_and(|n| cmp.evaluate(n)),
             Self::Chosen => {
                 !outcome.has_execution_fact(|fact| matches!(fact, ExecutionFact::Declined))
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Expand the Sphere
Initial parse error:
```
unsupported trailing proliferate clause (clause: 'a number of times equal to the difference'); oracle-only fallback also failed: unsupported trailing proliferate clause (clause: 'a number of times equal to the difference')
```

Current worker: i-03f375afdb9bc15ed
Branch: codex/aws-card-fix-expand-the-sphere
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0036
