### PR TITLE
Fix Ironsmith parse failure: Vedalken Shackles

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -76,6 +76,7 @@ pub enum ControlDurationAst {
     UntilYourNextTurnEnd,
     DuringNextTurn,
     AsLongAsYouControlSource,
+    AsLongAsSourceRemainsTapped,
     Forever,
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1204,16 +1204,13 @@ fn compile_subject_verb_effect(
                     controller,
                 )
             };
-            let effect = tag_object_target_effect(
-                Effect::new(crate::effects::ApplyContinuousEffect::with_spec_runtime(
-                    spec.clone(),
-                    runtime_modification,
-                    duration.clone(),
-                )),
-                &spec,
-                ctx,
-                "controlled",
+            let apply = crate::effects::ApplyContinuousEffect::with_spec_runtime(
+                spec.clone(),
+                runtime_modification,
+                duration.clone(),
             );
+            let effect =
+                tag_object_target_effect(Effect::new(apply), &spec, ctx, "controlled");
             Ok((vec![effect], choices))
         }
         SubjectVerbActionAst::RevealTop => {
@@ -5363,6 +5360,12 @@ fn compile_subject_verb_effect(
                     crate::game_state::PlayerControlStart::Immediate,
                     crate::game_state::PlayerControlDuration::UntilSourceLeaves,
                 ),
+                ControlDurationAst::AsLongAsSourceRemainsTapped => {
+                    return Err(CardTextError::ParseError(
+                        "unsupported player-control duration while source remains tapped"
+                            .to_string(),
+                    ));
+                }
             };
 
             let mut choices = Vec::new();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -190,16 +190,6 @@ pub(crate) fn parse_gain_control(
     subject: Option<SubjectAst>,
 ) -> Result<EffectAst, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
-    let has_dynamic_power_bound = grammar::contains_word(tokens, "power")
-        && grammar::contains_word(tokens, "number")
-        && grammar::words_find_phrase(tokens, &["you", "control"]).is_some();
-    if has_dynamic_power_bound {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported dynamic power-bound control clause (clause: '{}')",
-            clause_words.join(" ")
-        )));
-    }
-
     let mut idx = 0;
     if token_slice_at_is(tokens, idx, "control") {
         idx += 1;
@@ -252,6 +242,8 @@ pub(crate) fn parse_gain_control(
             )
         } else if crate::runtime_backend::lexer::contains_token_word(target_tokens, "unless") {
             return Err(invalid_conditional_error());
+        } else if let Some(target) = parse_dynamic_power_bound_control_target(target_tokens)? {
+            (target, None, false)
         } else {
             (parse_target_phrase(target_tokens)?, None, false)
         };
@@ -262,9 +254,13 @@ pub(crate) fn parse_gain_control(
     let player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
     let base_effect = match target_ast {
         TargetAst::Player(filter, _) => {
-            if matches!(duration, ControlDurationAst::UntilYourNextTurnEnd) {
+            if matches!(
+                duration,
+                ControlDurationAst::UntilYourNextTurnEnd
+                    | ControlDurationAst::AsLongAsSourceRemainsTapped
+            ) {
                 return Err(CardTextError::ParseError(
-                    "unsupported player-control duration until the end of your next turn"
+                    "unsupported player-control duration for gain-control clause"
                         .to_string(),
                 ));
             }
@@ -280,6 +276,7 @@ pub(crate) fn parse_gain_control(
                 ControlDurationAst::UntilYourNextTurnEnd => Until::YourNextTurnEnd,
                 ControlDurationAst::Forever => Until::Forever,
                 ControlDurationAst::AsLongAsYouControlSource => Until::YouStopControllingThis,
+                ControlDurationAst::AsLongAsSourceRemainsTapped => Until::SourceRemainsTapped,
                 ControlDurationAst::DuringNextTurn => {
                     return Err(CardTextError::ParseError(
                         "unsupported control duration for permanents".to_string(),
@@ -309,6 +306,79 @@ pub(crate) fn parse_gain_control(
     Ok(base_effect)
 }
 
+fn parse_dynamic_power_bound_control_target(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<TargetAst>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(with_idx) = words
+        .windows(2)
+        .position(|window| window == ["with", "power"])
+    else {
+        return Ok(None);
+    };
+    let value_idx = with_idx + 2;
+    if !word_slice_at_is(&words, value_idx, "less")
+        || !word_slice_at_is(&words, value_idx + 1, "than")
+        || !word_slice_at_is(&words, value_idx + 2, "or")
+        || !word_slice_at_is(&words, value_idx + 3, "equal")
+        || !word_slice_at_is(&words, value_idx + 4, "to")
+    {
+        return Ok(None);
+    }
+
+    let Some(leading_end) = token_index_for_word_index(tokens, with_idx) else {
+        return Ok(None);
+    };
+    let leading = trim_commas(&tokens[..leading_end]);
+    if leading.is_empty() {
+        return Ok(None);
+    }
+    let mut target = parse_target_phrase(&leading)?;
+    let value_words = &words[value_idx + 5..];
+    let Some((value, used)) = parse_value_expr_words(value_words) else {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported dynamic power-bound control operand (clause: '{}')",
+            words.join(" ")
+        )));
+    };
+    if used == 0 || used != value_words.len() {
+        return Ok(None);
+    }
+
+    fn apply(target: &mut TargetAst, value: Value) -> bool {
+        match target {
+            TargetAst::Object(filter, _, _) => {
+                filter.power = Some(crate::filter::Comparison::LessThanOrEqualExpr(Box::new(
+                    value,
+                )));
+                true
+            }
+            TargetAst::WithCount(inner, _) | TargetAst::WithCountValue(inner, _, _) => {
+                apply(inner, value)
+            }
+            _ => false,
+        }
+    }
+
+    if apply(&mut target, value) {
+        Ok(Some(target))
+    } else {
+        Ok(None)
+    }
+}
+
+fn control_duration_source_remains_tapped(tokens: &[OwnedLexToken]) -> bool {
+    grammar::words_find_phrase(tokens, &["for", "as", "long", "as"]).is_some()
+        && grammar::contains_word(tokens, "remains")
+        && grammar::contains_word(tokens, "tapped")
+        && (grammar::contains_word(tokens, "this")
+            || grammar::contains_word(tokens, "thiss")
+            || grammar::contains_word(tokens, "source")
+            || grammar::contains_word(tokens, "artifact")
+            || grammar::contains_word(tokens, "creature")
+            || grammar::contains_word(tokens, "permanent"))
+}
+
 pub(crate) fn parse_control_duration(
     tokens: &[OwnedLexToken],
 ) -> Result<ControlDurationAst, CardTextError> {
@@ -318,6 +388,9 @@ pub(crate) fn parse_control_duration(
 
     let has_for_as_long_as =
         grammar::words_find_phrase(tokens, &["for", "as", "long", "as"]).is_some();
+    if control_duration_source_remains_tapped(tokens) {
+        return Ok(ControlDurationAst::AsLongAsSourceRemainsTapped);
+    }
     if has_for_as_long_as
         && grammar::contains_word(tokens, "you")
         && grammar::contains_word(tokens, "control")

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -71,6 +71,7 @@ pub enum Until {
     EndOfCombat,
     ThisLeavesTheBattlefield,
     YouStopControllingThis,
+    SourceRemainsTapped,
     TurnsPass(crate::value_model::Value),
 }
 

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -2449,7 +2449,7 @@ fn describe_comparison(cmp: &Comparison) -> String {
             Value::SurfaceHinted { value, .. } => describe_value_expr(value),
             Value::Fixed(v) => v.to_string(),
             Value::X => "X".to_string(),
-            Value::Count(filter) => format!("the number of {}", filter.description()),
+            Value::Count(filter) => format!("the number of {}", describe_count_filter(filter)),
             Value::CountScaled(filter, factor) => {
                 format!("{factor} times the number of {}", filter.description())
             }
@@ -2557,7 +2557,7 @@ fn describe_comparison(cmp: &Comparison) -> String {
         }
         Comparison::LessThanExpr(value) => format!("less than {}", describe_value_expr(value)),
         Comparison::LessThanOrEqualExpr(value) => {
-            format!("{} or less", describe_value_expr(value))
+            format!("less than or equal to {}", describe_value_expr(value))
         }
         Comparison::GreaterThanExpr(value) => {
             format!("greater than {}", describe_value_expr(value))
@@ -2566,6 +2566,23 @@ fn describe_comparison(cmp: &Comparison) -> String {
             format!("{} or greater", describe_value_expr(value))
         }
     }
+}
+
+fn describe_count_filter(filter: &ObjectFilter) -> String {
+    let description = filter.description();
+    for (singular, plural) in [
+        ("a Plains", "Plains"),
+        ("a Island", "Islands"),
+        ("an Island", "Islands"),
+        ("a Swamp", "Swamps"),
+        ("a Mountain", "Mountains"),
+        ("a Forest", "Forests"),
+    ] {
+        if let Some(rest) = description.strip_prefix(singular) {
+            return format!("{plural}{rest}");
+        }
+    }
+    description
 }
 
 fn describe_value_choose_spec_possessive(spec: &ChooseSpec) -> String {

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -1028,8 +1028,10 @@ pub(crate) enum ZoneReplacementDurationAst {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ControlDurationAst {
     UntilEndOfTurn,
+    UntilYourNextTurnEnd,
     DuringNextTurn,
     AsLongAsYouControlSource,
+    AsLongAsSourceRemainsTapped,
     Forever,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6303,6 +6303,53 @@ fn test_parse_gain_control_each_noncommander_creature_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn vedalken_shackles_parses_dynamic_power_bound_control_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(425_824), "Vedalken Shackles")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "You may choose not to untap this artifact during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as this artifact remains tapped.",
+        )
+        .expect("Vedalken Shackles should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Gain control of target creature with power less than or equal to the number of Islands you control for as long as this artifact remains tapped"),
+        "expected compiled text to preserve the dynamic Island-count control clause, got {rendered}"
+    );
+
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Vedalken Shackles should have an activated ability");
+    let debug = format!("{:#?}", activated.effects);
+    assert!(
+        debug.contains("ChangeControllerToEffectController")
+            && debug.contains("LessThanOrEqualExpr")
+            && debug.contains("Count")
+            && debug.contains("Island")
+            && debug.contains("SourceRemainsTapped"),
+        "expected gain-control effect to carry dynamic Island-count bound and source-tapped duration, got {debug}"
+    );
+    let target_spec = activated
+        .choices
+        .first()
+        .expect("Vedalken Shackles should declare one target choice");
+    let ChooseSpec::Object(filter) = target_spec.base() else {
+        panic!("expected an object target for Vedalken Shackles, got {target_spec:?}");
+    };
+    assert!(
+        filter.subtypes.is_empty(),
+        "Island count must not be parsed as a target creature subtype, got {filter:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_create_token_for_each_creature_that_died_this_turn() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Mahadi Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9457,7 +9457,10 @@ pub(super) fn describe_apply_continuous_effect(
         )
     {
         let mut text = format!("Gain control of {target}");
-        if !matches!(effect.until, Until::Forever) {
+        if let Some(duration) = describe_apply_continuous_duration(effect) {
+            text.push(' ');
+            text.push_str(&duration);
+        } else if !matches!(effect.until, Until::Forever) {
             text.push(' ');
             text.push_str(&describe_until(&effect.until));
         }
@@ -9483,8 +9486,13 @@ pub(super) fn describe_apply_continuous_effect(
             return Some(text);
         }
         if !matches!(effect.until, Until::Forever) {
-            text.push(' ');
-            text.push_str(&describe_until(&effect.until));
+            if let Some(duration) = describe_apply_continuous_duration(effect) {
+                text.push(' ');
+                text.push_str(&duration);
+            } else {
+                text.push(' ');
+                text.push_str(&describe_until(&effect.until));
+            }
         }
         return Some(text);
     }
@@ -9497,14 +9505,20 @@ pub(super) fn describe_apply_continuous_effect(
         && ability.id() == crate::static_abilities::StaticAbilityId::Haste
     {
         let mut text = format!("Gain control of {target}");
-        if !matches!(effect.until, Until::Forever) {
+        if let Some(duration) = describe_apply_continuous_duration(effect) {
+            text.push(' ');
+            text.push_str(&duration);
+        } else if !matches!(effect.until, Until::Forever) {
             text.push(' ');
             text.push_str(&describe_until(&effect.until));
         }
         text.push_str(". ");
         text.push_str(&capitalize_first(&target));
         text.push_str(" gains haste");
-        if !matches!(effect.until, Until::Forever) {
+        if let Some(duration) = describe_apply_continuous_duration(effect) {
+            text.push(' ');
+            text.push_str(&duration);
+        } else if !matches!(effect.until, Until::Forever) {
             text.push(' ');
             text.push_str(&describe_until(&effect.until));
         }
@@ -9545,6 +9559,16 @@ pub(super) fn describe_apply_continuous_effect(
         text.push_str(&tail);
     }
     Some(text)
+}
+
+fn describe_apply_continuous_duration(
+    effect: &crate::effects::ApplyContinuousEffect,
+) -> Option<&'static str> {
+    if effect.until == Until::SourceRemainsTapped {
+        Some("for as long as this source remains tapped")
+    } else {
+        None
+    }
 }
 
 fn describe_dies_return_counter_grant(
@@ -10066,6 +10090,7 @@ pub(super) fn describe_until(until: &Until) -> String {
             "for as long as this source remains on the battlefield".to_string()
         }
         Until::YouStopControllingThis => "while you control this source".to_string(),
+        Until::SourceRemainsTapped => "for as long as this source remains tapped".to_string(),
         Until::TurnsPass(turns) => format!("for {} turn(s)", describe_value(turns)),
     }
 }

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -664,6 +664,12 @@ impl ContinuousEffectManager {
         self.revision += 1;
     }
 
+    pub fn remove_effects_from_source_with_duration(&mut self, source: ObjectId, duration: Until) {
+        self.effects
+            .retain(|e| e.source != source || e.duration != duration);
+        self.revision += 1;
+    }
+
     /// Remove all effects with duration UntilEndOfTurn.
     pub fn cleanup_end_of_turn(&mut self) {
         self.effects
@@ -2198,6 +2204,9 @@ fn continuous_effect_duration_is_active(
                     .current_controller_excluding_change_effect(effect.source, Some(effect.id))
                     .is_some_and(|controller| controller == effect.controller)
         }),
+        Until::SourceRemainsTapped => game
+            .object(effect.source)
+            .is_some_and(|obj| obj.zone == Zone::Battlefield && game.is_tapped(effect.source)),
         _ => true,
     }
 }

--- a/crates/ironsmith-runtime/src/effects/continuous/apply_continuous.rs
+++ b/crates/ironsmith-runtime/src/effects/continuous/apply_continuous.rs
@@ -444,6 +444,9 @@ impl EffectExecutor for ApplyContinuousEffect {
         if target_invalid {
             return Ok(EffectOutcome::target_invalid());
         }
+        if self.until == Until::SourceRemainsTapped && !game.is_tapped(ctx.source) {
+            return Ok(EffectOutcome::resolved());
+        }
         let mut source_type = self.source_type.clone();
 
         let filter_locked_targets = if let EffectTarget::Filter(filter) = &target {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1205,6 +1205,161 @@ fn create_test_land(game: &mut GameState, name: &str, controller: PlayerId) -> O
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn create_test_island(game: &mut GameState, name: &str, controller: PlayerId) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Island])
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn vedalken_shackles_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(425_824), "Vedalken Shackles")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "You may choose not to untap this artifact during your untap step.\n{2}, {T}: Gain control of target creature with power less than or equal to the number of Islands you control for as long as this artifact remains tapped.",
+        )
+        .expect("Vedalken Shackles should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn vedalken_shackles_targets_by_island_count_and_control_expires_when_untapped() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let shackles_def = vedalken_shackles_definition();
+    let shackles_id = game.create_object_from_definition(&shackles_def, alice, Zone::Battlefield);
+    let target_id = create_vanilla_creature(&mut game, "Bob's Hill Giant", bob, 3, 3);
+    let too_large_id = create_vanilla_creature(&mut game, "Bob's Baloth", bob, 4, 4);
+    create_test_island(&mut game, "Alice's First Island", alice);
+    create_test_island(&mut game, "Alice's Second Island", alice);
+
+    let activated = shackles_def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Vedalken Shackles should have an activated ability");
+    let target_spec = activated
+        .choices
+        .first()
+        .expect("Vedalken Shackles should declare a target choice");
+    let legal_targets = super::targeting::compute_legal_targets(
+        &game,
+        target_spec,
+        alice,
+        Some(shackles_id),
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(target_id)),
+        "a 3-power creature should not be legal with only two Islands"
+    );
+
+    create_test_island(&mut game, "Alice's Third Island", alice);
+    let legal_targets = super::targeting::compute_legal_targets(
+        &game,
+        target_spec,
+        alice,
+        Some(shackles_id),
+    );
+    assert!(
+        legal_targets.contains(&Target::Object(target_id)),
+        "a 3-power creature should be legal with three Islands"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(too_large_id)),
+        "a 4-power creature should remain illegal with three Islands"
+    );
+
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+    let ability_index = game
+        .object(shackles_id)
+        .expect("Vedalken Shackles should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Vedalken Shackles should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == shackles_id && *idx == ability_index
+            )
+        })
+        .expect("Vedalken Shackles activation should be legal with mana and a valid target");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Vedalken Shackles activation should start and pay costs");
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Vedalken Shackles, got {other:?}"),
+    }
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target_id)]),
+        &mut dm,
+    )
+    .expect("choosing the legal creature should complete Shackles activation");
+    assert!(
+        game.is_tapped(shackles_id),
+        "activation should tap Vedalken Shackles"
+    );
+    resolve_stack_entry(&mut game).expect("Vedalken Shackles ability should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.current_controller(target_id),
+        Some(alice),
+        "Alice should control the targeted creature while Shackles remains tapped"
+    );
+
+    game.untap(shackles_id);
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.current_controller(target_id),
+        Some(bob),
+        "control effect should stop when Vedalken Shackles becomes untapped"
+    );
+
+    game.tap(shackles_id);
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.current_controller(target_id),
+        Some(bob),
+        "the old control effect must not resume if Vedalken Shackles is tapped again later"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn vastwood_animist_activation_animates_only_your_land_using_ally_count_until_end_of_turn() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -737,6 +737,9 @@ impl RestrictionEffectInstance {
                     obj.zone == Zone::Battlefield && game.controller_of(obj) == self.controller
                 })
             }
+            crate::effect::Until::SourceRemainsTapped => game.object(self.source).is_some_and(|obj| {
+                obj.zone == Zone::Battlefield && game.is_tapped(self.source)
+            }),
             _ => true,
         }
     }
@@ -776,6 +779,9 @@ impl GoadEffectInstance {
                     obj.zone == Zone::Battlefield && game.controller_of(obj) == self.goaded_by
                 })
             }
+            crate::effect::Until::SourceRemainsTapped => game.object(self.source).is_some_and(|obj| {
+                obj.zone == Zone::Battlefield && game.is_tapped(self.source)
+            }),
             _ => true,
         }
     }
@@ -8092,7 +8098,14 @@ impl GameState {
     /// Untap a permanent.
     pub fn untap(&mut self, id: ObjectId) {
         self.mark_continuous_state_dirty();
-        self.tapped_permanents.remove(&id);
+        if self.tapped_permanents.remove(&id) {
+            self.effect_store
+                .continuous_effects
+                .remove_effects_from_source_with_duration(
+                    id,
+                    crate::effect::Until::SourceRemainsTapped,
+                );
+        }
     }
 
     /// Check if a creature has summoning sickness.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Vedalken Shackles
Initial parse error:
```
unsupported dynamic power-bound control clause (clause: 'control of target creature with power less than or equal to the number of islands you control for as long as this artifact remains tapped'); oracle-only fallback also failed: unsupported dynamic power-bound control clause (clause: 'control of target creature with power less than or equal to the number of islands you control for as long as this artifact remains tapped')
```

Current worker: i-09a7b8301ac56198e
Branch: codex/aws-card-fix-vedalken-shackles
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260530T151905Z-controller-dev-loop-wave0048
