### PR TITLE
Fix Ironsmith parse failure: Unesh, Criosphinx Sovereign

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
@@ -748,6 +748,100 @@ pub(super) fn try_parse_divvy_sentence_sequence(
         return Ok(Some(effects));
     }
 
+    if first_sentence_has_prefix(&sentence_words, &["reveal", "the", "top"])
+        && sentence_has_phrase(&sentence_words, &["cards", "of", "your", "library"])
+        && sentence_has_phrase(
+            &sentence_words,
+            &[
+                "an",
+                "opponent",
+                "separates",
+                "those",
+                "cards",
+                "into",
+                "two",
+                "piles",
+            ],
+        )
+        && sentence_has_phrase(
+            &sentence_words,
+            &["put", "one", "pile", "into", "your", "hand"],
+        )
+        && sentence_has_phrase(&sentence_words, &["the", "other", "into", "your", "graveyard"])
+    {
+        let mut effects = parse_effect_sentence_sequence(sentences[0].lowered())?;
+        effects.extend(vec![
+            EffectAst::subject_verb_tag_matching_objects(
+                ObjectFilter::tagged(TagKey::from(IT_TAG)),
+                vec![Zone::Library],
+                TagKey::from("divvy_source"),
+            ),
+            EffectAst::ChooseObjectsAcrossZones {
+                filter: ObjectFilter::tagged(TagKey::from("divvy_source")),
+                count: ChoiceCount::any_number(),
+                count_value: None,
+                player: PlayerAst::Opponent,
+                tag: TagKey::from("divvy_pile"),
+                zones: vec![Zone::Library],
+                search_mode: None,
+            },
+            EffectAst::UnlessAction {
+                player: PlayerAst::You,
+                effects: vec![
+                    EffectAst::subject_verb_move_to_zone(
+                        TargetAst::Tagged(TagKey::from("divvy_pile"), None),
+                        Zone::Hand,
+                        false,
+                        ReturnControllerAst::Preserve,
+                        false,
+                        None,
+                    ),
+                    EffectAst::ForEachTagged {
+                        tag: TagKey::from("divvy_source"),
+                        effects: vec![EffectAst::Conditional {
+                            predicate: membership_predicate_for_iterated_object("divvy_pile"),
+                            if_true: Vec::new(),
+                            if_false: vec![EffectAst::subject_verb_move_to_zone(
+                                TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                                Zone::Graveyard,
+                                false,
+                                ReturnControllerAst::Preserve,
+                                false,
+                                None,
+                            )],
+                        }],
+                    },
+                ],
+                alternative: vec![
+                    EffectAst::subject_verb_move_to_zone(
+                        TargetAst::Tagged(TagKey::from("divvy_pile"), None),
+                        Zone::Graveyard,
+                        false,
+                        ReturnControllerAst::Preserve,
+                        false,
+                        None,
+                    ),
+                    EffectAst::ForEachTagged {
+                        tag: TagKey::from("divvy_source"),
+                        effects: vec![EffectAst::Conditional {
+                            predicate: membership_predicate_for_iterated_object("divvy_pile"),
+                            if_true: Vec::new(),
+                            if_false: vec![EffectAst::subject_verb_move_to_zone(
+                                TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                                Zone::Hand,
+                                false,
+                                ReturnControllerAst::Preserve,
+                                false,
+                                None,
+                            )],
+                        }],
+                    },
+                ],
+            },
+        ]);
+        return Ok(Some(effects));
+    }
+
     if matches_sentence_sequence(
         &sentence_words,
         &[

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35485,6 +35485,43 @@ fn parse_split_the_spoils_divvy_uses_splitter_then_opponent_choice() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_unesh_criosphinx_sovereign_reveal_top_opponent_split_piles() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(91_102), "Unesh, Criosphinx Sovereign")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Sphinx])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Flying\n\
+             Sphinx spells you cast cost {2} less to cast.\n\
+             Whenever Unesh or another Sphinx you control enters, reveal the top four cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
+        )
+        .expect("Unesh, Criosphinx Sovereign should parse strictly");
+
+    let rendered = compiled_text_lines(&def).join("\n");
+    assert_eq!(
+        rendered,
+        "Flying\nSphinx spells you cast cost {2} less to cast.\nWhenever Unesh or another Sphinx you control enters, reveal the top four cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard."
+    );
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("LookAtTopCardsEffect")
+            && abilities_debug.contains("divvy_source")
+            && abilities_debug.contains("divvy_pile")
+            && abilities_debug.contains("chooser: Opponent")
+            && abilities_debug.contains("player: You"),
+        "expected Unesh's reveal-and-piles trigger to preserve the opponent split and caster pile choice structurally, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn render_make_an_example_preserves_choose_then_sacrifice_surface() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Make an Example")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -872,6 +872,7 @@ pub(super) fn substitute_legendary_source_reference(
         || conditional_static_self_surface
         || lower.contains("if this land has ")
         || lower.starts_with("whenever this creature deals combat damage to a player")
+        || lower.starts_with("whenever this creature or another ")
         || lower.contains(": this creature gets ")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -5119,6 +5119,16 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     {
         return format!("Whenever this creature or another {rest}");
     }
+    for article in ["a", "an"] {
+        let marker = format!("When this creature enters or {article} ");
+        if let Some(rest) = normalized.strip_prefix(&marker)
+            && let Some((subject, effect_clause)) = rest.split_once(" you control other than this enters,")
+        {
+            return format!(
+                "Whenever this creature or another {subject} you control enters,{effect_clause}"
+            );
+        }
+    }
     if let Some(rest) = normalized.strip_prefix("When this enters or another ")
         && rest.contains(" enters")
     {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -7015,6 +7015,83 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         ))
     }
 
+    fn describe_reveal_top_opponent_split_you_choose_pile_bundle(
+        filtered: &[&Effect],
+    ) -> Option<String> {
+        let filtered = if let [first, rest @ ..] = filtered {
+            if first
+                .downcast_ref::<crate::effects::TagTriggeringObjectEffect>()
+                .is_some()
+            {
+                rest
+            } else {
+                filtered
+            }
+        } else {
+            filtered
+        };
+        let [reveal_effect, tag_effect, choose_effect, unless_effect] = filtered else {
+            return None;
+        };
+
+        let reveal = reveal_effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+        let tag_matching = tag_effect.downcast_ref::<crate::effects::TagMatchingObjectsEffect>()?;
+        let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+        let unless_action = unless_effect.downcast_ref::<crate::effects::UnlessActionEffect>()?;
+
+        if !reveal.reveal
+            || reveal.player != PlayerFilter::You
+            || tag_matching.tag.as_str() != "divvy_source"
+            || choose.tag.as_str() != "divvy_pile"
+            || choose.chooser != PlayerFilter::Opponent
+            || choose_primary_zone(choose) != Some(Zone::Library)
+            || choose.is_search
+            || !choose.count.is_any_number()
+            || unless_action.player != PlayerFilter::You
+            || !choose.filter.tagged_constraints.iter().any(|constraint| {
+                constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                    && constraint.tag == tag_matching.tag
+            })
+        {
+            return None;
+        }
+
+        let [main_selected, main_rest] = unless_action.effects.as_slice() else {
+            return None;
+        };
+        let [alt_selected, alt_rest] = unless_action.alternative.as_slice() else {
+            return None;
+        };
+
+        let main_selected = downcast_move_to_zone(main_selected)?;
+        let alt_selected = downcast_move_to_zone(alt_selected)?;
+        let (_, main_rest) = for_each_tagged_for_compaction(main_rest)?;
+        let (_, alt_rest) = for_each_tagged_for_compaction(alt_rest)?;
+
+        if !move_to_zone_uses_tag(main_selected, choose.tag.as_str(), Zone::Hand)
+            || !move_to_zone_uses_tag(alt_selected, choose.tag.as_str(), Zone::Graveyard)
+            || !for_each_moves_unselected_to_zone(
+                main_rest,
+                tag_matching.tag.as_str(),
+                choose.tag.as_str(),
+                Zone::Graveyard,
+            )
+            || !for_each_moves_unselected_to_zone(
+                alt_rest,
+                tag_matching.tag.as_str(),
+                choose.tag.as_str(),
+                Zone::Hand,
+            )
+        {
+            return None;
+        }
+
+        let reveal_text = describe_effect(reveal_effect);
+        Some(format!(
+            "{reveal_text}. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard."
+        ))
+    }
+
     fn filter_has_not_tagged_constraint(filter: &ObjectFilter, tag: &str) -> bool {
         filter.tagged_constraints.iter().any(|constraint| {
             constraint.relation == crate::filter::TaggedOpbjectRelation::IsNotTaggedObject
@@ -8929,6 +9006,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     if let Some(compact) = describe_exile_split_pile_opponent_choice_bundle(&filtered) {
+        return compact;
+    }
+    if let Some(compact) = describe_reveal_top_opponent_split_you_choose_pile_bundle(&filtered) {
         return compact;
     }
     if let Some(compact) = describe_creature_pile_destroy_bundle(&filtered) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -28277,6 +28277,286 @@ fn test_split_the_spoils_opponent_can_take_the_other_pile_into_hand() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn unesh_criosphinx_sovereign_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(91_130), "Unesh, Criosphinx Sovereign")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Sphinx])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Flying\n\
+             Sphinx spells you cast cost {2} less to cast.\n\
+             Whenever Unesh or another Sphinx you control enters, reveal the top four cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
+        )
+        .expect("Unesh, Criosphinx Sovereign should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn unesh_library_card(id: u32, name: &str) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Sorcery])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct UneshPileDecisionMaker {
+    opponent: PlayerId,
+    split_names: &'static [&'static str],
+    choose_split_pile: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for UneshPileDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.choose_split_pile
+    }
+
+    fn decide_objects(
+        &mut self,
+        game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        assert_eq!(
+            ctx.player, self.opponent,
+            "only the opponent should separate Unesh's revealed cards into a pile"
+        );
+        let legal = ctx
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .collect::<Vec<_>>();
+        self.split_names
+            .iter()
+            .map(|wanted_name| {
+                legal
+                    .iter()
+                    .find(|candidate| {
+                        game.object(candidate.id)
+                            .is_some_and(|object| object.name == *wanted_name)
+                    })
+                    .map(|candidate| candidate.id)
+                    .unwrap_or_else(|| panic!("expected to find {wanted_name} in Unesh's pile"))
+            })
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_unesh_trigger_with_pile_choice(
+    choose_split_pile: bool,
+) -> (GameState, Vec<&'static str>, Vec<&'static str>) {
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let unesh = unesh_criosphinx_sovereign_definition();
+    let source_id = game.create_object_from_definition(&unesh, alice, Zone::Battlefield);
+    let triggered = unesh
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Unesh should have an enters trigger");
+
+    game.create_object_from_card(
+        &unesh_library_card(91_131, "Unesh Bottom Card"),
+        alice,
+        Zone::Library,
+    );
+    for (id, name) in [
+        (91_132, "Unesh Gamma"),
+        (91_133, "Unesh Delta"),
+        (91_134, "Unesh Beta"),
+        (91_135, "Unesh Alpha"),
+    ] {
+        game.create_object_from_card(&unesh_library_card(id, name), alice, Zone::Library);
+    }
+
+    let mut dm = UneshPileDecisionMaker {
+        opponent: bob,
+        split_names: &["Unesh Alpha", "Unesh Beta"],
+        choose_split_pile,
+    };
+    let entering_event = TriggerEvent::new_with_provenance(
+        EnterBattlefieldEvent::new(source_id, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = ExecutionContext::new(source_id, alice, &mut dm)
+        .with_triggering_event(entering_event);
+    for effect in &triggered.effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("Unesh trigger effect should resolve");
+    }
+
+    if choose_split_pile {
+        (game, vec!["Unesh Gamma", "Unesh Delta"], vec!["Unesh Alpha", "Unesh Beta"])
+    } else {
+        (game, vec!["Unesh Alpha", "Unesh Beta"], vec!["Unesh Gamma", "Unesh Delta"])
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn unesh_criosphinx_sovereign_reduces_only_sphinx_spell_costs() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let unesh = unesh_criosphinx_sovereign_definition();
+    game.create_object_from_definition(&unesh, alice, Zone::Battlefield);
+
+    let sphinx_spell = CardDefinitionBuilder::new(CardId::from_raw(91_136), "Runtime Sphinx")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Sphinx])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bear_spell = CardDefinitionBuilder::new(CardId::from_raw(91_137), "Runtime Bear")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let sphinx_id = game.create_object_from_definition(&sphinx_spell, alice, Zone::Hand);
+    let bear_id = game.create_object_from_definition(&bear_spell, alice, Zone::Hand);
+
+    let sphinx = game.object(sphinx_id).expect("sphinx spell exists");
+    let sphinx_cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        alice,
+        sphinx,
+        sphinx.mana_cost.as_ref().expect("sphinx mana cost"),
+    );
+    assert_eq!(sphinx_cost.to_oracle(), "{2}");
+
+    let bear = game.object(bear_id).expect("bear spell exists");
+    let bear_cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        alice,
+        bear,
+        bear.mana_cost.as_ref().expect("bear mana cost"),
+    );
+    assert_eq!(bear_cost.to_oracle(), "{4}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn unesh_criosphinx_sovereign_trigger_matches_self_and_other_sphinx_only() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let unesh = unesh_criosphinx_sovereign_definition();
+    let unesh_id = game.create_object_from_definition(&unesh, alice, Zone::Battlefield);
+    let other_sphinx = CardDefinitionBuilder::new(CardId::from_raw(91_138), "Other Runtime Sphinx")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Sphinx])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let other_sphinx_id = game.create_object_from_definition(&other_sphinx, alice, Zone::Battlefield);
+    let bear = CardDefinitionBuilder::new(CardId::from_raw(91_139), "Other Runtime Bear")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bear_id = game.create_object_from_definition(&bear, alice, Zone::Battlefield);
+
+    let entering_event = |object_id| {
+        crate::events::RawEvent::new(
+            crate::events::ZoneChangeEvent::with_cause(
+                object_id,
+                Zone::Stack,
+                Zone::Battlefield,
+                crate::events::cause::EventCause::from_game_rule(),
+                None,
+            ),
+            crate::provenance::ProvNodeId::default(),
+        )
+    };
+
+    let self_triggers = crate::triggers::check_triggers(&game, &entering_event(unesh_id));
+    assert!(
+        self_triggers.iter().any(|trigger| trigger.source == unesh_id),
+        "Unesh should trigger when it enters"
+    );
+    let sphinx_triggers = crate::triggers::check_triggers(&game, &entering_event(other_sphinx_id));
+    assert!(
+        sphinx_triggers.iter().any(|trigger| trigger.source == unesh_id),
+        "Unesh should trigger when another Sphinx you control enters"
+    );
+    let bear_triggers = crate::triggers::check_triggers(&game, &entering_event(bear_id));
+    assert!(
+        !bear_triggers.iter().any(|trigger| trigger.source == unesh_id),
+        "Unesh should not trigger for a non-Sphinx entering"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn unesh_criosphinx_sovereign_puts_opponent_split_pile_into_hand() {
+    let (game, expected_hand, expected_graveyard) = execute_unesh_trigger_with_pile_choice(false);
+    let alice = PlayerId::from_index(0);
+    let hand = game.player(alice).expect("alice exists").hand.clone();
+    let graveyard = game.player(alice).expect("alice exists").graveyard.clone();
+
+    for name in expected_hand {
+        assert!(
+            hand.iter()
+                .any(|&id| game.object(id).is_some_and(|object| object.name == name)),
+            "{name} should be in hand when the caster chooses the opponent-created pile"
+        );
+    }
+    for name in expected_graveyard {
+        assert!(
+            graveyard
+                .iter()
+                .any(|&id| game.object(id).is_some_and(|object| object.name == name)),
+            "{name} should be in graveyard as part of the other pile"
+        );
+    }
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .library
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|object| object.name == "Unesh Bottom Card")),
+        "Unesh should reveal only the top four cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn unesh_criosphinx_sovereign_can_choose_the_other_pile_for_hand() {
+    let (game, expected_hand, expected_graveyard) = execute_unesh_trigger_with_pile_choice(true);
+    let alice = PlayerId::from_index(0);
+    let hand = game.player(alice).expect("alice exists").hand.clone();
+    let graveyard = game.player(alice).expect("alice exists").graveyard.clone();
+
+    for name in expected_hand {
+        assert!(
+            hand.iter()
+                .any(|&id| game.object(id).is_some_and(|object| object.name == name)),
+            "{name} should be in hand when the caster chooses the other pile"
+        );
+    }
+    for name in expected_graveyard {
+        assert!(
+            graveyard
+                .iter()
+                .any(|&id| game.object(id).is_some_and(|object| object.name == name)),
+            "{name} should be in graveyard when the caster declines the opponent-created pile"
+        );
+    }
+}
+
 #[test]
 fn test_dash_grants_haste_and_returns_to_hand_at_next_end_step() {
     use crate::cards::CardDefinitionBuilder;

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1410,6 +1410,48 @@ fn compile_oracle_text_strictly_compiles_kydele_chosen_of_kruphix_from_workspace
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_unesh_criosphinx_sovereign_from_workspace_cards() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Unesh, Criosphinx Sovereign")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Unesh, Criosphinx Sovereign --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Unesh, Criosphinx Sovereign should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(
+        stdout.contains("Name: Unesh, Criosphinx Sovereign"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Similarity: 1.0000"), "{stdout}");
+    assert!(
+        stdout.contains("An opponent separates those cards into two piles.")
+            && stdout.contains("Put one pile into your hand and the other into your graveyard."),
+        "expected Unesh reveal-and-piles clause in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_strictly_compiles_sakashimas_will_with_choose_both_instead_clause() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Unesh, Criosphinx Sovereign
Initial parse error:
```
could not find verb in effect clause (clause: 'an opponent separates those cards into two piles'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'an opponent separates those cards into two piles'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-061d22ec50eab7047
Branch: codex/aws-card-fix-unesh-criosphinx-sovereign
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0048
