### PR TITLE
Fix Ironsmith parse failure: Knight of New Alara

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -379,6 +379,15 @@ const ANTHEM_FOR_EACH_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["for", "each"]);
 const ANTHEM_AFFECTED_ATTACKED_THIS_TURN_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["time", "it", "has", "attacked", "this", "turn"]);
+const ANTHEM_AFFECTED_COLORS_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["of", "its", "colors"],
+            &["of", "their", "colors"],
+            &["color", "it", "is"],
+            &["colors", "it", "is"],
+        ]
+);
 const ANTHEM_WARD_PAY_LIFE_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["ward", "pay"]; suffix & ["life"]);
 const ANTHEM_BASIC_LAND_TYPES_AMONG_PREFIX_PATTERN: ClauseShape<'static> =
@@ -3556,6 +3565,10 @@ pub(crate) fn parse_anthem_for_each_expression(
     let rest_words = crate::runtime_backend::token_word_refs(rest);
     if ANTHEM_AFFECTED_ATTACKED_THIS_TURN_PATTERN.matches_words(&rest_words) {
         return Ok(AnthemCountExpression::AffectedAttackedThisTurn);
+    }
+
+    if ANTHEM_AFFECTED_COLORS_PATTERN.matches_words(&rest_words) {
+        return Ok(AnthemCountExpression::ColorsOfAffected);
     }
 
     if ANTHEM_BASIC_LAND_TYPES_AMONG_PREFIX_PATTERN.matches_words(&rest_words) {

--- a/crates/ironsmith-core/src/anthem_model.rs
+++ b/crates/ironsmith-core/src/anthem_model.rs
@@ -6,6 +6,7 @@ pub enum AnthemCountExpression {
     GreatestManaValueAmong(ObjectFilter),
     AttachedToSource(ObjectFilter),
     AttachedToAffected(ObjectFilter),
+    ColorsOfAffected,
     AffectedAttackedThisTurn,
     CountersOnSource(CounterType),
     CountersAmong(ObjectFilter, CounterType),
@@ -42,6 +43,7 @@ impl AnthemValue {
             self,
             Self::PerCount {
                 count: AnthemCountExpression::AttachedToAffected(_)
+                    | AnthemCountExpression::ColorsOfAffected
                     | AnthemCountExpression::AffectedAttackedThisTurn,
                 ..
             }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -421,6 +421,130 @@ fn king_darien_xlviii_anthem_buffs_only_your_other_creatures_runtime() {
 }
 
 #[test]
+fn knight_of_new_alara_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Knight of New Alara");
+    let def = parse_oracle_card_definition("Knight of New Alara");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered_lower.contains(
+            "other multicolored creatures you control get +1/+1 for each of its colors"
+        ),
+        "Knight of New Alara should render the affected-creature color-count anthem, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("ColorsOfAffected")
+            && !abilities_debug.contains("UnsupportedParserLine")
+            && !abilities_debug.contains("RuleFallbackText"),
+        "Knight of New Alara should structurally count each affected creature's colors, got {abilities_debug}"
+    );
+}
+
+#[test]
+fn knight_of_new_alara_counts_each_affected_creatures_colors_runtime() {
+    fn colored_creature_def(
+        name: &str,
+        colors: crate::color::ColorSet,
+        power: i32,
+        toughness: i32,
+    ) -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .color_indicator(colors)
+            .power_toughness(PowerToughness::fixed(power, toughness))
+            .build()
+    }
+
+    let knight_oracle = oracle_text_by_name()
+        .get("Knight of New Alara")
+        .expect("missing oracle text for Knight of New Alara")
+        .clone();
+    let knight = CardDefinitionBuilder::new(CardId::new(), "Knight of New Alara")
+        .card_types(vec![CardType::Creature])
+        .color_indicator(crate::color::ColorSet::GREEN.union(crate::color::ColorSet::WHITE))
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(knight_oracle)
+        .expect("Knight of New Alara should parse for runtime regression");
+    let two_color = colored_creature_def(
+        "Alice Two-Color Creature",
+        crate::color::ColorSet::WHITE.union(crate::color::ColorSet::BLUE),
+        2,
+        2,
+    );
+    let three_color = colored_creature_def(
+        "Alice Three-Color Creature",
+        crate::color::ColorSet::WHITE
+            .union(crate::color::ColorSet::BLUE)
+            .union(crate::color::ColorSet::BLACK),
+        1,
+        1,
+    );
+    let one_color = colored_creature_def(
+        "Alice One-Color Creature",
+        crate::color::ColorSet::GREEN,
+        2,
+        2,
+    );
+    let bob_two_color = colored_creature_def(
+        "Bob Two-Color Creature",
+        crate::color::ColorSet::RED.union(crate::color::ColorSet::GREEN),
+        2,
+        2,
+    );
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let knight_id = game.create_object_from_definition(&knight, alice, Zone::Battlefield);
+    let two_color_id = game.create_object_from_definition(&two_color, alice, Zone::Battlefield);
+    let three_color_id = game.create_object_from_definition(&three_color, alice, Zone::Battlefield);
+    let one_color_id = game.create_object_from_definition(&one_color, alice, Zone::Battlefield);
+    let bob_two_color_id =
+        game.create_object_from_definition(&bob_two_color, bob, Zone::Battlefield);
+
+    assert_eq!(
+        (
+            game.calculated_power(two_color_id),
+            game.calculated_toughness(two_color_id)
+        ),
+        (Some(4), Some(4)),
+        "a two-color creature Alice controls should get +2/+2"
+    );
+    assert_eq!(
+        (
+            game.calculated_power(three_color_id),
+            game.calculated_toughness(three_color_id)
+        ),
+        (Some(4), Some(4)),
+        "a three-color creature Alice controls should get +3/+3"
+    );
+    assert_eq!(
+        (
+            game.calculated_power(one_color_id),
+            game.calculated_toughness(one_color_id)
+        ),
+        (Some(2), Some(2)),
+        "a monocolored creature should not match the multicolored subject"
+    );
+    assert_eq!(
+        (
+            game.calculated_power(bob_two_color_id),
+            game.calculated_toughness(bob_two_color_id)
+        ),
+        (Some(2), Some(2)),
+        "an opponent's multicolored creature should not be affected"
+    );
+    assert_eq!(
+        (game.calculated_power(knight_id), game.calculated_toughness(knight_id)),
+        (Some(2), Some(2)),
+        "Knight of New Alara should not buff itself"
+    );
+}
+
+#[test]
 fn king_darien_xlviii_mana_ability_puts_counter_on_self_and_creates_soldier_runtime() {
     let def = parse_oracle_card_definition("King Darien XLVIII");
     let activated = def

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -493,6 +493,17 @@ fn knight_of_new_alara_counts_each_affected_creatures_colors_runtime() {
         2,
         2,
     );
+    let color_granter = CardDefinitionBuilder::new(CardId::new(), "Alice Color Granter")
+        .card_types(vec![CardType::Enchantment])
+        .with_ability(Ability::static_ability(
+            crate::static_abilities::StaticAbility::add_colors(
+                ObjectFilter::creature()
+                    .you_control()
+                    .named("Alice Two-Color Creature"),
+                crate::color::ColorSet::RED,
+            ),
+        ))
+        .build();
 
     let mut game =
         crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
@@ -504,14 +515,15 @@ fn knight_of_new_alara_counts_each_affected_creatures_colors_runtime() {
     let one_color_id = game.create_object_from_definition(&one_color, alice, Zone::Battlefield);
     let bob_two_color_id =
         game.create_object_from_definition(&bob_two_color, bob, Zone::Battlefield);
+    game.create_object_from_definition(&color_granter, alice, Zone::Battlefield);
 
     assert_eq!(
         (
             game.calculated_power(two_color_id),
             game.calculated_toughness(two_color_id)
         ),
-        (Some(4), Some(4)),
-        "a two-color creature Alice controls should get +2/+2"
+        (Some(5), Some(5)),
+        "a two-color creature Alice controls that gains a third color should get +3/+3"
     );
     assert_eq!(
         (

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -433,6 +433,12 @@ pub enum Modification {
     /// Modify both power and toughness (7c) - e.g., +2/+2
     ModifyPowerToughness { power: i32, toughness: i32 },
 
+    /// Modify P/T by the affected object's current color count in layer 7c.
+    ModifyPowerToughnessByColorCount {
+        power_multiplier: i32,
+        toughness_multiplier: i32,
+    },
+
     /// Switch power and toughness (7e)
     SwitchPowerToughness,
 }
@@ -548,6 +554,7 @@ impl Modification {
             | Modification::ModifyPower(_)
             | Modification::ModifyToughness(_)
             | Modification::ModifyPowerToughness { .. }
+            | Modification::ModifyPowerToughnessByColorCount { .. }
             | Modification::SwitchPowerToughness => Layer::PowerToughness,
         }
     }
@@ -561,7 +568,8 @@ impl Modification {
 
             Modification::ModifyPower(_)
             | Modification::ModifyToughness(_)
-            | Modification::ModifyPowerToughness { .. } => Some(PtSublayer::Modifying),
+            | Modification::ModifyPowerToughness { .. }
+            | Modification::ModifyPowerToughnessByColorCount { .. } => Some(PtSublayer::Modifying),
 
             Modification::SwitchPowerToughness => Some(PtSublayer::Switching),
 
@@ -2786,6 +2794,18 @@ fn apply_modification_to_chars(
                 *t += t_delta;
             }
         }
+        Modification::ModifyPowerToughnessByColorCount {
+            power_multiplier,
+            toughness_multiplier,
+        } => {
+            let color_count = chars.colors.count() as i32;
+            if let Some(ref mut p) = chars.power {
+                *p += power_multiplier * color_count;
+            }
+            if let Some(ref mut t) = chars.toughness {
+                *t += toughness_multiplier * color_count;
+            }
+        }
 
         // Layer 7e: Switching P/T
         Modification::SwitchPowerToughness => {
@@ -3485,6 +3505,7 @@ fn calculate_with_layers(object: &Object, ctx: &CalculationContext) -> Calculate
                 | Modification::ModifyPower(_)
                 | Modification::ModifyToughness(_)
                 | Modification::ModifyPowerToughness { .. }
+                | Modification::ModifyPowerToughnessByColorCount { .. }
                 | Modification::SwitchPowerToughness => {}
             }
 
@@ -3745,6 +3766,18 @@ fn apply_layer_7_effects(
                 }
                 if let Some(ref mut t) = toughness {
                     *t += dt;
+                }
+            }
+            Modification::ModifyPowerToughnessByColorCount {
+                power_multiplier,
+                toughness_multiplier,
+            } => {
+                let color_count = chars.colors.count() as i32;
+                if let Some(ref mut p) = power {
+                    *p += power_multiplier * color_count;
+                }
+                if let Some(ref mut t) = toughness {
+                    *t += toughness_multiplier * color_count;
                 }
             }
             Modification::SwitchPowerToughness => {

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1262,6 +1262,18 @@ pub(crate) fn apply_modification_to_chars_for_dependency(
                 *t += toughness;
             }
         }
+        Modification::ModifyPowerToughnessByColorCount {
+            power_multiplier,
+            toughness_multiplier,
+        } => {
+            let color_count = chars.colors.count() as i32;
+            if let Some(ref mut p) = chars.power {
+                *p += power_multiplier * color_count;
+            }
+            if let Some(ref mut t) = chars.toughness {
+                *t += toughness_multiplier * color_count;
+            }
+        }
         Modification::SwitchPowerToughness => {
             std::mem::swap(&mut chars.power, &mut chars.toughness);
         }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -654,6 +654,7 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
         AnthemCountExpression::AttachedToAffected(filter) => {
             format!("{} attached to it", strip_article(filter.description()))
         }
+        AnthemCountExpression::ColorsOfAffected => "color it has".to_string(),
         AnthemCountExpression::AffectedAttackedThisTurn => {
             "time it has attacked this turn".to_string()
         }
@@ -755,6 +756,7 @@ fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Op
             "{} attached to it",
             strip_article(filter.description())
         )),
+        AnthemCountExpression::ColorsOfAffected => Some("of its colors".to_string()),
         AnthemCountExpression::AffectedAttackedThisTurn => {
             Some("time it has attacked this turn".to_string())
         }
@@ -1543,6 +1545,10 @@ pub(crate) fn resolve_anthem_count_expression(
                     .filter(|obj| filter.matches_non_recursive(obj, &filter_ctx, game))
                     .count() as i32
             })
+            .unwrap_or(0),
+        AnthemCountExpression::ColorsOfAffected => game
+            .object(source)
+            .map(|object| object.colors().count() as i32)
             .unwrap_or(0),
         AnthemCountExpression::AffectedAttackedThisTurn => {
             game.creature_attack_count_this_turn(source) as i32

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -613,6 +613,17 @@ impl AnthemValueRuntimeExt for AnthemValue {
     }
 }
 
+fn color_count_multiplier(value: &AnthemValue) -> Option<i32> {
+    match value {
+        AnthemValue::Fixed(0) => Some(0),
+        AnthemValue::PerCount {
+            multiplier,
+            count: AnthemCountExpression::ColorsOfAffected,
+        } => Some(*multiplier),
+        _ => None,
+    }
+}
+
 fn strip_article(text: String) -> String {
     if let Some(rest) = text.strip_prefix("a ") {
         return rest.to_string();
@@ -1547,8 +1558,8 @@ pub(crate) fn resolve_anthem_count_expression(
             })
             .unwrap_or(0),
         AnthemCountExpression::ColorsOfAffected => game
-            .object(source)
-            .map(|object| object.colors().count() as i32)
+            .calculated_characteristics(source)
+            .map(|chars| chars.colors.count() as i32)
             .unwrap_or(0),
         AnthemCountExpression::AffectedAttackedThisTurn => {
             game.creature_attack_count_this_turn(source) as i32
@@ -1992,13 +2003,37 @@ impl StaticAbilityKind for Anthem {
         controller: PlayerId,
         game: &GameState,
     ) -> Vec<ContinuousEffect> {
-        // When the anthem value depends on properties of the affected creature
-        // (e.g. "for each Equipment attached to it" where "it" is each creature
-        // the anthem affects), we must enumerate affected creatures individually
-        // and evaluate the count per-creature.
+        // Color-count anthems need the affected object's layer-5 colors, so keep
+        // the target dynamic and defer the count until layer 7 applies.
+        if let (Some(power_multiplier), Some(toughness_multiplier)) = (
+            color_count_multiplier(&self.power),
+            color_count_multiplier(&self.toughness),
+        ) {
+            let target = if self.source_only {
+                EffectTarget::Source
+            } else {
+                effect_target_for_filter(source, &self.filter)
+            };
+            return vec![effect_with_optional_static_condition(
+                ContinuousEffect::new(
+                    source,
+                    controller,
+                    target,
+                    Modification::ModifyPowerToughnessByColorCount {
+                        power_multiplier,
+                        toughness_multiplier,
+                    },
+                )
+                .with_source_type(EffectSourceType::StaticAbility),
+                &self.condition,
+            )];
+        }
+
         let uses_affected =
             self.power.uses_affected_object() || self.toughness.uses_affected_object();
 
+        // Other affected-object counts are game-state counts, so enumerate each
+        // affected creature and evaluate the count per-creature.
         if uses_affected && !self.source_only {
             let filter_ctx = game.filter_context_for(controller, Some(source));
             let attached_target = if attached_subject(&self.filter).is_some() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Knight of New Alara
Initial parse error:
```
unsupported 'for each' filter in anthem clause (clause: 'for each of its colors'); oracle-only fallback also failed: unsupported 'for each' filter in anthem clause (clause: 'for each of its colors')
```

Current worker: i-06e276bc00b3b523f
Branch: codex/aws-card-fix-knight-of-new-alara
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0015
