### PR TITLE
Fix Ironsmith parse failure: Ruin Raider

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2872,6 +2872,9 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
     }
 
     if let Some(used) = matching_prefix_len(&[
+        &["the", "card", "mana", "value"],
+        &["the", "card's", "mana", "value"],
+        &["the", "cards", "mana", "value"],
         &["that", "card", "mana", "value"],
         &["that", "card's", "mana", "value"],
         &["that", "cards", "mana", "value"],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -997,6 +997,29 @@ fn jadar_ghoulcaller_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[test]
+fn ruin_raider_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Ruin Raider");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        ability_debug.contains("BeginningOfEndStepTrigger")
+            && ability_debug.contains("AttackedThisTurn")
+            && ability_debug.contains("RevealTopEffect")
+            && ability_debug.contains("MoveToZoneEffect")
+            && ability_debug.contains("LoseLifeEffect")
+            && ability_debug.contains("ManaValueOf"),
+        "Ruin Raider should structurally keep the raid trigger, top-card reveal, hand move, and mana-value life loss, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "Raid — At the beginning of your end step, if you attacked this turn, reveal the top card of your library and put that card into your hand. You lose life equal to the card's mana value."
+        ),
+        "expected Ruin Raider compiled text to preserve the reveal-to-hand and mana-value life-loss clause, got {rendered}"
+    );
+}
+
 fn jadar_end_step_event(player: PlayerId) -> crate::triggers::TriggerEvent {
     crate::triggers::TriggerEvent::new_with_provenance(
         crate::events::phase::BeginningOfEndStepEvent::new(player),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3070,6 +3070,53 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
 }
 
+fn describe_reveal_top_to_hand_then_lose_mana_value_effects(effects: &[Effect]) -> Option<String> {
+    let [reveal_effect, move_effect, lose_effect] = effects else {
+        return None;
+    };
+    let reveal = unwrap_basic_tag_wrappers(reveal_effect)
+        .downcast_ref::<crate::effects::RevealTopEffect>()?;
+    if reveal.player != PlayerFilter::You {
+        return None;
+    }
+    let tag = reveal.tag.as_ref()?;
+    let move_effect = unwrap_basic_tag_wrappers(move_effect);
+    let moves_tag_to_hand = move_effect
+        .downcast_ref::<crate::effects::ReturnToHandEffect>()
+        .is_some_and(|return_to_hand| {
+            matches!(return_to_hand.spec.base(), ChooseSpec::Tagged(found) if found == tag)
+        })
+        || move_effect
+            .downcast_ref::<crate::effects::MoveToZoneEffect>()
+            .is_some_and(|move_to_zone| {
+                move_to_zone.zone == Zone::Hand
+                    && matches!(
+                        move_to_zone.target.base(),
+                        ChooseSpec::Tagged(found) if found == tag
+                    )
+            });
+    if !moves_tag_to_hand {
+        return None;
+    }
+    let lose_life = unwrap_basic_tag_wrappers(lose_effect)
+        .downcast_ref::<crate::effects::LoseLifeEffect>()?;
+    if lose_life.player != ChooseSpec::Player(PlayerFilter::You) {
+        return None;
+    }
+    if !matches!(
+        &lose_life.amount,
+        Value::ManaValueOf(spec)
+            if matches!(spec.base(), ChooseSpec::Tagged(found) if found == tag)
+    )
+    {
+        return None;
+    }
+    Some(
+        "Reveal the top card of your library and put that card into your hand. You lose life equal to the card's mana value"
+            .to_string(),
+    )
+}
+
 fn is_all_attacking_creatures(spec: &ChooseSpec) -> bool {
     let ChooseSpec::All(filter) = spec.base() else {
         return false;
@@ -3955,6 +4002,9 @@ fn describe_revealed_cards_opponent_may_put_or_draw(effects: &[&Effect]) -> Opti
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_reveal_top_to_hand_then_lose_mana_value_effects(effects) {
+        return compact;
+    }
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
     }
@@ -14624,6 +14674,11 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
 
     let compact = describe_effect_list(effects);
     let compact_trimmed = compact.trim();
+    if compact_trimmed
+        == "Reveal the top card of your library and put that card into your hand. You lose life equal to the card's mana value"
+    {
+        return Some(cleanup_decompiled_text(&lowercase_first(compact_trimmed)));
+    }
     if !compact_trimmed.is_empty()
         && !compact_trimmed.contains(". ")
         && !compact_trimmed.contains(": ")

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -5992,6 +5992,116 @@ fn singe_mind_ogre_reveals_a_random_card_from_target_players_hand_and_makes_them
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn ruin_raider_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(70_020), "Ruin Raider")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Orc, Subtype::Pirate])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Raid — At the beginning of your end step, if you attacked this turn, reveal the top card of your library and put that card into your hand. You lose life equal to the card's mana value.",
+        )
+        .expect("Ruin Raider should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn ruin_raider_end_step_event(player: PlayerId) -> TriggerEvent {
+    TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(player),
+        crate::provenance::ProvNodeId::default(),
+    )
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn ruin_raider_top_card(raw_id: u32, name: &str, mana_value: u8) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(raw_id), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(mana_value)]]))
+        .card_types(vec![CardType::Artifact])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn ruin_raider_does_not_trigger_at_end_step_without_raid() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let ruin_raider = ruin_raider_definition();
+    let ruin_raider_id = game.create_object_from_definition(&ruin_raider, alice, Zone::Battlefield);
+    game.turn.active_player = alice;
+
+    let event = ruin_raider_end_step_event(alice);
+    let triggers = crate::triggers::check_triggers(&game, &event);
+
+    assert!(
+        triggers
+            .into_iter()
+            .all(|trigger| trigger.source != ruin_raider_id),
+        "Ruin Raider should not trigger if its controller did not attack this turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn ruin_raider_reveals_top_card_puts_it_into_hand_and_loses_life_after_raid() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let ruin_raider = ruin_raider_definition();
+    let ruin_raider_id = game.create_object_from_definition(&ruin_raider, alice, Zone::Battlefield);
+    let top_card = ruin_raider_top_card(70_021, "Ruin Raider Revealed Probe", 4);
+    let top_id = game.create_object_from_card(&top_card, alice, Zone::Library);
+    let top_stable = game.object(top_id).expect("top card exists").stable_id;
+    game.turn.active_player = alice;
+    game.turn_store
+        .turn_history
+        .players_attacked_this_turn
+        .insert(alice);
+
+    let event = ruin_raider_end_step_event(alice);
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        if trigger.source == ruin_raider_id {
+            trigger_queue.add(trigger);
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Ruin Raider should trigger at your end step after you attacked"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Ruin Raider trigger should go on the stack");
+
+    let life_before = game.player(alice).expect("alice exists").life;
+    let mut dm = CaptureRevealDecisionMaker::default();
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Ruin Raider trigger should resolve");
+
+    assert!(
+        dm.view_calls.iter().any(|(_, subject, zone, public, cards)| {
+            *subject == alice && *zone == Zone::Library && *public && cards.contains(&top_id)
+        }),
+        "Ruin Raider should publicly reveal the top card of Alice's library"
+    );
+    let revealed_id = game
+        .find_object_by_stable_id(top_stable)
+        .expect("revealed card should still exist");
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .contains(&revealed_id),
+        "Ruin Raider should put the revealed card into its controller's hand"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        life_before - 4,
+        "Ruin Raider should make its controller lose life equal to the revealed card's mana value"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn dinrova_horror_returns_target_and_its_owner_discards() {
     struct ChooseDiscardCardDecisionMaker {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ruin Raider
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to the card's mana value'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to the card's mana value')
```

Current worker: i-05036525dba56fc5f
Branch: codex/aws-card-fix-ruin-raider
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0019
