### PR TITLE
Fix Ironsmith parse failure: Release to the Wind

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -151,6 +151,14 @@ fn parse_permission_lead_inner<'a>(
             player: PlayerAst::Any,
             allow_land: true,
         }),
+        grammar::phrase(&["its", "owner", "may", "cast"]).value(PermissionLead {
+            player: PlayerAst::ItsOwner,
+            allow_land: false,
+        }),
+        grammar::phrase(&["its", "owner", "may", "play"]).value(PermissionLead {
+            player: PlayerAst::ItsOwner,
+            allow_land: true,
+        }),
         grammar::phrase(&["cast"]).value(PermissionLead {
             player: PlayerAst::Implicit,
             allow_land: false,
@@ -468,6 +476,15 @@ fn parse_permission_duration_prefix_tokens<'a>(
         return (Some(PermissionLifetime::ForAsLongAsExiled), rest);
     }
 
+    if let Some(rest) = token_slice_strip_word_prefix(
+        tokens,
+        &[
+            "for", "as", "long", "as", "that", "card", "remains", "exiled",
+        ],
+    ) {
+        return (Some(PermissionLifetime::ForAsLongAsExiled), rest);
+    }
+
     (None, tokens)
 }
 
@@ -526,6 +543,17 @@ fn parse_permission_tail_tokens(
     if token_slice_strip_word_prefix(
         tokens,
         &["for", "as", "long", "as", "it", "remains", "exiled"],
+    )
+    .is_some_and(|rest| rest.is_empty())
+    {
+        return Some((PermissionLifetime::ForAsLongAsExiled, false));
+    }
+
+    if token_slice_strip_word_prefix(
+        tokens,
+        &[
+            "for", "as", "long", "as", "that", "card", "remains", "exiled",
+        ],
     )
     .is_some_and(|rest| rest.is_empty())
     {
@@ -1009,13 +1037,6 @@ pub(crate) fn parse_permission_clause_spec_lexed(
                 clause_refs.join(" ")
             )));
         }
-        if lifetime == PermissionLifetime::ForAsLongAsExiled && without_paying_mana_cost {
-            return Err(CardTextError::ParseError(format!(
-                "unsupported for-as-long-as-exiled play target with alternative cost (clause: '{}')",
-                clause_refs.join(" ")
-            )));
-        }
-
         if lifetime == PermissionLifetime::ForAsLongAsYouControlSource && without_paying_mana_cost {
             return Err(CardTextError::ParseError(format!(
                 "unsupported for-as-long-as-you-control-source play target with alternative cost (clause: '{}')",
@@ -1933,13 +1954,17 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             player,
             allow_land,
             as_copy: false,
-            without_paying_mana_cost: false,
+            without_paying_mana_cost,
             lifetime: PermissionLifetime::ForAsLongAsExiled,
-        }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
+        }) if matches!(
+            player,
+            PlayerAst::Implicit | PlayerAst::You | PlayerAst::ItsOwner
+        ) => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
                 tag,
-                PlayerAst::Implicit,
+                player,
                 allow_land,
+                without_paying_mana_cost,
                 allow_any_color_for_cast,
             ),
         )),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2099,6 +2099,7 @@ fn compile_subject_verb_effect(
             tag,
             player,
             allow_land,
+            without_paying_mana_cost,
             allow_any_color_for_cast,
         } => {
             let player_filter =
@@ -2119,16 +2120,23 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            Ok((
-                vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
-                    resolved_tag,
-                    player_filter,
-                    crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled,
-                    *allow_land,
-                    *allow_any_color_for_cast,
-                ))],
-                Vec::new(),
-            ))
+            let mut effects = vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+                resolved_tag.clone(),
+                player_filter.clone(),
+                crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled,
+                *allow_land,
+                *allow_any_color_for_cast,
+            ))];
+            if *without_paying_mana_cost {
+                effects.push(Effect::new(
+                    crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect::new(
+                        resolved_tag,
+                        player_filter,
+                    )
+                    .for_as_long_as_exiled(),
+                ));
+            }
+            Ok((effects, Vec::new()))
         }
         SubjectVerbActionAst::GrantPlayTaggedForAsLongAsYouControlSource {
             tag,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1080,6 +1080,7 @@ pub(crate) enum SubjectVerbActionAst {
         tag: TagKey,
         player: PlayerAst,
         allow_land: bool,
+        without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
     },
     GrantPlayTaggedForAsLongAsYouControlSource {
@@ -2305,12 +2306,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 tag,
                 player,
                 allow_land,
+                without_paying_mana_cost,
                 allow_any_color_for_cast,
             } => f
                 .debug_struct("GrantPlayTaggedForAsLongAsExiled")
                 .field("tag", tag)
                 .field("player", player)
                 .field("allow_land", allow_land)
+                .field("without_paying_mana_cost", without_paying_mana_cost)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
                 .finish(),
             Self::GrantPlayTaggedForAsLongAsYouControlSource {
@@ -3864,6 +3867,7 @@ impl EffectAst {
         tag: TagKey,
         player: PlayerAst,
         allow_land: bool,
+        without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
     ) -> Self {
         Self::subject_verb(
@@ -3873,6 +3877,7 @@ impl EffectAst {
                 tag,
                 player,
                 allow_land,
+                without_paying_mana_cost,
                 allow_any_color_for_cast,
             },
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -627,6 +627,7 @@ fn parse_exile_top_library_then_play_bundle(
                 SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled {
                     player,
                     allow_land,
+                    without_paying_mana_cost,
                     allow_any_color_for_cast,
                     ..
                 },
@@ -635,6 +636,7 @@ fn parse_exile_top_library_then_play_bundle(
             tag,
             player,
             allow_land,
+            without_paying_mana_cost,
             allow_any_color_for_cast,
         ),
         _ => return Ok(None),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -432,6 +432,7 @@ pub(crate) fn parse_look_at_top_then_exile_face_down_then_play_while_exiled(
             SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled {
                 player: permission_player,
                 allow_land,
+                without_paying_mana_cost,
                 allow_any_color_for_cast,
                 ..
             },
@@ -449,6 +450,7 @@ pub(crate) fn parse_look_at_top_then_exile_face_down_then_play_while_exiled(
             looked_tag,
             permission_player,
             allow_land,
+            without_paying_mana_cost,
             allow_any_color_for_cast,
         ),
     ]))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -484,6 +484,7 @@ pub(crate) fn parse_look(
                 PlayerAst::You,
                 true,
                 false,
+                false,
             ),
         );
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5290,6 +5290,27 @@ fn rewrite_lexed_permission_helpers_parse_while_exiled_you_may_spend_mana_suffix
 }
 
 #[test]
+fn rewrite_lexed_permission_helpers_parse_while_exiled_owner_prefix() {
+    let tokens = lex_line(
+        "For as long as that card remains exiled, its owner may cast it without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify while-exiled owner cast permission");
+
+    let parsed = super::permission_helpers::parse_cast_or_play_tagged_clause(&tokens)
+        .expect("while-exiled owner permission should parse")
+        .expect("while-exiled owner permission should produce an effect");
+    let debug = format!("{parsed:?}");
+
+    assert!(
+        debug.contains("GrantPlayTaggedForAsLongAsExiled"),
+        "{debug}"
+    );
+    assert!(debug.contains("player: ItsOwner"), "{debug}");
+    assert!(debug.contains("without_paying_mana_cost: true"), "{debug}");
+}
+
+#[test]
 fn rewrite_lowering_choose_from_opponent_graveyard_or_hand_keeps_choice_zones()
 -> Result<(), CardTextError> {
     let def = CardDefinitionBuilder::new(CardId::new(), "Psychic Intrusion Variant")

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3005,6 +3005,7 @@ impl<E> VoteEffect<E> {
 pub struct GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
     pub tag: crate::tag::TagKey,
     pub player: PlayerFilter,
+    pub duration: GrantPlayTaggedDuration,
     pub while_on_top_of_library: bool,
     pub zone: Option<crate::zone::Zone>,
 }
@@ -3014,6 +3015,7 @@ impl GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
         Self {
             tag: tag.into(),
             player,
+            duration: GrantPlayTaggedDuration::UntilEndOfTurn,
             while_on_top_of_library: false,
             zone: Some(crate::zone::Zone::Exile),
         }
@@ -3021,6 +3023,11 @@ impl GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
 
     pub fn while_on_top_of_library(mut self) -> Self {
         self.while_on_top_of_library = true;
+        self
+    }
+
+    pub fn for_as_long_as_exiled(mut self) -> Self {
+        self.duration = GrantPlayTaggedDuration::ForAsLongAsExiled;
         self
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -21500,18 +21500,44 @@ fn parse_fastbond_additional_land_permission_is_explicitly_unsupported() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn parse_for_as_long_as_play_permission_is_explicitly_unsupported() {
-    let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Elite Spellbinder Variant")
-        .card_types(vec![CardType::Creature])
+fn parse_release_to_the_wind_owner_while_exiled_free_cast_permission() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Release to the Wind Variant")
+        .card_types(vec![CardType::Instant])
         .parse_text(
-            "Flying\nWhen this creature enters, look at target opponent's hand. You may exile a nonland card from it. For as long as that card remains exiled, its owner may play it.",
+            "Exile target nonland permanent. For as long as that card remains exiled, its owner may cast it without paying its mana cost.",
         )
-        .expect_err("for-as-long-as play permission should stay unsupported");
+        .expect("Release to the Wind owner while-exiled free-cast permission should parse");
 
-    let debug = format!("{err:?}").to_ascii_lowercase();
+    let debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
     assert!(
-        debug.contains("unsupported for-as-long-as play/cast permission clause"),
-        "expected explicit for-as-long-as play permission error, got {debug}"
+        debug.contains("grantplaytaggedeffect")
+            && debug.contains("granttaggedspellfreecastuntilendofturneffect")
+            && debug.contains("foraslongasexiled")
+            && debug.contains("ownerof"),
+        "expected Release to the Wind owner while-exiled free-cast permission, got {debug}"
+    );
+}
+
+#[test]
+fn release_to_the_wind_oracle_parses_and_renders_while_exiled_free_cast_permission() {
+    let def = parse_oracle_card_definition("Release to the Wind");
+
+    let spell_debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        spell_debug.contains("movetozoneeffect")
+            && spell_debug.contains("excluded_card_types")
+            && spell_debug.contains("land")
+            && spell_debug.contains("grantplaytaggedeffect")
+            && spell_debug.contains("granttaggedspellfreecastuntilendofturneffect")
+            && spell_debug.contains("foraslongasexiled")
+            && spell_debug.contains("ownerof"),
+        "Release to the Wind should structurally exile a nonland permanent and grant its owner a while-exiled free-cast permission, got {spell_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "Exile target nonland permanent. For as long as that card remains exiled, its owner may cast it without paying its mana cost."
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2939,6 +2939,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
+        .or_else(|| describe_exile_then_free_cast_while_exiled_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
 }
@@ -3431,6 +3432,42 @@ fn describe_choose_top_exile_then_play_structural(effects: &[Effect]) -> Option<
     let verb = if grant.allow_land { "play" } else { "cast" };
     Some(format!(
         "Exile the top card of your library. You may {verb} that card this turn"
+    ))
+}
+
+fn describe_exile_then_free_cast_while_exiled_structural(effects: &[Effect]) -> Option<String> {
+    let [move_effect, grant_play_effect, grant_free_cast_effect] = effects else {
+        return None;
+    };
+    let tag = structural_effect_tag(move_effect)?;
+    let move_to_zone = unwrap_structural_effect_tag(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    let grant_play = grant_play_effect.downcast_ref::<crate::effects::GrantPlayTaggedEffect>()?;
+    let grant_free_cast = grant_free_cast_effect
+        .downcast_ref::<crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect>()?;
+    if move_to_zone.zone != Zone::Exile
+        || grant_play.tag != *tag
+        || grant_free_cast.tag != *tag
+        || grant_play.player != grant_free_cast.player
+        || grant_play.duration != crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+        || grant_free_cast.duration != crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+        || grant_play.allow_land
+        || grant_play.allow_any_color_for_cast
+        || grant_free_cast.zone != Some(Zone::Exile)
+        || grant_free_cast.while_on_top_of_library
+    {
+        return None;
+    }
+    if !matches!(
+        grant_play.player,
+        PlayerFilter::OwnerOf(crate::filter::ObjectRef::Tagged(ref owner_tag)) if owner_tag == tag
+    ) {
+        return None;
+    }
+
+    Some(format!(
+        "Exile {}. For as long as that card remains exiled, its owner may cast it without paying its mana cost",
+        describe_choose_spec(&move_to_zone.target)
     ))
 }
 
@@ -33952,8 +33989,20 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             Some(crate::zone::Zone::OutsideGame) => " from outside the game",
             None => "",
         };
+        let timing_text = match grant_tagged_spell_free_cast.duration {
+            crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn => "this turn",
+            crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd => {
+                "until the end of your next turn"
+            }
+            crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled => {
+                "for as long as it remains exiled"
+            }
+            crate::effects::GrantPlayTaggedDuration::ForAsLongAsYouControlSource => {
+                "for as long as you control this source"
+            }
+        };
         return format!(
-            "{} may cast {object_text}{zone_text} this turn without paying {cost_text}",
+            "{} may cast {object_text}{zone_text} {timing_text} without paying {cost_text}",
             describe_player_filter(&grant_tagged_spell_free_cast.player),
         );
     }

--- a/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_tagged_spell_free_cast_until_end_of_turn.rs
@@ -24,7 +24,14 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
             return Ok(EffectOutcome::count(0));
         };
 
-        let expires_end_of_turn = game.turn.turn_number;
+        let expires_end_of_turn = match self.duration {
+            crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn => game.turn.turn_number,
+            crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd => {
+                game.turn.turn_number.saturating_add(1)
+            }
+            crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+            | crate::effects::GrantPlayTaggedDuration::ForAsLongAsYouControlSource => u32::MAX,
+        };
         let mut granted = 0usize;
         let mut seen = std::collections::HashSet::new();
 
@@ -68,12 +75,160 @@ impl EffectExecutor for GrantTaggedSpellFreeCastUntilEndOfTurnEffect {
                 None,
                 vec![],
             );
-            game.effect_store
-                .grant_registry
-                .grant_alternative_cast_to_card(object_id, zone, player_id, method, source);
+            if self.duration == crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled {
+                game.effect_store.grant_registry.grant_alternative_cast_to_stable_card(
+                    object_id,
+                    object.stable_id,
+                    zone,
+                    player_id,
+                    method,
+                    source,
+                );
+            } else {
+                game.effect_store
+                    .grant_registry
+                    .grant_alternative_cast_to_card(object_id, zone, player_id, method, source);
+            }
             granted += 1;
         }
 
         Ok(EffectOutcome::count(granted as i32))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alternative_cast::AlternativeCastingMethod;
+    use crate::card::CardBuilder;
+    use crate::decision::SelectFirstDecisionMaker;
+    use crate::effects::{GrantPlayTaggedDuration, GrantPlayTaggedEffect};
+    use crate::ids::{CardId, ObjectId, PlayerId};
+    use crate::snapshot::ObjectSnapshot;
+    use crate::target::{ObjectRef, PlayerFilter};
+    use crate::types::CardType;
+    use crate::zone::Zone;
+
+    #[test]
+    fn release_to_the_wind_owner_free_cast_permission_tracks_exiled_card_zone() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let card = CardBuilder::new(CardId::from_raw(46), "Released Creature")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let exiled_id = game.create_object_from_card(&card, bob, Zone::Exile);
+        let snapshot = ObjectSnapshot::from_object(
+            game.object(exiled_id).expect("exiled card should exist"),
+            &game,
+        );
+
+        let tag = crate::TagKey::from("release_to_the_wind_exiled");
+        let mut tags = std::collections::HashMap::new();
+        tags.insert(tag.clone(), vec![snapshot]);
+
+        let mut dm = SelectFirstDecisionMaker;
+        let source = ObjectId::from_raw(475);
+        let mut ctx = ExecutionContext::new(source, alice, &mut dm).with_tagged_objects(tags);
+        let owner_filter = PlayerFilter::OwnerOf(ObjectRef::tagged(tag.clone()));
+
+        GrantPlayTaggedEffect::new(
+            tag.clone(),
+            owner_filter.clone(),
+            GrantPlayTaggedDuration::ForAsLongAsExiled,
+            false,
+            false,
+        )
+        .execute(&mut game, &mut ctx)
+        .expect("Release to the Wind play permission should resolve");
+        GrantTaggedSpellFreeCastUntilEndOfTurnEffect::new(tag, owner_filter)
+            .for_as_long_as_exiled()
+            .execute(&mut game, &mut ctx)
+            .expect("Release to the Wind free-cast permission should resolve");
+
+        assert!(
+            game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                bob
+            ),
+            "the exiled card's owner should be allowed to cast it from exile"
+        );
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled_id,
+                Zone::Exile,
+                alice
+            ),
+            "Release to the Wind grants permission to the card's owner, not the spell controller"
+        );
+
+        let alternatives = game
+            .effect_store
+            .grant_registry
+            .granted_alternative_casts_for_card(&game, exiled_id, Zone::Exile, bob);
+        assert!(
+            alternatives.iter().any(|alternative| matches!(
+                alternative.method,
+                AlternativeCastingMethod::Composed {
+                    name: "Without paying its mana cost",
+                    ..
+                }
+            )),
+            "the owner should receive a no-mana alternative cast from exile, got {alternatives:?}"
+        );
+
+        game.turn.turn_number = game.turn.turn_number.saturating_add(20);
+        assert!(
+            !game
+                .effect_store
+                .grant_registry
+                .granted_alternative_casts_for_card(&game, exiled_id, Zone::Exile, bob)
+                .is_empty(),
+            "the free-cast permission should not expire at end of turn while the card remains exiled"
+        );
+
+        let graveyard_id = game
+            .move_object_by_effect(exiled_id, Zone::Graveyard)
+            .expect("exiled card should move to graveyard");
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                graveyard_id,
+                Zone::Graveyard,
+                bob
+            ),
+            "Release to the Wind's play permission should stop outside exile"
+        );
+        assert!(
+            game.effect_store
+                .grant_registry
+                .granted_alternative_casts_for_card(&game, graveyard_id, Zone::Graveyard, bob)
+                .is_empty(),
+            "Release to the Wind's free-cast permission should stop outside exile"
+        );
+
+        let reexiled_id = game
+            .move_object_by_effect(graveyard_id, Zone::Exile)
+            .expect("card should be able to move back to exile");
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                reexiled_id,
+                Zone::Exile,
+                bob
+            ),
+            "Release to the Wind's permission should not revive after the card leaves exile"
+        );
+        assert!(
+            game.effect_store
+                .grant_registry
+                .granted_alternative_casts_for_card(&game, reexiled_id, Zone::Exile, bob)
+                .is_empty(),
+            "Release to the Wind's free-cast permission should not revive after the card leaves exile"
+        );
     }
 }

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -3945,6 +3945,12 @@ impl GameState {
         let old_zone = old_object.zone;
         let owner = old_object.owner;
 
+        if old_zone != new_zone {
+            self.effect_store
+                .grant_registry
+                .remove_stable_card_grants_for_zone(old_object.stable_id, old_zone);
+        }
+
         if let Some(target) = old_object.attached_to {
             match target {
                 AttachmentTarget::Object(id) => {

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -378,6 +378,26 @@ impl GrantRegistry {
         );
     }
 
+    /// Add an alternative cast grant for a specific physical card that should survive object-id changes.
+    pub fn grant_alternative_cast_to_stable_card(
+        &mut self,
+        target_id: ObjectId,
+        target_stable_id: StableId,
+        zone: Zone,
+        player: PlayerId,
+        method: AlternativeCastingMethod,
+        source: GrantSource,
+    ) {
+        self.grant_to_stable_card(
+            target_id,
+            target_stable_id,
+            zone,
+            player,
+            Grantable::AlternativeCast(method),
+            source,
+        );
+    }
+
     /// Add an alternative cast grant for cards matching a filter.
     pub fn grant_alternative_cast_to_filter(
         &mut self,
@@ -589,6 +609,12 @@ impl GrantRegistry {
                 if *sid == source_id
             )
         });
+    }
+
+    /// Remove grants tied to a physical card's continuous presence in a zone.
+    pub fn remove_stable_card_grants_for_zone(&mut self, stable_id: StableId, zone: Zone) {
+        self.grants
+            .retain(|grant| grant.target_stable_id != Some(stable_id) || grant.zone != zone);
     }
 
     /// Clean up expired grants (call at end of turn).


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Release to the Wind
Initial parse error:
```
unsupported for-as-long-as play/cast permission clause (clause: 'for as long as that card remains exiled its owner may cast it without paying its mana cost'); oracle-only fallback also failed: unsupported for-as-long-as play/cast permission clause (clause: 'for as long as that card remains exiled its owner may cast it without paying its mana cost')
```

Current worker: i-09d0a60f4bb3e7f49
Branch: codex/aws-card-fix-release-to-the-wind
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0001
