### PR TITLE
Fix Ironsmith parse failure: Ghastly Conscription

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
@@ -284,6 +284,14 @@ pub(crate) fn has_face_down_clause_sentence_lexed(
         return false;
     }
 
+    let supported_exile_pile_manifest = words.first() == Some(&"exile")
+        && word_slice_contains_phrase(words, &["in", "a", "face", "down", "pile"])
+        && word_slice_contains_phrase(words, &["shuffle", "that", "pile"])
+        && word_slice_contains_phrase(words, &["then", "manifest", "those", "cards"]);
+    if supported_exile_pile_manifest {
+        return false;
+    }
+
     let simple_exile_face_down = primitives::words_match_any_prefix(tokens, EXILE_PREFIXES)
         .is_some()
         && !primitives::contains_word(tokens, "then")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2336,6 +2336,7 @@ fn compile_subject_verb_effect(
             battlefield_controller,
             battlefield_tapped,
             battlefield_attacking,
+            battlefield_manifested,
             attached_to,
         } => {
             let (mut spec, mut choices) =
@@ -2401,6 +2402,11 @@ fn compile_subject_verb_effect(
                 } else {
                     move_effect
                 };
+                let move_effect = if *zone == Zone::Battlefield && *battlefield_manifested {
+                    move_effect.manifested()
+                } else {
+                    move_effect
+                };
                 let move_effect = match battlefield_controller {
                     ReturnControllerAst::Preserve => move_effect,
                     ReturnControllerAst::Owner => move_effect.under_owner_control(),
@@ -2457,6 +2463,11 @@ fn compile_subject_verb_effect(
             };
             let move_effect = if *zone == Zone::Battlefield && *battlefield_attacking {
                 move_effect.attacking()
+            } else {
+                move_effect
+            };
+            let move_effect = if *zone == Zone::Battlefield && *battlefield_manifested {
+                move_effect.manifested()
             } else {
                 move_effect
             };

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1098,6 +1098,7 @@ pub(crate) enum SubjectVerbActionAst {
         battlefield_controller: ReturnControllerAst,
         battlefield_tapped: bool,
         battlefield_attacking: bool,
+        battlefield_manifested: bool,
         attached_to: Option<TargetAst>,
     },
     MoveToLibraryTopOrBottomChoice {
@@ -2346,6 +2347,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 battlefield_controller,
                 battlefield_tapped,
                 battlefield_attacking,
+                battlefield_manifested,
                 attached_to,
             } => f
                 .debug_struct("MoveToZone")
@@ -2355,6 +2357,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("battlefield_controller", battlefield_controller)
                 .field("battlefield_tapped", battlefield_tapped)
                 .field("battlefield_attacking", battlefield_attacking)
+                .field("battlefield_manifested", battlefield_manifested)
                 .field("attached_to", attached_to)
                 .finish(),
             Self::MoveToLibraryTopOrBottomChoice { target } => f
@@ -3932,6 +3935,44 @@ impl EffectAst {
         battlefield_attacking: bool,
         attached_to: Option<TargetAst>,
     ) -> Self {
+        Self::subject_verb_move_to_zone_with_battlefield_flags(
+            target,
+            zone,
+            to_top,
+            battlefield_controller,
+            battlefield_tapped,
+            battlefield_attacking,
+            false,
+            attached_to,
+        )
+    }
+
+    pub(crate) fn subject_verb_move_to_zone_manifested(
+        target: TargetAst,
+        battlefield_controller: ReturnControllerAst,
+    ) -> Self {
+        Self::subject_verb_move_to_zone_with_battlefield_flags(
+            target,
+            Zone::Battlefield,
+            false,
+            battlefield_controller,
+            false,
+            false,
+            true,
+            None,
+        )
+    }
+
+    pub(crate) fn subject_verb_move_to_zone_with_battlefield_flags(
+        target: TargetAst,
+        zone: Zone,
+        to_top: bool,
+        battlefield_controller: ReturnControllerAst,
+        battlefield_tapped: bool,
+        battlefield_attacking: bool,
+        battlefield_manifested: bool,
+        attached_to: Option<TargetAst>,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
@@ -3942,6 +3983,7 @@ impl EffectAst {
                 battlefield_controller,
                 battlefield_tapped,
                 battlefield_attacking,
+                battlefield_manifested,
                 attached_to,
             },
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -19,6 +19,7 @@ use super::super::lexer::{
     word_slice_starts_with_at,
 };
 use super::super::object_filters::parse_object_filter;
+use super::super::object_filters::parse_object_filter_lexed;
 use super::super::permission_helpers::{
     PermissionClauseSpec, PermissionLifetime, parse_additional_land_plays_clause_lexed,
     parse_cast_or_play_tagged_clause, parse_permission_clause_spec_lexed,
@@ -52,8 +53,8 @@ use super::{
 };
 #[allow(unused_imports)]
 use crate::cards::builders::{
-    CardTextError, EffectAst, IT_TAG, PlayerAst, PredicateAst, SubjectVerbActionAst,
-    SubjectVerbEffectAst, SubjectVerbSubjectAst, TagKey, TargetAst, TextSpan,
+    CardTextError, EffectAst, IT_TAG, PlayerAst, PredicateAst, ReturnControllerAst,
+    SubjectVerbActionAst, SubjectVerbEffectAst, SubjectVerbSubjectAst, TagKey, TargetAst, TextSpan,
 };
 use crate::effect::{ChoiceCount, Until, Value};
 use crate::target::{ObjectFilter, PlayerFilter, TaggedOpbjectRelation};
@@ -318,6 +319,62 @@ fn parse_exile_library_then_shuffle_graveyard_chain_lexed(
     ]))
 }
 
+fn parse_exile_face_down_pile_then_manifest_chain_lexed(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let clause_tokens = trim_lexed_commas(tokens);
+    if grammar::words_match_prefix(clause_tokens, &["exile", "all"]).is_none() {
+        return Ok(None);
+    }
+
+    let clause_words = token_word_refs(clause_tokens);
+    let Some(in_pile_idx) = word_slice_find_phrase_start(
+        &clause_words,
+        &["in", "a", "face", "down", "pile"],
+    )
+    .or_else(|| word_slice_find_phrase_start(&clause_words, &["in", "a", "face-down", "pile"]))
+    .or_else(|| word_slice_find_phrase_start(&clause_words, &["in", "a", "facedown", "pile"]))
+    else {
+        return Ok(None);
+    };
+    if in_pile_idx <= 2 {
+        return Ok(None);
+    }
+
+    let pile_tail_start = in_pile_idx
+        + if word_slice_starts_with_at(
+            &clause_words,
+            in_pile_idx,
+            &["in", "a", "face", "down", "pile"],
+        ) {
+            5
+        } else {
+            4
+        };
+    if !word_slice_eq(
+        &clause_words[pile_tail_start..],
+        &["shuffle", "that", "pile", "then", "manifest", "those", "cards"],
+    ) {
+        return Ok(None);
+    }
+
+    let filter = parse_object_filter_lexed(&clause_tokens[2..in_pile_idx], false)?;
+    if filter.zone != Some(Zone::Graveyard) {
+        return Ok(None);
+    }
+    let it_tag = TagKey::from(IT_TAG);
+    Ok(Some(vec![
+        EffectAst::subject_verb_exile_all(filter, true),
+        EffectAst::ForEachTagged {
+            tag: it_tag.clone(),
+            effects: vec![EffectAst::subject_verb_move_to_zone_manifested(
+                TargetAst::Tagged(it_tag, None),
+                ReturnControllerAst::You,
+            )],
+        },
+    ]))
+}
+
 pub(crate) fn looks_like_multi_create_chain_lexed(tokens: &[OwnedLexToken]) -> bool {
     matches!(find_verb_lexed(tokens), Some((Verb::Create, _)))
         && token_word_refs(tokens)
@@ -341,6 +398,9 @@ pub(crate) fn parse_effect_chain_lexed(
     }
 
     if let Some(effects) = parse_exile_library_then_shuffle_graveyard_chain_lexed(tokens)? {
+        return Ok(effects);
+    }
+    if let Some(effects) = parse_exile_face_down_pile_then_manifest_chain_lexed(tokens)? {
         return Ok(effects);
     }
     if let Some(effects) =

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1369,6 +1369,7 @@ pub struct MoveToZoneEffect {
     pub battlefield_controller: BattlefieldController,
     pub enters_tapped: bool,
     pub enters_attacking: bool,
+    pub enters_manifested: bool,
     pub transfer_exiled_with_source_links: bool,
 }
 
@@ -1381,6 +1382,7 @@ impl MoveToZoneEffect {
             battlefield_controller: BattlefieldController::Preserve,
             enters_tapped: false,
             enters_attacking: false,
+            enters_manifested: false,
             transfer_exiled_with_source_links: false,
         }
     }
@@ -1423,6 +1425,11 @@ impl MoveToZoneEffect {
 
     pub fn attacking(mut self) -> Self {
         self.enters_attacking = true;
+        self
+    }
+
+    pub fn manifested(mut self) -> Self {
+        self.enters_manifested = true;
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -16412,17 +16412,129 @@ fn parse_protection_from_spells_that_are_one_or_more_colors() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn parse_exile_face_down_manifest_tail_fails_instead_of_partial_exile() {
-    let err = CardDefinitionBuilder::new(CardId::new(), "Ghastly Conscription Variant")
-        .parse_text(
-            "Exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards.",
-        )
-        .expect_err("face-down/manifest exile tail should fail loudly when unsupported");
-    let message = format!("{err:?}");
+fn ghastly_conscription_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Ghastly Conscription");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
     assert!(
-        message.contains("unsupported face-down/manifest exile clause")
-            || message.contains("unsupported face-down clause"),
-        "expected actionable face-down/manifest parse error, got {message}"
+        rendered.contains(
+            "exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards"
+        ),
+        "expected Ghastly Conscription face-down pile manifest clause, got {rendered}"
+    );
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("ExileEffect")
+            && debug.contains("face_down: true")
+            && debug.contains("ForEachTaggedEffect")
+            && debug.contains("enters_manifested: true"),
+        "expected tagged face-down exile followed by manifested battlefield move, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn ghastly_conscription_manifests_only_target_players_creature_cards_runtime() {
+    let def = parse_oracle_card_definition("Ghastly Conscription");
+    let spell_effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Ghastly Conscription spell effects");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    let creature_def = |name: &str| {
+        CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build()
+    };
+    let bear = creature_def("Bob Bear");
+    let zombie = creature_def("Bob Zombie");
+    let artifact = CardDefinitionBuilder::new(CardId::new(), "Bob Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let alice_creature = creature_def("Alice Graveyard Creature");
+    game.create_object_from_definition(&bear, bob, Zone::Graveyard);
+    game.create_object_from_definition(&zombie, bob, Zone::Graveyard);
+    let artifact_id = game.create_object_from_definition(&artifact, bob, Zone::Graveyard);
+    let alice_graveyard_id =
+        game.create_object_from_definition(&alice_creature, alice, Zone::Graveyard);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source_id, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    let mut events = Vec::new();
+    for effect in spell_effects {
+        let outcome = crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Ghastly Conscription effect should resolve");
+        events.extend(outcome.events);
+    }
+
+    let manifested = game
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.owner == bob && game.is_manifested(*id))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        manifested.len(),
+        2,
+        "both target player's creature cards should be manifested"
+    );
+    for id in manifested {
+        let object = game.object(id).expect("manifested permanent should exist");
+        assert_eq!(object.owner, bob, "manifest keeps the card owner");
+        assert_eq!(
+            game.controller_of(object),
+            alice,
+            "spell controller should control manifested cards"
+        );
+        assert!(game.is_face_down(id), "manifested card should be face down");
+        assert!(game.is_manifested(id), "manifested card should be marked as manifested");
+        assert_eq!(game.calculated_power(id), Some(2));
+        assert_eq!(game.calculated_toughness(id), Some(2));
+    }
+    assert!(
+        game.object(artifact_id).is_some_and(|object| object.zone == Zone::Graveyard),
+        "target player's noncreature card should stay in their graveyard"
+    );
+    assert!(
+        game.object(alice_graveyard_id)
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "non-target player's creature card should stay in their graveyard"
+    );
+    let manifest_events = events
+        .iter()
+        .filter_map(|event| {
+            (event.kind() == crate::events::EventKind::KeywordAction)
+                .then(|| {
+                    event
+                        .inner()
+                        .as_any()
+                        .downcast_ref::<crate::events::KeywordActionEvent>()
+                })
+                .flatten()
+        })
+        .filter(|event| event.action == crate::events::KeywordActionKind::Manifest)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        manifest_events.iter().map(|event| event.amount).sum::<u32>(),
+        2,
+        "Ghastly Conscription should emit manifest keyword actions for manifested cards"
+    );
+    assert!(
+        manifest_events.iter().all(|event| event.player == alice),
+        "spell controller should perform the manifest keyword action"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3527,6 +3527,66 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         None
     }
 
+    fn describe_exile_face_down_pile_then_manifest(effects: &[Effect]) -> Option<String> {
+        let effects = if let [target_only, rest @ ..] = effects
+            && target_only
+                .downcast_ref::<crate::effects::TargetOnlyEffect>()
+                .is_some()
+        {
+            rest
+        } else {
+            effects
+        };
+        let [exile_effect, for_each_effect] = effects else {
+            return None;
+        };
+        let exile_tag = effect_tag(exile_effect)?;
+        let exile = unwrap_wrapped_effect(exile_effect)
+            .downcast_ref::<crate::effects::ExileEffect>()?;
+        if !exile.face_down {
+            return None;
+        }
+        let crate::target::ChooseSpec::All(filter) = &exile.spec else {
+            return None;
+        };
+        if filter.zone != Some(Zone::Graveyard) {
+            return None;
+        }
+        let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachTaggedEffect>()?;
+        if &for_each.tag != exile_tag || for_each.effects.len() != 1 {
+            return None;
+        }
+        let move_to_zone = unwrap_wrapped_effect(&for_each.effects[0])
+            .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+        if move_to_zone.zone != Zone::Battlefield
+            || move_to_zone.battlefield_controller != crate::effects::BattlefieldController::You
+            || move_to_zone.enters_tapped
+            || move_to_zone.enters_attacking
+            || !move_to_zone.enters_manifested
+        {
+            return None;
+        }
+        if !matches!(move_to_zone.target.base(), ChooseSpec::Iterated)
+            && !matches!(move_to_zone.target.base(), ChooseSpec::Tagged(tag) if tag == exile_tag)
+        {
+            return None;
+        }
+
+        let mut target = describe_choose_spec(&exile.spec);
+        target = target
+            .replace(" in target player's graveyard", " from target player's graveyard")
+            .replace(" in target opponent's graveyard", " from target opponent's graveyard")
+            .replace(" in your graveyard", " from your graveyard")
+            .replace(" in their graveyard", " from their graveyard");
+        Some(format!(
+            "Exile {target} in a face-down pile, shuffle that pile, then manifest those cards"
+        ))
+    }
+
+    if let Some(compact) = describe_exile_face_down_pile_then_manifest(effects) {
+        return compact;
+    }
+
     fn tagged_apply_continuous(effect: &Effect) -> Option<&crate::effects::ApplyContinuousEffect> {
         unwrap_wrapped_effect(effect).downcast_ref::<crate::effects::ApplyContinuousEffect>()
     }
@@ -28363,6 +28423,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 } else {
                     ""
                 };
+                let manifested_suffix = if move_to_zone.enters_manifested {
+                    " face down as a 2/2 creature"
+                } else {
+                    ""
+                };
                 let controller_suffix = match move_to_zone.battlefield_controller {
                     crate::effects::BattlefieldController::Preserve => "",
                     crate::effects::BattlefieldController::Owner => owner_control_suffix,
@@ -28373,9 +28438,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                         || tag.as_str().starts_with("exiled_")
                         || crate::cards::is_sentence_helper_tag(tag.as_str(), "exiled"))
                 {
-                    format!("Return {target} to the battlefield{tapped_suffix}{attacking_suffix}{controller_suffix}")
+                    format!("Return {target} to the battlefield{tapped_suffix}{attacking_suffix}{manifested_suffix}{controller_suffix}")
                 } else {
-                    format!("Put {target} onto the battlefield{tapped_suffix}{attacking_suffix}{controller_suffix}")
+                    format!("Put {target} onto the battlefield{tapped_suffix}{attacking_suffix}{manifested_suffix}{controller_suffix}")
                 }
             }
             Zone::Stack => format!("Put {target} on the stack"),

--- a/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
@@ -5,6 +5,7 @@ use crate::combat_state::{AttackTarget, AttackerInfo, CombatState};
 use crate::effects::helpers::{resolve_objects_for_effect, resolve_tagged_object_id};
 use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
 use crate::effects::{ExecutionContext, ExecutionError};
+use crate::events::{KeywordActionEvent, KeywordActionKind};
 use crate::events::processing::{EventOutcome, process_zone_change_with_additional_effects};
 use crate::filter::FilterContext;
 use crate::filter::ObjectFilterExt as _;
@@ -202,6 +203,7 @@ impl EffectExecutor for MoveToZoneEffect {
         let mut any_prevented = false;
         let mut any_replaced = false;
         let mut moved_source_lki = None;
+        let mut manifested_count = 0;
 
         for object_id in object_ids {
             let Some(obj) = game.object(object_id) else {
@@ -222,6 +224,11 @@ impl EffectExecutor for MoveToZoneEffect {
                 crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
                     obj, game,
                 );
+            if self.enters_manifested && self.zone == Zone::Battlefield {
+                if let Some(object) = game.object_mut(object_id) {
+                    object.apply_face_down_cast_overlay();
+                }
+            }
             let additional_effects = ctx.additional_replacement_effects_snapshot();
 
             // Process through replacement effects with decision maker
@@ -237,6 +244,11 @@ impl EffectExecutor for MoveToZoneEffect {
 
             match result {
                 EventOutcome::Prevented => {
+                    if self.enters_manifested && self.zone == Zone::Battlefield {
+                        if let Some(object) = game.object_mut(object_id) {
+                            object.end_face_down_cast_overlay();
+                        }
+                    }
                     return Ok(EffectOutcome::prevented());
                 }
                 EventOutcome::Proceed(final_zone) => {
@@ -255,6 +267,11 @@ impl EffectExecutor for MoveToZoneEffect {
                         };
                         match move_to_battlefield_with_options(game, ctx, object_id, options) {
                             BattlefieldEntryOutcome::Moved(new_id) => {
+                                if self.enters_manifested {
+                                    game.set_face_down(new_id);
+                                    game.set_manifested(new_id);
+                                    manifested_count += 1;
+                                }
                                 if self.enters_attacking
                                     && let Some(target) =
                                         choose_enters_attacking_target(game, ctx, new_id)
@@ -275,10 +292,21 @@ impl EffectExecutor for MoveToZoneEffect {
                                 moved_ids.push(new_id);
                             }
                             BattlefieldEntryOutcome::Prevented => {
+                                if self.enters_manifested {
+                                    if let Some(object) = game.object_mut(object_id) {
+                                        object.end_face_down_cast_overlay();
+                                    }
+                                }
                                 any_prevented = true;
                             }
                         }
                         continue;
+                    }
+
+                    if self.enters_manifested {
+                        if let Some(object) = game.object_mut(object_id) {
+                            object.end_face_down_cast_overlay();
+                        }
                     }
 
                     let mut result =
@@ -334,6 +362,14 @@ impl EffectExecutor for MoveToZoneEffect {
                     continue;
                 }
                 EventOutcome::Replaced => {
+                    if self.enters_manifested {
+                        if let Some(object) = game
+                            .find_object_by_stable_id(stable_id)
+                            .and_then(|id| game.object_mut(id))
+                        {
+                            object.end_face_down_cast_overlay();
+                        }
+                    }
                     any_replaced = true;
                     if let Some(result) = take_recorded_zone_change(game, object_id) {
                         affected_ids.extend(result.new_object_ids);
@@ -361,6 +397,17 @@ impl EffectExecutor for MoveToZoneEffect {
         if !moved_ids.is_empty() {
             let mut outcome =
                 EffectOutcome::with_objects(moved_ids).with_affected_objects(affected_ids);
+            if manifested_count > 0 {
+                outcome = outcome.with_event(crate::triggers::TriggerEvent::new_with_provenance(
+                    KeywordActionEvent::new(
+                        KeywordActionKind::Manifest,
+                        ctx.controller,
+                        ctx.source,
+                        manifested_count,
+                    ),
+                    ctx.provenance,
+                ));
+            }
             if !affected_memory.is_empty() {
                 outcome = outcome.with_affected_object_memory(affected_memory);
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ghastly Conscription
Initial parse error:
```
unsupported face-down clause (clause: 'exile all creature cards from target players graveyard in a face down pile shuffle that pile then manifest those cards') [rule=face-down]; oracle-only fallback also failed: unsupported face-down clause (clause: 'exile all creature cards from target players graveyard in a face down pile shuffle that pile then manifest those cards') [rule=face-down]
```

Current worker: i-03018ef21fda77a9c
Branch: codex/aws-card-fix-ghastly-conscription
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0037
