### PR TITLE
Fix Ironsmith parse failure: Leori, Sparktouched Hunter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -23,6 +23,8 @@ const CHOOSE_WORD_PATTERN: ClauseShape<'static> =
 const CHOICE_CONNECTOR_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["or"], &["and"]]);
 const CREATURE_TYPE_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["creature", "type"]);
+const PLANESWALKER_TYPE_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix & ["planeswalker", "type"]);
 const OTHER_THAN_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["other", "than"]);
 const COLOR_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["color"]);
 const PERMANENT_TYPE_PATTERN: ClauseShape<'static> =
@@ -998,25 +1000,41 @@ pub(crate) fn parse_choose_card_type_then_reveal_top_and_put_chosen_to_hand(
 pub(crate) fn parse_choose_creature_type_phrase_words(
     words: &[&str],
 ) -> Result<Option<(usize, Vec<Subtype>)>, CardTextError> {
+    let Some((idx, family, excluded_subtypes)) = parse_choose_subtype_phrase_words(words)? else {
+        return Ok(None);
+    };
+    if family != crate::types::SubtypeFamily::Creature {
+        return Ok(None);
+    }
+    Ok(Some((idx, excluded_subtypes)))
+}
+
+pub(crate) fn parse_choose_subtype_phrase_words(
+    words: &[&str],
+) -> Result<Option<(usize, crate::types::SubtypeFamily, Vec<Subtype>)>, CardTextError> {
     let Some(mut idx) = parse_choose_phrase_prefix_words(words) else {
         return Ok(None);
     };
-    if !CREATURE_TYPE_PATTERN.matches_words(&words[idx..]) {
+    let family = if CREATURE_TYPE_PATTERN.matches_words(&words[idx..]) {
+        crate::types::SubtypeFamily::Creature
+    } else if PLANESWALKER_TYPE_PATTERN.matches_words(&words[idx..]) {
+        crate::types::SubtypeFamily::Planeswalker
+    } else {
         return Ok(None);
-    }
+    };
     idx += 2;
 
     let mut excluded_subtypes = Vec::new();
     if OTHER_THAN_PATTERN.matches_words(&words[idx..]) {
         let subtype_word = words.get(idx + 2).copied().ok_or_else(|| {
             CardTextError::ParseError(format!(
-                "missing creature subtype exclusion in creature-type choice clause (clause: '{}')",
+                "missing subtype exclusion in subtype choice clause (clause: '{}')",
                 words.join(" ")
             ))
         })?;
         let subtype = parse_subtype_flexible(subtype_word).ok_or_else(|| {
                 CardTextError::ParseError(format!(
-                    "unsupported creature subtype exclusion in creature-type choice clause (clause: '{}')",
+                    "unsupported subtype exclusion in subtype choice clause (clause: '{}')",
                     words.join(" ")
                 ))
             })?;
@@ -1024,7 +1042,7 @@ pub(crate) fn parse_choose_creature_type_phrase_words(
         idx += 3;
     }
 
-    Ok(Some((idx, excluded_subtypes)))
+    Ok(Some((idx, family, excluded_subtypes)))
 }
 
 pub(crate) fn parse_choose_phrase_prefix_words(words: &[&str]) -> Option<usize> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/mod.rs
@@ -111,6 +111,7 @@ pub(crate) use choice_object_clauses::{
     parse_choose_card_type_then_reveal_top_and_put_chosen_to_hand, parse_choose_color_phrase_words,
     parse_choose_creature_type_phrase_words, parse_choose_creature_type_then_become_type,
     parse_choose_land_type_phrase_words, parse_choose_player_phrase_words,
+    parse_choose_subtype_phrase_words,
     parse_sentence_target_player_chooses_then_puts_on_top_of_library,
     parse_sentence_target_player_chooses_then_you_put_it_onto_battlefield,
     parse_target_player_choose_objects_clause, parse_target_player_chooses_then_other_cant_block,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2,6 +2,7 @@ use super::*;
 
 const THIS_DESTINATION_TRIGGER_NAME_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["this"]);
 const THIS_OR_IT_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["this"], &["it"]]);
+const OF_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["of"]);
 const DAMAGER_NAMED_SOURCE_LEADING_EXCLUDED_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -4087,6 +4088,36 @@ fn parse_possessive_ability_trigger_tail_lexed<'a>(
     let Some(ability_idx) = find_token_shape(tail_tokens, &ABILITY_OR_ABILITIES_PATTERN) else {
         return Ok(None);
     };
+    if tail_tokens
+        .get(ability_idx + 1)
+        .is_some_and(|token| OF_WORD_PATTERN.matches_token(token))
+    {
+        let owner_tokens = trim_commas(&tail_tokens[ability_idx + 2..]);
+        if owner_tokens.is_empty() {
+            return Ok(None);
+        }
+        let mut owner_filter_tokens = owner_tokens.clone();
+        let mut of_chosen_type = false;
+        if let Some(of_idx) = find_token_shape(&owner_filter_tokens, &OF_WORD_PATTERN) {
+            let tail_words =
+                crate::runtime_backend::token_word_refs(&owner_filter_tokens[of_idx + 1..]);
+            let tail_words = non_article_word_refs(&tail_words);
+            if matches!(tail_words.as_slice(), ["that", "type"] | ["chosen", "type"]) {
+                owner_filter_tokens = trim_commas(&owner_filter_tokens[..of_idx]);
+                of_chosen_type = true;
+            }
+        }
+        let mut owner_filter = parse_object_filter_lexed(&owner_filter_tokens, false).map_err(|_| {
+            CardTextError::ParseError(format!(
+                "unsupported activated-ability trigger source filter (clause: '{}')",
+                tail_words.join(" ")
+            ))
+        })?;
+        if of_chosen_type {
+            owner_filter.chosen_creature_type = true;
+        }
+        return Ok(Some((owner_filter, None)));
+    }
     if ability_idx == 0 || ability_idx + 1 != tail_tokens.len() {
         return Ok(None);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -124,7 +124,7 @@ const OBJECT_FILTER_FACE_UP_PREFIX_PATTERN: ClauseShape<'static> =
 const OBJECT_FILTER_CHOSEN_COLOR_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["chosen", "color"]);
 const OBJECT_FILTER_CHOSEN_TYPE_PREFIX_PATTERN: ClauseShape<'static> =
-    clause_shape!(prefix & ["chosen", "type"]);
+    clause_shape!(prefix_any & [&["chosen", "type"], &["that", "type"]]);
 const OBJECT_FILTER_NONCHOSEN_TYPE_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["nonchosen", "type"]);
 const OBJECT_FILTER_YOU_CONTROL_BUT_DONT_OWN_SUFFIX_PATTERN: ClauseShape<'static> = clause_shape!(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -728,11 +728,17 @@ fn compile_subject_verb_effect(
                 Effect::choose_named_option(subject.into_player_filter(), options.clone())
             })
         }
-        SubjectVerbActionAst::ChooseCreatureType { excluded_subtypes } => {
+        SubjectVerbActionAst::ChooseCreatureType {
+            family,
+            excluded_subtypes,
+        } => {
             compile_player_role_effect(role, player, ctx, true, true, true, |subject| {
-                Effect::choose_creature_type(
-                    subject.into_player_filter(),
-                    excluded_subtypes.clone(),
+                Effect::new(
+                    crate::effects::ChooseCreatureTypeEffect::new(
+                        subject.into_player_filter(),
+                        excluded_subtypes.clone(),
+                    )
+                    .with_family(*family),
                 )
             })
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -39,6 +39,15 @@ fn compile_delayed_trigger_spec(
                 one_or_more: *one_or_more,
             },
         ),
+        TriggerSpec::AbilityActivated {
+            activator,
+            filter,
+            non_mana_only,
+        } => Ok(ironsmith_core::DelayedTriggerSpec::AbilityActivated {
+            activator: activator.clone(),
+            filter: filter.clone(),
+            non_mana_only: *non_mana_only,
+        }),
         TriggerSpec::ThisDies => Ok(ironsmith_core::DelayedTriggerSpec::ThisDies),
         TriggerSpec::ThisLeavesBattlefield => {
             Ok(ironsmith_core::DelayedTriggerSpec::ThisLeavesBattlefield)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -350,6 +350,7 @@ pub(crate) fn effect_references_tag(effect: &EffectAst, tag: &str) -> bool {
                 .any(|constraint| constraint.tag.as_str() == tag)
                 || effects_reference_tag(effects, tag)
         }
+        EffectAst::DelayedTriggerThisTurn { .. } => false,
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
             action: SubjectVerbActionAst::Cant { restriction, .. },
             ..

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -800,6 +800,7 @@ pub(crate) enum SubjectVerbActionAst {
         options: Vec<String>,
     },
     ChooseCreatureType {
+        family: SubtypeFamily,
         excluded_subtypes: Vec<Subtype>,
     },
     ChooseCardName {
@@ -1851,8 +1852,12 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::ChooseNamedOption { options } => {
                 f.debug_tuple("ChooseNamedOption").field(options).finish()
             }
-            Self::ChooseCreatureType { excluded_subtypes } => f
+            Self::ChooseCreatureType {
+                family,
+                excluded_subtypes,
+            } => f
                 .debug_struct("ChooseCreatureType")
+                .field("family", family)
                 .field("excluded_subtypes", excluded_subtypes)
                 .finish(),
             Self::ChooseCardName { filter, tag } => f
@@ -5764,12 +5769,16 @@ impl EffectAst {
 
     pub(crate) fn subject_verb_choose_creature_type(
         player: PlayerAst,
+        family: SubtypeFamily,
         excluded_subtypes: Vec<Subtype>,
     ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Chooser,
             player,
-            SubjectVerbActionAst::ChooseCreatureType { excluded_subtypes },
+            SubjectVerbActionAst::ChooseCreatureType {
+                family,
+                excluded_subtypes,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -31,7 +31,9 @@ use super::super::util::{
 };
 use super::super::value_helpers::{parse_number_from_lexed, parse_value_from_lexed};
 use super::clause_pattern_helpers::{ClauseShape, clause_shape};
-use super::dispatch_inner::parse_subject_verb_extension_sentence;
+use super::dispatch_inner::{
+    parse_sentence_delayed_trigger_this_turn, parse_subject_verb_extension_sentence,
+};
 use super::lex_chain_helpers::{
     find_verb_lexed, has_effect_head_without_verb_lexed, segment_has_effect_head_lexed,
     split_effect_chain_on_and_lexed, split_segments_on_comma_effect_head_lexed,
@@ -935,6 +937,9 @@ pub(crate) fn parse_effect_chain_with_subject_verb_primitives_lexed(
 
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     if starts_with_until_end_of_turn_trigger_clause(&clause_words) {
+        if let Some(effects) = parse_sentence_delayed_trigger_this_turn(tokens)? {
+            return Ok(effects);
+        }
         return Err(CardTextError::ParseError(format!(
             "unsupported until-end-of-turn permission clause (clause: '{}')",
             clause_words.join(" ")

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -8,7 +8,7 @@ use self::next_turn_cant::parse_next_turn_cant_clause;
 use super::super::activation_and_restrictions::{
     build_may_cast_tagged_effect, find_negation_span, parse_cant_restriction_clause,
     parse_cant_restrictions, parse_choose_card_type_phrase_words, parse_choose_color_phrase_words,
-    parse_choose_creature_type_phrase_words, parse_choose_player_phrase_words,
+    parse_choose_player_phrase_words, parse_choose_subtype_phrase_words,
     parse_may_cast_it_sentence, parse_single_word_keyword_action,
     parse_target_player_choose_objects_clause, parse_you_choose_objects_clause,
     parse_you_choose_player_clause, starts_with_target_indicator,
@@ -1013,12 +1013,13 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         ));
     }
 
-    if let Some((consumed, excluded_subtypes)) =
-        parse_choose_creature_type_phrase_words(choice_words)?
+    if let Some((consumed, family, excluded_subtypes)) =
+        parse_choose_subtype_phrase_words(choice_words)?
         && consumed == choice_words.len()
     {
         return Ok(EffectAst::subject_verb_choose_creature_type(
             crate::cards::builders::PlayerAst::Implicit,
+            family,
             excluded_subtypes,
         ));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
@@ -181,9 +181,103 @@ fn retarget_source_copy_spell_to_delayed_triggering_object(effects: &mut [Effect
     }
 }
 
+fn parse_leading_until_end_of_turn_delayed_trigger_sentence(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let mut idx = 0usize;
+    if !token_slice_at_is(tokens, idx, "until") {
+        return Ok(None);
+    }
+    idx += 1;
+    if token_slice_at_is(tokens, idx, "the") {
+        idx += 1;
+    }
+    if !token_slice_at_is(tokens, idx, "end")
+        || !token_slice_at_is(tokens, idx + 1, "of")
+        || !token_slice_at_is(tokens, idx + 2, "turn")
+    {
+        return Ok(None);
+    }
+    idx += 3;
+    if tokens.get(idx).is_some_and(OwnedLexToken::is_comma) {
+        idx += 1;
+    }
+
+    let delayed_clause = trim_commas(&tokens[idx..]);
+    if !delayed_clause
+        .first()
+        .is_some_and(|token| WHEN_OR_WHENEVER_WORD_PATTERN.matches_token(token))
+    {
+        return Ok(None);
+    }
+
+    let (trigger_part, effect_part) = if let Some((before_comma, after_comma)) =
+        super::super::grammar::primitives::split_lexed_once_on_delimiter(
+            &delayed_clause,
+            super::super::lexer::TokenKind::Comma,
+        ) {
+        (before_comma.to_vec(), trim_commas(after_comma))
+    } else {
+        let Some(copy_idx) = delayed_clause.iter().enumerate().find_map(|(idx, _token)| {
+            if idx > 0 && (token_slice_at_is(&delayed_clause, idx, "copy")
+                || token_slice_at_is(&delayed_clause, idx, "copies"))
+            {
+                Some(idx)
+            } else {
+                None
+            }
+        }) else {
+            return Ok(None);
+        };
+        (delayed_clause[..copy_idx].to_vec(), trim_commas(&delayed_clause[copy_idx..]))
+    };
+
+    let mut trigger_tokens = trim_commas(&trigger_part);
+    if trigger_tokens
+        .first()
+        .is_some_and(|token| WHEN_OR_WHENEVER_WORD_PATTERN.matches_token(token))
+    {
+        trigger_tokens = trigger_tokens[1..].to_vec();
+    }
+    if trigger_tokens.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing delayed trigger clause after 'until end of turn' (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        )));
+    }
+    if effect_part.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing delayed trigger effect clause (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        )));
+    }
+
+    let trigger = parse_trigger_clause_lexed(&trigger_tokens)?;
+    let mut delayed_effects = parse_effect_chain(&effect_part)?;
+    if delayed_effects.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing delayed trigger effect clause (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        )));
+    }
+    if matches!(trigger, TriggerSpec::SpellCast { .. }) {
+        retarget_source_copy_spell_to_delayed_triggering_object(&mut delayed_effects);
+    }
+
+    Ok(Some(vec![EffectAst::DelayedTriggerThisTurn {
+        trigger,
+        effects: delayed_effects,
+        one_shot: false,
+    }]))
+}
+
 pub(crate) fn parse_sentence_delayed_trigger_this_turn(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    if let Some(effects) = parse_leading_until_end_of_turn_delayed_trigger_sentence(tokens)? {
+        return Ok(Some(effects));
+    }
+
     if COPY_NEXT_THIS_TURN_PREFIX_PATTERN.matches_words(&crate::runtime_backend::token_word_refs(
         tokens,
     )) {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/combat_and_damage_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/combat_and_damage_family.rs
@@ -237,7 +237,11 @@ pub(crate) fn parse_sentence_destroy_creature_type_of_choice_matched(
     }
 
     Ok(Some(vec![
-        EffectAst::subject_verb_choose_creature_type(PlayerAst::You, vec![]),
+        EffectAst::subject_verb_choose_creature_type(
+            PlayerAst::You,
+            crate::types::SubtypeFamily::Creature,
+            vec![],
+        ),
         EffectAst::subject_verb_destroy_all(ObjectFilter::creature().of_chosen_creature_type()),
     ]))
 }
@@ -320,6 +324,7 @@ pub(crate) fn parse_sentence_pump_creature_type_of_choice_matched(
         if patched {
             let mut effects = vec![EffectAst::subject_verb_choose_creature_type(
                 PlayerAst::You,
+                crate::types::SubtypeFamily::Creature,
                 vec![],
             )];
             effects.extend(gain_effects);
@@ -375,7 +380,11 @@ pub(crate) fn parse_sentence_pump_creature_type_of_choice_matched(
     filter.chosen_creature_type = true;
 
     Ok(Some(vec![
-        EffectAst::subject_verb_choose_creature_type(PlayerAst::You, vec![]),
+        EffectAst::subject_verb_choose_creature_type(
+            PlayerAst::You,
+            crate::types::SubtypeFamily::Creature,
+            vec![],
+        ),
         EffectAst::subject_verb_pump_all(filter, power, toughness, duration),
     ]))
 }
@@ -434,7 +443,11 @@ pub(crate) fn parse_sentence_must_attack_creature_type_of_choice_matched(
     filter.chosen_creature_type = true;
 
     Ok(Some(vec![
-        EffectAst::subject_verb_choose_creature_type(PlayerAst::You, vec![]),
+        EffectAst::subject_verb_choose_creature_type(
+            PlayerAst::You,
+            crate::types::SubtypeFamily::Creature,
+            vec![],
+        ),
         EffectAst::subject_verb_grant_abilities_all(
             filter,
             vec![crate::runtime_backend::GrantedAbilityAst::MustAttack],
@@ -628,6 +641,7 @@ pub(crate) fn parse_sentence_return_targets_of_creature_type_of_choice_matched(
     if needs_inline_choice_effect {
         effects.push(EffectAst::subject_verb_choose_creature_type(
             PlayerAst::You,
+            crate::types::SubtypeFamily::Creature,
             vec![],
         ));
     }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -159,6 +159,11 @@ pub enum DelayedTriggerSpec {
         from: crate::zone::Zone,
         one_or_more: bool,
     },
+    AbilityActivated {
+        activator: PlayerFilter,
+        filter: ObjectFilter,
+        non_mana_only: bool,
+    },
     SpellCast {
         filter: Option<ObjectFilter>,
         caster: PlayerFilter,
@@ -4030,6 +4035,7 @@ impl ChooseColorEffect {
 pub struct ChooseCreatureTypeEffect {
     pub chooser: PlayerFilter,
     pub excluded_subtypes: Vec<Subtype>,
+    pub family: crate::types::SubtypeFamily,
 }
 
 impl ChooseCreatureTypeEffect {
@@ -4037,7 +4043,13 @@ impl ChooseCreatureTypeEffect {
         Self {
             chooser,
             excluded_subtypes,
+            family: crate::types::SubtypeFamily::Creature,
         }
+    }
+
+    pub fn with_family(mut self, family: crate::types::SubtypeFamily) -> Self {
+        self.family = family;
+        self
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -55686,6 +55686,190 @@ fn fatespinner_draw_step_choice_skips_only_that_players_draw_step() {
     assert!(!game.turn_store.skip_next_combat_phases.contains(&bob));
 }
 
+fn leori_triggered_ability(def: &CardDefinition) -> crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered
+                    .trigger
+                    .display()
+                    .contains("deals combat damage to a player") =>
+            {
+                Some(triggered.clone())
+            }
+            _ => None,
+        })
+        .expect("Leori should compile a combat-damage trigger")
+}
+
+fn leori_delayed_schedule(
+    triggered: &crate::ability::TriggeredAbility,
+) -> &crate::effects::ScheduleDelayedTriggerEffect {
+    triggered.effects.segments[0].default_effects[1]
+        .downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()
+        .expect("Leori trigger should schedule an until-end delayed trigger")
+}
+
+struct ChooseSubtypeByName(&'static str);
+
+impl crate::decision::DecisionMaker for ChooseSubtypeByName {
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        ctx.options
+            .iter()
+            .find(|option| option.description.eq_ignore_ascii_case(self.0))
+            .map(|option| vec![option.index])
+            .unwrap_or_else(|| vec![0])
+    }
+}
+
+#[test]
+fn leori_oracle_parses_strictly_and_renders_planeswalker_copy_clause() {
+    assert_oracle_card_parses_strict("Leori, Sparktouched Hunter");
+    let def = parse_oracle_card_definition("Leori, Sparktouched Hunter");
+    let rendered = compiled_text_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("choose a planeswalker type"),
+        "Leori should render the planeswalker-type choice, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Until end of turn, whenever you activate an ability of a planeswalker of that type, copy that ability"),
+        "Leori should render the delayed ability-copy clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("You may choose new targets for the copies"),
+        "Leori should render the copy retarget follow-up, got {rendered}"
+    );
+}
+
+#[test]
+fn leori_lowers_to_planeswalker_type_delayed_ability_copy() {
+    let def = parse_oracle_card_definition("Leori, Sparktouched Hunter");
+    let triggered = leori_triggered_ability(&def);
+    let debug = format!("{triggered:#?}");
+
+    assert!(
+        debug.contains("ChooseCreatureTypeEffect")
+            && debug.contains("family: Planeswalker")
+            && debug.contains("ScheduleDelayedTriggerEffect")
+            && debug.contains("AbilityActivatedTrigger")
+            && debug.contains("chosen_creature_type: true")
+            && debug.contains("CopySpellEffect")
+            && debug.contains("triggering_source")
+            && debug.contains("RetargetStackObjectEffect"),
+        "Leori should structurally choose a planeswalker type, schedule the matching ability trigger, copy that ability, and retarget the copies, got {debug}"
+    );
+}
+
+#[test]
+fn leori_planeswalker_type_choice_filters_delayed_ability_trigger() {
+    let def = parse_oracle_card_definition("Leori, Sparktouched Hunter");
+    let triggered = leori_triggered_ability(&def);
+    let schedule = leori_delayed_schedule(&triggered);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let leori_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let jace_def = CardDefinitionBuilder::new(CardId::new(), "Jace Test")
+        .card_types(vec![CardType::Planeswalker])
+        .subtypes(vec![Subtype::Jace])
+        .build();
+    let chandra_def = CardDefinitionBuilder::new(CardId::new(), "Chandra Test")
+        .card_types(vec![CardType::Planeswalker])
+        .subtypes(vec![Subtype::Chandra])
+        .build();
+    let jace_id = game.create_object_from_definition(&jace_def, alice, Zone::Battlefield);
+    let chandra_id = game.create_object_from_definition(&chandra_def, alice, Zone::Battlefield);
+
+    let choose_effect = triggered.effects.segments[0].default_effects[0]
+        .downcast_ref::<crate::effects::ChooseCreatureTypeEffect>()
+        .expect("Leori's first effect should choose a planeswalker type");
+    let mut dm = ChooseSubtypeByName("jace");
+    let mut exec_ctx = crate::effects::ExecutionContext::new(leori_id, alice, &mut dm);
+    choose_effect
+        .execute(&mut game, &mut exec_ctx)
+        .expect("planeswalker type choice should execute");
+    assert_eq!(game.chosen_creature_type(leori_id), Some(Subtype::Jace));
+
+    let trigger_ctx = crate::triggers::TriggerContext::for_source(leori_id, alice, &game);
+    let jace_event = crate::events::RawEvent::new(
+        crate::events::spells::AbilityActivatedEvent::new(jace_id, alice, false),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let chandra_event = crate::events::RawEvent::new(
+        crate::events::spells::AbilityActivatedEvent::new(chandra_id, alice, false),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let opponent_event = crate::events::RawEvent::new(
+        crate::events::spells::AbilityActivatedEvent::new(jace_id, bob, false),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert!(
+        schedule.trigger.matches(&jace_event, &trigger_ctx),
+        "Leori's delayed trigger should match your chosen-type planeswalker ability"
+    );
+    assert!(
+        !schedule.trigger.matches(&chandra_event, &trigger_ctx),
+        "Leori's delayed trigger should ignore planeswalkers outside the chosen type"
+    );
+    assert!(
+        !schedule.trigger.matches(&opponent_event, &trigger_ctx),
+        "Leori's delayed trigger should ignore abilities activated by another player"
+    );
+}
+
+#[test]
+fn leori_delayed_effect_copies_the_triggering_ability_on_the_stack() {
+    let def = parse_oracle_card_definition("Leori, Sparktouched Hunter");
+    let triggered = leori_triggered_ability(&def);
+    let schedule = leori_delayed_schedule(&triggered);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let leori_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let jace_def = CardDefinitionBuilder::new(CardId::new(), "Jace Test")
+        .card_types(vec![CardType::Planeswalker])
+        .subtypes(vec![Subtype::Jace])
+        .build();
+    let jace_id = game.create_object_from_definition(&jace_def, alice, Zone::Battlefield);
+    game.stack.push(crate::game_state::StackEntry::ability(
+        jace_id,
+        alice,
+        vec![Effect::draw(1)],
+    ));
+    let event = crate::events::RawEvent::new(
+        crate::events::spells::AbilityActivatedEvent::new(jace_id, alice, false),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut dm = ChooseSubtypeByName("jace");
+    let mut ctx = crate::effects::ExecutionContext::new(leori_id, alice, &mut dm)
+        .with_triggering_event(event);
+
+    for effect in schedule.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Leori delayed copy effect should resolve");
+    }
+
+    assert_eq!(game.stack.len(), 2, "Leori should add one copied ability to the stack");
+    let copy_entry = game.stack.last().expect("copied ability should be on stack");
+    assert!(copy_entry.is_ability, "the copied stack object should remain an ability");
+    assert!(
+        copy_entry.ability_effects.is_some(),
+        "the copied ability should preserve the original ability effects"
+    );
+}
+
 #[test]
 fn fatespinner_main_phase_choice_skips_each_remaining_main_phase_this_turn() {
     let (mut game, bob) = resolve_fatespinner_upkeep_choice("main phase");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28093,6 +28093,12 @@ fn describe_remove_counter_phrase(
 }
 
 pub(super) fn describe_effect_impl(effect: &Effect) -> String {
+    if effect
+        .downcast_ref::<crate::effects::TagTriggeringSourceEffect>()
+        .is_some()
+    {
+        return String::new();
+    }
     if let Some(sequence) = effect.downcast_ref::<crate::effects::SequenceEffect>() {
         if let Some(compact) = describe_reveal_until_sequence(sequence) {
             return compact;
@@ -28670,8 +28676,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     {
         let chooser = describe_player_filter(&choose_creature_type.chooser);
         let choose_verb = player_verb(&chooser, "choose", "chooses");
+        let type_phrase = choose_creature_type.family.type_phrase();
+        let chooser_prefix = if chooser.eq_ignore_ascii_case("you") {
+            "Choose".to_string()
+        } else {
+            format!("{chooser} {choose_verb}")
+        };
         if choose_creature_type.excluded_subtypes.is_empty() {
-            return format!("{chooser} {choose_verb} a creature type");
+            return format!("{chooser_prefix} a {type_phrase}");
         }
         let excluded = choose_creature_type
             .excluded_subtypes
@@ -28679,7 +28691,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             .map(|subtype| subtype.to_string().to_ascii_lowercase())
             .collect::<Vec<_>>();
         return format!(
-            "{chooser} {choose_verb} a creature type other than {}",
+            "{chooser_prefix} a {type_phrase} other than {}",
             join_with_or(&excluded)
         );
     }
@@ -32616,6 +32628,10 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             target_text = target_text.replacen("instant or sorcery", "instant or sorcery spell", 1);
         }
         if matches!(copy_spell.count, Value::Fixed(1)) {
+            if matches!(&copy_spell.target, ChooseSpec::Tagged(tag) if tag.as_str() == "triggering_source")
+            {
+                return "Copy that ability".to_string();
+            }
             if matches!(copy_spell.target, ChooseSpec::Iterated) {
                 let mut text = "Copy that spell".to_string();
                 if copy_spell
@@ -33323,15 +33339,25 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         }
         let trigger_display = schedule.trigger.display();
         let mut trigger_text = trigger_display.trim().trim_end_matches('.').to_string();
+        let until_end_prefix = schedule.until_end_of_turn
+            && (trigger_text.to_ascii_lowercase().starts_with("whenever ")
+                || trigger_text.to_ascii_lowercase().starts_with("when "));
         if schedule.until_end_of_turn {
             let trigger_lower = trigger_text.to_ascii_lowercase();
-            if !trigger_lower.contains(" this turn") {
+            if !until_end_prefix && !trigger_lower.contains(" this turn") {
                 trigger_text.push_str(" this turn");
             }
         }
         trigger_text = cleanup_decompiled_text(&trigger_text);
         let trigger_lower = trigger_text.to_ascii_lowercase();
         let mut delayed_text = lowercase_first(&describe_effect_list(&schedule.effects));
+        if until_end_prefix {
+            delayed_text = delayed_text.replace("for the copy", "for the copies");
+            return format!(
+                "Until end of turn, {}, {delayed_text}",
+                lowercase_first(&trigger_text)
+            );
+        }
         if delayed_text.contains("if it matches card in exile, put it into its owner's graveyard") {
             delayed_text = delayed_text.replace(
                 "if it matches card in exile, put it into its owner's graveyard",

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1289,7 +1289,7 @@ where
         return Ok(Effect::new(crate::effects::ChooseCreatureTypeEffect::new(
             payload.chooser.clone(),
             payload.excluded_subtypes.clone(),
-        )));
+        ).with_family(payload.family)));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::FlipCoinEffect>(&effect) {
         return Ok(Effect::new(crate::effects::FlipCoinEffect::new(

--- a/crates/ironsmith-runtime/src/effects/composition/tag_triggering_source.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/tag_triggering_source.rs
@@ -24,9 +24,12 @@ impl EffectExecutor for TagTriggeringSourceEffect {
         let event = ctx.triggering_event.as_ref().ok_or_else(|| {
             ExecutionError::UnresolvableValue("missing triggering event".to_string())
         })?;
-        let source_id = event.source_object().ok_or_else(|| {
-            ExecutionError::UnresolvableValue("triggering event missing source".to_string())
-        })?;
+        let source_id = event
+            .source_object()
+            .or_else(|| event.object_id())
+            .ok_or_else(|| {
+                ExecutionError::UnresolvableValue("triggering event missing source".to_string())
+            })?;
         let Some(source) = game.object(source_id) else {
             return Ok(EffectOutcome::count(0));
         };

--- a/crates/ironsmith-runtime/src/effects/player/choose_creature_type.rs
+++ b/crates/ironsmith-runtime/src/effects/player/choose_creature_type.rs
@@ -10,12 +10,13 @@ use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::target::PlayerFilter;
-use crate::types::Subtype;
+use crate::types::{Subtype, SubtypeFamily};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChooseCreatureTypeEffect {
     pub chooser: PlayerFilter,
     pub excluded_subtypes: Vec<Subtype>,
+    pub family: SubtypeFamily,
 }
 
 impl ChooseCreatureTypeEffect {
@@ -23,11 +24,22 @@ impl ChooseCreatureTypeEffect {
         Self {
             chooser,
             excluded_subtypes,
+            family: SubtypeFamily::Creature,
         }
     }
 
-    fn creature_type_options(&self) -> Vec<Subtype> {
-        BecomeCreatureTypeChoiceEffect::all_creature_types()
+    pub fn with_family(mut self, family: SubtypeFamily) -> Self {
+        self.family = family;
+        self
+    }
+
+    fn subtype_options(&self) -> Vec<Subtype> {
+        let options = if self.family == SubtypeFamily::Creature {
+            BecomeCreatureTypeChoiceEffect::all_creature_types()
+        } else {
+            self.family.all_subtypes().to_vec()
+        };
+        options
             .iter()
             .copied()
             .filter(|subtype| !self.excluded_subtypes.contains(subtype))
@@ -46,7 +58,7 @@ impl EffectExecutor for ChooseCreatureTypeEffect {
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
         let chooser = resolve_player_filter(game, &self.chooser, ctx)?;
-        let subtype_options = self.creature_type_options();
+        let subtype_options = self.subtype_options();
         if subtype_options.is_empty() {
             return Ok(EffectOutcome::resolved());
         }
@@ -59,7 +71,7 @@ impl EffectExecutor for ChooseCreatureTypeEffect {
         let choice_ctx = SelectOptionsContext::new(
             chooser,
             Some(ctx.source),
-            "Choose a creature type",
+            format!("Choose a {}", self.family.type_phrase()),
             options,
             1,
             1,

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -537,6 +537,11 @@ impl super::Trigger {
                     Self::new(trigger)
                 }
             }
+            ironsmith_core::DelayedTriggerSpec::AbilityActivated {
+                activator,
+                filter,
+                non_mana_only,
+            } => Self::ability_activated_qualified(activator, filter, non_mana_only),
             ironsmith_core::DelayedTriggerSpec::SpellCast {
                 filter,
                 caster,

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/ability_activated.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/ability_activated.rs
@@ -52,17 +52,43 @@ impl TriggerMatcher for AbilityActivatedTrigger {
 
     fn display(&self) -> String {
         let subject = self.activator.description();
+        let verb = if subject.eq_ignore_ascii_case("you") {
+            "activate"
+        } else {
+            "activates"
+        };
         let ability = if self.non_mana_only {
             "a non-mana ability"
         } else {
             "an ability"
         };
         if self.filter == ObjectFilter::default() {
-            format!("Whenever {subject} activates {ability}")
+            format!("Whenever {subject} {verb} {ability}")
         } else {
+            let filter_description = self
+                .filter
+                .description()
+                .replace("of the chosen type", "of that type");
+            let filter_description = if filter_description.ends_with('s')
+                || filter_description.starts_with("a ")
+                || filter_description.starts_with("an ")
+                || filter_description.starts_with("the ")
+            {
+                filter_description
+            } else {
+                let article = if matches!(
+                    filter_description.chars().next(),
+                    Some('a' | 'e' | 'i' | 'o' | 'u')
+                ) {
+                    "an"
+                } else {
+                    "a"
+                };
+                format!("{article} {filter_description}")
+            };
             format!(
-                "Whenever {subject} activates {ability} of {}",
-                self.filter.description()
+                "Whenever {subject} {verb} {ability} of {}",
+                filter_description
             )
         }
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Leori, Sparktouched Hunter
Initial parse error:
```
unsupported until-end-of-turn permission clause (clause: 'until end of turn whenever you activate an ability of a planeswalker of that type copy that ability'); oracle-only fallback also failed: unsupported until-end-of-turn permission clause (clause: 'until end of turn whenever you activate an ability of a planeswalker of that type copy that ability')
```

Current worker: i-080724077cf031e7b
Branch: codex/aws-card-fix-leori-sparktouched-hunter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0004
