### PR TITLE
Fix Ironsmith parse failure: The Eternity Elevator

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -2297,26 +2297,31 @@ fn parse_number_of_counters_on_source_value(filter_words: &[&str]) -> Option<Val
         return None;
     }
     idx += 1;
-    match filter_words.get(idx..) {
-        Some(["it"])
-        | Some(["this"])
-        | Some(["this", "card"])
-        | Some(["this", "creature"])
-        | Some(["this", "permanent"])
-        | Some(["this", "source"])
-        | Some(["this", "artifact"])
-        | Some(["this", "land"])
-        | Some(["this", "enchantment"])
-        | Some(["thiss"])
-        | Some(["thiss", "card"])
-        | Some(["thiss", "creature"])
-        | Some(["thiss", "permanent"])
-        | Some(["thiss", "source"])
-        | Some(["thiss", "artifact"])
-        | Some(["this", "equipment"])
-        | Some(["thiss", "land"])
-        | Some(["thiss", "enchantment"])
-        | Some(["thiss", "equipment"]) => Some(Value::CountersOnSource(counter_type)),
+    let source_words = filter_words.get(idx..)?;
+    if is_source_reference_words(source_words) {
+        return Some(Value::CountersOnSource(counter_type));
+    }
+
+    match source_words {
+        ["it"]
+        | ["this"]
+        | ["this", "card"]
+        | ["this", "creature"]
+        | ["this", "permanent"]
+        | ["this", "source"]
+        | ["this", "artifact"]
+        | ["this", "land"]
+        | ["this", "enchantment"]
+        | ["thiss"]
+        | ["thiss", "card"]
+        | ["thiss", "creature"]
+        | ["thiss", "permanent"]
+        | ["thiss", "source"]
+        | ["thiss", "artifact"]
+        | ["this", "equipment"]
+        | ["thiss", "land"]
+        | ["thiss", "enchantment"]
+        | ["thiss", "equipment"] => Some(Value::CountersOnSource(counter_type)),
         _ => None,
     }
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -830,6 +830,11 @@ fn apply_chosen_option_condition_to_activated(
         Some(existing) => crate::ConditionExpr::And(Box::new(existing), Box::new(condition)),
         None => condition,
     });
+    if let Some(threshold) = station_threshold_from_chosen_option_label(label) {
+        activated
+            .additional_restrictions
+            .push(format!("__ironsmith_station_threshold:{threshold}"));
+    }
 }
 
 fn rewrite_activated_display_text(line: &RewriteActivatedLine) -> Option<String> {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_sentence_grouping.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_sentence_grouping.rs
@@ -12,10 +12,7 @@ pub(crate) fn condition_for_chosen_option_label(label: &str) -> crate::Condition
             right: crate::effect::Value::Fixed(4),
         };
     }
-    if let Some(threshold) = label
-        .strip_prefix(STATION_THRESHOLD_CONDITION_PREFIX)
-        .and_then(|value| value.parse::<i32>().ok())
-    {
+    if let Some(threshold) = station_threshold_from_chosen_option_label(label) {
         return crate::ConditionExpr::ValueComparison {
             left: crate::effect::Value::CountersOnSource(crate::CounterType::Charge),
             operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
@@ -51,6 +48,12 @@ pub(crate) fn condition_for_chosen_option_label(label: &str) -> crate::Condition
         return crate::ConditionExpr::Or(Box::new(left_condition), Box::new(right_condition));
     }
     crate::ConditionExpr::SourceChosenOption(label.to_string())
+}
+
+pub(crate) fn station_threshold_from_chosen_option_label(label: &str) -> Option<i32> {
+    label
+        .strip_prefix(STATION_THRESHOLD_CONDITION_PREFIX)
+        .and_then(|value| value.parse::<i32>().ok())
 }
 
 fn color_from_label(label: &str) -> Option<crate::Color> {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37439,6 +37439,74 @@ fn parse_station_threshold_reminder_adds_creature_pt_support() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_the_eternity_elevator_station_threshold_mana_regression() {
+    assert_oracle_card_parses_strict("The Eternity Elevator");
+    let oracle = oracle_text_by_name()
+        .get("The Eternity Elevator")
+        .expect("missing oracle text for The Eternity Elevator")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "The Eternity Elevator")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Spacecraft])
+        .parse_text(oracle)
+        .expect("The Eternity Elevator should parse with its type line");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Station")
+            && rendered.contains(
+                "20+ | {T}: Add X mana of any one color, where X is the number of charge counters on The Eternity Elevator"
+            ),
+        "expected The Eternity Elevator to preserve station threshold mana text, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("Activate only if"),
+        "station threshold should render as a threshold prefix, got {rendered}"
+    );
+
+    let debug = format!("{def:?}");
+    assert!(
+        debug.contains("AddManaOfAnyOneColorEffect")
+            && debug.contains("CountersOnSource(Charge)")
+            && debug.contains("GreaterThanOrEqual")
+            && debug.contains("Fixed(20)"),
+        "expected threshold mana ability to count charge counters on source at 20+, got {debug}"
+    );
+}
+
+#[test]
+fn render_charge_counter_condition_does_not_imply_station_threshold() {
+    let mut mana_ability = Ability::mana(TotalCost::free(), vec![ManaSymbol::Green]);
+    let AbilityKind::Activated(activated) = &mut mana_ability.kind else {
+        panic!("mana ability should be activated");
+    };
+    activated.activation_condition = Some(Condition::ValueComparison {
+        left: Value::CountersOnSource(CounterType::Charge),
+        operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+        right: Value::Fixed(3),
+    });
+
+    let def = CardDefinitionBuilder::new(CardId::new(), "Charge Gate")
+        .card_types(vec![CardType::Artifact])
+        .with_ability(mana_ability)
+        .build();
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Activate only if")
+            && rendered.contains("charge counters")
+            && rendered.contains("greater than or equal to 3"),
+        "ordinary charge-counter activation conditions should render as activation conditions, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("3+ |"),
+        "only station threshold lines should render with a numeric threshold prefix, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_eldritch_evolution_sacrifice_scaled_where_x_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Eldritch Evolution")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1047,6 +1047,7 @@ pub(super) fn substitute_legendary_source_reference(
     let uses_named_source_surface = lower.starts_with("this creature gets ")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
+        || lower.contains(" counters on this artifact")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.starts_with("whenever this creature or another ")
         || lower.contains(": this creature gets ")
@@ -1064,7 +1065,9 @@ pub(super) fn substitute_legendary_source_reference(
         .replace("This creature", source_name)
         .replace("this creature", source_name)
         .replace("This land", source_name)
-        .replace("this land", source_name);
+        .replace("this land", source_name)
+        .replace("This artifact", source_name)
+        .replace("this artifact", source_name);
     let lower_source_name = source_name.to_ascii_lowercase();
     if lower_source_name != source_name {
         substituted.replace(&lower_source_name, source_name)
@@ -2476,6 +2479,11 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                 ability_idx += 1;
                 continue;
             }
+            if let Some(keyword) = describe_structural_station_keyword(ability) {
+                output.push(format!("Keyword ability {}: {keyword}", ability_idx + 1));
+                ability_idx += 1;
+                continue;
+            }
             if ability_idx + 1 < def.abilities.len()
                 && let Some(partner_with) =
                     describe_structural_partner_with_pair(ability, &def.abilities[ability_idx + 1])
@@ -2645,6 +2653,74 @@ fn ability_prefers_card_name_subject(ability: &Ability) -> bool {
     static_ability
         .enter_as_copy_as_enters()
         .is_some_and(|spec| spec.linked_exile_pair.is_some())
+}
+
+fn describe_structural_station_keyword(ability: &Ability) -> Option<&'static str> {
+    let AbilityKind::Activated(activated) = &ability.kind else {
+        return None;
+    };
+    if !matches!(activated.timing, ActivationTiming::SorcerySpeed)
+        || activated.activation_condition.is_some()
+        || !activated.choices.is_empty()
+        || !activated.mana_usage_restrictions.is_empty()
+    {
+        return None;
+    }
+    if !activated
+        .additional_restrictions
+        .iter()
+        .any(|restriction| restriction.eq_ignore_ascii_case("Activate only as a sorcery"))
+    {
+        return None;
+    }
+
+    let costs = activated.mana_cost.costs();
+    if !costs.iter().any(station_cost_chooses_tap_cost_creature)
+        || !costs.iter().any(station_cost_taps_chosen_creature)
+    {
+        return None;
+    }
+
+    let [effect] = activated.effects.flattened_default_effects() else {
+        return None;
+    };
+    let put = effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.counter_type != crate::CounterType::Charge
+        || !matches!(put.target.unhinted(), ChooseSpec::Source)
+    {
+        return None;
+    }
+    let Value::PowerOf(source) = put.amount.unhinted() else {
+        return None;
+    };
+    match source.unhinted() {
+        ChooseSpec::Tagged(tag) if tag.as_str() == "tap_cost_0" => Some("Station"),
+        _ => None,
+    }
+}
+
+fn station_cost_chooses_tap_cost_creature(cost: &crate::costs::Cost) -> bool {
+    let Some(effect) = cost.effect_ref() else {
+        return false;
+    };
+    let Some(choose) = effect.downcast_ref::<crate::effects::ChooseObjectsEffect>() else {
+        return false;
+    };
+    choose.tag.as_str() == "tap_cost_0"
+        && choose.filter.controller == Some(PlayerFilter::You)
+        && choose.filter.card_types.contains(&CardType::Creature)
+        && choose.filter.other
+        && choose.filter.untapped
+}
+
+fn station_cost_taps_chosen_creature(cost: &crate::costs::Cost) -> bool {
+    let Some(effect) = cost.effect_ref() else {
+        return false;
+    };
+    let Some(tap) = effect.downcast_ref::<crate::effects::TapEffect>() else {
+        return false;
+    };
+    matches!(tap.target.unhinted(), ChooseSpec::Tagged(tag) if tag.as_str() == "tap_cost_0")
 }
 
 fn rewrite_additional_sacrifice_reference_surface(def: &CardDefinition, text: &str) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -88,6 +88,7 @@ pub(super) fn is_keyword_phrase(phrase: &str) -> bool {
             | "provoke"
             | "riot"
             | "training"
+            | "station"
             | "persist"
             | "undying"
             | "partner"

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -15,6 +15,48 @@ fn value_prefers_equal_to(value: &Value) -> bool {
     value_has_surface_hint(value, ValueSurfaceHint::EqualTo)
 }
 
+const STATION_THRESHOLD_RESTRICTION_PREFIX: &str = "__ironsmith_station_threshold:";
+
+fn station_threshold_prefix(activated: &crate::ability::ActivatedAbility) -> Option<String> {
+    let threshold = activated
+        .additional_restrictions
+        .iter()
+        .find_map(|restriction| {
+            restriction
+                .strip_prefix(STATION_THRESHOLD_RESTRICTION_PREFIX)
+                .and_then(|value| value.parse::<i32>().ok())
+        })?;
+    let crate::effect::Condition::ValueComparison {
+        left,
+        operator,
+        right,
+    } = activated.activation_condition.as_ref()?
+    else {
+        return None;
+    };
+    if !matches!(left, Value::CountersOnSource(crate::CounterType::Charge))
+        || !matches!(operator, crate::effect::ValueComparisonOperator::GreaterThanOrEqual)
+    {
+        return None;
+    }
+    let Value::Fixed(condition_threshold) = right else {
+        return None;
+    };
+    if threshold != *condition_threshold {
+        return None;
+    }
+    Some(format!("{threshold}+"))
+}
+
+fn prefix_rendered_ability_body(line: String, prefix: &str) -> String {
+    if let Some((heading, body)) = line.split_once(": ")
+        && is_render_heading_prefix(heading)
+    {
+        return format!("{heading}: {prefix}{body}");
+    }
+    format!("{prefix}{line}")
+}
+
 fn describe_pay_any_energy_amount(
     pay_any_energy: &crate::effects::PayAnyEnergyEffect,
 ) -> Option<&'static str> {
@@ -15199,7 +15241,9 @@ pub(super) fn describe_inline_ability_with_self_subject(
                 }
                 line.push_str(&payload);
             }
-            if let Some(condition) = &activated.activation_condition {
+            if let Some(prefix) = station_threshold_prefix(activated) {
+                line = prefix_rendered_ability_body(line, &format!("{prefix} | "));
+            } else if let Some(condition) = &activated.activation_condition {
                 let clause = describe_mana_activation_condition(condition);
                 if !clause.is_empty() {
                     if !line.is_empty() {
@@ -35244,6 +35288,9 @@ pub(super) fn collect_activation_restriction_clauses(
         if raw.starts_with("__ironsmith_class_level:") {
             continue;
         }
+        if raw.starts_with(STATION_THRESHOLD_RESTRICTION_PREFIX) {
+            continue;
+        }
         if raw
             .to_ascii_lowercase()
             .contains("exhaust ability only once")
@@ -38285,7 +38332,9 @@ pub(super) fn describe_ability(
                 }
                 line.push_str(&effects);
             }
-            if let Some(condition) = &activated.activation_condition {
+            if let Some(prefix) = station_threshold_prefix(activated) {
+                line = prefix_rendered_ability_body(line, &format!("{prefix} | "));
+            } else if let Some(condition) = &activated.activation_condition {
                 let clause = describe_mana_activation_condition(condition);
                 if !clause.is_empty() {
                     line.push_str(". ");

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39,6 +39,189 @@ fn setup_three_player_game() -> GameState {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn the_eternity_elevator_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(645_444), "The Eternity Elevator")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Spacecraft])
+        .parse_text(
+            "{T}: Add {C}{C}{C}.\n\
+             Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery.)\n\
+             20+ | {T}: Add X mana of any one color, where X is the number of charge counters on The Eternity Elevator.",
+        )
+        .expect("The Eternity Elevator should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn the_eternity_elevator_threshold_ability_index(def: &crate::cards::CardDefinition) -> usize {
+    def.abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::AddManaOfAnyOneColorEffect>()
+                        .is_some()
+                }),
+            _ => false,
+        })
+        .expect("The Eternity Elevator should have a threshold any-one-color mana ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_eternity_elevator_threshold_mana_requires_twenty_charge_counters() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let elevator = the_eternity_elevator_definition();
+    let elevator_id = game.create_object_from_definition(&elevator, alice, Zone::Battlefield);
+    let threshold_ability_index = game
+        .object(elevator_id)
+        .expect("The Eternity Elevator should exist")
+        .abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::AddManaOfAnyOneColorEffect>()
+                        .is_some()
+                }),
+            _ => false,
+        })
+        .expect("The Eternity Elevator object should have threshold mana ability");
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateManaAbility { source, ability_index }
+                    if *source == elevator_id && *ability_index == threshold_ability_index
+            )),
+        "The Eternity Elevator's 20+ mana ability should be locked with no charge counters"
+    );
+
+    game.add_counters(elevator_id, crate::object::CounterType::Charge, 19)
+        .expect("charge counters should be addable to The Eternity Elevator");
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateManaAbility { source, ability_index }
+                    if *source == elevator_id && *ability_index == threshold_ability_index
+            )),
+        "The Eternity Elevator's 20+ mana ability should remain locked at 19 charge counters"
+    );
+
+    game.add_counters(elevator_id, crate::object::CounterType::Charge, 1)
+        .expect("the twentieth charge counter should be addable");
+    assert!(
+        crate::decision::compute_legal_actions(&game, alice)
+            .iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateManaAbility { source, ability_index }
+                    if *source == elevator_id && *ability_index == threshold_ability_index
+            )),
+        "The Eternity Elevator's 20+ mana ability should unlock at 20 charge counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_eternity_elevator_threshold_mana_counts_current_charge_counters() {
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let elevator = the_eternity_elevator_definition();
+    let threshold_ability_index = the_eternity_elevator_threshold_ability_index(&elevator);
+    let elevator_id = game.create_object_from_definition(&elevator, alice, Zone::Battlefield);
+    game.add_counters(elevator_id, crate::object::CounterType::Charge, 23)
+        .expect("charge counters should be addable to The Eternity Elevator");
+
+    let ability = match &elevator.abilities[threshold_ability_index].kind {
+        AbilityKind::Activated(activated) => activated,
+        _ => panic!("threshold ability should be activated"),
+    };
+    let [effect] = ability.effects.flattened_default_effects() else {
+        panic!("threshold ability should have one mana effect");
+    };
+    let mut ctx = ExecutionContext::new_default(elevator_id, alice);
+    execute_effect(&mut game, effect, &mut ctx)
+        .expect("The Eternity Elevator threshold mana ability should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").mana_pool.green,
+        23,
+        "The Eternity Elevator should add X mana of one color where X is its charge counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_eternity_elevator_station_adds_charge_counters_equal_to_tapped_creature_power() {
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let elevator = the_eternity_elevator_definition();
+    let elevator_id = game.create_object_from_definition(&elevator, alice, Zone::Battlefield);
+    let creature = CardBuilder::new(CardId::new(), "Station Helper")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Construct])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let creature_id = game.create_object_from_card(&creature, alice, Zone::Battlefield);
+
+    let station_ability = elevator
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.effects.flattened_default_effects().iter().any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::PutCountersEffect>()
+                        .is_some_and(|put| put.counter_type == crate::object::CounterType::Charge)
+                }) => Some(activated),
+            _ => None,
+        })
+        .expect("The Eternity Elevator should have a station ability");
+    let [effect] = station_ability.effects.flattened_default_effects() else {
+        panic!("station ability should have one counter effect");
+    };
+
+    let creature_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(creature_id).expect("station helper exists"),
+        &game,
+    );
+    let mut ctx = ExecutionContext::new_default(elevator_id, alice);
+    ctx.tag_object("tap_cost_0", creature_snapshot);
+    execute_effect(&mut game, effect, &mut ctx)
+        .expect("The Eternity Elevator station ability should put counters on the source");
+
+    assert_eq!(
+        game.counter_count(elevator_id, crate::object::CounterType::Charge),
+        4,
+        "Station should put charge counters equal to the tapped creature's power on The Eternity Elevator"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn rampaging_aetherhood_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(74_200), "Rampaging Aetherhood")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The Eternity Elevator
Initial parse error:
```
unsupported where-x clause (clause: 'add x mana of any one color where x is the number of charge counters on the eternity elevator'); oracle-only fallback also failed: unsupported where-x clause (clause: 'add x mana of any one color where x is the number of charge counters on the eternity elevator')
```

Current worker: i-0f7855036b0f364c5
Branch: codex/aws-card-fix-the-eternity-elevator
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0010
