### PR TITLE
Fix Ironsmith parse failure: Reverberation

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -150,6 +150,7 @@ pub enum PreventNextTimeDamageSourceAst<Filter = crate::target::ObjectFilter> {
 pub enum RedirectNextTimeDamageDestinationAst {
     SourceObject,
     Controller,
+    SourceController,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1750,6 +1750,9 @@ fn compile_subject_verb_effect(
                     crate::cards::builders::RedirectNextTimeDamageDestinationAst::Controller => {
                         effect.to_controller()
                     }
+                    crate::cards::builders::RedirectNextTimeDamageDestinationAst::SourceController => {
+                        effect.to_source_controller()
+                    }
                 };
                 let effect = if *all_this_turn {
                     effect.all_this_turn()
@@ -1757,6 +1760,15 @@ fn compile_subject_verb_effect(
                     effect
                 };
                 Effect::new(effect)
+            })
+        }
+        SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { source } => {
+            compile_effect_for_target(source, ctx, |spec| {
+                Effect::new(
+                    crate::effects::RedirectNextTimeDamageToSourceEffect::from_source_target(spec)
+                        .to_source_controller()
+                        .all_this_turn(),
+                )
             })
         }
         SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -124,6 +124,9 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::PreventAllCombatDamageFromSource { source: target, .. }
             | SubjectVerbActionAst::RedirectNextDamageFromSourceToTarget { target, .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { target, .. }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
+                source: target,
+            }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { target, .. }
             | SubjectVerbActionAst::CreateTokenCopyFromSource { source: target, .. }
             | SubjectVerbActionAst::PreventDamage { target, .. }
@@ -708,6 +711,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
         | SubjectVerbActionAst::PreventNextTimeDamage { .. }
         | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
+        | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
         | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
         | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
         | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1378,6 +1378,9 @@ pub(crate) enum SubjectVerbActionAst {
         destination: RedirectNextTimeDamageDestinationAst,
         all_this_turn: bool,
     },
+    RedirectAllDamageThisTurnBySourceToSourceController {
+        source: TargetAst,
+    },
     RedirectAllDamageThisTurnToTarget {
         player_filter: PlayerFilter,
         object_filter: ObjectFilter,
@@ -2772,6 +2775,10 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("target", target)
                 .field("destination", destination)
                 .field("all_this_turn", all_this_turn)
+                .finish(),
+            Self::RedirectAllDamageThisTurnBySourceToSourceController { source } => f
+                .debug_struct("RedirectAllDamageThisTurnBySourceToSourceController")
+                .field("source", source)
                 .finish(),
             Self::RedirectAllDamageThisTurnToTarget {
                 player_filter,
@@ -4629,6 +4636,16 @@ impl EffectAst {
                 destination,
                 all_this_turn: true,
             },
+        )
+    }
+
+    pub(crate) fn subject_verb_redirect_all_damage_this_turn_by_source_to_source_controller(
+        source: TargetAst,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { source },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -421,6 +421,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -723,6 +723,9 @@ fn advance_reference_frame_for_effect(
                 }
                 SubjectVerbActionAst::RedirectNextDamageFromSourceToTarget { target, .. }
                 | SubjectVerbActionAst::RedirectNextTimeDamageToSource { target, .. }
+                | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
+                    source: target,
+                }
                 | SubjectVerbActionAst::PreventDamage { target, .. }
                 | SubjectVerbActionAst::PreventAllDamageToTarget { target, .. }
                 | SubjectVerbActionAst::PreventDamageToTargetPutCounters { target, .. }
@@ -1988,6 +1991,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
@@ -2767,6 +2771,9 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 bind_unresolved_it_in_prevent_next_source(source, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
             }
+            SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
+                source,
+            } => bind_unresolved_it_in_target(source, seed_tag),
             SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget {
                 object_filter,
                 target,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1857,6 +1857,49 @@ pub(crate) fn parse_redirect_next_damage_sentence(
         ]));
     }
 
+    if clause_words.starts_with(&[
+        "all", "damage", "that", "would", "be", "dealt", "this", "turn", "by",
+    ]) {
+        let is_dealt_rel = clause
+            .from_word(9)
+            .unwrap_or_else(|| clause.from(clause.len()))
+            .find_phrase_start(&["is", "dealt", "to"])
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unsupported redirected-source-damage destination (clause: '{}')",
+                    clause_text
+                ))
+            })?;
+        let is_dealt_idx = 9 + is_dealt_rel;
+        let source_clause = clause.between_words_trimmed(9, is_dealt_idx);
+        if source_clause.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing redirected-source-damage source (clause: '{}')",
+                clause_text
+            )));
+        }
+
+        let redirect_clause = clause
+            .after_words(is_dealt_idx + 3)
+            .unwrap_or_else(|| clause.from(clause.len()))
+            .trimmed();
+        if !redirect_clause.matches_any_words(&[
+            &["that", "spell's", "controller", "instead"],
+            &["that", "spells", "controller", "instead"],
+            &["that", "source's", "controller", "instead"],
+            &["that", "sources", "controller", "instead"],
+        ]) {
+            return Ok(None);
+        }
+
+        let source = parse_target_phrase(source_clause.tokens())?;
+        return Ok(Some(vec![
+            EffectAst::subject_verb_redirect_all_damage_this_turn_by_source_to_source_controller(
+                source,
+            ),
+        ]));
+    }
+
     if CLAUSE_ALL_DAMAGE_WOULD_BE_DEALT_TO_PREFIX_PATTERN.matches(clause) {
         let idx = 7usize;
         let this_turn_rel = LexedClause::new(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -883,7 +883,8 @@ fn maybe_rewrite_future_zone_replacement_sentence(
             EffectAst::SubjectVerb(SubjectVerbEffectAst {
                 action: SubjectVerbActionAst::ExileInsteadOfGraveyardThisTurn
                     | SubjectVerbActionAst::PreventNextTimeDamage { .. }
-                    | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. },
+                    | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
+                    | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. },
                 ..
             })
         )
@@ -2100,6 +2101,9 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::SacrificeSourceWhenLeaves { target }
             | SubjectVerbActionAst::RedirectNextDamageFromSourceToTarget { target, .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { target, .. }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
+                source: target,
+            }
             | SubjectVerbActionAst::PreventDamage { target, .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { target, .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { target, .. }
@@ -2583,6 +2587,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::PreventAllCombatDamageToYou { .. }
             | SubjectVerbActionAst::PreventNextTimeDamage { .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { .. }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
@@ -2861,6 +2866,9 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource {
                 target: effect_target,
                 ..
+            }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
+                source: effect_target,
             }
             | SubjectVerbActionAst::PreventDamage {
                 target: effect_target,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -885,6 +885,9 @@ fn parse_effect_sentence_with_where_x_lexed(
             | SubjectVerbActionAst::GrantAbilitiesChoiceToTarget { target, .. }
             | SubjectVerbActionAst::RedirectNextDamageFromSourceToTarget { target, .. }
             | SubjectVerbActionAst::RedirectNextTimeDamageToSource { target, .. }
+            | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
+                source: target,
+            }
             | SubjectVerbActionAst::RetargetStackObject { target, .. }
             | SubjectVerbActionAst::DealDamage { target, .. }
             | SubjectVerbActionAst::DealDistributedDamage { target, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8549,6 +8549,28 @@ fn parse_prevent_all_damage_by_opponents_creatures_effect_clause() {
 }
 
 #[test]
+fn parse_reverberation_target_sorcery_damage_redirect_effect_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Reverberation")
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "All damage that would be dealt this turn by target sorcery spell is dealt to that spell's controller instead.",
+        )
+        .expect("Reverberation target-sorcery redirect clause should parse");
+
+    let spell_debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        spell_debug.contains("redirectnexttimedamagetosourceeffect")
+            && spell_debug.contains("source: target")
+            && spell_debug.contains("target: none")
+            && spell_debug.contains("destination: sourcecontroller")
+            && spell_debug.contains("all_this_turn: true")
+            && spell_debug.contains("target")
+            && spell_debug.contains("sorcery"),
+        "expected targeted sorcery source redirected to its controller, got {spell_debug}"
+    );
+}
+
+#[test]
 fn rewrite_grammar_attached_prevent_all_damage_to_enchanted_creature_line() {
     let tokens = lex_line(
         "Prevent all damage that would be dealt to enchanted creature.",

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -117,12 +117,14 @@ pub enum PreventNextTimeDamageTarget {
 pub enum RedirectNextTimeDamageSource {
     Choice,
     Filter(crate::filter_model::ObjectFilter),
+    Target(crate::target_model::ChooseSpec),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RedirectNextTimeDamageDestination {
     SourceObject,
     Controller,
+    SourceController,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3513,8 +3515,22 @@ impl RedirectNextTimeDamageToSourceEffect {
         }
     }
 
+    pub fn from_source_target(source: ChooseSpec) -> Self {
+        Self {
+            source: RedirectNextTimeDamageSource::Target(source),
+            target: None,
+            destination: RedirectNextTimeDamageDestination::SourceController,
+            all_this_turn: false,
+        }
+    }
+
     pub fn to_controller(mut self) -> Self {
         self.destination = RedirectNextTimeDamageDestination::Controller;
+        self
+    }
+
+    pub fn to_source_controller(mut self) -> Self {
+        self.destination = RedirectNextTimeDamageDestination::SourceController;
         self
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -1083,6 +1083,7 @@ pub(crate) enum PreventNextTimeDamageSourceAst {
 pub(crate) enum RedirectNextTimeDamageDestinationAst {
     SourceObject,
     Controller,
+    SourceController,
 }
 
 #[cfg(any(test, ironsmith_runtime_parser_tests))]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -26206,6 +26206,26 @@ fn harsh_judgment_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn reverberation_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Reverberation");
+
+    let compiled = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        compiled,
+        "All damage that would be dealt this turn by target sorcery spell is dealt to that spell's controller instead."
+    );
+
+    let spell_debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        spell_debug.contains("redirectnexttimedamagetosourceeffect")
+            && spell_debug.contains("sorcery")
+            && spell_debug.contains("sourcecontroller"),
+        "expected Reverberation to compile into a targeted sorcery damage redirect, got {spell_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_red_noncombat_damage_minimum_replacement_line() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Deepest Might Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32961,6 +32961,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     format!("{desc} source")
                 }
             }
+            crate::effects::RedirectNextTimeDamageSource::Target(spec) => {
+                describe_choose_spec(spec)
+            }
         };
         if redirect_next_time.all_this_turn {
             let destination_text = match redirect_next_time.destination {
@@ -32968,20 +32971,51 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     "this creature".to_string()
                 }
                 crate::effects::RedirectNextTimeDamageDestination::Controller => "you".to_string(),
+                crate::effects::RedirectNextTimeDamageDestination::SourceController => {
+                    if source_text.ends_with("spell") {
+                        "that spell's controller".to_string()
+                    } else {
+                        "that source's controller".to_string()
+                    }
+                }
             };
-            return format!(
-                "All damage that would be dealt to {} this turn by {source_text} is dealt to {destination_text} instead",
-                describe_choose_spec(&redirect_next_time.target)
-            );
+            return if let Some(target) = &redirect_next_time.target {
+                format!(
+                    "All damage that would be dealt to {} this turn by {source_text} is dealt to {destination_text} instead",
+                    describe_choose_spec(target)
+                )
+            } else {
+                format!(
+                    "All damage that would be dealt this turn by {source_text} is dealt to {destination_text} instead"
+                )
+            };
         }
         return match redirect_next_time.destination {
             crate::effects::RedirectNextTimeDamageDestination::SourceObject => format!(
                 "The next time {source_text} would deal damage to {} this turn, that damage is dealt to this creature instead",
-                describe_choose_spec(&redirect_next_time.target)
+                describe_choose_spec(
+                    redirect_next_time
+                        .target
+                        .as_ref()
+                        .expect("redirect-next damage target")
+                )
             ),
             crate::effects::RedirectNextTimeDamageDestination::Controller => format!(
                 "The next time {source_text} would deal damage to {} this turn, that source deals that damage to you instead",
-                describe_choose_spec(&redirect_next_time.target)
+                describe_choose_spec(
+                    redirect_next_time
+                        .target
+                        .as_ref()
+                        .expect("redirect-next damage target")
+                )
+            ),
+            crate::effects::RedirectNextTimeDamageDestination::SourceController => format!(
+                "The next time {source_text} would deal damage this turn, that damage is dealt to {} instead",
+                if source_text.ends_with("spell") {
+                    "that spell's controller"
+                } else {
+                    "that source's controller"
+                }
             ),
         };
     }

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -990,16 +990,26 @@ where
             ironsmith_core::RedirectNextTimeDamageSource::Filter(filter) => {
                 crate::effects::RedirectNextTimeDamageSource::Filter(filter.clone())
             }
+            ironsmith_core::RedirectNextTimeDamageSource::Target(spec) => {
+                crate::effects::RedirectNextTimeDamageSource::Target(spec.clone())
+            }
         };
-        let Some(target) = payload.target.clone() else {
-            return Err(hooks.unsupported_effect(
-                "redirect next time damage to source without a protected target".to_string(),
-            ));
+        let effect = if let Some(target) = payload.target.clone() {
+            crate::effects::RedirectNextTimeDamageToSourceEffect::new(source, target)
+        } else {
+            crate::effects::RedirectNextTimeDamageToSourceEffect {
+                source,
+                target: None,
+                destination: crate::effects::RedirectNextTimeDamageDestination::SourceObject,
+                all_this_turn: false,
+            }
         };
-        let effect = crate::effects::RedirectNextTimeDamageToSourceEffect::new(source, target);
         let effect = match payload.destination {
             ironsmith_core::RedirectNextTimeDamageDestination::SourceObject => effect,
             ironsmith_core::RedirectNextTimeDamageDestination::Controller => effect.to_controller(),
+            ironsmith_core::RedirectNextTimeDamageDestination::SourceController => {
+                effect.to_source_controller()
+            }
         };
         let effect = if payload.all_this_turn {
             effect.all_this_turn()

--- a/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
@@ -5,7 +5,9 @@ use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_objects_for_effect;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::DamageTarget;
-use crate::events::damage::matchers::{DamageSourceConstraint, DamageToPlayerOrObjectMatcher};
+use crate::events::damage::matchers::{
+    DamageFromSourceMatcher, DamageSourceConstraint, DamageToPlayerOrObjectMatcher,
+};
 use crate::events::traits::{EventKind, GameEventType, ReplacementMatcher};
 use crate::filter::ObjectFilterExt as _;
 use crate::game_state::GameState;
@@ -56,12 +58,14 @@ impl ReplacementMatcher for DamageSourceToSpecificObjectMatcher {
 pub enum RedirectNextTimeDamageSource {
     Choice,
     Filter(ObjectFilter),
+    Target(ChooseSpec),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RedirectNextTimeDamageDestination {
     SourceObject,
     Controller,
+    SourceController,
 }
 
 /// "The next time a source of your choice would deal damage to target creature this turn,
@@ -69,7 +73,7 @@ pub enum RedirectNextTimeDamageDestination {
 #[derive(Debug, Clone, PartialEq)]
 pub struct RedirectNextTimeDamageToSourceEffect {
     pub source: RedirectNextTimeDamageSource,
-    pub target: ChooseSpec,
+    pub target: Option<ChooseSpec>,
     pub destination: RedirectNextTimeDamageDestination,
     pub all_this_turn: bool,
 }
@@ -138,14 +142,28 @@ impl RedirectNextTimeDamageToSourceEffect {
     pub fn new(source: RedirectNextTimeDamageSource, target: ChooseSpec) -> Self {
         Self {
             source,
-            target,
+            target: Some(target),
             destination: RedirectNextTimeDamageDestination::SourceObject,
+            all_this_turn: false,
+        }
+    }
+
+    pub fn from_source_target(source: ChooseSpec) -> Self {
+        Self {
+            source: RedirectNextTimeDamageSource::Target(source),
+            target: None,
+            destination: RedirectNextTimeDamageDestination::SourceController,
             all_this_turn: false,
         }
     }
 
     pub fn to_controller(mut self) -> Self {
         self.destination = RedirectNextTimeDamageDestination::Controller;
+        self
+    }
+
+    pub fn to_source_controller(mut self) -> Self {
+        self.destination = RedirectNextTimeDamageDestination::SourceController;
         self
     }
 
@@ -161,14 +179,16 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        let protected_target = resolve_objects_for_effect(game, ctx, &self.target)?
-            .into_iter()
-            .next()
-            .ok_or(ExecutionError::InvalidTarget)?;
-
         let source_constraint = match &self.source {
             RedirectNextTimeDamageSource::Filter(filter) => {
                 DamageSourceConstraint::Filter(filter.clone())
+            }
+            RedirectNextTimeDamageSource::Target(spec) => {
+                let source = resolve_objects_for_effect(game, ctx, spec)?
+                    .into_iter()
+                    .next()
+                    .ok_or(ExecutionError::InvalidTarget)?;
+                DamageSourceConstraint::Specific(source)
             }
             RedirectNextTimeDamageSource::Choice => {
                 let mut candidates = Vec::new();
@@ -220,17 +240,40 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
             RedirectNextTimeDamageDestination::Controller => {
                 RedirectTarget::ToPlayer(ctx.controller)
             }
+            RedirectNextTimeDamageDestination::SourceController => {
+                RedirectTarget::ToSourceController
+            }
         };
 
-        let replacement = ReplacementEffect::with_matcher(
-            ctx.source,
-            ctx.controller,
-            DamageSourceToSpecificObjectMatcher::new(source_constraint, protected_target),
-            ReplacementAction::Redirect {
-                target: redirect_target,
-                which: RedirectWhich::First,
-            },
-        );
+        let replacement = if let Some(target) = &self.target {
+            let protected_target = resolve_objects_for_effect(game, ctx, target)?
+                .into_iter()
+                .next()
+                .ok_or(ExecutionError::InvalidTarget)?;
+            ReplacementEffect::with_matcher(
+                ctx.source,
+                ctx.controller,
+                DamageSourceToSpecificObjectMatcher::new(source_constraint, protected_target),
+                ReplacementAction::Redirect {
+                    target: redirect_target,
+                    which: RedirectWhich::First,
+                },
+            )
+        } else {
+            let filter = match source_constraint {
+                DamageSourceConstraint::Specific(source) => ObjectFilter::specific(source),
+                DamageSourceConstraint::Filter(filter) => filter,
+            };
+            ReplacementEffect::with_matcher(
+                ctx.source,
+                ctx.controller,
+                DamageFromSourceMatcher::new(filter),
+                ReplacementAction::Redirect {
+                    target: redirect_target,
+                    which: RedirectWhich::First,
+                },
+            )
+        };
         if self.all_this_turn {
             game.effect_store
                 .replacement_effects
@@ -244,11 +287,14 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
     }
 
     fn get_target_spec(&self) -> Option<&ChooseSpec> {
-        Some(&self.target)
+        self.target.as_ref().or_else(|| match &self.source {
+            RedirectNextTimeDamageSource::Target(spec) => Some(spec),
+            _ => None,
+        })
     }
 
     fn target_description(&self) -> &'static str {
-        "target creature to protect and redirect from"
+        "damage source or protected target for redirection"
     }
 }
 
@@ -301,6 +347,20 @@ mod tests {
             .card_types(vec![CardType::Creature])
             .build();
         game.create_object_from_card(&card, controller, Zone::Battlefield)
+    }
+
+    fn create_sorcery_on_stack(
+        game: &mut crate::game_state::GameState,
+        name: &str,
+        controller: PlayerId,
+        card_id: u32,
+    ) -> crate::ids::ObjectId {
+        let card = CardBuilder::new(CardId::from_raw(card_id), name)
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        let object_id = game.create_object_from_card(&card, controller, Zone::Stack);
+        game.push_to_stack(crate::game_state::StackEntry::new(object_id, controller));
+        object_id
     }
 
     #[test]
@@ -386,6 +446,117 @@ mod tests {
             0,
             "next-time redirect should not register until end of turn"
         );
+    }
+
+    #[test]
+    fn reverberation_redirects_target_sorcery_spell_damage_to_that_spells_controller() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let target_sorcery = create_sorcery_on_stack(&mut game, "Target Sorcery", bob, 80_020);
+        let reverberation = CardBuilder::new(CardId::from_raw(80_021), "Reverberation")
+            .card_types(vec![CardType::Instant])
+            .build();
+        let reverberation_id = game.create_object_from_card(&reverberation, alice, Zone::Stack);
+
+        let mut ctx = ExecutionContext::new_default(reverberation_id, alice)
+            .with_targets(vec![ResolvedTarget::Object(target_sorcery)]);
+        RedirectNextTimeDamageToSourceEffect::from_source_target(ChooseSpec::target(
+            ChooseSpec::Object(crate::target::ObjectFilter::spell().with_type(CardType::Sorcery)),
+        ))
+        .all_this_turn()
+        .execute(&mut game, &mut ctx)
+        .expect("Reverberation replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            target_sorcery,
+            DamageTarget::Player(alice),
+            3,
+            false,
+            EventCause::effect(),
+        );
+        let alice_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(alice))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let bob_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(bob))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(alice_damage, 0);
+        assert_eq!(bob_damage, 3);
+        assert!(!processed.replacement_prevented);
+
+        let second = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            target_sorcery,
+            DamageTarget::Player(alice),
+            2,
+            false,
+            EventCause::effect(),
+        );
+        let second_bob_damage: u32 = second
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(bob))
+            .map(|assignment| assignment.amount)
+            .sum();
+        assert_eq!(second_bob_damage, 2, "effect should last for the turn");
+    }
+
+    #[test]
+    fn reverberation_does_not_redirect_damage_from_untargeted_sorcery_spell() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let target_sorcery = create_sorcery_on_stack(&mut game, "Target Sorcery", bob, 80_025);
+        let other_sorcery = create_sorcery_on_stack(&mut game, "Other Sorcery", bob, 80_026);
+        let reverberation = CardBuilder::new(CardId::from_raw(80_027), "Reverberation")
+            .card_types(vec![CardType::Instant])
+            .build();
+        let reverberation_id = game.create_object_from_card(&reverberation, alice, Zone::Stack);
+
+        let mut ctx = ExecutionContext::new_default(reverberation_id, alice)
+            .with_targets(vec![ResolvedTarget::Object(target_sorcery)]);
+        RedirectNextTimeDamageToSourceEffect::from_source_target(ChooseSpec::target(
+            ChooseSpec::Object(crate::target::ObjectFilter::spell().with_type(CardType::Sorcery)),
+        ))
+        .all_this_turn()
+        .execute(&mut game, &mut ctx)
+        .expect("Reverberation replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            other_sorcery,
+            DamageTarget::Player(alice),
+            4,
+            false,
+            EventCause::effect(),
+        );
+        let alice_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(alice))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let bob_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(bob))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(alice_damage, 4);
+        assert_eq!(bob_damage, 0);
+        assert!(!processed.replacement_prevented);
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Reverberation
Initial parse error:
```
parser does not yet support line family: 'All damage that would be dealt this turn by target sorcery spell is dealt to that spell's controller instead.'; oracle-only fallback also failed: parser does not yet support line family: 'All damage that would be dealt this turn by target sorcery spell is dealt to that spell's controller instead.'
```

Current worker: i-01071412839902dfd
Branch: codex/aws-card-fix-reverberation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0001
