### PR TITLE
Fix Ironsmith parse failure: Mindleech Mass

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -180,6 +180,7 @@ fn compile_effect_inner(
     }
     if let EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
         player,
+        zone_owner,
         filter,
         zone,
         payment,
@@ -187,6 +188,10 @@ fn compile_effect_inner(
     {
         let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
         let player = resolve_non_target_player_filter(player.clone(), &current_reference_env(ctx))?;
+        let zone_owner = resolve_non_target_player_filter(
+            zone_owner.clone(),
+            &current_reference_env(ctx),
+        )?;
         return Ok((
             vec![Effect::new({
                 let mut effect =
@@ -194,7 +199,8 @@ fn compile_effect_inner(
                         player,
                         resolved_filter,
                         *zone,
-                    );
+                    )
+                    .with_zone_owner(zone_owner);
                 effect.payment = payment.clone();
                 effect
             })],
@@ -4724,15 +4730,29 @@ fn compile_subject_verb_effect(
             Ok((prelude, choices))
         }
         SubjectVerbActionAst::LookAtHand { target } => {
-            let (effects, choices) = compile_effect_for_target(target, ctx, |spec| {
-                Effect::new(crate::effects::LookAtHandEffect::new(spec))
-            })?;
-            if let TargetAst::Player(filter, _) | TargetAst::PlayerOrPlaneswalker(filter, _) =
-                target
-            {
-                ctx.last_player_filter = Some(PlayerFilter::Target(Box::new(filter.clone())));
+            let refs = current_reference_env(ctx);
+            let (spec, choices) = resolve_target_spec_with_choices(target, &refs)?;
+            let effect = tag_object_target_effect(
+                Effect::new(crate::effects::LookAtHandEffect::new(spec.clone())),
+                &spec,
+                ctx,
+                "targeted",
+            );
+            match spec.unhinted() {
+                ChooseSpec::Player(filter) | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+                    ctx.last_player_filter = Some(filter.clone());
+                }
+                ChooseSpec::Target(inner) => match inner.unhinted() {
+                    ChooseSpec::Player(filter) | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+                        ctx.last_player_filter = Some(PlayerFilter::Target(Box::new(
+                            filter.clone(),
+                        )));
+                    }
+                    _ => {}
+                },
+                _ => {}
             }
-            Ok((effects, choices))
+            Ok((vec![effect], choices))
         }
         SubjectVerbActionAst::Counter { target } => {
             compile_tagged_effect_for_target(target, ctx, "countered", Effect::counter)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -878,9 +878,16 @@ pub(crate) fn effect_references_its_controller(effect: &EffectAst) -> bool {
             )
         }
         EffectAst::ChooseObjects { player, .. }
-        | EffectAst::ChooseObjectsAcrossZones { player, .. }
-        | EffectAst::MayCastMatchingSpellWithoutPayingManaCost { player, .. } => {
+        | EffectAst::ChooseObjectsAcrossZones { player, .. } => {
             matches!(player, PlayerAst::ItsController | PlayerAst::ItsOwner)
+        }
+        EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+            player,
+            zone_owner,
+            ..
+        } => {
+            matches!(player, PlayerAst::ItsController | PlayerAst::ItsOwner)
+                || matches!(zone_owner, PlayerAst::ItsController | PlayerAst::ItsOwner)
         }
         EffectAst::MayByPlayer { player, effects } => {
             matches!(player, PlayerAst::ItsController | PlayerAst::ItsOwner)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -3271,6 +3271,7 @@ pub(crate) enum EffectAst {
     },
     MayCastMatchingSpellWithoutPayingManaCost {
         player: PlayerAst,
+        zone_owner: PlayerAst,
         filter: ObjectFilter,
         zone: Zone,
         payment: ironsmith_core::MayCastMatchingSpellPayment,
@@ -3724,6 +3725,22 @@ impl EffectAst {
     ) -> Self {
         Self::MayCastMatchingSpellWithoutPayingManaCost {
             player,
+            zone_owner: player,
+            filter,
+            zone,
+            payment: ironsmith_core::MayCastMatchingSpellPayment::WithoutPayingManaCost,
+        }
+    }
+
+    pub(crate) fn may_cast_matching_spell_without_paying_mana_cost_from_zone_owner(
+        player: PlayerAst,
+        zone_owner: PlayerAst,
+        filter: ObjectFilter,
+        zone: Zone,
+    ) -> Self {
+        Self::MayCastMatchingSpellWithoutPayingManaCost {
+            player,
+            zone_owner,
             filter,
             zone,
             payment: ironsmith_core::MayCastMatchingSpellPayment::WithoutPayingManaCost,
@@ -3738,6 +3755,7 @@ impl EffectAst {
     ) -> Self {
         Self::MayCastMatchingSpellWithoutPayingManaCost {
             player,
+            zone_owner: player,
             filter,
             zone,
             payment: ironsmith_core::MayCastMatchingSpellPayment::AlternativeCost(kind),

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -209,7 +209,14 @@ fn predicate_bound_player_filter(predicate: &PredicateAst) -> Option<PlayerFilte
 fn track_target_player(target: &TargetAst, frame: &mut ReferenceFrame) {
     match target {
         TargetAst::Player(filter, _) | TargetAst::PlayerOrPlaneswalker(filter, _) => {
-            frame.last_player_filter = Some(PlayerFilter::Target(Box::new(filter.clone())));
+            frame.last_player_filter = Some(if matches!(filter, PlayerFilter::IteratedPlayer) {
+                frame
+                    .last_player_filter
+                    .clone()
+                    .unwrap_or(PlayerFilter::IteratedPlayer)
+            } else {
+                PlayerFilter::Target(Box::new(filter.clone()))
+            });
         }
         TargetAst::Object(filter, _, _) => track_player_from_object_filter(filter, frame),
         _ => {}

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -534,6 +534,42 @@ fn parse_cast_any_number_from_among_tagged_clause(tokens: &[OwnedLexToken]) -> O
     })
 }
 
+fn parse_cast_single_spell_from_among_hand_cards_clause(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    let clause_word_view = ClauseDispatchCompatWords::new(tokens);
+    let clause_words = clause_word_view.to_word_refs();
+    let mut words = clause_words.as_slice();
+    if word_slice_starts_with(words, &["if", "you", "do"]) {
+        words = &words[3..];
+        if word_slice_first_is_any(words, &["then", "and"]) {
+            words = &words[1..];
+        }
+    }
+    let words = if word_slice_starts_with(words, &["you", "may"]) {
+        &words[2..]
+    } else {
+        words
+    };
+
+    if !word_slice_eq(
+        words,
+        &[
+            "cast", "a", "spell", "from", "among", "those", "cards", "without", "paying",
+            "its", "mana", "cost",
+        ],
+    ) {
+        return None;
+    }
+
+    Some(EffectAst::may_cast_matching_spell_without_paying_mana_cost_from_zone_owner(
+        PlayerAst::You,
+        PlayerAst::That,
+        ObjectFilter::nonland().in_zone(Zone::Hand),
+        Zone::Hand,
+    ))
+}
+
 pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
     if tokens.is_empty() {
         return Err(CardTextError::ParseError("empty effect clause".to_string()));
@@ -552,6 +588,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         }
 
         if let Some(effect) = parse_cast_any_number_from_among_tagged_clause(tokens) {
+            return Ok(effect);
+        }
+
+        if let Some(effect) = parse_cast_single_spell_from_among_hand_cards_clause(tokens) {
             return Ok(effect);
         }
     }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3034,6 +3034,7 @@ pub enum MayCastMatchingSpellPayment {
 #[derive(Debug, Clone, PartialEq)]
 pub struct MayCastMatchingSpellWithoutPayingManaCostEffect {
     pub player: PlayerFilter,
+    pub zone_owner: PlayerFilter,
     pub filter: ObjectFilter,
     pub zone: crate::Zone,
     pub payment: MayCastMatchingSpellPayment,
@@ -3042,11 +3043,17 @@ pub struct MayCastMatchingSpellWithoutPayingManaCostEffect {
 impl MayCastMatchingSpellWithoutPayingManaCostEffect {
     pub fn new(player: PlayerFilter, filter: ObjectFilter, zone: crate::Zone) -> Self {
         Self {
+            zone_owner: player.clone(),
             player,
             filter,
             zone,
             payment: MayCastMatchingSpellPayment::WithoutPayingManaCost,
         }
+    }
+
+    pub fn with_zone_owner(mut self, owner: PlayerFilter) -> Self {
+        self.zone_owner = owner;
+        self
     }
 
     pub fn with_alternative_cost(mut self, kind: AlternativeCastKind) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -51233,6 +51233,30 @@ fn villainous_wealth_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn mindleech_mass_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Mindleech Mass");
+
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("LookAtHandEffect")
+            && abilities_debug.contains("IfEffect")
+            && abilities_debug.contains("MayCastMatchingSpellWithoutPayingManaCostEffect")
+            && abilities_debug.contains("zone_owner: DamagedPlayer"),
+        "expected Mindleech Mass to lower to look-at-hand followed by a free cast from that player's hand, got {abilities_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert_eq!(def.card.name, "Mindleech Mass");
+    assert!(
+        rendered.contains("you may cast a spell from among those cards without paying its mana cost"),
+        "expected Mindleech Mass compiled text to preserve the hand free-cast clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn villainous_wealth_runtime_casts_only_exiled_nonland_spells_with_mana_value_at_most_x() {
     let def = parse_oracle_card_definition("Villainous Wealth");
     let spell = def

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33561,6 +33561,20 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             }
         }
 
+        if may_cast_matching.zone == Zone::Hand
+            && may_cast_matching.zone_owner != may_cast_matching.player
+            && may_cast_matching.filter
+                == crate::target::ObjectFilter::nonland().in_zone(Zone::Hand)
+            && matches!(
+                may_cast_matching.payment,
+                ironsmith_core::MayCastMatchingSpellPayment::WithoutPayingManaCost
+            )
+        {
+            return format!(
+                "{player} may cast a spell from among those cards without paying its mana cost"
+            );
+        }
+
         let mut spell_text = if let Some(kind) = may_cast_matching.filter.alternative_cast {
             format!("a spell with {}", alternative_cast_kind_text(kind))
         } else if !may_cast_matching.filter.card_types.is_empty() {
@@ -33594,10 +33608,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             spell_text = format!("a {spell_text}");
         }
         let zone_text = match may_cast_matching.zone {
-            Zone::Hand => format!(
-                "from {} hand",
-                describe_possessive_player_filter(&may_cast_matching.player)
-            ),
+            Zone::Hand => {
+                let owner = if may_cast_matching.zone_owner == may_cast_matching.player {
+                    &may_cast_matching.player
+                } else {
+                    &may_cast_matching.zone_owner
+                };
+                format!("from {} hand", describe_possessive_player_filter(owner))
+            }
             Zone::Graveyard => {
                 if may_cast_matching.filter.owner == Some(crate::filter::PlayerFilter::You) {
                     "from your graveyard".to_string()

--- a/crates/ironsmith-runtime/src/effects/player/may_cast_matching_spell.rs
+++ b/crates/ironsmith-runtime/src/effects/player/may_cast_matching_spell.rs
@@ -54,7 +54,8 @@ impl EffectExecutor for MayCastMatchingSpellWithoutPayingManaCostEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let player_id = resolve_player_filter(game, &self.player, ctx)?;
-        let object_ids = object_ids_in_zone(game, player_id, self.zone);
+        let zone_owner_id = resolve_player_filter(game, &self.zone_owner, ctx)?;
+        let object_ids = object_ids_in_zone(game, zone_owner_id, self.zone);
         let mut options = Vec::<EffectDrivenCastOption>::new();
         let payment = runtime_payment(&self.payment);
         for object_id in object_ids {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -21979,6 +21979,182 @@ fn test_fallen_shinobi_trigger_exiles_top_two_cards_and_grants_play_permission()
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn mindleech_mass_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(90_467), "Mindleech Mass")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .parse_text(
+            "Trample\nWhenever this creature deals combat damage to a player, you may look at that player's hand. If you do, you may cast a spell from among those cards without paying its mana cost.",
+        )
+        .expect("Mindleech Mass should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct MindleechMassDecisionMaker {
+    boolean_choices: Vec<bool>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for MindleechMassDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        if self.boolean_choices.is_empty() {
+            return false;
+        }
+        self.boolean_choices.remove(0)
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_mindleech_mass_damage_trigger(
+    game: &mut GameState,
+    definition: &crate::cards::CardDefinition,
+    source_id: ObjectId,
+    damaged_player: PlayerId,
+    dm: &mut dyn DecisionMaker,
+) {
+    let controller = game
+        .controller_of_id(source_id)
+        .expect("Mindleech Mass should have a controller");
+    let triggered = definition
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Mindleech Mass should have a combat damage trigger");
+
+    let damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            source_id,
+            crate::events::DamageTarget::Player(damaged_player),
+            6,
+            true,
+            crate::events::cause::EventCause::combat_damage(source_id),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = ExecutionContext::new_default(source_id, controller)
+        .with_decision_maker(dm)
+        .with_triggering_event(damage_event);
+    for effect in &triggered.effects {
+        execute_effect(game, effect, &mut ctx).expect("Mindleech Mass trigger should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mindleech_mass_casts_spell_from_damaged_players_hand_without_paying() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let definition = mindleech_mass_definition();
+    let mindleech_id = game.create_object_from_definition(&definition, alice, Zone::Battlefield);
+
+    let spell = CardBuilder::new(CardId::from_raw(90_468), "Mindleech Victim Spell")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    let land = CardBuilder::new(CardId::from_raw(90_469), "Mindleech Victim Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let _spell_id = game.create_object_from_card(&spell, bob, Zone::Hand);
+    let land_id = game.create_object_from_card(&land, bob, Zone::Hand);
+
+    let mut dm = MindleechMassDecisionMaker {
+        boolean_choices: vec![true, true, true],
+    };
+    resolve_mindleech_mass_damage_trigger(&mut game, &definition, mindleech_id, bob, &mut dm);
+
+    assert!(
+        dm.boolean_choices.is_empty(),
+        "Mindleech Mass should consume the look and free-cast choices"
+    );
+
+    let stack_entry = game
+        .stack
+        .last()
+        .expect("accepting Mindleech Mass should cast the spell from hand");
+    assert_eq!(stack_entry.controller, alice);
+    assert_eq!(stack_entry.casting_method, crate::alternative_cast::CastingMethod::Normal);
+    let stack_spell = game
+        .object(stack_entry.object_id)
+        .expect("cast spell should be on stack");
+    assert_eq!(stack_spell.name, "Mindleech Victim Spell");
+    assert_eq!(stack_spell.zone, Zone::Stack);
+    assert_eq!(stack_spell.owner, bob);
+    assert!(
+        game.object(land_id).is_some_and(|object| object.zone == Zone::Hand),
+        "Mindleech Mass should not offer lands as spells to cast"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mindleech_mass_declining_look_prevents_free_cast_branch() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let definition = mindleech_mass_definition();
+    let mindleech_id = game.create_object_from_definition(&definition, alice, Zone::Battlefield);
+
+    let spell = CardBuilder::new(CardId::from_raw(90_470), "Declined Mindleech Spell")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    let spell_id = game.create_object_from_card(&spell, bob, Zone::Hand);
+
+    let mut dm = MindleechMassDecisionMaker {
+        boolean_choices: vec![false],
+    };
+    resolve_mindleech_mass_damage_trigger(&mut game, &definition, mindleech_id, bob, &mut dm);
+
+    assert!(game.stack.is_empty(), "declining the look should skip the free-cast branch");
+    assert!(
+        game.object(spell_id).is_some_and(|object| object.zone == Zone::Hand),
+        "declining the look should leave the damaged player's spell in hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mindleech_mass_declining_free_cast_leaves_spell_in_hand() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let definition = mindleech_mass_definition();
+    let mindleech_id = game.create_object_from_definition(&definition, alice, Zone::Battlefield);
+
+    let spell = CardBuilder::new(CardId::from_raw(90_471), "Uncast Mindleech Spell")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    let spell_id = game.create_object_from_card(&spell, bob, Zone::Hand);
+
+    let mut dm = MindleechMassDecisionMaker {
+        boolean_choices: vec![true, false],
+    };
+    resolve_mindleech_mass_damage_trigger(&mut game, &definition, mindleech_id, bob, &mut dm);
+
+    assert!(game.stack.is_empty(), "declining the free cast should not cast a spell");
+    assert!(
+        game.object(spell_id).is_some_and(|object| object.zone == Zone::Hand),
+        "declining the free cast should leave the damaged player's spell in hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn riveteers_charm_mode_one_limits_sacrifice_to_greatest_mana_value_ties() {
     struct ChooseSacrificeFromGreatestTie {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mindleech Mass
Initial parse error:
```
could not find verb in effect clause (clause: 'cast a spell from among those cards without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast a spell from among those cards without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0c9ce7711f0ab4bca
Branch: codex/aws-card-fix-mindleech-mass
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0037
