### PR TITLE
Fix Ironsmith parse failure: Thelon's Chant

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3093,6 +3093,36 @@ pub(crate) fn parse_trigger_clause_lexed(
         let subject = &words[..put_word_idx];
         if let Some(player) = parse_trigger_subject_player_filter(subject) {
             let tail = &words[put_word_idx + 1..];
+            let onto_battlefield_start = tail
+                .windows(3)
+                .position(|window| window == ["onto", "the", "battlefield"])
+                .or_else(|| {
+                    tail.windows(2)
+                        .position(|window| window == ["onto", "battlefield"])
+                });
+            if let Some(onto_battlefield_start) = onto_battlefield_start
+                && onto_battlefield_start > 0
+            {
+                let word_view = ActivationRestrictionCompatWords::new(tokens);
+                let object_start_word = put_word_idx + 1;
+                let object_end_word = object_start_word + onto_battlefield_start;
+                let object_start_token = word_view
+                    .token_index_for_word_index(object_start_word)
+                    .unwrap_or(tokens.len());
+                let object_end_token = word_view
+                    .token_index_for_word_index(object_end_word)
+                    .unwrap_or(tokens.len());
+                if object_start_token < object_end_token && object_end_token <= tokens.len() {
+                    let object_tokens = strip_leading_articles(&tokens[object_start_token..object_end_token]);
+                    if let Ok(mut filter) = parse_object_filter_lexed(&object_tokens, false) {
+                        filter.controller = Some(player);
+                        return Ok(TriggerSpec::EntersBattlefield {
+                            filter,
+                            cause_filter: None,
+                        });
+                    }
+                }
+            }
             if NAME_STICKER_PUT_TAIL_PATTERN.matches_words(tail) {
                 return Ok(TriggerSpec::KeywordAction {
                     action: crate::events::KeywordActionKind::NameSticker,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4315,6 +4315,8 @@ fn compile_subject_verb_effect(
                     &PlayerFilter::Target(Box::new(filter.clone())),
                 );
             }
+            let (resolved_target, _) =
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
             let (mut effects, choices) =
                 compile_tagged_effect_for_target(target, ctx, "damaged", |spec| {
                     Effect::deal_damage(resolved_amount.clone(), spec)
@@ -4322,7 +4324,19 @@ fn compile_subject_verb_effect(
             if let TargetAst::Player(filter, _) | TargetAst::PlayerOrPlaneswalker(filter, _) =
                 target
             {
-                ctx.last_player_filter = Some(PlayerFilter::Target(Box::new(filter.clone())));
+                let filter = match resolved_target.unhinted() {
+                    ChooseSpec::Target(inner) => match inner.unhinted() {
+                        ChooseSpec::Player(filter) | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+                            PlayerFilter::Target(Box::new(filter.clone()))
+                        }
+                        _ => PlayerFilter::Target(Box::new(filter.clone())),
+                    },
+                    ChooseSpec::Player(filter) | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+                        filter.clone()
+                    }
+                    _ => PlayerFilter::Target(Box::new(filter.clone())),
+                };
+                ctx.last_player_filter = Some(filter);
             } else if target_is_any_damage_target(target) {
                 let tag = ctx.next_tag("damaged");
                 ctx.last_object_tag = Some(tag.clone());

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
@@ -245,11 +245,17 @@ pub(super) fn try_compile_flow_and_iteration_effect(
 
             let previous_last_player_filter = ctx.last_player_filter.clone();
             let (inner_effects, inner_choices) = compile_effects(effects, ctx)?;
-            let (alt_effects, alt_choices) = compile_effects(alternative, ctx)?;
             let player_filter = resolve_unless_player_filter(
                 *player,
                 &current_reference_env(ctx),
                 previous_last_player_filter,
+            )?;
+            let (alt_effects, alt_choices) = with_preserved_lowering_context(
+                ctx,
+                |ctx| {
+                    ctx.last_player_filter = Some(player_filter.clone());
+                },
+                |ctx| compile_effects(alternative, ctx),
             )?;
             if !matches!(*player, PlayerAst::Implicit) {
                 ctx.last_player_filter = Some(player_filter.clone());

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -23,6 +23,22 @@ pub(crate) fn resolve_unless_player_filter(
         && !refs.iterated_player
         && refs
             .known_last_player_filter()
+            .is_some_and(PlayerFilter::mentions_iterated_player)
+        && previous_last_player_filter
+            .as_ref()
+            .is_some_and(|filter| !filter.mentions_iterated_player())
+    {
+        return previous_last_player_filter.ok_or_else(|| {
+            CardTextError::InvariantViolation(
+                "expected previous non-iterated player filter for unless-player resolution"
+                    .to_string(),
+            )
+        });
+    }
+    if matches!(player, PlayerAst::That)
+        && !refs.iterated_player
+        && refs
+            .known_last_player_filter()
             .is_some_and(is_you_player_filter)
         && previous_last_player_filter
             .as_ref()

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -289,7 +289,23 @@ fn maybe_tag_target(
     {
         frame.last_object_tag = Some(tag);
     }
-    track_target_player(target, frame);
+    match target {
+        TargetAst::Player(filter, _) | TargetAst::PlayerOrPlaneswalker(filter, _) => {
+            frame.last_player_filter = Some(match spec.unhinted() {
+                ChooseSpec::Target(inner) => match inner.unhinted() {
+                    ChooseSpec::Player(filter) | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+                        PlayerFilter::Target(Box::new(filter.clone()))
+                    }
+                    _ => PlayerFilter::Target(Box::new(filter.clone())),
+                },
+                ChooseSpec::Player(filter) | ChooseSpec::PlayerOrPlaneswalker(filter) => {
+                    filter.clone()
+                }
+                _ => PlayerFilter::Target(Box::new(filter.clone())),
+            });
+        }
+        _ => track_target_player(target, frame),
+    }
     Ok(())
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/choice_damage_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/choice_damage_family.rs
@@ -976,6 +976,62 @@ pub(crate) fn parse_sentence_unless_pays(
     parse_sentence_unless_pays_matched(clause, &matched)
 }
 
+pub(crate) fn parse_sentence_damage_unless_player_takes_action(
+    clause: SubjectVerbPrimitiveClause<'_>,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let pattern = LexPattern::new(UNLESS_PAYS_PATTERN_ATOMS);
+    let Some(matched) = clause.match_pattern(pattern) else {
+        return Ok(None);
+    };
+    parse_sentence_damage_unless_player_takes_action_matched(clause, &matched)
+}
+
+pub(crate) fn parse_sentence_damage_unless_player_takes_action_matched(
+    clause: SubjectVerbPrimitiveClause<'_>,
+    _matched: &LexPatternMatch<'_>,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some((before_clause, after_clause)) = clause.split_once_on_word("unless") else {
+        return Ok(None);
+    };
+    let effects = parse_effect_chain(before_clause.trimmed().tokens())?;
+    if effects.len() != 1
+        || !matches!(
+            effects.first(),
+            Some(EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                action: SubjectVerbActionAst::DealDamage { .. },
+                ..
+            }))
+        )
+    {
+        return Ok(None);
+    }
+
+    let after_clause = after_clause.trimmed();
+    let after_words = after_clause.word_refs();
+    let (player, action_clause) = if after_words.starts_with(&["that", "player"])
+        || after_words.starts_with(&["the", "player"])
+    {
+        (PlayerAst::That, after_clause.after_words(2))
+    } else if after_words.starts_with(&["they"]) {
+        (PlayerAst::That, after_clause.after_words(1))
+    } else {
+        return Ok(None);
+    };
+    let Some(action_clause) = action_clause else {
+        return Ok(None);
+    };
+    let alternative = parse_effect_chain(action_clause.trimmed().tokens())?;
+    if alternative.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(vec![EffectAst::UnlessAction {
+        effects,
+        alternative,
+        player,
+    }]))
+}
+
 pub(crate) fn parse_sentence_unless_pays_matched(
     clause: SubjectVerbPrimitiveClause<'_>,
     _matched: &LexPatternMatch<'_>,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/mechanic_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/mechanic_marker_family.rs
@@ -731,6 +731,33 @@ pub(crate) const PRE_CONDITIONAL_SUBJECT_VERB_PRIMITIVES: &[SubjectVerbPrimitive
         parse_sentence_target_player_reveals_random_card_from_hand,
         parse_sentence_target_player_reveals_random_card_from_hand_matched
     ),
+    primitive_with_pattern_parser!(
+        "unless-action-before-subject-verb",
+        190,
+        PreDiagnostic,
+        &[
+            LexRuleHeadHint::Single("unless"),
+            LexRuleHeadHint::Single("for"),
+            LexRuleHeadHint::Single("each"),
+            LexRuleHeadHint::Single("this")
+        ],
+        UNLESS_PAYS_PATTERN_ATOMS,
+        parse_sentence_unless_pays,
+        parse_sentence_unless_pays_matched
+    ),
+    primitive_with_pattern_parser!(
+        "damage-unless-player-takes-action",
+        195,
+        PreDiagnostic,
+        &[
+            LexRuleHeadHint::Single("this"),
+            LexRuleHeadHint::Single("it"),
+            LexRuleHeadHint::Single("that")
+        ],
+        UNLESS_PAYS_PATTERN_ATOMS,
+        parse_sentence_damage_unless_player_takes_action,
+        parse_sentence_damage_unless_player_takes_action_matched
+    ),
 ];
 
 pub(crate) static PRE_CONDITIONAL_SUBJECT_VERB_PRIMITIVE_INDEX: LazyLock<LexRuleHintIndex> =
@@ -1376,7 +1403,8 @@ pub(crate) const POST_CONDITIONAL_SUBJECT_VERB_PRIMITIVES: &[SubjectVerbPrimitiv
         &[
             LexRuleHeadHint::Single("unless"),
             LexRuleHeadHint::Single("for"),
-            LexRuleHeadHint::Single("each")
+            LexRuleHeadHint::Single("each"),
+            LexRuleHeadHint::Single("this")
         ],
         UNLESS_PAYS_PATTERN_ATOMS,
         parse_sentence_unless_pays,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -686,6 +686,23 @@ pub(crate) fn parse_deal_damage_with_amount(
         });
     }
 
+    let target_word_refs = crate::runtime_backend::token_word_refs(target_tokens);
+    if let Some(unless_idx) = target_word_refs
+        .iter()
+        .position(|word| *word == "unless")
+        .and_then(|word_idx| token_index_for_word_index(target_tokens, word_idx))
+    {
+        let pre_target_tokens = trim_commas(&target_tokens[..unless_idx]);
+        if !pre_target_tokens.is_empty() {
+            let target = parse_target_phrase(&pre_target_tokens)?;
+            let effects = vec![EffectAst::subject_verb_damage(amount.clone(), target)];
+            let clause = SubjectVerbPrimitiveClause::new(target_tokens);
+            if let Some(unless_effect) = try_build_unless(effects, clause, unless_idx)? {
+                return Ok(unless_effect);
+            }
+        }
+    }
+
     if let Some(spec) = split_trailing_if_clause_lexed(target_tokens) {
         let target = parse_target_phrase(spec.leading_tokens)?;
         return Ok(EffectAst::Conditional {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -143,6 +143,146 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn thelons_chant_strict_parser_compiled_text_and_bound_player_regression() {
+    let def = parse_oracle_card_definition("Thelon's Chant");
+    let rendered = compiled_text_lines(&def).join("\n");
+    assert!(
+        rendered.contains(
+            "Whenever a player puts a Swamp onto the battlefield, this enchantment deals 3 damage to that player unless the player puts a -1/-1 counter on a creature they control."
+        ),
+        "Thelon's Chant should preserve the Swamp controller's unless-action text, got {rendered}"
+    );
+
+    let triggered = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .nth(1)
+        .expect("Thelon's Chant should have a Swamp-entered triggered ability");
+    let [segment] = triggered.effects.segments.as_slice() else {
+        panic!("expected a single resolution segment, got {:#?}", triggered.effects);
+    };
+    let [effect] = segment.default_effects.as_slice() else {
+        panic!("expected a single default effect, got {:#?}", segment.default_effects);
+    };
+    let unless = effect
+        .downcast_ref::<crate::effects::UnlessActionEffect>()
+        .expect("Swamp trigger should lower to UnlessActionEffect");
+    let expected_player = PlayerFilter::ControllerOf(ObjectRef::Tagged(crate::TagKey::from(
+        "triggering",
+    )));
+    assert_eq!(unless.player, expected_player);
+
+    let damage = unless.effects[0]
+        .downcast_ref::<crate::effects::DealDamageEffect>()
+        .expect("unless default should deal damage");
+    assert_eq!(damage.target, ChooseSpec::Player(expected_player.clone()));
+
+    let counters = unless.alternative[0]
+        .downcast_ref::<crate::effects::PutCountersEffect>()
+        .expect("unless alternative should put a -1/-1 counter");
+    let ChooseSpec::WithCount(inner, count) = &counters.target else {
+        panic!("counter target should choose one controlled creature, got {:#?}", counters.target);
+    };
+    assert!(count.is_single());
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        panic!("counter target should be an object filter, got {inner:#?}");
+    };
+    assert_eq!(filter.controller, Some(expected_player));
+    assert!(filter.card_types.contains(&CardType::Creature));
+}
+
+#[test]
+fn thelons_chant_swamp_trigger_alternative_targets_that_players_creature_runtime() {
+    struct AcceptAlternative;
+
+    impl crate::decision::DecisionMaker for AcceptAlternative {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+    }
+
+    let def = parse_oracle_card_definition("Thelon's Chant");
+    let triggered = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .nth(1)
+        .expect("Thelon's Chant should have a Swamp-entered triggered ability");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let chant_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let alice_creature = crate::card::CardBuilder::new(CardId::from_raw(70_001), "Alice Bear")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let alice_creature_id = game.create_object_from_card(&alice_creature, alice, Zone::Battlefield);
+    let bob_creature = crate::card::CardBuilder::new(CardId::from_raw(70_002), "Bob Bear")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let bob_creature_id = game.create_object_from_card(&bob_creature, bob, Zone::Battlefield);
+    let swamp = crate::card::CardBuilder::new(CardId::from_raw(70_003), "Bob Swamp")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Swamp])
+        .build();
+    let swamp_id = game.create_object_from_card(&swamp, bob, Zone::Battlefield);
+    let event = crate::events::RawEvent::new(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            swamp_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let trigger_ctx = crate::triggers::TriggerContext::for_source(chant_id, alice, &game);
+    assert!(
+        triggered.trigger.matches(&event, &trigger_ctx),
+        "Thelon's Chant should trigger when Bob puts a Swamp onto the battlefield"
+    );
+
+    let mut dm = AcceptAlternative;
+    let mut ctx = crate::effects::ExecutionContext::new(chant_id, alice, &mut dm)
+        .with_triggering_event(event);
+    for effect in triggered.effects.flattened_default_effects() {
+        effect
+            .0
+            .execute(&mut game, &mut ctx)
+            .expect("Thelon's Chant Swamp trigger should resolve");
+    }
+
+    assert_eq!(
+        game.player(bob).expect("Bob should exist").life,
+        20,
+        "accepting the alternative should prevent damage to the Swamp's controller"
+    );
+    assert_eq!(
+        game.counter_count(bob_creature_id, crate::object::CounterType::MinusOneMinusOne),
+        1,
+        "the alternative should put a -1/-1 counter on Bob's creature"
+    );
+    assert_eq!(
+        game.counter_count(alice_creature_id, crate::object::CounterType::MinusOneMinusOne),
+        0,
+        "the alternative should not target Alice's creature"
+    );
+}
+
+#[test]
 fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Commander Liara Portyr");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27612,6 +27612,77 @@ pub(super) fn describe_effect(effect: &Effect) -> String {
     with_effect_render_depth(|| describe_effect_impl(effect))
 }
 
+fn unless_action_player_subject(player: &PlayerFilter) -> String {
+    match player {
+        PlayerFilter::You => "you".to_string(),
+        PlayerFilter::Specific(_)
+        | PlayerFilter::TaggedPlayer(_)
+        | PlayerFilter::Active
+        | PlayerFilter::DamagedPlayer
+        | PlayerFilter::IteratedPlayer
+        | PlayerFilter::ControllerOf(_)
+        | PlayerFilter::OwnerOf(_)
+        | PlayerFilter::AliasedOwnerOf(_)
+        | PlayerFilter::AliasedControllerOf(_) => "the player".to_string(),
+        _ => describe_player_filter(player),
+    }
+}
+
+fn controlled_object_filter_for_player<'a>(
+    spec: &'a ChooseSpec,
+    player: &PlayerFilter,
+) -> Option<&'a ObjectFilter> {
+    match spec.unhinted() {
+        ChooseSpec::WithCount(inner, count) if count.is_single() => {
+            controlled_object_filter_for_player(inner, player)
+        }
+        ChooseSpec::Target(inner) => controlled_object_filter_for_player(inner, player),
+        ChooseSpec::Object(filter) if filter.controller.as_ref() == Some(player) => Some(filter),
+        _ => None,
+    }
+}
+
+fn describe_unless_action_put_counters_alternative(
+    put_counters: &crate::effects::PutCountersEffect,
+    player: &PlayerFilter,
+) -> Option<String> {
+    if put_counters.distributed
+        || put_counters
+            .target_count
+            .is_some_and(|count| !count.is_single())
+    {
+        return None;
+    }
+    let filter = controlled_object_filter_for_player(&put_counters.target, player)?;
+    let mut object_filter = filter.clone();
+    object_filter.controller = None;
+    object_filter.zone = None;
+    let object_text = with_indefinite_article(strip_leading_article(&object_filter.description()));
+    let control_text = match player {
+        PlayerFilter::You => "you control",
+        _ => "they control",
+    };
+    let subject = unless_action_player_subject(player);
+    let verb = player_verb(&subject, "put", "puts");
+    Some(format!(
+        "{subject} {verb} {} on {object_text} {control_text}",
+        describe_put_counter_phrase(&put_counters.amount, put_counters.counter_type)
+    ))
+}
+
+fn describe_unless_action_inner_text(unless_action: &crate::effects::UnlessActionEffect) -> String {
+    let mut inner_text = describe_effect_list(&unless_action.effects);
+    if let [effect] = unless_action.effects.as_slice()
+        && let Some(damage) = effect.downcast_ref::<crate::effects::DealDamageEffect>()
+        && let ChooseSpec::Player(player) = damage.target.unhinted()
+        && player == &unless_action.player
+    {
+        let player_text = describe_player_filter(player);
+        inner_text = inner_text.replace(&format!("to {player_text}"), "to that player");
+    }
+    inner_text
+}
+
 fn describe_unless_any_player_pays_search_prefix(
     unless_pays: &crate::effects::UnlessPaysEffect,
     payment_text: &str,
@@ -29564,7 +29635,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(unless_action) = effect.downcast_ref::<crate::effects::UnlessActionEffect>() {
-        let inner_text = describe_effect_list(&unless_action.effects);
+        let inner_text = describe_unless_action_inner_text(unless_action);
         if unless_action.alternative.len() == 1
             && let Some(pay_mana) =
                 unless_action.alternative[0].downcast_ref::<crate::effects::PayManaEffect>()
@@ -29614,6 +29685,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 "{} unless {} {} or {}",
                 inner_text, player, first_choice, second_choice
             );
+        }
+        if unless_action.alternative.len() == 1
+            && let Some(put_counters) = unless_action.alternative[0]
+                .downcast_ref::<crate::effects::PutCountersEffect>()
+            && let Some(alt_clause) = describe_unless_action_put_counters_alternative(
+                put_counters,
+                &unless_action.player,
+            )
+        {
+            return format!("{inner_text} unless {alt_clause}");
         }
         let alt_text = describe_effect_list(&unless_action.alternative);
         let player = describe_player_filter(&unless_action.player);

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2181,6 +2181,13 @@ fn resolve_controller_of(
         ObjectRef::Tagged(tag) => {
             if let Some(snapshot) = ctx.get_tagged(tag) {
                 Ok(snapshot.controller)
+            } else if let Some(snapshot) = ctx
+                .filter_context(game)
+                .tagged_objects
+                .get(tag)
+                .and_then(|snapshots| snapshots.first())
+            {
+                Ok(snapshot.controller)
             } else {
                 Err(ExecutionError::TagNotFound(tag.to_string()))
             }
@@ -2215,6 +2222,13 @@ fn resolve_owner_of(
         }
         ObjectRef::Tagged(tag) => {
             if let Some(snapshot) = ctx.get_tagged(tag) {
+                Ok(snapshot.owner)
+            } else if let Some(snapshot) = ctx
+                .filter_context(game)
+                .tagged_objects
+                .get(tag)
+                .and_then(|snapshots| snapshots.first())
+            {
                 Ok(snapshot.owner)
             } else {
                 Err(ExecutionError::TagNotFound(tag.to_string()))

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
@@ -410,6 +410,31 @@ impl ZoneChangeTrigger {
             };
         }
 
+        if self.from == ZonePattern::Any
+            && self.to == ZonePattern::Specific(Zone::Battlefield)
+            && self.player == PlayerRelation::Any
+            && self.count_mode == CountMode::Each
+            && self.object_filter.controller == Some(PlayerFilter::Any)
+        {
+            let mut object_filter = self.object_filter.clone();
+            object_filter.controller = None;
+            let object_desc = subject_description_for_zone_change(&object_filter);
+            let has_article = object_desc.starts_with("a ")
+                || object_desc.starts_with("an ")
+                || object_desc.starts_with("the ")
+                || object_desc.starts_with("this ")
+                || object_desc.starts_with("that ")
+                || object_desc.starts_with("another ")
+                || object_desc.starts_with("enchanted ")
+                || object_desc.starts_with("equipped ");
+            let object_text = if has_article {
+                object_desc
+            } else {
+                format!("a {object_desc}")
+            };
+            return format!("Whenever a player puts {object_text} onto the battlefield");
+        }
+
         let mut parts = vec!["Whenever".to_string()];
 
         // Player relation


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thelon's Chant
Initial parse error:
```
triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(PutCountersEffect { counter_type: MinusOneMinusOne, amount: Fixed(1), target: WithCount(Object(ObjectFilter { zone: Some(Battlefield), controller: Some(IteratedPlayer), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, dealt_damage_to_player_this_turn: None, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }), ChoiceCount { min: 1, max: Some(1), dynamic_x: false, up_to_x: false, random: false }), target_count: Some(ChoiceCount { min: 1, max: Some(1), dynamic_x: false, up_to_x: false, random: false }), distributed: false }); oracle-only fallback also failed: triggered ability effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(PutCountersEffect { counter_type: MinusOneMinusOne, amount: Fixed(1), target: WithCount(Object(ObjectFilter { zone: Some(Battlefield), controller: Some(IteratedPlayer), cast_by: None, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [Creature], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, dealt_damage_to_player_this_turn: None, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [], specific: None, any_of: [], source: false }), ChoiceCount { min: 1, max: Some(1), dynamic_x: false, up_to_x: false, random: false }), target_count: Some(ChoiceCount { min: 1, max: Some(1), dynamic_x: false, up_to_x: false, random: false }), distributed: false })
```

Current worker: i-0d355fa7e42ad0570
Branch: codex/aws-card-fix-thelon-s-chant
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0010
