### PR TITLE
Fix Ironsmith parse failure: Mycosynth Fiend

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -375,6 +375,19 @@ const ANTHEM_OPPONENT_HAS_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["an", "opponent", "has"], &["opponent", "has"]]);
 const ANTHEM_A_PLAYER_HAS_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["a", "player", "has"], &["player", "has"]]);
+const ANTHEM_PLAYER_COUNTER_OWNER_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["you", "have"],
+            &["an", "opponent", "has"],
+            &["opponent", "has"],
+            &["opponents", "have"],
+            &["your", "opponents", "have"],
+            &["a", "player", "has"],
+            &["player", "has"],
+            &["players", "have"],
+        ]
+);
 const ANTHEM_FOR_EACH_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["for", "each"]);
 const ANTHEM_AFFECTED_ATTACKED_THIS_TURN_PATTERN: ClauseShape<'static> =
@@ -3617,6 +3630,9 @@ pub(crate) fn parse_anthem_for_each_expression(
         && let Some(counter_type) = parse_counter_type_word(rest_words[counter_word_idx - 1])
     {
         let tail_words = &rest_words[counter_word_idx + 1..];
+        if let Some(player) = parse_player_counter_owner_tail(tail_words) {
+            return Ok(AnthemCountExpression::PlayerCounters(player, counter_type));
+        }
         if ON_SOURCE_COUNTER_TAIL_PATTERN.matches_words(tail_words) {
             return Ok(AnthemCountExpression::CountersOnSource(counter_type));
         }
@@ -3629,6 +3645,23 @@ pub(crate) fn parse_anthem_for_each_expression(
         ))
     })?;
     Ok(AnthemCountExpression::MatchingFilter(filter))
+}
+
+fn parse_player_counter_owner_tail(words: &[&str]) -> Option<PlayerFilter> {
+    if !ANTHEM_PLAYER_COUNTER_OWNER_TAIL_PATTERN.matches_words(words) {
+        return None;
+    }
+    match words {
+        ["you", "have"] => Some(PlayerFilter::You),
+        ["an", "opponent", "has"]
+        | ["opponent", "has"]
+        | ["opponents", "have"]
+        | ["your", "opponents", "have"] => Some(PlayerFilter::Opponent),
+        ["a", "player", "has"] | ["player", "has"] | ["players", "have"] => {
+            Some(PlayerFilter::Any)
+        }
+        _ => None,
+    }
 }
 
 fn parse_compound_anthem_count_filter(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2317,6 +2317,7 @@ pub(crate) fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "depletion" => Some(CounterType::Depletion),
         "storage" => Some(CounterType::Storage),
         "ki" => Some(CounterType::Ki),
+        "poison" => Some(CounterType::Poison),
         "energy" => Some(CounterType::Energy),
         "age" => Some(CounterType::Age),
         "blood" => Some(CounterType::Blood),

--- a/crates/ironsmith-core/src/anthem_model.rs
+++ b/crates/ironsmith-core/src/anthem_model.rs
@@ -8,6 +8,7 @@ pub enum AnthemCountExpression {
     AttachedToAffected(ObjectFilter),
     AffectedAttackedThisTurn,
     CountersOnSource(CounterType),
+    PlayerCounters(PlayerFilter, CounterType),
     CountersAmong(ObjectFilter, CounterType),
     BasicLandTypesAmong(ObjectFilter),
     CreatureTypesAmong(ObjectFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46377,6 +46377,16 @@ fn mycosynth_fiend_runtime_counts_only_opponents_poison_counters() {
         (Some(7), Some(7)),
         "Mycosynth Fiend should count only opponents' poison counters, not its controller's"
     );
+
+    game.set_current_controller(fiend, PlayerId::from_index(1));
+    let controlled_chars = game
+        .calculated_characteristics(fiend)
+        .expect("Mycosynth Fiend should update after control changes");
+    assert_eq!(
+        (controlled_chars.power, controlled_chars.toughness),
+        (Some(8), Some(8)),
+        "Mycosynth Fiend should count opponents relative to its current controller"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -46319,6 +46319,66 @@ fn exuberant_fuseling_compiled_text_keeps_oil_counter_scaling_clause() {
     );
 }
 
+#[test]
+fn mycosynth_fiend_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Mycosynth Fiend");
+    let def = parse_oracle_card_definition("Mycosynth Fiend");
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("PlayerCounters") && debug.contains("Opponent") && debug.contains("Poison"),
+        "expected Mycosynth Fiend to lower to opponent poison-counter scaling, got {debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("this creature gets +1/+1 for each poison counter your opponents have"),
+        "expected Mycosynth Fiend compiled text to preserve opponent poison-counter scaling, got {rendered}"
+    );
+}
+
+#[test]
+fn mycosynth_fiend_runtime_counts_only_opponents_poison_counters() {
+    let oracle = oracle_text_by_name()
+        .get("Mycosynth Fiend")
+        .expect("missing Mycosynth Fiend oracle text")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Mycosynth Fiend")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(oracle)
+        .expect("Mycosynth Fiend should parse with base characteristics");
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Cara".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let fiend = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let base_chars = game
+        .calculated_characteristics(fiend)
+        .expect("Mycosynth Fiend should have characteristics");
+    assert_eq!(
+        (base_chars.power, base_chars.toughness),
+        (Some(2), Some(2)),
+        "Mycosynth Fiend should be 2/2 while opponents have no poison counters"
+    );
+
+    game.players[0].poison_counters = 4;
+    game.players[1].poison_counters = 3;
+    game.players[2].poison_counters = 2;
+    let poisoned_chars = game
+        .calculated_characteristics(fiend)
+        .expect("Mycosynth Fiend should still have characteristics");
+    assert_eq!(
+        (poisoned_chars.power, poisoned_chars.toughness),
+        (Some(7), Some(7)),
+        "Mycosynth Fiend should count only opponents' poison counters, not its controller's"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn exuberant_fuseling_trigger_adds_oil_counter_for_etb_and_other_controlled_death_only() {

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -660,6 +660,11 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
         AnthemCountExpression::CountersOnSource(counter_type) => {
             format!("{} counter on this permanent", counter_type.description())
         }
+        AnthemCountExpression::PlayerCounters(player, counter_type) => format!(
+            "{} counter {} have",
+            counter_type.description(),
+            anthem_player_counter_subject(player),
+        ),
         AnthemCountExpression::CountersAmong(filter, counter_type) => format!(
             "{} counter among {}",
             counter_type.description(),
@@ -761,6 +766,11 @@ fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Op
         AnthemCountExpression::CountersOnSource(counter_type) => {
             Some(format!("{} counter on it", counter_type.description()))
         }
+        AnthemCountExpression::PlayerCounters(player, counter_type) => Some(format!(
+            "{} counter {} have",
+            counter_type.description(),
+            anthem_player_counter_subject(player),
+        )),
         AnthemCountExpression::CountersAmong(filter, counter_type) => Some(format!(
             "{} counter among {}",
             counter_type.description(),
@@ -819,6 +829,27 @@ fn mana_symbol_word(symbol: crate::mana::ManaSymbol) -> &'static str {
         crate::mana::ManaSymbol::Green => "green",
         crate::mana::ManaSymbol::Colorless => "colorless",
         _ => "mana",
+    }
+}
+
+fn anthem_player_counter_subject(player: &PlayerFilter) -> String {
+    match player {
+        PlayerFilter::You => "you".to_string(),
+        PlayerFilter::Opponent => "your opponents".to_string(),
+        PlayerFilter::Any => "players".to_string(),
+        other => other.description(),
+    }
+}
+
+fn player_counter_count(game: &GameState, player: PlayerId, counter_type: CounterType) -> u32 {
+    let Some(player) = game.player(player) else {
+        return 0;
+    };
+    match counter_type {
+        CounterType::Poison => player.poison_counters,
+        CounterType::Energy => player.energy_counters,
+        CounterType::Experience => player.experience_counters,
+        _ => 0,
     }
 }
 
@@ -1550,6 +1581,20 @@ pub(crate) fn resolve_anthem_count_expression(
         AnthemCountExpression::CountersOnSource(counter_type) => {
             game.counter_count(source, *counter_type) as i32
         }
+        AnthemCountExpression::PlayerCounters(player_filter, counter_type) => game
+            .players
+            .iter()
+            .filter(|player| {
+                player.is_in_game()
+                    && crate::filter::player_filter_matches_game(
+                        player_filter,
+                        player.id,
+                        game,
+                        &filter_ctx,
+                    )
+            })
+            .map(|player| player_counter_count(game, player.id, *counter_type) as i32)
+            .sum(),
         AnthemCountExpression::CountersAmong(filter, counter_type) => all_game_object_ids(game)
             .into_iter()
             .filter_map(|id| game.object(id))


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mycosynth Fiend
Initial parse error:
```
unsupported 'for each' filter in anthem clause (clause: 'for each poison counter your opponents have'); oracle-only fallback also failed: unsupported 'for each' filter in anthem clause (clause: 'for each poison counter your opponents have')
```

Current worker: i-035bbf034d374f0b0
Branch: codex/aws-card-fix-mycosynth-fiend
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0012
