### PR TITLE
Fix Ironsmith parse failure: Ashad, the Lone Cyberman

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -911,6 +911,54 @@ fn first_spell_each_turn_subject(filter_words: &[&str]) -> Option<AnthemSubjectA
         })
 }
 
+fn first_spell_each_turn_subject_tokens(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<AnthemSubjectAst>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.len() < 6 {
+        return Ok(None);
+    }
+
+    let first_word_idx = if words.first().copied() == Some("the") {
+        1
+    } else {
+        0
+    };
+    if words.get(first_word_idx).copied() != Some("first") {
+        return Ok(None);
+    }
+
+    let Some(tail_start_word_idx) = words.len().checked_sub(4) else {
+        return Ok(None);
+    };
+    if words.get(tail_start_word_idx..) != Some(&["you", "cast", "each", "turn"][..])
+        || tail_start_word_idx <= first_word_idx + 1
+    {
+        return Ok(None);
+    }
+
+    let Some(filter_start) = token_index_for_word_index(tokens, first_word_idx + 1) else {
+        return Ok(None);
+    };
+    let Some(filter_end) = token_index_for_word_index(tokens, tail_start_word_idx) else {
+        return Ok(None);
+    };
+    let filter_tokens = trim_commas(&tokens[filter_start..filter_end]);
+    if filter_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let mut filter = parse_object_filter_lexed(&filter_tokens, false)?;
+    if filter.stack_kind != Some(crate::filter::StackObjectKind::Spell)
+        && filter.zone != Some(Zone::Stack)
+    {
+        return Ok(None);
+    }
+    filter.cast_by = Some(PlayerFilter::You);
+    filter.first_spell_cast_each_turn = true;
+    Ok(Some(AnthemSubjectAst::Filter(filter)))
+}
+
 fn triggered_grant_effects_and_condition(
     trigger: &TriggerSpec,
     effects: &[EffectAst],
@@ -2567,6 +2615,9 @@ pub(crate) fn parse_anthem_subject(
     tokens: &[OwnedLexToken],
 ) -> Result<AnthemSubjectAst, CardTextError> {
     let subject_words = crate::runtime_backend::token_word_refs(tokens);
+    if let Some(subject) = first_spell_each_turn_subject_tokens(tokens)? {
+        return Ok(subject);
+    }
     if FIRST_SPELL_EACH_TURN_SUBJECT_PATTERN.matches_words(&subject_words) {
         return Ok(AnthemSubjectAst::Filter(
             ObjectFilter::spell()
@@ -5632,6 +5683,15 @@ fn parse_granted_object_ability_segment(
         return Ok(None);
     }
 
+    if let Some(actions) = parse_ability_line(&ability_tokens)
+        && actions.len() == 1
+        && let Some(granted) = nonstatic_keyword_action_as_granted_object_ability(
+            actions.into_iter().next().expect("single action exists"),
+        )
+    {
+        return Ok(Some(granted));
+    }
+
     if attached_subject && contains_token_kind(&ability_tokens, TokenKind::Colon) {
         let Some(parsed) = parse_attached_granted_activated_line(raw_segment)? else {
             return Err(CardTextError::ParseError(format!(
@@ -5676,6 +5736,54 @@ fn parse_granted_object_ability_segment(
     }
 
     Ok(None)
+}
+
+fn nonstatic_keyword_action_as_granted_object_ability(
+    action: KeywordAction,
+) -> Option<(ParsedAbility, String)> {
+    match action {
+        KeywordAction::Casualty(power) => {
+            let mut creature_filter = ObjectFilter::creature().you_control();
+            creature_filter.power = Some(crate::filter::Comparison::GreaterThanOrEqual(
+                power as i32,
+            ));
+            let ability = Ability {
+                kind: AbilityKind::Triggered(TriggeredAbility {
+                    trigger: Trigger::you_cast_this_spell(),
+                    effects: crate::resolution::ResolutionProgram::from_effects(vec![
+                        Effect::may(vec![
+                            Effect::sacrifice(creature_filter, 1),
+                            Effect::with_id(
+                                0,
+                                Effect::new(crate::effects::CopySpellEffect::single(
+                                    ChooseSpec::Source,
+                                )),
+                            ),
+                            Effect::may_choose_new_targets_player(
+                                crate::effect::EffectId(0),
+                                PlayerFilter::You,
+                            ),
+                        ]),
+                    ]),
+                    choices: Vec::new(),
+                    intervening_if: None,
+                    presentation_label: Some(format!("keyword:casualty {power}")),
+                }),
+                functional_zones: vec![Zone::Stack],
+            };
+            Some((
+                ParsedAbility {
+                    ability: ability.into(),
+                    text: Some(format!("Casualty {power}")),
+                    effects_ast: None,
+                    reference_imports: ReferenceImports::default(),
+                    trigger_spec: None,
+                },
+                format!("Casualty {power}"),
+            ))
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn parse_heterogeneous_granted_tail(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -635,6 +635,246 @@ fn stoic_sphinx_hexproof_tracks_whether_controller_cast_a_spell_this_turn() {
     );
 }
 
+#[test]
+fn ashad_the_lone_cyberman_parses_and_renders_casualty_grant() {
+    let def = parse_oracle_card_definition("Ashad, the Lone Cyberman");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        rendered.contains("first nonlegendary artifact spell you cast each turn"),
+        "Ashad should render the first nonlegendary artifact spell grant, got {rendered}"
+    );
+    assert!(
+        rendered.contains("casualty 2"),
+        "Ashad should render the granted casualty value, got {rendered}"
+    );
+}
+
+fn setup_ashad_casualty_game() -> (crate::game_state::GameState, PlayerId, PlayerId) {
+    let ashad = parse_oracle_card_definition("Ashad, the Lone Cyberman");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.create_object_from_definition(&ashad, alice, Zone::Battlefield);
+    (game, alice, bob)
+}
+
+fn record_ashad_spell_cast(
+    game: &mut crate::game_state::GameState,
+    caster: PlayerId,
+    raw_id: u32,
+    name: &str,
+    card_types: Vec<CardType>,
+    supertypes: Vec<Supertype>,
+) -> ObjectId {
+    let mut builder = CardBuilder::new(CardId::from_raw(raw_id), name).card_types(card_types);
+    if !supertypes.is_empty() {
+        builder = builder.supertypes(supertypes);
+    }
+    let spell = builder.build();
+    let spell_id = game.create_object_from_card(&spell, caster, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(spell_id, caster));
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(spell_id)
+            .expect("recorded Ashad test spell should exist on the stack"),
+        game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::spells::SpellCastEvent::new_with_snapshot(
+            spell_id,
+            caster,
+            Zone::Hand,
+            snapshot.clone(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.turn_store
+        .turn_history
+        .record_event(&event, Some(snapshot), None);
+    spell_id
+}
+
+fn spell_has_ashad_casualty_two(game: &crate::game_state::GameState, spell: ObjectId) -> bool {
+    game.current_abilities(spell)
+        .unwrap_or_default()
+        .iter()
+        .any(|ability| {
+            let AbilityKind::Triggered(triggered) = &ability.kind else {
+                return false;
+            };
+            if triggered
+                .trigger
+                .downcast_ref::<crate::triggers::YouCastThisSpellTrigger>()
+                .is_none()
+            {
+                return false;
+            }
+            let [effect] = triggered.effects.flattened_default_effects() else {
+                return false;
+            };
+            let Some(may) = effect.downcast_ref::<crate::effects::MayEffect>() else {
+                return false;
+            };
+            let [sacrifice, copy, choose_targets] = may.effects.as_slice() else {
+                return false;
+            };
+            let Some(sacrifice) = sacrifice.downcast_ref::<crate::effects::SacrificeEffect>()
+            else {
+                return false;
+            };
+            if sacrifice.player != PlayerFilter::You
+                || sacrifice.count != crate::effect::Value::Fixed(1)
+                || sacrifice.filter.power
+                    != Some(crate::filter::Comparison::GreaterThanOrEqual(2))
+                || !sacrifice.filter.card_types.contains(&CardType::Creature)
+            {
+                return false;
+            }
+            let Some(copy) = copy.downcast_ref::<crate::effects::WithIdEffect>() else {
+                return false;
+            };
+            if copy
+                .effect
+                .downcast_ref::<crate::effects::CopySpellEffect>()
+                .is_none()
+            {
+                return false;
+            }
+            choose_targets
+                .downcast_ref::<crate::effects::ChooseNewTargetsEffect>()
+                .is_some_and(|choose| choose.from_effect == copy.id && choose.may)
+        })
+}
+
+#[test]
+fn ashad_grants_casualty_to_first_nonlegendary_artifact_spell_you_cast() {
+    let (mut game, alice, bob) = setup_ashad_casualty_game();
+
+    record_ashad_spell_cast(
+        &mut game,
+        bob,
+        93_200,
+        "Bob's First Spell",
+        vec![CardType::Instant],
+        vec![],
+    );
+    let first_alice_artifact = record_ashad_spell_cast(
+        &mut game,
+        alice,
+        93_201,
+        "Alice's First Artifact",
+        vec![CardType::Artifact],
+        vec![],
+    );
+    assert!(
+        spell_has_ashad_casualty_two(&game, first_alice_artifact),
+        "Ashad should grant casualty 2 to the first nonlegendary artifact spell Alice casts even if Bob cast a spell first; abilities: {:#?}",
+        game.current_abilities(first_alice_artifact)
+    );
+
+    let second_alice_artifact = record_ashad_spell_cast(
+        &mut game,
+        alice,
+        93_202,
+        "Alice's Second Artifact",
+        vec![CardType::Artifact],
+        vec![],
+    );
+    assert!(
+        !spell_has_ashad_casualty_two(&game, second_alice_artifact),
+        "Ashad should not grant casualty 2 to Alice's second spell that turn"
+    );
+}
+
+#[test]
+fn ashad_ignores_prior_spells_that_do_not_match_the_granted_subject() {
+    let (mut nonartifact_game, alice, _) = setup_ashad_casualty_game();
+    let prior_nonartifact = record_ashad_spell_cast(
+        &mut nonartifact_game,
+        alice,
+        93_203,
+        "Prior Nonartifact Spell",
+        vec![CardType::Instant],
+        vec![],
+    );
+    assert!(
+        !spell_has_ashad_casualty_two(&nonartifact_game, prior_nonartifact),
+        "Ashad should not grant casualty 2 to a nonartifact spell"
+    );
+    let first_matching_artifact = record_ashad_spell_cast(
+        &mut nonartifact_game,
+        alice,
+        93_204,
+        "First Matching Artifact",
+        vec![CardType::Artifact],
+        vec![],
+    );
+    assert!(
+        spell_has_ashad_casualty_two(&nonartifact_game, first_matching_artifact),
+        "Ashad should grant casualty 2 to the first nonlegendary artifact spell even after a prior nonartifact spell"
+    );
+
+    let (mut legendary_game, alice, _) = setup_ashad_casualty_game();
+    let prior_legendary_artifact = record_ashad_spell_cast(
+        &mut legendary_game,
+        alice,
+        93_205,
+        "Prior Legendary Artifact",
+        vec![CardType::Artifact],
+        vec![Supertype::Legendary],
+    );
+    assert!(
+        !spell_has_ashad_casualty_two(&legendary_game, prior_legendary_artifact),
+        "Ashad should not grant casualty 2 to a legendary artifact spell"
+    );
+    let first_nonlegendary_artifact = record_ashad_spell_cast(
+        &mut legendary_game,
+        alice,
+        93_206,
+        "First Nonlegendary Artifact",
+        vec![CardType::Artifact],
+        vec![],
+    );
+    assert!(
+        spell_has_ashad_casualty_two(&legendary_game, first_nonlegendary_artifact),
+        "Ashad should grant casualty 2 to the first nonlegendary artifact spell even after a prior legendary artifact spell"
+    );
+}
+
+#[test]
+fn ashad_does_not_grant_casualty_to_legendary_or_nonartifact_first_spells() {
+    let (mut legendary_game, alice, _) = setup_ashad_casualty_game();
+    let legendary_artifact = record_ashad_spell_cast(
+        &mut legendary_game,
+        alice,
+        93_207,
+        "Legendary Artifact Probe",
+        vec![CardType::Artifact],
+        vec![Supertype::Legendary],
+    );
+    assert!(
+        !spell_has_ashad_casualty_two(&legendary_game, legendary_artifact),
+        "Ashad should not grant casualty 2 to a legendary artifact spell"
+    );
+
+    let (mut nonartifact_game, alice, _) = setup_ashad_casualty_game();
+    let nonartifact_spell = record_ashad_spell_cast(
+        &mut nonartifact_game,
+        alice,
+        93_208,
+        "Nonartifact Spell Probe",
+        vec![CardType::Instant],
+        vec![],
+    );
+    assert!(
+        !spell_has_ashad_casualty_two(&nonartifact_game, nonartifact_spell),
+        "Ashad should not grant casualty 2 to a nonartifact spell"
+    );
+}
+
 fn alacrian_armory_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
     def.abilities
         .iter()

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -50,6 +50,35 @@ fn object_is_enlist_eligible(game: &GameState, id: ObjectId) -> bool {
     !game.is_summoning_sick(id) || game.current_has_static_ability_id(id, StaticAbilityId::Haste)
 }
 
+fn first_matching_spell_cast_each_turn_matches(
+    filter: &ObjectFilter,
+    object_id: ObjectId,
+    ctx: &FilterContext,
+    game: &GameState,
+    fallback_cast_player: Option<PlayerId>,
+) -> bool {
+    let mut matching_filter = filter.clone();
+    matching_filter.first_spell_cast_each_turn = false;
+
+    let mut history_ctx = ctx.clone();
+    history_ctx.caster = None;
+
+    for snapshot in game.turn_store.turn_history.spell_cast_snapshot_history() {
+        if matching_filter.matches_snapshot(&snapshot, &history_ctx, game) {
+            return snapshot.object_id == object_id;
+        }
+    }
+
+    let cast_order = fallback_cast_player
+        .and_then(|player| {
+            game.turn_store
+                .turn_history
+                .spell_cast_order_for_player(object_id, player)
+        })
+        .or_else(|| game.turn_store.turn_history.spell_cast_order(object_id));
+    cast_order == Some(1)
+}
+
 fn expand_semantic_subtypes(chars: &mut crate::continuous::CalculatedCharacteristics) {
     let has_changeling = chars
         .static_abilities
@@ -1921,6 +1950,8 @@ impl ObjectFilterExt for ObjectFilter {
             return false;
         }
 
+        let mut resolved_cast_player = None;
+
         // Caster check
         if let Some(caster_filter) = &self.cast_by {
             let cast_player = ctx.caster.or_else(|| {
@@ -1936,10 +1967,17 @@ impl ObjectFilterExt for ObjectFilter {
             if !caster_filter.matches_player(cast_player, ctx) {
                 return false;
             }
+            resolved_cast_player = Some(cast_player);
         }
 
         if self.first_spell_cast_each_turn
-            && game.turn_store.turn_history.spell_cast_order(object.id) != Some(1)
+            && !first_matching_spell_cast_each_turn_matches(
+                self,
+                object.id,
+                ctx,
+                game,
+                resolved_cast_player,
+            )
         {
             return false;
         }
@@ -2555,11 +2593,13 @@ impl ObjectFilterExt for ObjectFilter {
         }
 
         if self.first_spell_cast_each_turn
-            && game
-                .turn_store
-                .turn_history
-                .spell_cast_order(snapshot.object_id)
-                != Some(1)
+            && !first_matching_spell_cast_each_turn_matches(
+                self,
+                snapshot.object_id,
+                ctx,
+                game,
+                None,
+            )
         {
             return false;
         }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -505,6 +505,9 @@ fn spell_grant_subject_text(filter: &ObjectFilter) -> Option<String> {
     for card_type in &filter.excluded_card_types {
         qualifiers.push(format!("non{}", card_type.name().to_ascii_lowercase()));
     }
+    for supertype in &filter.excluded_supertypes {
+        qualifiers.push(format!("non{}", supertype.name().to_ascii_lowercase()));
+    }
     if !filter.subtypes.is_empty() {
         qualifiers.push(join_with_and(
             &filter
@@ -524,7 +527,13 @@ fn spell_grant_subject_text(filter: &ObjectFilter) -> Option<String> {
         ));
     }
 
-    let mut subject = if qualifiers.is_empty() {
+    let mut subject = if filter.first_spell_cast_each_turn {
+        if qualifiers.is_empty() {
+            "the first spell".to_string()
+        } else {
+            format!("the first {} spell", qualifiers.join(" "))
+        }
+    } else if qualifiers.is_empty() {
         "spells".to_string()
     } else {
         format!("{} spells", qualifiers.join(" "))
@@ -565,6 +574,10 @@ fn spell_grant_subject_text(filter: &ObjectFilter) -> Option<String> {
     if let Some(zone_suffix) = zone_suffix {
         subject.push(' ');
         subject.push_str(&zone_suffix);
+    }
+
+    if filter.first_spell_cast_each_turn {
+        subject.push_str(" each turn");
     }
 
     if let Some(power) = &filter.power {

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -832,6 +832,23 @@ impl TurnHistory {
         None
     }
 
+    pub fn spell_cast_order_for_player(&self, spell: ObjectId, player: PlayerId) -> Option<u32> {
+        let mut order = 0u32;
+        for record in self.projected_records() {
+            let Some(event) = record.event.downcast::<SpellCastEvent>() else {
+                continue;
+            };
+            if event.caster != player {
+                continue;
+            }
+            order = order.saturating_add(1);
+            if event.spell == spell {
+                return Some(order);
+            }
+        }
+        None
+    }
+
     pub fn spell_cast_snapshot_history(&self) -> Vec<ObjectSnapshot> {
         let mut order = 0u32;
         let mut snapshots = Vec::new();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ashad, the Lone Cyberman
Initial parse error:
```
parser does not yet support line family: 'The first nonlegendary artifact spell you cast each turn has casualty 2. (As you cast it, you may sacrifice a creature with power 2 or greater. When you do, copy it. A copy of an artifact spell becomes a token.)'; oracle-only fallback also failed: parser does not yet support line family: 'The first nonlegendary artifact spell you cast each turn has casualty 2.'
```

Current worker: i-0435a375809192ca9
Branch: codex/aws-card-fix-ashad-the-lone-cyberman
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0018
