### PR TITLE
Fix Ironsmith parse failure: Elemental Teachings

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/divvy.rs
@@ -1175,6 +1175,82 @@ pub(super) fn try_parse_divvy_sentence_sequence(
         return Ok(Some(effects));
     }
 
+    if first_sentence_has_prefix(
+        &sentence_words,
+        &[
+            "search",
+            "your",
+            "library",
+            "for",
+            "up",
+            "to",
+            "four",
+            "land",
+            "cards",
+            "with",
+            "different",
+            "names",
+            "and",
+            "reveal",
+            "them",
+        ],
+    ) && sentence_has_phrase(
+        &sentence_words,
+        &["an", "opponent", "chooses", "two", "of", "those", "cards"],
+    ) && sentence_has_phrase(
+        &sentence_words,
+        &["put", "the", "chosen", "cards", "into", "your", "graveyard"],
+    ) && sentence_has_phrase(
+        &sentence_words,
+        &["the", "rest", "onto", "the", "battlefield", "tapped"],
+    ) && sentence_has_phrase(&sentence_words, &["shuffle"])
+    {
+        let mut effects = parse_effect_sentence_lexed(sentences[0].lowered())?;
+        effects.push(EffectAst::subject_verb_tag_matching_objects(
+            ObjectFilter::tagged(TagKey::from(IT_TAG)),
+            vec![Zone::Library],
+            TagKey::from("divvy_source"),
+        ));
+        effects.push(EffectAst::ChooseObjectsAcrossZones {
+            filter: ObjectFilter::tagged(TagKey::from("divvy_source")),
+            count: ChoiceCount::exactly(2),
+            count_value: None,
+            player: PlayerAst::Opponent,
+            tag: TagKey::from("divvy_chosen"),
+            zones: vec![Zone::Library],
+            search_mode: None,
+        });
+        effects.push(EffectAst::subject_verb_move_to_zone(
+            TargetAst::Tagged(TagKey::from("divvy_chosen"), None),
+            Zone::Graveyard,
+            false,
+            ReturnControllerAst::Preserve,
+            false,
+            None,
+        ));
+        effects.push(EffectAst::ForEachTagged {
+            tag: TagKey::from("divvy_source"),
+            effects: vec![EffectAst::Conditional {
+                predicate: membership_predicate_for_iterated_object("divvy_chosen"),
+                if_true: Vec::new(),
+                if_false: vec![EffectAst::subject_verb_move_to_zone(
+                    TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                    Zone::Battlefield,
+                    false,
+                    ReturnControllerAst::Preserve,
+                    true,
+                    None,
+                )],
+            }],
+        });
+        effects.push(EffectAst::subject_verb(
+            SubjectVerbRoleAst::LibraryOwner,
+            PlayerAst::You,
+            SubjectVerbActionAst::ShuffleLibrary,
+        ));
+        return Ok(Some(effects));
+    }
+
     if sentence_has_phrase(&sentence_words, &["target", "opponent", "chooses", "one"])
         && sentence_has_phrase(
             &sentence_words,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36426,6 +36426,42 @@ fn parse_oracle_ecological_appreciation_divvy_surface_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_elemental_teachings_divvy_surface_regression() {
+    let def = parse_oracle_card_definition("Elemental Teachings");
+    let rendered = debug_compiled_lines(&def).join(" ");
+
+    assert_eq!(
+        rendered,
+        "Search your library for up to 4 land cards with different names and reveal them. An opponent chooses two of those cards. Put the chosen cards into your graveyard and the rest onto the battlefield tapped. Then shuffle.",
+        "expected Elemental Teachings to render its exact opponent-choice land divvy wording"
+    );
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("divvy_chosen")
+            && debug.contains("divvy_source")
+            && debug.contains("distinct_names: true")
+            && debug.contains("enters_tapped: true"),
+        "expected Elemental Teachings to preserve the tagged divvy bundle, distinct-name search, and tapped battlefield move, got {debug}"
+    );
+
+    let oracle = oracle_text_by_name()
+        .get("Elemental Teachings")
+        .expect("missing Elemental Teachings oracle text");
+    let rendered_lines = vec![rendered.clone()];
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_card_semantics_scored(
+            "Elemental Teachings",
+            oracle,
+            &rendered_lines,
+            crate::semantic_compare::report_embedding_config(),
+        );
+    assert!(similarity >= 0.99, "expected >=0.99 similarity, got {similarity}");
+    assert!(!mismatch, "expected no semantic mismatch, got {rendered}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_split_the_spoils_divvy_uses_splitter_then_opponent_choice() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Split the Spoils")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -9081,11 +9081,11 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         Some(zones)
     }
 
-    fn effect_moves_chosen_to_zone(effect: &Effect, chosen_tag: &str) -> Option<Zone> {
+    fn effect_moves_chosen_to_zone(effect: &Effect, chosen_tag: &str) -> Option<(Zone, bool)> {
         if let Some(move_to_zone) = downcast_move_to_zone(effect)
             && move_to_zone_uses_tag(move_to_zone, chosen_tag, move_to_zone.zone)
         {
-            return Some(move_to_zone.zone);
+            return Some((move_to_zone.zone, move_to_zone.enters_tapped));
         }
 
         let (_, for_each) = for_each_tagged_for_compaction(effect)?;
@@ -9093,7 +9093,8 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             return None;
         }
         let move_to_zone = downcast_move_to_zone(&for_each.effects[0])?;
-        matches!(move_to_zone.target, ChooseSpec::Iterated).then_some(move_to_zone.zone)
+        matches!(move_to_zone.target, ChooseSpec::Iterated)
+            .then_some((move_to_zone.zone, move_to_zone.enters_tapped))
     }
 
     fn effect_moves_unselected_to_zone(
@@ -9101,15 +9102,26 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         source_tag: &str,
         chosen_tag: &str,
     ) -> Option<Zone> {
+        effect_moves_unselected_to_zone_and_tapped(effect, source_tag, chosen_tag)
+            .map(|(zone, _)| zone)
+    }
+
+    fn effect_moves_unselected_to_zone_and_tapped(
+        effect: &Effect,
+        source_tag: &str,
+        chosen_tag: &str,
+    ) -> Option<(Zone, bool)> {
         let (_, for_each) = for_each_tagged_for_compaction(effect)?;
-        [
-            Zone::Hand,
-            Zone::Graveyard,
-            Zone::Library,
-            Zone::Battlefield,
-        ]
-        .into_iter()
-        .find(|zone| for_each_moves_unselected_to_zone(for_each, source_tag, chosen_tag, *zone))
+        let [effect] = for_each.effects.as_slice() else {
+            return None;
+        };
+        let conditional = effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        let [rest_move] = conditional.if_false.as_slice() else {
+            return None;
+        };
+        let move_to_zone = downcast_move_to_zone(rest_move)?;
+        for_each_moves_unselected_to_zone(for_each, source_tag, chosen_tag, move_to_zone.zone)
+            .then_some((move_to_zone.zone, move_to_zone.enters_tapped))
     }
 
     fn divvy_search_selection(search: &crate::effects::ChooseObjectsEffect) -> String {
@@ -9287,12 +9299,12 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         let first_chosen_zone = effect_moves_chosen_to_zone(first_move_effect, choose.tag.as_str());
         let second_chosen_zone =
             effect_moves_chosen_to_zone(second_move_effect, choose.tag.as_str());
-        let first_rest_zone = effect_moves_unselected_to_zone(
+        let first_rest_zone = effect_moves_unselected_to_zone_and_tapped(
             first_move_effect,
             tag_source.tag.as_str(),
             choose.tag.as_str(),
         );
-        let second_rest_zone = effect_moves_unselected_to_zone(
+        let second_rest_zone = effect_moves_unselected_to_zone_and_tapped(
             second_move_effect,
             tag_source.tag.as_str(),
             choose.tag.as_str(),
@@ -9317,12 +9329,13 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         }
 
         let searched_owner = describe_possessive_player_filter(&search.chooser);
-        let describe_searched_owner_zone = |zone: Zone| -> Option<String> {
+        let describe_searched_owner_zone = |zone: Zone, tapped: bool| -> Option<String> {
+            let tapped_suffix = if tapped { " tapped" } else { "" };
             match zone {
                 Zone::Hand => Some(format!("into {searched_owner} hand")),
                 Zone::Graveyard => Some(format!("into {searched_owner} graveyard")),
                 Zone::Library => Some(format!("into {searched_owner} library")),
-                Zone::Battlefield => Some("onto the battlefield".to_string()),
+                Zone::Battlefield => Some(format!("onto the battlefield{tapped_suffix}")),
                 _ => None,
             }
         };
@@ -9399,7 +9412,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         } else {
             "the rest"
         };
-        let rest_destination = describe_searched_owner_zone(rest_zone)?;
+        let (chosen_zone, chosen_tapped) = chosen_zone;
+        let (rest_zone, rest_tapped) = rest_zone;
+        let rest_destination = describe_searched_owner_zone(rest_zone, rest_tapped)?;
         let (move_line, shuffle_line) = if chosen_zone == Zone::Library {
             let shuffle_verb = if shuffle.player == PlayerFilter::You {
                 "Shuffle".to_string()
@@ -9414,7 +9429,7 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
                 None,
             )
         } else {
-            let selected_destination = describe_searched_owner_zone(chosen_zone)?;
+            let selected_destination = describe_searched_owner_zone(chosen_zone, chosen_tapped)?;
             let shuffle_line = if shuffle.player == PlayerFilter::You {
                 "Then shuffle".to_string()
             } else {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11100,6 +11100,146 @@ fn ecological_appreciation_puts_two_chosen_cards_back_and_recruits_the_rest() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn elemental_teachings_buries_two_opponent_chosen_lands_and_recruits_the_rest_tapped() {
+    struct ElementalTeachingsDecisionMaker {
+        caster: PlayerId,
+        opponent: PlayerId,
+    }
+
+    impl DecisionMaker for ElementalTeachingsDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            let legal = ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .collect::<Vec<_>>();
+
+            if ctx.player == self.caster {
+                assert_eq!(
+                    ctx.min, 0,
+                    "Elemental Teachings searches for up to four lands"
+                );
+                assert_eq!(
+                    ctx.max,
+                    Some(4),
+                    "Elemental Teachings searches for up to four lands"
+                );
+                assert!(
+                    legal
+                        .iter()
+                        .all(|candidate| game.object_has_card_type(candidate.id, CardType::Land)),
+                    "only land cards should be legal search choices"
+                );
+                return legal.into_iter().map(|candidate| candidate.id).collect();
+            }
+
+            assert_eq!(
+                ctx.player, self.opponent,
+                "the opponent should make the divvy choice"
+            );
+            assert_eq!(ctx.min, 2, "the opponent should choose exactly two cards");
+            assert_eq!(ctx.max, Some(2), "the opponent should choose exactly two cards");
+
+            ["Plains", "Island"]
+                .into_iter()
+                .map(|wanted_name| {
+                    legal
+                        .iter()
+                        .find(|candidate| {
+                            game.object(candidate.id)
+                                .is_some_and(|object| object.name == wanted_name)
+                        })
+                        .map(|candidate| candidate.id)
+                        .unwrap_or_else(|| panic!("expected to find {wanted_name} in the divvy"))
+                })
+                .collect()
+        }
+    }
+
+    fn test_land(name: &str) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Land])
+            .build()
+    }
+
+    fn test_creature(name: &str) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let text = "Search your library for up to four land cards with different names and reveal them. \
+        An opponent chooses two of those cards. Put the chosen cards into your graveyard and the \
+        rest onto the battlefield tapped, then shuffle.";
+
+    let elemental_teachings =
+        CardDefinitionBuilder::new(CardId::from_raw(91_002), "Elemental Teachings")
+            .card_types(vec![CardType::Instant])
+            .parse_text(text)
+            .expect("Elemental Teachings should parse");
+
+    let source_id = game.create_object_from_definition(&elemental_teachings, alice, Zone::Stack);
+    let _plains = game.create_object_from_card(&test_land("Plains"), alice, Zone::Library);
+    let _island = game.create_object_from_card(&test_land("Island"), alice, Zone::Library);
+    let _swamp = game.create_object_from_card(&test_land("Swamp"), alice, Zone::Library);
+    let _forest = game.create_object_from_card(&test_land("Forest"), alice, Zone::Library);
+    let _nonland =
+        game.create_object_from_card(&test_creature("Elvish Mystic"), alice, Zone::Library);
+
+    game.stack.push(StackEntry::new(source_id, alice));
+
+    let mut dm = ElementalTeachingsDecisionMaker {
+        caster: alice,
+        opponent: bob,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Elemental Teachings should resolve");
+
+    let zone_has_name = |ids: &[ObjectId], name: &str| {
+        ids.iter()
+            .any(|&id| game.object(id).is_some_and(|object| object.name == name))
+    };
+    let battlefield_id = |name: &str| {
+        game.battlefield
+            .iter()
+            .copied()
+            .find(|&id| game.object(id).is_some_and(|object| object.name == name))
+            .unwrap_or_else(|| panic!("expected {name} on the battlefield"))
+    };
+
+    assert!(
+        zone_has_name(&game.player(alice).expect("alice exists").graveyard, "Plains"),
+        "the first opponent-chosen land should go to the graveyard"
+    );
+    assert!(
+        zone_has_name(&game.player(alice).expect("alice exists").graveyard, "Island"),
+        "the second opponent-chosen land should go to the graveyard"
+    );
+    let swamp = battlefield_id("Swamp");
+    let forest = battlefield_id("Forest");
+    assert!(
+        game.is_tapped(swamp),
+        "the first unchosen land should enter tapped"
+    );
+    assert!(
+        game.is_tapped(forest),
+        "the second unchosen land should enter tapped"
+    );
+    assert!(
+        zone_has_name(&game.player(alice).expect("alice exists").library, "Elvish Mystic"),
+        "nonland cards should remain in the library"
+    );
+}
+
 // === Target Extraction Tests ===
 
 #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Elemental Teachings
Initial parse error:
```
could not find verb in effect clause (clause: 'an opponent chooses two of those cards'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'an opponent chooses two of those cards'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-07e11f542cdb362e3
Branch: codex/aws-card-fix-elemental-teachings
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0010
