### PR TITLE
Fix Ironsmith parse failure: Spear of Heliod

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2405,6 +2405,7 @@ pub(crate) fn object_filter_specificity_score(filter: &ObjectFilter) -> usize {
     score += usize::from(filter.entered_battlefield_this_turn) * 2;
     score += usize::from(filter.entered_battlefield_controller.is_some()) * 2;
     score += usize::from(filter.was_dealt_damage_this_turn) * 2;
+    score += usize::from(filter.dealt_damage_to_player_this_turn.is_some()) * 2;
     score += usize::from(!filter.excluded_card_types.is_empty()) * 2;
     score += usize::from(!filter.excluded_supertypes.is_empty()) * 2;
     score += usize::from(!filter.excluded_colors.is_empty()) * 2;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/remove_destroy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/remove_destroy.rs
@@ -564,6 +564,11 @@ pub(crate) fn parse_destroy_combat_history_target(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<TargetAst>, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if let Some(target) =
+        parse_destroy_target_dealt_damage_to_player_this_turn(tokens, &clause_words)?
+    {
+        return Ok(Some(target));
+    }
     let Some(that_idx) = DEALT_DAMAGE_THIS_TURN_TAIL_PATTERN.find_exact_window(&clause_words, 6)
     else {
         return Ok(None);
@@ -582,6 +587,50 @@ pub(crate) fn parse_destroy_combat_history_target(
         return Ok(None);
     };
     filter.was_dealt_damage_this_turn = true;
+    Ok(Some(TargetAst::Object(filter, target_span, it_span)))
+}
+
+fn parse_destroy_target_dealt_damage_to_player_this_turn(
+    tokens: &[OwnedLexToken],
+    clause_words: &[&str],
+) -> Result<Option<TargetAst>, CardTextError> {
+    let Some(that_idx) = clause_words
+        .windows(4)
+        .position(|window| window == ["that", "dealt", "damage", "to"])
+    else {
+        return Ok(None);
+    };
+    if that_idx == 0
+        || clause_words.len() < that_idx + 7
+        || !matches!(clause_words[clause_words.len() - 2..], ["this", "turn"])
+    {
+        return Ok(None);
+    }
+
+    let player_start_word_idx = that_idx + 4;
+    let player_end_word_idx = clause_words.len() - 2;
+    if player_start_word_idx >= player_end_word_idx {
+        return Ok(None);
+    }
+
+    let target_cutoff = token_index_for_word_index(tokens, that_idx).unwrap_or(tokens.len());
+    let player_start =
+        token_index_for_word_index(tokens, player_start_word_idx).unwrap_or(tokens.len());
+    let player_end = token_index_for_word_index(tokens, player_end_word_idx).unwrap_or(tokens.len());
+    let target_tokens = trim_commas(&tokens[..target_cutoff]);
+    let player_tokens = trim_commas(&tokens[player_start..player_end]);
+    if target_tokens.is_empty() || player_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let TargetAst::Player(player, _) = parse_target_phrase(&player_tokens)? else {
+        return Ok(None);
+    };
+    let target = parse_target_phrase(&target_tokens)?;
+    let TargetAst::Object(mut filter, target_span, it_span) = target else {
+        return Ok(None);
+    };
+    filter.dealt_damage_to_player_this_turn = Some(player);
     Ok(Some(TargetAst::Object(filter, target_span, it_span)))
 }
 

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -418,6 +418,7 @@ pub struct ObjectFilter {
     pub entered_graveyard_from_battlefield_this_turn: bool,
     pub surveilled_this_turn: bool,
     pub was_dealt_damage_this_turn: bool,
+    pub dealt_damage_to_player_this_turn: Option<PlayerFilter>,
     pub drawn_this_turn: bool,
     pub power: Option<Comparison>,
     pub power_parity: Option<ParityRequirement>,
@@ -2014,6 +2015,12 @@ impl ObjectFilter {
 
         if self.was_dealt_damage_this_turn {
             parts.push("that was dealt damage this turn".to_string());
+        }
+        if let Some(player) = &self.dealt_damage_to_player_this_turn {
+            parts.push(format!(
+                "that dealt damage to {} this turn",
+                describe_player_filter(player)
+            ));
         }
         if self.drawn_this_turn {
             parts.push("drawn this turn".to_string());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -28388,6 +28388,200 @@ fn parse_destroy_target_creature_dealt_damage_this_turn() {
     );
 }
 
+fn spear_of_heliod_destroy_activated_ability(
+    def: &CardDefinition,
+) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.effects.flattened_default_effects().iter().any(|effect| {
+                    effect.downcast_ref::<DestroyEffect>().is_some()
+                }) => Some(activated),
+            _ => None,
+        })
+        .expect("Spear of Heliod should have a destroy activated ability")
+}
+
+fn spear_of_heliod_destroy_filter(
+    activated: &crate::ability::ActivatedAbility,
+) -> &crate::target::ObjectFilter {
+    let effects = activated.effects.flattened_default_effects();
+    let destroy = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<DestroyEffect>())
+        .expect("Spear of Heliod activated ability should destroy a target creature");
+    let ChooseSpec::Target(inner) = destroy.spec.unhinted() else {
+        panic!("Spear destroy effect should be targeted, got {:?}", destroy.spec);
+    };
+    let ChooseSpec::Object(filter) = inner.unhinted() else {
+        panic!("Spear destroy target should be an object filter, got {inner:?}");
+    };
+    filter
+}
+
+fn create_spear_runtime_creature(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    name: &str,
+) -> ObjectId {
+    let def = CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_definition(&def, controller, Zone::Battlefield)
+}
+
+fn record_spear_player_damage(
+    game: &mut crate::game_state::GameState,
+    source: ObjectId,
+    player: PlayerId,
+) {
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            source,
+            crate::events::DamageTarget::Player(player),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&event);
+}
+
+#[test]
+fn spear_of_heliod_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Spear of Heliod");
+    let rendered = unprocessed_compiled_lines(&def).join(" ").to_ascii_lowercase();
+    let activated = spear_of_heliod_destroy_activated_ability(&def);
+    let target_filter = spear_of_heliod_destroy_filter(activated);
+
+    assert!(
+        (rendered.contains("creatures you control get +1/+1")
+            || rendered.contains("each creature you control gets +1/+1"))
+            && rendered.contains("destroy target creature that dealt damage to you this turn"),
+        "expected Spear of Heliod compiled text to keep anthem and combat-history destroy target, got {rendered}"
+    );
+    assert_eq!(
+        target_filter.dealt_damage_to_player_this_turn,
+        Some(PlayerFilter::You),
+        "Spear of Heliod target filter should structurally require damage dealt to you this turn"
+    );
+    assert!(
+        target_filter
+            .description()
+            .contains("that dealt damage to you this turn"),
+        "Spear of Heliod target filter description should preserve the player damage-history clause, got {}",
+        target_filter.description()
+    );
+}
+
+#[test]
+fn spear_of_heliod_anthem_and_damage_history_destroy_runtime() {
+    let def = parse_oracle_card_definition("Spear of Heliod");
+    let activated = spear_of_heliod_destroy_activated_ability(&def);
+    let target_filter = spear_of_heliod_destroy_filter(activated);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let spear = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(spear);
+    let alice_creature = create_spear_runtime_creature(&mut game, alice, "Alice Hoplite");
+    let bob_creature = create_spear_runtime_creature(&mut game, bob, "Bob Raider");
+    let bob_other_creature = create_spear_runtime_creature(&mut game, bob, "Bob Bystander");
+
+    assert_eq!(
+        game.current_power(alice_creature),
+        Some(3),
+        "Spear of Heliod should give Alice's creatures +1/+1"
+    );
+    assert_eq!(
+        game.current_toughness(alice_creature),
+        Some(3),
+        "Spear of Heliod should give Alice's creatures +1/+1"
+    );
+    assert_eq!(
+        game.current_power(bob_creature),
+        Some(2),
+        "Spear of Heliod should not pump opposing creatures"
+    );
+
+    let filter_ctx =
+        crate::effects::ExecutionContext::new_default(spear, alice).filter_context(&game);
+    assert!(
+        !target_filter.matches(
+            game.object(bob_creature).expect("Bob Raider should exist"),
+            &filter_ctx,
+            &game,
+        ),
+        "Spear should not be able to target a creature before it deals damage to you"
+    );
+    record_spear_player_damage(&mut game, bob_other_creature, bob);
+    let filter_ctx =
+        crate::effects::ExecutionContext::new_default(spear, alice).filter_context(&game);
+    assert!(
+        !target_filter.matches(
+            game.object(bob_other_creature)
+                .expect("Bob Bystander should exist"),
+            &filter_ctx,
+            &game,
+        ),
+        "Spear should not target a creature that dealt damage to a different player"
+    );
+
+    record_spear_player_damage(&mut game, bob_creature, alice);
+    let filter_ctx =
+        crate::effects::ExecutionContext::new_default(spear, alice).filter_context(&game);
+    assert!(
+        target_filter.matches(
+            game.object(bob_creature).expect("Bob Raider should exist"),
+            &filter_ctx,
+            &game,
+        ),
+        "Spear should target a creature that dealt damage to you this turn"
+    );
+
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .white = 3;
+    crate::cost::can_pay_cost(&game, spear, alice, &activated.mana_cost).expect(
+        "Spear activation cost should be payable with three white mana and an untapped source",
+    );
+    let mut dm = crate::decision::AutoPassDecisionMaker::default();
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        spear,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("Spear activation cost should be paid");
+    assert!(game.is_tapped(spear), "Spear activation cost should tap it");
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").mana_pool.total(),
+        0,
+        "Spear activation cost should spend {{1}}{{W}}{{W}}"
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(spear, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(bob_creature)]);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Spear destroy activation should resolve");
+    }
+    assert!(
+        game.player(bob)
+            .expect("Bob should exist")
+            .graveyard
+            .iter()
+            .any(|id| game.object(*id).is_some_and(|object| object.name == "Bob Raider")),
+        "Spear should destroy the creature that dealt damage to you this turn"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_exile_target_creature_and_target_land_sentence() {

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1722,6 +1722,17 @@ impl ObjectFilterExt for ObjectFilter {
             return false;
         }
 
+        if let Some(player_filter) = &self.dealt_damage_to_player_this_turn {
+            let dealt_damage_to_matching_player = game.players.iter().any(|player| {
+                player.is_in_game()
+                    && player_filter.matches_player(player.id, ctx)
+                    && game.source_dealt_damage_to_player_this_turn(object.id, player.id)
+            });
+            if !dealt_damage_to_matching_player {
+                return false;
+            }
+        }
+
         if self.drawn_this_turn
             && !game
                 .turn_store
@@ -3874,6 +3885,12 @@ impl ObjectFilterExt for ObjectFilter {
 
         if self.was_dealt_damage_this_turn {
             parts.push("that was dealt damage this turn".to_string());
+        }
+        if let Some(player) = &self.dealt_damage_to_player_this_turn {
+            parts.push(format!(
+                "that dealt damage to {} this turn",
+                describe_player_filter(player)
+            ));
         }
         if self.drawn_this_turn {
             parts.push("drawn this turn".to_string());

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -8183,6 +8183,17 @@ impl GameState {
             .source_dealt_combat_damage_to_player_this_turn(source, stable_id)
     }
 
+    pub fn source_dealt_damage_to_player_this_turn(
+        &self,
+        source: ObjectId,
+        player: PlayerId,
+    ) -> bool {
+        let stable_id = self.object(source).map(|obj| obj.stable_id);
+        self.turn_store
+            .turn_history
+            .source_dealt_damage_to_player_this_turn(source, stable_id, player)
+    }
+
     /// Clear damage from an object.
     pub fn clear_damage(&mut self, id: ObjectId) {
         self.damage_marked.remove(&id);

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -538,6 +538,31 @@ impl TurnHistory {
         })
     }
 
+    pub fn source_dealt_damage_to_player_this_turn(
+        &self,
+        source: ObjectId,
+        source_stable_id: Option<StableId>,
+        player: PlayerId,
+    ) -> bool {
+        self.projected_records().any(|record| {
+            record.event.downcast::<DamageEvent>().is_some_and(|event| {
+                event.amount > 0
+                    && matches!(
+                        event.target,
+                        crate::events::DamageTarget::Player(pid) if pid == player
+                    )
+                    && (event.source == source
+                        || source_stable_id.is_some_and(|stable_id| {
+                            record
+                                .source_snapshot
+                                .as_ref()
+                                .or(record.object_snapshot.as_ref())
+                                .is_some_and(|snapshot| snapshot.stable_id == stable_id)
+                        }))
+            })
+        })
+    }
+
     pub fn player_dealt_combat_damage_to_player_with_subtype_this_turn(
         &self,
         dealer: PlayerId,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Spear of Heliod
Initial parse error:
```
unsupported combat-history destroy clause (clause: 'target creature that dealt damage to you this turn'); oracle-only fallback also failed: unsupported combat-history destroy clause (clause: 'target creature that dealt damage to you this turn')
```

Current worker: i-04200a077950e1652
Branch: codex/aws-card-fix-spear-of-heliod
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0007
