### PR TITLE
Fix Ironsmith parse failure: Cavern-Hoard Dragon

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -1474,6 +1474,11 @@ pub(crate) fn parse_value_binding_clause(tokens: &[OwnedLexToken]) -> Option<Val
         return Some(value);
     }
 
+    // where X is the greatest number of <objects> <player> controls
+    if let Some(value) = parse_where_x_is_greatest_number_of_filter_value(tokens) {
+        return Some(value);
+    }
+
     // where X is the number of <objects>
     if let Some(value) = parse_where_x_is_number_of_filter_value(tokens) {
         return Some(value);
@@ -2083,6 +2088,32 @@ pub(crate) fn parse_where_x_is_number_of_different_powers_filter_value(
     let filter_tokens = &tokens[object_start_token_idx..];
     let filter = parse_object_filter(filter_tokens, false).ok()?;
     Some(Value::DistinctPowers(filter))
+}
+
+pub(crate) fn parse_where_x_is_greatest_number_of_filter_value(
+    tokens: &[OwnedLexToken],
+) -> Option<Value> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if !ETB_WHERE_X_IS_PREFIX_PATTERN.matches_words(&clause_words) {
+        return None;
+    }
+
+    let greatest_idx = ETB_GREATEST_WORD_PATTERN.find_word(&clause_words)?;
+    if !clause_words
+        .get(greatest_idx + 1)
+        .is_some_and(|word| ETB_NUMBER_WORD_PATTERN.matches_word(word))
+        || !clause_words
+            .get(greatest_idx + 2)
+            .is_some_and(|word| ETB_OF_WORD_PATTERN.matches_word(word))
+    {
+        return None;
+    }
+
+    let object_start_token_idx = token_index_for_word_index(tokens, greatest_idx + 3)?;
+    let filter_tokens = &tokens[object_start_token_idx..];
+    let filter = parse_object_filter_lexed(filter_tokens, false).ok()?;
+    filter.controller.as_ref()?;
+    Some(Value::GreatestCount(filter))
 }
 
 pub(crate) fn parse_where_x_is_number_of_filter_value(tokens: &[OwnedLexToken]) -> Option<Value> {

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -58,6 +58,7 @@ pub enum Value {
     HalfRoundedDown(Box<Value>),
     Count(ObjectFilter),
     CountScaled(ObjectFilter, i32),
+    GreatestCount(ObjectFilter),
     TotalPower(ObjectFilter),
     TotalToughness(ObjectFilter),
     TotalManaValue(ObjectFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -28433,6 +28433,62 @@ fn parse_spells_cost_modifier_supports_extended_where_x_clauses() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn cavern_hoard_dragon_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(119_956), "Cavern-Hoard Dragon")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(7)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dragon])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .parse_text(
+            "This spell costs {X} less to cast, where X is the greatest number of artifacts an opponent controls.\nFlying, trample, haste\nWhenever this creature deals combat damage to a player, you create a Treasure token for each artifact that player controls.",
+        )
+        .expect("Cavern-Hoard Dragon should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cavern_hoard_dragon_strict_parser_regression() {
+    let def = cavern_hoard_dragon_definition();
+
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+            _ => None,
+        })
+        .expect("expected Cavern-Hoard Dragon to have a this-spell cost reduction");
+
+    let crate::effect::Value::GreatestCount(filter) = &reduction.reduction else {
+        panic!(
+            "expected greatest-count cost reduction for Cavern-Hoard Dragon, got {:?}",
+            reduction.reduction
+        );
+    };
+    assert!(filter.card_types.contains(&CardType::Artifact));
+    assert_eq!(filter.controller, Some(PlayerFilter::Opponent));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cavern_hoard_dragon_compiled_text_keeps_greatest_artifact_clause() {
+    let def = cavern_hoard_dragon_definition();
+
+    assert_eq!(
+        crate::compiled_text::compiled_text_lines(&def),
+        vec![
+            "This spell costs {X} less to cast, where X is the greatest number of artifacts an opponent controls.".to_string(),
+            "Flying, trample, haste".to_string(),
+            "Whenever this creature deals combat damage to a player, create a Treasure token for each artifact that player controls.".to_string(),
+        ]
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn shadow_of_mortality_strict_parser_regression() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(90_321), "Shadow of Mortality")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6623,7 +6623,7 @@ pub(super) fn describe_for_each_count_filter(filter: &ObjectFilter) -> String {
         Some(PlayerFilter::Active) => Some("they control"),
         Some(PlayerFilter::Defending) => Some("defending player controls"),
         Some(PlayerFilter::Attacking) => Some("attacking player controls"),
-        Some(PlayerFilter::DamagedPlayer) => Some("damaged player controls"),
+        Some(PlayerFilter::DamagedPlayer) => Some("that player controls"),
         Some(PlayerFilter::Teammate) => Some("a teammate controls"),
         Some(PlayerFilter::Specific(_)) => Some("that player controls"),
         Some(PlayerFilter::Target(_)) | Some(PlayerFilter::IteratedPlayer) => Some("they control"),
@@ -6650,7 +6650,7 @@ pub(super) fn describe_for_each_count_filter(filter: &ObjectFilter) -> String {
             Some(PlayerFilter::Active) => Some("they own"),
             Some(PlayerFilter::Defending) => Some("defending player owns"),
             Some(PlayerFilter::Attacking) => Some("attacking player owns"),
-            Some(PlayerFilter::DamagedPlayer) => Some("damaged player owns"),
+            Some(PlayerFilter::DamagedPlayer) => Some("that player owns"),
             Some(PlayerFilter::Teammate) => Some("a teammate owns"),
             Some(PlayerFilter::Specific(_)) => Some("that player owns"),
             Some(PlayerFilter::Target(_)) | Some(PlayerFilter::IteratedPlayer) => Some("they own"),
@@ -8090,6 +8090,12 @@ pub(crate) fn describe_value(value: &Value) -> String {
             } else {
                 format!("{multiplier} times the number of {subject}")
             }
+        }
+        Value::GreatestCount(filter) => {
+            format!(
+                "the greatest number of {}",
+                describe_count_filter_value_subject(filter)
+            )
         }
         Value::TotalPower(filter) => {
             format!(

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4044,6 +4044,23 @@ fn resolve_value_with_context(
             let count = count_filter_matches(filter, ctx, &filter_ctx);
             count * *multiplier
         }
+        Value::GreatestCount(filter) => {
+            let filter_ctx = continuous_filter_context(ctx.game, controller, source);
+            let Some(controller_filter) = &filter.controller else {
+                return count_filter_matches(filter, ctx, &filter_ctx);
+            };
+
+            let mut greatest = 0i32;
+            for player in ctx.game.players.iter().filter(|player| player.is_in_game()) {
+                if !controller_filter.matches_player(player.id, &filter_ctx) {
+                    continue;
+                }
+                let mut player_filter = filter.clone();
+                player_filter.controller = Some(PlayerFilter::Specific(player.id));
+                greatest = greatest.max(count_filter_matches(&player_filter, ctx, &filter_ctx));
+            }
+            greatest
+        }
         Value::BasicLandTypesAmong(filter) => {
             use std::collections::HashSet;
 

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -5077,3 +5077,124 @@ pub fn calculate_convoke_cost(
     let effective_cost = crate::mana::ManaCost::from_pips(remaining_pips);
     (creatures_to_tap, effective_cost)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ability::AbilityKind;
+    use crate::alternative_cast::CastingMethod;
+    use crate::card::{CardBuilder, PowerToughness};
+    use crate::cards::builders::CardDefinitionBuilder;
+    use crate::ids::{CardId, PlayerId};
+    use crate::mana::{ManaCost, ManaSymbol};
+    use crate::types::{CardType, Subtype};
+    use crate::zone::Zone;
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn cavern_hoard_dragon_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::from_raw(119_956), "Cavern-Hoard Dragon")
+            .mana_cost(ManaCost::from_pips(vec![
+                vec![ManaSymbol::Generic(7)],
+                vec![ManaSymbol::Red],
+                vec![ManaSymbol::Red],
+            ]))
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Dragon])
+            .power_toughness(PowerToughness::fixed(6, 6))
+            .parse_text(
+                "This spell costs {X} less to cast, where X is the greatest number of artifacts an opponent controls.\nFlying, trample, haste\nWhenever this creature deals combat damage to a player, you create a Treasure token for each artifact that player controls.",
+            )
+            .expect("Cavern-Hoard Dragon should parse for cost runtime test")
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn create_artifact(game: &mut GameState, owner: PlayerId, name: &str) {
+        let card = CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Artifact])
+            .build();
+        game.create_object_from_card(&card, owner, Zone::Battlefield);
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn cavern_hoard_dragon_cost_reduction_uses_greatest_opponent_artifact_count() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let charlie = PlayerId::from_index(2);
+
+        for idx in 0..7 {
+            create_artifact(&mut game, alice, &format!("Alice Artifact {idx}"));
+        }
+        for idx in 0..2 {
+            create_artifact(&mut game, bob, &format!("Bob Artifact {idx}"));
+        }
+        for idx in 0..5 {
+            create_artifact(&mut game, charlie, &format!("Charlie Artifact {idx}"));
+        }
+
+        let def = cavern_hoard_dragon_definition();
+        let dragon_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+        let dragon = game.object(dragon_id).expect("dragon should be in hand");
+        let reduction = dragon
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+                _ => None,
+            })
+            .expect("Cavern-Hoard Dragon should have a this-spell cost reduction");
+
+        assert_eq!(
+            resolve_this_spell_cost_reduction_value(&game, alice, dragon, reduction),
+            5,
+            "cost reduction should use the greatest single opponent artifact count, not your artifacts or all opponents combined"
+        );
+
+        let adjusted = apply_spell_cost_modifiers(
+            &game,
+            alice,
+            dragon,
+            dragon.mana_cost.as_ref().expect("dragon should have a mana cost"),
+            0,
+            &[],
+            &CastingMethod::Normal,
+        );
+        assert_eq!(
+            adjusted.to_oracle(),
+            "{2}{R}{R}",
+            "{{7}}{{R}}{{R}} reduced by the greatest opponent artifact count of five should cost {{2}}{{R}}{{R}}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn cavern_hoard_dragon_cost_reduction_is_zero_without_opponent_artifacts() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        for idx in 0..3 {
+            create_artifact(&mut game, alice, &format!("Alice Artifact {idx}"));
+        }
+
+        let def = cavern_hoard_dragon_definition();
+        let dragon_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+        let dragon = game.object(dragon_id).expect("dragon should be in hand");
+        let reduction = dragon
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+                _ => None,
+            })
+            .expect("Cavern-Hoard Dragon should have a this-spell cost reduction");
+
+        assert_eq!(
+            resolve_this_spell_cost_reduction_value(&game, alice, dragon, reduction),
+            0,
+            "artifacts controlled by Cavern-Hoard Dragon's caster must not reduce its cost"
+        );
+    }
+}

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1326,6 +1326,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::VoteCount(_)
         | Value::Count(_)
         | Value::CountScaled(_, _)
+        | Value::GreatestCount(_)
         | Value::TotalManaValue(_)
         | Value::GreatestManaValue(_)
         | Value::BasicLandTypesAmong(_)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -441,6 +441,33 @@ pub fn resolve_value(
                 .count() as i32;
             Ok(count * *multiplier)
         }
+        Value::GreatestCount(filter) => {
+            let filter_ctx = ctx.filter_context(game);
+            let Some(controller_filter) = &filter.controller else {
+                let count = value_candidate_ids_for_filter(game, filter, ctx)
+                    .iter()
+                    .filter_map(|&id| game.object(id))
+                    .filter(|obj| filter.matches(obj, &filter_ctx, game))
+                    .count();
+                return Ok(count as i32);
+            };
+
+            let mut greatest = 0i32;
+            for player in game.players.iter().filter(|player| player.is_in_game()) {
+                if !controller_filter.matches_player(player.id, &filter_ctx) {
+                    continue;
+                }
+                let mut player_filter = filter.clone();
+                player_filter.controller = Some(crate::filter::PlayerFilter::Specific(player.id));
+                let count = value_candidate_ids_for_filter(game, &player_filter, ctx)
+                    .iter()
+                    .filter_map(|&id| game.object(id))
+                    .filter(|obj| player_filter.matches(obj, &filter_ctx, game))
+                    .count() as i32;
+                greatest = greatest.max(count);
+            }
+            Ok(greatest)
+        }
         Value::TotalPower(filter) => {
             let filter_ctx = ctx.filter_context(game);
             if let Some(snapshots) = value_tagged_snapshots_for_filter(filter, ctx) {

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1157,8 +1157,10 @@ impl PlayerFilterExt for PlayerFilter {
 
             PlayerFilter::Attacking => ctx.attacking_player.is_some_and(|ap| player == ap),
 
-            // Resolved from the triggering event during effect execution.
-            PlayerFilter::DamagedPlayer => false,
+            PlayerFilter::DamagedPlayer => ctx
+                .tagged_players
+                .get("damaged_player")
+                .is_some_and(|players| players.contains(&player)),
 
             PlayerFilter::EffectController => false,
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -23269,6 +23269,80 @@ fn test_ragavan_trigger_exiles_top_card_of_damaged_players_library() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn cavern_hoard_dragon_combat_damage_trigger_counts_damaged_players_artifacts() {
+    fn create_artifact(game: &mut GameState, owner: PlayerId, name: &str) {
+        let card = CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Artifact])
+            .build();
+        game.create_object_from_card(&card, owner, Zone::Battlefield);
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::CombatDamage);
+
+    let dragon = CardDefinitionBuilder::new(CardId::from_raw(119_956), "Cavern-Hoard Dragon")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(7)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Dragon])
+        .power_toughness(PowerToughness::fixed(6, 6))
+        .parse_text(
+            "This spell costs {X} less to cast, where X is the greatest number of artifacts an opponent controls.\nFlying, trample, haste\nWhenever this creature deals combat damage to a player, you create a Treasure token for each artifact that player controls.",
+        )
+        .expect("Cavern-Hoard Dragon should parse for trigger runtime test");
+    let dragon_id = game.create_object_from_definition(&dragon, alice, Zone::Battlefield);
+
+    create_artifact(&mut game, alice, "Alice Artifact");
+    create_artifact(&mut game, bob, "Bob Artifact One");
+    create_artifact(&mut game, bob, "Bob Artifact Two");
+    create_artifact(&mut game, bob, "Bob Artifact Three");
+    let battlefield_before = game.battlefield.len();
+
+    let damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            dragon_id,
+            crate::events::DamageTarget::Player(bob),
+            6,
+            true,
+            crate::events::cause::EventCause::combat_damage(dragon_id),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let mut trigger_queue = TriggerQueue::new();
+    for trigger in check_triggers(&game, &damage_event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(trigger_queue.entries.len(), 1, "dragon should trigger once");
+    put_triggers_on_stack(&mut game, &mut trigger_queue).expect("dragon trigger should stack");
+    resolve_stack_entry(&mut game).expect("dragon trigger should resolve");
+
+    let treasure_count = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .filter(|obj| obj.name == "Treasure")
+        .count();
+    assert_eq!(
+        treasure_count, 3,
+        "Cavern-Hoard Dragon should create one Treasure for each artifact the damaged player controls"
+    );
+    assert_eq!(
+        game.battlefield.len(),
+        battlefield_before + 3,
+        "caster's own artifact should not be counted by the damage trigger"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn ancient_bronze_dragon_trigger_uses_die_result_for_up_to_two_targets() {
     struct SelectUpToTwoDecisionMaker;
     impl DecisionMaker for SelectUpToTwoDecisionMaker {

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -63,6 +63,66 @@ fn join_with_or(items: &[String]) -> String {
     }
 }
 
+fn strip_indefinite_article(text: &str) -> &str {
+    text.strip_prefix("a ")
+        .or_else(|| text.strip_prefix("an "))
+        .unwrap_or(text)
+}
+
+fn pluralize_cost_noun_phrase(phrase: &str) -> String {
+    if let Some((head, tail)) = phrase.split_once(" ") {
+        if matches!(tail, "you control" | "an opponent controls" | "that player controls") {
+            return format!("{} {tail}", pluralize_cost_noun_phrase(head));
+        }
+    }
+    match phrase {
+        "artifact" => "artifacts".to_string(),
+        "creature" => "creatures".to_string(),
+        "enchantment" => "enchantments".to_string(),
+        "land" => "lands".to_string(),
+        "permanent" => "permanents".to_string(),
+        "card" => "cards".to_string(),
+        _ if phrase.ends_with('s') => phrase.to_string(),
+        _ => format!("{phrase}s"),
+    }
+}
+
+fn describe_greatest_count_cost_filter(filter: &ObjectFilter) -> String {
+    let Some(controller) = &filter.controller else {
+        return pluralize_cost_noun_phrase(strip_indefinite_article(&filter.description()));
+    };
+
+    let mut bare = filter.clone();
+    bare.controller = None;
+    let bare_description = bare.description();
+    let subject = pluralize_cost_noun_phrase(
+        strip_indefinite_article(&bare_description)
+            .trim()
+            .trim_end_matches(" on the battlefield")
+            .trim(),
+    );
+    let suffix = match controller {
+        PlayerFilter::You => "you control",
+        PlayerFilter::Opponent => "an opponent controls",
+        PlayerFilter::Any => "a player controls",
+        PlayerFilter::DamagedPlayer | PlayerFilter::Specific(_) | PlayerFilter::Target(_) => {
+            "that player controls"
+        }
+        PlayerFilter::IteratedPlayer => "they control",
+        _ => return pluralize_cost_noun_phrase(strip_indefinite_article(&filter.description())),
+    };
+    format!("{subject} {suffix}")
+}
+
+fn append_cost_modifier_tail(line: &mut String, tail: &str) {
+    if tail.starts_with("where ") {
+        line.push_str(", ");
+    } else {
+        line.push(' ');
+    }
+    line.push_str(tail);
+}
+
 fn describe_colors(colors: ColorSet) -> String {
     let mut words = Vec::new();
     if colors.contains(Color::White) {
@@ -183,6 +243,13 @@ fn describe_cost_modifier_amount(amount: &Value) -> (String, Option<String>) {
         Value::CountScaled(filter, multiplier) => (
             format!("{{{multiplier}}}"),
             Some(format!("for each {}", filter.description())),
+        ),
+        Value::GreatestCount(filter) => (
+            "{X}".to_string(),
+            Some(format!(
+                "where X is the greatest number of {}",
+                describe_greatest_count_cost_filter(filter)
+            )),
         ),
         Value::BasicLandTypesAmong(filter) => (
             "{1}".to_string(),
@@ -783,8 +850,7 @@ impl StaticAbilityKind for CostReduction {
         if let Some(subject) = describe_alternative_cost_subject(&self.filter) {
             let mut line = format!("{subject} cost {amount_text} less");
             if let Some(tail) = tail {
-                line.push(' ');
-                line.push_str(&tail);
+                append_cost_modifier_tail(&mut line, &tail);
             }
             return describe_cost_modifier_with_condition(line, &self.condition);
         }
@@ -794,8 +860,7 @@ impl StaticAbilityKind for CostReduction {
             amount_text
         );
         if let Some(tail) = tail {
-            line.push(' ');
-            line.push_str(&tail);
+            append_cost_modifier_tail(&mut line, &tail);
         }
         describe_cost_modifier_with_condition(line, &self.condition)
     }
@@ -1718,8 +1783,7 @@ impl StaticAbilityKind for ThisSpellCostReduction {
         let (amount_text, tail) = describe_cost_modifier_amount(&self.reduction);
         let mut line = format!("This spell costs {amount_text} less to cast");
         if let Some(tail) = tail {
-            line.push(' ');
-            line.push_str(&tail);
+            append_cost_modifier_tail(&mut line, &tail);
         } else if matches!(self.reduction, Value::X)
             && matches!(
                 self.condition,
@@ -1839,8 +1903,7 @@ impl StaticAbilityKind for CostIncrease {
             amount_text
         );
         if let Some(tail) = tail {
-            line.push(' ');
-            line.push_str(&tail);
+            append_cost_modifier_tail(&mut line, &tail);
         }
         describe_cost_modifier_with_condition(line, &self.condition)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cavern-Hoard Dragon
Initial parse error:
```
unsupported where-x clause in spells-cost modifier (clause: 'this spell costs less to cast where x is the greatest number of artifacts an opponent controls'); oracle-only fallback also failed: unsupported where-x clause in spells-cost modifier (clause: 'this spell costs less to cast where x is the greatest number of artifacts an opponent controls')
```

Current worker: i-0a88136e81425c06a
Branch: codex/aws-card-fix-cavern-hoard-dragon
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0021
