### PR TITLE
Fix Ironsmith parse failure: Rumbling Ruin

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -469,6 +469,10 @@ fn triggered_effect_tokens_have_trailing_static_sentences(tokens: &[OwnedLexToke
 }
 
 fn sentence_is_static_after_trigger_effect(tokens: &[OwnedLexToken]) -> bool {
+    let words = token_word_refs(tokens);
+    if words.windows(2).any(|window| window == ["that", "number"]) {
+        return false;
+    }
     looks_like_self_enters_with_x_counters_static_sentence(tokens)
         || matches!(parse_static_ability_ast_line_lexed(tokens), Ok(Some(_)))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1181,6 +1181,7 @@ const EVENT_AMOUNT_VALUE_PATTERNS: &[(ClauseShape<'static>, usize)] = &[
         clause_shape!(prefix_any & [&["that", "many"], &["that", "much"], &["that", "amount"]]),
         2,
     ),
+    (clause_shape!(prefix & ["that", "number"]), 2),
     (
         clause_shape!(prefix & ["the", "amount", "of", "e", "paid", "this", "way"]),
         7,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -49,6 +49,7 @@ use super::{
 };
 
 const ENCHANTED_TAG_NAME: &str = "enchanted";
+const COUNTED_COUNTER_OBJECTS_TAG: &str = "__ironsmith_counted_counter_objects";
 const SENTENCE_HELPER_REVEALED_TAG_PREFIX: &str = "__sentence_helper_revealed";
 #[allow(unused_imports)]
 use crate::cards::builders::{
@@ -56,7 +57,7 @@ use crate::cards::builders::{
     SubjectVerbEffectAst, SubjectVerbSubjectAst, TagKey, TargetAst, TextSpan,
 };
 use crate::effect::{ChoiceCount, Until, Value};
-use crate::target::{ObjectFilter, PlayerFilter, TaggedOpbjectRelation};
+use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter, TaggedOpbjectRelation};
 use crate::types::Subtype;
 use crate::zone::Zone;
 
@@ -1248,7 +1249,90 @@ pub(crate) fn parse_effect_chain_inner_lexed(
     collapse_token_copy_next_end_step_exile_followup_lexed(&mut effects, tokens);
     collapse_token_copy_next_end_step_sacrifice_followup_lexed(&mut effects, tokens);
     collapse_token_copy_end_of_combat_exile_followup_lexed(&mut effects, tokens);
+    bind_counted_counter_number_references(&mut effects);
     Ok(effects)
+}
+
+pub(super) fn bind_counted_counter_number_references(effects: &mut [EffectAst]) {
+    let mut counted_filter: Option<ObjectFilter> = None;
+    for effect in effects {
+        if let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::TagMatchingObjects { filter, tag, .. },
+            ..
+        }) = effect
+            && tag.as_str() == COUNTED_COUNTER_OBJECTS_TAG
+        {
+            counted_filter = Some(filter.clone());
+            continue;
+        }
+
+        let Some(filter) = counted_filter.clone() else {
+            continue;
+        };
+        bind_counted_counter_number_reference_in_effect(effect, &filter);
+    }
+}
+
+fn bind_counted_counter_number_reference_in_effect(
+    effect: &mut EffectAst,
+    counted_filter: &ObjectFilter,
+) {
+    if let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action: SubjectVerbActionAst::Cant { restriction, .. },
+        ..
+    }) = effect
+    {
+        bind_counted_counter_number_reference_in_restriction(restriction, counted_filter);
+    }
+    let _ = for_each_nested_effects_mut(effect, true, |nested| {
+        for nested_effect in nested {
+            bind_counted_counter_number_reference_in_effect(nested_effect, counted_filter);
+        }
+    });
+}
+
+fn bind_counted_counter_number_reference_in_restriction(
+    restriction: &mut crate::effect::Restriction,
+    counted_filter: &ObjectFilter,
+) {
+    let crate::effect::Restriction::Block(filter) = restriction else {
+        return;
+    };
+    let Some(power) = filter.power.as_mut() else {
+        return;
+    };
+    let counter_type = match counted_filter.with_counter {
+        Some(crate::filter::CounterConstraint::Typed(counter_type)) => Some(counter_type),
+        Some(crate::filter::CounterConstraint::Any) | None => None,
+    };
+    replace_event_amount_comparison_value(
+        power,
+        Value::CountersOn(
+            Box::new(ChooseSpec::Tagged(TagKey::from(COUNTED_COUNTER_OBJECTS_TAG))),
+            counter_type,
+        ),
+    );
+}
+
+fn replace_event_amount_comparison_value(
+    comparison: &mut crate::filter::Comparison,
+    replacement: Value,
+) {
+    use crate::effect::EventValueSpec;
+    use crate::filter::Comparison;
+
+    let value = match comparison {
+        Comparison::EqualExpr(value)
+        | Comparison::NotEqualExpr(value)
+        | Comparison::LessThanExpr(value)
+        | Comparison::LessThanOrEqualExpr(value)
+        | Comparison::GreaterThanExpr(value)
+        | Comparison::GreaterThanOrEqualExpr(value) => value,
+        _ => return,
+    };
+    if matches!(value.as_ref(), Value::EventValue(EventValueSpec::Amount)) {
+        *value = Box::new(replacement);
+    }
 }
 
 fn is_orphan_rounded_up_where_x_tail(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -27,10 +27,10 @@ use super::super::object_filters::parse_object_filter;
 use super::super::permission_helpers::parse_cast_or_play_tagged_clause;
 use super::super::token_primitives::find_index as find_token_index;
 use super::super::util::{
-    contains_until_end_of_turn, parse_card_type, parse_color, parse_number, parse_subject,
-    parse_subtype_flexible, parse_target_phrase, parse_value, parser_trace, parser_trace_stack,
-    span_from_tokens, starts_with_until_end_of_turn, token_index_for_word_index, trim_commas,
-    word_refs_except,
+    contains_until_end_of_turn, parse_card_type, parse_color, parse_counter_type_word,
+    parse_number, parse_subject, parse_subtype_flexible, parse_target_phrase, parse_value,
+    parser_trace, parser_trace_stack, span_from_tokens, starts_with_until_end_of_turn,
+    token_index_for_word_index, trim_commas, word_refs_except,
 };
 use super::chain_carry::{parse_leading_player_may, remove_first_word, remove_through_first_word};
 use super::clause_pattern_helpers::{ClauseShape, clause_shape, extract_subject_player};
@@ -221,6 +221,7 @@ const TARGET_ONLY_RESTRICTION_WORD_PATTERN: ClauseShape<'static> = clause_shape!
             "blocked", "except", "unless", "attack", "attacks", "block", "blocks",
         ]]
 );
+const COUNTED_COUNTER_OBJECTS_TAG: &str = "__ironsmith_counted_counter_objects";
 
 fn dispatch_find_phrase_shape(
     words: &[&str],
@@ -318,6 +319,62 @@ fn parse_copular_base_pt_animation_clause(
     }
 
     parse_become_clause(subject_tokens, rest_tokens).map(Some)
+}
+
+fn parse_count_counters_on_filter_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let clause = LexedClause::new(tokens).trimmed();
+    let words = clause.word_refs();
+    if !word_slice_starts_with(&words, &["count"]) {
+        return Ok(None);
+    }
+
+    let mut idx = 1usize;
+    if words.get(idx).copied() == Some("the") {
+        idx += 1;
+    }
+    if words.get(idx..idx + 2) != Some(&["number", "of"][..]) {
+        return Ok(None);
+    }
+    idx += 2;
+
+    if words.get(idx).is_some_and(|word| matches!(*word, "a" | "an" | "one")) {
+        idx += 1;
+    }
+
+    let Some(counter_word) = words.get(idx).copied() else {
+        return Ok(None);
+    };
+    let Some(counter_type) = parse_counter_type_word(counter_word) else {
+        return Ok(None);
+    };
+    idx += 1;
+
+    if !words
+        .get(idx)
+        .is_some_and(|word| matches!(*word, "counter" | "counters"))
+        || words.get(idx + 1).copied() != Some("on")
+    {
+        return Ok(None);
+    }
+    idx += 2;
+
+    let Some(filter_token_idx) = token_index_for_word_index(tokens, idx) else {
+        return Ok(None);
+    };
+    let filter_tokens = trim_commas(&tokens[filter_token_idx..]);
+    if filter_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let mut filter = parse_object_filter(&filter_tokens, false)?;
+    filter.with_counter = Some(crate::filter::CounterConstraint::Typed(counter_type));
+    Ok(Some(EffectAst::subject_verb_tag_matching_objects(
+        filter,
+        vec![Zone::Battlefield],
+        TagKey::from(COUNTED_COUNTER_OBJECTS_TAG),
+    )))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -795,6 +852,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     let clause_words = clause_word_view.to_word_refs();
 
     if let Some(effect) = parse_for_each_prevent_damage_clause(tokens)? {
+        return Ok(effect);
+    }
+
+    if let Some(effect) = parse_count_counters_on_filter_clause(tokens)? {
         return Ok(effect);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -46,6 +46,7 @@ use super::super::value_helpers::parse_value_from_lexed;
 use super::bundle_rules::{
     parse_exact_card_effect_bundle_lexed, parse_same_sentence_copy_and_may_cast_copy,
 };
+use super::chain_carry::bind_counted_counter_number_references;
 use super::consult_family;
 use super::divvy::try_parse_divvy_sentence_sequence;
 use super::looked_cards_family;
@@ -1354,6 +1355,7 @@ fn parse_effect_sentences_from_sentence_inputs(
     if let Some(last_sentence) = sentences.last() {
         parser_trace("parse_effect_sentences:done", last_sentence.lowered());
     }
+    bind_counted_counter_number_references(&mut effects);
     Ok(effects)
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41636,6 +41636,158 @@ fn assert_oracle_card_parses_strict(name: &str) {
     );
 }
 
+fn rumbling_ruin_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Rumbling Ruin should have an enters triggered ability")
+}
+
+fn create_vanilla_creature(
+    game: &mut crate::game_state::GameState,
+    id: u32,
+    name: &str,
+    controller: PlayerId,
+    power: i32,
+    toughness: i32,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+fn resolve_rumbling_ruin_trigger(
+    game: &mut crate::game_state::GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    triggered: &crate::ability::TriggeredAbility,
+) {
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller);
+    for effect in triggered.effects.flattened_default_effects() {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Rumbling Ruin trigger effect should resolve");
+    }
+}
+
+#[test]
+fn rumbling_ruin_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Rumbling Ruin");
+    let def = parse_oracle_card_definition("Rumbling Ruin");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("count the number of +1/+1 counters on creatures you control")
+            && rendered.contains(
+                "Creatures your opponents control with power less than or equal to that number can't block this turn"
+            ),
+        "Rumbling Ruin should render the count-and-block restriction exactly, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", rumbling_ruin_trigger(&def));
+    assert!(
+        debug.contains("TagMatchingObjectsEffect")
+            && debug.contains("CantEffect")
+            && debug.contains("CountersOn")
+            && debug.contains("Tagged")
+            && debug.contains("PlusOnePlusOne"),
+        "Rumbling Ruin should structurally count +1/+1 counters for the block restriction, got {debug}"
+    );
+}
+
+#[test]
+fn rumbling_ruin_runtime_counts_plus_one_counters_for_block_restriction() {
+    let def = parse_oracle_card_definition("Rumbling Ruin");
+    let triggered = rumbling_ruin_trigger(&def);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let ruin = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let counted_a = create_vanilla_creature(&mut game, 91_501, "Countered Ally A", alice, 2, 2);
+    let counted_b = create_vanilla_creature(&mut game, 91_502, "Countered Ally B", alice, 2, 2);
+    game.object_mut(counted_a)
+        .expect("countered ally A should exist")
+        .add_counters(crate::object::CounterType::PlusOnePlusOne, 2);
+    game.object_mut(counted_b)
+        .expect("countered ally B should exist")
+        .add_counters(crate::object::CounterType::PlusOnePlusOne, 1);
+
+    let equal_power_blocker =
+        create_vanilla_creature(&mut game, 91_503, "Equal Power Blocker", bob, 3, 3);
+    let greater_power_blocker =
+        create_vanilla_creature(&mut game, 91_504, "Greater Power Blocker", bob, 4, 4);
+
+    resolve_rumbling_ruin_trigger(&mut game, ruin, alice, triggered);
+
+    let attacker = game.object(ruin).expect("Rumbling Ruin should exist").clone();
+    let equal = game
+        .object(equal_power_blocker)
+        .expect("equal-power blocker should exist")
+        .clone();
+    let greater = game
+        .object(greater_power_blocker)
+        .expect("greater-power blocker should exist")
+        .clone();
+    assert!(
+        !crate::rules::combat::can_block(&attacker, &equal, &game),
+        "opponent creature with power equal to the counted counters should be unable to block"
+    );
+    assert!(
+        crate::rules::combat::can_block(&attacker, &greater, &game),
+        "opponent creature with power greater than the counted counters should still block"
+    );
+
+    game.object_mut(counted_b)
+        .expect("countered ally B should still exist")
+        .add_counters(crate::object::CounterType::PlusOnePlusOne, 1);
+    game.update_cant_effects();
+    assert!(
+        crate::rules::combat::can_block(&attacker, &greater, &game),
+        "the counted number should be locked when the trigger resolves"
+    );
+}
+
+#[test]
+fn rumbling_ruin_runtime_zero_counters_only_stops_zero_power_blockers() {
+    let def = parse_oracle_card_definition("Rumbling Ruin");
+    let triggered = rumbling_ruin_trigger(&def);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let ruin = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let zero_power_blocker =
+        create_vanilla_creature(&mut game, 91_505, "Zero Power Blocker", bob, 0, 1);
+    let one_power_blocker =
+        create_vanilla_creature(&mut game, 91_506, "One Power Blocker", bob, 1, 1);
+
+    resolve_rumbling_ruin_trigger(&mut game, ruin, alice, triggered);
+
+    let attacker = game.object(ruin).expect("Rumbling Ruin should exist").clone();
+    let zero = game
+        .object(zero_power_blocker)
+        .expect("zero-power blocker should exist")
+        .clone();
+    let one = game
+        .object(one_power_blocker)
+        .expect("one-power blocker should exist")
+        .clone();
+    assert!(
+        !crate::rules::combat::can_block(&attacker, &zero, &game),
+        "zero counted counters should still stop zero-power opposing creatures"
+    );
+    assert!(
+        crate::rules::combat::can_block(&attacker, &one, &game),
+        "opposing creatures with power greater than zero should block when no +1/+1 counters are counted"
+    );
+}
+
 fn assert_oracle_card_fails_strict(name: &str) {
     let oracle = oracle_text_by_name()
         .get(name)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3928,6 +3928,63 @@ fn describe_choose_color_then_chosen_color_mana(effects: &[&Effect]) -> Option<S
     None
 }
 
+const COUNTED_COUNTER_OBJECTS_TAG: &str = "__ironsmith_counted_counter_objects";
+
+fn describe_count_counters_then_cant_block(effects: &[&Effect]) -> Option<String> {
+    let [count_effect, cant_effect] = effects else {
+        return None;
+    };
+    let count = count_effect.downcast_ref::<crate::effects::TagMatchingObjectsEffect>()?;
+    if count.tag.as_str() != COUNTED_COUNTER_OBJECTS_TAG {
+        return None;
+    }
+    let counter_type = match count.filter.with_counter {
+        Some(crate::filter::CounterConstraint::Typed(counter_type)) => counter_type,
+        _ => return None,
+    };
+
+    let cant = cant_effect.downcast_ref::<crate::effects::CantEffect>()?;
+    if cant.duration != Until::EndOfTurn {
+        return None;
+    }
+    let crate::effect::Restriction::Block(block_filter) = &cant.restriction else {
+        return None;
+    };
+    let Some(crate::filter::Comparison::LessThanOrEqualExpr(value)) = block_filter.power.as_ref()
+    else {
+        return None;
+    };
+    let Value::CountersOn(spec, Some(value_counter_type)) = value.as_ref() else {
+        return None;
+    };
+    if *value_counter_type != counter_type {
+        return None;
+    }
+    let ChooseSpec::Tagged(value_tag) = spec.as_ref() else {
+        return None;
+    };
+    if value_tag != &count.tag {
+        return None;
+    }
+    let mut count_filter = count.filter.clone();
+    count_filter.with_counter = None;
+
+    let counted = pluralize_noun_phrase(strip_leading_article(&count_filter.description()));
+    let blockers = if block_filter.card_types == vec![CardType::Creature]
+        && block_filter.controller == Some(PlayerFilter::Opponent)
+    {
+        "Creatures your opponents control".to_string()
+    } else {
+        let mut base = block_filter.clone();
+        base.power = None;
+        capitalize_first(&pluralize_noun_phrase(strip_leading_article(&base.description())))
+    };
+    Some(format!(
+        "Count the number of {} counters on {counted}. {blockers} with power less than or equal to that number can't block this turn",
+        describe_counter_type(counter_type)
+    ))
+}
+
 fn describe_revealed_cards_opponent_may_put_or_draw(effects: &[&Effect]) -> Option<String> {
     let [look_effect, may_effect, fallback_effect] = effects else {
         return None;
@@ -4010,6 +4067,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     let raw_effects = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_count_counters_then_cant_block(&raw_effects) {
+        return compact;
+    }
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&raw_effects) {
         return compact;
     }

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -2,12 +2,12 @@
 
 use std::collections::HashSet;
 
-use crate::effect::{EffectOutcome, Restriction, Until};
+use crate::effect::{EffectOutcome, Restriction, Until, Value};
 use crate::effects::EffectExecutor;
 use crate::effects::{ExecutionContext, ExecutionError};
-use crate::filter::ObjectFilterExt;
+use crate::filter::{Comparison, ObjectFilterExt, resolve_filter_comparison_rhs_value};
 use crate::game_state::GameState;
-use crate::target::ObjectFilter;
+use crate::target::{ChooseSpec, ObjectFilter};
 pub use ironsmith_core::CantEffect;
 
 fn collapse_tagged_filter_to_specific_objects(
@@ -122,6 +122,73 @@ fn collapse_filter_to_current_matching_objects(
     }
 }
 
+fn is_tagged_counter_value(value: &Value) -> bool {
+    match value {
+        Value::SurfaceHinted { value, .. } => is_tagged_counter_value(value),
+        Value::CountersOn(spec, _) => matches!(spec.as_ref(), ChooseSpec::Tagged(_)),
+        _ => false,
+    }
+}
+
+fn freeze_tagged_counter_comparison(
+    comparison: &mut Option<Comparison>,
+    ctx: &ExecutionContext,
+    game: &GameState,
+) {
+    let Some(frozen) = comparison.as_ref().and_then(|comparison| {
+        let filter_ctx = ctx.filter_context(game);
+        match comparison {
+            Comparison::EqualExpr(value) if is_tagged_counter_value(value) => {
+                resolve_filter_comparison_rhs_value(value, game, &filter_ctx, None)
+                    .map(Comparison::Equal)
+            }
+            Comparison::NotEqualExpr(value) if is_tagged_counter_value(value) => {
+                resolve_filter_comparison_rhs_value(value, game, &filter_ctx, None)
+                    .map(Comparison::NotEqual)
+            }
+            Comparison::LessThanExpr(value) if is_tagged_counter_value(value) => {
+                resolve_filter_comparison_rhs_value(value, game, &filter_ctx, None)
+                    .map(Comparison::LessThan)
+            }
+            Comparison::LessThanOrEqualExpr(value) if is_tagged_counter_value(value) => {
+                resolve_filter_comparison_rhs_value(value, game, &filter_ctx, None)
+                    .map(Comparison::LessThanOrEqual)
+            }
+            Comparison::GreaterThanExpr(value) if is_tagged_counter_value(value) => {
+                resolve_filter_comparison_rhs_value(value, game, &filter_ctx, None)
+                    .map(Comparison::GreaterThan)
+            }
+            Comparison::GreaterThanOrEqualExpr(value) if is_tagged_counter_value(value) => {
+                resolve_filter_comparison_rhs_value(value, game, &filter_ctx, None)
+                    .map(Comparison::GreaterThanOrEqual)
+            }
+            _ => None,
+        }
+    }) else {
+        return;
+    };
+    *comparison = Some(frozen);
+}
+
+fn freeze_tagged_counter_values_for_resolution(
+    filter: &ObjectFilter,
+    ctx: &ExecutionContext,
+    game: &GameState,
+) -> ObjectFilter {
+    let mut frozen = filter.clone();
+    freeze_tagged_counter_comparison(&mut frozen.color_count, ctx, game);
+    freeze_tagged_counter_comparison(&mut frozen.power, ctx, game);
+    freeze_tagged_counter_comparison(&mut frozen.toughness, ctx, game);
+    freeze_tagged_counter_comparison(&mut frozen.total_power_toughness, ctx, game);
+    freeze_tagged_counter_comparison(&mut frozen.mana_value, ctx, game);
+    frozen.any_of = frozen
+        .any_of
+        .iter()
+        .map(|filter| freeze_tagged_counter_values_for_resolution(filter, ctx, game))
+        .collect();
+    frozen
+}
+
 fn normalize_restriction_for_resolution(
     restriction: &Restriction,
     ctx: &ExecutionContext,
@@ -146,9 +213,10 @@ fn normalize_restriction_for_resolution(
                 player.clone(),
             )
         }
-        Restriction::Block(filter) => Restriction::block(
-            collapse_filter_to_current_matching_objects(filter, ctx, game),
-        ),
+        Restriction::Block(filter) => {
+            let filter = freeze_tagged_counter_values_for_resolution(filter, ctx, game);
+            Restriction::block(collapse_filter_to_current_matching_objects(&filter, ctx, game))
+        }
         _ => restriction.clone(),
     }
 }

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -727,7 +727,7 @@ impl ParityRequirementRuntimeExt for ParityRequirement {
     }
 }
 
-fn resolve_filter_comparison_rhs_value(
+pub(crate) fn resolve_filter_comparison_rhs_value(
     rhs: &crate::effect::Value,
     game: &crate::game_state::GameState,
     ctx: &FilterContext,
@@ -945,13 +945,17 @@ fn resolve_filter_comparison_rhs_value(
             }
             ChooseSpec::Tagged(tag) => {
                 let snapshots = ctx.tagged_objects.get(tag)?;
-                let snapshot = snapshots.first()?;
-                Some(match counter_type {
-                    Some(counter_type) => {
-                        snapshot.counters.get(counter_type).copied().unwrap_or(0) as i32
-                    }
-                    None => total_counters(&snapshot.counters),
-                })
+                Some(
+                    snapshots
+                        .iter()
+                        .map(|snapshot| match counter_type {
+                            Some(counter_type) => {
+                                snapshot.counters.get(counter_type).copied().unwrap_or(0) as i32
+                            }
+                            None => total_counters(&snapshot.counters),
+                        })
+                        .sum(),
+                )
             }
             _ => None,
         },


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rumbling Ruin
Initial parse error:
```
could not find verb in effect clause (clause: 'count the number of +1/+1 counters on creatures you control'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'count the number of +1/+1 counters on creatures you control'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-07de835c2afe12b06
Branch: codex/aws-card-fix-rumbling-ruin
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0022
