### PR TITLE
Fix Ironsmith parse failure: Defiler of Instinct

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -5100,9 +5100,109 @@ pub(crate) fn parse_cost_modifier_prefix_condition(
     Ok((None, 0))
 }
 
+fn parse_optional_life_additional_cost_reduction_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let additional_words = crate::runtime_backend::token_word_refs(tokens);
+    if !word_slice_starts_with(
+        &additional_words,
+        &["as", "an", "additional", "cost", "to", "cast"],
+    ) {
+        return Ok(None);
+    }
+
+    let Some(additional_spells_word_idx) = find_index(&additional_words, |word| {
+        *word == "spell" || *word == "spells"
+    }) else {
+        return Ok(None);
+    };
+    let Some(cost_subject_start) = token_index_for_word_index(tokens, 6) else {
+        return Ok(None);
+    };
+    let Some(additional_spells_idx) = token_index_for_word_index(tokens, additional_spells_word_idx)
+    else {
+        return Ok(None);
+    };
+    let subject_tokens = trim_commas(&tokens[cost_subject_start..additional_spells_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let mut filter = parse_spell_filter_with_grammar_entrypoint(&subject_tokens);
+    let subject_words = crate::runtime_backend::token_word_refs(&subject_tokens);
+    if word_slice_contains_word(&subject_words, "permanent") {
+        filter.card_types = ObjectFilter::permanent_card().card_types;
+    }
+    filter.cast_by = Some(PlayerFilter::You);
+
+    let Some(pay_word_idx) = find_index(&additional_words, |word| *word == "pay") else {
+        return Ok(None);
+    };
+    let payment_words = &additional_words[pay_word_idx + 1..];
+    let Some(life_cost) = payment_words
+        .first()
+        .and_then(|word| parse_number_word_i32(word))
+        .and_then(|amount| u32::try_from(amount).ok())
+    else {
+        return Ok(None);
+    };
+    if !word_slice_contains_word(&payment_words, "life") {
+        return Ok(None);
+    }
+
+    let Some(those_spells_idx) =
+        word_slice_find_phrase_start(&additional_words, &["those", "spells"])
+    else {
+        return Ok(None);
+    };
+    if !word_slice_contains_phrase(
+        &additional_words[those_spells_idx..],
+        &["paid", "life", "this", "way"],
+    )
+    {
+        return Ok(None);
+    }
+    let Some(costs_word_idx) = find_index(&additional_words[those_spells_idx..], |word| {
+        *word == "cost" || *word == "costs"
+    }) else {
+        return Ok(None);
+    };
+    let costs_word_idx = those_spells_idx + costs_word_idx;
+    let Some(costs_idx) = token_index_for_word_index(tokens, costs_word_idx) else {
+        return Ok(None);
+    };
+    let amount_tokens = &tokens[costs_idx + 1..];
+    let (_, parsed_mana_cost) = parse_cost_modifier_components(amount_tokens);
+    let Some((reduction, _)) = parsed_mana_cost else {
+        return Ok(None);
+    };
+    let remaining_words = crate::runtime_backend::token_word_refs(amount_tokens);
+    if parse_cost_modifier_direction(&remaining_words) != Some(CostModifierDirection::Less)
+        || !word_slice_contains_word(&remaining_words, "cast")
+    {
+        return Ok(None);
+    }
+
+    let label_end = find_token_kind(tokens, TokenKind::Period)
+        .map(|idx| idx + 1)
+        .unwrap_or(costs_idx);
+    let label = render_token_slice(&tokens[..label_end])
+        .trim()
+        .trim_end_matches('.')
+        .to_string();
+    Ok(Some(StaticAbility::new(
+        crate::static_abilities::CostReductionManaCost::new(filter, reduction)
+            .with_optional_life_additional_cost(label, life_cost),
+    )))
+}
+
 pub(crate) fn parse_spells_cost_modifier_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
+    if let Some(ability) = parse_optional_life_additional_cost_reduction_line(tokens)? {
+        return Ok(Some(ability));
+    }
+
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     if clause_words.len() < 4 {
         return Ok(None);

--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -627,6 +627,9 @@ fn parse_simple_object_filter_lexed(tokens: &[OwnedLexToken], other: bool) -> Op
         return None;
     }
 
+    if saw_spell && saw_permanent && filter.card_types.is_empty() {
+        filter.card_types = ObjectFilter::permanent_card().card_types;
+    }
     if filter.zone.is_none() {
         if saw_spell {
             filter.zone = Some(Zone::Stack);
@@ -637,6 +640,7 @@ fn parse_simple_object_filter_lexed(tokens: &[OwnedLexToken], other: bool) -> Op
         }
     }
     if saw_spell {
+        filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
         filter.has_mana_cost = true;
     }
 

--- a/crates/ironsmith-compiler/src/static_abilities.rs
+++ b/crates/ironsmith-compiler/src/static_abilities.rs
@@ -5,8 +5,9 @@ pub use ironsmith_core::{
     CopyActivatedAbilities, CopyTriggeredAbilities, CostIncrease, CostIncreaseManaCost,
     CostReduction, CostReductionManaCost, DefendingPlayerAttackCondition,
     EnterAsCopyLinkedExilePairSpec, GraveyardCountMetric, LandwalkKind, ManaSpendPermission,
-    PregameActionKind, PregameBeginOnBattlefieldSpec, RemoveCardTypesForFilter, SetColorsForFilter,
-    StaticAbilityId, ThisSpellCastRestrictionKind, ThisSpellCastTiming,
+    OptionalLifeAdditionalCost, PregameActionKind, PregameBeginOnBattlefieldSpec,
+    RemoveCardTypesForFilter, SetColorsForFilter, StaticAbilityId, ThisSpellCastRestrictionKind,
+    ThisSpellCastTiming,
 };
 
 pub const PREVENT_ALL_DAMAGE_DEALT_BY_THIS_PERMANENT: StaticAbilityId =

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -170,9 +170,9 @@ pub use static_ability_model::{
     CopyActivatedAbilities, CopyTriggeredAbilities, CostIncrease, CostIncreaseManaCost,
     CostReduction, CostReductionManaCost, DefendingPlayerAttackCondition, EnterAsCopyAsEntersSpec,
     EnterAsCopyLinkedExilePairSpec, GrantAbility, GrantObjectAbilityForFilter,
-    GraveyardCountMetric, LandwalkKind, PowerToughnessChoiceOption, PregameActionKind,
-    PregameBeginOnBattlefieldSpec, RemoveCardTypesForFilter, SetColorsForFilter, StaticAbility,
-    StaticAbilityPayload, ThisSpellCastRestrictionKind, ThisSpellCostReduction,
+    GraveyardCountMetric, LandwalkKind, OptionalLifeAdditionalCost, PowerToughnessChoiceOption,
+    PregameActionKind, PregameBeginOnBattlefieldSpec, RemoveCardTypesForFilter, SetColorsForFilter,
+    StaticAbility, StaticAbilityPayload, ThisSpellCastRestrictionKind, ThisSpellCostReduction,
     ThisSpellCostReductionManaCost,
 };
 pub use tag::{EXPLOITED_TAG, EXPLOITER_TAG, SOURCE_EXILED_TAG, TagKey};

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -4165,14 +4165,45 @@ impl CostReduction {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct OptionalLifeAdditionalCost {
+    pub label: String,
+    pub life_cost: u32,
+}
+
+impl OptionalLifeAdditionalCost {
+    pub fn new(label: impl Into<String>, life_cost: u32) -> Self {
+        Self {
+            label: label.into(),
+            life_cost,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct CostReductionManaCost {
     pub filter: ObjectFilter,
     pub cost: ManaCost,
+    pub optional_life_additional_cost: Option<OptionalLifeAdditionalCost>,
 }
 
 impl CostReductionManaCost {
     pub fn new(filter: ObjectFilter, cost: ManaCost) -> Self {
-        Self { filter, cost }
+        Self {
+            filter,
+            cost,
+            optional_life_additional_cost: None,
+        }
+    }
+
+    pub fn with_optional_life_additional_cost(
+        mut self,
+        label: impl Into<String>,
+        life_cost: u32,
+    ) -> Self {
+        self.optional_life_additional_cost = Some(OptionalLifeAdditionalCost::new(
+            label, life_cost,
+        ));
+        self
     }
     pub fn with_condition(self, _condition: Condition) -> Self {
         self

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -27337,6 +27337,49 @@ fn parse_spells_cost_modifier_supports_colored_mana_increase() {
     );
 }
 
+#[test]
+fn parse_oracle_defiler_of_instinct_optional_life_cost_reduction_regression() {
+    let def = parse_oracle_card_definition("Defiler of Instinct");
+    let raw = format!("{def:#?}");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.cost_reduction_mana_cost(),
+            _ => None,
+        })
+        .expect("Defiler of Instinct should have a mana-symbol cost reduction");
+
+    assert_eq!(reduction.filter.cast_by, Some(PlayerFilter::You));
+    assert!(
+        reduction.filter.card_types.contains(&CardType::Creature)
+            && reduction.filter.card_types.contains(&CardType::Artifact)
+            && reduction.filter.card_types.contains(&CardType::Enchantment)
+            && reduction.filter.card_types.contains(&CardType::Planeswalker)
+            && reduction.filter.card_types.contains(&CardType::Battle),
+        "Defiler cost reduction should apply to red permanent spells, got {:?}",
+        reduction.filter
+    );
+    assert!(
+        reduction.optional_life_additional_cost.is_some(),
+        "Defiler cost reduction should be gated by its optional life additional cost, got {raw}"
+    );
+    assert!(
+        rendered_lower.contains("as an additional cost to cast red permanent spells, you may pay 2 life")
+            && rendered_lower.contains("those spells cost {r} less to cast if you paid life this way")
+            && rendered_lower.contains("this effect reduces only the amount of red mana you pay"),
+        "Defiler compiled text should preserve the optional additional cost and gated colored reduction, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("whenever you cast a red permanent spell")
+            && rendered_lower.contains("deals 1 damage to any target"),
+        "Defiler compiled text should preserve its red-permanent cast trigger, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_spells_cost_modifier_supports_where_x_differently_named_lands() {

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -569,6 +569,71 @@ fn spell_view_for_cost_filter_match(
     None
 }
 
+pub(crate) fn optional_life_cost_reduction_costs_for_cast(
+    game: &GameState,
+    caster: PlayerId,
+    spell_id: ObjectId,
+    casting_method: &CastingMethod,
+) -> Vec<(ObjectId, ironsmith_core::OptionalLifeAdditionalCost)> {
+    let Some(spell) = game.object(spell_id) else {
+        return Vec::new();
+    };
+    let mut spell_for_filter = spell_view_for_cost_filter_match(game, caster, spell, casting_method)
+        .unwrap_or_else(|| {
+            let mut spell_for_filter = spell.clone();
+            if let Some(chars) = game.current_characteristics(spell_id) {
+                spell_for_filter.name = chars.name;
+                spell_for_filter.card_types = chars.card_types;
+                spell_for_filter.subtypes = chars.subtypes;
+                spell_for_filter.supertypes = chars.supertypes;
+                spell_for_filter.color_override = Some(chars.colors);
+            }
+            spell_for_filter
+        });
+    spell_for_filter.zone = Zone::Stack;
+
+    let mut costs = Vec::new();
+    for &perm_id in &game.battlefield {
+        let Some(perm) = game.object(perm_id) else {
+            continue;
+        };
+        let controller = game.controller_of(perm);
+        let filter_ctx = game
+            .filter_context_for(controller, Some(perm_id))
+            .with_caster(Some(caster));
+        let abilities = game
+            .current_characteristics(perm_id)
+            .map(|chars| chars.static_abilities)
+            .unwrap_or_default();
+        for static_ability in abilities {
+            if !static_ability.is_active(game, perm_id) {
+                continue;
+            }
+            let Some(reduction) = static_ability.cost_reduction_mana_cost() else {
+                continue;
+            };
+            let Some(optional) = &reduction.optional_life_additional_cost else {
+                continue;
+            };
+            if reduction
+                .filter
+                .matches_non_recursive(&spell_for_filter, &filter_ctx, game)
+            {
+                costs.push((perm_id, optional.clone()));
+            }
+        }
+    }
+
+    costs
+}
+
+pub(crate) fn optional_life_cost_reduction_label(
+    optional: &ironsmith_core::OptionalLifeAdditionalCost,
+    source: ObjectId,
+) -> String {
+    format!("{} [source:{}]", optional.label, source.0)
+}
+
 fn disturb_linked_face_matches_cost_filter(
     game: &GameState,
     caster: PlayerId,
@@ -1426,7 +1491,30 @@ fn effective_cost_with_affordable_non_mana_optional_cost(
     casting_method: &CastingMethod,
     view: &DerivedGameView<'_>,
 ) -> Option<crate::mana::ManaCost> {
-    for (index, optional_cost) in spell.optional_costs.iter().enumerate() {
+    let mut spell_with_optional_costs = spell.clone();
+    for (source, optional) in optional_life_cost_reduction_costs_for_cast(
+        game,
+        player,
+        spell.id,
+        casting_method,
+    ) {
+        let label = optional_life_cost_reduction_label(&optional, source);
+        if spell_with_optional_costs
+            .optional_costs
+            .iter()
+            .any(|existing| existing.label == label)
+        {
+            continue;
+        }
+        spell_with_optional_costs
+            .optional_costs
+            .push(crate::cost::OptionalCost::custom(
+                label,
+                crate::cost::TotalCost::from_cost(crate::costs::Cost::life(optional.life_cost)),
+            ));
+    }
+
+    for (index, optional_cost) in spell_with_optional_costs.optional_costs.iter().enumerate() {
         if optional_cost.cost.mana_cost().is_some() {
             continue;
         }
@@ -1442,7 +1530,8 @@ fn effective_cost_with_affordable_non_mana_optional_cost(
             continue;
         }
 
-        let mut hypothetical = spell.clone();
+        let mut hypothetical = spell_with_optional_costs.clone();
+        hypothetical.zone = Zone::Stack;
         hypothetical.optional_costs_paid =
             crate::cost::OptionalCostsPaid::from_costs(&hypothetical.optional_costs);
         hypothetical.optional_costs_paid.pay_times(index, 1);
@@ -2879,6 +2968,19 @@ pub(crate) fn apply_spell_cost_modifiers(
             })
     }
 
+    fn optional_life_reduction_was_paid(
+        spell: &crate::object::Object,
+        reduction: &crate::static_abilities::CostReductionManaCost,
+        source: ObjectId,
+    ) -> bool {
+        match &reduction.optional_life_additional_cost {
+            Some(optional) => spell
+                .optional_costs_paid
+                .was_paid_label(&optional_life_cost_reduction_label(optional, source)),
+            None => true,
+        }
+    }
+
     let mut total_increase: i32 = 0;
     let mut total_reduction: i32 = 0;
     let mut increase_pips: Vec<Vec<ManaSymbol>> = Vec::new();
@@ -2952,6 +3054,7 @@ pub(crate) fn apply_spell_cost_modifiers(
         }
         if let Some(reduction) = static_ability.cost_reduction_mana_cost()
             && spell_matches_filter(game, spell, player, &reduction.filter, &ctx, casting_method)
+            && optional_life_reduction_was_paid(spell, reduction, spell.id)
         {
             reduction_pips.extend(reduction.reduction.pips().iter().cloned());
         }
@@ -3053,6 +3156,19 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
             })
     }
 
+    fn optional_life_reduction_was_paid(
+        spell: &crate::object::Object,
+        reduction: &crate::static_abilities::CostReductionManaCost,
+        source: ObjectId,
+    ) -> bool {
+        match &reduction.optional_life_additional_cost {
+            Some(optional) => spell
+                .optional_costs_paid
+                .was_paid_label(&optional_life_cost_reduction_label(optional, source)),
+            None => true,
+        }
+    }
+
     let mut total_increase: i32 = 0;
     let mut total_reduction: i32 = 0;
     let mut increase_pips: Vec<Vec<ManaSymbol>> = Vec::new();
@@ -3139,6 +3255,7 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
                         casting_method,
                         chosen_target_count,
                     )
+                    && optional_life_reduction_was_paid(spell, reduction, perm_id)
                 {
                     reduction_pips.extend(reduction.reduction.pips().iter().cloned());
                 }
@@ -3235,6 +3352,7 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
                         casting_method,
                         chosen_target_count,
                     )
+                    && optional_life_reduction_was_paid(spell, reduction, perm_id)
                 {
                     reduction_pips.extend(reduction.reduction.pips().iter().cloned());
                 }

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -123,6 +123,36 @@ fn ensure_granted_conspire_optional_costs(game: &mut GameState, pending: &mut Pe
     pending.optional_costs_paid = crate::cost::OptionalCostsPaid::from_costs(&spell.optional_costs);
 }
 
+fn ensure_optional_life_cost_reduction_costs(game: &mut GameState, pending: &mut PendingCast) {
+    let costs = crate::decision::optional_life_cost_reduction_costs_for_cast(
+        game,
+        pending.caster,
+        pending.spell_id,
+        &pending.casting_method,
+    );
+    if costs.is_empty() {
+        return;
+    }
+    let Some(spell) = game.object_mut(pending.spell_id) else {
+        return;
+    };
+    for (source, optional) in costs {
+        let label = crate::decision::optional_life_cost_reduction_label(&optional, source);
+        if spell
+            .optional_costs
+            .iter()
+            .any(|existing| existing.label == label)
+        {
+            continue;
+        }
+        spell.optional_costs.push(crate::cost::OptionalCost::custom(
+            label,
+            crate::cost::TotalCost::from_cost(crate::costs::Cost::life(optional.life_cost)),
+        ));
+    }
+    pending.optional_costs_paid = crate::cost::OptionalCostsPaid::from_costs(&spell.optional_costs);
+}
+
 /// Collect all available casting methods for a spell.
 /// Returns a list of CastingMethodOption structs for each method that can be used.
 pub(super) fn collect_available_casting_methods(
@@ -963,6 +993,7 @@ pub(super) fn check_optional_costs_or_continue(
     decision_maker: &mut impl DecisionMaker,
 ) -> Result<GameProgress, GameLoopError> {
     ensure_granted_conspire_optional_costs(game, &mut pending);
+    ensure_optional_life_cost_reduction_costs(game, &mut pending);
 
     // Check if the spell has optional costs
     let optional_costs = if let Some(obj) = game.object(pending.spell_id) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -29447,6 +29447,186 @@ fn test_next_matching_spell_cost_reduction_is_consumed_by_first_match_only() {
     );
 }
 
+fn defiler_of_instinct_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(466_119), "Defiler of Instinct")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Phyrexian, Subtype::Kavu])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "First strike\n\
+             As an additional cost to cast red permanent spells, you may pay 2 life. Those spells cost {R} less to cast if you paid life this way. This effect reduces only the amount of red mana you pay.\n\
+             Whenever you cast a red permanent spell, this creature deals 1 damage to any target.",
+        )
+        .expect("Defiler of Instinct should parse for runtime tests")
+}
+
+fn one_red_creature_definition(name: &str) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build()
+}
+
+fn start_defiler_red_creature_cast(
+    game: &mut GameState,
+    creature_id: ObjectId,
+) -> (
+    TriggerQueue,
+    PriorityLoopState,
+    crate::decisions::context::SelectOptionsContext,
+) {
+    let alice = PlayerId::from_index(0);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(crate::decision::LegalAction::CastSpell {
+            spell_id: creature_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+        &mut dm,
+    )
+    .expect("red creature cast should start");
+
+    let ctx = match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectOptions(ctx),
+        ) => ctx,
+        other => panic!("expected Defiler optional-cost prompt, got {other:?}"),
+    };
+    assert_eq!(ctx.player, alice);
+    (trigger_queue, state, ctx)
+}
+
+#[test]
+fn defiler_of_instinct_optional_life_cost_reduces_red_permanent_spell_cost() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let defiler = defiler_of_instinct_definition();
+    game.create_object_from_definition(&defiler, alice, Zone::Battlefield);
+    let red_creature = one_red_creature_definition("Defiler of Instinct Red Creature Probe");
+    let red_creature_id = game.create_object_from_definition(&red_creature, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let (mut trigger_queue, mut state, optional_ctx) =
+        start_defiler_red_creature_cast(&mut game, red_creature_id);
+    assert!(
+        optional_ctx.options.iter().any(|option| {
+            option.description.to_ascii_lowercase().contains(
+                "as an additional cost to cast red permanent spells, you may pay 2 life",
+            )
+        }),
+        "Defiler should offer its optional life additional cost, got {:?}",
+        optional_ctx.options
+    );
+
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::OptionalCosts(vec![(0, 1)]),
+        &mut dm,
+    )
+    .expect("paying Defiler optional life cost should continue casting");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        18,
+        "paying the Defiler additional cost should cost 2 life"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.total(),
+        1,
+        "paying life should reduce the red pip and leave the red mana unspent"
+    );
+}
+
+#[test]
+fn defiler_of_instinct_declining_life_cost_does_not_reduce_red_permanent_spell_cost() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let defiler = defiler_of_instinct_definition();
+    game.create_object_from_definition(&defiler, alice, Zone::Battlefield);
+    let red_creature = one_red_creature_definition("Defiler of Instinct Decline Probe");
+    let red_creature_id = game.create_object_from_definition(&red_creature, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    let (mut trigger_queue, mut state, _optional_ctx) =
+        start_defiler_red_creature_cast(&mut game, red_creature_id);
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::OptionalCosts(vec![]),
+        &mut dm,
+    )
+    .expect("declining Defiler optional life cost should continue casting");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        20,
+        "declining the Defiler additional cost should not cost life"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.total(),
+        0,
+        "declining life should leave the red pip unreduced and spend the red mana"
+    );
+}
+
+#[test]
+fn defiler_of_instinct_life_cost_makes_red_permanent_spell_legal_without_red_mana() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let defiler = defiler_of_instinct_definition();
+    game.create_object_from_definition(&defiler, alice, Zone::Battlefield);
+    let red_creature = one_red_creature_definition("Defiler of Instinct Legal Action Probe");
+    let red_creature_id = game.create_object_from_definition(&red_creature, alice, Zone::Hand);
+
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::CastSpell { spell_id, from_zone: Zone::Hand, .. }
+                if *spell_id == red_creature_id
+        )),
+        "Defiler's optional life additional cost should make a one-red permanent spell castable with no red mana, got {actions:?}"
+    );
+}
+
 #[test]
 fn test_face_down_cast_matches_panoptic_filter_and_enters_battlefield_face_down() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -490,6 +490,16 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
     if filter.source {
         return "this spell".to_string();
     }
+    fn is_permanent_card_type_set(types: &[CardType]) -> bool {
+        types.len() == 6
+            && types.contains(&CardType::Artifact)
+            && types.contains(&CardType::Creature)
+            && types.contains(&CardType::Enchantment)
+            && types.contains(&CardType::Land)
+            && types.contains(&CardType::Planeswalker)
+            && types.contains(&CardType::Battle)
+    }
+
     let mut qualifiers = Vec::<String>::new();
     if let Some(colors) = filter.colors {
         let color_text = describe_colors(colors);
@@ -509,12 +519,16 @@ fn describe_spell_filter(filter: &ObjectFilter) -> String {
         qualifiers.push(join_with_and(&subtypes));
     }
     if !filter.card_types.is_empty() {
-        let types = filter
-            .card_types
-            .iter()
-            .map(|card_type| describe_card_type(*card_type).to_string())
-            .collect::<Vec<_>>();
-        qualifiers.push(join_with_and(&types));
+        if is_permanent_card_type_set(&filter.card_types) {
+            qualifiers.push("permanent".to_string());
+        } else {
+            let types = filter
+                .card_types
+                .iter()
+                .map(|card_type| describe_card_type(*card_type).to_string())
+                .collect::<Vec<_>>();
+            qualifiers.push(join_with_and(&types));
+        }
     }
 
     let mut description = if qualifiers.is_empty() {
@@ -1854,6 +1868,7 @@ pub struct CostReductionManaCost {
     pub filter: ObjectFilter,
     pub reduction: ManaCost,
     pub condition: Option<crate::ConditionExpr>,
+    pub optional_life_additional_cost: Option<ironsmith_core::OptionalLifeAdditionalCost>,
 }
 
 impl CostReductionManaCost {
@@ -1862,7 +1877,19 @@ impl CostReductionManaCost {
             filter,
             reduction,
             condition: None,
+            optional_life_additional_cost: None,
         }
+    }
+
+    pub fn with_optional_life_additional_cost(
+        mut self,
+        label: impl Into<String>,
+        life_cost: u32,
+    ) -> Self {
+        self.optional_life_additional_cost = Some(ironsmith_core::OptionalLifeAdditionalCost::new(
+            label, life_cost,
+        ));
+        self
     }
 
     pub fn with_condition(mut self, condition: crate::ConditionExpr) -> Self {
@@ -1877,6 +1904,26 @@ impl StaticAbilityKind for CostReductionManaCost {
     }
 
     fn display(&self) -> String {
+        if let Some(optional) = &self.optional_life_additional_cost {
+            let mut subject_filter = self.filter.clone();
+            subject_filter.cast_by = None;
+            let subject = describe_spell_filter(&subject_filter);
+            let mut line = format!(
+                "As an additional cost to cast {subject}, you may pay {} life. Those spells cost {} less to cast if you paid life this way",
+                optional.life_cost,
+                describe_cost_modifier_mana_cost(&self.reduction)
+            );
+            if mana_cost_contains_colored_symbol(&self.reduction) {
+                if let Some(color) = single_colored_mana_word(&self.reduction) {
+                    line.push_str(&format!(
+                        ". This effect reduces only the amount of {color} mana you pay"
+                    ));
+                } else {
+                    line.push_str(". This effect reduces only the amount of colored mana you pay");
+                }
+            }
+            return describe_cost_modifier_with_condition(line, &self.condition);
+        }
         let mut line = format!(
             "{} cost {} less to cast",
             describe_spell_filter(&self.filter),
@@ -1920,6 +1967,24 @@ fn mana_cost_contains_colored_symbol(cost: &ManaCost) -> bool {
                 | ManaSymbol::Green
         )
     })
+}
+
+fn single_colored_mana_word(cost: &ManaCost) -> Option<&'static str> {
+    let pips = cost.pips();
+    let [pip] = pips else {
+        return None;
+    };
+    let [symbol] = pip.as_slice() else {
+        return None;
+    };
+    match symbol {
+        ManaSymbol::White => Some("white"),
+        ManaSymbol::Blue => Some("blue"),
+        ManaSymbol::Black => Some("black"),
+        ManaSymbol::Red => Some("red"),
+        ManaSymbol::Green => Some("green"),
+        _ => None,
+    }
 }
 
 /// Mana-symbol cost increase: "Spells cost {B} more to cast"

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -655,9 +655,15 @@ impl StaticAbilityModelInterpreter {
         model: &CompiledStaticAbility,
     ) -> Option<super::CostReductionManaCost> {
         match &model.payload {
-            ironsmith_core::StaticAbilityPayload::CostReductionManaCost(reduction) => Some(
-                super::CostReductionManaCost::new(reduction.filter.clone(), reduction.cost.clone()),
-            ),
+            ironsmith_core::StaticAbilityPayload::CostReductionManaCost(reduction) => {
+                let mut runtime = super::CostReductionManaCost::new(
+                    reduction.filter.clone(),
+                    reduction.cost.clone(),
+                );
+                runtime.optional_life_additional_cost =
+                    reduction.optional_life_additional_cost.clone();
+                Some(runtime)
+            }
             ironsmith_core::StaticAbilityPayload::Conditional { ability, condition } => {
                 Self::cached_cost_reduction_mana_cost(ability)
                     .map(|reduction| reduction.with_condition(condition.clone()))


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Defiler of Instinct
Initial parse error:
```
compiled text dropped required semantic marker: additional-cost
```

Current worker: i-0f063c7b341fac670
Branch: codex/aws-card-fix-defiler-of-instinct
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0037
