### PR TITLE
Fix Ironsmith parse failure: Auditore Ambush

### DIFF
--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -448,6 +448,7 @@ impl KeywordAction {
 pub enum IfResultPredicate {
     Did,
     DidNot,
+    SearchedLibrary,
     DiesThisWay,
     WasDeclined,
     Value(ironsmith_core::Comparison),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/search_library.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/search_library.rs
@@ -43,6 +43,23 @@ const BATTLEFIELD_HAND_OTHER_ONE_MARKER_PATTERN: ClauseShape<'static> =
 const TAPPED_MARKER_PATTERN: ClauseShape<'static> = clause_shape!(contains_words & ["tapped"]);
 const YOUR_OR_THEIR_LIBRARY_FOR_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["your", "library", "for"], &["their", "library", "for"]]);
+const YOUR_OR_THEIR_LIBRARY_GRAVEYARD_FOR_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["your", "library", "and/or", "graveyard", "for"],
+            &["their", "library", "and/or", "graveyard", "for"],
+            &["your", "library", "and", "graveyard", "for"],
+            &["their", "library", "and", "graveyard", "for"],
+            &["your", "library", "and", "or", "graveyard", "for"],
+            &["their", "library", "and", "or", "graveyard", "for"],
+            &["your", "graveyard", "and/or", "library", "for"],
+            &["their", "graveyard", "and/or", "library", "for"],
+            &["your", "graveyard", "and", "library", "for"],
+            &["their", "graveyard", "and", "library", "for"],
+            &["your", "graveyard", "and", "or", "library", "for"],
+            &["their", "graveyard", "and", "or", "library", "for"],
+        ]
+);
 const CONTROLLER_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [
@@ -872,7 +889,16 @@ pub(crate) fn derive_search_library_subject_routing_lexed(
     let mut forced_library_owner: Option<PlayerFilter> = None;
     let mut search_zones_override: Option<Vec<Zone>> = None;
 
-    if YOUR_OR_THEIR_LIBRARY_FOR_PREFIX_PATTERN.matches_words(search_body_words) {
+    if YOUR_OR_THEIR_LIBRARY_GRAVEYARD_FOR_PREFIX_PATTERN.matches_words(search_body_words) {
+        forced_library_owner = Some(match chooser {
+            PlayerAst::Target => PlayerFilter::target_player(),
+            PlayerAst::TargetOpponent => PlayerFilter::target_opponent(),
+            PlayerAst::Opponent => PlayerFilter::Opponent,
+            PlayerAst::That => PlayerFilter::IteratedPlayer,
+            _ => PlayerFilter::You,
+        });
+        search_zones_override = Some(vec![Zone::Library, Zone::Graveyard]);
+    } else if YOUR_OR_THEIR_LIBRARY_FOR_PREFIX_PATTERN.matches_words(search_body_words) {
         // Keep player from parsed subject/default context.
     } else if CONTROLLER_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN.matches_words(search_body_words)
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -68,6 +68,8 @@ const RESULT_VERB_WORD_PATTERN: ClauseShape<'static> = clause_shape!(
             &["milled"],
         ]
 );
+const SEARCH_RESULT_VERB_WORD_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["search"], &["searches"], &["searched"]]);
 const THIS_WAY_SUFFIX_PATTERN: ClauseShape<'static> = clause_shape!(suffix & ["this", "way"]);
 const UNQUALIFIED_THIS_WAY_RESULT_QUALIFIER_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
@@ -714,6 +716,26 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
         let qualifiers = &words[action_idx + 1..words.len() - 2];
         qualifiers.is_empty() || matches!(qualifiers, ["it"] | ["them"] | ["that"])
     };
+    let is_searched_library_this_way = || {
+        if words.len() < 5 || !THIS_WAY_SUFFIX_PATTERN.matches_words(words) {
+            return false;
+        }
+        let subject_len = match words {
+            ["you", ..] | ["they", ..] | ["player", ..] | ["players", ..] => 1,
+            ["that", "player", ..] | ["first", "player", ..] => 2,
+            _ => return false,
+        };
+        let Some(verb) = words.get(subject_len) else {
+            return false;
+        };
+        if !SEARCH_RESULT_VERB_WORD_PATTERN.matches_word(verb) {
+            return false;
+        }
+        matches!(
+            &words[subject_len + 1..words.len() - 2],
+            ["your", "library"] | ["their", "library"] | ["library"]
+        )
+    };
 
     if YOU_DO_RESULT_PATTERN.matches_words(words) {
         return Some(IfResultPredicate::Did);
@@ -753,6 +775,9 @@ fn classify_if_result_predicate(words: &[&str]) -> Option<IfResultPredicate> {
     }
     if YOU_SEARCHED_THIS_WAY_PATTERN.matches_words(words) {
         return Some(IfResultPredicate::Did);
+    }
+    if is_searched_library_this_way() {
+        return Some(IfResultPredicate::SearchedLibrary);
     }
     if is_unqualified_this_way_result("you") {
         return Some(IfResultPredicate::Did);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -691,6 +691,7 @@ pub(crate) fn effect_predicate_from_if_result(predicate: IfResultPredicate) -> E
     match predicate {
         IfResultPredicate::Did => EffectPredicate::Happened,
         IfResultPredicate::DidNot => EffectPredicate::DidNotHappen,
+        IfResultPredicate::SearchedLibrary => EffectPredicate::Happened,
         IfResultPredicate::DiesThisWay => EffectPredicate::HappenedNotReplaced,
         IfResultPredicate::WasDeclined => EffectPredicate::WasDeclined,
         IfResultPredicate::Value(cmp) => EffectPredicate::Value(cmp),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1433,11 +1433,12 @@ fn compile_subject_verb_effect(
         )),
         SubjectVerbActionAst::ShuffleLibrary => {
             let ast_is_explicit_you = matches!(player, PlayerAst::You | PlayerAst::Implicit);
+            let follows_search_collection = ctx
+                .last_object_tag
+                .as_ref()
+                .is_some_and(|tag| is_searched_collection_tag(tag));
             if !ast_is_explicit_you
-                && ctx
-                    .last_object_tag
-                    .as_ref()
-                    .is_some_and(|tag| is_searched_collection_tag(tag))
+                && follows_search_collection
                 && ctx
                     .last_player_filter
                     .as_ref()
@@ -1448,6 +1449,11 @@ fn compile_subject_verb_effect(
                         ctx.last_player_filter.clone().expect("checked above"),
                     )],
                     Vec::new(),
+                ))
+            } else if matches!(player, PlayerAst::That) && !ctx.iterated_player {
+                Ok((
+                    vec![Effect::shuffle_library_player(PlayerFilter::target_player())],
+                    vec![ChooseSpec::target_player()],
                 ))
             } else {
                 compile_player_role_effect(role, player, ctx, true, true, true, |subject| {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
@@ -276,7 +276,12 @@ pub(super) fn try_compile_flow_and_iteration_effect(
             (vec![effect], choices)
         }
         EffectAst::IfResult { predicate, effects } => {
-            let condition = ctx.last_effect_id.ok_or_else(|| {
+            let condition = if matches!(predicate, IfResultPredicate::SearchedLibrary) {
+                ctx.last_library_search_effect_id.or(ctx.last_effect_id)
+            } else {
+                ctx.last_effect_id
+            }
+            .ok_or_else(|| {
                 CardTextError::ParseError("missing prior effect for if clause".to_string())
             })?;
             let (inner_effects, inner_choices) = with_preserved_lowering_context(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/player_effect_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/player_effect_helpers.rs
@@ -295,9 +295,10 @@ impl LoweredSubject {
     pub(crate) fn bind_library_filter(
         &self,
         filter: &ObjectFilter,
-        _ctx: &mut EffectLoweringContext,
+        ctx: &mut EffectLoweringContext,
     ) -> Result<ObjectFilter, CardTextError> {
         let mut resolved = filter.clone();
+        self.apply_player_refs_to_filter(&mut resolved, ctx);
         if resolved.zone.is_none() {
             resolved.zone = Some(Zone::Library);
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -537,6 +537,7 @@ fn parse_modal_header_prefix_effects(
             let effect_predicate = match gate_spec.predicate {
                 IfResultPredicate::Did => EffectPredicate::Happened,
                 IfResultPredicate::DidNot => EffectPredicate::DidNotHappen,
+                IfResultPredicate::SearchedLibrary => EffectPredicate::Happened,
                 IfResultPredicate::DiesThisWay => EffectPredicate::HappenedNotReplaced,
                 IfResultPredicate::WasDeclined => EffectPredicate::WasDeclined,
                 IfResultPredicate::Value(cmp) => EffectPredicate::Value(cmp),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/shared_types.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/shared_types.rs
@@ -40,6 +40,7 @@ pub(crate) struct IdGenContext {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct LoweringFrame {
     pub(crate) last_effect_id: Option<EffectId>,
+    pub(crate) last_library_search_effect_id: Option<EffectId>,
     pub(crate) last_object_tag: Option<String>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_revealed_tag: Option<String>,
@@ -161,6 +162,7 @@ impl EffectLoweringContext {
 
     pub(crate) fn apply_reference_frame(&mut self, frame: LoweringFrame) {
         self.last_effect_id = frame.last_effect_id;
+        self.last_library_search_effect_id = frame.last_library_search_effect_id;
         self.last_object_tag = frame.last_object_tag;
         self.last_it_choice_is_set = frame.last_it_choice_is_set;
         self.last_exiled_collection_tag = frame.last_exiled_collection_tag;

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_model.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_model.rs
@@ -15,6 +15,7 @@ pub(crate) enum RefState<T> {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ReferenceFrame {
     pub(crate) last_effect_id: Option<EffectId>,
+    pub(crate) last_library_search_effect_id: Option<EffectId>,
     pub(crate) last_object_tag: Option<String>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: Option<PlayerFilter>,
@@ -31,6 +32,7 @@ impl ReferenceFrame {
     pub(crate) fn from_lowering_frame(frame: &LoweringFrame) -> Self {
         Self {
             last_effect_id: frame.last_effect_id,
+            last_library_search_effect_id: frame.last_library_search_effect_id,
             last_object_tag: frame.last_object_tag.clone(),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: frame.last_player_filter.clone(),
@@ -47,6 +49,7 @@ impl ReferenceFrame {
     pub(crate) fn to_lowering_frame(&self) -> LoweringFrame {
         LoweringFrame {
             last_effect_id: self.last_effect_id,
+            last_library_search_effect_id: self.last_library_search_effect_id,
             last_object_tag: self.last_object_tag.clone(),
             last_it_choice_is_set: self.last_it_choice_is_set,
             last_revealed_tag: None,
@@ -96,6 +99,7 @@ pub(crate) struct ReferenceImports {
     pub(crate) last_player_filter: Option<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
     pub(crate) last_effect_id: Option<EffectId>,
+    pub(crate) last_library_search_effect_id: Option<EffectId>,
 }
 
 impl ReferenceImports {
@@ -105,6 +109,7 @@ impl ReferenceImports {
             && self.last_player_filter.is_none()
             && !self.source_object_antecedent
             && self.last_effect_id.is_none()
+            && self.last_library_search_effect_id.is_none()
     }
 
     pub(crate) fn with_last_object_tag(tag: impl Into<TagKey>) -> Self {
@@ -122,6 +127,7 @@ impl ReferenceImports {
             last_player_filter: frame.last_player_filter.clone(),
             source_object_antecedent: frame.source_object_antecedent,
             last_effect_id: frame.last_effect_id,
+            last_library_search_effect_id: frame.last_library_search_effect_id,
         }
     }
 
@@ -137,6 +143,7 @@ pub(crate) struct ReferenceEnv {
     pub(crate) last_player_filter: RefState<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
     pub(crate) last_effect_id: RefState<EffectId>,
+    pub(crate) last_library_search_effect_id: RefState<EffectId>,
     pub(crate) iterated_player: bool,
     pub(crate) allow_life_event_value: bool,
     pub(crate) bind_unbound_x_to_last_effect: bool,
@@ -150,6 +157,7 @@ impl Default for ReferenceEnv {
             last_player_filter: RefState::Unknown,
             source_object_antecedent: false,
             last_effect_id: RefState::Unknown,
+            last_library_search_effect_id: RefState::Unknown,
             iterated_player: false,
             allow_life_event_value: false,
             bind_unbound_x_to_last_effect: false,
@@ -173,6 +181,9 @@ impl ReferenceEnv {
             last_effect_id: RefState::from_option(
                 imports.last_effect_id.or(initial_last_effect_id),
             ),
+            last_library_search_effect_id: RefState::from_option(
+                imports.last_library_search_effect_id,
+            ),
             iterated_player,
             allow_life_event_value,
             bind_unbound_x_to_last_effect,
@@ -188,6 +199,9 @@ impl ReferenceEnv {
             last_player_filter: RefState::from_option(frame.last_player_filter.clone()),
             source_object_antecedent: frame.source_object_antecedent,
             last_effect_id: RefState::from_option(frame.last_effect_id),
+            last_library_search_effect_id: RefState::from_option(
+                frame.last_library_search_effect_id,
+            ),
             iterated_player: frame.iterated_player,
             allow_life_event_value: frame.allow_life_event_value,
             bind_unbound_x_to_last_effect: frame.bind_unbound_x_to_last_effect,
@@ -205,6 +219,10 @@ impl ReferenceEnv {
     ) -> ReferenceFrame {
         ReferenceFrame {
             last_effect_id: self.last_effect_id.clone().into_option(),
+            last_library_search_effect_id: self
+                .last_library_search_effect_id
+                .clone()
+                .into_option(),
             last_object_tag: self
                 .last_object_tag
                 .clone()
@@ -264,6 +282,7 @@ pub(crate) struct ReferenceExports {
     pub(crate) last_player_filter: RefState<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
     pub(crate) last_effect_id: RefState<EffectId>,
+    pub(crate) last_library_search_effect_id: RefState<EffectId>,
     pub(crate) iterated_player: bool,
 }
 
@@ -275,6 +294,7 @@ impl Default for ReferenceExports {
             last_player_filter: RefState::Unknown,
             source_object_antecedent: false,
             last_effect_id: RefState::Unknown,
+            last_library_search_effect_id: RefState::Unknown,
             iterated_player: false,
         }
     }
@@ -288,6 +308,7 @@ impl ReferenceExports {
             last_player_filter: env.last_player_filter.clone(),
             source_object_antecedent: env.source_object_antecedent,
             last_effect_id: env.last_effect_id.clone(),
+            last_library_search_effect_id: env.last_library_search_effect_id.clone(),
             iterated_player: env.iterated_player,
         }
     }
@@ -300,6 +321,10 @@ impl ReferenceExports {
             source_object_antecedent: left.source_object_antecedent
                 && right.source_object_antecedent,
             last_effect_id: RefState::join(&left.last_effect_id, &right.last_effect_id),
+            last_library_search_effect_id: RefState::join(
+                &left.last_library_search_effect_id,
+                &right.last_library_search_effect_id,
+            ),
             iterated_player: left.iterated_player && right.iterated_player,
         }
     }
@@ -311,6 +336,10 @@ impl ReferenceExports {
             last_player_filter: self.last_player_filter.clone().into_option(),
             source_object_antecedent: self.source_object_antecedent,
             last_effect_id: self.last_effect_id.clone().into_option(),
+            last_library_search_effect_id: self
+                .last_library_search_effect_id
+                .clone()
+                .into_option(),
         }
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -54,6 +54,7 @@ pub(crate) struct EffectReferenceResolutionConfig {
 #[derive(Debug, Clone, Copy)]
 struct EffectReferenceResolutionState {
     last_effect_id: Option<EffectId>,
+    last_library_search_effect_id: Option<EffectId>,
     allow_life_event_value: bool,
     bind_unbound_x_to_last_effect: bool,
 }
@@ -1172,6 +1173,7 @@ fn advance_reference_frame_for_effect(
 fn effect_reference_resolution_state(env: &ReferenceEnv) -> EffectReferenceResolutionState {
     EffectReferenceResolutionState {
         last_effect_id: env.last_effect_id.clone().into_option(),
+        last_library_search_effect_id: env.last_library_search_effect_id.clone().into_option(),
         allow_life_event_value: env.allow_life_event_value,
         bind_unbound_x_to_last_effect: env.bind_unbound_x_to_last_effect,
     }
@@ -1227,6 +1229,11 @@ fn annotate_effect_sequence_with_env_internal(
             )
         {
             out_env.last_effect_id = RefState::Known(id);
+        }
+        if let Some(id) = assigned_effect_id
+            && effect_is_library_search(&effect)
+        {
+            out_env.last_library_search_effect_id = RefState::Known(id);
         }
 
         current_env = out_env.clone();
@@ -1318,6 +1325,9 @@ fn maybe_assign_effect_result_id(
                     SubjectVerbActionAst::PumpByLastEffect { .. }
                 )
         );
+    let later_needs_library_search_result = effect_is_library_search(&effects[idx])
+        && idx + 1 < effects.len()
+        && effects[idx + 1..].iter().any(effect_is_searched_library_gate);
 
     if !(next_is_if_result_with_opponent_doesnt
         || next_is_if_result_with_player_doesnt
@@ -1326,7 +1336,8 @@ fn maybe_assign_effect_result_id(
         || next_is_result_gate
         || next_needs_event_derived_amount
         || later_needs_event_derived_amount
-        || next_needs_prior_effect_value)
+        || next_needs_prior_effect_value
+        || later_needs_library_search_result)
     {
         return None;
     }
@@ -1334,6 +1345,32 @@ fn maybe_assign_effect_result_id(
     let id = EffectId(id_gen.next_effect_id);
     id_gen.next_effect_id += 1;
     Some(id)
+}
+
+fn effect_is_searched_library_gate(effect: &EffectAst) -> bool {
+    matches!(
+        effect,
+        EffectAst::IfResult {
+            predicate: crate::cards::builders::IfResultPredicate::SearchedLibrary,
+            ..
+        } | EffectAst::WhenResult {
+            predicate: crate::cards::builders::IfResultPredicate::SearchedLibrary,
+            ..
+        }
+    )
+}
+
+fn effect_is_library_search(effect: &EffectAst) -> bool {
+    match effect {
+        EffectAst::ChooseObjectsAcrossZones {
+            zones, search_mode, ..
+        } => search_mode.is_some() && zones.contains(&crate::zone::Zone::Library),
+        EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::SearchLibrary { shuffle, .. },
+            ..
+        }) => *shuffle,
+        _ => false,
+    }
 }
 
 fn effect_can_supply_prior_effect_memory(effect: &EffectAst) -> bool {
@@ -1591,7 +1628,15 @@ fn resolve_effect_references_in_effect(
     state: EffectReferenceResolutionState,
 ) -> Result<EffectAst, CardTextError> {
     if let EffectAst::IfResult { predicate, effects } = effect {
-        let condition = state.last_effect_id.ok_or_else(|| {
+        let condition = if matches!(
+            predicate,
+            crate::cards::builders::IfResultPredicate::SearchedLibrary
+        ) {
+            state.last_library_search_effect_id.or(state.last_effect_id)
+        } else {
+            state.last_effect_id
+        }
+        .ok_or_else(|| {
             CardTextError::ParseError("missing prior effect for if clause".to_string())
         })?;
         let effects = resolve_effect_sequence_references_with_state(
@@ -1599,6 +1644,7 @@ fn resolve_effect_references_in_effect(
             id_gen,
             EffectReferenceResolutionState {
                 last_effect_id: Some(condition),
+                last_library_search_effect_id: state.last_library_search_effect_id,
                 allow_life_event_value: state.allow_life_event_value,
                 bind_unbound_x_to_last_effect: true,
             },
@@ -1619,6 +1665,7 @@ fn resolve_effect_references_in_effect(
             id_gen,
             EffectReferenceResolutionState {
                 last_effect_id: Some(condition),
+                last_library_search_effect_id: state.last_library_search_effect_id,
                 allow_life_event_value: state.allow_life_event_value,
                 bind_unbound_x_to_last_effect: true,
             },
@@ -1658,6 +1705,7 @@ fn resolve_effect_references_in_effect(
     {
         let nested_state = EffectReferenceResolutionState {
             last_effect_id: state.last_effect_id,
+            last_library_search_effect_id: state.last_library_search_effect_id,
             allow_life_event_value: trigger_supports_event_amount(trigger),
             bind_unbound_x_to_last_effect: state.bind_unbound_x_to_last_effect,
         };
@@ -1703,6 +1751,11 @@ fn resolve_effect_sequence_references_with_state(
         } else {
             assigned_effect_id
         };
+        if let Some(id) = assigned_effect_id
+            && effect_is_library_search(&effect)
+        {
+            state.last_library_search_effect_id = Some(id);
+        }
         resolved.push(effect);
     }
 
@@ -1760,6 +1813,7 @@ fn advance_reference_env_for_effect(
                 source_object_antecedent: true_sequence.final_env.source_object_antecedent
                     && false_sequence.final_env.source_object_antecedent,
                 last_effect_id: env.last_effect_id.clone(),
+                last_library_search_effect_id: env.last_library_search_effect_id.clone(),
                 iterated_player: env.iterated_player,
                 allow_life_event_value: env.allow_life_event_value,
                 bind_unbound_x_to_last_effect: env.bind_unbound_x_to_last_effect,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8,8 +8,8 @@ use crate::compiled_text::{
 use crate::effects::{
     AddManaEffect, ChooseModeEffect, ChooseObjectsEffect, ConsultTopOfLibraryEffect,
     CreateTokenEffect, DestroyEffect, DrawCardsEffect, EffectExecutor, GainLifeEffect,
-    MoveToZoneEffect, ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect, TaggedEffect,
-    TargetOnlyEffect, UntapEffect,
+    IfEffect, MoveToZoneEffect, ReturnFromGraveyardToHandEffect, TagTriggeringObjectEffect,
+    TaggedEffect, TargetOnlyEffect, UntapEffect, WithIdEffect,
 };
 use crate::filter::ObjectFilterExt;
 use crate::object::AuraAttachmentFilter;
@@ -53983,6 +53983,245 @@ fn chandras_outburst_compiled_text_preserves_shuffle() {
     assert!(
         !rendered.contains("shuffle target"),
         "shuffle should not reference 'target player', got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn auditore_ambush_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Auditore Ambush");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+    let modal = def
+        .spell_effect
+        .as_ref()
+        .and_then(|effects| {
+            effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        })
+        .expect("Auditore Ambush should lower to a modal spell effect");
+
+    assert_eq!(modal.modes.len(), 2, "Auditore Ambush should have two modes");
+    assert!(
+        matches!(modal.min_choose_count, crate::effect::Value::Fixed(1))
+            && matches!(modal.choose_count, crate::effect::Value::Fixed(2)),
+        "choose one or both should allow choosing one or two modes, got {modal:?}"
+    );
+    assert!(
+        lower.contains("target player searches their library and/or graveyard")
+            && lower.contains("if they search their library this way, they shuffle"),
+        "expected target-player multi-zone search and conditional shuffle text, got {rendered}"
+    );
+
+    let search_mode = &modal.modes[1];
+    let search_id = search_mode
+        .effects
+        .iter()
+        .find_map(|effect| {
+            let with_id = effect.downcast_ref::<WithIdEffect>()?;
+            with_id
+                .effect
+                .downcast_ref::<ChooseObjectsEffect>()
+                .filter(|choose| choose.is_search)
+                .map(|_| with_id.id)
+        })
+        .expect("library search should be effect-id tracked");
+    let shuffle_condition = search_mode
+        .effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<IfEffect>())
+        .expect("conditional library shuffle should lower to IfEffect");
+    assert_eq!(
+        shuffle_condition.condition, search_id,
+        "the shuffle condition must be keyed to the library search, not to moving a found card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn auditore_ambush_runtime_returns_target_creature() {
+    use crate::effects::ResolvedTarget;
+
+    let def = parse_oracle_card_definition("Auditore Ambush");
+    let modal = def
+        .spell_effect
+        .as_ref()
+        .and_then(|effects| {
+            effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        })
+        .expect("Auditore Ambush should lower to a modal spell effect");
+    let return_mode: crate::resolution::ResolutionProgram = modal.modes[0].effects.clone().into();
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_501), "Ambushed Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_targets(vec![ResolvedTarget::Object(target_creature)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: crate::target::ChooseSpec::target_creature(),
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &return_mode,
+        None,
+        &[],
+    )
+    .expect("Auditore Ambush return mode should resolve");
+
+    let bob_hand_names: Vec<_> = game
+        .player(bob)
+        .expect("bob exists")
+        .hand
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect();
+    assert!(
+        bob_hand_names.iter().any(|name| name == "Ambushed Creature"),
+        "return mode should put the target creature into its owner's hand, got {bob_hand_names:?}"
+    );
+    assert!(
+        !game.battlefield.contains(&target_creature),
+        "return mode should remove the target creature from the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn auditore_ambush_runtime_target_player_searches_for_ezio() {
+    use crate::effects::ResolvedTarget;
+
+    let def = parse_oracle_card_definition("Auditore Ambush");
+    let modal = def
+        .spell_effect
+        .as_ref()
+        .and_then(|effects| {
+            effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        })
+        .expect("Auditore Ambush should lower to a modal spell effect");
+    let search_mode: crate::resolution::ResolutionProgram = modal.modes[1].effects.clone().into();
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(91_502), "Ezio, Blade of Vengeance")
+            .card_types(vec![CardType::Creature])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_targets(vec![ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: crate::target::ChooseSpec::target_player(),
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &search_mode,
+        None,
+        &[],
+    )
+    .expect("Auditore Ambush search mode should resolve");
+
+    let bob_hand_names: Vec<_> = game
+        .player(bob)
+        .expect("bob exists")
+        .hand
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect();
+    assert!(
+        bob_hand_names
+            .iter()
+            .any(|name| name == "Ezio, Blade of Vengeance"),
+        "search mode should put the named Ezio card into the target player's hand, got {bob_hand_names:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn auditore_ambush_runtime_search_mode_allows_no_matching_card() {
+    use crate::effects::ResolvedTarget;
+
+    let def = parse_oracle_card_definition("Auditore Ambush");
+    let modal = def
+        .spell_effect
+        .as_ref()
+        .and_then(|effects| {
+            effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        })
+        .expect("Auditore Ambush should lower to a modal spell effect");
+    let search_mode: crate::resolution::ResolutionProgram = modal.modes[1].effects.clone().into();
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(91_503), "Not Ezio")
+            .card_types(vec![CardType::Creature])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_targets(vec![ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: crate::target::ChooseSpec::target_player(),
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &search_mode,
+        None,
+        &[],
+    )
+    .expect("Auditore Ambush search mode should resolve without a matching card");
+
+    let bob_hand_names: Vec<_> = game
+        .player(bob)
+        .expect("bob exists")
+        .hand
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect();
+    assert!(
+        bob_hand_names.is_empty(),
+        "search mode should not move a nonmatching card into hand, got {bob_hand_names:?}"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Auditore Ambush
Initial parse error:
```
unsupported predicate (predicate: 'they search their library this way'); oracle-only fallback also failed: unsupported predicate (predicate: 'they search their library this way')
```

Current worker: i-0f2f4895e5c43bb79
Branch: codex/aws-card-fix-auditore-ambush
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0009
