### PR TITLE
Fix Ironsmith parse failure: Volatile Stormdrake

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -674,6 +674,16 @@ fn parse_dynamic_payment_clause_as_total_cost(
         return Ok(None);
     }
     let token_words = words(&tokens);
+    let energy_count = tokens.iter().filter(|token| is_energy_cost_token(token)).count();
+    if energy_count > 0
+        && let Some(value) = parse_equal_to_aggregate_filter_value(&tokens)
+            .or_else(|| parse_equal_to_number_of_filter_value(&tokens))
+            .or_else(|| parse_equal_to_value(&tokens))
+            .or_else(|| parse_dynamic_cost_modifier_value(&tokens).ok().flatten())
+    {
+        return Ok(Some(TotalCost::from_cost(crate::costs::Cost::energy(value))));
+    }
+
     if MANA_PREFIX_PATTERN.matches_words(&token_words)
         && let Some(value) = parse_equal_to_aggregate_filter_value(&tokens)
             .or_else(|| parse_equal_to_number_of_filter_value(&tokens))
@@ -779,6 +789,30 @@ fn parse_dynamic_payment_clause_as_total_cost(
             ironsmith_core::DynamicManaDisplayHint::Default,
         )),
     )))
+}
+
+fn parse_equal_to_value(tokens: &[OwnedLexToken]) -> Option<Value> {
+    let words = words(tokens);
+    let equal_idx = words
+        .windows(2)
+        .position(|window| window == ["equal", "to"])?;
+    let value_start = token_index_for_word_index(tokens, equal_idx + 2)?;
+    let value_tokens = trim_edge_punctuation(&trim_commas(&tokens[value_start..]));
+    let (value, used) = parse_value(&value_tokens)?;
+    trim_edge_punctuation(&trim_commas(&value_tokens[used..]))
+        .is_empty()
+        .then_some(value)
+}
+
+fn is_energy_cost_token(token: &OwnedLexToken) -> bool {
+    if token.kind == crate::runtime_backend::lexer::TokenKind::ManaGroup {
+        return token
+            .slice
+            .trim_start_matches('{')
+            .trim_end_matches('}')
+            .eq_ignore_ascii_case("e");
+    }
+    token.as_word().is_some_and(|word| word == "energy")
 }
 
 pub(crate) fn marker_keyword_id(keyword: &str) -> Option<&'static str> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -337,6 +337,39 @@ fn color_only_hexproof_filter_words(words: &[&str]) -> Option<ObjectFilter> {
     }
 }
 
+fn stack_ability_filter(kind: crate::filter::StackObjectKind) -> ObjectFilter {
+    ObjectFilter {
+        zone: Some(Zone::Stack),
+        stack_kind: Some(kind),
+        ..Default::default()
+    }
+}
+
+fn ability_hexproof_filter_words(words: &[&str]) -> Option<ObjectFilter> {
+    match words {
+        ["activated", "ability" | "abilities"] => Some(stack_ability_filter(
+            crate::filter::StackObjectKind::ActivatedAbility,
+        )),
+        ["triggered", "ability" | "abilities"] => Some(stack_ability_filter(
+            crate::filter::StackObjectKind::TriggeredAbility,
+        )),
+        ["activated", "and" | "or", "triggered", "ability" | "abilities"] => {
+            Some(ObjectFilter {
+                any_of: vec![
+                    stack_ability_filter(crate::filter::StackObjectKind::ActivatedAbility),
+                    stack_ability_filter(crate::filter::StackObjectKind::TriggeredAbility),
+                ],
+                ..Default::default()
+            })
+        }
+        _ => None,
+    }
+}
+
+fn hexproof_from_filter_words(words: &[&str]) -> Option<ObjectFilter> {
+    color_only_hexproof_filter_words(words).or_else(|| ability_hexproof_filter_words(words))
+}
+
 fn parse_hexproof_from_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
     let words_view = TokenWordView::new(tokens);
     let words = words_view.word_refs();
@@ -352,7 +385,7 @@ fn parse_hexproof_from_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordActi
         return None;
     }
 
-    color_only_hexproof_filter_words(&words[first_word_idx + 2..])
+    hexproof_from_filter_words(&words[first_word_idx + 2..])
         .map(|filter| vec![KeywordAction::HexproofFrom(filter)])
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1,6 +1,6 @@
 use crate::cards::builders::{
     CardTextError, EffectAst, IT_TAG, IdGenContext, PlayerAst, PredicateAst, SubjectVerbActionAst,
-    SubjectVerbEffectAst, SubjectVerbRoleAst, TargetAst, TriggerSpec,
+    SubjectVerbEffectAst, SubjectVerbRoleAst, TagKey, TargetAst, TriggerSpec,
 };
 use crate::effect::{EffectId, EventValueSpec};
 use crate::filter::{Comparison, TaggedOpbjectRelation};
@@ -9,8 +9,6 @@ use crate::target::ObjectRef;
 use crate::{ObjectFilter, PlayerFilter, Value};
 use ironsmith_core::{EffectMetric, EffectMetricSource};
 
-#[cfg(test)]
-use crate::TagKey;
 #[cfg(test)]
 use crate::cards::builders::{ObjectRefAst, PreventNextTimeDamageSourceAst, RetargetModeAst};
 #[cfg(test)]
@@ -51,9 +49,10 @@ pub(crate) struct EffectReferenceResolutionConfig {
     pub(crate) force_auto_tag_object_targets: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct EffectReferenceResolutionState {
     last_effect_id: Option<EffectId>,
+    last_object_tag: Option<TagKey>,
     allow_life_event_value: bool,
     bind_unbound_x_to_last_effect: bool,
 }
@@ -676,6 +675,7 @@ fn advance_reference_frame_for_effect(
                     permanent2,
                     ..
                 } => {
+                    let _ = next_reference_tag(id_gen, "exchange_first");
                     frame.last_object_tag = Some(next_reference_tag(id_gen, "exchanged"));
                     track_target_player(permanent1, frame);
                     track_target_player(permanent2, frame);
@@ -1172,6 +1172,7 @@ fn advance_reference_frame_for_effect(
 fn effect_reference_resolution_state(env: &ReferenceEnv) -> EffectReferenceResolutionState {
     EffectReferenceResolutionState {
         last_effect_id: env.last_effect_id.clone().into_option(),
+        last_object_tag: env.known_last_object_tag().cloned(),
         allow_life_event_value: env.allow_life_event_value,
         bind_unbound_x_to_last_effect: env.bind_unbound_x_to_last_effect,
     }
@@ -1599,6 +1600,7 @@ fn resolve_effect_references_in_effect(
             id_gen,
             EffectReferenceResolutionState {
                 last_effect_id: Some(condition),
+                last_object_tag: state.last_object_tag.clone(),
                 allow_life_event_value: state.allow_life_event_value,
                 bind_unbound_x_to_last_effect: true,
             },
@@ -1619,6 +1621,7 @@ fn resolve_effect_references_in_effect(
             id_gen,
             EffectReferenceResolutionState {
                 last_effect_id: Some(condition),
+                last_object_tag: state.last_object_tag.clone(),
                 allow_life_event_value: state.allow_life_event_value,
                 bind_unbound_x_to_last_effect: true,
             },
@@ -1658,6 +1661,7 @@ fn resolve_effect_references_in_effect(
     {
         let nested_state = EffectReferenceResolutionState {
             last_effect_id: state.last_effect_id,
+            last_object_tag: state.last_object_tag.clone(),
             allow_life_event_value: trigger_supports_event_amount(trigger),
             bind_unbound_x_to_last_effect: state.bind_unbound_x_to_last_effect,
         };
@@ -1665,9 +1669,10 @@ fn resolve_effect_references_in_effect(
         return Ok(effect);
     }
 
-    resolve_effect_result_values_in_fields(&mut effect, state)?;
+    resolve_effect_result_values_in_fields(&mut effect, &state)?;
     try_for_each_nested_effects_mut(&mut effect, true, |nested| {
-        let resolved = resolve_effect_sequence_references_with_state(nested, id_gen, state)?;
+        let resolved =
+            resolve_effect_sequence_references_with_state(nested, id_gen, state.clone())?;
         nested.clone_from_slice(&resolved);
         Ok::<_, CardTextError>(())
     })?;
@@ -1683,7 +1688,7 @@ fn resolve_effect_sequence_references_with_state(
 
     for (idx, effect) in effects.iter().enumerate() {
         let saved_last_effect_id = state.last_effect_id;
-        let effect = resolve_effect_references_in_effect(effect.clone(), id_gen, state)?;
+        let effect = resolve_effect_references_in_effect(effect.clone(), id_gen, state.clone())?;
         let remaining = if idx + 1 < effects.len() {
             &effects[idx + 1..]
         } else {
@@ -1804,7 +1809,7 @@ fn advance_reference_env_for_effect(
 
 fn resolve_effect_result_values_in_fields(
     effect: &mut EffectAst,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match effect {
         EffectAst::SubjectVerb(subject_verb) => match &mut subject_verb.action {
@@ -2148,6 +2153,9 @@ fn resolve_effect_result_values_in_fields(
                 resolve_effect_result_value(count_value, state)?;
             }
         }
+        EffectAst::UnlessPays { cost, .. } => {
+            resolve_effect_result_values_in_total_cost(cost, state)?;
+        }
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}
         _ => {}
     }
@@ -2156,7 +2164,7 @@ fn resolve_effect_result_values_in_fields(
 
 fn resolve_effect_result_values_in_total_cost(
     cost: &mut crate::cost::TotalCost,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match cost.kind() {
         ironsmith_core::TotalCostKind::All(_) => {
@@ -2179,7 +2187,7 @@ fn resolve_effect_result_values_in_total_cost(
 
 fn resolve_effect_result_values_in_cost_component(
     component: &mut crate::costs::Cost,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match component {
         crate::costs::Cost::DynamicMana(dynamic) => {
@@ -2203,7 +2211,7 @@ fn resolve_effect_result_values_in_cost_component(
 
 fn resolve_effect_result_value(
     value: &mut Value,
-    state: EffectReferenceResolutionState,
+    state: &EffectReferenceResolutionState,
 ) -> Result<(), CardTextError> {
     match value {
         Value::X if state.bind_unbound_x_to_last_effect => {
@@ -2221,6 +2229,9 @@ fn resolve_effect_result_value(
         }
         Value::SurfaceHinted { value, .. } => {
             resolve_effect_result_value(value, state)?;
+        }
+        Value::PowerOf(spec) | Value::ToughnessOf(spec) | Value::ManaValueOf(spec) => {
+            resolve_effect_value_choose_spec(spec, state)?;
         }
         Value::PendingEffectMetric { source, metric } => {
             let id = state.last_effect_id.ok_or_else(|| {
@@ -2299,6 +2310,31 @@ fn resolve_effect_result_value(
                 metric: EffectMetric::LifeLost,
                 offset: *offset,
             };
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn resolve_effect_value_choose_spec(
+    spec: &mut ChooseSpec,
+    state: &EffectReferenceResolutionState,
+) -> Result<(), CardTextError> {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. } => resolve_effect_value_choose_spec(spec, state)?,
+        ChooseSpec::Tagged(tag) if tag.as_str() == IT_TAG => {
+            if let Some(last_object_tag) = &state.last_object_tag
+                && last_object_tag.as_str() != IT_TAG
+            {
+                *tag = last_object_tag.clone();
+            }
+        }
+        ChooseSpec::Target(inner) | ChooseSpec::WithCount(inner, _) => {
+            resolve_effect_value_choose_spec(inner, state)?;
+        }
+        ChooseSpec::WithCountValue(inner, _, value) => {
+            resolve_effect_value_choose_spec(inner, state)?;
+            resolve_effect_result_value(value, state)?;
         }
         _ => {}
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -1264,6 +1264,10 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     && grammar::words_match_any_prefix(after_then, PUT_BACK_PREFIXES).is_some()
                     && grammar::contains_word(after_then, "any")
                     && grammar::contains_word(after_then, "order");
+                let allow_sacrifice_backref_followup = !starts_with_for_each_player_or_opponent
+                    && has_back_ref
+                    && find_verb_lexed(after_then)
+                        .is_some_and(|(verb, verb_idx)| verb == Verb::Sacrifice && verb_idx == 0);
                 let allow_clash_followup = starts_with_clash;
                 if has_effect_head && (!has_back_ref || allow_backref_split)
                     || has_effect_head && allow_clash_followup
@@ -1277,6 +1281,7 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     || has_effect_head && allow_put_battlefield_with_counter_followup
                     || has_effect_head && allow_put_into_hand_followup
                     || has_effect_head && allow_put_back_in_any_order_followup
+                    || has_effect_head && allow_sacrifice_backref_followup
                 {
                     split_point = Some(i);
                     break;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -244,6 +244,16 @@ pub(crate) fn parse_sacrifice(
                     if_false: vec![base],
                 });
             }
+            if let Some((player, cost)) = parse_unless_pay_energy_equal_to_tagged_mana_value(
+                &sacrifice_tokens,
+                &tokens[unless_token_idx + 1..],
+            ) {
+                return Ok(EffectAst::UnlessPays {
+                    effects: vec![base],
+                    player,
+                    cost,
+                });
+            }
             if let Some(unless_effect) = try_build_unless(
                 vec![base],
                 SubjectVerbPrimitiveClause::new(tokens),
@@ -423,6 +433,45 @@ pub(crate) fn parse_sacrifice(
         sacrifice
     };
     Ok(wrap_unless_escaped(effect, unless_escaped))
+}
+
+fn parse_unless_pay_energy_equal_to_tagged_mana_value(
+    sacrifice_tokens: &[OwnedLexToken],
+    unless_tokens: &[OwnedLexToken],
+) -> Option<(PlayerAst, crate::cost::TotalCost)> {
+    let sacrifice_words = crate::runtime_backend::token_word_refs(sacrifice_tokens);
+    if !sacrifice_words.iter().any(|word| *word == "that") {
+        return None;
+    }
+
+    let words = crate::runtime_backend::token_word_refs(unless_tokens);
+    if !words.starts_with(&["you", "pay"])
+        || !words.windows(3).any(|window| window == ["its", "mana", "value"])
+        || !words.windows(2).any(|window| window == ["equal", "to"])
+        || !unless_tokens.iter().any(is_energy_payment_token)
+    {
+        return None;
+    }
+
+    Some((
+        PlayerAst::You,
+        crate::cost::TotalCost::from_cost(crate::costs::Cost::energy(Value::ManaValueOf(
+            Box::new(ChooseSpec::Target(Box::new(ChooseSpec::Object(
+                ObjectFilter::creature(),
+            )))),
+        ))),
+    ))
+}
+
+fn is_energy_payment_token(token: &OwnedLexToken) -> bool {
+    if token.kind == crate::runtime_backend::lexer::TokenKind::ManaGroup {
+        return token
+            .slice
+            .trim_start_matches('{')
+            .trim_end_matches('}')
+            .eq_ignore_ascii_case("e");
+    }
+    token.as_word().is_some_and(|word| word == "energy")
 }
 
 pub(crate) fn parse_discard(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/choice_damage_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/choice_damage_family.rs
@@ -3,6 +3,7 @@ use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseSha
 use crate::runtime_backend::front_end::lex_patterns::{
     LexCaptureKind, LexCaptureRole, LexPattern, LexPatternAtom, LexPatternMatch,
 };
+use crate::target::ChooseSpec;
 
 const REVEAL_HAND_SUFFIXES: &[&[&str]] = &[
     &["in", "your", "hand"],
@@ -1126,6 +1127,24 @@ pub(crate) fn parse_sentence_unless_pays_matched(
         }
     }
 
+    if let Some((prefix_tokens, trailing_tokens)) =
+        split_trailing_then_sacrifice_clause(effect_clause.tokens())
+    {
+        let mut effects = parse_effect_chain(prefix_tokens)?;
+        let trailing_effects = parse_effect_chain(trailing_tokens)?;
+        if !effects.is_empty()
+            && !trailing_effects.is_empty()
+            && let Some(unless_effect) = try_build_referential_energy_sacrifice_unless(
+                trailing_effects,
+                clause,
+                unless_idx,
+            )?
+        {
+            effects.push(unless_effect);
+            return Ok(Some(effects));
+        }
+    }
+
     let effects = parse_effect_chain(effect_clause.tokens())?;
     if effects.is_empty() {
         return Ok(None);
@@ -1135,4 +1154,63 @@ pub(crate) fn parse_sentence_unless_pays_matched(
         return Ok(Some(vec![unless_effect]));
     }
     Ok(None)
+}
+
+fn split_trailing_then_sacrifice_clause(
+    tokens: &[OwnedLexToken],
+) -> Option<(&[OwnedLexToken], &[OwnedLexToken])> {
+    for idx in (0..tokens.len()).rev() {
+        let token = &tokens[idx];
+        if !token.as_word().is_some_and(|word| word == "then") {
+            continue;
+        }
+        let before = crate::runtime_backend::front_end::lexer::trim_lexed_commas(&tokens[..idx]);
+        let after = crate::runtime_backend::front_end::lexer::trim_lexed_commas(&tokens[idx + 1..]);
+        if before.is_empty() || after.is_empty() {
+            continue;
+        }
+        if after
+            .first()
+            .and_then(OwnedLexToken::as_word)
+            .is_some_and(|word| word == "sacrifice")
+        {
+            return Some((before, after));
+        }
+    }
+    None
+}
+
+fn try_build_referential_energy_sacrifice_unless(
+    effects: Vec<EffectAst>,
+    clause: SubjectVerbPrimitiveClause<'_>,
+    unless_idx: usize,
+) -> Result<Option<EffectAst>, CardTextError> {
+    let unless_clause = clause.from(unless_idx + 1).trimmed();
+    let words = unless_clause.word_refs();
+    if !words.starts_with(&["you", "pay"])
+        || !words.windows(2).any(|window| window == ["equal", "to"])
+        || !words.windows(3).any(|window| window == ["its", "mana", "value"])
+        || !unless_clause.tokens().iter().any(is_energy_payment_token)
+    {
+        return try_build_unless(effects, clause, unless_idx);
+    }
+
+    Ok(Some(EffectAst::UnlessPays {
+        effects,
+        player: PlayerAst::You,
+        cost: crate::cost::TotalCost::from_cost(crate::costs::Cost::energy(
+            Value::ManaValueOf(Box::new(ChooseSpec::Tagged(TagKey::from(IT_TAG)))),
+        )),
+    }))
+}
+
+fn is_energy_payment_token(token: &OwnedLexToken) -> bool {
+    if token.kind == crate::runtime_backend::lexer::TokenKind::ManaGroup {
+        return token
+            .slice
+            .trim_start_matches('{')
+            .trim_end_matches('}')
+            .eq_ignore_ascii_case("e");
+    }
+    token.as_word().is_some_and(|word| word == "energy")
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7571,6 +7571,30 @@ fn rewrite_lexed_keyword_line_parses_hexproof_from_color_in_keyword_list() {
 }
 
 #[test]
+fn rewrite_lexed_keyword_line_parses_hexproof_from_activated_and_triggered_abilities() {
+    let keyword_tokens = lex_line("Flying, hexproof from activated and triggered abilities", 0)
+        .expect("rewrite lexer should classify ability-scoped hexproof-from keyword line");
+
+    let parsed = super::clause_support::parse_ability_line_lexed(&keyword_tokens)
+        .expect("ability-scoped hexproof-from keyword line should parse");
+    assert_eq!(parsed.len(), 2, "{parsed:?}");
+    assert_eq!(parsed[0], crate::cards::builders::KeywordAction::Flying);
+
+    let crate::cards::builders::KeywordAction::HexproofFrom(filter) = &parsed[1] else {
+        panic!("expected hexproof-from action, got {parsed:?}");
+    };
+    assert_eq!(filter.any_of.len(), 2, "{filter:?}");
+    assert!(filter.any_of.iter().any(|candidate| {
+        candidate.zone == Some(crate::zone::Zone::Stack)
+            && candidate.stack_kind == Some(crate::filter::StackObjectKind::ActivatedAbility)
+    }));
+    assert!(filter.any_of.iter().any(|candidate| {
+        candidate.zone == Some(crate::zone::Zone::Stack)
+            && candidate.stack_kind == Some(crate::filter::StackObjectKind::TriggeredAbility)
+    }));
+}
+
+#[test]
 fn rewrite_lexed_triggered_and_static_entrypoints_work_natively() {
     let triggered_tokens = lex_line(
         "Whenever you cast an Aura, Equipment, or Vehicle spell, draw a card.",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42543,6 +42543,63 @@ fn parse_sporeweb_weaver_strict_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn volatile_stormdrake_strict_parser_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Volatile Stormdrake");
+    let def = parse_oracle_card_definition("Volatile Stormdrake");
+    let rendered_lines = canonical_compiled_lines(&def);
+    let rendered = rendered_lines.join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Flying, hexproof from activated and triggered abilities".to_string(),
+            "When this creature enters, exchange control of this creature and target creature an opponent controls. If you do, you get {E}{E}{E}{E}. You sacrifice that creature unless you pay an amount of {E} equal to that creature's mana value."
+                .to_string(),
+        ],
+        "unexpected Volatile Stormdrake compiled text"
+    );
+    assert!(
+        rendered.contains("hexproof from activated and triggered abilities")
+            && rendered.contains("sacrifice that creature unless you pay an amount of {E} equal to that creature's mana value"),
+        "Volatile Stormdrake compiled text should preserve ability-scoped hexproof and dynamic energy sacrifice text, got {rendered}"
+    );
+
+    let hexproof_from = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::HexproofFrom =>
+            {
+                static_ability.hexproof_from_filter()
+            }
+            _ => None,
+        })
+        .expect("Volatile Stormdrake should have hexproof from activated and triggered abilities");
+    assert!(
+        hexproof_from.any_of.iter().any(|filter| {
+            filter.zone == Some(Zone::Stack)
+                && filter.stack_kind == Some(crate::filter::StackObjectKind::ActivatedAbility)
+        }) && hexproof_from.any_of.iter().any(|filter| {
+            filter.zone == Some(Zone::Stack)
+                && filter.stack_kind == Some(crate::filter::StackObjectKind::TriggeredAbility)
+        }),
+        "expected ability-scoped hexproof-from stack filters, got {hexproof_from:?}"
+    );
+    assert!(
+        ability_debug.contains("ExchangeControlEffect")
+            && ability_debug.contains("EnergyCountersEffect")
+            && ability_debug.contains("UnlessPaysEffect")
+            && ability_debug.contains("PayEnergyEffect")
+            && ability_debug.contains("ManaValueOf")
+            && ability_debug.contains("exchanged_"),
+        "expected exchange, energy, unless-pay, and tagged mana-value payment in Volatile Stormdrake, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn sporeweb_weaver_hexproof_from_blue_blocks_only_opposing_blue_sources() {
     let def = parse_oracle_card_definition("Sporeweb Weaver");
     let mut game =

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -379,6 +379,10 @@ pub(super) fn repeated_energy_symbols(count: usize) -> String {
 pub(super) fn describe_energy_payment_amount(value: &Value) -> String {
     match value {
         Value::Fixed(amount) if *amount > 0 => repeated_energy_symbols(*amount as usize),
+        Value::ManaValueOf(spec) => format!(
+            "an amount of {{E}} equal to {}",
+            super::render_effects::describe_dynamic_counter_basis(spec, "mana value")
+        ),
         _ => format!("{} energy counter(s)", describe_value(value)),
     }
 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -20053,6 +20053,13 @@ pub(super) fn describe_choose_then_sacrifice(
         if refers_to_triggering_object {
             return Some(format!("{player} {verb} it"));
         }
+        if choose.filter.card_types.contains(&CardType::Creature)
+            && choose.filter.tagged_constraints.iter().any(|constraint| {
+                constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            })
+        {
+            return Some(format!("{player} {verb} that creature"));
+        }
         if let Some(rest) = chosen.strip_prefix(&format!("{player}'s ")) {
             let chosen_kind = with_indefinite_article(rest);
             return Some(format!("{player} {verb} {chosen_kind} of their choice"));
@@ -21164,7 +21171,7 @@ fn describe_dynamic_counter_amount_phrase(
     Some((amount_text, basis))
 }
 
-fn describe_dynamic_counter_basis(spec: &ChooseSpec, attribute: &str) -> String {
+pub(super) fn describe_dynamic_counter_basis(spec: &ChooseSpec, attribute: &str) -> String {
     if spec.is_target() {
         return format!("that creature's {attribute}");
     }

--- a/crates/ironsmith-runtime/src/costs/cost_effect.rs
+++ b/crates/ironsmith-runtime/src/costs/cost_effect.rs
@@ -206,8 +206,44 @@ fn simple_exile_from_graveyard_filter(
     (filter == &expected).then_some(card_type)
 }
 
+fn pay_energy_cost_precheck(
+    effect: &Effect,
+    game: &GameState,
+    ctx: &CostContext,
+) -> Option<Result<(), CostPaymentError>> {
+    let pay_energy = effect.downcast_ref::<crate::effects::PayEnergyEffect>()?;
+    let exec_ctx = ExecutionContext::new_default(ctx.source, ctx.payer)
+        .with_tagged_objects(ctx.tagged_objects.clone());
+    let payer =
+        crate::effects::helpers::resolve_player_from_spec(game, &pay_energy.player, &exec_ctx)
+            .map_err(|_| {
+                CostPaymentError::Other("unable to resolve player for energy cost".to_string())
+            });
+    let needed = crate::effects::helpers::resolve_value(game, &pay_energy.amount, &exec_ctx)
+        .map(|value| value.max(0) as u32)
+        .map_err(|_| CostPaymentError::Other("unable to resolve energy amount".to_string()));
+    Some(match (payer, needed) {
+        (Ok(payer), Ok(needed)) => {
+            if game
+                .player(payer)
+                .is_some_and(|player| player.energy_counters >= needed)
+            {
+                Ok(())
+            } else {
+                Err(CostPaymentError::Other(
+                    "not enough energy counters".to_string(),
+                ))
+            }
+        }
+        (Err(err), _) | (_, Err(err)) => Err(err),
+    })
+}
+
 impl CostPayer for CostEffect {
     fn can_pay(&self, game: &GameState, ctx: &CostContext) -> Result<(), CostPaymentError> {
+        if let Some(result) = pay_energy_cost_precheck(&self.effect, game, ctx) {
+            return result;
+        }
         self.effect
             .0
             .can_execute_as_cost_with_reason(game, ctx.source, ctx.payer, ctx.reason)

--- a/crates/ironsmith-runtime/src/costs/mod.rs
+++ b/crates/ironsmith-runtime/src/costs/mod.rs
@@ -206,7 +206,15 @@ impl Cost {
                     Self::remove_any_counters_from_source(counter_type, display_x)
                 }
             }
-            ironsmith_core::Cost::Energy(amount) => Self::energy(fixed_u32(amount, "energy cost")?),
+            ironsmith_core::Cost::Energy(amount) => match fixed_u32(amount.clone(), "energy cost") {
+                Ok(fixed) => Self::energy(fixed),
+                Err(_) => Self::try_effect(crate::effect::Effect::new(
+                    crate::effects::PayEnergyEffect::new(
+                        amount,
+                        crate::target::ChooseSpec::Player(crate::target::PlayerFilter::You),
+                    ),
+                ))?,
+            },
             ironsmith_core::Cost::Mill(count) => Self::mill(fixed_u32(count, "mill cost")?),
             ironsmith_core::Cost::Life(amount) => Self::life(fixed_u32(amount, "life cost")?),
             ironsmith_core::Cost::ExileSelf => Self::exile_self(),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -209,6 +209,257 @@ fn assaultron_dominator_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn volatile_stormdrake_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_300), "Volatile Stormdrake")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Drake])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Flying, hexproof from activated and triggered abilities\n\
+             When this creature enters, exchange control of this creature and target creature an opponent controls. If you do, you get {E}{E}{E}{E}, then sacrifice that creature unless you pay an amount of {E} equal to its mana value.",
+        )
+        .expect("Volatile Stormdrake should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct VolatileStormdrakeDecisionMaker {
+    pay_unless: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for VolatileStormdrakeDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.pay_unless
+    }
+
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<crate::Target> {
+        ctx.requirements
+            .iter()
+            .flat_map(|requirement| {
+                let count = requirement
+                    .max_targets
+                    .unwrap_or(1)
+                    .max(requirement.min_targets)
+                    .min(requirement.legal_targets.len());
+                requirement.legal_targets.iter().take(count).copied()
+            })
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_three_mana_value_bob_creature(game: &mut GameState) -> ObjectId {
+    let bob = PlayerId::from_index(1);
+    let target = CardBuilder::new(CardId::from_raw(74_301), "Three-Drop Target")
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(3)]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&target, bob, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_volatile_stormdrake_enters_trigger_on_stack(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    stormdrake_id: ObjectId,
+    decision_maker: &mut dyn DecisionMaker,
+) {
+    let event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            stormdrake_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    for trigger in crate::triggers::check_triggers(game, &event) {
+        if trigger.source == stormdrake_id {
+            trigger_queue.add(trigger);
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Volatile Stormdrake should trigger when it enters"
+    );
+    put_triggers_on_stack_with_dm(game, trigger_queue, decision_maker)
+        .expect("Volatile Stormdrake enters trigger should go on the stack");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn volatile_stormdrake_enters_pays_energy_equal_to_exchanged_creature_mana_value() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let stormdrake = volatile_stormdrake_definition();
+    let stormdrake_id = game.create_object_from_definition(&stormdrake, alice, Zone::Battlefield);
+    let target_id = create_three_mana_value_bob_creature(&mut game);
+    let mut dm = VolatileStormdrakeDecisionMaker { pay_unless: true };
+
+    put_volatile_stormdrake_enters_trigger_on_stack(
+        &mut game,
+        &mut trigger_queue,
+        stormdrake_id,
+        &mut dm,
+    );
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Volatile Stormdrake enters trigger should resolve");
+
+    assert_eq!(game.controller_of_id(stormdrake_id), Some(bob));
+    assert_eq!(game.controller_of_id(target_id), Some(alice));
+    assert!(
+        game.battlefield.contains(&target_id),
+        "paying three energy should keep the exchanged creature on the battlefield"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        1,
+        "Alice should get four energy, then pay the exchanged creature's mana value of three"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn volatile_stormdrake_enters_declining_payment_sacrifices_exchanged_creature() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let stormdrake = volatile_stormdrake_definition();
+    let stormdrake_id = game.create_object_from_definition(&stormdrake, alice, Zone::Battlefield);
+    let target_id = create_three_mana_value_bob_creature(&mut game);
+    let mut dm = VolatileStormdrakeDecisionMaker { pay_unless: false };
+
+    put_volatile_stormdrake_enters_trigger_on_stack(
+        &mut game,
+        &mut trigger_queue,
+        stormdrake_id,
+        &mut dm,
+    );
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Volatile Stormdrake enters trigger should resolve when payment is declined");
+
+    assert_eq!(game.controller_of_id(stormdrake_id), Some(bob));
+    assert!(
+        !game.battlefield.contains(&target_id),
+        "declining the energy payment should sacrifice the exchanged creature"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        4,
+        "declining payment should keep the four energy gained before the unless branch"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn volatile_stormdrake_enters_invalid_target_skips_if_you_do_branch() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let stormdrake = volatile_stormdrake_definition();
+    let stormdrake_id = game.create_object_from_definition(&stormdrake, alice, Zone::Battlefield);
+    let target_id = create_three_mana_value_bob_creature(&mut game);
+    let mut dm = VolatileStormdrakeDecisionMaker { pay_unless: true };
+
+    put_volatile_stormdrake_enters_trigger_on_stack(
+        &mut game,
+        &mut trigger_queue,
+        stormdrake_id,
+        &mut dm,
+    );
+    game.move_object(
+        target_id,
+        Zone::Graveyard,
+        crate::events::cause::EventCause::from_game_rule(),
+    );
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Volatile Stormdrake enters trigger with invalid target should resolve safely");
+
+    assert_eq!(game.controller_of_id(stormdrake_id), Some(alice));
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        0,
+        "if the exchange does not happen, the if-you-do energy and sacrifice branch should be skipped"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn volatile_stormdrake_hexproof_from_abilities_blocks_abilities_not_spells() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let stormdrake = volatile_stormdrake_definition();
+    let stormdrake_id = game.create_object_from_definition(&stormdrake, alice, Zone::Battlefield);
+    let source_card = CardBuilder::new(CardId::from_raw(74_302), "Targeting Source")
+        .card_types(vec![CardType::Instant])
+        .build();
+
+    let activated_source = game.create_object_from_card(&source_card, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::ability(
+        activated_source,
+        bob,
+        crate::resolution::ResolutionProgram::from_effects(Vec::<Effect>::new()),
+    ));
+    assert_eq!(
+        crate::targeting::can_target_object(&game, stormdrake_id, activated_source, bob),
+        crate::targeting::TargetingResult::Invalid(
+            crate::targeting::TargetingInvalidReason::HasHexproofFrom
+        ),
+        "opposing activated abilities should not be able to target Volatile Stormdrake"
+    );
+    game.stack.clear();
+
+    let triggered_source = game.create_object_from_card(&source_card, bob, Zone::Stack);
+    let trigger_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfUpkeepEvent::new(bob),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.push_to_stack(
+        StackEntry::ability(
+            triggered_source,
+            bob,
+            crate::resolution::ResolutionProgram::from_effects(Vec::<Effect>::new()),
+        )
+        .with_triggering_event(trigger_event),
+    );
+    assert_eq!(
+        crate::targeting::can_target_object(&game, stormdrake_id, triggered_source, bob),
+        crate::targeting::TargetingResult::Invalid(
+            crate::targeting::TargetingInvalidReason::HasHexproofFrom
+        ),
+        "opposing triggered abilities should not be able to target Volatile Stormdrake"
+    );
+    game.stack.clear();
+
+    let spell_source = game.create_object_from_card(&source_card, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_source, bob));
+    assert!(
+        crate::targeting::can_target_object(&game, stormdrake_id, spell_source, bob).is_legal(),
+        "hexproof from activated and triggered abilities should not block spells"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 struct AssaultronDecisionMaker {
     pay_energy: bool,
     mode_index: usize,

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -1748,9 +1748,6 @@ pub(crate) fn can_pay_total_cost_with_reason_in_context(
     reason: crate::costs::PaymentReason,
     execution_ctx: &mut ExecutionContext<'_>,
 ) -> Result<(), CostPaymentError> {
-    use crate::costs::{CostCheckContext, can_pay_with_check_context};
-
-    let check_ctx = CostCheckContext::new(source, payer).with_reason(reason);
     match cost.kind() {
         ironsmith_core::TotalCostKind::All(costs) => {
             for component in costs {
@@ -1764,7 +1761,11 @@ pub(crate) fn can_pay_total_cost_with_reason_in_context(
                 )?;
                 game.validate_cost_for_payment_reason(payer, source, &adjusted_component, reason)
                     .map_err(|err| err)?;
-                can_pay_with_check_context(&*adjusted_component.0, game, &check_ctx)?;
+                let mut check_dm = crate::decision::CliDecisionMaker;
+                let mut cost_ctx = crate::costs::CostContext::new(source, payer, &mut check_dm)
+                    .with_reason(reason);
+                cost_ctx.tagged_objects = execution_ctx.tagged_objects.clone();
+                adjusted_component.0.can_pay(game, &cost_ctx)?;
             }
             Ok(())
         }
@@ -2333,6 +2334,7 @@ fn pay_component_in_context(
     let mut cost_ctx = CostContext::new(source, payer, execution_ctx.decision_maker)
         .with_reason(reason)
         .with_provenance(provenance);
+    cost_ctx.tagged_objects = execution_ctx.tagged_objects.clone();
     pay_component_without_execution_context(game, component, &mut cost_ctx)
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -219,6 +219,13 @@ impl HexproofFrom {
 }
 
 fn describe_hexproof_from_filter(filter: &ObjectFilter) -> String {
+    if filter.any_of.len() == 2
+        && filter.any_of.iter().any(is_activated_ability_stack_filter)
+        && filter.any_of.iter().any(is_triggered_ability_stack_filter)
+    {
+        return "activated and triggered abilities".to_string();
+    }
+
     if !filter.any_of.is_empty() {
         return filter
             .any_of
@@ -232,6 +239,18 @@ fn describe_hexproof_from_filter(filter: &ObjectFilter) -> String {
         return "each color".to_string();
     }
 
+    if is_activated_ability_stack_filter(filter) {
+        return "activated abilities".to_string();
+    }
+    if is_triggered_ability_stack_filter(filter) {
+        return "triggered abilities".to_string();
+    }
+    if filter.zone == Some(crate::zone::Zone::Stack)
+        && filter.stack_kind == Some(crate::filter::StackObjectKind::Ability)
+    {
+        return "abilities".to_string();
+    }
+
     let description = filter.description();
     description
         .strip_suffix(" permanent")
@@ -239,6 +258,18 @@ fn describe_hexproof_from_filter(filter: &ObjectFilter) -> String {
         .or_else(|| description.strip_suffix(" source"))
         .unwrap_or(description.as_str())
         .to_string()
+}
+
+fn is_activated_ability_stack_filter(filter: &ObjectFilter) -> bool {
+    filter.zone == Some(crate::zone::Zone::Stack)
+        && filter.stack_kind == Some(crate::filter::StackObjectKind::ActivatedAbility)
+        && filter.any_of.is_empty()
+}
+
+fn is_triggered_ability_stack_filter(filter: &ObjectFilter) -> bool {
+    filter.zone == Some(crate::zone::Zone::Stack)
+        && filter.stack_kind == Some(crate::filter::StackObjectKind::TriggeredAbility)
+        && filter.any_of.is_empty()
 }
 
 fn is_exactly_all_magic_colors_filter(filter: &ObjectFilter) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Volatile Stormdrake
Initial parse error:
```
parser does not yet support line family: 'Flying, hexproof from activated and triggered abilities'; oracle-only fallback also failed: parser does not yet support line family: 'Flying, hexproof from activated and triggered abilities'
```

Current worker: i-02974ed5c7cefec86
Branch: codex/aws-card-fix-volatile-stormdrake
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0004
