### PR TITLE
Fix Ironsmith parse failure: Demilich

### DIFF
--- a/crates/ironsmith-compiler/src/costs/mod.rs
+++ b/crates/ironsmith-compiler/src/costs/mod.rs
@@ -240,6 +240,16 @@ pub(crate) fn cost_to_payment_effect(cost: &Cost) -> Option<crate::effect::Effec
                     .with_count(crate::effect::ChoiceCount::exactly(*count as usize)),
             ))
         }
+        Cost::ExileFromGraveyard { count, card_types } => {
+            let mut filter = crate::target::ObjectFilter::default()
+                .in_zone(crate::zone::Zone::Graveyard)
+                .owned_by(crate::target::PlayerFilter::You);
+            filter.card_types = card_types.clone();
+            Some(crate::effect::Effect::exile(
+                crate::target::ChooseSpec::Object(filter)
+                    .with_count(crate::effect::ChoiceCount::exactly(*count as usize)),
+            ))
+        }
         Cost::ReturnSelfToHand => Some(crate::effect::Effect::return_to_hand(
             crate::target::ChooseSpec::Source,
         )),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -6873,6 +6873,7 @@ pub(crate) fn parse_spells_cost_modifier_line(
 
     let amount_tokens = &tokens[cost_token_idx + 1..];
     let (parsed_amount, mut parsed_mana_cost) = parse_cost_modifier_components(amount_tokens);
+    let mut parsed_mana_cost_repetitions = None;
     let (mut amount_value, used) = parsed_amount
         .clone()
         .map(|(value, used)| (value, used))
@@ -6890,20 +6891,21 @@ pub(crate) fn parse_spells_cost_modifier_line(
     };
 
     if let Some(dynamic_value) = parse_dynamic_cost_modifier_value(remaining_tokens)? {
-        // Wording like "{G} less for each green creature you control" is still a dynamic
-        // reduction even though the printed amount is a colored symbol. Model as a generic
-        // dynamic reduction so the clause remains playable.
-        let multiplier = parsed_amount
-            .as_ref()
-            .and_then(|(value, _)| match value {
-                Value::Fixed(value) => Some(*value),
-                _ => None,
-            })
-            .unwrap_or(1);
-        if parsed_mana_cost.is_some() {
-            parsed_mana_cost = None;
+        if parsed_mana_cost.is_some() && is_this_spell {
+            parsed_mana_cost_repetitions = Some(dynamic_value);
+        } else {
+            if parsed_mana_cost.is_some() {
+                parsed_mana_cost = None;
+            }
+            let multiplier = parsed_amount
+                .as_ref()
+                .and_then(|(value, _)| match value {
+                    Value::Fixed(value) => Some(*value),
+                    _ => None,
+                })
+                .unwrap_or(1);
+            amount_value = scale_dynamic_cost_modifier_value(dynamic_value, multiplier);
         }
-        amount_value = scale_dynamic_cost_modifier_value(dynamic_value, multiplier);
     } else if parsed_amount.is_none() && parsed_mana_cost.is_none() {
         return Err(CardTextError::ParseError(
             "missing cost modifier amount".to_string(),
@@ -6998,12 +7000,14 @@ pub(crate) fn parse_spells_cost_modifier_line(
             )));
         }
         if is_this_spell && let Some((cost, _)) = parsed_mana_cost.clone() {
-            return Ok(Some(StaticAbility::new(
-                crate::static_abilities::ThisSpellCostReductionManaCost::new(
-                    cost,
-                    this_spell_condition,
-                ),
-            )));
+            let mut ability = crate::static_abilities::ThisSpellCostReductionManaCost::new(
+                cost,
+                this_spell_condition,
+            );
+            if let Some(repetitions) = parsed_mana_cost_repetitions {
+                ability = ability.with_repetitions(repetitions);
+            }
+            return Ok(Some(StaticAbility::new(ability)));
         }
         if let Some((cost, _)) = parsed_mana_cost {
             let mut ability = crate::static_abilities::CostReductionManaCost::new(filter, cost);

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -838,6 +838,74 @@ fn parse_sacrificing_additional_cost_tokens(
     Ok(Some(crate::costs::Cost::sacrifice(filter.you_control())))
 }
 
+fn parse_card_type_word(word: &str) -> Option<CardType> {
+    match word {
+        "artifact" | "artifacts" => Some(CardType::Artifact),
+        "creature" | "creatures" => Some(CardType::Creature),
+        "enchantment" | "enchantments" => Some(CardType::Enchantment),
+        "instant" | "instants" => Some(CardType::Instant),
+        "land" | "lands" => Some(CardType::Land),
+        "planeswalker" | "planeswalkers" => Some(CardType::Planeswalker),
+        "sorcery" | "sorceries" => Some(CardType::Sorcery),
+        _ => None,
+    }
+}
+
+fn parse_exiling_graveyard_additional_cost_tokens(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<crate::costs::Cost>, CardTextError> {
+    parse_exiling_graveyard_additional_cost_words(&token_word_refs(tokens))
+}
+
+fn parse_exiling_graveyard_additional_cost_words(
+    words: &[&str],
+) -> Result<Option<crate::costs::Cost>, CardTextError> {
+    let Some(rest) = words.strip_prefix(&["exiling"]) else {
+        return Ok(None);
+    };
+    let Some(count_word) = rest.first() else {
+        return Ok(None);
+    };
+    let Some(count) = parse_named_number(count_word) else {
+        return Ok(None);
+    };
+    let Some(card_idx) = rest
+        .iter()
+        .position(|word| matches!(*word, "card" | "cards"))
+    else {
+        return Ok(None);
+    };
+    if rest.get(card_idx + 1..) != Some(&["from", "your", "graveyard"][..]) {
+        return Ok(None);
+    }
+
+    let mut card_types = Vec::new();
+    for word in &rest[1..card_idx] {
+        if matches!(*word, "and" | "or" | "and/or") {
+            continue;
+        }
+        let Some(card_type) = parse_card_type_word(word) else {
+            return Ok(None);
+        };
+        if !card_types.contains(&card_type) {
+            card_types.push(card_type);
+        }
+    }
+
+    Ok(Some(crate::costs::Cost::exile_from_graveyard(
+        count, card_types,
+    )))
+}
+
+fn parse_graveyard_cast_additional_cost_tokens(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<crate::costs::Cost>, CardTextError> {
+    if let Some(cost) = parse_sacrificing_additional_cost_tokens(tokens)? {
+        return Ok(Some(cost));
+    }
+    parse_exiling_graveyard_additional_cost_tokens(tokens)
+}
+
 fn parse_once_each_turn_graveyard_cast_permission(
     tokens: &[OwnedLexToken],
     clause_refs: &[&str],
@@ -910,7 +978,7 @@ fn parse_once_each_turn_graveyard_cast_permission(
         let Some(cost_tokens) = token_slice_for_word_range(tokens, cost_start, cost_end) else {
             return Ok(None);
         };
-        let Some(cost) = parse_sacrificing_additional_cost_tokens(trim_lexed_commas(cost_tokens))?
+        let Some(cost) = parse_graveyard_cast_additional_cost_tokens(trim_lexed_commas(cost_tokens))?
         else {
             return Ok(None);
         };
@@ -1055,6 +1123,55 @@ pub(crate) fn parse_permission_clause_spec_lexed(
     }
 
     let rest_words = token_word_refs(rest_tokens);
+    if let Some(after_source) = rest_words
+        .strip_prefix(&["this", "card", "from", "your", "graveyard", "by"])
+        .or_else(|| {
+            rest_words.strip_prefix(&["this", "spell", "from", "your", "graveyard", "by"])
+        })
+    {
+        const ADDITIONAL_COST_SUFFIX: &[&str] =
+            &["in", "addition", "to", "paying", "its", "other", "costs"];
+        if word_slice_ends_with(after_source, ADDITIONAL_COST_SUFFIX) {
+            let cost_words = &after_source[..after_source.len() - ADDITIONAL_COST_SUFFIX.len()];
+            if let Some(cost) = parse_exiling_graveyard_additional_cost_words(cost_words)? {
+                return Ok(Some(PermissionClauseSpec::GrantBySpec {
+                    player,
+                    spec: crate::grant::GrantSpec::new(
+                        crate::grant::Grantable::graveyard_cast_from_cards_mana_cost(
+                            vec![cost], false,
+                        ),
+                        ObjectFilter::source(),
+                        Zone::Graveyard,
+                    ),
+                    lifetime: PermissionLifetime::Static,
+                }));
+            }
+
+            let cost_start = rest_words.len() - after_source.len();
+            let cost_end = rest_words.len() - ADDITIONAL_COST_SUFFIX.len();
+            let Some(cost_tokens) = token_slice_for_word_range(rest_tokens, cost_start, cost_end)
+            else {
+                return Ok(None);
+            };
+            let Some(cost) =
+                parse_graveyard_cast_additional_cost_tokens(trim_lexed_commas(cost_tokens))?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(PermissionClauseSpec::GrantBySpec {
+                player,
+                spec: crate::grant::GrantSpec::new(
+                    crate::grant::Grantable::graveyard_cast_from_cards_mana_cost(
+                        vec![cost], false,
+                    ),
+                    ObjectFilter::source(),
+                    Zone::Graveyard,
+                ),
+                lifetime: PermissionLifetime::Static,
+            }));
+        }
+    }
+
     if SOURCE_CARD_OR_SPELL_FROM_GRAVEYARD_PATTERN.matches_words(&rest_words) {
         return Ok(Some(PermissionClauseSpec::GrantBySpec {
             player,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -645,6 +645,16 @@ pub(crate) fn classify_static_line_family_lexed(
         return Some(StaticLineFamily::UntapAllDuringEachOtherPlayersUntapStep);
     }
 
+    if primitives::contains_any_phrase(
+        tokens,
+        &[
+            &["you", "may", "cast", "this", "card", "from", "your", "graveyard"],
+            &["you", "may", "cast", "this", "spell", "from", "your", "graveyard"],
+        ],
+    ) {
+        return Some(StaticLineFamily::Generic);
+    }
+
     if let Some(quote_idx) = primitives::find_token_index(tokens, |token| token.is_quote()) {
         let head = trim_lexed_commas(&tokens[..quote_idx]);
         if !head.is_empty()

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5447,6 +5447,26 @@ fn jump_start_keyword_line_is_classified_as_alternative_cast() {
 }
 
 #[test]
+fn demilich_graveyard_cast_additional_exile_cost_permission_parses() {
+    let tokens = lex_line(
+        "You may cast this card from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.",
+        0,
+    )
+    .expect("rewrite lexer should classify Demilich graveyard-cast line");
+
+    let words = super::token_word_refs(&tokens).join(" ");
+    let parsed = super::permission_helpers::parse_permission_clause_spec_lexed(&tokens)
+        .expect("Demilich graveyard-cast permission should not error")
+        .unwrap_or_else(|| panic!("Demilich graveyard-cast permission should parse: {words}"));
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("GraveyardCastFromCardManaCost"), "{debug}");
+    assert!(debug.contains("ExileFromGraveyard"), "{debug}");
+    assert!(debug.contains("Instant"), "{debug}");
+    assert!(debug.contains("Sorcery"), "{debug}");
+}
+
+#[test]
 fn equal_to_number_of_cards_you_ve_discarded_this_turn_parses() {
     let tokens = lex_line("equal to the number of cards you've discarded this turn", 0)
         .expect("rewrite lexer should classify value clause");

--- a/crates/ironsmith-core/src/cost_model.rs
+++ b/crates/ironsmith-core/src/cost_model.rs
@@ -130,6 +130,10 @@ pub enum Cost<E> {
         count: u32,
         color_filter: Option<ColorSet>,
     },
+    ExileFromGraveyard {
+        count: u32,
+        card_types: Vec<CardType>,
+    },
     ReturnSelfToHand,
     Effect(E),
 }
@@ -253,6 +257,10 @@ impl<E> Cost<E> {
         }
     }
 
+    pub fn exile_from_graveyard(count: u32, card_types: Vec<CardType>) -> Self {
+        Self::ExileFromGraveyard { count, card_types }
+    }
+
     pub fn return_self_to_hand() -> Self {
         Self::ReturnSelfToHand
     }
@@ -305,6 +313,9 @@ impl<E> Cost<E> {
                 count,
                 color_filter,
             },
+            Self::ExileFromGraveyard { count, card_types } => {
+                Cost::ExileFromGraveyard { count, card_types }
+            }
             Self::ReturnSelfToHand => Cost::ReturnSelfToHand,
             Self::Effect(effect) => Cost::Effect(map_effect(effect)?),
         })
@@ -348,6 +359,11 @@ where
             Self::Life(amount) => format!("pay {amount:?} life"),
             Self::ExileSelf => "exile this card".to_string(),
             Self::ExileFromHand { count, .. } => format!("exile {count} card(s) from hand"),
+            Self::ExileFromGraveyard { count, card_types } => {
+                let type_text = describe_card_type_cost_list(card_types);
+                let card_word = if *count == 1 { "card" } else { "cards" };
+                format!("exile {count} {type_text}{card_word} from your graveyard")
+            }
             Self::ReturnSelfToHand => "return this permanent to its owner's hand".to_string(),
             Self::Effect(_) => "effect".to_string(),
         }
@@ -378,6 +394,13 @@ where
         }
     }
 
+    fn exile_from_graveyard_details(&self) -> Option<(u32, &[CardType])> {
+        match self {
+            Self::ExileFromGraveyard { count, card_types } => Some((*count, card_types)),
+            _ => None,
+        }
+    }
+
     fn is_loyalty_activation_cost(&self) -> bool {
         matches!(
             self,
@@ -401,6 +424,25 @@ where
 {
     fn tap_cost() -> Self {
         Self::Tap
+    }
+}
+
+fn describe_card_type_cost_list(card_types: &[CardType]) -> String {
+    match card_types {
+        [] => String::new(),
+        [one] => format!("{} ", one.to_string().to_ascii_lowercase()),
+        [left, right] => format!(
+            "{} and/or {} ",
+            left.to_string().to_ascii_lowercase(),
+            right.to_string().to_ascii_lowercase()
+        ),
+        _ => {
+            let names = card_types
+                .iter()
+                .map(|card_type| card_type.to_string().to_ascii_lowercase())
+                .collect::<Vec<_>>();
+            format!("{} ", names.join(", "))
+        }
     }
 }
 
@@ -434,6 +476,10 @@ pub trait CostComponent: Clone + std::fmt::Debug + PartialEq {
     }
 
     fn exile_from_hand_details(&self) -> Option<(u32, Option<ColorSet>)> {
+        None
+    }
+
+    fn exile_from_graveyard_details(&self) -> Option<(u32, &[CardType])> {
         None
     }
 

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -121,6 +121,18 @@ impl<C: CostComponent> DerivedAlternativeCast<C> {
         }
     }
 
+    pub fn graveyard_cast_from_cards_mana_cost(
+        additional_costs: Vec<C>,
+        exiles_after_resolution: bool,
+    ) -> Self {
+        Self::GraveyardCastFromCardManaCost {
+            additional_costs,
+            usage_limit: None,
+            condition: None,
+            exiles_after_resolution,
+        }
+    }
+
     pub fn life_equal_mana_value_from_hand(usage_limit: Option<GrantUsageLimit>) -> Self {
         Self::LifeEqualManaValueFromHand { usage_limit }
     }
@@ -257,6 +269,18 @@ where
     ) -> Self {
         Self::DerivedAlternativeCast(
             DerivedAlternativeCast::once_each_turn_graveyard_cast_from_cards_mana_cost_exiles_after_resolution(
+                additional_costs,
+                exiles_after_resolution,
+            ),
+        )
+    }
+
+    pub fn graveyard_cast_from_cards_mana_cost(
+        additional_costs: Vec<C>,
+        exiles_after_resolution: bool,
+    ) -> Self {
+        Self::DerivedAlternativeCast(
+            DerivedAlternativeCast::graveyard_cast_from_cards_mana_cost(
                 additional_costs,
                 exiles_after_resolution,
             ),
@@ -469,6 +493,24 @@ where
             }
         }
 
+        fn list_card_types_and_or(types: &[CardType]) -> String {
+            let names = types
+                .iter()
+                .map(|card_type| card_type.to_string().to_ascii_lowercase())
+                .collect::<Vec<_>>();
+            match names.as_slice() {
+                [] => String::new(),
+                [one] => one.clone(),
+                [left, right] => format!("{left} and/or {right}"),
+                _ => {
+                    let Some((last, rest)) = names.split_last() else {
+                        return String::new();
+                    };
+                    format!("{}, and/or {last}", rest.join(", "))
+                }
+            }
+        }
+
         fn is_simple_card_type_filter(filter: &ObjectFilter) -> bool {
             if filter.card_types.is_empty() {
                 return false;
@@ -607,6 +649,26 @@ where
                 && let Some(filter_text) = sacrifice_cost_filter_description(filter)
             {
                 return format!("sacrificing {filter_text} in addition to paying its other costs");
+            }
+
+            if let [cost] = additional_costs
+                && let Some((count, card_types)) = cost.exile_from_graveyard_details()
+            {
+                let count_text = if count == 1 {
+                    "a".to_string()
+                } else {
+                    crate::cardinal_word(count).unwrap_or_else(|| count.to_string())
+                };
+                let type_text = list_card_types_and_or(card_types);
+                let type_prefix = if type_text.is_empty() {
+                    String::new()
+                } else {
+                    format!("{type_text} ")
+                };
+                let card_word = if count == 1 { "card" } else { "cards" };
+                return format!(
+                    "exiling {count_text} {type_prefix}{card_word} from your graveyard in addition to paying its other costs"
+                );
             }
 
             if additional_costs.is_empty() {
@@ -980,6 +1042,10 @@ where
                 {
                     line.push_str(" as long as ");
                     line.push_str(&condition_text);
+                }
+                if !additional_costs.is_empty() {
+                    line.push_str(" by ");
+                    line.push_str(&cost_text);
                 }
                 if *exiles_after_resolution {
                     line.push_str(". If you cast it this way and it would be put into your graveyard, exile it instead");

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -4282,12 +4282,22 @@ impl<Cond> ThisSpellCostReduction<Cond> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ThisSpellCostReductionManaCost<Cond> {
     pub cost: ManaCost,
+    pub repetitions: Option<Value>,
     pub condition: Cond,
 }
 
 impl<Cond> ThisSpellCostReductionManaCost<Cond> {
     pub fn new(cost: ManaCost, condition: Cond) -> Self {
-        Self { cost, condition }
+        Self {
+            cost,
+            repetitions: None,
+            condition,
+        }
+    }
+
+    pub fn with_repetitions(mut self, repetitions: Value) -> Self {
+        self.repetitions = Some(repetitions);
+        self
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3735,6 +3735,36 @@ fn parse_oracle_maestros_ascendancy_graveyard_cast_cost_and_exile_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_demilich_graveyard_cast_additional_exile_cost() {
+    assert_oracle_card_parses_strict("Demilich");
+    let def = parse_oracle_card_definition("Demilich");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+    assert!(
+        rendered.contains(
+            "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn"
+        ),
+        "expected Demilich to render its dynamic blue cost reduction, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "You may cast this card from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs"
+        ),
+        "expected Demilich to render its graveyard-cast additional exile cost, got {rendered}"
+    );
+    assert!(
+        debug.contains("GraveyardCastFromCardManaCost")
+            && debug.contains("ExileEffect")
+            && debug.contains("min: 4")
+            && debug.contains("Instant")
+            && debug.contains("Sorcery"),
+        "expected Demilich to lower to a graveyard-cast grant with a four-card instant/sorcery exile cost, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_oracle_squee_the_immortal_graveyard_or_exile_cast_permission() {
     assert_oracle_card_parses_strict("Squee, the Immortal");
     let def = parse_oracle_card_definition("Squee, the Immortal");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3894,6 +3894,44 @@ fn describe_revealed_cards_opponent_may_put_or_draw(effects: &[&Effect]) -> Opti
     ))
 }
 
+fn tagged_exile_effect_tag(effect: &Effect) -> Option<&str> {
+    let tagged = effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    tagged
+        .effect
+        .downcast_ref::<crate::effects::ExileEffect>()
+        .map(|_| tagged.tag.as_str())
+}
+
+fn copied_spell_targets_tag(effect: &Effect, tag: &str) -> bool {
+    let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() else {
+        return false;
+    };
+    let Some(with_id) = tagged
+        .effect
+        .downcast_ref::<crate::effects::WithIdEffect>()
+    else {
+        return false;
+    };
+    with_id
+        .effect
+        .downcast_ref::<crate::effects::CopySpellEffect>()
+        .is_some_and(|copy| {
+            matches!(&copy.target, ChooseSpec::Tagged(copy_tag) if copy_tag.as_str() == tag)
+        })
+}
+
+fn may_cast_copy_targets_tag(effect: &Effect, tag: &str) -> bool {
+    let Some(may) = effect.downcast_ref::<crate::effects::MayEffect>() else {
+        return false;
+    };
+    let [cast_effect] = may.effects.as_slice() else {
+        return false;
+    };
+    cast_effect
+        .downcast_ref::<crate::effects::CastTaggedEffect>()
+        .is_some_and(|cast| cast.as_copy && cast.tag.as_str() == tag)
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
@@ -9885,6 +9923,16 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     let mut parts = Vec::new();
     let mut idx = 0usize;
     while idx < filtered.len() {
+        if idx + 2 < filtered.len()
+            && let Some(exiled_tag) = tagged_exile_effect_tag(filtered[idx])
+            && copied_spell_targets_tag(filtered[idx + 1], exiled_tag)
+            && may_cast_copy_targets_tag(filtered[idx + 2], exiled_tag)
+        {
+            let exile_text = describe_effect(filtered[idx]).replace(" in your graveyard", " from your graveyard");
+            parts.push(format!("{exile_text}. Copy it. You may cast the copy"));
+            idx += 3;
+            continue;
+        }
         if idx + 2 < filtered.len()
             && let Some(compact) = describe_look_at_hand_top_and_face_down_creatures(&[
                 filtered[idx],

--- a/crates/ironsmith-runtime/src/cost.rs
+++ b/crates/ironsmith-runtime/src/cost.rs
@@ -52,6 +52,10 @@ impl ironsmith_core::CostComponent for Cost {
         self.exile_from_hand_details()
     }
 
+    fn exile_from_graveyard_details(&self) -> Option<(u32, &[crate::types::CardType])> {
+        self.exile_from_graveyard_details()
+    }
+
     fn mana_cost_ref(&self) -> Option<&ManaCost> {
         self.mana_cost_ref()
     }

--- a/crates/ironsmith-runtime/src/costs/cost_effect.rs
+++ b/crates/ironsmith-runtime/src/costs/cost_effect.rs
@@ -378,6 +378,21 @@ impl CostPayer for CostEffect {
         self.effect.0.exile_from_hand_cost_info()
     }
 
+    fn exile_from_graveyard_details(&self) -> Option<(u32, &[crate::types::CardType])> {
+        let exile = self.effect.downcast_ref::<crate::effects::ExileEffect>()?;
+        let crate::target::ChooseSpec::Object(filter) = exile.spec.base() else {
+            return None;
+        };
+        if filter.zone != Some(crate::zone::Zone::Graveyard) {
+            return None;
+        }
+        let count = exile.spec.count();
+        if count.min == 0 || count.max != Some(count.min) {
+            return None;
+        }
+        Some((count.min as u32, &filter.card_types))
+    }
+
     fn is_remove_counters(&self) -> bool {
         self.effect
             .downcast_ref::<crate::effects::RemoveCountersEffect>()

--- a/crates/ironsmith-runtime/src/costs/mod.rs
+++ b/crates/ironsmith-runtime/src/costs/mod.rs
@@ -214,6 +214,9 @@ impl Cost {
                 count,
                 color_filter,
             } => Self::exile_from_hand(count, color_filter),
+            ironsmith_core::Cost::ExileFromGraveyard { count, card_types } => {
+                Self::exile_from_graveyard_types(count, card_types)
+            }
             ironsmith_core::Cost::ReturnSelfToHand => Self::return_self_to_hand(),
             ironsmith_core::Cost::Effect(effect) => Self::try_from_runtime_effect(effect)
                 .map_err(|detail| format!("effect-backed cost is not cost-executable: {detail}"))?,
@@ -274,8 +277,17 @@ impl Cost {
 
     /// Create an exile from graveyard cost.
     pub fn exile_from_graveyard(count: u32, card_type: Option<CardType>) -> Self {
+        Self::exile_from_graveyard_types(count, card_type.into_iter().collect())
+    }
+
+    /// Create an exile-from-graveyard cost with one-or-more allowed card types.
+    pub fn exile_from_graveyard_types(count: u32, card_types: Vec<CardType>) -> Self {
+        let mut filter = crate::filter::ObjectFilter::default()
+            .in_zone(crate::zone::Zone::Graveyard)
+            .owned_by(crate::target::PlayerFilter::You);
+        filter.card_types = card_types;
         Self::validated_effect(crate::effect::Effect::exile_from_graveyard_as_cost(
-            count, card_type,
+            count, filter,
         ))
     }
 
@@ -448,6 +460,11 @@ impl Cost {
     /// Get the exile from hand details if applicable.
     pub fn exile_from_hand_details(&self) -> Option<(u32, Option<crate::color::ColorSet>)> {
         self.0.exile_from_hand_details()
+    }
+
+    /// Get the exile from graveyard details if applicable.
+    pub fn exile_from_graveyard_details(&self) -> Option<(u32, &[crate::types::CardType])> {
+        self.0.exile_from_graveyard_details()
     }
 
     /// Check if this is a remove counters cost.

--- a/crates/ironsmith-runtime/src/costs/payer_trait.rs
+++ b/crates/ironsmith-runtime/src/costs/payer_trait.rs
@@ -385,6 +385,11 @@ pub trait CostPayer: std::fmt::Debug + Send + Sync + CostPayerClone + Any {
         None
     }
 
+    /// Returns the exile from graveyard details (count, allowed card types) if applicable.
+    fn exile_from_graveyard_details(&self) -> Option<(u32, &[crate::types::CardType])> {
+        None
+    }
+
     /// Returns true if this is a remove counters cost.
     fn is_remove_counters(&self) -> bool {
         false

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -3039,7 +3039,14 @@ pub(crate) fn apply_spell_cost_modifiers(
                 chosen_targets,
                 Some(&spell.optional_costs_paid),
             ) {
-                reduction_pips.extend(reduction.reduction.pips().iter().cloned());
+                let repetitions = reduction
+                    .repetitions
+                    .as_ref()
+                    .map(|value| resolve_cost_modifier_value(game, player, spell, value).max(0))
+                    .unwrap_or(1);
+                for _ in 0..repetitions {
+                    reduction_pips.extend(reduction.reduction.pips().iter().cloned());
+                }
             }
         }
         if !functions_in_current_zone {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -2610,18 +2610,8 @@ impl Effect {
     }
 
     /// Create an "exile cards from your graveyard" cost effect.
-    pub fn exile_from_graveyard_as_cost(
-        count: u32,
-        card_type: Option<crate::types::CardType>,
-    ) -> Self {
+    pub fn exile_from_graveyard_as_cost(count: u32, filter: ObjectFilter) -> Self {
         use crate::effects::ExileEffect;
-
-        let mut filter = ObjectFilter::default()
-            .in_zone(Zone::Graveyard)
-            .owned_by(PlayerFilter::You);
-        if let Some(card_type) = card_type {
-            filter = filter.with_type(card_type);
-        }
 
         Self::new(ExileEffect::with_spec(
             ChooseSpec::Object(filter).with_count(ChoiceCount::exactly(count as usize)),

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -132,6 +132,9 @@ where
             count,
             color_filter,
         },
+        ironsmith_core::Cost::ExileFromGraveyard { count, card_types } => {
+            ironsmith_core::Cost::ExileFromGraveyard { count, card_types }
+        }
         ironsmith_core::Cost::ReturnSelfToHand => ironsmith_core::Cost::ReturnSelfToHand,
         ironsmith_core::Cost::Effect(effect) => {
             ironsmith_core::Cost::Effect(interpret_effect_model::<M, H>(effect, hooks)?)

--- a/crates/ironsmith-runtime/src/effects/zones/exile.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/exile.rs
@@ -132,6 +132,25 @@ fn exile_from_graveyard_cost_filter(effect: &ExileEffect) -> Option<(&ObjectFilt
     (filter.zone == Some(Zone::Graveyard)).then_some((filter, count))
 }
 
+fn describe_card_type_cost_list(card_types: &[crate::types::CardType]) -> String {
+    match card_types {
+        [] => "card".to_string(),
+        [one] => one.card_phrase().to_string(),
+        [left, right] => format!(
+            "{} and/or {} card",
+            left.to_string().to_ascii_lowercase(),
+            right.to_string().to_ascii_lowercase()
+        ),
+        _ => {
+            let names = card_types
+                .iter()
+                .map(|card_type| card_type.to_string().to_ascii_lowercase())
+                .collect::<Vec<_>>();
+            format!("{} card", names.join(", "))
+        }
+    }
+}
+
 fn matching_cost_candidates(
     game: &GameState,
     filter: &ObjectFilter,
@@ -350,11 +369,7 @@ impl EffectExecutor for ExileEffect {
         }
 
         if let Some((filter, count)) = exile_from_graveyard_cost_filter(self) {
-            let type_str = filter
-                .card_types
-                .first()
-                .map(|card_type| card_type.card_phrase().to_string())
-                .unwrap_or_else(|| "card".to_string());
+            let type_str = describe_card_type_cost_list(&filter.card_types);
             return Some(if count == 1 {
                 format!("Exile a {type_str} from your graveyard")
             } else {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26943,6 +26943,304 @@ fn maestros_ascendancy_is_once_each_turn_and_only_on_your_turn() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn demilich_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(92_190), "Demilich")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Skeleton, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(4, 3))
+        .parse_text(
+            "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn.\n\
+             Whenever this creature attacks, exile up to one target instant or sorcery card from your graveyard. Copy it. You may cast the copy.\n\
+             You may cast this card from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.",
+        )
+        .expect("Demilich should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn demilich_graveyard_cast_action(
+    game: &GameState,
+    player: PlayerId,
+    spell_id: ObjectId,
+) -> Option<LegalAction> {
+    compute_legal_actions(game, player)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id: action_spell_id,
+                    from_zone: Zone::Graveyard,
+                    casting_method: CastingMethod::PlayFrom {
+                        source,
+                        zone: Zone::Graveyard,
+                        use_alternative: Some(_),
+                    },
+                } if *action_spell_id == spell_id && *source == spell_id
+            )
+        })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn graveyard_cost_card(name: &str, card_type: CardType) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .card_types(vec![card_type])
+        .mana_cost(ManaCost::new())
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn record_demilich_test_spell_cast(
+    game: &mut GameState,
+    player: PlayerId,
+    name: &str,
+    card_type: CardType,
+) {
+    let spell_id = game.create_object_from_card(
+        &graveyard_cost_card(name, card_type),
+        player,
+        Zone::Stack,
+    );
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, player, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&event);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demilich_cost_reduction_removes_one_blue_for_each_instant_or_sorcery_cast() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let demilich_id = game.create_object_from_definition(&demilich_definition(), alice, Zone::Hand);
+    let demilich = game.object(demilich_id).expect("Demilich should exist");
+    let base_cost = demilich
+        .mana_cost
+        .as_ref()
+        .expect("Demilich has mana cost")
+        .clone();
+    assert_eq!(base_cost.to_oracle(), "{U}{U}{U}{U}");
+
+    record_demilich_test_spell_cast(&mut game, alice, "Cast Instant", CardType::Instant);
+    let demilich = game.object(demilich_id).expect("Demilich should exist");
+    let reduced_once = crate::decision::calculate_effective_mana_cost(
+        &game, alice, demilich, &base_cost,
+    );
+    assert_eq!(reduced_once.to_oracle(), "{U}{U}{U}");
+
+    record_demilich_test_spell_cast(&mut game, alice, "Cast Sorcery", CardType::Sorcery);
+    record_demilich_test_spell_cast(&mut game, alice, "Cast Creature", CardType::Creature);
+    let demilich = game.object(demilich_id).expect("Demilich should exist");
+    let reduced_twice = crate::decision::calculate_effective_mana_cost(
+        &game, alice, demilich, &base_cost,
+    );
+    assert_eq!(reduced_twice.to_oracle(), "{U}{U}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demilich_casts_from_graveyard_by_exiling_four_instant_or_sorcery_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let demilich_id =
+        game.create_object_from_definition(&demilich_definition(), alice, Zone::Graveyard);
+    for idx in 0..4 {
+        record_demilich_test_spell_cast(
+            &mut game,
+            alice,
+            &format!("Previously Cast Instant {idx}"),
+            CardType::Instant,
+        );
+    }
+    let valid_cards = [
+        game.create_object_from_card(
+            &graveyard_cost_card("First Buried Instant", CardType::Instant),
+            alice,
+            Zone::Graveyard,
+        ),
+        game.create_object_from_card(
+            &graveyard_cost_card("Second Buried Instant", CardType::Instant),
+            alice,
+            Zone::Graveyard,
+        ),
+        game.create_object_from_card(
+            &graveyard_cost_card("Third Buried Instant", CardType::Instant),
+            alice,
+            Zone::Graveyard,
+        ),
+        game.create_object_from_card(
+            &graveyard_cost_card("Buried Sorcery", CardType::Sorcery),
+            alice,
+            Zone::Graveyard,
+        ),
+    ];
+    let artifact_id = game.create_object_from_card(
+        &graveyard_cost_card("Buried Artifact", CardType::Artifact),
+        alice,
+        Zone::Graveyard,
+    );
+
+    let action = demilich_graveyard_cast_action(&game, alice, demilich_id)
+        .expect("Demilich should be castable from graveyard with four instant/sorcery cards to exile");
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = AutoPassDecisionMaker;
+    let mut progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(action),
+        &mut dm,
+    )
+    .expect("Demilich graveyard cast should start");
+
+    for _ in 0..8 {
+        progress = match progress {
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) => {
+                let option_index = ctx
+                    .options
+                    .iter()
+                    .find(|option| option.description.to_ascii_lowercase().contains("exile"))
+                    .map(|option| option.index)
+                    .expect("Demilich cast should offer an exile cost step");
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(option_index),
+                    &mut dm,
+                )
+                .expect("Demilich cast should accept the exile cost step")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectObjects(ctx),
+            ) => {
+                assert!(
+                    ctx.candidates
+                        .iter()
+                        .all(|candidate| candidate.id != artifact_id || !candidate.legal),
+                    "Demilich exile cost must not allow artifact cards"
+                );
+                let card_id = ctx
+                    .candidates
+                    .iter()
+                    .find(|candidate| candidate.legal)
+                    .map(|candidate| candidate.id)
+                    .expect("Demilich exile cost should have an instant or sorcery choice");
+                assert!(
+                    valid_cards.contains(&card_id),
+                    "Demilich exile cost should choose only the prepared instant/sorcery cards"
+                );
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::CardCostChoice(card_id),
+                    &mut dm,
+                )
+                .expect("Demilich cast should accept an instant or sorcery exile choice")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            ) => break,
+            other => panic!("expected Demilich exile cost flow, got {other:?}"),
+        };
+    }
+
+    assert!(
+        matches!(
+            progress,
+            GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Priority(_))
+        ),
+        "Demilich cast should finish after four exile choices, got {progress:?}"
+    );
+    assert!(
+        game.stack.iter().any(|entry| game
+            .object(entry.object_id)
+            .is_some_and(|object| object.name == "Demilich")),
+        "Demilich should be on the stack after paying its graveyard-cast cost"
+    );
+    for name in [
+        "First Buried Instant",
+        "Second Buried Instant",
+        "Third Buried Instant",
+        "Buried Sorcery",
+    ] {
+        assert!(
+            game.exile
+                .iter()
+                .any(|id| game.object(*id).is_some_and(|object| object.name == name)),
+            "{name} should be exiled to pay Demilich's graveyard-cast cost"
+        );
+    }
+    assert!(
+        game.player(alice)
+            .expect("Alice exists")
+            .graveyard
+            .iter()
+            .any(|id| *id == artifact_id),
+        "the artifact card should remain in the graveyard because it is not a legal Demilich cost card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn demilich_graveyard_cast_requires_four_instant_or_sorcery_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let demilich_id =
+        game.create_object_from_definition(&demilich_definition(), alice, Zone::Graveyard);
+    for idx in 0..4 {
+        record_demilich_test_spell_cast(
+            &mut game,
+            alice,
+            &format!("Previously Cast Instant {idx}"),
+            CardType::Instant,
+        );
+    }
+    for idx in 0..3 {
+        game.create_object_from_card(
+            &graveyard_cost_card(&format!("Buried Instant {idx}"), CardType::Instant),
+            alice,
+            Zone::Graveyard,
+        );
+    }
+    game.create_object_from_card(
+        &graveyard_cost_card("Buried Artifact", CardType::Artifact),
+        alice,
+        Zone::Graveyard,
+    );
+
+    assert!(
+        demilich_graveyard_cast_action(&game, alice, demilich_id).is_none(),
+        "Demilich should not be castable from graveyard with only three instant/sorcery cards plus an artifact"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn demon_of_fates_design_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(92_200), "Demon of Fate's Design")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -157,6 +157,40 @@ fn describe_types_among_scope(filter: &ObjectFilter) -> String {
     description
 }
 
+fn describe_spell_cast_count_tail(
+    player: &PlayerFilter,
+    filter: &ObjectFilter,
+    exclude_source: bool,
+) -> String {
+    let spell_text = match filter.card_types.as_slice() {
+        [] => "spell".to_string(),
+        [one] => format!("{} spell", one.to_string().to_ascii_lowercase()),
+        [left, right] => format!(
+            "{} and {} spell",
+            left.to_string().to_ascii_lowercase(),
+            right.to_string().to_ascii_lowercase()
+        ),
+        _ => {
+            let names = filter
+                .card_types
+                .iter()
+                .map(|card_type| card_type.to_string().to_ascii_lowercase())
+                .collect::<Vec<_>>();
+            format!("{} spell", names.join(", "))
+        }
+    };
+    let other = if exclude_source { "other " } else { "" };
+    let cast_text = match player {
+        PlayerFilter::You => "you've cast this turn".to_string(),
+        PlayerFilter::Opponent => "your opponents have cast this turn".to_string(),
+        _ => format!(
+            "{} has cast this turn",
+            describe_player_filter_for_spell_target(player)
+        ),
+    };
+    format!("for each {other}{spell_text} {cast_text}")
+}
+
 fn describe_cost_modifier_amount(amount: &Value) -> (String, Option<String>) {
     match amount {
         Value::Min(value, cap) => {
@@ -376,6 +410,18 @@ fn describe_cost_modifier_amount(amount: &Value) -> (String, Option<String>) {
                 )),
             )
         }
+        Value::SpellsCastThisTurnMatching {
+            player,
+            filter,
+            exclude_source,
+        } => (
+            "{1}".to_string(),
+            Some(describe_spell_cast_count_tail(
+                player,
+                filter,
+                *exclude_source,
+            )),
+        ),
         Value::Speed(player) => {
             let phrase = match player {
                 PlayerFilter::You => "your speed".to_string(),
@@ -1756,6 +1802,7 @@ impl StaticAbilityKind for ThisSpellCostReduction {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ThisSpellCostReductionManaCost {
     pub reduction: ManaCost,
+    pub repetitions: Option<Value>,
     pub condition: ThisSpellCostCondition,
 }
 
@@ -1763,8 +1810,14 @@ impl ThisSpellCostReductionManaCost {
     pub fn new(reduction: ManaCost, condition: ThisSpellCostCondition) -> Self {
         Self {
             reduction,
+            repetitions: None,
             condition,
         }
+    }
+
+    pub fn with_repetitions(mut self, repetitions: Option<Value>) -> Self {
+        self.repetitions = repetitions;
+        self
     }
 }
 
@@ -1775,11 +1828,25 @@ impl StaticAbilityKind for ThisSpellCostReductionManaCost {
 
     fn display(&self) -> String {
         let amount_text = describe_cost_modifier_mana_cost(&self.reduction);
+        let tail = self.repetitions.as_ref().and_then(|repetitions| {
+            let (_, tail) = describe_cost_modifier_amount(repetitions);
+            tail
+        });
         let Some(condition_text) = describe_this_spell_cost_condition(&self.condition) else {
-            return format!("This spell costs {amount_text} less to cast");
+            let mut line = format!("This spell costs {amount_text} less to cast");
+            if let Some(tail) = tail {
+                line.push(' ');
+                line.push_str(&tail);
+            }
+            return line;
         };
 
-        format!("This spell costs {amount_text} less to cast if {condition_text}")
+        let mut line = format!("This spell costs {amount_text} less to cast");
+        if let Some(tail) = tail {
+            line.push(' ');
+            line.push_str(&tail);
+        }
+        format!("{line} if {condition_text}")
     }
 
     fn modifies_costs(&self) -> bool {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -725,10 +725,13 @@ impl StaticAbilityModelInterpreter {
     ) -> Option<super::ThisSpellCostReductionManaCost> {
         match &model.payload {
             ironsmith_core::StaticAbilityPayload::ThisSpellCostReductionManaCost(reduction) => {
-                Some(super::ThisSpellCostReductionManaCost::new(
-                    reduction.cost.clone(),
-                    reduction.condition.clone(),
-                ))
+                Some(
+                    super::ThisSpellCostReductionManaCost::new(
+                        reduction.cost.clone(),
+                        reduction.condition.clone(),
+                    )
+                    .with_repetitions(reduction.repetitions.clone()),
+                )
             }
             ironsmith_core::StaticAbilityPayload::ThisSpellCastRestriction { .. } => None,
             ironsmith_core::StaticAbilityPayload::Conditional { ability, .. } => {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Demilich
Initial parse error:
```
parser does not yet support line family: 'You may cast this card from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast this card from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs.'
```

Current worker: i-08ef34e0565c86b95
Branch: codex/aws-card-fix-demilich
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0016
