### PR TITLE
Fix Ironsmith parse failure: Predict

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -398,6 +398,9 @@ pub(crate) fn parse_you_choose_objects_clause(
             clause_words.join(" ")
         )));
     }
+    if choose_words.ends_with(&["card", "name"]) {
+        return Ok(None);
+    }
     if OF_TAGGED_CHOICE_PATTERN.matches_words(&choose_words) {
         references_it = true;
         references_container_it = true;

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -118,6 +118,7 @@ const MORE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["more"]);
 const OTHER_OR_ANOTHER_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["another"], &["other"]]);
 const OR_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["or"]);
+const CHOSEN_NAME_TAG: &str = "__chosen_name__";
 const PUT_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["put"]);
 const YOU_REVEALED_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["you", "revealed"]);
@@ -1623,6 +1624,13 @@ fn parse_color_only_object_filter_words(words: &[&str]) -> Option<ObjectFilter> 
 }
 
 fn parse_this_way_object_filter_words(words: &[&str]) -> Option<ObjectFilter> {
+    let (words, needs_chosen_name) = if let Some(base_words) =
+        crate::runtime_backend::lexer::word_slice_strip_suffix(words, &["with", "chosen", "name"])
+    {
+        (base_words, true)
+    } else {
+        (words, false)
+    };
     let has_card_noun = words
         .last()
         .is_some_and(|word| CARD_OR_CARDS_WORD_PATTERN.matches_word(word));
@@ -1641,18 +1649,37 @@ fn parse_this_way_object_filter_words(words: &[&str]) -> Option<ObjectFilter> {
     ];
     for (candidate, stripped_card_noun) in candidates {
         if candidate.is_empty() {
-            return Some(ObjectFilter::default());
+            let mut filter = ObjectFilter::default();
+            if needs_chosen_name {
+                filter.tagged_constraints.push(TaggedObjectConstraint {
+                    tag: TagKey::from(CHOSEN_NAME_TAG),
+                    relation: TaggedOpbjectRelation::SameNameAsTagged,
+                });
+            }
+            return Some(filter);
         }
         let tokens = predicate_tokens_from_words(candidate);
         if let Ok(mut filter) = parse_object_filter(&tokens, false) {
             if stripped_card_noun {
                 filter.zone = None;
             }
+            if needs_chosen_name {
+                filter.tagged_constraints.push(TaggedObjectConstraint {
+                    tag: TagKey::from(CHOSEN_NAME_TAG),
+                    relation: TaggedOpbjectRelation::SameNameAsTagged,
+                });
+            }
             return Some(filter);
         }
         if let Some(mut filter) = parse_color_only_object_filter_words(candidate) {
             if stripped_card_noun {
                 filter.zone = None;
+            }
+            if needs_chosen_name {
+                filter.tagged_constraints.push(TaggedObjectConstraint {
+                    tag: TagKey::from(CHOSEN_NAME_TAG),
+                    relation: TaggedOpbjectRelation::SameNameAsTagged,
+                });
             }
             return Some(filter);
         }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -25993,6 +25993,116 @@ fn parse_choose_card_name_then_draw_for_each_card_exiled_from_hand_this_way() {
     );
 }
 
+#[test]
+fn parse_predict_oracle_strict_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Predict");
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Choose a card name, then target player mills a card")
+            && rendered.contains("If a card with the chosen name was milled this way")
+            && rendered.contains("Otherwise, draw a card"),
+        "expected Predict compiled text to preserve choose-name mill condition, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("ChooseCardNameEffect")
+            && debug.contains("MillEffect")
+            && debug.contains("ConditionalEffect")
+            && debug.contains("SameNameAsTagged"),
+        "expected Predict to lower to choose-name, tagged mill, and same-name condition, got {debug}"
+    );
+}
+
+#[test]
+fn predict_draws_two_when_milled_card_has_chosen_name() {
+    let (alice_hand, bob_graveyard) = execute_predict_with_top_card("Brainstorm", "Brainstorm");
+
+    assert_eq!(
+        alice_hand, 2,
+        "Predict should draw two when the milled card has the chosen name"
+    );
+    assert_eq!(
+        bob_graveyard,
+        vec!["Brainstorm".to_string()],
+        "Predict should mill the target player's top card"
+    );
+}
+
+#[test]
+fn predict_draws_one_when_milled_card_has_different_name() {
+    let (alice_hand, bob_graveyard) = execute_predict_with_top_card("Brainstorm", "Opt");
+
+    assert_eq!(
+        alice_hand, 1,
+        "Predict should draw one when the milled card does not have the chosen name"
+    );
+    assert_eq!(
+        bob_graveyard,
+        vec!["Opt".to_string()],
+        "Predict should still mill the target player's top card"
+    );
+}
+
+fn execute_predict_with_top_card(chosen_name: &str, top_card_name: &str) -> (usize, Vec<String>) {
+    struct PredictDecisionMaker {
+        chosen_name: String,
+    }
+
+    impl crate::decision::DecisionMaker for PredictDecisionMaker {
+        fn decide_text(
+            &mut self,
+            _game: &crate::GameState,
+            _ctx: &crate::decisions::context::TextInputContext,
+        ) -> String {
+            self.chosen_name.clone()
+        }
+    }
+
+    fn simple_card(name: &str) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Instant])
+            .build()
+    }
+
+    let def = parse_oracle_card_definition("Predict");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    game.create_object_from_card(&simple_card("Alice Draw One"), alice, Zone::Library);
+    game.create_object_from_card(&simple_card("Alice Draw Two"), alice, Zone::Library);
+    game.create_object_from_card(&simple_card(top_card_name), bob, Zone::Library);
+
+    let mut dm = PredictDecisionMaker {
+        chosen_name: chosen_name.to_string(),
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        def.spell_effect.as_ref().expect("Predict spell effect"),
+        None,
+        &[],
+    )
+    .expect("Predict should resolve");
+
+    let alice_hand = game.player(alice).expect("Alice").hand.len();
+    let bob_graveyard = game
+        .player(bob)
+        .expect("Bob")
+        .graveyard
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect::<Vec<_>>();
+    (alice_hand, bob_graveyard)
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_destroy_then_search_target_opponent_library_preserves_destroy_clause() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3024,6 +3024,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_exile_then_free_cast_while_exiled_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
+        .or_else(|| describe_choose_name_target_mills_conditional_draw(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
 }
 
@@ -3546,6 +3547,65 @@ fn describe_choose_top_exile_then_play_structural(effects: &[Effect]) -> Option<
     Some(format!(
         "Exile the top card of your library. You may {verb} that card this turn"
     ))
+}
+
+fn describe_choose_name_target_mills_conditional_draw(effects: &[Effect]) -> Option<String> {
+    let [choose_effect, target_effect, mill_effect, conditional_effect] = effects else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseCardNameEffect>()?;
+    if choose.chooser != PlayerFilter::You || choose.filter.is_some() {
+        return None;
+    }
+    let target = target_effect.downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+    if target.target != ChooseSpec::target_player() {
+        return None;
+    }
+    let tagged_mill = mill_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let mill = tagged_mill
+        .effect
+        .downcast_ref::<crate::effects::MillEffect>()?;
+    if mill.count != Value::Fixed(1) || mill.player != PlayerFilter::target_player() {
+        return None;
+    }
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let crate::effect::Condition::TaggedObjectMatches(milled_tag, filter) = &conditional.condition
+    else {
+        return None;
+    };
+    if milled_tag != &tagged_mill.tag {
+        return None;
+    }
+    let mut expected_filter = ObjectFilter::default();
+    expected_filter
+        .tagged_constraints
+        .push(crate::filter::TaggedObjectConstraint {
+            tag: choose.tag.clone(),
+            relation: crate::filter::TaggedOpbjectRelation::SameNameAsTagged,
+        });
+    if filter != &expected_filter {
+        return None;
+    }
+    let [draw_two_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let [draw_one_effect] = conditional.if_false.as_slice() else {
+        return None;
+    };
+    let draw_two = draw_two_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    let draw_one = draw_one_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if draw_two.player != PlayerFilter::You
+        || draw_two.count != Value::Fixed(2)
+        || draw_one.player != PlayerFilter::You
+        || draw_one.count != Value::Fixed(1)
+    {
+        return None;
+    }
+
+    Some(
+        "Choose a card name, then target player mills a card. If a card with the chosen name was milled this way, draw two cards. Otherwise, draw a card"
+            .to_string(),
+    )
 }
 
 fn describe_exile_then_free_cast_while_exiled_structural(effects: &[Effect]) -> Option<String> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Predict
Initial parse error:
```
unsupported chosen object filter in choose clause (clause: 'choose a card name'); oracle-only fallback also failed: unsupported chosen object filter in choose clause (clause: 'choose a card name')
```

Current worker: i-0a217263bd91fca6c
Branch: codex/aws-card-fix-predict
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0014
