### PR TITLE
Fix Ironsmith parse failure: Zilortha, Strength Incarnate

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -24,6 +24,7 @@ use super::grammar::abilities::{
     is_if_source_you_control_with_mana_value_double_instead_marker_line_lexed,
     is_krrik_black_mana_life_payment_line_lexed,
     is_lands_dont_untap_during_their_controllers_untap_steps_line_lexed,
+    is_lethal_damage_to_creatures_you_control_uses_power_line_lexed,
     is_mana_group_slash_marker_line_lexed, is_may_assign_damage_as_unblocked_line_lexed,
     is_minimum_spell_total_mana_three_line_lexed, is_more_than_meets_the_eye_marker_line_lexed,
     is_no_maximum_hand_size_line_lexed, is_once_each_turn_play_from_exile_marker_guard_lexed,
@@ -649,6 +650,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         ),
         single_static_ability_ast_passthrough_rule!(parse_trigger_suppression_line_ast),
         single_static_ability_ast_rule!(parse_creatures_assign_combat_damage_using_toughness_line),
+        single_static_ability_ast_rule!(
+            parse_lethal_damage_to_creatures_you_control_uses_power_line
+        ),
         single_static_ability_ast_rule!(parse_players_cant_cycle_line),
         single_static_ability_ast_rule!(parse_starting_life_bonus_line),
         single_static_ability_ast_rule!(parse_buyback_cost_reduction_line),
@@ -4135,6 +4139,17 @@ pub(crate) fn parse_creatures_assign_combat_damage_using_toughness_line(
             ));
         }
         None => {}
+    }
+    Ok(None)
+}
+
+pub(crate) fn parse_lethal_damage_to_creatures_you_control_uses_power_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_lethal_damage_to_creatures_you_control_uses_power_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::lethal_damage_to_creatures_you_control_uses_power(),
+        ));
     }
     Ok(None)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -1995,6 +1995,36 @@ pub(crate) fn parse_creatures_assign_combat_damage_using_toughness_line_lexed(
     None
 }
 
+pub(crate) fn is_lethal_damage_to_creatures_you_control_uses_power_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    primitives::parse_prefix(
+        tokens,
+        (
+            primitives::phrase(&[
+                "lethal",
+                "damage",
+                "dealt",
+                "to",
+                "creatures",
+                "you",
+                "control",
+                "is",
+                "determined",
+                "by",
+                "their",
+                "power",
+                "rather",
+                "than",
+                "their",
+                "toughness",
+            ]),
+            primitives::sentence_end(),
+        ),
+    )
+    .is_some_and(|(((), ()), remainder)| remainder.is_empty())
+}
+
 fn parse_players_cant_cycle_line<'a>(
     input: &mut LexStream<'a>,
 ) -> Result<(), ErrMode<ContextError>> {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8156,6 +8156,32 @@ fn rewrite_grammar_combat_damage_using_toughness_probe_tracks_subject_variant() 
 }
 
 #[test]
+fn rewrite_grammar_zilortha_lethal_damage_power_static_line() {
+    let tokens = lex_line(
+        "Lethal damage dealt to creatures you control is determined by their power rather than their toughness.",
+        0,
+    )
+    .expect("rewrite lexer should classify Zilortha lethal-damage static line");
+
+    assert!(
+        super::grammar::abilities::is_lethal_damage_to_creatures_you_control_uses_power_line_lexed(
+            &tokens
+        ),
+        "grammar-owned lethal-damage power probe should match Zilortha's static line"
+    );
+
+    let parsed = super::keyword_static::parse_lethal_damage_to_creatures_you_control_uses_power_line(&tokens)
+        .expect("Zilortha lethal-damage static line should parse");
+
+    assert!(matches!(
+        parsed,
+        Some(ability)
+            if ability.id()
+                == crate::static_abilities::StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower
+    ));
+}
+
+#[test]
 fn rewrite_grammar_players_cant_cycle_probe_matches_static_line() {
     let tokens = lex_line("Players can't cycle cards.", 0)
         .expect("rewrite lexer should classify anti-cycle static line");

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -89,6 +89,7 @@ pub enum StaticAbilityId {
     ThisCreatureAssignsCombatDamageUsingToughness,
     CreaturesAssignCombatDamageUsingToughness,
     CreaturesYouControlAssignCombatDamageUsingToughness,
+    LethalDamageToCreaturesYouControlUsesPower,
     Anthem,
     GrantAbility,
     RemoveAbilityForFilter,
@@ -339,6 +340,7 @@ impl StaticAbilityId {
             | ThisCreatureAssignsCombatDamageUsingToughness
             | CreaturesAssignCombatDamageUsingToughness
             | CreaturesYouControlAssignCombatDamageUsingToughness
+            | LethalDamageToCreaturesYouControlUsesPower
             | Anthem
             | GrantAbility
             | RemoveAbilityForFilter
@@ -632,6 +634,7 @@ impl StaticAbilityId {
                 | ThisCreatureAssignsCombatDamageUsingToughness
                 | CreaturesAssignCombatDamageUsingToughness
                 | CreaturesYouControlAssignCombatDamageUsingToughness
+                | LethalDamageToCreaturesYouControlUsesPower
         )
     }
 

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3143,6 +3143,12 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn lethal_damage_to_creatures_you_control_uses_power() -> Self {
+        Self::identified(
+            StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower,
+            "lethal damage to creatures you control uses power",
+        )
+    }
     pub fn players_cant_cycle() -> Self {
         Self {
             id: Some(StaticAbilityId::PlayersCantCycle),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36087,6 +36087,26 @@ fn calamity_bearer_strict_parser_and_text_regression() {
 }
 
 #[test]
+fn zilortha_strength_incarnate_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Zilortha, Strength Incarnate");
+    let rendered_lines = canonical_compiled_lines(&def);
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower
+        )),
+        "Zilortha, Strength Incarnate should compile to a lethal-damage power static ability"
+    );
+    assert!(
+        rendered_lines.iter().any(|line| line
+            == "Lethal damage dealt to creatures you control is determined by their power rather than their toughness."),
+        "Zilortha, Strength Incarnate should render its lethal-damage clause, got {rendered_lines:?}"
+    );
+}
+
+#[test]
 fn calamity_bearer_runtime_doubles_giant_source_damage_to_players_and_permanents() {
     let def = parse_oracle_card_definition("Calamity Bearer");
     let mut game = crate::game_state::GameState::new(

--- a/crates/ironsmith-runtime/src/game_loop/combat_damage.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_damage.rs
@@ -327,12 +327,11 @@ fn distribute_explicit_trample_damage(
         let blocker_id = blocker_ids[index];
         let lethal = if has_deathtouch {
             1
-        } else if let Some(toughness) = game
-            .calculated_toughness(blocker.id)
-            .or_else(|| blocker.toughness())
+        } else if let Some(threshold) =
+            crate::rules::damage::lethal_damage_threshold_for_creature(game, blocker)
         {
             let existing_damage = game.damage_on(blocker.id);
-            (toughness - existing_damage as i32).max(0) as u32
+            (threshold - existing_damage as i32).max(0) as u32
         } else {
             0
         };
@@ -364,12 +363,11 @@ fn distribute_explicit_damage_to_creatures(
 
     for (index, recipient) in recipients.iter().enumerate() {
         let recipient_id = recipient_ids[index];
-        let lethal = if let Some(toughness) = game
-            .calculated_toughness(recipient.id)
-            .or_else(|| recipient.toughness())
+        let lethal = if let Some(threshold) =
+            crate::rules::damage::lethal_damage_threshold_for_creature(game, recipient)
         {
             let existing_damage = game.damage_on(recipient.id);
-            (toughness - existing_damage as i32).max(0) as u32
+            (threshold - existing_damage as i32).max(0) as u32
         } else {
             0
         };

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -16002,6 +16002,201 @@ fn test_unblocked_attacker_uses_toughness_for_combat_damage_when_static_applies(
 }
 
 #[test]
+fn test_zilortha_strength_incarnate_power_sets_lethal_damage_for_your_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let zilortha = CardDefinitionBuilder::new(CardId::new(), "Zilortha, Strength Incarnate")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(7, 3))
+        .parse_text(
+            "Trample\n\
+             Lethal damage dealt to creatures you control is determined by their power rather than their toughness.",
+        )
+        .expect("Zilortha, Strength Incarnate should parse for runtime test");
+    let zilortha_id = game.create_object_from_definition(&zilortha, alice, Zone::Battlefield);
+    assert!(game.current_has_static_ability_id(
+        zilortha_id,
+        crate::static_abilities::StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower,
+    ));
+
+    let high_power_creature = create_creature(&mut game, "Alice's High-Power Creature", alice, 5, 2);
+    game.mark_damage(high_power_creature, 4);
+    crate::rules::state_based::apply_state_based_actions(&mut game);
+
+    assert!(
+        game.battlefield.contains(&high_power_creature),
+        "Zilortha should let Alice's 5/2 survive 4 marked damage because lethal damage uses power"
+    );
+
+    game.mark_damage(high_power_creature, 1);
+    assert_eq!(
+        game.damage_on(high_power_creature),
+        5,
+        "marked damage should remain between SBA checks until cleanup"
+    );
+    assert!(
+        crate::rules::state_based::check_state_based_actions(&game)
+            .contains(&crate::rules::state_based::StateBasedAction::ObjectDies(
+                high_power_creature,
+            )),
+        "Zilortha should make 5 damage lethal to Alice's 5-power creature"
+    );
+    crate::rules::state_based::apply_state_based_actions(&mut game);
+
+    assert!(
+        game.current_object_id_after_zone_change(high_power_creature)
+            .and_then(|id| game.object(id))
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "Zilortha should make Alice's 5/2 die once marked damage reaches its power"
+    );
+}
+
+#[test]
+fn test_zilortha_strength_incarnate_only_changes_lethal_damage_for_controller_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let zilortha = CardDefinitionBuilder::new(CardId::new(), "Zilortha, Strength Incarnate")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(7, 3))
+        .parse_text(
+            "Trample\n\
+             Lethal damage dealt to creatures you control is determined by their power rather than their toughness.",
+        )
+        .expect("Zilortha, Strength Incarnate should parse for runtime test");
+    let zilortha_id = game.create_object_from_definition(&zilortha, alice, Zone::Battlefield);
+    assert!(game.current_has_static_ability_id(
+        zilortha_id,
+        crate::static_abilities::StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower,
+    ));
+
+    let alice_low_power_creature =
+        create_creature(&mut game, "Alice's Low-Power Creature", alice, 2, 5);
+    let bob_low_power_creature = create_creature(&mut game, "Bob's Low-Power Creature", bob, 2, 5);
+
+    game.mark_damage(alice_low_power_creature, 2);
+    game.mark_damage(bob_low_power_creature, 2);
+    assert!(
+        crate::rules::state_based::check_state_based_actions(&game).contains(
+            &crate::rules::state_based::StateBasedAction::ObjectDies(alice_low_power_creature),
+        ),
+        "Zilortha should make 2 damage lethal to Alice's 2-power creature"
+    );
+    crate::rules::state_based::apply_state_based_actions(&mut game);
+
+    assert!(
+        game.current_object_id_after_zone_change(alice_low_power_creature)
+            .and_then(|id| game.object(id))
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "Zilortha should make Alice's 2/5 die from 2 marked damage because lethal damage uses power"
+    );
+    assert!(
+        game.battlefield.contains(&bob_low_power_creature),
+        "Zilortha should not change lethal damage for Bob's creatures"
+    );
+}
+
+#[test]
+fn test_zilortha_strength_incarnate_lethal_damage_interacts_with_deathtouch_and_trample() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let zilortha = CardDefinitionBuilder::new(CardId::new(), "Zilortha, Strength Incarnate")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(7, 3))
+        .parse_text(
+            "Trample\n\
+             Lethal damage dealt to creatures you control is determined by their power rather than their toughness.",
+        )
+        .expect("Zilortha, Strength Incarnate should parse for runtime test");
+    game.create_object_from_definition(&zilortha, alice, Zone::Battlefield);
+
+    let deathtouch_victim = create_creature(&mut game, "Alice's Zero-Power Creature", alice, 0, 5);
+    game.mark_damage(deathtouch_victim, 1);
+    game.mark_deathtouch_damage_since_sba(deathtouch_victim);
+    crate::rules::state_based::apply_state_based_actions(&mut game);
+
+    assert!(
+        game.current_object_id_after_zone_change(deathtouch_victim)
+            .and_then(|id| game.object(id))
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "deathtouch damage should still destroy Alice's creature even when Zilortha makes its power 0 the lethal threshold"
+    );
+
+    let zero_power_victim = create_creature(&mut game, "Alice's Damaged Zero-Power Creature", alice, 0, 5);
+    game.mark_damage(zero_power_victim, 1);
+    crate::rules::state_based::apply_state_based_actions(&mut game);
+
+    assert!(
+        game.current_object_id_after_zone_change(zero_power_victim)
+            .and_then(|id| game.object(id))
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "Zilortha should destroy Alice's 0-power creature once it has at least 1 damage marked"
+    );
+
+    let trampler = CardDefinitionBuilder::new(CardId::new(), "Bob's Trampler")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .parse_text("Trample")
+        .expect("trample attacker should parse");
+    let attacker_id = game.create_object_from_definition(&trampler, bob, Zone::Battlefield);
+    let blocker_id = create_creature(&mut game, "Alice's High-Power Blocker", alice, 5, 2);
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker_id,
+        target: AttackTarget::Player(alice),
+    });
+    combat.blockers.insert(attacker_id, vec![blocker_id]);
+
+    let events = execute_combat_damage_step(&mut game, &combat, false);
+    assert_eq!(
+        game.player(alice).unwrap().life,
+        20,
+        "Zilortha should make the trampler assign all 5 damage to Alice's 5-power blocker"
+    );
+    assert!(
+        events.iter().any(|event| event.target
+            == DamageEventTarget::Object(blocker_id)
+            && event.amount == 5),
+        "combat damage should assign lethal damage by blocker power under Zilortha, got {events:?}"
+    );
+
+    let second_trampler = CardDefinitionBuilder::new(CardId::new(), "Bob's Second Trampler")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .parse_text("Trample")
+        .expect("second trample attacker should parse");
+    let second_attacker_id = game.create_object_from_definition(&second_trampler, bob, Zone::Battlefield);
+    let zero_power_blocker = create_creature(&mut game, "Alice's Zero-Power Blocker", alice, 0, 5);
+
+    let mut second_combat = CombatState::default();
+    second_combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: second_attacker_id,
+        target: AttackTarget::Player(alice),
+    });
+    second_combat
+        .blockers
+        .insert(second_attacker_id, vec![zero_power_blocker]);
+
+    let second_events = execute_combat_damage_step(&mut game, &second_combat, false);
+    assert_eq!(
+        game.player(alice).unwrap().life,
+        16,
+        "Zilortha should require 1 assigned damage before trampling over a 0-power blocker"
+    );
+    assert!(
+        second_events.iter().any(|event| event.target
+            == DamageEventTarget::Object(zero_power_blocker)
+            && event.amount == 1),
+        "combat damage should assign 1 lethal damage to a 0-power blocker under Zilortha, got {second_events:?}"
+    );
+}
+
+#[test]
 fn test_blocked_attacker_deals_damage_to_blocker() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/rules/damage.rs
+++ b/crates/ironsmith-runtime/src/rules/damage.rs
@@ -424,11 +424,9 @@ pub fn distribute_trample_damage(
         let existing_damage = game.damage_on(blocker.id);
         let lethal = if has_deathtouch {
             1
-        } else if let Some(toughness) = game
-            .calculated_toughness(blocker.id)
-            .or_else(|| blocker.toughness())
+        } else if let Some(threshold) = lethal_damage_threshold_for_creature(game, blocker)
         {
-            (toughness - existing_damage as i32).max(0) as u32
+            (threshold - existing_damage as i32).max(0) as u32
         } else {
             0
         };
@@ -469,11 +467,9 @@ pub fn distribute_combat_damage_to_creatures(
         let existing_damage = game.damage_on(creature.id);
         let lethal = if has_deathtouch {
             1
-        } else if let Some(toughness) = game
-            .calculated_toughness(creature.id)
-            .or_else(|| creature.toughness())
+        } else if let Some(threshold) = lethal_damage_threshold_for_creature(game, creature)
         {
-            (toughness - existing_damage as i32).max(0) as u32
+            (threshold - existing_damage as i32).max(0) as u32
         } else {
             0
         };
@@ -491,6 +487,29 @@ pub fn distribute_combat_damage_to_creatures(
     }
 
     distribution
+}
+
+pub(crate) fn lethal_damage_threshold_for_creature(
+    game: &crate::game_state::GameState,
+    creature: &Object,
+) -> Option<i32> {
+    let creature_controller = game.controller_of(creature);
+    let uses_power = game.battlefield.iter().any(|&source_id| {
+        game.controller_of_id(source_id) == Some(creature_controller)
+            && game.object_has_static_ability_id(
+                source_id,
+                StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower,
+            )
+    });
+
+    if uses_power {
+        game.calculated_power(creature.id)
+            .or_else(|| creature.power())
+            .map(|power| power.max(1))
+    } else {
+        game.calculated_toughness(creature.id)
+            .or_else(|| creature.toughness())
+    }
 }
 
 #[cfg(test)]

--- a/crates/ironsmith-runtime/src/rules/state_based.rs
+++ b/crates/ironsmith-runtime/src/rules/state_based.rs
@@ -285,10 +285,8 @@ fn check_permanent_sbas_with_view(
         };
         let calculated_subtypes = view.calculated_subtypes(obj_id);
 
-        // Creature with 0 or less toughness dies (unless indestructible)
-        // Check both:
-        // 1. CantEffectTracker (catches indestructibility from external sources)
-        // 2. Direct ability check (in case tracker hasn't been refreshed)
+        // Creature with 0 or less toughness dies. This is not destruction,
+        // so indestructible and regeneration do not stop it.
         // IMPORTANT: Use calculated_toughness to account for counters and effects!
         if view.object_has_card_type(obj_id, CardType::Creature) {
             let is_indestructible = !game.can_be_destroyed(obj_id)
@@ -298,7 +296,6 @@ fn check_permanent_sbas_with_view(
             // Use calculated toughness to include -1/-1 counters, pump effects, etc.
             if let Some(toughness) = view.calculated_toughness(obj_id)
                 && toughness <= 0
-                && !is_indestructible
             {
                 actions.push(StateBasedAction::ObjectDies(obj_id));
                 continue;
@@ -306,18 +303,19 @@ fn check_permanent_sbas_with_view(
 
             // Creature with lethal damage dies (unless indestructible)
             let damage_marked = game.damage_on(obj_id);
-            let toughness_for_lethal = view
-                .calculated_toughness(obj_id)
-                .or_else(|| obj.toughness());
-            if toughness_for_lethal
-                .is_some_and(|toughness| toughness > 0 && damage_marked >= toughness as u32)
+            let lethal_damage_threshold = lethal_damage_threshold_for_creature(game, view, obj_id);
+            if lethal_damage_threshold
+                .is_some_and(|threshold| threshold > 0 && damage_marked >= threshold as u32)
                 && !is_indestructible
             {
                 actions.push(StateBasedAction::ObjectDies(obj_id));
                 continue;
             }
 
-            if toughness_for_lethal.is_some_and(|toughness| toughness > 0)
+            let toughness_for_deathtouch = view
+                .calculated_toughness(obj_id)
+                .or_else(|| obj.toughness());
+            if toughness_for_deathtouch.is_some_and(|toughness| toughness > 0)
                 && game.has_deathtouch_damage_since_sba(obj_id)
                 && !is_indestructible
             {
@@ -390,6 +388,58 @@ fn check_permanent_sbas_with_view(
             }
         }
     }
+}
+
+fn lethal_damage_threshold_for_creature(
+    game: &GameState,
+    view: &crate::derived_view::DerivedGameView<'_>,
+    creature_id: ObjectId,
+) -> Option<i32> {
+    let creature = game.object(creature_id)?;
+    let creature_controller = game.controller_of(creature);
+    let uses_power = game.battlefield.iter().any(|&source_id| {
+        game.controller_of_id(source_id) == Some(creature_controller)
+            && view.object_has_static_ability_id(
+                source_id,
+                StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower,
+            )
+    });
+
+    if uses_power {
+        view.calculated_characteristics(creature_id)
+            .and_then(|chars| chars.power)
+            .or_else(|| creature.power())
+            .map(|power| power.max(1))
+    } else {
+        view.calculated_toughness(creature_id)
+            .or_else(|| creature.toughness())
+    }
+}
+
+fn is_damage_based_creature_death_sba(
+    game: &GameState,
+    view: &crate::derived_view::DerivedGameView<'_>,
+    creature_id: ObjectId,
+) -> bool {
+    if game.object(creature_id).is_none() {
+        return false;
+    }
+    if !view.object_has_card_type(creature_id, CardType::Creature) {
+        return false;
+    }
+    let toughness = view
+        .calculated_toughness(creature_id)
+        .or_else(|| game.object(creature_id).and_then(|object| object.toughness()));
+    if !toughness.is_some_and(|toughness| toughness > 0) {
+        return false;
+    }
+
+    let Some(threshold) = lethal_damage_threshold_for_creature(game, view, creature_id) else {
+        return false;
+    };
+    threshold > 0
+        && (game.damage_on(creature_id) >= threshold as u32
+            || game.has_deathtouch_damage_since_sba(creature_id))
 }
 
 fn check_role_sbas_with_view(
@@ -650,6 +700,17 @@ pub(crate) fn apply_state_based_actions_from_actions_with(
             })
         })
         .collect();
+    let damage_destroyed_object_ids: HashSet<ObjectId> = {
+        let view = crate::derived_view::DerivedGameView::from_effects(game, all_effects.to_vec());
+        actions
+            .iter()
+            .filter_map(|action| match action {
+                StateBasedAction::ObjectDies(obj_id) => Some(*obj_id),
+                _ => None,
+            })
+            .filter(|&obj_id| is_damage_based_creature_death_sba(game, &view, obj_id))
+            .collect()
+    };
 
     let mut any_applied = false;
     for action in actions {
@@ -657,7 +718,13 @@ pub(crate) fn apply_state_based_actions_from_actions_with(
         if matches!(action, StateBasedAction::LegendRuleViolation { .. }) {
             continue;
         }
-        apply_single_sba_with_snapshots(game, action, &pre_captured_snapshots, decision_maker);
+        apply_single_sba_with_snapshots(
+            game,
+            action,
+            &pre_captured_snapshots,
+            &damage_destroyed_object_ids,
+            decision_maker,
+        );
         any_applied = true;
     }
 
@@ -757,6 +824,7 @@ fn apply_single_sba_with_snapshots(
     game: &mut GameState,
     action: StateBasedAction,
     pre_captured_snapshots: &std::collections::HashMap<ObjectId, ObjectSnapshot>,
+    damage_destroyed_object_ids: &HashSet<ObjectId>,
     decision_maker: &mut dyn crate::decision::DecisionMaker,
 ) {
     match action {
@@ -767,16 +835,7 @@ fn apply_single_sba_with_snapshots(
             // - Rule 704.5f: 0 toughness -> put into graveyard directly, regeneration can't help
             // - Rules 704.5g-h: lethal damage or deathtouch damage -> destroyed,
             //   regeneration CAN replace this
-            let is_destroyed_by_damage_sba = game
-                .object(obj_id)
-                .map(|obj| {
-                    let toughness = game.calculated_toughness(obj_id).unwrap_or(0);
-                    let damage = game.damage_on(obj_id);
-                    toughness > 0
-                        && (obj.has_lethal_damage(damage)
-                            || game.has_deathtouch_damage_since_sba(obj_id))
-                })
-                .unwrap_or(false);
+            let is_destroyed_by_damage_sba = damage_destroyed_object_ids.contains(&obj_id);
 
             if is_destroyed_by_damage_sba {
                 // Damage-based SBAs are destruction, so process through the event
@@ -981,6 +1040,30 @@ mod tests {
             .card_types(vec![CardType::Creature])
             .power_toughness(PowerToughness::fixed(power, toughness))
             .build()
+    }
+
+    #[test]
+    fn zero_toughness_sba_ignores_indestructible() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+
+        let card = creature_card(399, "Indestructible Zero", 1, 0);
+        let creature_id = game.create_object_from_card(&card, alice, Zone::Battlefield);
+        game.object_mut(creature_id)
+            .expect("indestructible zero should exist")
+            .abilities
+            .push(Ability::static_ability(StaticAbility::indestructible()));
+
+        let actions = check_state_based_actions(&game);
+        assert!(actions.contains(&StateBasedAction::ObjectDies(creature_id)));
+        assert!(apply_state_based_actions(&mut game));
+
+        assert!(
+            game.current_object_id_after_zone_change(creature_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Graveyard),
+            "0-toughness creature should go to the graveyard even with indestructible"
+        );
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -1806,6 +1806,12 @@ define_combat_ability!(
     "Each creature you control assigns combat damage equal to its toughness rather than its power"
 );
 
+define_combat_ability!(
+    LethalDamageToCreaturesYouControlUsesPower,
+    LethalDamageToCreaturesYouControlUsesPower,
+    "Lethal damage dealt to creatures you control is determined by their power rather than their toughness"
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -121,6 +121,9 @@ impl StaticAbility {
             Some(StaticAbilityId::ThisCreatureAssignsCombatDamageUsingToughness) => {
                 Self::this_creature_assigns_combat_damage_using_toughness()
             }
+            Some(StaticAbilityId::LethalDamageToCreaturesYouControlUsesPower) => {
+                Self::lethal_damage_to_creatures_you_control_uses_power()
+            }
             Some(StaticAbilityId::BlackManaMayBePaidWithLife) => {
                 Self::krrik_black_mana_may_be_paid_with_life()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2278,6 +2278,10 @@ impl StaticAbility {
         Self::new(CreaturesYouControlAssignCombatDamageUsingToughness)
     }
 
+    pub fn lethal_damage_to_creatures_you_control_uses_power() -> Self {
+        Self::new(LethalDamageToCreaturesYouControlUsesPower)
+    }
+
     pub fn prevent_all_damage_dealt_to_creatures() -> Self {
         Self::new(PreventAllDamageDealtToCreatures)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Zilortha, Strength Incarnate
Initial parse error:
```
parser does not yet support line family: 'Lethal damage dealt to creatures you control is determined by their power rather than their toughness.'; oracle-only fallback also failed: parser does not yet support line family: 'Lethal damage dealt to creatures you control is determined by their power rather than their toughness.'
```

Current worker: i-023a2521ba4cafe32
Branch: codex/aws-card-fix-zilortha-strength-incarnate
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0019
