### PR TITLE
Fix Ironsmith parse failure: Lost Monarch of Ifnir

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -4058,9 +4058,6 @@ pub(crate) fn parse_trigger_clause_lexed(
         _ if BEGINNING_DRAW_STEP_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfDrawStep(parse_possessive_clause_player_filter(&words)),
         ),
-        _ if BEGINNING_COMBAT_TRIGGER_PATTERN.matches_words(&words) => Ok(
-            TriggerSpec::BeginningOfCombat(parse_possessive_clause_player_filter(&words)),
-        ),
         _ if BEGINNING_FIRST_MAIN_PHASE_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfPrecombatMain(parse_possessive_clause_player_filter(&words)),
         ),
@@ -4072,6 +4069,9 @@ pub(crate) fn parse_trigger_clause_lexed(
         ),
         _ if BEGINNING_POSTCOMBAT_MAIN_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfPostcombatMain(parse_possessive_clause_player_filter(&words)),
+        ),
+        _ if BEGINNING_COMBAT_TRIGGER_PATTERN.matches_words(&words) => Ok(
+            TriggerSpec::BeginningOfCombat(parse_possessive_clause_player_filter(&words)),
         ),
         _ => Err(CardTextError::ParseError(format!(
             "unsupported trigger clause (clause: '{}')",

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -1662,11 +1662,18 @@ pub(crate) fn parse_granted_keyword_static_line(
         return Ok(Some(compiled));
     }
 
-    let mapped = actions
-        .into_iter()
-        .filter(|action| action.lowers_to_static_ability())
-        .collect::<Vec<_>>();
-    if mapped.is_empty() && !grants_must_attack {
+    let mut mapped = Vec::new();
+    let mut object_ability_grants = Vec::new();
+    for action in actions {
+        if action.lowers_to_static_ability() {
+            mapped.push(action);
+        } else if let Some(granted) = granted_object_ability_for_keyword_action(&action) {
+            object_ability_grants.push(granted);
+        } else {
+            return Ok(None);
+        }
+    }
+    if mapped.is_empty() && object_ability_grants.is_empty() && !grants_must_attack {
         return Ok(None);
     }
 
@@ -1708,6 +1715,19 @@ pub(crate) fn parse_granted_keyword_static_line(
             },
         };
         compiled.push(ast);
+    }
+    let grant_clause = ParsedAnthemClause {
+        subject,
+        power: AnthemValue::Fixed(0),
+        toughness: AnthemValue::Fixed(0),
+        condition,
+    };
+    for (ability, display) in object_ability_grants {
+        compiled.push(grant_object_ability_for_anthem_subject(
+            &grant_clause,
+            ability,
+            display,
+        ));
     }
     Ok(Some(compiled))
 }
@@ -5144,6 +5164,18 @@ fn grant_keyword_action_for_anthem_subject(
             action,
             condition: clause.condition.clone(),
         },
+    }
+}
+
+fn granted_object_ability_for_keyword_action(
+    action: &KeywordAction,
+) -> Option<(ParsedAbility, String)> {
+    match action {
+        KeywordAction::Afflict(amount) => Some((
+            parsed_ability_from_ability(afflict_triggered_ability(*amount)),
+            action.display_text(),
+        )),
+        _ => None,
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -91,7 +91,8 @@ use super::lowering_support::rewrite_parsed_triggered_ability as parsed_triggere
 use super::object_filters::{parse_object_filter, parse_object_filter_lexed};
 use super::rule_engine::{LexRuleHeadHint, LexRuleHintIndex, build_lex_rule_hint_index};
 use super::static_ability_helpers::{
-    lower_granted_abilities_ast_to_object_abilities, static_ability_for_keyword_action,
+    afflict_triggered_ability, lower_granted_abilities_ast_to_object_abilities,
+    static_ability_for_keyword_action,
 };
 use super::token_primitives::{
     find_index, find_window_by, is_core_keyword_marker_text, is_ticket_sticker_marker_text,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -258,6 +258,22 @@ pub(crate) fn decayed_triggered_ability() -> Ability {
     )
 }
 
+pub(crate) fn afflict_triggered_ability(amount: u32) -> Ability {
+    Ability {
+        kind: crate::ability::AbilityKind::Triggered(crate::ability::TriggeredAbility {
+            trigger: Trigger::this_becomes_blocked(),
+            effects: ResolutionProgram::from_effects(vec![Effect::lose_life_player(
+                amount as i32,
+                PlayerFilter::Defending,
+            )]),
+            choices: vec![],
+            intervening_if: None,
+            presentation_label: Some(format!("keyword:afflict {amount}")),
+        }),
+        functional_zones: vec![crate::zone::Zone::Battlefield],
+    }
+}
+
 pub(crate) fn decayed_object_abilities() -> Vec<Ability> {
     vec![
         Ability::static_ability(StaticAbility::keyword_marker("decayed")),
@@ -414,6 +430,9 @@ pub(crate) fn lower_granted_abilities_ast_to_object_abilities(
     let mut lowered = Vec::new();
     for ability in abilities {
         match ability {
+            GrantedAbilityAst::KeywordAction(KeywordAction::Afflict(amount)) => {
+                lowered.push(afflict_triggered_ability(*amount));
+            }
             GrantedAbilityAst::KeywordAction(KeywordAction::Decayed) => {
                 lowered.extend(decayed_object_abilities());
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -752,6 +752,23 @@ const SOURCE_DEALT_COMBAT_DAMAGE_TO_PLAYER_THIS_TURN_PATTERN: ClauseShape<'stati
             ],
         ]
 );
+const PLAYER_WAS_DEALT_COMBAT_DAMAGE_BY_SUBTYPE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &[
+                "a", "player", "was", "dealt", "combat", "damage", "by",
+            ],
+            &[
+                "player", "was", "dealt", "combat", "damage", "by",
+            ],
+            &[
+                "an", "opponent", "was", "dealt", "combat", "damage", "by",
+            ],
+            &[
+                "opponent", "was", "dealt", "combat", "damage", "by",
+            ],
+        ]
+);
 const CAST_THIS_SPELL_DURING_YOUR_MAIN_PHASE_PATTERN: ClauseShape<'static> = clause_shape!(
     exact
         & [
@@ -4327,6 +4344,29 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if SOURCE_DEALT_COMBAT_DAMAGE_TO_PLAYER_THIS_TURN_PATTERN.matches_words(&filtered) {
         return Ok(PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
+    }
+
+    if THIS_TURN_TAIL_PATTERN.matches_words(filtered.get(filtered.len().saturating_sub(2)..).unwrap_or_default())
+        && PLAYER_WAS_DEALT_COMBAT_DAMAGE_BY_SUBTYPE_PREFIX_PATTERN.matches_words(&filtered)
+    {
+        let subtype_idx = filtered.len().saturating_sub(3);
+        let subtype = parse_subtype_word(filtered[subtype_idx]).ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "unsupported combat-damage source subtype predicate: {}",
+                filtered.join(" ")
+            ))
+        })?;
+        let player = if filtered.first() == Some(&"opponent")
+            || filtered.get(1) == Some(&"opponent")
+        {
+            PlayerAst::Opponent
+        } else {
+            PlayerAst::Any
+        };
+        return Ok(PredicateAst::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
+            player,
+            subtype,
+        });
     }
 
     if CAST_THIS_SPELL_DURING_YOUR_MAIN_PHASE_PATTERN.matches_words(&filtered) {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -584,6 +584,12 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::SourceDealtCombatDamageToPlayerThisTurn => {
             Condition::SourceDealtCombatDamageToPlayerThisTurn
         }
+        PredicateAst::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { player, subtype } => {
+            Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
+                player: resolve_non_target_player_filter(*player, &refs)?,
+                subtype: *subtype,
+            }
+        }
         PredicateAst::SourceAttackedThisTurn => Condition::SourceAttackedThisTurn,
         PredicateAst::SourceCameUnderYourControlThisTurn => {
             Condition::SourceCameUnderYourControlThisTurn

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -561,6 +561,10 @@ pub(crate) enum PredicateAst {
     },
     SourcePowerAtLeast(u32),
     SourceDealtCombatDamageToPlayerThisTurn,
+    PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
+        player: PlayerAst,
+        subtype: Subtype,
+    },
     SourceAttackedThisTurn,
     SourceCameUnderYourControlThisTurn,
     SourceAttackedOrBlockedThisTurn,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -1,7 +1,7 @@
 use crate::{
     ActivationTiming, AnthemCountExpression, Comparison, CounterType, EffectId, EventValueSpec,
-    ManaSymbol, ObjectFilter, PlayerFilter, PlayerId, StableId, TagKey, ValueComparisonOperator,
-    Zone,
+    ManaSymbol, ObjectFilter, PlayerFilter, PlayerId, StableId, Subtype, TagKey,
+    ValueComparisonOperator, Zone,
 };
 use crate::{ChooseSpec, Color, ColorSet};
 
@@ -759,6 +759,10 @@ pub enum Condition {
     SourceHasCountersAtLeast(u32),
     SourcePowerAtLeast(u32),
     SourceDealtCombatDamageToPlayerThisTurn,
+    PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
+        player: PlayerFilter,
+        subtype: Subtype,
+    },
     ManaSpentToCastThisSpellAtLeast {
         amount: u32,
         symbol: Option<ManaSymbol>,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3351,6 +3351,45 @@ fn test_parse_afflict_equivalent_rules_text_does_not_render_keyword() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn lost_monarch_of_ifnir_parses_afflict_grant_and_second_main_condition() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(692_108), "Lost Monarch of Ifnir")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Noble])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\n\
+             Other Zombies you control have afflict 3.\n\
+             At the beginning of your second main phase, if a player was dealt combat damage by a Zombie this turn, mill three cards, then you may return a creature card from your graveyard to your hand.",
+        )
+        .expect("Lost Monarch of Ifnir should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Other Zombies you control have afflict 3"),
+        "expected granted afflict keyword text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("At the beginning of your second main phase")
+            && rendered.contains("if a player was dealt combat damage by a Zombie this turn"),
+        "expected second-main Zombie combat-damage condition, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("GrantObjectAbilityForFilter")
+            && debug.contains("PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn")
+            && debug.contains("phase_type: Postcombat")
+            && !debug.contains("BeginningOfCombat"),
+        "expected structural afflict grant and postcombat-main condition, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_bloodthirst_keyword_line_compiles_without_unsupported_marker() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Bloodthirst Parse Test")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12301,6 +12301,16 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {
             "it dealt combat damage to a player this turn".to_string()
         }
+        Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { player, subtype } => {
+            let player_text = match player {
+                PlayerFilter::Any => "a player".to_string(),
+                PlayerFilter::Opponent => "an opponent".to_string(),
+                _ => describe_player_filter(player),
+            };
+            format!(
+                "{player_text} was dealt combat damage by a {subtype} this turn"
+            )
+        }
         Condition::SourceCameUnderYourControlThisTurn => {
             "this creature came under your control this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -873,6 +873,28 @@ fn evaluate_condition_shared_core(
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {
             Some(game.source_dealt_combat_damage_to_player_this_turn(ctx.source))
         }
+        Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { player, subtype } => {
+            let filter_ctx = game.filter_context_for(ctx.controller, ctx.filter_source);
+            let players: Vec<PlayerId> = match player {
+                PlayerFilter::You => vec![ctx.controller],
+                PlayerFilter::Opponent => filter_ctx.opponents.clone(),
+                PlayerFilter::Specific(id) => vec![*id],
+                PlayerFilter::Any => game.players.iter().map(|p| p.id).collect(),
+                PlayerFilter::NotYou => game
+                    .players
+                    .iter()
+                    .filter_map(|p| (p.id != ctx.controller).then_some(p.id))
+                    .collect(),
+                _ => Vec::new(),
+            };
+            Some(
+                game.turn_store
+                    .turn_history
+                    .player_was_dealt_combat_damage_by_creature_subtype_this_turn(
+                        &players, *subtype,
+                    ),
+            )
+        }
         Condition::SourceMatches(filter) => {
             let filter_ctx = game.filter_context_for(ctx.controller, Some(ctx.source));
             Some(
@@ -989,6 +1011,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::SourceHasCountersAtLeast(..) => {}
         Condition::SourcePowerAtLeast(..) => {}
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {}
+        Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { .. } => {}
         Condition::SourceAttackedOrBlockedThisTurn => {}
         Condition::SourceIsInZone(..) => {}
         Condition::ManaSpentToCastThisSpellAtLeast { .. } => {}
@@ -1200,6 +1223,24 @@ pub fn evaluate_condition_external(
                 .map(|pid| game.turn_store.turn_history.spells_cast_by_player(*pid))
                 .sum();
             cast_count >= *count
+        }
+        Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { player, subtype } => {
+            let filter_ctx = game.filter_context_for(ctx.controller, ctx.filter_source);
+            let players: Vec<PlayerId> = match player {
+                PlayerFilter::You => vec![ctx.controller],
+                PlayerFilter::Opponent => filter_ctx.opponents.clone(),
+                PlayerFilter::Specific(id) => vec![*id],
+                PlayerFilter::Any => game.players.iter().map(|p| p.id).collect(),
+                PlayerFilter::NotYou => game
+                    .players
+                    .iter()
+                    .filter_map(|p| (p.id != ctx.controller).then_some(p.id))
+                    .collect(),
+                _ => Vec::new(),
+            };
+            game.turn_store
+                .turn_history
+                .player_was_dealt_combat_damage_by_creature_subtype_this_turn(&players, *subtype)
         }
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
@@ -2074,6 +2115,23 @@ fn evaluate_condition_simple(
             .filter_map(|&id| game.object(id))
             .filter(|obj| opponents.contains(&game.controller_of(obj)))
             .any(|obj| filter.matches(obj, &filter_ctx, game)),
+        Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { player, subtype } => {
+            let players: Vec<PlayerId> = match player {
+                PlayerFilter::You => vec![controller],
+                PlayerFilter::Opponent => opponents.clone(),
+                PlayerFilter::Specific(id) => vec![*id],
+                PlayerFilter::Any => game.players.iter().map(|p| p.id).collect(),
+                PlayerFilter::NotYou => game
+                    .players
+                    .iter()
+                    .filter_map(|p| (p.id != controller).then_some(p.id))
+                    .collect(),
+                _ => Vec::new(),
+            };
+            game.turn_store
+                .turn_history
+                .player_was_dealt_combat_damage_by_creature_subtype_this_turn(&players, *subtype)
+        }
         Condition::PlayerControls { player, filter } => {
             let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
                 return false;
@@ -2831,6 +2889,27 @@ fn evaluate_condition(
                 .any(|obj| filter.matches(obj, &filter_ctx, game));
 
             Ok(has_matching)
+        }
+        Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { player, subtype } => {
+            let filter_ctx = ctx.filter_context(game);
+            let players: Vec<PlayerId> = match player {
+                PlayerFilter::You => vec![ctx.controller],
+                PlayerFilter::Opponent => filter_ctx.opponents.clone(),
+                PlayerFilter::Specific(id) => vec![*id],
+                PlayerFilter::Any => game.players.iter().map(|p| p.id).collect(),
+                PlayerFilter::NotYou => game
+                    .players
+                    .iter()
+                    .filter_map(|p| (p.id != ctx.controller).then_some(p.id))
+                    .collect(),
+                _ => Vec::new(),
+            };
+            Ok(game
+                .turn_store
+                .turn_history
+                .player_was_dealt_combat_damage_by_creature_subtype_this_turn(
+                    &players, *subtype,
+                ))
         }
         Condition::PlayerControls { player, filter } => {
             let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -102,6 +102,313 @@ fn put_rampaging_aetherhood_upkeep_trigger_on_stack(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn lost_monarch_of_ifnir_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(692_108), "Lost Monarch of Ifnir")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Noble])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Afflict 3 (Whenever this creature becomes blocked, defending player loses 3 life.)\n\
+             Other Zombies you control have afflict 3.\n\
+             At the beginning of your second main phase, if a player was dealt combat damage by a Zombie this turn, mill three cards, then you may return a creature card from your graveyard to your hand.",
+        )
+        .expect("Lost Monarch of Ifnir should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_typed_creature(
+    game: &mut GameState,
+    name: &str,
+    owner: PlayerId,
+    subtypes: Vec<Subtype>,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .subtypes(subtypes)
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn block_lost_monarch_attacker(
+    game: &mut GameState,
+    attacker: ObjectId,
+    blocker: ObjectId,
+    defending_player: PlayerId,
+    attack_target: AttackTarget,
+) -> TriggerQueue {
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: attack_target,
+    });
+    let mut trigger_queue = TriggerQueue::new();
+    apply_blocker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[BlockerDeclaration {
+            blocker,
+            blocking: attacker,
+        }],
+        defending_player,
+    )
+    .expect("Lost Monarch combat block should be legal");
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn record_combat_damage_to_player(
+    game: &mut GameState,
+    source: ObjectId,
+    player: PlayerId,
+) {
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            source,
+            crate::events::DamageTarget::Player(player),
+            2,
+            true,
+            crate::events::cause::EventCause::combat_damage(source),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&event);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_lost_monarch_second_main_trigger_on_stack(game: &mut GameState) {
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::NextMain;
+    game.turn.step = None;
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Lost Monarch of Ifnir should have one second-main trigger"
+    );
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Lost Monarch of Ifnir second-main trigger should go on the stack");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn lost_monarch_of_ifnir_grants_afflict_only_to_other_zombies_you_control() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let monarch = lost_monarch_of_ifnir_definition();
+    let monarch_id = game.create_object_from_definition(&monarch, alice, Zone::Battlefield);
+    let other_zombie =
+        create_typed_creature(&mut game, "Ifnir Loyalist", alice, vec![Subtype::Zombie]);
+    let non_zombie = create_typed_creature(&mut game, "Ifnir Human", alice, vec![Subtype::Human]);
+    let opposing_zombie =
+        create_typed_creature(&mut game, "Opposing Zombie", bob, vec![Subtype::Zombie]);
+    let bob_blocker_1 =
+        create_typed_creature(&mut game, "Bob Blocker One", bob, vec![Subtype::Human]);
+    let bob_blocker_2 =
+        create_typed_creature(&mut game, "Bob Blocker Two", bob, vec![Subtype::Human]);
+    let bob_blocker_3 =
+        create_typed_creature(&mut game, "Bob Blocker Three", bob, vec![Subtype::Human]);
+    let alice_blocker =
+        create_typed_creature(&mut game, "Alice Blocker", alice, vec![Subtype::Human]);
+    game.refresh_continuous_state();
+
+    let mut queue = block_lost_monarch_attacker(
+        &mut game,
+        other_zombie,
+        bob_blocker_1,
+        bob,
+        AttackTarget::Player(bob),
+    );
+    assert_eq!(
+        queue.entries.len(),
+        1,
+        "other controlled Zombies should gain afflict 3"
+    );
+    put_triggers_on_stack(&mut game, &mut queue).expect("granted afflict should go on the stack");
+    resolve_stack_entry(&mut game).expect("granted afflict should resolve");
+    assert_eq!(game.player(bob).expect("bob exists").life, 17);
+
+    let mut queue = block_lost_monarch_attacker(
+        &mut game,
+        monarch_id,
+        bob_blocker_2,
+        bob,
+        AttackTarget::Player(bob),
+    );
+    assert_eq!(
+        queue.entries.len(),
+        1,
+        "Lost Monarch should keep only its own afflict trigger; the static grant says other Zombies"
+    );
+    put_triggers_on_stack(&mut game, &mut queue).expect("intrinsic afflict should go on the stack");
+    resolve_stack_entry(&mut game).expect("intrinsic afflict should resolve");
+    assert_eq!(game.player(bob).expect("bob exists").life, 14);
+
+    let queue = block_lost_monarch_attacker(
+        &mut game,
+        non_zombie,
+        bob_blocker_3,
+        bob,
+        AttackTarget::Player(bob),
+    );
+    assert!(queue.entries.is_empty(), "non-Zombies should not gain afflict");
+    assert_eq!(game.player(bob).expect("bob exists").life, 14);
+
+    let queue = block_lost_monarch_attacker(
+        &mut game,
+        opposing_zombie,
+        alice_blocker,
+        alice,
+        AttackTarget::Player(alice),
+    );
+    assert!(
+        queue.entries.is_empty(),
+        "Zombies not controlled by Lost Monarch's controller should not gain afflict"
+    );
+    assert_eq!(game.player(alice).expect("alice exists").life, 20);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn lost_monarch_of_ifnir_second_main_trigger_requires_zombie_combat_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let monarch = lost_monarch_of_ifnir_definition();
+    game.create_object_from_definition(&monarch, alice, Zone::Battlefield);
+    let non_zombie =
+        create_typed_creature(&mut game, "Combat Human", alice, vec![Subtype::Human]);
+    for idx in 0..3 {
+        let card = CardBuilder::new(CardId::new(), &format!("Library Card {idx}"))
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    let library_before = game.player(alice).expect("alice exists").library.len();
+    let graveyard_before = game.player(alice).expect("alice exists").graveyard.len();
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::NextMain;
+    game.turn.step = None;
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Lost Monarch should not trigger without prior Zombie combat damage to a player"
+    );
+
+    record_combat_damage_to_player(&mut game, non_zombie, PlayerId::from_index(1));
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Lost Monarch should not trigger for combat damage dealt by a non-Zombie"
+    );
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        library_before,
+        "Lost Monarch should not mill without prior Zombie combat damage to a player"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").graveyard.len(),
+        graveyard_before,
+        "Lost Monarch should not move cards when the condition is false"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn lost_monarch_of_ifnir_second_main_trigger_mills_and_may_return_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let monarch = lost_monarch_of_ifnir_definition();
+    game.create_object_from_definition(&monarch, alice, Zone::Battlefield);
+    let zombie = create_typed_creature(&mut game, "Combat Zombie", alice, vec![Subtype::Zombie]);
+    for idx in 0..3 {
+        let card = CardBuilder::new(CardId::new(), &format!("Mill Card {idx}"))
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    let creature_card = CardBuilder::new(CardId::new(), "Recoverable Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let creature_id = game.create_object_from_card(&creature_card, alice, Zone::Graveyard);
+    let creature_stable_id = game.object(creature_id).expect("creature card exists").stable_id;
+    record_combat_damage_to_player(&mut game, zombie, bob);
+
+    put_lost_monarch_second_main_trigger_on_stack(&mut game);
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("condition-true second-main trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        0,
+        "Lost Monarch should mill three cards after Zombie combat damage"
+    );
+    let returned_id = game
+        .find_object_by_stable_id(creature_stable_id)
+        .expect("returned creature card should still exist");
+    assert!(
+        game.player(alice).expect("alice exists").hand.contains(&returned_id),
+        "accepting the may choice should return a creature card to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn lost_monarch_of_ifnir_second_main_return_is_optional() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let monarch = lost_monarch_of_ifnir_definition();
+    game.create_object_from_definition(&monarch, alice, Zone::Battlefield);
+    let zombie = create_typed_creature(&mut game, "Combat Zombie", alice, vec![Subtype::Zombie]);
+    for idx in 0..3 {
+        let card = CardBuilder::new(CardId::new(), &format!("Decline Mill Card {idx}"))
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    let creature_card = CardBuilder::new(CardId::new(), "Declined Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let creature_id = game.create_object_from_card(&creature_card, alice, Zone::Graveyard);
+    record_combat_damage_to_player(&mut game, zombie, bob);
+
+    put_lost_monarch_second_main_trigger_on_stack(&mut game);
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("declined second-main trigger should resolve");
+
+    assert_eq!(
+        game.object(creature_id).expect("creature card exists").zone,
+        Zone::Graveyard,
+        "declining the may choice should leave the creature card in the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn rampaging_aetherhood_upkeep_pays_energy_and_adds_that_many_counters() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -13,7 +13,9 @@ use crate::continuous::{
 };
 use crate::effect::{Comparison, Value};
 use crate::filter::ObjectFilterExt as _;
-use crate::filter::{PlayerFilterExt, TaggedConstraintSubject, TaggedOpbjectRelation};
+use crate::filter::{
+    PlayerFilterExt, TaggedConstraintSubject, TaggedOpbjectRelation, describe_player_filter,
+};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::object::CounterType;
@@ -111,6 +113,26 @@ fn lowercase_first_ascii(text: &str) -> String {
 
 fn object_ability_is_static_keyword(ability: &Ability) -> bool {
     matches!(&ability.kind, AbilityKind::Static(static_ability) if static_ability.is_keyword())
+}
+
+fn object_ability_keyword_label(ability: &Ability) -> Option<&str> {
+    match &ability.kind {
+        AbilityKind::Triggered(triggered) => triggered
+            .presentation_label
+            .as_deref()
+            .and_then(|label| label.strip_prefix("keyword:")),
+        _ => None,
+    }
+}
+
+fn explicit_granted_keyword_label(display: &str) -> Option<String> {
+    let label = display.trim().trim_end_matches('.');
+    let lower = label.to_ascii_lowercase();
+    let amount = lower.strip_prefix("afflict ")?;
+    amount
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+        .then_some(lower)
 }
 
 fn subject_text(filter: &ObjectFilter) -> String {
@@ -965,6 +987,19 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         }
         crate::ConditionExpr::OpponentLostLifeThisTurn => {
             "as long as an opponent lost life this turn".to_string()
+        }
+        crate::ConditionExpr::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
+            player,
+            subtype,
+        } => {
+            let player_text = match player {
+                PlayerFilter::Any => "a player".to_string(),
+                PlayerFilter::Opponent => "an opponent".to_string(),
+                _ => describe_player_filter(player),
+            };
+            format!(
+                "as long as {player_text} was dealt combat damage by a {subtype} this turn"
+            )
         }
         crate::ConditionExpr::SourceCameUnderYourControlThisTurn => {
             "as long as this creature came under your control this turn".to_string()
@@ -4230,11 +4265,17 @@ impl StaticAbilityKind for GrantObjectAbilityForFilter {
         }
 
         let filter_desc = self.filter.description();
+        let keyword_label = object_ability_keyword_label(&self.ability)
+            .map(str::to_string)
+            .or_else(|| explicit_granted_keyword_label(&ability_text));
         if object_ability_is_static_keyword(&self.ability) {
             ability_text = lowercase_first_ascii(&ability_text);
+        } else if let Some(label) = keyword_label.as_deref() {
+            ability_text = lowercase_first_ascii(label.trim());
         }
-        let rendered_ability = match self.ability.kind {
-            AbilityKind::Activated(_) | AbilityKind::Triggered(_) => {
+        let rendered_ability = match (&self.ability.kind, keyword_label.as_deref()) {
+            (_, Some(_)) => ability_text,
+            (AbilityKind::Activated(_) | AbilityKind::Triggered(_), _) => {
                 if !ability_text.ends_with('.') {
                     ability_text.push('.');
                 }

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -309,6 +309,34 @@ impl TurnHistory {
         self.total_damage_to_player(player) > 0
     }
 
+    pub fn player_was_dealt_combat_damage_by_creature_subtype_this_turn(
+        &self,
+        players: &[PlayerId],
+        subtype: Subtype,
+    ) -> bool {
+        self.projected_records().any(|record| {
+            let Some(event) = record.event.downcast::<DamageEvent>() else {
+                return false;
+            };
+            if !event.is_combat || event.amount == 0 {
+                return false;
+            }
+            match event.target {
+                crate::events::DamageTarget::Player(player) if players.contains(&player) => {}
+                _ => return false,
+            }
+
+            record
+                .source_snapshot
+                .as_ref()
+                .or(record.object_snapshot.as_ref())
+                .is_some_and(|snapshot| {
+                    snapshot.card_types.contains(&CardType::Creature)
+                        && snapshot.subtypes.contains(&subtype)
+                })
+        })
+    }
+
     pub fn player_lost_life_this_turn(&self, player: PlayerId) -> bool {
         self.projected_records()
             .filter_map(|record| record.event.downcast::<LifeLossEvent>())


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Lost Monarch of Ifnir
Initial parse error:
```
parser does not yet support line family: 'Other Zombies you control have afflict 3.'; oracle-only fallback also failed: parser does not yet support line family: 'Other Zombies you control have afflict 3.'
```

Current worker: i-0bcb1a180c2535c1f
Branch: codex/aws-card-fix-lost-monarch-of-ifnir
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0003
