### PR TITLE
Fix Ironsmith parse failure: Betor, Kin to All

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1995,6 +1995,45 @@ fn parse_counted_objects_have_counter_predicate(words: &[&str]) -> Option<Predic
     })
 }
 
+fn parse_objects_have_total_metric_predicate(words: &[&str]) -> Option<PredicateAst> {
+    let have_idx = find_index(words, |word| HAS_OR_HAVE_WORD_PATTERN.matches_word(word))?;
+    if have_idx == 0 || words.len() < have_idx + 5 {
+        return None;
+    }
+
+    let tail = &words[have_idx + 1..];
+    if tail.first().copied() != Some("total") {
+        return None;
+    }
+    let metric = *tail.get(1)?;
+    if !POWER_OR_TOUGHNESS_WORD_PATTERN.matches_word(metric) {
+        return None;
+    }
+    let (comparison, used) = predicate_quantity_prefix(&tail[2..])?;
+    if used != tail.len() - 2 {
+        return None;
+    }
+    let (operator, amount) = comparison_to_value_comparison_operator(comparison)?;
+
+    let object_words = &words[..have_idx];
+    let object_tokens = crate::runtime_backend::lexer::synthetic_word_tokens(object_words);
+    let other = object_tokens
+        .first()
+        .is_some_and(|token| OTHER_OR_ANOTHER_WORD_PATTERN.matches_token(token));
+    let filter = parse_object_filter(&object_tokens, other).ok()?;
+    let left = if POWER_WORD_PATTERN.matches_word(metric) {
+        Value::TotalPower(filter)
+    } else {
+        Value::TotalToughness(filter)
+    };
+
+    Some(PredicateAst::ValueComparison {
+        left,
+        operator,
+        right: Value::Fixed(amount),
+    })
+}
+
 fn parse_happily_style_conjoined_predicate(words: &[&str]) -> Option<PredicateAst> {
     let cleaned = word_refs_except(words, &[","]);
     let words = cleaned.as_slice();
@@ -2833,6 +2872,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         && let Some(count) = comparison_to_at_least_threshold(&comparison)
     {
         return Ok(PredicateAst::SourcePowerAtLeast(count));
+    }
+
+    if let Some(predicate) = parse_objects_have_total_metric_predicate(&filtered) {
+        return Ok(predicate);
     }
 
     if filtered.len() >= 10 && THERE_ARE_PREFIX_PATTERN.matches_words(&filtered) {
@@ -4816,6 +4859,28 @@ mod tests {
         let parsed = parse_predicate(&predicate_tokens)?;
 
         assert_eq!(parsed, PredicateAst::SourcePowerAtLeast(7));
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_objects_you_control_have_total_toughness_or_greater()
+    -> Result<(), CardTextError> {
+        let tokens = lex_line(
+            "If creatures you control have total toughness 10 or greater",
+            0,
+        )?;
+        let predicate_tokens = predicate_tokens_after_if(&tokens);
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::ValueComparison {
+                left: Value::TotalToughness(ObjectFilter::creature().you_control()),
+                operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                right: Value::Fixed(10),
+            }
+        );
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -1093,7 +1093,20 @@ fn parse_half_life_value(tokens: &[OwnedLexToken], player: PlayerAst) -> Option<
         return None;
     }
 
-    let player_filter = player_filter_for_life_reference(player)?;
+    let referenced_player = if clause_words
+        .iter()
+        .any(|word| matches!(*word, "their" | "theirs"))
+        || clause_words
+            .windows(2)
+            .any(|words| matches!(words, ["that", "player"] | ["that", "players"]))
+    {
+        PlayerAst::That
+    } else if clause_words.iter().any(|word| matches!(*word, "your")) {
+        PlayerAst::You
+    } else {
+        player
+    };
+    let player_filter = player_filter_for_life_reference(referenced_player)?;
     let rounded_down = ROUNDED_DOWN_MARKER_PATTERN.matches_words(&clause_words);
     if rounded_down {
         Some(Value::HalfLifeTotalRoundedDown(player_filter))

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33462,6 +33462,37 @@ fn parse_then_if_conditional_sentence_is_preserved() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_betor_kin_to_all_total_toughness_threshold_chain() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(353_001), "Betor, Kin to All")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 7))
+        .parse_text(
+            "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
+        )
+        .expect("Betor, Kin to All should parse strict oracle text");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        !rendered.contains("unsupported predicate") && !rendered.contains("unsupported effect"),
+        "Betor, Kin to All should compile without unsupported output, got {rendered}"
+    );
+    assert!(
+        rendered.contains("if creatures you control have total toughness 10 or greater")
+            && rendered.contains("then if creatures you control have total toughness 20 or greater")
+            && rendered.contains("then if creatures you control have total toughness 40 or greater"),
+        "expected all total-toughness threshold clauses, got {rendered}"
+    );
+    assert!(
+        rendered.contains("untap each creature you control")
+            && rendered.contains("each opponent loses half their life, rounded up"),
+        "expected Betor's threshold effects in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_additional_cost_and_trigger_when_on_same_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Additional Cost Split Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12205,6 +12205,21 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 return format!("{subject} drawn {count_text} or more cards this turn");
             }
             if let (
+                Value::TotalPower(filter) | Value::TotalToughness(filter),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                Value::Fixed(count),
+            ) = (left, operator, right)
+                && *count >= 0
+            {
+                let subject = describe_count_filter_value_subject(filter);
+                let metric = if matches!(left, Value::TotalPower(_)) {
+                    "power"
+                } else {
+                    "toughness"
+                };
+                return format!("{subject} have total {metric} {count} or greater");
+            }
+            if let (
                 Value::Count(filter),
                 crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
                 Value::Fixed(count),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2136,10 +2136,16 @@ fn describe_for_players_simple_iterated_action(
             ChooseSpec::Player(PlayerFilter::IteratedPlayer)
         )
     {
+        let amount = describe_half_life_amount_for_same_player(
+            &lose.amount,
+            &PlayerFilter::IteratedPlayer,
+        )
+        .map(str::to_string)
+        .unwrap_or_else(|| describe_life_amount_phrase(&lose.amount));
         return Some(format!(
             "{subject} {} {}",
             verb("lose", "loses"),
-            describe_life_amount_phrase(&lose.amount)
+            amount
         ));
     }
     if let Some(gain) = effect.downcast_ref::<crate::effects::GainLifeEffect>()
@@ -21305,6 +21311,24 @@ fn singularize_for_each_basis(basis: &str) -> String {
     basis.to_string()
 }
 
+fn singularize_each_target(target: &str) -> String {
+    let mut words = target.split_whitespace().collect::<Vec<_>>();
+    for word in &mut words {
+        *word = match *word {
+            "artifacts" => "artifact",
+            "cards" => "card",
+            "creatures" => "creature",
+            "enchantments" => "enchantment",
+            "lands" => "land",
+            "permanents" => "permanent",
+            "planeswalkers" => "planeswalker",
+            _ => continue,
+        };
+        break;
+    }
+    words.join(" ")
+}
+
 fn describe_tagged_creature_power_count_basis(spec: &ChooseSpec) -> Option<&'static str> {
     match spec.base() {
         ChooseSpec::Tagged(tag)
@@ -30542,7 +30566,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return format!("Tap {}", describe_choose_spec(&tap.target));
     }
     if let Some(untap) = effect.downcast_ref::<crate::effects::UntapEffect>() {
-        return format!("Untap {}", describe_choose_spec(&untap.target));
+        let target = describe_choose_spec(&untap.target);
+        if let Some(each_target) = target.strip_prefix("all ") {
+            return format!("Untap each {}", singularize_each_target(each_target));
+        }
+        return format!("Untap {target}");
     }
     if let Some(phase_out) = effect.downcast_ref::<crate::effects::PhaseOutEffect>() {
         if let ChooseSpec::All(filter) = phase_out.spec.base()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -9655,6 +9655,190 @@ fn cloud_ex_soldier_attack_trigger_skips_treasures_below_power_7() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn betor_kin_to_all_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(353_010), "Betor, Kin to All")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit, Subtype::Dragon])
+        .power_toughness(PowerToughness::fixed(5, 7))
+        .parse_text(
+            "Flying\nAt the beginning of your end step, if creatures you control have total toughness 10 or greater, draw a card. Then if creatures you control have total toughness 20 or greater, untap each creature you control. Then if creatures you control have total toughness 40 or greater, each opponent loses half their life, rounded up.",
+        )
+        .expect("Betor, Kin to All should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn set_alice_end_step(game: &mut GameState) {
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_betor_draw_card(game: &mut GameState, card_id: u32) {
+    let alice = PlayerId::from_index(0);
+    let library_card = CardBuilder::new(CardId::from_raw(card_id), "Betor Draw Card")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&library_card, alice, Zone::Library);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn betor_kin_to_all_does_not_trigger_below_total_toughness_10() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+
+    game.create_object_from_definition(&betor_kin_to_all_definition(), alice, Zone::Battlefield);
+    create_creature(&mut game, "Small Kin", alice, 1, 2);
+
+    set_alice_end_step(&mut game);
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Betor should not trigger below total toughness 10"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn betor_kin_to_all_draws_only_at_total_toughness_10() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&betor_kin_to_all_definition(), alice, Zone::Battlefield);
+    let ally = create_creature(&mut game, "Ten Toughness Ally", alice, 1, 3);
+    game.tap(ally);
+    add_betor_draw_card(&mut game, 353_011);
+
+    let hand_before = game.player(alice).expect("Alice exists").hand.len();
+    let bob_life_before = game.player(bob).expect("Bob exists").life;
+    set_alice_end_step(&mut game);
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Betor should trigger at total toughness 10");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Betor end-step trigger should go on stack");
+    resolve_stack_entry(&mut game).expect("Betor trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        hand_before + 1,
+        "Betor should draw a card at total toughness 10"
+    );
+    assert!(
+        game.is_tapped(ally),
+        "Betor should not untap creatures below total toughness 20"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob exists").life,
+        bob_life_before,
+        "Betor should not make opponents lose life below total toughness 40"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn betor_kin_to_all_draws_and_untaps_at_total_toughness_20() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let betor = game.create_object_from_definition(
+        &betor_kin_to_all_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let ally = create_creature(&mut game, "Twenty Toughness Ally", alice, 1, 13);
+    game.tap(betor);
+    game.tap(ally);
+    add_betor_draw_card(&mut game, 353_012);
+
+    let hand_before = game.player(alice).expect("Alice exists").hand.len();
+    let bob_life_before = game.player(bob).expect("Bob exists").life;
+    set_alice_end_step(&mut game);
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Betor should trigger at total toughness 20");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Betor end-step trigger should go on stack");
+    resolve_stack_entry(&mut game).expect("Betor trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        hand_before + 1,
+        "Betor should draw a card at total toughness 20"
+    );
+    assert!(
+        !game.is_tapped(betor) && !game.is_tapped(ally),
+        "Betor should untap each creature you control at total toughness 20"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob exists").life,
+        bob_life_before,
+        "Betor should not make opponents lose life below total toughness 40"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn betor_kin_to_all_applies_all_thresholds_at_total_toughness_40() {
+    let mut game = setup_three_player_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let betor = game.create_object_from_definition(
+        &betor_kin_to_all_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let ally = create_creature(&mut game, "Forty Toughness Ally", alice, 1, 33);
+    game.tap(betor);
+    game.tap(ally);
+    add_betor_draw_card(&mut game, 353_013);
+
+    let hand_before = game.player(alice).expect("Alice exists").hand.len();
+    let alice_life_before = game.player(alice).expect("Alice exists").life;
+    set_alice_end_step(&mut game);
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Betor should trigger at total toughness 40");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Betor end-step trigger should go on stack");
+    resolve_stack_entry(&mut game).expect("Betor trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        hand_before + 1,
+        "Betor should draw a card at total toughness 40"
+    );
+    assert!(
+        !game.is_tapped(betor) && !game.is_tapped(ally),
+        "Betor should untap each creature you control at total toughness 40"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob exists").life,
+        10,
+        "Betor should make each opponent lose half their life, rounded up"
+    );
+    assert_eq!(
+        game.player(charlie).expect("Charlie exists").life,
+        10,
+        "Betor should affect every opponent"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        alice_life_before,
+        "Betor should not make its controller lose life"
+    );
+}
+
 fn bridge_from_below_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(472), "Bridge from Below")
         .card_types(vec![CardType::Enchantment])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Betor, Kin to All
Initial parse error:
```
unsupported predicate (predicate: 'creatures you control have total toughness 10 or greater'); oracle-only fallback also failed: unsupported predicate (predicate: 'creatures you control have total toughness 10 or greater')
```

Current worker: i-0bebd215d76703229
Branch: codex/aws-card-fix-betor-kin-to-all
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0011
