### PR TITLE
Fix Ironsmith parse failure: Torch the Witness

### DIFF
--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -449,6 +449,7 @@ pub enum IfResultPredicate {
     Did,
     DidNot,
     DiesThisWay,
+    ExcessDamageDealt,
     WasDeclined,
     Value(ironsmith_core::Comparison),
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/modal_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/modal_helpers.rs
@@ -93,6 +93,11 @@ const WOULD_DIE_THIS_TURN_PATTERN: ClauseShape<'static> = clause_shape!(
 );
 const EXCESS_DAMAGE_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["it", "deals", "excess", "damage", "this", "way"]);
+const EXCESS_DAMAGE_WAS_DEALT_THIS_WAY_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix & ["excess", "damage", "was", "dealt", "to"];
+    suffix & ["this", "way"];
+    contains_words & ["creature"]
+);
 const POWER_BECOMES_THIS_WAY_PATTERN: ClauseShape<'static> = clause_shape!(prefix_any & [&["its", "power", "becomes"], &["it", "power", "becomes"]]; suffix & ["this", "way"]);
 
 fn modal_words_match_shape(words: &[&str], shape: &ClauseShape<'static>) -> bool {
@@ -254,9 +259,15 @@ pub(crate) fn parse_if_result_predicate_lexed(
         return Some(IfResultPredicate::DiesThisWay);
     }
 
-    if modal_words_match_shape(&words, &EXCESS_DAMAGE_THIS_WAY_PATTERN)
-        || (words.len() == 5 && modal_words_match_shape(&words, &POWER_BECOMES_THIS_WAY_PATTERN))
-    {
+    if modal_words_match_shape(&words, &EXCESS_DAMAGE_WAS_DEALT_THIS_WAY_PATTERN) {
+        return Some(IfResultPredicate::ExcessDamageDealt);
+    }
+
+    if modal_words_match_shape(&words, &EXCESS_DAMAGE_THIS_WAY_PATTERN) {
+        return Some(IfResultPredicate::Did);
+    }
+
+    if words.len() == 5 && modal_words_match_shape(&words, &POWER_BECOMES_THIS_WAY_PATTERN) {
         return Some(IfResultPredicate::Did);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -175,6 +175,11 @@ const OBJECT_DAMAGE_WOULD_DIE_THIS_WAY_PATTERN: ClauseShape<'static> = clause_sh
 );
 const EXCESS_DAMAGE_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["it", "deals", "excess", "damage", "this", "way"]);
+const EXCESS_DAMAGE_WAS_DEALT_THIS_WAY_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix & ["excess", "damage", "was", "dealt", "to"];
+    suffix & ["this", "way"];
+    contains_words & ["creature"]
+);
 const YOU_LOSE_FLIP_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["you", "lose"], &["you", "lost"]]; contains_words & ["flip"]);
 const PLAYER_SHORT_NEGATED_RESULT_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -795,6 +800,9 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
             | ["it", "power", "becomes", _, "this", "way"]
     ) {
         return Some(IfResultPredicate::Did);
+    }
+    if EXCESS_DAMAGE_WAS_DEALT_THIS_WAY_PATTERN.matches_words(words) {
+        return Some(IfResultPredicate::ExcessDamageDealt);
     }
     if EXCESS_DAMAGE_THIS_WAY_PATTERN.matches_words(words) {
         return Some(IfResultPredicate::Did);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2668,6 +2668,13 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         return Some((Value::EventValue(EventValueSpec::Amount), words.len()));
     }
 
+    if words
+        .get(..2)
+        .is_some_and(|prefix| matches!(prefix, ["twice", x] if X_WORD_PATTERN.matches_word(x)))
+    {
+        return Some((Value::XTimes(2), 2));
+    }
+
     if X_WORD_PATTERN.matches_word(words[0]) {
         return Some((Value::X, 1));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -692,6 +692,7 @@ pub(crate) fn effect_predicate_from_if_result(predicate: IfResultPredicate) -> E
         IfResultPredicate::Did => EffectPredicate::Happened,
         IfResultPredicate::DidNot => EffectPredicate::DidNotHappen,
         IfResultPredicate::DiesThisWay => EffectPredicate::HappenedNotReplaced,
+        IfResultPredicate::ExcessDamageDealt => EffectPredicate::ExcessDamageDealt,
         IfResultPredicate::WasDeclined => EffectPredicate::WasDeclined,
         IfResultPredicate::Value(cmp) => EffectPredicate::Value(cmp),
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -538,6 +538,7 @@ fn parse_modal_header_prefix_effects(
                 IfResultPredicate::Did => EffectPredicate::Happened,
                 IfResultPredicate::DidNot => EffectPredicate::DidNotHappen,
                 IfResultPredicate::DiesThisWay => EffectPredicate::HappenedNotReplaced,
+                IfResultPredicate::ExcessDamageDealt => EffectPredicate::ExcessDamageDealt,
                 IfResultPredicate::WasDeclined => EffectPredicate::WasDeclined,
                 IfResultPredicate::Value(cmp) => EffectPredicate::Value(cmp),
             };

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -81,6 +81,7 @@ pub enum EffectPredicate {
     Happened,
     DidNotHappen,
     HappenedNotReplaced,
+    ExcessDamageDealt,
     Value(crate::effect_model::Comparison),
     Chosen,
     WasDeclined,

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -1321,6 +1321,7 @@ pub(crate) enum IfResultPredicate {
     Did,
     DidNot,
     DiesThisWay,
+    ExcessDamageDealt,
     WasDeclined,
     Value(crate::effect::Comparison),
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -26455,6 +26455,34 @@ fn parse_that_much_damage_trigger_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_torch_the_witness_strictly_parses_and_renders_excess_damage_branch() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Torch the Witness")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Torch the Witness deals twice X damage to target creature. If excess damage was dealt to that creature this way, investigate.",
+        )
+        .expect("Torch the Witness should parse strictly");
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("XTimes") && debug.contains("ExcessDamageDealt"),
+        "expected twice-X damage and excess-damage predicate in Torch the Witness definition, got {debug}"
+    );
+
+    let joined = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        joined.contains("Torch the Witness deals twice X damage to target creature")
+            && joined.contains("If excess damage was dealt to that creature this way, investigate"),
+        "expected Torch the Witness compiled text to preserve twice-X damage and excess-damage condition, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_gain_choice_of_keywords_clause() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Gift Variant")
         .parse_text("Target creature gets +1/+1 and gains your choice of deathtouch or lifelink until end of turn.")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10534,6 +10534,7 @@ pub(super) fn describe_effect_predicate(predicate: &EffectPredicate) -> String {
         EffectPredicate::Happened => "happened".to_string(),
         EffectPredicate::DidNotHappen => "that doesn't happen".to_string(),
         EffectPredicate::HappenedNotReplaced => "happened and was not replaced".to_string(),
+        EffectPredicate::ExcessDamageDealt => "excess damage was dealt this way".to_string(),
         EffectPredicate::Value(cmp) => format!("its count {}", describe_comparison(cmp)),
         EffectPredicate::Chosen => "was chosen".to_string(),
         EffectPredicate::WasDeclined => "was declined".to_string(),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14936,6 +14936,9 @@ fn describe_damage_amount_clause(amount: &Value) -> (String, Option<String>) {
     if is_effect_count_reference(amount, None) {
         return ("that much".to_string(), None);
     }
+    if matches!(amount.unhinted(), Value::XTimes(2)) {
+        return ("twice X damage".to_string(), None);
+    }
     if let Some((amount_text, where_x)) = describe_damage_amount_with_revealed_count_where_x(amount)
     {
         return (amount_text, Some(where_x));
@@ -25916,6 +25919,10 @@ fn describe_with_id_if_clause(
         } else {
             "If you do".to_string()
         }
+    } else if let Some(target) = excess_damage_condition_target_from_effect(&with_id.effect)
+        && matches!(if_effect.predicate, EffectPredicate::ExcessDamageDealt)
+    {
+        format!("If excess damage was dealt to {target} this way")
     } else {
         match if_effect.predicate {
             EffectPredicate::Happened => "If it happened".to_string(),
@@ -29380,6 +29387,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(where_x) = describe_where_x_basis(&deal_damage.amount) {
             return format!(
                 "Deal X damage to {}, where X is {where_x}",
+                describe_choose_spec(&deal_damage.target)
+            );
+        }
+        if matches!(deal_damage.amount.unhinted(), Value::XTimes(2)) {
+            return format!(
+                "Deal twice X damage to {}",
                 describe_choose_spec(&deal_damage.target)
             );
         }
@@ -34754,6 +34767,25 @@ pub(super) fn describe_activation_timing_clause(timing: &ActivationTiming) -> Op
         ActivationTiming::DuringYourTurn => Some("Activate only during your turn"),
         ActivationTiming::DuringOpponentsTurn => Some("Activate only during an opponent's turn"),
     }
+}
+
+fn describe_excess_damage_condition_target(target: &ChooseSpec) -> String {
+    let described = describe_choose_spec(target);
+    if let Some(rest) = described.strip_prefix("target ") {
+        format!("that {rest}")
+    } else {
+        described
+    }
+}
+
+fn excess_damage_condition_target_from_effect(effect: &Effect) -> Option<String> {
+    if let Some(damage) = effect.downcast_ref::<crate::effects::DealDamageEffect>() {
+        return Some(describe_excess_damage_condition_target(&damage.target));
+    }
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return excess_damage_condition_target_from_effect(&tagged.effect);
+    }
+    None
 }
 
 pub(super) fn normalize_activation_restriction_clause(raw: &str) -> String {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -196,6 +196,7 @@ pub enum ExecutionFact {
     AffectedObjectMemory(Vec<OutcomeObjectMemory>),
     PlayerAffectedObjectMemory(Vec<(PlayerId, Vec<OutcomeObjectMemory>)>),
     PlayerCounts(Vec<(PlayerId, i32)>),
+    ExcessDamageDealt,
     ChosenOptions(Vec<usize>),
     ChosenNumber(u32),
     OtherNumber(u32),
@@ -779,6 +780,9 @@ impl EffectPredicateRuntimeExt for EffectPredicate {
                 Self::Happened.evaluate_outcome(outcome)
                     && !outcome.has_execution_fact(|fact| matches!(fact, ExecutionFact::Replaced))
                     && outcome.status != OutcomeStatus::Replaced
+            }
+            Self::ExcessDamageDealt => {
+                outcome.has_execution_fact(|fact| matches!(fact, ExecutionFact::ExcessDamageDealt))
             }
             Self::Value(cmp) => outcome.as_count().is_some_and(|n| cmp.evaluate(n)),
             Self::Chosen => {

--- a/crates/ironsmith-runtime/src/effects/damage/deal_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/deal_damage.rs
@@ -3,7 +3,7 @@
 //! This module implements the `DealDamage` effect, which deals damage to a target
 //! creature, planeswalker, or player.
 
-use crate::effect::EffectOutcome;
+use crate::effect::{EffectOutcome, ExecutionFact};
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::{
     resolve_objects_for_effect, resolve_player_from_spec, resolve_value,
@@ -80,6 +80,12 @@ pub(crate) fn apply_processed_damage_outcome(
             }),
             DamageTarget::Player(_) => None,
         };
+        let excess_damage = match assignment.target {
+            DamageTarget::Object(object_id) => {
+                excess_damage_to_object(game, object_id, assignment.amount, keywords)
+            }
+            DamageTarget::Player(_) => 0,
+        };
         let applied = crate::rules::damage::apply_processed_damage_assignment(
             game,
             source,
@@ -97,6 +103,9 @@ pub(crate) fn apply_processed_damage_outcome(
             affected_objects.push(object_id);
         }
         let mut outcome = EffectOutcome::count(assignment.amount as i32);
+        if excess_damage > 0 {
+            outcome = outcome.with_execution_fact(ExecutionFact::ExcessDamageDealt);
+        }
         if assignment.amount > 0 {
             let mut damage_event = DamageEvent::with_cause(
                 source,
@@ -154,6 +163,33 @@ pub(crate) fn apply_processed_damage_outcome(
         outcome = outcome.with_affected_objects_from_game(game, affected_objects);
     }
     outcome
+}
+
+fn excess_damage_to_object(
+    game: &GameState,
+    target: crate::ids::ObjectId,
+    amount: u32,
+    keywords: crate::rules::damage::SourceDamageKeywords,
+) -> u32 {
+    if amount == 0 {
+        return 0;
+    }
+    let Some(object) = game.object(target) else {
+        return 0;
+    };
+    if object.has_card_type(CardType::Creature) {
+        let lethal = if keywords.has_deathtouch {
+            1
+        } else {
+            let Some(toughness) = game.calculated_toughness(target).or_else(|| object.toughness())
+            else {
+                return 0;
+            };
+            (toughness - game.damage_on(target) as i32).max(0) as u32
+        };
+        return amount.saturating_sub(lethal);
+    }
+    0
 }
 
 impl EffectExecutor for DealDamageEffect {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -933,6 +933,130 @@ fn from_under_the_floorboards_paid_madness_uses_x_token_and_life_branch() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn torch_the_witness_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_260), "Torch the Witness")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Torch the Witness deals twice X damage to target creature. If excess damage was dealt to that creature this way, investigate.",
+        )
+        .expect("Torch the Witness should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn clue_tokens_controlled_by(game: &GameState, player: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|id| {
+            game.object(*id).is_some_and(|object| {
+                game.controller_of(object) == player
+                    && object.kind == ObjectKind::Token
+                    && object.name == "Clue"
+            })
+        })
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_torch_the_witness_on_stack(
+    game: &mut GameState,
+    controller: PlayerId,
+    target: ObjectId,
+    x_value: u32,
+) {
+    let def = torch_the_witness_definition();
+    let spell_id = game.create_object_from_definition(&def, controller, Zone::Stack);
+    game.object_mut(spell_id)
+        .expect("Torch on stack")
+        .x_value = Some(x_value);
+    game.push_to_stack(
+        StackEntry::new(spell_id, controller)
+            .with_x(x_value)
+            .with_targets(vec![Target::Object(target)]),
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn torch_the_witness_targets_only_battlefield_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell = torch_the_witness_definition();
+    let effects = spell.spell_effect.as_ref().expect("Torch should have effects");
+
+    let creature = create_creature(&mut game, "Witness Target", bob, 2, 2);
+    let artifact = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(74_261), "Noncreature Evidence")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(requirements.len(), 1, "Torch should have one target requirement");
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(creature)),
+        "battlefield creatures should be legal Torch targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(artifact)),
+        "noncreature artifacts should not be legal Torch targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Player(bob)),
+        "players should not be legal Torch targets, got {legal_targets:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn torch_the_witness_investigates_when_twice_x_deals_excess_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_creature(&mut game, "Small Witness", bob, 2, 3);
+
+    put_torch_the_witness_on_stack(&mut game, alice, target, 2);
+    resolve_stack_entry(&mut game).expect("Torch the Witness should resolve");
+
+    assert_eq!(
+        clue_tokens_controlled_by(&game, alice).len(),
+        1,
+        "twice X should deal 4 damage to a 3-toughness creature and investigate for excess damage"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn torch_the_witness_does_not_investigate_without_excess_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_creature(&mut game, "Large Witness", bob, 2, 5);
+
+    put_torch_the_witness_on_stack(&mut game, alice, target, 2);
+    resolve_stack_entry(&mut game).expect("Torch the Witness should resolve");
+
+    assert_eq!(
+        game.damage_on(target),
+        4,
+        "twice X should deal 4 damage when X is 2"
+    );
+    assert_eq!(
+        clue_tokens_controlled_by(&game, alice).len(),
+        0,
+        "Torch should not investigate when the damage is not excess"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn put_test_cards_in_zone(game: &mut GameState, player: PlayerId, zone: Zone, count: u32) {
     for index in 0..count {
         let card = CardBuilder::new(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Torch the Witness
Initial parse error:
```
missing damage amount (clause: 'twice x damage to target creature'); oracle-only fallback also failed: missing damage amount (clause: 'twice x damage to target creature')
```

Current worker: i-06de6cd7eb6735ab3
Branch: codex/aws-card-fix-torch-the-witness
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0006
