### PR TITLE
Fix Ironsmith parse failure: Obeka, Brute Chronologist

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -15,6 +15,7 @@ pub enum PlayerAst {
     Chosen,
     Defending,
     Attacking,
+    Active,
     MostCardsInHand,
     MostLifeTied,
     LowestLifeTied,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1770,6 +1770,7 @@ fn player_filter_for_turn_value(player: PlayerAst) -> Option<PlayerFilter> {
         PlayerAst::Chosen => Some(PlayerFilter::ChosenPlayer),
         PlayerAst::Defending => Some(PlayerFilter::Defending),
         PlayerAst::Attacking => Some(PlayerFilter::Attacking),
+        PlayerAst::Active => Some(PlayerFilter::Active),
         PlayerAst::MostCardsInHand => Some(PlayerFilter::MostCardsInHand),
         PlayerAst::MostLifeTied => Some(PlayerFilter::MostLifeTied),
         PlayerAst::LowestLifeTied => Some(PlayerFilter::LowestLifeTied),

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -47,6 +47,7 @@ pub(crate) fn resolve_non_target_player_filter(
         PlayerAst::Chosen => Ok(PlayerFilter::ChosenPlayer),
         PlayerAst::Defending => Ok(PlayerFilter::Defending),
         PlayerAst::Attacking => Ok(PlayerFilter::Attacking),
+        PlayerAst::Active => Ok(PlayerFilter::Active),
         PlayerAst::MostCardsInHand => Ok(PlayerFilter::MostCardsInHand),
         PlayerAst::MostLifeTied => Ok(PlayerFilter::MostLifeTied),
         PlayerAst::LowestLifeTied => Ok(PlayerFilter::LowestLifeTied),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2294,6 +2294,7 @@ fn subject_verb_player_action_player_mut(effect: &mut EffectAst) -> Option<&mut 
                 | SubjectVerbActionAst::DoubleManaPool
                 | SubjectVerbActionAst::EmptyManaPool
                 | SubjectVerbActionAst::SetLifeTotal { .. }
+                | SubjectVerbActionAst::EndTurn
                 | SubjectVerbActionAst::SkipTurn
                 | SubjectVerbActionAst::SkipCombatPhases
                 | SubjectVerbActionAst::SkipNextCombatPhaseThisTurn
@@ -2368,6 +2369,7 @@ fn subject_verb_player_action_player(effect: &EffectAst) -> Option<PlayerAst> {
                 | SubjectVerbActionAst::DoubleManaPool
                 | SubjectVerbActionAst::EmptyManaPool
                 | SubjectVerbActionAst::SetLifeTotal { .. }
+                | SubjectVerbActionAst::EndTurn
                 | SubjectVerbActionAst::SkipTurn
                 | SubjectVerbActionAst::SkipCombatPhases
                 | SubjectVerbActionAst::SkipNextCombatPhaseThisTurn
@@ -2694,6 +2696,16 @@ fn parse_leading_player_may_words(words: &[&str]) -> Option<PlayerAst> {
                         .value(PlayerAst::ItsOwner),
                 )),
                 alt((
+                    (
+                        word_eq("the"),
+                        player_word(),
+                        word_eq("whose"),
+                        word_eq("turn"),
+                        word_eq("it"),
+                        word_eq("is"),
+                        word_eq("may"),
+                    )
+                        .value(PlayerAst::Active),
                     (word_eq("the"), player_word(), word_eq("may")).value(PlayerAst::That),
                     (word_eq("defending"), word_eq("player"), word_eq("may"))
                         .value(PlayerAst::Defending),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -1074,6 +1074,7 @@ fn player_filter_for_life_reference(player: PlayerAst) -> Option<PlayerFilter> {
         PlayerAst::Chosen => Some(PlayerFilter::ChosenPlayer),
         PlayerAst::Defending => Some(PlayerFilter::Defending),
         PlayerAst::Attacking => Some(PlayerFilter::Attacking),
+        PlayerAst::Active => Some(PlayerFilter::Active),
         PlayerAst::MostCardsInHand => Some(PlayerFilter::MostCardsInHand),
         PlayerAst::MostLifeTied => Some(PlayerFilter::MostLifeTied),
         PlayerAst::LowestLifeTied => Some(PlayerFilter::LowestLifeTied),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -1084,6 +1084,7 @@ fn player_filter_for_set_life_total_reference(player: PlayerAst) -> Option<Playe
         PlayerAst::Chosen => Some(PlayerFilter::ChosenPlayer),
         PlayerAst::Defending => Some(PlayerFilter::Defending),
         PlayerAst::Attacking => Some(PlayerFilter::Attacking),
+        PlayerAst::Active => Some(PlayerFilter::Active),
         PlayerAst::MostCardsInHand => Some(PlayerFilter::MostCardsInHand),
         PlayerAst::MostLifeTied => Some(PlayerFilter::MostLifeTied),
         PlayerAst::LowestLifeTied => Some(PlayerFilter::LowestLifeTied),

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -947,6 +947,7 @@ pub(crate) enum PlayerAst {
     Chosen,
     Defending,
     Attacking,
+    Active,
     MostCardsInHand,
     MostLifeTied,
     LowestLifeTied,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7,9 +7,9 @@ use crate::compiled_text::{
 };
 use crate::effects::{
     AddManaEffect, ChooseModeEffect, ChooseObjectsEffect, ConsultTopOfLibraryEffect,
-    CreateTokenEffect, DestroyEffect, DrawCardsEffect, EffectExecutor, GainLifeEffect,
-    MoveToZoneEffect, ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect, TaggedEffect,
-    TargetOnlyEffect, UntapEffect,
+    CreateTokenEffect, DestroyEffect, DrawCardsEffect, EffectExecutor, EndTurnEffect,
+    GainLifeEffect, MayEffect, MoveToZoneEffect, ReturnFromGraveyardToHandEffect,
+    TagTriggeringObjectEffect, TaggedEffect, TargetOnlyEffect, UntapEffect,
 };
 use crate::filter::ObjectFilterExt;
 use crate::object::AuraAttachmentFilter;
@@ -44470,6 +44470,131 @@ fn sundial_of_the_infinite_end_turn_effect_runtime_branches_by_active_player() {
         .expect("Sundial effect should no-op for non-active player");
     assert_eq!(game.turn.phase, crate::game_state::Phase::Combat);
     assert_eq!(game.turn.step, Some(crate::game_state::Step::BeginCombat));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn obeka_brute_chronologist_strict_regression() {
+    assert_oracle_card_parses_strict("Obeka, Brute Chronologist");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn obeka_brute_chronologist_compiled_text_keeps_active_player_may_end_turn_clause() {
+    let def = parse_oracle_card_definition("Obeka, Brute Chronologist");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Obeka should have an activated ability");
+    let cost_debug = format!("{:?}", activated.mana_cost);
+    assert!(
+        cost_debug.contains("Tap"),
+        "Obeka activation should preserve its tap cost, got {cost_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("the player whose turn it is may end the turn"),
+        "expected Obeka rendered text to preserve the active-player optional end-turn clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn obeka_brute_chronologist_active_player_decides_and_can_end_their_turn() {
+    struct BooleanDecision {
+        expected_player: PlayerId,
+        answer: bool,
+        calls: usize,
+    }
+
+    impl crate::decision::DecisionMaker for BooleanDecision {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            assert_eq!(ctx.player, self.expected_player);
+            self.calls += 1;
+            self.answer
+        }
+    }
+
+    let def = parse_oracle_card_definition("Obeka, Brute Chronologist");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if !activated.effects.segments.is_empty() => {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("Obeka should have an activated ability");
+    let may_effect = activated.effects.flattened_default_effects()[0]
+        .downcast_ref::<MayEffect>()
+        .expect("Obeka activation should lower to a player-specific may effect")
+        .clone();
+    assert_eq!(may_effect.decider, Some(PlayerFilter::Active));
+    let end_turn = may_effect.effects[0]
+        .downcast_ref::<EndTurnEffect>()
+        .expect("Obeka may branch should end the active player's turn");
+    assert_eq!(end_turn.player, PlayerFilter::Active);
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = game
+        .players
+        .iter()
+        .find(|p| p.name == "Alice")
+        .expect("Alice should exist")
+        .id;
+    let bob = game
+        .players
+        .iter()
+        .find(|p| p.name == "Bob")
+        .expect("Bob should exist")
+        .id;
+    let obeka_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut accept = BooleanDecision {
+        expected_player: bob,
+        answer: true,
+        calls: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(obeka_id, alice)
+        .with_decision_maker(&mut accept);
+    may_effect
+        .execute(&mut game, &mut ctx)
+        .expect("Obeka effect should resolve when the active player accepts");
+    assert_eq!(accept.calls, 1);
+    assert_eq!(game.turn.phase, crate::game_state::Phase::Ending);
+    assert_eq!(game.turn.step, Some(crate::game_state::Step::Cleanup));
+
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    let mut decline = BooleanDecision {
+        expected_player: bob,
+        answer: false,
+        calls: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(obeka_id, alice)
+        .with_decision_maker(&mut decline);
+    may_effect
+        .execute(&mut game, &mut ctx)
+        .expect("Obeka effect should resolve when the active player declines");
+    assert_eq!(decline.calls, 1);
+    assert_eq!(game.turn.phase, crate::game_state::Phase::FirstMain);
+    assert_eq!(game.turn.step, None);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -31382,6 +31382,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return format!("{who} may choose new targets for the copy");
         }
         if let Some(decider) = may.decider.as_ref() {
+            if matches!(decider, PlayerFilter::Active)
+                && may.effects.len() == 1
+                && let Some(end_turn) = may.effects[0].downcast_ref::<crate::effects::EndTurnEffect>()
+                && matches!(end_turn.player, PlayerFilter::Active)
+            {
+                return "the player whose turn it is may end the turn".to_string();
+            }
             let who = describe_player_filter(decider);
             let mut inner = describe_effect_list(&may.effects);
             let may_prefix = format!("{who} may ");
@@ -32509,7 +32516,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(end_turn) = effect.downcast_ref::<crate::effects::EndTurnEffect>() {
         if matches!(
             end_turn.player,
-            PlayerFilter::You | PlayerFilter::EffectController
+            PlayerFilter::You | PlayerFilter::EffectController | PlayerFilter::Active
         ) {
             return "end the turn".to_string();
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Obeka, Brute Chronologist
Initial parse error:
```
activated ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(EndTurnEffect { player: IteratedPlayer }); oracle-only fallback also failed: activated ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(EndTurnEffect { player: IteratedPlayer })
```

Current worker: i-06ef90a02b8c78baa
Branch: codex/aws-card-fix-obeka-brute-chronologist
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0004
