### PR TITLE
Fix Ironsmith parse failure: Hexplate Wallbreaker

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -741,6 +741,19 @@ const YOU_CAST_ANOTHER_SPELL_THIS_TURN_PATTERN: ClauseShape<'static> = clause_sh
 const THIS_TURN_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["this", "turn"]);
 const IT_IS_NIGHT_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["its", "night"], &["it", "is", "night"], &["it", "night"]]);
+const FIRST_COMBAT_PHASE_OF_TURN_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &[
+                "its", "the", "first", "combat", "phase", "of", "the", "turn",
+            ],
+            &[
+                "it", "is", "the", "first", "combat", "phase", "of", "the", "turn",
+            ],
+            &["it", "first", "combat", "phase", "of", "turn"],
+            &["it", "the", "first", "combat", "phase", "of", "the", "turn"],
+        ]
+);
 const SOURCE_DEALT_COMBAT_DAMAGE_TO_PLAYER_THIS_TURN_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -4345,6 +4358,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(PredicateAst::ItIsNight);
     }
 
+    if FIRST_COMBAT_PHASE_OF_TURN_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::FirstCombatPhaseOfTurn);
+    }
+
     if SOURCE_DEALT_COMBAT_DAMAGE_TO_PLAYER_THIS_TURN_PATTERN.matches_words(&filtered) {
         return Ok(PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
     }
@@ -4521,6 +4538,17 @@ mod tests {
         let parsed = parse_predicate(&predicate_tokens)?;
 
         assert_eq!(parsed, PredicateAst::ItIsNight);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_accepts_first_combat_phase_of_turn() -> Result<(), CardTextError> {
+        let tokens = lex_line("If it's the first combat phase of the turn", 0)?;
+        let predicate_tokens = predicate_tokens_after_if(&tokens);
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(parsed, PredicateAst::FirstCombatPhaseOfTurn);
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -178,6 +178,7 @@ pub(crate) fn compile_condition_from_predicate_ast(
     let refs = current_reference_env(ctx);
     Ok(match predicate {
         PredicateAst::ItIsNight => Condition::ItIsNight,
+        PredicateAst::FirstCombatPhaseOfTurn => Condition::FirstCombatPhaseOfTurn,
         PredicateAst::ItIsLandCard => {
             let mut filter = ObjectFilter {
                 zone: None,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -385,6 +385,7 @@ pub(crate) enum TriggerSpec {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PredicateAst {
     ItIsNight,
+    FirstCombatPhaseOfTurn,
     ItIsLandCard,
     ItIsSoulbondPaired,
     SourceChosenOption(String),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -746,6 +746,7 @@ pub enum Condition {
     TargetHasGreatestPowerAmongCreatures,
     TargetManaValueLteColorsSpentToCastThisSpell,
     ItIsNight,
+    FirstCombatPhaseOfTurn,
     SourceIsTapped,
     SourceIsSaddled,
     SourceDevouredCreaturesOrMore(u32),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -25606,6 +25606,43 @@ fn render_kembas_banner_equipped_bonus_uses_for_each_wording() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn hexplate_wallbreaker_parses_and_renders_first_combat_phase_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(605_584), "Hexplate Wallbreaker")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "For Mirrodin! (When this Equipment enters, create a 2/2 red Rebel creature token, then attach this to it.)\n\
+             Equipped creature gets +2/+2.\n\
+             Whenever equipped creature attacks, if it's the first combat phase of the turn, untap each attacking creature. After this phase, there is an additional combat phase.\n\
+             Equip {3}{R}",
+        )
+        .expect("Hexplate Wallbreaker should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        !lower.contains("unsupported predicate") && !lower.contains("unsupported effect"),
+        "Hexplate Wallbreaker should not fall back to unsupported output, got {rendered}"
+    );
+    assert!(
+        lower.contains("for mirrodin!")
+            && lower.contains("equipped creature gets +2/+2")
+            && lower.contains("whenever equipped creature attacks")
+            && lower.contains("if it's the first combat phase of the turn")
+            && lower.contains("untap each attacking creature")
+            && lower.contains("there is an additional combat phase")
+            && lower.contains("equip {3}{r}"),
+        "expected Hexplate Wallbreaker compiled text to preserve its equipment trigger, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn render_static_bonus_preserves_creature_type_among_scope() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Kindred Scout Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11459,6 +11459,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         }
         Condition::NoSpellsWereCastLastTurn => "no spells were cast last turn".to_string(),
         Condition::ItIsNight => "it's night".to_string(),
+        Condition::FirstCombatPhaseOfTurn => "it's the first combat phase of the turn".to_string(),
         Condition::SpellsWereCastLastTurnOrMore(count) => {
             let count_text = small_number_word(*count)
                 .unwrap_or_else(|| count.to_string());

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2992,6 +2992,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return describe_structural_multisentence_effect_list(rest);
     }
 
+    if let Some(compact) = describe_untap_attacking_then_additional_combat(effects) {
+        return Some(compact);
+    }
+
     if let Some(compact) = describe_council_dilemma_named_vote_sequence(effects) {
         return Some(compact);
     }
@@ -3021,6 +3025,36 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_exile_then_free_cast_while_exiled_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn is_all_attacking_creatures(spec: &ChooseSpec) -> bool {
+    let ChooseSpec::All(filter) = spec.base() else {
+        return false;
+    };
+    if !filter.attacking {
+        return false;
+    }
+    let mut base = filter.clone();
+    base.attacking = false;
+    base == ObjectFilter::creature()
+}
+
+fn describe_untap_attacking_then_additional_combat(effects: &[Effect]) -> Option<String> {
+    let [untap_effect, phases_effect] = effects else {
+        return None;
+    };
+    let untap = untap_effect.downcast_ref::<crate::effects::UntapEffect>()?;
+    if !is_all_attacking_creatures(&untap.target) {
+        return None;
+    }
+    let additional_phases = phases_effect.downcast_ref::<crate::effects::AdditionalPhasesEffect>()?;
+    if additional_phases.phases != [crate::effects::AdditionalPhase::Combat] {
+        return None;
+    }
+    Some(
+        "Untap each attacking creature. After this phase, there is an additional combat phase"
+            .to_string(),
+    )
 }
 
 fn describe_counter_unless_then_kick_count_draw(effects: &[Effect]) -> Option<String> {
@@ -17163,6 +17197,23 @@ mod tests {
         assert_eq!(
             describe_effect_list(&[Effect::new(choose), Effect::new(for_each)]),
             "Choose four permanents you don't control and put an aim counter on each of them"
+        );
+    }
+
+    #[test]
+    fn describe_effect_list_compacts_untap_attackers_then_additional_combat() {
+        let mut attacking_creature = ObjectFilter::creature();
+        attacking_creature.attacking = true;
+        let effects = vec![
+            Effect::new(crate::effects::UntapEffect::with_spec(ChooseSpec::All(
+                attacking_creature,
+            ))),
+            Effect::new(crate::effects::AdditionalPhasesEffect::combat()),
+        ];
+
+        assert_eq!(
+            describe_effect_list(&effects),
+            "Untap each attacking creature. After this phase, there is an additional combat phase"
         );
     }
 

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -827,6 +827,10 @@ fn evaluate_condition_shared_core(
             Some(game.turn_store.spells_cast_last_turn_total == 0)
         }
         Condition::ItIsNight => Some(game.is_night),
+        Condition::FirstCombatPhaseOfTurn => Some(
+            game.turn.phase == crate::game_state::Phase::Combat
+                && game.turn_store.combat_phases_started_this_turn <= 1,
+        ),
         Condition::SpellsWereCastLastTurnOrMore(count) => {
             Some(game.turn_store.spells_cast_last_turn_total >= *count)
         }
@@ -999,6 +1003,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::ThisSpellWasCastFromNonHand => {}
         Condition::NoSpellsWereCastLastTurn => {}
         Condition::ItIsNight => {}
+        Condition::FirstCombatPhaseOfTurn => {}
         Condition::SpellsWereCastLastTurnOrMore(..) => {}
         Condition::YouHaveFullParty => {}
         Condition::TargetIsTapped => {}
@@ -1189,6 +1194,10 @@ pub fn evaluate_condition_external(
     match condition {
         Condition::XValueAtLeast(_) => false, // X not available in static context
         Condition::ItIsNight => game.is_night,
+        Condition::FirstCombatPhaseOfTurn => {
+            game.turn.phase == crate::game_state::Phase::Combat
+                && game.turn_store.combat_phases_started_this_turn <= 1
+        }
         Condition::ThisSpellEscaped => source_escaped(game, ctx.source),
         Condition::ThisSpellWasKicked => game
             .object(ctx.source)
@@ -2096,6 +2105,10 @@ fn evaluate_condition_simple(
 
     match condition {
         Condition::ItIsNight => game.is_night,
+        Condition::FirstCombatPhaseOfTurn => {
+            game.turn.phase == crate::game_state::Phase::Combat
+                && game.turn_store.combat_phases_started_this_turn <= 1
+        }
         Condition::ThisSpellWasKicked => game
             .object(source)
             .is_some_and(|obj| obj.optional_costs_paid.was_kicked()),
@@ -2857,6 +2870,10 @@ fn evaluate_condition(
 
     match condition {
         Condition::ItIsNight => Ok(game.is_night),
+        Condition::FirstCombatPhaseOfTurn => Ok(
+            game.turn.phase == crate::game_state::Phase::Combat
+                && game.turn_store.combat_phases_started_this_turn <= 1,
+        ),
         Condition::YouControl(filter) => {
             let filter_ctx = ctx.filter_context(game);
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -22049,6 +22049,158 @@ fn test_combat_damage_with_triggers() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn hexplate_wallbreaker_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(605_584), "Hexplate Wallbreaker")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .parse_text(
+            "For Mirrodin! (When this Equipment enters, create a 2/2 red Rebel creature token, then attach this to it.)\n\
+             Equipped creature gets +2/+2.\n\
+             Whenever equipped creature attacks, if it's the first combat phase of the turn, untap each attacking creature. After this phase, there is an additional combat phase.\n\
+             Equip {3}{R}",
+        )
+        .expect("Hexplate Wallbreaker should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hexplate_wallbreaker_buffs_equipped_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bearer_id = create_creature(&mut game, "Wallbreaker Bearer", alice, 2, 2);
+    let hexplate_id = game.create_object_from_definition(
+        &hexplate_wallbreaker_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    assert!(game.attach_object_to_target(
+        hexplate_id,
+        crate::object::AttachmentTarget::Object(bearer_id),
+    ));
+
+    assert_eq!(game.calculated_power(bearer_id), Some(4));
+    assert_eq!(game.calculated_toughness(bearer_id), Some(4));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hexplate_wallbreaker_first_combat_attack_untaps_attackers_and_adds_combat() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    game.turn_store.combat_phases_started_this_turn = 1;
+
+    let bearer_id = create_creature(&mut game, "Wallbreaker Bearer", alice, 2, 2);
+    let ally_id = create_creature(&mut game, "Attacking Ally", alice, 2, 2);
+    let bystander_id = create_creature(&mut game, "Bystander", alice, 2, 2);
+    let hexplate_id = game.create_object_from_definition(
+        &hexplate_wallbreaker_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    assert!(game.attach_object_to_target(
+        hexplate_id,
+        crate::object::AttachmentTarget::Object(bearer_id),
+    ));
+    game.tap(bearer_id);
+    game.tap(ally_id);
+    game.tap(bystander_id);
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![
+            crate::combat_state::AttackerInfo {
+                creature: bearer_id,
+                target: AttackTarget::Player(bob),
+            },
+            crate::combat_state::AttackerInfo {
+                creature: ally_id,
+                target: AttackTarget::Player(bob),
+            },
+        ],
+        ..Default::default()
+    });
+
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::with_total_attackers(
+            bearer_id,
+            crate::events::combat::AttackEventTarget::Player(bob),
+            2,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in check_triggers(&game, &event) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Hexplate Wallbreaker trigger should go on the stack");
+    assert_eq!(game.stack.len(), 1, "first combat should queue Hexplate trigger");
+
+    resolve_stack_entry(&mut game).expect("Hexplate Wallbreaker trigger should resolve");
+
+    assert!(!game.is_tapped(bearer_id));
+    assert!(!game.is_tapped(ally_id));
+    assert!(game.is_tapped(bystander_id));
+    assert_eq!(game.turn_store.additional_phases, vec![Phase::Combat]);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hexplate_wallbreaker_later_combat_attack_does_not_trigger() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    game.turn_store.combat_phases_started_this_turn = 2;
+
+    let bearer_id = create_creature(&mut game, "Wallbreaker Bearer", alice, 2, 2);
+    let hexplate_id = game.create_object_from_definition(
+        &hexplate_wallbreaker_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    assert!(game.attach_object_to_target(
+        hexplate_id,
+        crate::object::AttachmentTarget::Object(bearer_id),
+    ));
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: bearer_id,
+            target: AttackTarget::Player(bob),
+        }],
+        ..Default::default()
+    });
+
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::with_total_attackers(
+            bearer_id,
+            crate::events::combat::AttackEventTarget::Player(bob),
+            1,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in check_triggers(&game, &event) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("later combat attack event should be processed cleanly");
+
+    assert!(game.stack.is_empty());
+    assert!(game.turn_store.additional_phases.is_empty());
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_quintessential_katana_granted_combat_damage_trigger_stacks_and_resolves() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -235,6 +235,8 @@ pub struct TurnStore {
     /// Additional phases inserted after the current phase.
     /// These are consumed before the normal turn sequence advances.
     pub additional_phases: Vec<Phase>,
+    /// Number of combat phases that have started during the current turn.
+    pub combat_phases_started_this_turn: u32,
     /// Normal phase to resume after inserted additional phases finish.
     pub additional_phase_continuation: Option<Phase>,
     /// Players who will skip their next turn.
@@ -7149,6 +7151,7 @@ impl GameState {
         self.turn.step = Some(Step::Untap);
         self.turn_store.tracked_draw_step_player = None;
         self.turn_store.cards_drawn_this_draw_step = 0;
+        self.turn_store.combat_phases_started_this_turn = 0;
         self.turn_store.skip_current_turn_combat_phases.clear();
         self.turn_store.skip_current_turn_main_phases.clear();
 
@@ -7180,6 +7183,13 @@ impl GameState {
         if let Some(player) = self.player_mut(next_player) {
             player.begin_turn();
         }
+    }
+
+    pub fn mark_combat_phase_started(&mut self) {
+        self.turn_store.combat_phases_started_this_turn = self
+            .turn_store
+            .combat_phases_started_this_turn
+            .saturating_add(1);
     }
 
     /// Add a player-control effect.

--- a/crates/ironsmith-runtime/src/turn.rs
+++ b/crates/ironsmith-runtime/src/turn.rs
@@ -204,6 +204,9 @@ pub fn advance_phase(game: &mut GameState) -> Result<(), TurnError> {
             next = Phase::NextMain;
         }
         game.turn.phase = next;
+        if matches!(next, Phase::Combat) {
+            game.mark_combat_phase_started();
+        }
         game.turn.step = first_step_of_phase(next);
         game.turn.priority_player = Some(game.turn.active_player);
         Ok(())

--- a/crates/ironsmith-runtime/src/turn_runner.rs
+++ b/crates/ironsmith-runtime/src/turn_runner.rs
@@ -393,7 +393,7 @@ impl TurnRunner {
 
             TurnState::FirstMainPriority => {
                 game.empty_mana_pools();
-                self.state = TurnState::BeginCombat;
+                self.state = next_runner_state_after_phase(game, TurnState::BeginCombat);
                 Ok(TurnAction::Continue)
             }
 
@@ -414,6 +414,7 @@ impl TurnRunner {
                     return Ok(TurnAction::Continue);
                 }
                 game.turn.phase = Phase::Combat;
+                game.mark_combat_phase_started();
                 game.turn.step = Some(Step::BeginCombat);
                 game.turn.priority_player = Some(game.turn.active_player);
                 generate_and_queue_step_triggers(game, tq);
@@ -625,7 +626,7 @@ impl TurnRunner {
                 game.empty_mana_pools();
                 crate::combat_state::end_combat(&mut self.combat);
                 game.combat = Some(self.combat.clone());
-                self.state = TurnState::NextMain;
+                self.state = next_runner_state_after_phase(game, TurnState::NextMain);
                 Ok(TurnAction::Continue)
             }
 
@@ -652,7 +653,7 @@ impl TurnRunner {
 
             TurnState::NextMainPriority => {
                 game.empty_mana_pools();
-                self.state = TurnState::EndStep;
+                self.state = next_runner_state_after_phase(game, TurnState::EndStep);
                 Ok(TurnAction::Continue)
             }
 
@@ -1147,6 +1148,25 @@ fn check_first_strike(game: &GameState, combat: &CombatState) -> bool {
     })
 }
 
+fn next_runner_state_after_phase(game: &mut GameState, normal_next: TurnState) -> TurnState {
+    let next_phase = if !game.turn_store.additional_phases.is_empty() {
+        Some(game.turn_store.additional_phases.remove(0))
+    } else if game.turn_store.additional_phase_continuation.is_some() {
+        game.turn_store.additional_phase_continuation.take()
+    } else {
+        None
+    };
+
+    match next_phase {
+        Some(Phase::Beginning) => TurnState::BeginTurn,
+        Some(Phase::FirstMain) => TurnState::FirstMain,
+        Some(Phase::Combat) => TurnState::BeginCombat,
+        Some(Phase::NextMain) => TurnState::NextMain,
+        Some(Phase::Ending) => TurnState::EndStep,
+        None => normal_next,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1376,6 +1396,39 @@ mod tests {
                 .attackers
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn test_turn_runner_consumes_additional_combat_before_normal_next_main() {
+        let mut game = setup_game();
+        let mut tq = TriggerQueue::new();
+        let mut runner = TurnRunner::new();
+
+        game.turn.phase = Phase::Combat;
+        game.turn.step = Some(Step::EndCombat);
+        game.turn_store.combat_phases_started_this_turn = 1;
+        game.turn_store.additional_phases.push(Phase::Combat);
+        game.turn_store.additional_phase_continuation = Some(Phase::NextMain);
+        runner.state = TurnState::EndCombatPriority;
+
+        let action = runner.advance(&mut game, &mut tq).unwrap();
+
+        assert!(matches!(action, TurnAction::Continue));
+        assert!(matches!(runner.state(), TurnState::BeginCombat));
+        assert!(game.turn_store.additional_phases.is_empty());
+        assert_eq!(game.turn_store.additional_phase_continuation, Some(Phase::NextMain));
+
+        let action = runner.advance(&mut game, &mut tq).unwrap();
+        assert!(matches!(action, TurnAction::RunPriority));
+        assert_eq!(game.turn.phase, Phase::Combat);
+        assert_eq!(game.turn_store.combat_phases_started_this_turn, 2);
+
+        runner.state = TurnState::EndCombatPriority;
+        let action = runner.advance(&mut game, &mut tq).unwrap();
+
+        assert!(matches!(action, TurnAction::Continue));
+        assert!(matches!(runner.state(), TurnState::NextMain));
+        assert_eq!(game.turn_store.additional_phase_continuation, None);
     }
 
     #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hexplate Wallbreaker
Initial parse error:
```
unsupported predicate (predicate: 'it first combat phase of turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'it first combat phase of turn')
```

Current worker: i-0ce17db9610b2feaa
Branch: codex/aws-card-fix-hexplate-wallbreaker
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0006
