### PR TITLE
Fix Ironsmith parse failure: Templar Knight

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -243,6 +243,7 @@ pub(super) fn parse_static_line_cst(
     ) || is_first_equip_cost_alternative_line(normalized)
         || is_additional_land_play_static_line(normalized)
         || is_can_block_additional_creatures_static_line(normalized)
+        || is_any_number_named_deck_construction_line(normalized)
     {
         return Ok(Some(make_static(None)));
     }
@@ -300,6 +301,12 @@ pub(super) fn parse_static_line_cst(
     }
 
     Ok(None)
+}
+
+fn is_any_number_named_deck_construction_line(text: &str) -> bool {
+    let trimmed = text.trim().trim_end_matches('.');
+    trimmed.starts_with("a deck can have any number of cards named ")
+        && trimmed.len() > "a deck can have any number of cards named ".len()
 }
 
 /// Recognizes "you may pay {COST} rather than pay the equip cost of the first

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1321,6 +1321,15 @@ fn lower_rewrite_static_to_chunk_impl(
             chosen_option_label,
         );
     }
+    if is_any_number_named_deck_construction_line(raw) {
+        return wrap_chosen_option_static_chunk(
+            LineAst::StaticAbility(
+                StaticAbility::deck_construction_rule_text(raw.trim_end_matches('.').to_string())
+                    .into(),
+            ),
+            chosen_option_label,
+        );
+    }
     if is_first_equip_cost_alternative_lowering_line(&line.text) {
         let display = capitalize_first_equip_cost_alternative_display(&line.text);
         return wrap_chosen_option_static_chunk(
@@ -1465,6 +1474,13 @@ fn is_draft_rule_static_line(raw: &str) -> bool {
         || lower.starts_with("during the draft, ")
         || lower.starts_with("immediately after the draft, ")
         || lower.starts_with("each player passes ") && lower.contains("booster pack")
+}
+
+fn is_any_number_named_deck_construction_line(raw: &str) -> bool {
+    let trimmed = raw.trim().trim_end_matches('.');
+    let lower = trimmed.to_ascii_lowercase();
+    let prefix = "a deck can have any number of cards named ";
+    lower.starts_with(prefix) && trimmed.len() > prefix.len()
 }
 
 fn parse_additional_land_play_static_count_from_text(text: &str) -> Option<u32> {

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1556,6 +1556,13 @@ impl ObjectFilter {
             };
             post_noun_qualifiers.push(format!("blocked by {blocker_text} this turn"));
         }
+        if self.tapped && self.untapped {
+            parts.push("tapped/untapped".to_string());
+        } else if self.tapped {
+            parts.push("tapped".to_string());
+        } else if self.untapped {
+            parts.push("untapped".to_string());
+        }
         if self.attacking && self.blocking {
             parts.push("attacking/blocking".to_string());
         } else {
@@ -1590,13 +1597,6 @@ impl ObjectFilter {
             if self.nonblocking {
                 parts.push("nonblocking".to_string());
             }
-        }
-        if self.tapped && self.untapped {
-            parts.push("tapped/untapped".to_string());
-        } else if self.tapped {
-            parts.push("tapped".to_string());
-        } else if self.untapped {
-            parts.push("untapped".to_string());
         }
         if self.entered_since_your_last_turn_ended {
             post_noun_qualifiers.push("that entered since your last turn ended".to_string());
@@ -1795,6 +1795,23 @@ impl ObjectFilter {
         }
 
         if let Some(ref name) = self.name {
+            match (&controller_suffix, &owner_suffix) {
+                (Some(controller), Some(owner)) => {
+                    if controller == "you control" && owner == "you own" {
+                        parts.push("you both own and control".to_string());
+                    } else if controller == "you control" && owner == "you don't own" {
+                        parts.push("you control but don't own".to_string());
+                    } else if controller == "that player controls" && owner == "that player owns" {
+                        parts.push("that player both owns and controls".to_string());
+                    } else {
+                        parts.push(controller.clone());
+                        parts.push(owner.clone());
+                    }
+                }
+                (Some(controller), None) => parts.push(controller.clone()),
+                (None, Some(owner)) => parts.push(owner.clone()),
+                (None, None) => {}
+            }
             return format!("a {} named {}", parts.join(" "), name);
         }
         if let Some(ref name) = self.excluded_name {

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -248,6 +248,7 @@ pub enum StaticAbilityId {
     DiscardOrRedirectReplacement,
     PayLifeOrEnterTappedReplacement,
     PregameAction,
+    DeckConstructionRuleText,
     DraftRuleText,
     KeywordText,
     KeywordMarker,
@@ -504,6 +505,7 @@ impl StaticAbilityId {
             | DiscardOrRedirectReplacement
             | PayLifeOrEnterTappedReplacement
             | PregameAction
+            | DeckConstructionRuleText
             | DraftRuleText
             | KeywordText
             | KeywordMarker

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1767,6 +1767,10 @@ impl<
         Self::identified(StaticAbilityId::DraftRuleText, text)
     }
 
+    pub fn deck_construction_rule_text(text: impl Into<String>) -> Self {
+        Self::identified(StaticAbilityId::DeckConstructionRuleText, text)
+    }
+
     pub fn rule_fallback_text(text: impl Into<String>) -> Self {
         Self::identified(StaticAbilityId::RuleFallbackText, text)
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11,6 +11,7 @@ use crate::effects::{
     MoveToZoneEffect, ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect, TaggedEffect,
     TargetOnlyEffect, UntapEffect,
 };
+use crate::filter::ObjectFilterExt;
 use crate::object::AuraAttachmentFilter;
 use crate::static_abilities::StaticAbilityId;
 use crate::target::{ChooseSpec, ObjectRef, PlayerFilter, SourceReferenceSurface};
@@ -163,6 +164,153 @@ fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
         rendered,
         "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards."
     );
+}
+
+#[test]
+fn templar_knight_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Templar Knight");
+    let rendered = unprocessed_compiled_lines(&def);
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(
+        rendered,
+        vec![
+            "Vigilance".to_string(),
+            "{W}, Tap five untapped attacking creatures you control named Templar Knight: Search your library for a legendary artifact card, put it onto the battlefield, then shuffle.".to_string(),
+            "A deck can have any number of cards named Templar Knight.".to_string(),
+        ],
+        "Templar Knight should parse strictly and preserve its activation and deck-construction text"
+    );
+    assert!(
+        def.abilities.iter().any(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => {
+                static_ability.id() == StaticAbilityId::DeckConstructionRuleText
+            }
+            _ => false,
+        }),
+        "Templar Knight should lower its any-number deck rule to typed deck-construction text, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("untapped: true")
+            && ability_debug.contains("attacking: true")
+            && ability_debug.contains("name: Some(")
+            && ability_debug.contains("\"templar knight\"")
+            && !ability_debug.contains("RuleFallbackText")
+            && !ability_debug.contains("UnsupportedParserLine"),
+        "Templar Knight should structurally model the named untapped attacking creature cost without parser fallbacks, got {ability_debug}"
+    );
+}
+
+#[test]
+fn templar_knight_deck_construction_rule_has_no_game_runtime_effects() {
+    let def = parse_oracle_card_definition("Templar Knight");
+    let static_ability = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => {
+                if static_ability.id() == StaticAbilityId::DeckConstructionRuleText {
+                    Some(static_ability)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .expect("Templar Knight should have a typed deck-construction static ability");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert!(static_ability.generate_effects(source, alice, &game).is_empty());
+    assert!(static_ability
+        .generate_replacement_effect(source, alice)
+        .is_none());
+    assert!(static_ability.pregame_action_kind().is_none());
+}
+
+#[test]
+fn templar_knight_activation_cost_filter_requires_untapped_attacking_named_creatures_you_control() {
+    let def = parse_oracle_card_definition("Templar Knight");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Templar Knight should have an activated ability");
+    let choose_cost = activated
+        .mana_cost
+        .costs()
+        .iter()
+        .filter_map(|cost| cost.effect_ref())
+        .find_map(|effect| effect.downcast_ref::<ChooseObjectsEffect>())
+        .expect("Templar Knight activation should choose creatures to tap as a cost");
+
+    assert_eq!(choose_cost.count.min, 5);
+    assert_eq!(choose_cost.count.max, Some(5));
+    assert!(choose_cost.filter.untapped);
+    assert!(choose_cost.filter.attacking);
+    assert_eq!(choose_cost.filter.controller, Some(PlayerFilter::You));
+    assert_eq!(choose_cost.filter.name.as_deref(), Some("templar knight"));
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let matching = (0..5)
+        .map(|_| game.create_object_from_definition(&def, alice, Zone::Battlefield))
+        .collect::<Vec<_>>();
+    let nonattacking = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let tapped_attacker = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.tap(tapped_attacker);
+    let bob_attacker = game.create_object_from_definition(&def, bob, Zone::Battlefield);
+    let decoy_def = CardDefinitionBuilder::new(CardId::new(), "Templar Decoy")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let wrong_name_attacker =
+        game.create_object_from_definition(&decoy_def, alice, Zone::Battlefield);
+
+    let mut attackers = matching
+        .iter()
+        .chain([&tapped_attacker, &bob_attacker, &wrong_name_attacker])
+        .map(|creature| crate::combat_state::AttackerInfo {
+            creature: *creature,
+            target: crate::combat_state::AttackTarget::Player(bob),
+        })
+        .collect::<Vec<_>>();
+    attackers.push(crate::combat_state::AttackerInfo {
+        creature: source,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    });
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers,
+        ..Default::default()
+    });
+    let ctx = game.filter_context_for(alice, Some(source));
+
+    for creature in matching {
+        let object = game.object(creature).expect("matching Templar should exist");
+        assert!(
+            choose_cost.filter.matches(object, &ctx, &game),
+            "untapped attacking Templars you control should satisfy the activation cost filter"
+        );
+    }
+    for (creature, reason) in [
+        (nonattacking, "nonattacking"),
+        (tapped_attacker, "tapped"),
+        (bob_attacker, "opponent-controlled"),
+        (wrong_name_attacker, "wrong-name"),
+    ] {
+        let object = game.object(creature).expect("negative branch object should exist");
+        assert!(
+            !choose_cost.filter.matches(object, &ctx, &game),
+            "{reason} creatures should not satisfy the Templar Knight activation cost filter"
+        );
+    }
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3418,6 +3418,13 @@ impl ObjectFilterExt for ObjectFilter {
             };
             post_noun_qualifiers.push(format!("blocked by {blocker_text} this turn"));
         }
+        if self.tapped && self.untapped {
+            parts.push("tapped/untapped".to_string());
+        } else if self.tapped {
+            parts.push("tapped".to_string());
+        } else if self.untapped {
+            parts.push("untapped".to_string());
+        }
         if self.attacking && self.blocking {
             parts.push("attacking/blocking".to_string());
         } else {
@@ -3452,13 +3459,6 @@ impl ObjectFilterExt for ObjectFilter {
             if self.nonblocking {
                 parts.push("nonblocking".to_string());
             }
-        }
-        if self.tapped && self.untapped {
-            parts.push("tapped/untapped".to_string());
-        } else if self.tapped {
-            parts.push("tapped".to_string());
-        } else if self.untapped {
-            parts.push("untapped".to_string());
         }
         if self.entered_since_your_last_turn_ended {
             post_noun_qualifiers.push("that entered since your last turn ended".to_string());
@@ -3653,6 +3653,23 @@ impl ObjectFilterExt for ObjectFilter {
 
         // Handle name
         if let Some(ref name) = self.name {
+            match (&controller_suffix, &owner_suffix) {
+                (Some(controller), Some(owner)) => {
+                    if controller == "you control" && owner == "you own" {
+                        parts.push("you both own and control".to_string());
+                    } else if controller == "you control" && owner == "you don't own" {
+                        parts.push("you control but don't own".to_string());
+                    } else if controller == "that player controls" && owner == "that player owns" {
+                        parts.push("that player both owns and controls".to_string());
+                    } else {
+                        parts.push(controller.clone());
+                        parts.push(owner.clone());
+                    }
+                }
+                (Some(controller), None) => parts.push(controller.clone()),
+                (None, Some(owner)) => parts.push(owner.clone()),
+                (None, None) => {}
+            }
             return format!("a {} named {}", parts.join(" "), name);
         }
         if let Some(ref name) = self.excluded_name {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -254,6 +254,9 @@ impl StaticAbility {
                 Self::enters_tapped_unless_two_or_more_opponents()
             }
             Some(StaticAbilityId::CanBeCommander) => Self::can_be_commander(),
+            Some(StaticAbilityId::DeckConstructionRuleText) => {
+                Self::deck_construction_rule_text(label)
+            }
             Some(StaticAbilityId::DraftRuleText) => Self::draft_rule_text(label),
             Some(StaticAbilityId::KeywordText) => Self::keyword_text(label),
             Some(StaticAbilityId::KeywordMarker) => Self::keyword_marker(label),

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -4978,6 +4978,28 @@ impl StaticAbilityKind for DraftRuleText {
     }
 }
 
+/// Deck-construction rule text with no in-game rules impact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeckConstructionRuleText {
+    pub text: String,
+}
+
+impl DeckConstructionRuleText {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+impl StaticAbilityKind for DeckConstructionRuleText {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::DeckConstructionRuleText
+    }
+
+    fn display(&self) -> String {
+        self.text.clone()
+    }
+}
+
 // =============================================================================
 // Placeholder / Marker Abilities
 // =============================================================================

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -3108,6 +3108,10 @@ impl StaticAbility {
         Self::new(DraftRuleText::new(text))
     }
 
+    pub fn deck_construction_rule_text(text: impl Into<String>) -> Self {
+        Self::new(DeckConstructionRuleText::new(text))
+    }
+
     pub fn rule_fallback_text(text: impl Into<String>) -> Self {
         Self::new(RuleFallbackText::new(text))
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Templar Knight
Initial parse error:
```
parser does not yet support line family: 'A deck can have any number of cards named Templar Knight.'; oracle-only fallback also failed: parser does not yet support line family: 'A deck can have any number of cards named Templar Knight.'
```

Current worker: i-075d667f565912a63
Branch: codex/aws-card-fix-templar-knight
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0048
