### PR TITLE
Fix Ironsmith parse failure: Stoic Sphinx

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2167,6 +2167,38 @@ pub(crate) fn parse_static_condition_clause(
     if word_slice_eq_any(
         &clause_words,
         &[
+            &["you", "havent", "cast", "a", "spell", "this", "turn"],
+            &["you", "have", "not", "cast", "a", "spell", "this", "turn"],
+            &["you", "didnt", "cast", "a", "spell", "this", "turn"],
+            &["you", "did", "not", "cast", "a", "spell", "this", "turn"],
+        ],
+    ) {
+        return Ok(crate::ConditionExpr::Not(Box::new(
+            crate::ConditionExpr::PlayerCastSpellsThisTurnOrMore {
+                player: PlayerFilter::You,
+                count: 1,
+            },
+        )));
+    }
+
+    if word_slice_eq_any(
+        &clause_words,
+        &[
+            &["youve", "cast", "a", "spell", "this", "turn"],
+            &["you", "ve", "cast", "a", "spell", "this", "turn"],
+            &["you", "have", "cast", "a", "spell", "this", "turn"],
+            &["you", "cast", "a", "spell", "this", "turn"],
+        ],
+    ) {
+        return Ok(crate::ConditionExpr::PlayerCastSpellsThisTurnOrMore {
+            player: PlayerFilter::You,
+            count: 1,
+        });
+    }
+
+    if word_slice_eq_any(
+        &clause_words,
+        &[
             &["there", "are", "no", "cards", "in", "your", "library"],
             &["your", "library", "has", "no", "cards", "in", "it"],
         ],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -371,6 +371,85 @@ fn king_darien_xlviii_sacrifice_ability_grants_keywords_only_to_your_tokens_runt
     );
 }
 
+#[test]
+fn stoic_sphinx_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Stoic Sphinx");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("Hexproof")
+            && ability_debug.contains("Not")
+            && ability_debug.contains("PlayerCastSpellsThisTurnOrMore"),
+        "Stoic Sphinx should model conditional hexproof using the player-cast-spell condition, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("This creature has Hexproof as long as you haven't cast a spell this turn."),
+        "Stoic Sphinx compiled text should preserve the haven't-cast-a-spell static clause, got {rendered}"
+    );
+}
+
+fn record_stoic_sphinx_spell_cast_event(
+    game: &mut crate::game_state::GameState,
+    caster: PlayerId,
+    raw_id: u32,
+) {
+    let spell = CardBuilder::new(CardId::from_raw(raw_id), "Recorded Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let spell_id = game.create_object_from_card(&spell, caster, Zone::Stack);
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(spell_id)
+            .expect("recorded spell should exist on the stack"),
+        game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::spells::SpellCastEvent::new_with_snapshot(
+            spell_id,
+            caster,
+            Zone::Hand,
+            snapshot.clone(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.turn_store
+        .turn_history
+        .record_event(&event, Some(snapshot), None);
+}
+
+#[test]
+fn stoic_sphinx_hexproof_tracks_whether_controller_cast_a_spell_this_turn() {
+    let def = parse_oracle_card_definition("Stoic Sphinx");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sphinx_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert!(
+        game.object_has_static_ability_id(sphinx_id, StaticAbilityId::Hexproof),
+        "Stoic Sphinx should have hexproof before its controller casts a spell this turn"
+    );
+
+    record_stoic_sphinx_spell_cast_event(&mut game, bob, 92_102);
+    assert!(
+        game.object_has_static_ability_id(sphinx_id, StaticAbilityId::Hexproof),
+        "an opponent casting a spell should not turn off Stoic Sphinx's hexproof"
+    );
+
+    record_stoic_sphinx_spell_cast_event(&mut game, alice, 92_103);
+    assert!(
+        !game.object_has_static_ability_id(sphinx_id, StaticAbilityId::Hexproof),
+        "Stoic Sphinx should lose hexproof after its controller has cast a spell this turn"
+    );
+
+    game.turn_store.turn_history.clear_for_new_turn();
+    assert!(
+        game.object_has_static_ability_id(sphinx_id, StaticAbilityId::Hexproof),
+        "Stoic Sphinx should regain hexproof after turn-scoped spell-cast history clears"
+    );
+}
+
 fn alacrian_armory_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
     def.abilities
         .iter()

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -974,6 +974,35 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         {
             "as long as this creature didn't attack this turn".to_string()
         }
+        crate::ConditionExpr::Not(inner) => {
+            if let crate::ConditionExpr::PlayerCastSpellsThisTurnOrMore { player, count: 1 } =
+                inner.as_ref()
+            {
+                return match player {
+                    crate::target::PlayerFilter::You => {
+                        "as long as you haven't cast a spell this turn".to_string()
+                    }
+                    crate::target::PlayerFilter::Opponent => {
+                        "as long as an opponent hasn't cast a spell this turn".to_string()
+                    }
+                    crate::target::PlayerFilter::Any => {
+                        "as long as no player has cast a spell this turn".to_string()
+                    }
+                    _ => "as long as that player hasn't cast a spell this turn".to_string(),
+                };
+            }
+            format!("as long as not ({})", describe_static_condition(inner))
+        }
+        crate::ConditionExpr::PlayerCastSpellsThisTurnOrMore { player, count } => {
+            let subject = describe_static_player(player);
+            let count_text = number_word_u32(*count).unwrap_or_else(|| count.to_string());
+            let verb = if matches!(player, crate::target::PlayerFilter::You) {
+                "have"
+            } else {
+                "has"
+            };
+            format!("as long as {subject} {verb} cast {count_text} or more spells this turn")
+        }
         crate::ConditionExpr::SourceIsUntapped => {
             "as long as this creature is untapped".to_string()
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Stoic Sphinx
Initial parse error:
```
unsupported static condition clause (clause: 'you havent cast a spell this turn'); oracle-only fallback also failed: unsupported static condition clause (clause: 'you havent cast a spell this turn')
```

Current worker: i-075a7cc3c6f939c92
Branch: codex/aws-card-fix-stoic-sphinx
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0036
