### PR TITLE
Fix Ironsmith parse failure: Desertion

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1093,6 +1093,7 @@ fn compile_subject_verb_effect(
             from_zone,
             to_zone,
             replacement_zone,
+            battlefield_controller,
             duration,
             optional,
             choice_description,
@@ -1111,6 +1112,7 @@ fn compile_subject_verb_effect(
                 *replacement_zone,
                 mode,
             );
+            replacement.battlefield_controller = *battlefield_controller;
             if *optional {
                 replacement.optional = true;
                 replacement.choice_description = choice_description.clone();

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/prepared_effects.rs
@@ -353,14 +353,54 @@ fn extract_local_zone_replacement_followups(
         if register.mode != crate::effects::ReplacementApplyMode::OneShot {
             return None;
         }
-        if choose_spec_contains_it_tag(&register.target)
-            && let Some(target_spec) = &antecedent_target
-        {
-            register.target = target_spec.clone();
+        if let Some(target_spec) = &antecedent_target {
+            if choose_spec_contains_it_tag(&register.target) {
+                register.target = target_spec.clone();
+            } else if let Some(rebound) =
+                rebound_tagged_filter_to_antecedent_target(&register.target, target_spec)
+            {
+                register.target = rebound;
+            }
         }
         replacements.push(register);
     }
     Some(replacements)
+}
+
+fn rebound_tagged_filter_to_antecedent_target(
+    replacement_target: &ChooseSpec,
+    antecedent_target: &ChooseSpec,
+) -> Option<ChooseSpec> {
+    let ChooseSpec::Object(replacement_filter) = replacement_target else {
+        return None;
+    };
+    if replacement_filter.tagged_constraints.is_empty() {
+        return None;
+    }
+
+    fn merge_filter(mut base: ObjectFilter, replacement: &ObjectFilter) -> ObjectFilter {
+        if !replacement.card_types.is_empty() {
+            base.card_types = replacement.card_types.clone();
+        }
+        if replacement.has_mana_cost {
+            base.has_mana_cost = true;
+        }
+        base
+    }
+
+    match antecedent_target {
+        ChooseSpec::Object(base) => Some(ChooseSpec::Object(merge_filter(
+            base.clone(),
+            replacement_filter,
+        ))),
+        ChooseSpec::Target(inner) => match inner.as_ref() {
+            ChooseSpec::Object(base) => Some(ChooseSpec::Target(Box::new(ChooseSpec::Object(
+                merge_filter(base.clone(), replacement_filter),
+            )))),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn normalize_two_target_counter_then_fight(effects: Vec<Effect>) -> Vec<Effect> {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -892,6 +892,7 @@ pub(crate) enum SubjectVerbActionAst {
         from_zone: Option<Zone>,
         to_zone: Option<Zone>,
         replacement_zone: Zone,
+        battlefield_controller: crate::effects::BattlefieldController,
         duration: ZoneReplacementDurationAst,
         optional: bool,
         choice_description: Option<String>,
@@ -1985,6 +1986,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 from_zone,
                 to_zone,
                 replacement_zone,
+                battlefield_controller,
                 duration,
                 optional,
                 choice_description,
@@ -1994,6 +1996,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("from_zone", from_zone)
                 .field("to_zone", to_zone)
                 .field("replacement_zone", replacement_zone)
+                .field("battlefield_controller", battlefield_controller)
                 .field("duration", duration)
                 .field("optional", optional)
                 .field("choice_description", choice_description)
@@ -4918,6 +4921,30 @@ impl EffectAst {
                 from_zone,
                 to_zone,
                 replacement_zone,
+                battlefield_controller: crate::effects::BattlefieldController::Preserve,
+                duration,
+                optional: false,
+                choice_description: None,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_register_zone_replacement_under_you_control(
+        target: TargetAst,
+        from_zone: Option<Zone>,
+        to_zone: Option<Zone>,
+        replacement_zone: Zone,
+        duration: ZoneReplacementDurationAst,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::RegisterZoneReplacement {
+                target,
+                from_zone,
+                to_zone,
+                replacement_zone,
+                battlefield_controller: crate::effects::BattlefieldController::You,
                 duration,
                 optional: false,
                 choice_description: None,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -73,6 +73,7 @@ use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseSha
 use crate::target::{
     ChooseSpec, ObjectFilter, PlayerFilter, TaggedObjectConstraint, TaggedOpbjectRelation,
 };
+use crate::types::CardType;
 use crate::zone::Zone;
 use ironsmith_core::ValueSurfaceHint;
 use std::cell::OnceCell;
@@ -103,6 +104,11 @@ const GRAVEYARD_PHRASE: &[&str] = &["graveyard"];
 const EXILE_PHRASE: &[&str] = &["exile"];
 const HAND_PHRASE: &[&str] = &["hand"];
 const LIBRARY_PHRASE: &[&str] = &["library"];
+const BATTLEFIELD_PHRASE: &[&str] = &["battlefield"];
+const UNDER_YOUR_CONTROL_PHRASE: &[&str] = &["under", "your", "control"];
+const ARTIFACT_PHRASE: &[&str] = &["artifact"];
+const CREATURE_PHRASE: &[&str] = &["creature"];
+const SPELL_PHRASE: &[&str] = &["spell"];
 const WOULD_DIE_THIS_TURN_PHRASE: &[&str] = &["would", "die", "this", "turn"];
 const DEALT_DAMAGE_THIS_WAY_PHRASE: &[&str] = &["dealt", "damage", "this", "way"];
 const DEALT_DAMAGE_BY_PHRASE: &[&str] = &["dealt", "damage", "by"];
@@ -727,6 +733,23 @@ fn future_zone_replacement_from_sentence_text(sentence_text: &str) -> Option<Eff
 
 fn future_zone_replacement_from_sentence_tokens(tokens: &[OwnedLexToken]) -> Option<EffectAst> {
     let target = || TargetAst::Tagged(TagKey::from(IT_TAG), None);
+    let countered_spell_target = || {
+        if sentence_contains(tokens, ARTIFACT_PHRASE)
+            && sentence_contains(tokens, CREATURE_PHRASE)
+            && sentence_contains(tokens, SPELL_PHRASE)
+        {
+            let mut filter = ObjectFilter::default().in_zone(Zone::Stack);
+            filter.card_types = vec![CardType::Artifact, CardType::Creature];
+            filter.has_mana_cost = true;
+            filter.tagged_constraints.push(TaggedObjectConstraint {
+                tag: TagKey::from(IT_TAG),
+                relation: TaggedOpbjectRelation::IsTaggedObject,
+            });
+            TargetAst::Object(filter, None, None)
+        } else {
+            target()
+        }
+    };
     if sentence_contains(tokens, COUNTERED_THIS_WAY_PHRASE)
         && sentence_contains(tokens, INSTEAD_OF_PHRASE)
         && sentence_contains(tokens, GRAVEYARD_PHRASE)
@@ -765,6 +788,21 @@ fn future_zone_replacement_from_sentence_tokens(tokens: &[OwnedLexToken]) -> Opt
             Some(Zone::Stack),
             Some(Zone::Graveyard),
             Zone::Library,
+            ZoneReplacementDurationAst::OneShot,
+        ));
+    }
+
+    if sentence_contains(tokens, COUNTERED_THIS_WAY_PHRASE)
+        && sentence_contains(tokens, INSTEAD_OF_PHRASE)
+        && sentence_contains(tokens, GRAVEYARD_PHRASE)
+        && sentence_contains(tokens, BATTLEFIELD_PHRASE)
+        && sentence_contains(tokens, UNDER_YOUR_CONTROL_PHRASE)
+    {
+        return Some(EffectAst::subject_verb_register_zone_replacement_under_you_control(
+            countered_spell_target(),
+            Some(Zone::Stack),
+            Some(Zone::Graveyard),
+            Zone::Battlefield,
             ZoneReplacementDurationAst::OneShot,
         ));
     }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3585,6 +3585,7 @@ pub struct RegisterZoneReplacementEffect {
     pub from_zone: Option<crate::zone::Zone>,
     pub to_zone: Option<crate::zone::Zone>,
     pub replacement_zone: crate::zone::Zone,
+    pub battlefield_controller: BattlefieldController,
     pub mode: ReplacementApplyMode,
     pub optional: bool,
     pub choice_description: Option<String>,
@@ -3603,10 +3604,16 @@ impl RegisterZoneReplacementEffect {
             from_zone,
             to_zone,
             replacement_zone,
+            battlefield_controller: BattlefieldController::Preserve,
             mode,
             optional: false,
             choice_description: None,
         }
+    }
+
+    pub fn under_you_control(mut self) -> Self {
+        self.battlefield_controller = BattlefieldController::You;
+        self
     }
 
     pub fn optional(mut self, description: impl Into<String>) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -47967,6 +47967,31 @@ fn parse_counter_then_exile_clause_registers_future_zone_replacement() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_desertion_oracle_registers_battlefield_replacement() {
+    let def = parse_oracle_card_definition("Desertion");
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("LocalRewriteEffect")
+            && debug.contains("RegisterZoneReplacementEffect")
+            && debug.contains("replacement_zone: Battlefield")
+            && debug.contains("battlefield_controller: You")
+            && debug.contains("Artifact")
+            && debug.contains("Creature"),
+        "expected Desertion to lower its countered artifact/creature replacement structurally, got {debug}"
+    );
+
+    let rendered = compiled_text_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Counter target spell")
+            && rendered.contains("If an artifact or creature spell is countered this way")
+            && rendered.contains("put that card onto the battlefield under your control instead of into its owner's graveyard"),
+        "expected Desertion compiled text to preserve the conditional instead replacement, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_fatal_push_revolt_stays_self_replacement() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Fatal Push Variant")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -15,6 +15,24 @@ fn value_prefers_equal_to(value: &Value) -> bool {
     value_has_surface_hint(value, ValueSurfaceHint::EqualTo)
 }
 
+fn countered_this_way_referent_from_target(target: &ChooseSpec) -> Option<&'static str> {
+    let filter = match target {
+        ChooseSpec::Object(filter) => filter,
+        ChooseSpec::Target(inner) => match inner.as_ref() {
+            ChooseSpec::Object(filter) => filter,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    if filter.has_mana_cost
+        && filter.card_types.contains(&CardType::Artifact)
+        && filter.card_types.contains(&CardType::Creature)
+    {
+        return Some("an artifact or creature spell");
+    }
+    None
+}
+
 fn describe_pay_any_energy_amount(
     pay_any_energy: &crate::effects::PayAnyEnergyEffect,
 ) -> Option<&'static str> {
@@ -33333,7 +33351,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             .iter()
             .map(|register| {
                 let target = describe_choose_spec(&register.target);
-                let referent = if target.contains("spell") {
+                let referent = if let Some(referent) =
+                    countered_this_way_referent_from_target(&register.target)
+                {
+                    referent.to_string()
+                } else if target.contains("spell") {
                     "that spell".to_string()
                 } else if target.contains("creature") {
                     "that creature".to_string()
@@ -33345,6 +33367,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 if register.from_zone == Some(Zone::Stack)
                     && register.to_zone == Some(Zone::Graveyard)
                 {
+                    if register.replacement_zone == Zone::Battlefield {
+                        let controller_suffix = match register.battlefield_controller {
+                            crate::effects::BattlefieldController::You => " under your control",
+                            crate::effects::BattlefieldController::Owner => {
+                                " under its owner's control"
+                            }
+                            crate::effects::BattlefieldController::Preserve => "",
+                        };
+                        return format!(
+                            "If {referent} is countered this way, put that card onto the battlefield{controller_suffix} instead of into its owner's graveyard"
+                        );
+                    }
                     return format!(
                         "If {referent} is countered this way, it goes to {:?} instead of graveyard",
                         register.replacement_zone
@@ -33395,6 +33429,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             crate::effects::ReplacementApplyMode::Resolution => "",
         };
         let replacement = format!("{:?}", register.replacement_zone).to_ascii_lowercase();
+        if register.from_zone == Some(Zone::Stack)
+            && register.to_zone == Some(Zone::Graveyard)
+            && register.replacement_zone == Zone::Battlefield
+        {
+            let referent = countered_this_way_referent_from_target(&register.target)
+                .unwrap_or(target.as_str());
+            let controller_suffix = match register.battlefield_controller {
+                crate::effects::BattlefieldController::You => " under your control",
+                crate::effects::BattlefieldController::Owner => " under its owner's control",
+                crate::effects::BattlefieldController::Preserve => "",
+            };
+            return format!(
+                "If {referent} is countered this way, put that card onto the battlefield{controller_suffix} instead of into its owner's graveyard"
+            );
+        }
         if register.optional {
             return format!(
                 "If {target} would go{from}{to}{duration}, you may put it into {replacement} instead"

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1152,6 +1152,7 @@ where
             converted.optional = true;
             converted.choice_description = payload.choice_description.clone();
         }
+        converted.battlefield_controller = payload.battlefield_controller;
         return Ok(Effect::new(converted));
     }
     if let Some(converted) =

--- a/crates/ironsmith-runtime/src/effects/composition/local_rewrite.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/local_rewrite.rs
@@ -5,7 +5,7 @@ use crate::effects::{ExecutionContext, ExecutionError, execute_effect};
 use crate::events::ReplacementPriority;
 use crate::game_state::GameState;
 use crate::replacement::ReplacementEffect;
-use crate::target::ObjectFilter;
+use crate::target::{ChooseSpec, ObjectFilter};
 
 /// Execute an effect while temporary replacement effects are scoped to that execution.
 ///
@@ -40,10 +40,22 @@ fn resolve_zone_replacements(
                     replacement.replacement_zone,
                     replacement.optional,
                     replacement.choice_description.clone(),
+                    replacement.battlefield_controller,
+                    object_id,
                 ),
             )
         })
         .collect())
+}
+
+fn should_rebind_invalid_replacement_target(target: &ChooseSpec) -> bool {
+    match target {
+        ChooseSpec::Tagged(_) => true,
+        ChooseSpec::Target(inner) | ChooseSpec::WithCount(inner, _) => {
+            should_rebind_invalid_replacement_target(inner)
+        }
+        _ => false,
+    }
 }
 
 impl EffectExecutor for LocalRewriteEffect {
@@ -68,6 +80,9 @@ impl EffectExecutor for LocalRewriteEffect {
                     effect.with_priority_override(ReplacementPriority::SelfReplacement)
                 })),
                 Err(ExecutionError::InvalidTarget) => {
+                    if !should_rebind_invalid_replacement_target(&replacement.target) {
+                        continue;
+                    }
                     let Some(target_spec) = &fallback_target else {
                         continue;
                     };

--- a/crates/ironsmith-runtime/src/effects/replacement/register_zone_replacement.rs
+++ b/crates/ironsmith-runtime/src/effects/replacement/register_zone_replacement.rs
@@ -1,8 +1,11 @@
 use crate::effect::EffectOutcome;
 use crate::effects::helpers::resolve_objects_for_effect;
-use crate::effects::{EffectExecutionCategory, EffectExecutor, ReplacementApplyMode};
+use crate::effects::{
+    BattlefieldController, EffectExecutionCategory, EffectExecutor, ReplacementApplyMode,
+};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
+use crate::ids::ObjectId;
 use crate::replacement::{ReplacementAction, ReplacementEffect};
 use crate::target::{ChooseSpec, ObjectFilter};
 use crate::zone::Zone;
@@ -14,6 +17,7 @@ pub struct RegisterZoneReplacementEffect {
     pub from_zone: Option<Zone>,
     pub to_zone: Option<Zone>,
     pub replacement_zone: Zone,
+    pub battlefield_controller: BattlefieldController,
     pub mode: ReplacementApplyMode,
     pub optional: bool,
     pub choice_description: Option<String>,
@@ -32,10 +36,16 @@ impl RegisterZoneReplacementEffect {
             from_zone,
             to_zone,
             replacement_zone,
+            battlefield_controller: BattlefieldController::Preserve,
             mode,
             optional: false,
             choice_description: None,
         }
+    }
+
+    pub fn under_you_control(mut self) -> Self {
+        self.battlefield_controller = BattlefieldController::You;
+        self
     }
 
     pub fn optional(mut self, description: impl Into<String>) -> Self {
@@ -62,6 +72,8 @@ impl RegisterZoneReplacementEffect {
                     self.replacement_zone,
                     self.optional,
                     self.choice_description.clone(),
+                    self.battlefield_controller,
+                    object_id,
                 );
                 ReplacementEffect::with_matcher(
                     ctx.source,
@@ -83,6 +95,8 @@ pub(crate) fn zone_replacement_action(
     replacement_zone: Zone,
     optional: bool,
     choice_description: Option<String>,
+    battlefield_controller: BattlefieldController,
+    object_id: ObjectId,
 ) -> ReplacementAction {
     if optional {
         let mut destinations = Vec::new();
@@ -96,6 +110,18 @@ pub(crate) fn zone_replacement_action(
             destinations,
             description: choice_description.unwrap_or_else(|| "Choose a destination".to_string()),
         };
+    }
+
+    if replacement_zone == Zone::Battlefield
+        && battlefield_controller != BattlefieldController::Preserve
+    {
+        let mut move_effect = crate::effects::MoveToZoneEffect::new(
+            ChooseSpec::SpecificObject(object_id),
+            Zone::Battlefield,
+            false,
+        );
+        move_effect.battlefield_controller = battlefield_controller;
+        return ReplacementAction::Instead(vec![crate::effect::Effect::new(move_effect)]);
     }
 
     ReplacementAction::ChangeDestination(replacement_zone)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -35685,6 +35685,203 @@ fn test_force_of_negation_resolution_counters_and_exiles_target_spell() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_desertion_counters_creature_spell_onto_battlefield_under_your_control() {
+    use crate::game_loop::resolve_stack_entry;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let creature_card = CardBuilder::new(CardId::new(), "Desertion Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let creature_id = game.create_object_from_card(&creature_card, bob, Zone::Stack);
+    let creature_stable_id = game
+        .object(creature_id)
+        .expect("creature spell should exist on the stack")
+        .stable_id;
+    game.push_to_stack(StackEntry::new(creature_id, bob));
+
+    let desertion_def = CardDefinitionBuilder::new(CardId::new(), "Desertion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
+        )
+        .expect("Desertion should parse for runtime tests");
+    let desertion_id = game.create_object_from_definition(&desertion_def, alice, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(desertion_id, alice).with_targets(vec![Target::Object(creature_id)]),
+    );
+
+    resolve_stack_entry(&mut game).expect("Desertion should resolve");
+
+    let moved_creature_id = game
+        .find_object_by_stable_id(creature_stable_id)
+        .expect("countered creature should still be findable by stable id");
+    let moved_creature = game
+        .object(moved_creature_id)
+        .expect("countered creature should still exist after resolution");
+    assert_eq!(
+        moved_creature.zone,
+        Zone::Battlefield,
+        "Desertion should put the countered creature spell onto the battlefield"
+    );
+    assert_eq!(
+        moved_creature.owner, bob,
+        "Desertion should not change the card's owner"
+    );
+    assert_eq!(
+        game.controller_of_id(moved_creature_id),
+        Some(alice),
+        "Desertion should put the countered creature under its controller's control"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == creature_id),
+        "countered creature spell should leave the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_desertion_counters_artifact_spell_onto_battlefield_under_your_control() {
+    use crate::game_loop::resolve_stack_entry;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let artifact_card = CardBuilder::new(CardId::new(), "Desertion Target Artifact")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let artifact_id = game.create_object_from_card(&artifact_card, bob, Zone::Stack);
+    let artifact_stable_id = game
+        .object(artifact_id)
+        .expect("artifact spell should exist on the stack")
+        .stable_id;
+    game.push_to_stack(StackEntry::new(artifact_id, bob));
+
+    let desertion_def = CardDefinitionBuilder::new(CardId::new(), "Desertion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
+        )
+        .expect("Desertion should parse for runtime tests");
+    let desertion_id = game.create_object_from_definition(&desertion_def, alice, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(desertion_id, alice).with_targets(vec![Target::Object(artifact_id)]),
+    );
+
+    resolve_stack_entry(&mut game).expect("Desertion should resolve");
+
+    let moved_artifact_id = game
+        .find_object_by_stable_id(artifact_stable_id)
+        .expect("countered artifact should still be findable by stable id");
+    let moved_artifact = game
+        .object(moved_artifact_id)
+        .expect("countered artifact should still exist after resolution");
+    assert_eq!(
+        moved_artifact.zone,
+        Zone::Battlefield,
+        "Desertion should put the countered artifact spell onto the battlefield"
+    );
+    assert_eq!(
+        moved_artifact.owner, bob,
+        "Desertion should not change the card's owner"
+    );
+    assert_eq!(
+        game.controller_of_id(moved_artifact_id),
+        Some(alice),
+        "Desertion should put the countered artifact under its controller's control"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == artifact_id),
+        "countered artifact spell should leave the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_desertion_counters_nonartifact_noncreature_spell_to_graveyard() {
+    use crate::game_loop::resolve_stack_entry;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let instant_card = CardBuilder::new(CardId::new(), "Desertion Target Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let instant_id = game.create_object_from_card(&instant_card, bob, Zone::Stack);
+    let instant_stable_id = game
+        .object(instant_id)
+        .expect("instant spell should exist on the stack")
+        .stable_id;
+    game.push_to_stack(StackEntry::new(instant_id, bob));
+
+    let desertion_def = CardDefinitionBuilder::new(CardId::new(), "Desertion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Counter target spell. If an artifact or creature spell is countered this way, put that card onto the battlefield under your control instead of into its owner's graveyard.",
+        )
+        .expect("Desertion should parse for runtime tests");
+    let desertion_id = game.create_object_from_definition(&desertion_def, alice, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(desertion_id, alice).with_targets(vec![Target::Object(instant_id)]),
+    );
+
+    resolve_stack_entry(&mut game).expect("Desertion should resolve");
+
+    let moved_instant_id = game
+        .find_object_by_stable_id(instant_stable_id)
+        .expect("countered instant should still be findable by stable id");
+    let moved_instant = game
+        .object(moved_instant_id)
+        .expect("countered instant should still exist after resolution");
+    assert_eq!(
+        moved_instant.zone,
+        Zone::Graveyard,
+        "Desertion should counter a nonartifact noncreature spell normally"
+    );
+    assert_eq!(
+        moved_instant.owner, bob,
+        "countered instant should be in its owner's graveyard"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == instant_id),
+        "countered instant spell should leave the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_force_of_negation_exiles_nexus_of_fate_instead_of_shuffling_it() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::game_loop::resolve_stack_entry;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Desertion
Initial parse error:
```
compiled text dropped required semantic marker: instead
```

Current worker: i-042e7133b00d6a2b5
Branch: codex/aws-card-fix-desertion
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0002
