### PR TITLE
Fix Ironsmith parse failure: Scuttling Sentinel

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch/become_clause.rs
@@ -439,6 +439,34 @@ pub(crate) fn parse_become_clause(
         .map(|(_, head)| head)
         .unwrap_or(become_words);
     if !card_type_words.is_empty() {
+        let mut colors = crate::color::ColorSet::new();
+        let mut subtypes = Vec::new();
+        let mut all_color_or_subtype_words = true;
+        for word in card_type_words {
+            if AND_WORD_PATTERN.matches_word(word) {
+                continue;
+            }
+            if let Some(color) = parse_color(word) {
+                colors = colors.union(color);
+                continue;
+            }
+            if let Some(subtype) = parse_subtype_word_or_plural(word) {
+                push_unique_subtype(&mut subtypes, subtype);
+                continue;
+            }
+            all_color_or_subtype_words = false;
+            break;
+        }
+        if all_color_or_subtype_words && !colors.is_empty() && !subtypes.is_empty() {
+            return Ok(EffectAst::Sequence {
+                effects: vec![
+                    EffectAst::subject_verb_set_colors(target.clone(), colors, duration.clone()),
+                    EffectAst::subject_verb_add_subtypes(target, subtypes, duration),
+                ],
+            });
+        }
+    }
+    if !card_type_words.is_empty() {
         let mut card_types = Vec::new();
         let mut all_card_types = true;
         for word in card_type_words {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -1391,10 +1391,10 @@ pub(crate) fn parse_gain_ability_sentence(
     // Check for "gets +X/+Y and gains/has/loses ..." patterns - if there's a pump
     // modifier before the ability verb, extract it as a separate Pump/PumpAll effect.
     let before_gain = &word_list[subject_start_word_idx..gain_idx];
-    let leading_become_effect = if let Some(become_idx) =
-        BECOME_OR_BECOMES_WORD_PATTERN.find_word(before_gain)
-    {
-        let become_word_idx = subject_start_word_idx + become_idx;
+    let leading_become_subject_end_word_idx = BECOME_OR_BECOMES_WORD_PATTERN
+        .find_word(before_gain)
+        .map(|become_idx| subject_start_word_idx + become_idx);
+    let leading_become_effect = if let Some(become_word_idx) = leading_become_subject_end_word_idx {
         let Some(become_token_idx) = token_index_for_word_index(tokens, become_word_idx) else {
             return Ok(None);
         };
@@ -1546,6 +1546,7 @@ pub(crate) fn parse_gain_ability_sentence(
         .or(leading_base_pt_effect
             .as_ref()
             .map(|(_, _, has_idx, _)| *has_idx))
+        .or(leading_become_subject_end_word_idx)
         .unwrap_or(gain_idx);
     let real_subject_start_word_idx = if let Some(gi) = get_idx {
         let subject_start_for_word = |idx: usize, word: &str| -> Option<usize> {
@@ -1906,6 +1907,11 @@ fn reject_unsupported_lost_abilities(
 
 fn apply_gain_clause_duration_to_leading_effect(effect: &mut EffectAst, duration: &Until) {
     match effect {
+        EffectAst::Sequence { effects } => {
+            for child in effects {
+                apply_gain_clause_duration_to_leading_effect(child, duration);
+            }
+        }
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
             action:
                 SubjectVerbActionAst::SetBasePowerToughness {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -52208,6 +52208,46 @@ fn enter_the_avatar_state_keeps_shared_duration_and_targeted_subtype_gain() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn scuttling_sentinel_parses_blue_crab_until_end_of_turn_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(651_777), "Scuttling Sentinel")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Green, ManaSymbol::Blue],
+            vec![ManaSymbol::Green, ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Crab, Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Flash\nVigilance\nWhen this creature enters, put a +1/+1 counter on another target creature you control. Until end of turn, that creature becomes a blue Crab in addition to its other types and gains hexproof.",
+        )
+        .expect("Scuttling Sentinel should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("when this creature enters")
+            && rendered_lower.contains("another target creature you control")
+            && rendered_lower.contains(
+                "that creature becomes a blue crab in addition to its other types and gains hexproof until end of turn"
+            )
+            && !rendered_lower.contains("unsupported"),
+        "expected Scuttling Sentinel to render its blue Crab hexproof trigger cleanly, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("SetColors")
+            && debug.contains("AddSubtypes")
+            && debug.contains("Crab")
+            && debug.contains("Hexproof")
+            && debug.matches("EndOfTurn").count() >= 3,
+        "expected Scuttling Sentinel trigger to structurally set color, add Crab, and grant hexproof until end of turn, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn anti_venom_static_damage_replacement_compiles() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Anti-Venom, Horrifying Healer")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4205,6 +4205,108 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
+    fn keyword_label_from_static_ability_id(
+        ability: crate::static_abilities::StaticAbilityId,
+    ) -> Option<&'static str> {
+        Some(match ability {
+            crate::static_abilities::StaticAbilityId::Flying => "flying",
+            crate::static_abilities::StaticAbilityId::FirstStrike => "first strike",
+            crate::static_abilities::StaticAbilityId::DoubleStrike => "double strike",
+            crate::static_abilities::StaticAbilityId::Deathtouch => "deathtouch",
+            crate::static_abilities::StaticAbilityId::Haste => "haste",
+            crate::static_abilities::StaticAbilityId::Hexproof => "hexproof",
+            crate::static_abilities::StaticAbilityId::Indestructible => "indestructible",
+            crate::static_abilities::StaticAbilityId::Lifelink => "lifelink",
+            crate::static_abilities::StaticAbilityId::Menace => "menace",
+            crate::static_abilities::StaticAbilityId::Reach => "reach",
+            crate::static_abilities::StaticAbilityId::Trample => "trample",
+            crate::static_abilities::StaticAbilityId::Vigilance => "vigilance",
+            _ => return None,
+        })
+    }
+
+    fn describe_tagged_counter_then_color_subtype_keyword(effects: &[&Effect]) -> Option<String> {
+        let effects = if let Some(first) = effects.first()
+            && first
+                .downcast_ref::<crate::effects::TagTriggeringObjectEffect>()
+                .is_some()
+        {
+            &effects[1..]
+        } else {
+            effects
+        };
+        let [counter_effect, color_effect, subtype_effect, ability_effect] = effects else {
+            return None;
+        };
+        let counter_tag = effect_tag(counter_effect)?;
+        unwrap_wrapped_effect(counter_effect)
+            .downcast_ref::<crate::effects::PutCountersEffect>()?;
+
+        let color_apply = tagged_apply_continuous(color_effect)?;
+        let subtype_apply = tagged_apply_continuous(subtype_effect)?;
+        let ability_apply = tagged_apply_continuous(ability_effect)?;
+        if color_apply.until != subtype_apply.until
+            || color_apply.until != ability_apply.until
+            || color_apply.condition.is_some()
+            || subtype_apply.condition.is_some()
+            || ability_apply.condition.is_some()
+            || !apply_targets_tag(color_apply, counter_tag)
+            || !apply_targets_tag(subtype_apply, counter_tag)
+            || !apply_targets_tag(ability_apply, counter_tag)
+            || !color_apply.additional_modifications.is_empty()
+            || !subtype_apply.additional_modifications.is_empty()
+            || !ability_apply.additional_modifications.is_empty()
+            || !color_apply.runtime_modifications.is_empty()
+            || !subtype_apply.runtime_modifications.is_empty()
+            || !ability_apply.runtime_modifications.is_empty()
+        {
+            return None;
+        }
+
+        let Some(crate::continuous::Modification::SetColors(colors)) = &color_apply.modification
+        else {
+            return None;
+        };
+        let Some(crate::continuous::Modification::AddSubtypes(subtypes)) =
+            &subtype_apply.modification
+        else {
+            return None;
+        };
+        let Some(crate::continuous::Modification::AddAbility(ability)) = &ability_apply.modification
+        else {
+            return None;
+        };
+        let keyword = keyword_label_from_static_ability_id(ability.id())?;
+        if colors.is_empty() || subtypes.is_empty() {
+            return None;
+        }
+
+        let subtype_words = subtypes
+            .iter()
+            .map(|subtype| subtype.to_string().to_ascii_lowercase())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let descriptor = with_indefinite_article(&format!(
+            "{} {subtype_words}",
+            describe_token_color_words(*colors, false)
+        ));
+        let mut become_text = format!(
+            "That creature becomes {descriptor} in addition to its other types and gains {keyword}"
+        );
+        if !matches!(color_apply.until, Until::Forever) {
+            become_text.push(' ');
+            become_text.push_str(&describe_until(&color_apply.until));
+        }
+        Some(format!(
+            "{}. {become_text}",
+            describe_effect(counter_effect).trim_end_matches('.')
+        ))
+    }
+
+    if let Some(compact) = describe_tagged_counter_then_color_subtype_keyword(&raw_effects) {
+        return compact;
+    }
+
     fn describe_move_then_color_subtype_addition(effects: &[&Effect]) -> Option<String> {
         let [move_effect, color_effect, subtype_effect] = effects else {
             return None;

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1247,6 +1247,150 @@ fn ox_drover_attack_trigger_creates_ox_draws_and_vigilance_keeps_it_untapped() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn scuttling_sentinel_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(651_777), "Scuttling Sentinel")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Green, ManaSymbol::Blue],
+            vec![ManaSymbol::Green, ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Crab, Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Flash\nVigilance\nWhen this creature enters, put a +1/+1 counter on another target creature you control. Until end of turn, that creature becomes a blue Crab in addition to its other types and gains hexproof.",
+        )
+        .expect("Scuttling Sentinel should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn scuttling_sentinel_enter_trigger_buffs_only_another_creature_you_control_until_eot() {
+    struct ChooseSpecificCreatureDecisionMaker {
+        chosen: ObjectId,
+        seen_legal_targets: Vec<Target>,
+    }
+
+    impl DecisionMaker for ChooseSpecificCreatureDecisionMaker {
+        fn decide_targets(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<Target> {
+            self.seen_legal_targets = ctx
+                .requirements
+                .first()
+                .map(|requirement| requirement.legal_targets.clone())
+                .unwrap_or_default();
+            assert!(
+                self.seen_legal_targets.contains(&Target::Object(self.chosen)),
+                "the chosen creature should be a legal Scuttling Sentinel trigger target"
+            );
+            vec![Target::Object(self.chosen)]
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target_id = create_typed_creature(&mut game, "Alice's Elf", alice, vec![Subtype::Elf]);
+    let opponent_creature_id =
+        create_typed_creature(&mut game, "Bob's Elf", bob, vec![Subtype::Elf]);
+    let sentinel = scuttling_sentinel_definition();
+    let sentinel_id = game.create_object_from_definition(&sentinel, alice, Zone::Hand);
+    game.move_object_by_effect(sentinel_id, Zone::Battlefield)
+        .expect("Scuttling Sentinel should enter the battlefield");
+
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Scuttling Sentinel should trigger once when it enters"
+    );
+
+    let mut dm = ChooseSpecificCreatureDecisionMaker {
+        chosen: target_id,
+        seen_legal_targets: Vec::new(),
+    };
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Scuttling Sentinel trigger should go on the stack with a target");
+    assert!(
+        !dm.seen_legal_targets.contains(&Target::Object(sentinel_id)),
+        "Scuttling Sentinel should not be able to target itself"
+    );
+    assert!(
+        !dm.seen_legal_targets
+            .contains(&Target::Object(opponent_creature_id)),
+        "Scuttling Sentinel should not be able to target an opponent's creature"
+    );
+
+    resolve_stack_entry(&mut game).expect("Scuttling Sentinel trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(target_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "the chosen creature should get a +1/+1 counter"
+    );
+    assert_eq!(
+        game.counter_count(sentinel_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Scuttling Sentinel should not put its counter on itself"
+    );
+    assert_eq!(
+        game.counter_count(
+            opponent_creature_id,
+            crate::object::CounterType::PlusOnePlusOne
+        ),
+        0,
+        "opposing creatures should not receive Scuttling Sentinel's counter"
+    );
+    assert_eq!(
+        game.current_colors(target_id),
+        Some(crate::color::ColorSet::BLUE),
+        "the target should become blue until end of turn"
+    );
+    assert!(
+        game.current_has_subtype(target_id, Subtype::Elf)
+            && game.current_has_subtype(target_id, Subtype::Crab),
+        "the target should keep its existing type and gain Crab"
+    );
+    assert!(
+        game.object_has_static_ability_id(
+            target_id,
+            crate::static_abilities::StaticAbilityId::Hexproof
+        ),
+        "the target should gain hexproof until end of turn"
+    );
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.counter_count(target_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "the +1/+1 counter should remain after the turn ends"
+    );
+    assert!(
+        !game.current_has_subtype(target_id, Subtype::Crab)
+            && game.current_has_subtype(target_id, Subtype::Elf),
+        "the temporary Crab subtype should expire while the original type remains"
+    );
+    assert_ne!(
+        game.current_colors(target_id),
+        Some(crate::color::ColorSet::BLUE),
+        "the temporary blue color-setting effect should expire at end of turn"
+    );
+    assert!(
+        !game.object_has_static_ability_id(
+            target_id,
+            crate::static_abilities::StaticAbilityId::Hexproof
+        ),
+        "temporary hexproof should expire at end of turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn twenty_toed_toad_static_ability_sets_maximum_hand_size_to_twenty() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Scuttling Sentinel
Initial parse error:
```
unsupported become clause (clause: 'a blue crab in addition to its other types'); oracle-only fallback also failed: unsupported become clause (clause: 'a blue crab in addition to its other types')
```

Current worker: i-0bd0e2c27d797eaa1
Branch: codex/aws-card-fix-scuttling-sentinel
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0010
