### PR TITLE
Fix Ironsmith parse failure: See the Truth

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3512,6 +3512,9 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if filtered.len() >= 6 && THIS_SPELL_WAS_CAST_FROM_PREFIX_PATTERN.matches_words(&filtered) {
         let zone_words = &filtered[5..];
+        if zone_words == ["anywhere", "other", "than", "your", "hand"] {
+            return Ok(PredicateAst::ThisSpellWasCastFromNonHand);
+        }
         let zone = if zone_words.len() == 1 {
             parse_zone_word(zone_words[0])
         } else if zone_words.len() == 2 && is_article(zone_words[0]) {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -636,6 +636,7 @@ pub(crate) fn compile_condition_from_predicate_ast(
             Condition::SameColorManaSpentToCastThisSpellAtLeast(*amount)
         }
         PredicateAst::ThisSpellWasCastFromZone(zone) => Condition::ThisSpellWasCastFromZone(*zone),
+        PredicateAst::ThisSpellWasCastFromNonHand => Condition::ThisSpellWasCastFromNonHand,
         PredicateAst::ValueComparison {
             left,
             operator,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -597,6 +597,7 @@ pub(crate) enum PredicateAst {
     },
     SameColorManaSpentToCastThisSpellAtLeast(u32),
     ThisSpellWasCastFromZone(Zone),
+    ThisSpellWasCastFromNonHand,
     ValueComparison {
         left: Value,
         operator: crate::effect::ValueComparisonOperator,
@@ -632,7 +633,8 @@ impl PredicateAst {
             | PredicateAst::ThisSpellEscaped
             | PredicateAst::ThisSpellWasKicked
             | PredicateAst::ThisSpellPaidLabel(_)
-            | PredicateAst::ThisSpellWasCastFromZone(_) => {
+            | PredicateAst::ThisSpellWasCastFromZone(_)
+            | PredicateAst::ThisSpellWasCastFromNonHand => {
                 Some(PredicateReferenceAntecedent::SourceObject)
             }
             PredicateAst::And(left, right) | PredicateAst::Or(left, right) => left

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/triples.rs
@@ -154,6 +154,48 @@ const ONTO_BATTLEFIELD_TAPPED_ZONE_PREFIX_PATTERN: ClauseShape<'static> = clause
 const ONTO_BATTLEFIELD_ZONE_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["onto", "the", "battlefield"], &["onto", "battlefield"]]);
 const PUT_REST_BOTTOM_LIBRARY_PATTERN: ClauseShape<'static> = clause_shape!(prefix_any & [&["put"], &["puts"]]; contains_words & ["rest", "bottom", "library"]);
+const PUT_ONE_LOOKED_CARD_INTO_HAND_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["put", "one", "of", "them", "into", "your", "hand"],
+            &["put", "one", "of", "those", "cards", "into", "your", "hand"],
+            &["put", "one", "into", "your", "hand"],
+        ]
+);
+const PUT_OTHER_LOOKED_CARDS_ON_BOTTOM_PATTERN: ClauseShape<'static> = clause_shape!(
+    contains_any_phrases &[&[
+        &["other", "on", "bottom"],
+        &["other", "onto", "bottom"],
+        &["rest", "on", "bottom"],
+        &["rest", "onto", "bottom"],
+    ]];
+    contains_words &["library"]
+);
+const IF_CAST_NON_HAND_PUT_EACH_LOOKED_INTO_HAND_INSTEAD_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact
+        & [
+            "if",
+            "this",
+            "spell",
+            "was",
+            "cast",
+            "from",
+            "anywhere",
+            "other",
+            "than",
+            "your",
+            "hand",
+            "put",
+            "each",
+            "of",
+            "those",
+            "cards",
+            "into",
+            "your",
+            "hand",
+            "instead",
+        ]
+);
 const WITHOUT_PAYING_ITS_MANA_COST_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["without", "paying", "its", "mana", "cost"]);
 const REVEALED_CARDS_INTO_HAND_TAIL_PATTERN: ClauseShape<'static> =
@@ -2024,6 +2066,86 @@ pub(crate) fn parse_look_at_top_split_hand_bottom_exile_then_play_exiled(
     ));
 
     Ok(Some(effects))
+}
+
+pub(crate) fn parse_look_at_top_put_one_hand_bottom_cast_non_hand_put_all_hand(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some((player, count, reveal_top)) =
+        parse_top_cards_view_sentence(sentences[sentence_idx].lowered())
+    else {
+        return Ok(None);
+    };
+    if reveal_top {
+        return Ok(None);
+    }
+
+    let second_tokens = trim_commas(sentences[sentence_idx + 1].lowered());
+    let second_words = crate::runtime_backend::front_end::lexer::LexedClause::new(&second_tokens)
+        .word_refs();
+    if !PUT_ONE_LOOKED_CARD_INTO_HAND_PATTERN.matches_words(&second_words) {
+        return Ok(None);
+    }
+    let content_words = non_article_word_refs(&second_words);
+    if !PUT_OTHER_LOOKED_CARDS_ON_BOTTOM_PATTERN.matches_words(&content_words) {
+        return Ok(None);
+    }
+
+    let third_words = TokenWordView::new(sentences[sentence_idx + 2].lowered());
+    if !IF_CAST_NON_HAND_PUT_EACH_LOOKED_INTO_HAND_INSTEAD_PATTERN
+        .matches_words(&third_words.word_refs())
+    {
+        return Ok(None);
+    }
+
+    let looked_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "looked");
+    let hand_tag = helper_tag_for_tokens(sentences[sentence_idx + 1].lowered(), "hand");
+    let mut hand_filter = ObjectFilter::tagged(looked_tag.clone());
+    hand_filter.zone = Some(Zone::Library);
+
+    let look_effect = EffectAst::subject_verb_look_at_top_cards(player, count, looked_tag.clone());
+    let default_effects = vec![
+        look_effect.clone(),
+        EffectAst::ChooseObjects {
+            filter: hand_filter,
+            count: ChoiceCount::exactly(1),
+            count_value: None,
+            player,
+            tag: hand_tag.clone(),
+        },
+        EffectAst::subject_verb_move_to_zone(
+            TargetAst::Tagged(hand_tag.clone(), None),
+            Zone::Hand,
+            false,
+            ReturnControllerAst::Preserve,
+            false,
+            None,
+        ),
+        EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+            looked_tag.clone(),
+            Some(hand_tag),
+            crate::cards::builders::LibraryBottomOrderAst::ChooserChooses,
+            player,
+        ),
+    ];
+    let replacement_effects = vec![
+        look_effect,
+        EffectAst::subject_verb_move_to_zone(
+            TargetAst::Tagged(looked_tag, None),
+            Zone::Hand,
+            false,
+            ReturnControllerAst::Preserve,
+            false,
+            None,
+        ),
+    ];
+
+    Ok(Some(vec![EffectAst::SelfReplacement {
+        predicate: PredicateAst::ThisSpellWasCastFromNonHand,
+        if_true: replacement_effects,
+        if_false: default_effects,
+    }]))
 }
 
 pub(crate) fn parse_top_cards_put_match_onto_battlefield_and_match_into_hand_rest_bottom(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -313,6 +313,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         parser: generic_subject_verb_sequences::triples::parse_top_cards_put_any_matching_to_zone_rest_bottom,
     },
     SequenceRuleDef {
+        name: "look-at-top-put-one-hand-bottom-cast-non-hand-put-all-hand",
+        feature_tag: Some("looked-cards-cast-non-hand-override"),
+        priority: 335,
+        consumed_sentences: 3,
+        predicate: first_word_look,
+        parser: generic_subject_verb_sequences::triples::parse_look_at_top_put_one_hand_bottom_cast_non_hand_put_all_hand,
+    },
+    SequenceRuleDef {
         name: "top-cards-reveal-any-matching-to-hand-rest-bottom",
         feature_tag: Some("looked-cards-revealed-hand-bottom"),
         priority: 335,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -707,6 +707,7 @@ pub enum Condition {
     SourceWasCast,
     ThisSpellEscaped,
     ThisSpellWasCastFromZone(Zone),
+    ThisSpellWasCastFromNonHand,
     PlayerTappedLandForManaThisTurn {
         player: PlayerFilter,
     },

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -48625,6 +48625,28 @@ fn parse_consult_the_star_charts_kicker_count_override() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_see_the_truth_cast_non_hand_self_replacement() {
+    let def = parse_oracle_card_definition("See the Truth");
+    let program = def.spell_effect.as_ref().expect("See the Truth spell effect");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert_eq!(program.segments.len(), 1);
+    assert_eq!(program.segments[0].self_replacements.len(), 1);
+    assert_eq!(
+        program.segments[0].self_replacements[0].condition,
+        crate::effect::Condition::ThisSpellWasCastFromNonHand,
+        "See the Truth should branch on being cast from a non-hand zone"
+    );
+    assert_eq!(def.name(), "See the Truth");
+    assert_eq!(
+        rendered,
+        "Look at the top 3 cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order. If this spell was cast from anywhere other than your hand, put each of those cards into your hand instead.",
+        "expected See the Truth compiled text to preserve the exact non-hand all-cards replacement"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_aangs_journey_kicked_search_slots_as_self_replacement() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Aang's Journey Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -460,6 +460,13 @@ fn describe_single_self_replacement_segment(
     let default_text = describe_effect_list(&segment.default_effects);
     let replacement_text = describe_effect_list(&branch.replacement_effects);
     let condition_text = super::normalize_common::describe_condition(&branch.condition);
+    if let Some(looked_cards_text) = describe_looked_cards_non_hand_self_replacement(
+        &segment.default_effects,
+        &branch.replacement_effects,
+        &condition_text,
+    ) {
+        return Some(looked_cards_text);
+    }
     if let Some(local_rewrite_text) = describe_rendered_optional_zone_rewrite_self_replacement(
         &default_text,
         &replacement_text,
@@ -504,6 +511,80 @@ fn describe_single_self_replacement_segment(
     Some(format!(
         "{default_text}. If {condition_text}, {} instead",
         rewrite_self_replacement_referent_phrase(&default_text, &replacement_text)
+    ))
+}
+
+fn describe_looked_cards_non_hand_self_replacement(
+    default_effects: &[Effect],
+    replacement_effects: &[Effect],
+    condition_text: &str,
+) -> Option<String> {
+    if condition_text != "this spell was cast from anywhere other than your hand" {
+        return None;
+    }
+
+    let [default_look, choose, move_chosen, remainder] = default_effects else {
+        return None;
+    };
+    let [replacement_look, move_all] = replacement_effects else {
+        return None;
+    };
+
+    let default_look = default_look.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    let replacement_look = replacement_look.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    if default_look != replacement_look
+        || default_look.reveal
+        || default_look.player != PlayerFilter::You
+    {
+        return None;
+    }
+
+    let choose = choose.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if choose.count.min != 1
+        || choose.count.max != Some(1)
+        || choose.chooser != PlayerFilter::You
+        || choose.filter.zone != Some(Zone::Library)
+        || !choose
+            .filter
+            .tagged_constraints
+            .iter()
+            .any(|constraint| constraint.tag == default_look.tag)
+    {
+        return None;
+    }
+
+    let move_chosen = unwrap_tagged_effect(move_chosen)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_chosen.zone != Zone::Hand
+        || !matches!(&move_chosen.target, ChooseSpec::Tagged(tag) if tag == &choose.tag)
+    {
+        return None;
+    }
+
+    let remainder = remainder
+        .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()?;
+    if remainder.tag != default_look.tag
+        || remainder.keep_tagged.as_ref() != Some(&choose.tag)
+        || remainder.player != PlayerFilter::You
+    {
+        return None;
+    }
+
+    let move_all = unwrap_tagged_effect(move_all)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_all.zone != Zone::Hand
+        || !matches!(&move_all.target, ChooseSpec::Tagged(tag) if tag == &default_look.tag)
+    {
+        return None;
+    }
+
+    let count_text = describe_value(&default_look.count);
+    let order_suffix = match remainder.order {
+        crate::effects::consult_helpers::LibraryBottomOrder::ChooserChooses => " in any order",
+        crate::effects::consult_helpers::LibraryBottomOrder::Random => " in a random order",
+    };
+    Some(format!(
+        "Look at the top {count_text} cards of your library. Put one of those cards into your hand and the rest on the bottom of your library{order_suffix}. If {condition_text}, put each of those cards into your hand instead"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11430,6 +11430,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             };
             format!("this spell was cast from {zone_text}")
         }
+        Condition::ThisSpellWasCastFromNonHand => {
+            "this spell was cast from anywhere other than your hand".to_string()
+        }
         Condition::PlayerTappedLandForManaThisTurn { player } => {
             format!(
                 "{} tapped a land for mana this turn",

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -99,6 +99,29 @@ fn this_spell_was_cast_from_zone(
     }
 }
 
+fn this_spell_was_cast_from_non_hand(
+    game: &GameState,
+    source: ObjectId,
+    ctx: &ExecutionContext,
+) -> bool {
+    match &ctx.casting_method {
+        crate::alternative_cast::CastingMethod::Normal
+        | crate::alternative_cast::CastingMethod::FaceDown
+        | crate::alternative_cast::CastingMethod::SplitOtherHalf
+        | crate::alternative_cast::CastingMethod::Fuse => false,
+        crate::alternative_cast::CastingMethod::GrantedFlashback
+        | crate::alternative_cast::CastingMethod::GrantedEscape { .. } => true,
+        crate::alternative_cast::CastingMethod::PlayFrom { zone, .. }
+        | crate::alternative_cast::CastingMethod::SplitOtherHalfPlayFrom { zone, .. } => {
+            *zone != Zone::Hand
+        }
+        crate::alternative_cast::CastingMethod::Alternative(idx) => game
+            .object(source)
+            .and_then(|obj| obj.alternative_casts.get(*idx))
+            .is_some_and(|method| method.cast_from_zone() != Zone::Hand),
+    }
+}
+
 fn this_spell_escaped(game: &GameState, source: ObjectId, ctx: &ExecutionContext) -> bool {
     if ctx.optional_costs_paid.was_paid_label("Escape") || source_escaped(game, source) {
         return true;
@@ -799,6 +822,7 @@ fn evaluate_condition_shared_core(
         Condition::TaggedObjectWasCast(_) => None,
         Condition::ThisSpellEscaped => Some(source_escaped(game, ctx.source)),
         Condition::ThisSpellWasCastFromZone(_) => None,
+        Condition::ThisSpellWasCastFromNonHand => None,
         Condition::NoSpellsWereCastLastTurn => {
             Some(game.turn_store.spells_cast_last_turn_total == 0)
         }
@@ -962,6 +986,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::SourceWasCast => {}
         Condition::ThisSpellEscaped => {}
         Condition::ThisSpellWasCastFromZone(..) => {}
+        Condition::ThisSpellWasCastFromNonHand => {}
         Condition::NoSpellsWereCastLastTurn => {}
         Condition::ItIsNight => {}
         Condition::SpellsWereCastLastTurnOrMore(..) => {}
@@ -1158,6 +1183,7 @@ pub fn evaluate_condition_external(
             .object(ctx.source)
             .is_some_and(|obj| obj.optional_costs_paid.was_kicked()),
         Condition::ThisSpellWasCastFromZone(_) => false,
+        Condition::ThisSpellWasCastFromNonHand => false,
         Condition::ThisSpellPaidLabel(label) => game
             .object(ctx.source)
             .is_some_and(|obj| obj.optional_costs_paid.was_paid_label(label)),
@@ -2058,6 +2084,7 @@ fn evaluate_condition_simple(
             .is_some_and(|obj| obj.optional_costs_paid.was_kicked()),
         Condition::ThisSpellEscaped => source_escaped(game, source),
         Condition::ThisSpellWasCastFromZone(_) => false,
+        Condition::ThisSpellWasCastFromNonHand => false,
         Condition::ThisSpellPaidLabel(label) => game
             .object(source)
             .is_some_and(|obj| obj.optional_costs_paid.was_paid_label(label)),
@@ -3166,6 +3193,9 @@ fn evaluate_condition(
         Condition::ThisSpellEscaped => Ok(this_spell_escaped(game, ctx.source, ctx)),
         Condition::ThisSpellWasCastFromZone(zone) => {
             Ok(this_spell_was_cast_from_zone(game, ctx.source, ctx, *zone))
+        }
+        Condition::ThisSpellWasCastFromNonHand => {
+            Ok(this_spell_was_cast_from_non_hand(game, ctx.source, ctx))
         }
         Condition::ThisSpellPaidLabel(label) => {
             Ok(resolve_value(game, &Value::WasPaidLabel(label.clone()), ctx)? != 0)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -42031,6 +42031,110 @@ fn quandrix_apprentice_magecraft_can_decline_the_land_pick() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn see_the_truth_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(91_120), "See the Truth")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Look at the top three cards of your library. Put one of those cards into your hand and the rest on the bottom of your library in any order. If this spell was cast from anywhere other than your hand, put each of those cards into your hand instead.",
+        )
+        .expect("See the Truth should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_see_the_truth_library_cards(game: &mut GameState, player: PlayerId) {
+    for (idx, name) in ["Alpine Grizzly", "Bear Cub", "Centaur Courser"]
+        .into_iter()
+        .enumerate()
+    {
+        game.create_object_from_card(
+            &CardBuilder::new(CardId::from_raw(91_121 + idx as u32), name)
+                .card_types(vec![CardType::Creature])
+                .power_toughness(PowerToughness::fixed(2, 2))
+                .build(),
+            player,
+            Zone::Library,
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_see_the_truth_with_casting_method(
+    casting_method: crate::alternative_cast::CastingMethod,
+) -> GameState {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = see_the_truth_definition();
+    add_see_the_truth_library_cards(&mut game, alice);
+
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut entry = crate::game_state::StackEntry::new(spell_id, alice);
+    entry.casting_method = casting_method;
+    game.push_to_stack(entry);
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("See the Truth should resolve");
+    game
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn see_the_truth_cast_from_hand_puts_one_looked_card_into_hand() {
+    let game =
+        resolve_see_the_truth_with_casting_method(crate::alternative_cast::CastingMethod::Normal);
+    let alice = PlayerId::from_index(0);
+    let player = game.player(alice).expect("alice exists");
+
+    assert_eq!(
+        player.hand.len(),
+        1,
+        "See the Truth cast normally from hand should put exactly one looked card into hand"
+    );
+    assert_eq!(
+        player.library.len(),
+        2,
+        "See the Truth cast from hand should leave the other two looked cards in the library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn see_the_truth_cast_from_exile_puts_each_looked_card_into_hand() {
+    let game = resolve_see_the_truth_with_casting_method(
+        crate::alternative_cast::CastingMethod::PlayFrom {
+            source: ObjectId::from_raw(91_130),
+            zone: Zone::Exile,
+            use_alternative: None,
+        },
+    );
+    let alice = PlayerId::from_index(0);
+    let player = game.player(alice).expect("alice exists");
+    let mut hand_names: Vec<_> = player
+        .hand
+        .iter()
+        .filter_map(|&id| game.object(id).map(|obj| obj.name.clone()))
+        .collect();
+    hand_names.sort();
+
+    assert_eq!(
+        hand_names,
+        vec![
+            "Alpine Grizzly".to_string(),
+            "Bear Cub".to_string(),
+            "Centaur Courser".to_string(),
+        ],
+        "See the Truth cast from exile should put each looked card into hand"
+    );
+    assert!(
+        player.library.is_empty(),
+        "the non-hand replacement should not leave looked cards on the bottom of the library"
+    );
+}
+
 // ============================================================================
 // Saga Integration Tests
 // ============================================================================


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: See the Truth
Initial parse error:
```
unsupported target phrase (clause: 'each of those cards'); oracle-only fallback also failed: unsupported target phrase (clause: 'each of those cards')
```

Current worker: i-0c47155503eae21d1
Branch: codex/aws-card-fix-see-the-truth
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0003
