### PR TITLE
Fix Ironsmith parse failure: Selfless Squire

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -708,6 +708,16 @@ pub(crate) fn parse_trigger_clause_lexed(
         return Ok(spell_activity_trigger);
     }
 
+    if words.len() >= 9
+        && word_slice_starts_with(&words, &["damage", "that", "would", "be", "dealt", "to"])
+        && word_slice_ends_with(&words, &["is", "prevented"])
+    {
+        let target_words = &words[6..words.len() - 2];
+        if let Some(player) = parse_trigger_subject_player_filter(target_words) {
+            return Ok(TriggerSpec::DamagePreventedToPlayer(player));
+        }
+    }
+
     if let Some(play_idx) = find_index(tokens, |token| {
         token.is_word("play") || token.is_word("plays")
     }) {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -133,6 +133,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::IsDealtCombatDamage(filter) => {
             Trigger::is_dealt_combat_damage(ChooseSpec::Object(filter))
         }
+        TriggerSpec::DamagePreventedToPlayer(player) => Trigger::damage_prevented_to_player(player),
         TriggerSpec::YouGainLife => Trigger::you_gain_life(),
         TriggerSpec::YouGainLifeDuringTurn(during_turn) => {
             Trigger::you_gain_life_during_turn(during_turn)
@@ -542,6 +543,7 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
         | TriggerSpec::ThisDealsCombatDamageToPlayer
         | TriggerSpec::DealsCombatDamageToPlayer { .. } => Some(PlayerFilter::DamagedPlayer),
+        TriggerSpec::DamagePreventedToPlayer(player) => Some(player.clone()),
         TriggerSpec::ThisAttacks | TriggerSpec::ThisBecomesBlocked => Some(PlayerFilter::Defending),
         TriggerSpec::Attacks(filter) | TriggerSpec::AttacksOneOrMore(filter)
             if filter
@@ -623,6 +625,7 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             | TriggerSpec::ThisDealsCombatDamageToPlayer
             | TriggerSpec::DealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { .. }
+            | TriggerSpec::DamagePreventedToPlayer(_)
             | TriggerSpec::AttacksOneOrMore(_)
             | TriggerSpec::AttacksOneOrMoreWithMinTotal { .. }
             | TriggerSpec::AttacksYouOrPlaneswalkerYouControlOneOrMore(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -198,6 +198,7 @@ pub(crate) enum TriggerSpec {
     ThisIsDealtCombatDamage,
     IsDealtDamage(ObjectFilter),
     IsDealtCombatDamage(ObjectFilter),
+    DamagePreventedToPlayer(PlayerFilter),
     YouGainLife,
     YouGainLifeDuringTurn(PlayerFilter),
     PlayerLosesLife(PlayerFilter),

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -171,6 +171,9 @@ pub enum TriggerKind {
         target: ChooseSpec,
         combat_only: bool,
     },
+    DamagePreventedToPlayer {
+        player: PlayerFilter,
+    },
     YouGainLife,
     YouGainLifeDuringTurn {
         during_turn: PlayerFilter,
@@ -698,6 +701,12 @@ impl Trigger {
                 target,
                 combat_only: true,
             },
+        )
+    }
+    pub fn damage_prevented_to_player(player: PlayerFilter) -> Self {
+        Self::typed(
+            "damage_prevented_to_player",
+            TriggerKind::DamagePreventedToPlayer { player },
         )
     }
     pub fn you_gain_life() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17695,6 +17695,144 @@ fn healing_grace_runtime_only_protects_chosen_target() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn selfless_squire_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Selfless Squire");
+    let def = parse_oracle_card_definition("Selfless Squire");
+    assert_eq!(
+        unprocessed_compiled_lines(&def),
+        vec![
+            "Flash".to_string(),
+            "When this creature enters, prevent all damage that would be dealt to you this turn."
+                .to_string(),
+            "Whenever damage that would be dealt to you is prevented, put that many +1/+1 counters on this creature."
+                .to_string(),
+        ],
+        "expected Selfless Squire oracle wording to survive compilation"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn selfless_squire_prevents_damage_to_you_and_adds_prevented_amount_counters() {
+    let squire = parse_oracle_card_definition("Selfless Squire");
+    let etb_effects = squire
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered
+                .trigger
+                .display()
+                .to_ascii_lowercase()
+                .contains("enters")
+                .then(|| triggered.effects.clone()),
+            _ => None,
+        })
+        .expect("Selfless Squire should have an ETB prevention trigger");
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let squire_id = game.create_object_from_definition(&squire, alice, Zone::Battlefield);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_300), "Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+
+    let (unprevented_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        unprevented_damage, 3,
+        "damage before the ETB shield should not be prevented"
+    );
+    assert!(
+        trigger_queue.is_empty(),
+        "unprevented damage should not queue Selfless Squire's prevention trigger"
+    );
+    assert_eq!(
+        game.counter_count(squire_id, CounterType::PlusOnePlusOne),
+        0,
+        "Selfless Squire should not get counters without prevented damage"
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(squire_id, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        squire_id,
+        &etb_effects,
+        None,
+        &[],
+    )
+    .expect("Selfless Squire ETB prevention trigger should resolve");
+
+    let (damage_to_bob, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(bob),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        damage_to_bob, 4,
+        "Selfless Squire should only protect its controller"
+    );
+    assert!(
+        trigger_queue.is_empty(),
+        "damage to another player should not queue Selfless Squire's prevention trigger"
+    );
+
+    let (prevented_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(alice),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        prevented_damage, 0,
+        "Selfless Squire should prevent damage to you"
+    );
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "prevented damage to you should queue Selfless Squire's trigger"
+    );
+
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Selfless Squire trigger should be put on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Selfless Squire counter trigger should resolve");
+    assert_eq!(
+        game.counter_count(squire_id, CounterType::PlusOnePlusOne),
+        4,
+        "Selfless Squire should get counters equal to the prevented damage"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_oracle_cho_arrim_alchemist_strict_text_and_activation_shape() {
     assert_oracle_card_parses_strict("Cho-Arrim Alchemist");
     let def = parse_oracle_card_definition("Cho-Arrim Alchemist");

--- a/crates/ironsmith-runtime/src/events/damage/damage_prevented_event.rs
+++ b/crates/ironsmith-runtime/src/events/damage/damage_prevented_event.rs
@@ -1,0 +1,89 @@
+//! Damage-prevention event implementation.
+
+use std::any::Any;
+
+use crate::events::DamageTarget;
+use crate::events::cause::EventCause;
+use crate::events::traits::{EventKind, GameEventType};
+use crate::game_state::GameState;
+use crate::ids::{ObjectId, PlayerId};
+
+/// Event emitted after a prevention effect actually prevents damage.
+#[derive(Debug, Clone)]
+pub struct DamagePreventedEvent {
+    /// The source whose damage was prevented.
+    pub source: ObjectId,
+    /// The target the damage would have been dealt to.
+    pub target: DamageTarget,
+    /// Amount of damage actually prevented.
+    pub amount: u32,
+    /// Whether the prevented damage was combat damage.
+    pub is_combat: bool,
+    /// What caused the original damage event.
+    pub cause: EventCause,
+}
+
+impl DamagePreventedEvent {
+    pub fn with_cause(
+        source: ObjectId,
+        target: DamageTarget,
+        amount: u32,
+        is_combat: bool,
+        cause: EventCause,
+    ) -> Self {
+        Self {
+            source,
+            target,
+            amount,
+            is_combat,
+            cause,
+        }
+    }
+}
+
+impl GameEventType for DamagePreventedEvent {
+    fn event_kind(&self) -> EventKind {
+        EventKind::DamagePrevented
+    }
+
+    fn object_id(&self) -> Option<ObjectId> {
+        Some(self.source)
+    }
+
+    fn affected_player(&self, game: &GameState) -> PlayerId {
+        match self.target {
+            DamageTarget::Player(player) => player,
+            DamageTarget::Object(obj_id) => game
+                .object(obj_id)
+                .map(|o| game.controller_of(o))
+                .unwrap_or(game.turn.active_player),
+        }
+    }
+
+    fn source_object(&self) -> Option<ObjectId> {
+        Some(self.source)
+    }
+
+    fn player(&self) -> Option<PlayerId> {
+        match self.target {
+            DamageTarget::Player(player) => Some(player),
+            DamageTarget::Object(_) => None,
+        }
+    }
+
+    fn display(&self) -> String {
+        let target_str = match self.target {
+            DamageTarget::Player(_) => "player",
+            DamageTarget::Object(_) => "permanent",
+        };
+        let combat_str = if self.is_combat { "combat " } else { "" };
+        format!(
+            "Prevent {} {}damage to {}",
+            self.amount, combat_str, target_str
+        )
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/ironsmith-runtime/src/events/damage/mod.rs
+++ b/crates/ironsmith-runtime/src/events/damage/mod.rs
@@ -1,6 +1,8 @@
 //! Damage events and matchers.
 
 mod damage_event;
+mod damage_prevented_event;
 pub mod matchers;
 
 pub use damage_event::DamageEvent;
+pub use damage_prevented_event::DamagePreventedEvent;

--- a/crates/ironsmith-runtime/src/events/mod.rs
+++ b/crates/ironsmith-runtime/src/events/mod.rs
@@ -93,7 +93,7 @@ pub use traits::{
 // Re-export event types
 pub use cards::{DiscardEvent, DrawEvent};
 pub use counters::{MoveCountersEvent, PutCountersEvent, RemoveCountersEvent};
-pub use damage::DamageEvent;
+pub use damage::{DamageEvent, DamagePreventedEvent};
 pub use life::{LifeGainEvent, LifeLossEvent};
 pub use mana::ManaAddedEvent;
 pub use permanents::{DestroyEvent, SacrificeEvent, TapEvent, UntapEvent};

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2419,15 +2419,26 @@ fn apply_prevention_for_damage_assignment(
         }
     };
 
+    let prevented_amount = amount.saturating_sub(result.remaining);
+    if can_prevent && prevented_amount > 0 {
+        game.queue_trigger_event(
+            provenance,
+            crate::events::RawEvent::new(
+                crate::events::DamagePreventedEvent::with_cause(
+                    source,
+                    target,
+                    prevented_amount,
+                    is_combat,
+                    cause.clone(),
+                ),
+                provenance,
+            ),
+        );
+    }
+
     if can_prevent && !result.follow_ups.is_empty() {
         let prevented_event = crate::events::RawEvent::new(
-            DamageEvent::with_cause(
-                source,
-                target,
-                amount - result.remaining,
-                is_combat,
-                cause.clone(),
-            ),
+            DamageEvent::with_cause(source, target, prevented_amount, is_combat, cause.clone()),
             provenance,
         );
         for follow_up in result.follow_ups {

--- a/crates/ironsmith-runtime/src/events/traits.rs
+++ b/crates/ironsmith-runtime/src/events/traits.rs
@@ -19,6 +19,8 @@ use super::context::EventContext;
 pub enum EventKind {
     /// Damage being dealt
     Damage,
+    /// Damage was prevented
+    DamagePrevented,
     /// Object changing zones
     ZoneChange,
     /// Player drawing cards

--- a/crates/ironsmith-runtime/src/triggers/life_damage/damage_prevented.rs
+++ b/crates/ironsmith-runtime/src/triggers/life_damage/damage_prevented.rs
@@ -1,0 +1,47 @@
+//! "Whenever damage that would be dealt to [player] is prevented" triggers.
+
+use crate::events::{DamagePreventedEvent, DamageTarget, EventKind};
+use crate::filter::PlayerFilterExt;
+use crate::target::PlayerFilter;
+use crate::triggers::TriggerEvent;
+use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DamagePreventedTrigger {
+    pub player: PlayerFilter,
+}
+
+impl DamagePreventedTrigger {
+    pub fn new(player: PlayerFilter) -> Self {
+        Self { player }
+    }
+}
+
+impl TriggerMatcher for DamagePreventedTrigger {
+    fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
+        if event.kind() != EventKind::DamagePrevented {
+            return false;
+        }
+        let Some(e) = event.downcast::<DamagePreventedEvent>() else {
+            return false;
+        };
+        match e.target {
+            DamageTarget::Player(player_id) => {
+                self.player.matches_player(player_id, &ctx.filter_ctx)
+            }
+            DamageTarget::Object(_) => false,
+        }
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "Whenever damage that would be dealt to {} is prevented",
+            self.player.description()
+        )
+    }
+
+    fn event_value_amount(&self, event: &TriggerEvent, _ctx: &TriggerContext) -> Option<i32> {
+        let e = event.downcast::<DamagePreventedEvent>()?;
+        Some(e.amount as i32)
+    }
+}

--- a/crates/ironsmith-runtime/src/triggers/life_damage/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/life_damage/mod.rs
@@ -1,10 +1,12 @@
 //! Life and damage triggers.
 
+mod damage_prevented;
 mod is_dealt_damage;
 mod player_loses_life;
 mod you_gain_life;
 mod you_lose_life;
 
+pub use damage_prevented::DamagePreventedTrigger;
 pub use is_dealt_damage::IsDealtDamageTrigger;
 pub use player_loses_life::PlayerLosesLifeTrigger;
 pub use you_gain_life::YouGainLifeTrigger;

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -657,6 +657,11 @@ impl Trigger {
         Self::new(IsDealtDamageTrigger::combat_only(target))
     }
 
+    /// Create a "when damage that would be dealt to [player] is prevented" trigger.
+    pub fn damage_prevented_to_player(player: PlayerFilter) -> Self {
+        Self::new(DamagePreventedTrigger::new(player))
+    }
+
     // === Spell/Ability Triggers ===
 
     /// Create a "when [player] casts a spell" trigger.

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -261,6 +261,9 @@ pub(crate) fn interpret_trigger_model(
                 crate::triggers::Trigger::is_dealt_damage(target)
             }
         }
+        TriggerKind::DamagePreventedToPlayer { player } => {
+            crate::triggers::Trigger::damage_prevented_to_player(player)
+        }
         TriggerKind::YouGainLife => crate::triggers::Trigger::you_gain_life(),
         TriggerKind::YouGainLifeDuringTurn { during_turn } => {
             crate::triggers::Trigger::you_gain_life_during_turn(during_turn)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Selfless Squire
Initial parse error:
```
unsupported triggered line: 'Whenever damage that would be dealt to you is prevented, put that many +1/+1 counters on this creature.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever damage that would be dealt to you is prevented, put that many +1/+1 counters on this creature.'
```

Current worker: i-0b1d51e0b49b11041
Branch: codex/aws-card-fix-selfless-squire
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0044
