### PR TITLE
Fix Ironsmith parse failure: Phytotitan

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2212,7 +2212,7 @@ fn compile_subject_verb_effect(
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
             let from_exile_tag = choose_spec_references_exiled_tag(&spec);
             let use_move_to_zone =
-                from_exile_tag || !matches!(controller, ReturnControllerAst::Preserve);
+                from_exile_tag || matches!(controller, ReturnControllerAst::You);
             let mut effects = Vec::new();
             let resolved_spec = if !spec.is_target() {
                 match &spec {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
@@ -156,6 +156,14 @@ pub(crate) fn parse_delayed_return_timing_words(words: &[&str]) -> Option<Delaye
         return Some(DelayedReturnTimingAst::NextUpkeep(PlayerAst::You));
     }
 
+    if matches!(
+        words,
+        ["at", "beginning", "of", "their", "next", "upkeep"]
+            | ["at", "the", "beginning", "of", "their", "next", "upkeep"]
+    ) {
+        return Some(DelayedReturnTimingAst::NextUpkeep(PlayerAst::ItsOwner));
+    }
+
     None
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -23582,17 +23582,35 @@ fn parse_return_converted_clause_uses_shared_return_and_convert() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn parse_return_next_upkeep_clause_fails_instead_of_immediate_return() {
-    let err = CardDefinitionBuilder::new(CardId::new(), "Next Upkeep Return Variant")
-            .parse_text(
-                "When this creature dies, return it to the battlefield tapped under its owner's control at the beginning of their next upkeep.",
-            )
-            .expect_err("unsupported delayed return timing should fail parse");
-    let message = format!("{err:?}");
+fn parse_phytotitan_strictly_compiles_delayed_owner_upkeep_return() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Phytotitan")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Plant, Subtype::Elemental])
+        .power_toughness(PowerToughness::fixed(7, 2))
+        .parse_text(
+            "When this creature dies, return it to the battlefield tapped under its owner's control at the beginning of their next upkeep.",
+        )
+        .expect("Phytotitan delayed owner-upkeep return should parse strictly");
+
+    let ability_debug = format!("{:#?}", def.abilities);
     assert!(
-        message.contains("unsupported delayed return timing clause")
-            || message.contains("unsupported triggered line"),
-        "expected strict delayed-return parse error, got {message}"
+        ability_debug.contains("ScheduleDelayedTriggerEffect")
+            && ability_debug.contains("BeginningOfUpkeepTrigger")
+            && ability_debug.contains("OwnerOf")
+            && ability_debug.contains("Tagged")
+            && ability_debug.contains("tapped: true"),
+        "expected Phytotitan to schedule a tapped return on its owner's next upkeep, got {ability_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "When this creature dies, return it to the battlefield tapped under its owner's control at the beginning of their next upkeep."
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33484,6 +33484,43 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 "if any of those cards remain exiled, return them to their owners' graveyards",
             );
         }
+        if schedule.one_shot
+            && schedule.start_next_turn
+            && let Some(upkeep) = schedule
+                .trigger
+                .downcast_ref::<crate::triggers::BeginningOfUpkeepTrigger>()
+            && let [effect] = schedule.effects.flattened_default_effects()
+            && let PlayerFilter::OwnerOf(crate::filter::ObjectRef::Tagged(owner_tag)) =
+                &upkeep.player
+        {
+            let delayed_return_matches_owner = effect
+                .downcast_ref::<crate::effects::MoveToZoneEffect>()
+                .is_some_and(|move_to_zone| {
+                    move_to_zone.zone == Zone::Battlefield
+                        && move_to_zone.battlefield_controller
+                            == crate::effects::BattlefieldController::Owner
+                        && choose_spec_references_exact_tag(&move_to_zone.target, owner_tag)
+                })
+                || effect
+                    .downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()
+                    .is_some_and(|return_to_battlefield| {
+                        choose_spec_references_exact_tag(&return_to_battlefield.target, owner_tag)
+                    });
+            if delayed_return_matches_owner {
+                let mut delayed_text = delayed_text.replace(" from graveyard", "");
+                if effect
+                    .downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()
+                    .is_some()
+                    && !delayed_text.contains("under ")
+                {
+                    delayed_text.push_str(" under its owner's control");
+                }
+                return format!(
+                    "{} at the beginning of their next upkeep",
+                    capitalize_first(&delayed_text)
+                );
+            }
+        }
         if schedule.target_tag.is_some()
             && (trigger_lower.contains("when this creature is dealt damage")
                 || trigger_lower.contains("whenever this creature is dealt damage"))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -17040,6 +17040,38 @@ fn create_delayed_reanimator(game: &mut GameState, owner: PlayerId, name: &str) 
     id
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn phytotitan_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(383_344), "Phytotitan")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Plant, Subtype::Elemental])
+        .power_toughness(PowerToughness::fixed(7, 2))
+        .parse_text(
+            "When this creature dies, return it to the battlefield tapped under its owner's control at the beginning of their next upkeep.",
+        )
+        .expect("Phytotitan should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn queue_beginning_of_upkeep_delayed_triggers(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    player: PlayerId,
+) {
+    let upkeep_event = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfUpkeepEvent::new(player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(game, &upkeep_event) {
+        trigger_queue.add(trigger);
+    }
+}
+
 fn undying_effects() -> Vec<Effect> {
     let trigger_tag = "undying_trigger";
     let return_tag = "undying_return";
@@ -20376,6 +20408,115 @@ fn test_delayed_tagged_graveyard_return_does_not_follow_zone_hops() {
                 .is_some_and(|obj| obj.name == "Delayed Reanimator")
         }),
         "delayed return should not follow a different graveyard instance"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn phytotitan_returns_tapped_under_owner_control_at_owners_next_upkeep() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let def = phytotitan_definition();
+    let phytotitan_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let stable_id = game.object(phytotitan_id).expect("Phytotitan exists").stable_id;
+
+    game.set_current_controller(phytotitan_id, bob);
+    assert_eq!(
+        game.controller_of_id(phytotitan_id),
+        Some(bob),
+        "setup should make Bob control Alice's Phytotitan before it dies"
+    );
+
+    let graveyard_id = game
+        .move_object_by_effect(phytotitan_id, Zone::Graveyard)
+        .expect("Phytotitan should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("put Phytotitan dies trigger on stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("resolve Phytotitan dies trigger");
+    }
+    assert_eq!(game.effect_store.delayed_triggers.len(), 1);
+    assert!(
+        game.players[0].graveyard.contains(&graveyard_id),
+        "Phytotitan should stay in its owner's graveyard until the delayed trigger resolves"
+    );
+
+    game.turn.turn_number += 1;
+    queue_beginning_of_upkeep_delayed_triggers(&mut game, &mut trigger_queue, bob);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Phytotitan should not return at a non-owner's upkeep"
+    );
+
+    queue_beginning_of_upkeep_delayed_triggers(&mut game, &mut trigger_queue, alice);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("put Phytotitan owner-upkeep delayed trigger on stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("resolve Phytotitan delayed return");
+    }
+
+    let returned_id = game
+        .find_object_by_stable_id(stable_id)
+        .expect("Phytotitan should still be tracked after returning");
+    assert!(
+        game.battlefield.contains(&returned_id),
+        "Phytotitan should return to the battlefield"
+    );
+    assert!(
+        game.is_tapped(returned_id),
+        "Phytotitan should return tapped"
+    );
+    assert_eq!(
+        game.controller_of_id(returned_id),
+        Some(alice),
+        "Phytotitan should return under its owner's control, not its former controller's"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn phytotitan_delayed_return_does_not_follow_a_new_graveyard_instance() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let def = phytotitan_definition();
+    let phytotitan_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let first_graveyard_id = game
+        .move_object_by_effect(phytotitan_id, Zone::Graveyard)
+        .expect("Phytotitan should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("put Phytotitan dies trigger on stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("resolve Phytotitan dies trigger");
+    }
+    assert_eq!(game.effect_store.delayed_triggers.len(), 1);
+
+    let exile_id = game
+        .move_object_by_effect(first_graveyard_id, Zone::Exile)
+        .expect("Phytotitan should move to exile");
+    let second_graveyard_id = game
+        .move_object_by_effect(exile_id, Zone::Graveyard)
+        .expect("Phytotitan should move back to graveyard");
+    assert_ne!(second_graveyard_id, first_graveyard_id);
+
+    game.turn.turn_number += 1;
+    queue_beginning_of_upkeep_delayed_triggers(&mut game, &mut trigger_queue, alice);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("put Phytotitan owner-upkeep delayed trigger on stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("resolve Phytotitan delayed return");
+    }
+
+    assert!(
+        game.players[0].graveyard.contains(&second_graveyard_id),
+        "Phytotitan should remain in the graveyard after a zone hop"
+    );
+    assert!(
+        !game.battlefield.contains(&second_graveyard_id),
+        "Phytotitan delayed return should not follow a different graveyard instance"
     );
 }
 

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -1759,7 +1759,14 @@ pub fn check_delayed_triggers(
 
         let mut fired = false;
         for &source in candidate_sources {
-            let ctx = TriggerContext::for_source(source, delayed.controller, game);
+            let mut ctx = TriggerContext::for_source(source, delayed.controller, game);
+            for (tag, snapshots) in &delayed.tagged_objects {
+                ctx.filter_ctx
+                    .tagged_objects
+                    .entry(tag.clone())
+                    .or_default()
+                    .extend(snapshots.clone());
+            }
             if !delayed.trigger.matches(trigger_event, &ctx) {
                 continue;
             }

--- a/crates/ironsmith-runtime/src/triggers/phase_step/beginning_of_upkeep.rs
+++ b/crates/ironsmith-runtime/src/triggers/phase_step/beginning_of_upkeep.rs
@@ -1,6 +1,7 @@
 //! "At the beginning of [player]'s upkeep" trigger.
 
 use crate::events::EventKind;
+use crate::filter::PlayerFilterExt;
 use crate::ids::PlayerId;
 use crate::target::PlayerFilter;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
@@ -90,6 +91,16 @@ fn player_filter_matches(filter: &PlayerFilter, player: PlayerId, ctx: &TriggerC
                     .is_some_and(|obj| ctx.game.controller_of(obj) == player),
                 crate::object::AttachmentTarget::Player(id) => id == player,
             }
+        }
+        PlayerFilter::ControllerOf(crate::target::ObjectRef::Target)
+        | PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(_))
+        | PlayerFilter::OwnerOf(crate::target::ObjectRef::Target)
+        | PlayerFilter::OwnerOf(crate::target::ObjectRef::Tagged(_))
+        | PlayerFilter::AliasedControllerOf(crate::target::ObjectRef::Target)
+        | PlayerFilter::AliasedControllerOf(crate::target::ObjectRef::Tagged(_))
+        | PlayerFilter::AliasedOwnerOf(crate::target::ObjectRef::Target)
+        | PlayerFilter::AliasedOwnerOf(crate::target::ObjectRef::Tagged(_)) => {
+            filter.matches_player(player, &ctx.filter_ctx)
         }
         _ => true, // Default to true for complex filters evaluated at runtime
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Phytotitan
Initial parse error:
```
unsupported delayed return timing clause (clause: 'it to the battlefield tapped under its owner's control at the beginning of their next upkeep'); oracle-only fallback also failed: unsupported delayed return timing clause (clause: 'it to the battlefield tapped under its owner's control at the beginning of their next upkeep')
```

Current worker: i-0473dc0e93517ece1
Branch: codex/aws-card-fix-phytotitan
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0007
