### PR TITLE
Fix Ironsmith parse failure: Faerie Slumber Party

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4961,8 +4961,10 @@ fn compile_subject_verb_effect(
         }
         SubjectVerbActionAst::ReturnAllToHand { filter } => {
             let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            let tag = ctx.next_tag("returned");
+            ctx.last_object_tag = Some(tag.clone());
             Ok((
-                vec![Effect::return_all_to_hand(resolved_filter)],
+                vec![Effect::return_all_to_hand(resolved_filter).tag(tag)],
                 Vec::new(),
             ))
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
@@ -409,10 +409,36 @@ pub(super) fn try_compile_flow_and_iteration_effect(
                 "for each player who doesn't must follow a player clause".to_string(),
             ));
         }
+        EffectAst::ForEachOpponentDid {
+            effects,
+            predicate: Some(predicate),
+        } => {
+            let followup = EffectAst::ForEachOpponent {
+                effects: vec![EffectAst::Conditional {
+                    predicate: predicate.clone(),
+                    if_true: effects.clone(),
+                    if_false: Vec::new(),
+                }],
+            };
+            return Ok(Some(compile_effect(&followup, ctx)?));
+        }
         EffectAst::ForEachOpponentDid { .. } => {
             return Err(CardTextError::ParseError(
                 "for each opponent who ... this way must follow an opponent clause".to_string(),
             ));
+        }
+        EffectAst::ForEachPlayerDid {
+            effects,
+            predicate: Some(predicate),
+        } => {
+            let followup = EffectAst::ForEachPlayer {
+                effects: vec![EffectAst::Conditional {
+                    predicate: predicate.clone(),
+                    if_true: effects.clone(),
+                    if_false: Vec::new(),
+                }],
+            };
+            return Ok(Some(compile_effect(&followup, ctx)?));
         }
         EffectAst::ForEachPlayerDid { .. } => {
             return Err(CardTextError::ParseError(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -177,7 +177,8 @@ fn lower_rewrite_statement_to_chunks_impl(
 ) -> Result<Vec<LineAst>, CardTextError> {
     if !parse_groups.is_empty() {
         if parse_groups.len() > 1
-            && sentences_have_token_creation_followup_after_first(parse_groups)
+            && (sentences_have_token_creation_followup_after_first(parse_groups)
+                || sentences_have_this_way_for_each_followup_after_first(parse_groups))
         {
             let group_tokens = join_sentences_with_period(parse_groups);
             let effects = parse_effect_sentences_lexed(&group_tokens)?;
@@ -222,6 +223,7 @@ fn lower_rewrite_statement_to_chunks_impl(
         if !keep_linked_statement_grouped
             && sentence_tokens.len() > 1
             && !sentences_have_token_creation_followup_after_first(&sentence_tokens)
+            && !sentences_have_this_way_for_each_followup_after_first(&sentence_tokens)
             && !sentences_have_temporary_static_followup_after_first(&sentence_tokens)
             && sentence_tokens.iter().any(|sentence| {
                 parse_self_enters_with_x_counters_static_chunk(sentence).is_some()
@@ -311,6 +313,18 @@ fn sentences_have_token_creation_followup_after_first<S: AsRef<[OwnedLexToken]>>
                 ["its", "power", "is", "equal", ..] | ["their", "power", "is", "equal", ..]
             ) && words.contains(&"toughness")
         })
+}
+
+fn sentences_have_this_way_for_each_followup_after_first<S: AsRef<[OwnedLexToken]>>(
+    sentences: &[S],
+) -> bool {
+    sentences.iter().skip(1).any(|sentence| {
+        let words = token_word_refs(sentence.as_ref());
+        matches!(
+            words.as_slice(),
+            ["for", "each", "opponent", "who", ..] | ["for", "each", "player", "who", ..]
+        ) && word_slice_contains_phrase(&words, &["this", "way"])
+    })
 }
 
 fn sentences_have_temporary_static_followup_after_first<S: AsRef<[OwnedLexToken]>>(

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -542,7 +542,11 @@ fn advance_reference_frame_for_effect(
                             Some(PlayerFilter::AliasedOwnerOf(ObjectRef::tagged(tag)));
                     }
                 }
-                SubjectVerbActionAst::ReturnAllToHandOfChosenColor { filter } => {
+                SubjectVerbActionAst::ReturnAllToHand { filter }
+                | SubjectVerbActionAst::ReturnAllToHandOfChosenColor { filter } => {
+                    if frame.auto_tag_object_targets {
+                        frame.last_object_tag = Some(next_reference_tag(id_gen, "returned"));
+                    }
                     track_player_from_object_filter(filter, frame);
                 }
                 SubjectVerbActionAst::MoveToLibraryNthFromTop { target, .. } => {
@@ -1352,6 +1356,7 @@ fn effect_can_supply_prior_effect_memory(effect: &EffectAst) -> bool {
                 | SubjectVerbActionAst::RevealCardsFromHand { .. }
                 | SubjectVerbActionAst::LookAtTopCards { .. }
                 | SubjectVerbActionAst::Draw { .. }
+                | SubjectVerbActionAst::ReturnAllToHand { .. }
         ),
         EffectAst::ForEachOpponent { effects }
         | EffectAst::ForEachPlayersFiltered { effects, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
@@ -113,8 +113,15 @@ const FOR_EACH_TARGET_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact &
 const FOR_EACH_PLAYER_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["player"], &["players"]]);
 const FOR_EACH_EACH_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["each"]);
-const FOR_EACH_TAGGED_ACTION_WORD_PATTERN: ClauseShape<'static> =
-    clause_shape!(exact_any & [&["sacrificed"], &["destroyed"], &["exiled"], &["discarded"]]);
+const FOR_EACH_TAGGED_ACTION_WORD_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any & [
+        &["sacrificed"],
+        &["destroyed"],
+        &["exiled"],
+        &["discarded"],
+        &["returned"],
+    ]
+);
 const FOR_EACH_DISCARD_OR_DISCARDED_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["discard"], &["discarded"]]);
 
@@ -1248,6 +1255,43 @@ pub(crate) fn parse_who_did_this_way_predicate(
         return Ok(None);
     };
     let verb = inner_words.get(1).copied().unwrap_or("");
+    if matches!(verb, "control" | "controlled" | "controls")
+        && this_way_idx > 3
+        && inner_words
+            .get(this_way_idx - 1)
+            .is_some_and(|word| FOR_EACH_TAGGED_ACTION_WORD_PATTERN.matches_word(word))
+    {
+        let filter_start = inner_clause
+            .token_index_for_word_or_end(2)
+            .unwrap_or(inner_clause.len());
+        let filter_end = inner_clause
+            .token_index_for_word_or_end(this_way_idx - 1)
+            .unwrap_or(inner_clause.len());
+        if filter_start < filter_end {
+            let filter_tokens = LexedClause::new(&inner_tokens[filter_start..filter_end]).trim();
+            if !filter_tokens.is_empty() {
+                let filter = parse_object_filter(&filter_tokens, false).or_else(|err| {
+                    if filter_tokens
+                        .first()
+                        .and_then(|token| token.as_word())
+                        .is_some_and(|word| matches!(word, "a" | "an"))
+                    {
+                        parse_object_filter(&filter_tokens[1..], false)
+                    } else {
+                        Err(err)
+                    }
+                });
+                if let Ok(mut filter) = filter {
+                    filter.zone = None;
+                    return Ok(Some(PredicateAst::PlayerTaggedObjectMatches {
+                        player: PlayerAst::That,
+                        tag: TagKey::from(IT_TAG),
+                        filter,
+                    }));
+                }
+            }
+        }
+    }
     let supports_tag = FOR_EACH_TAGGED_ACTION_WORD_PATTERN.matches_word(verb);
     if !supports_tag || this_way_idx <= 2 {
         return Ok(None);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -15283,6 +15283,180 @@ fn test_for_each_opponent_who_does_binds_implicit_followup_to_you() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn faerie_slumber_party_strictly_parses_oracle_text() {
+    assert_oracle_card_parses_strict("Faerie Slumber Party");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn faerie_slumber_party_compiled_text_keeps_returned_creature_condition() {
+    let def = parse_oracle_card_definition("Faerie Slumber Party");
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("return all creatures to their owners' hands")
+            && rendered.contains("controlled a creature returned this way")
+            && rendered.contains("create two 1/1 blue faerie creature tokens")
+            && rendered.contains("block only creatures with flying"),
+        "expected Faerie Slumber Party compiled text to preserve return, condition, token count, and blocking restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn faerie_slumber_party_test_creature(name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_faerie_slumber_party(game: &mut crate::game_state::GameState, controller: PlayerId) {
+    let def = parse_oracle_card_definition("Faerie Slumber Party");
+    let source = game.create_object_from_definition(&def, controller, Zone::Hand);
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller);
+    for effect in def
+        .spell_effect
+        .as_ref()
+        .expect("Faerie Slumber Party should have spell effects")
+        .flattened_default_effects()
+    {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Faerie Slumber Party effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn count_named_objects_for_player(
+    game: &crate::game_state::GameState,
+    zone: Zone,
+    player: PlayerId,
+    name: &str,
+) -> usize {
+    game.objects_in_zone(zone)
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| object.name == name && object.owner == player)
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn count_faerie_tokens_for_controller(
+    game: &crate::game_state::GameState,
+    controller: PlayerId,
+) -> usize {
+    game.objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| {
+            object.kind == crate::object::ObjectKind::Token
+                && object.name == "Faerie"
+                && object.subtypes.contains(&Subtype::Faerie)
+                && object.card_types.contains(&CardType::Creature)
+                && game.controller_of(object) == controller
+        })
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn faerie_slumber_party_returns_all_creatures_and_counts_each_qualifying_opponent_once() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let dana = PlayerId::from_index(3);
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+            "Dana".to_string(),
+        ],
+        20,
+    );
+    let alice_creature = faerie_slumber_party_test_creature("Alice Test Creature");
+    let bob_creature = faerie_slumber_party_test_creature("Bob Test Creature");
+    let bob_second_creature = faerie_slumber_party_test_creature("Bob Second Test Creature");
+    let charlie_creature = faerie_slumber_party_test_creature("Charlie Test Creature");
+
+    game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+    game.create_object_from_definition(&bob_creature, bob, Zone::Battlefield);
+    game.create_object_from_definition(&bob_second_creature, bob, Zone::Battlefield);
+    game.create_object_from_definition(&charlie_creature, charlie, Zone::Battlefield);
+
+    execute_faerie_slumber_party(&mut game, alice);
+
+    assert_eq!(
+        count_named_objects_for_player(&game, Zone::Hand, alice, "Alice Test Creature"),
+        1,
+        "Faerie Slumber Party should return your creatures to their owners' hands"
+    );
+    assert_eq!(
+        count_named_objects_for_player(&game, Zone::Hand, bob, "Bob Test Creature"),
+        1,
+        "Faerie Slumber Party should return opponents' creatures to their owners' hands"
+    );
+    assert_eq!(
+        count_named_objects_for_player(&game, Zone::Hand, bob, "Bob Second Test Creature"),
+        1,
+        "multiple returned creatures controlled by one opponent should all return"
+    );
+    assert_eq!(
+        count_named_objects_for_player(&game, Zone::Hand, charlie, "Charlie Test Creature"),
+        1,
+        "each qualifying opponent's returned creatures should return"
+    );
+    assert_eq!(
+        count_faerie_tokens_for_controller(&game, alice),
+        4,
+        "Bob and Charlie each controlled returned creatures, so Alice should create exactly four Faeries"
+    );
+    assert_eq!(
+        count_faerie_tokens_for_controller(&game, bob),
+        0,
+        "opponents should not create the Faerie tokens"
+    );
+    assert_eq!(
+        count_faerie_tokens_for_controller(&game, charlie),
+        0,
+        "opponents should not create the Faerie tokens"
+    );
+    assert_eq!(
+        count_faerie_tokens_for_controller(&game, dana),
+        0,
+        "non-qualifying opponents should not create tokens"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn faerie_slumber_party_creates_no_tokens_without_opponent_returned_creatures() {
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let alice_creature = faerie_slumber_party_test_creature("Alice Test Creature");
+    game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+
+    execute_faerie_slumber_party(&mut game, alice);
+
+    assert_eq!(
+        count_named_objects_for_player(&game, Zone::Hand, alice, "Alice Test Creature"),
+        1,
+        "the return-all effect should still return your creature"
+    );
+    assert_eq!(
+        count_faerie_tokens_for_controller(&game, alice),
+        0,
+        "no opponent controlled a creature returned this way, so no Faeries should be created"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_for_each_player_who_does_binds_implicit_followup_to_you() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Group Offer Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -15297,10 +15297,11 @@ fn faerie_slumber_party_compiled_text_keeps_returned_creature_condition() {
 
     assert!(
         rendered.contains("return all creatures to their owners' hands")
-            && rendered.contains("controlled a creature returned this way")
-            && rendered.contains("create two 1/1 blue faerie creature tokens")
+            && rendered.contains(
+                "for each opponent who controlled a creature returned this way, you create two 1/1 blue faerie creature tokens"
+            )
             && rendered.contains("block only creatures with flying"),
-        "expected Faerie Slumber Party compiled text to preserve return, condition, token count, and blocking restriction, got {rendered}"
+        "expected Faerie Slumber Party compiled text to preserve return, controller identity, condition, token count, and blocking restriction, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10547,6 +10547,7 @@ pub(super) fn tag_action_from_name(tag: &str) -> Option<&'static str> {
         "destroyed" => Some("destroyed"),
         "exiled" => Some("exiled"),
         "discarded" => Some("discarded"),
+        "returned" => Some("returned"),
         "died" => Some("died"),
         "milled" => Some("milled"),
         "moved" => Some("put"),
@@ -10643,6 +10644,10 @@ pub(super) fn describe_player_relative_condition(condition: &Condition) -> Optio
         } => {
             if *player != PlayerFilter::IteratedPlayer {
                 return None;
+            }
+            if tag.as_str().starts_with("returned_") {
+                let object_text = describe_player_tagged_object_text(tag, filter);
+                return Some(format!("controlled {object_text} returned this way"));
             }
             let action = tag_action_from_name(tag.as_str())?;
             let object_text = with_indefinite_article(&filter.description());
@@ -11960,6 +11965,14 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             }
         }
         Condition::PlayerTaggedObjectMatches { player, tag, filter } => {
+            if tag.as_str().starts_with("returned_") {
+                let object_text = describe_player_tagged_object_text(tag, filter);
+                return format!(
+                    "{} controlled {} returned this way",
+                    describe_player_filter(player),
+                    object_text
+                );
+            }
             if let Some(action) = tag_action_from_name(tag.as_str()) {
                 let object_text = describe_player_tagged_object_text(tag, filter);
                 format!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28295,10 +28295,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 && let Some(create) =
                     conditional.if_true[0].downcast_ref::<crate::effects::CreateTokenEffect>()
                 && create.controller == PlayerFilter::You
-                && create.count == Value::Fixed(1)
             {
-                let token_text = describe_effect(&conditional.if_true[0]);
-                return format!("{token_text} for each {each_player} who {relative}");
+                let token_text = lowercase_first(&describe_effect(&conditional.if_true[0]));
+                return format!("For each {each_player} who {relative}, you {token_text}");
             }
             if conditional.if_true.len() == 1
                 && let Some(damage) =

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28291,12 +28291,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             {
                 return format!("you draw a card for each {each_player} who {relative}");
             }
-            if conditional.if_true.len() == 1
-                && let Some(create) =
-                    conditional.if_true[0].downcast_ref::<crate::effects::CreateTokenEffect>()
+            if let Some(create) = conditional.if_true.first().and_then(|effect| {
+                structural_unwrap_render_wrappers(effect)
+                    .downcast_ref::<crate::effects::CreateTokenEffect>()
+            })
                 && create.controller == PlayerFilter::You
             {
-                let token_text = lowercase_first(&describe_effect(&conditional.if_true[0]));
+                let token_text = lowercase_first(&describe_effect_list(&conditional.if_true));
                 return format!("For each {each_player} who {relative}, you {token_text}");
             }
             if conditional.if_true.len() == 1

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -3468,7 +3468,6 @@ fn evaluate_condition(
                     {
                         return Ok(true);
                     }
-                    continue;
                 }
                 if snapshot.controller != player_id {
                     continue;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Faerie Slumber Party
Initial parse error:
```
for each opponent who ... this way must follow an opponent clause; oracle-only fallback also failed: for each opponent who ... this way must follow an opponent clause
```

Current worker: i-0d9dd14a018e0c0a8
Branch: codex/aws-card-fix-faerie-slumber-party
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0001
