### PR TITLE
Fix Ironsmith parse failure: Tide of War

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3885,7 +3885,9 @@ pub(crate) fn parse_trigger_clause_lexed(
                 .token_index_for_word_index(block_word_idx)
                 .unwrap_or(tokens.len());
             let subject_tokens = &tokens[..block_token_idx];
+            let one_or_more = has_leading_one_or_more(subject_tokens);
             Ok(match parse_trigger_subject_filter_lexed(subject_tokens)? {
+                Some(filter) if one_or_more => TriggerSpec::BlocksOneOrMore(filter),
                 Some(filter) => TriggerSpec::Blocks(filter),
                 None => TriggerSpec::ThisBlocks,
             })

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -58,6 +58,11 @@ fn compile_delayed_trigger_spec(
         TriggerSpec::Blocks(filter) => {
             Ok(ironsmith_core::DelayedTriggerSpec::Blocks(filter.clone()))
         }
+        TriggerSpec::BlocksOneOrMore(filter) => {
+            Ok(ironsmith_core::DelayedTriggerSpec::BlocksOneOrMore(
+                filter.clone(),
+            ))
+        }
         TriggerSpec::LeavesBattlefield(filter) => Ok(
             ironsmith_core::DelayedTriggerSpec::LeavesBattlefield(filter.clone()),
         ),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -50,6 +50,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::ThisBlocks => Trigger::this_blocks(),
         TriggerSpec::ThisBlocksObject(filter) => Trigger::this_blocks_object(filter),
         TriggerSpec::Blocks(filter) => Trigger::blocks(filter),
+        TriggerSpec::BlocksOneOrMore(filter) => Trigger::blocks_one_or_more(filter),
         TriggerSpec::ThisBecomesBlocked => Trigger::this_becomes_blocked(),
         TriggerSpec::ThisBecomesBlockedByObject(filter) => {
             Trigger::this_becomes_blocked_by_object(filter)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -136,6 +136,7 @@ pub(crate) enum TriggerSpec {
     ThisBlocks,
     ThisBlocksObject(ObjectFilter),
     Blocks(ObjectFilter),
+    BlocksOneOrMore(ObjectFilter),
     ThisBecomesBlocked,
     ThisBecomesBlockedByObject(ObjectFilter),
     ThisDies,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -747,6 +747,52 @@ fn parse_cast_single_spell_from_among_hand_cards_clause(
     )
 }
 
+fn parse_passive_sacrifice_by_controller_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let word_view = ClauseDispatchCompatWords::new(tokens);
+    let words = word_view.to_word_refs();
+    let Some(sacrificed_idx) = words.iter().position(|word| *word == "sacrificed") else {
+        return Ok(None);
+    };
+    if sacrificed_idx < 3 || !matches!(words[sacrificed_idx - 1], "is" | "are") {
+        return Ok(None);
+    }
+    if !matches!(
+        words.get(sacrificed_idx + 1..),
+        Some(["by", "its", "controller"])
+            | Some(["by", "their", "controller"])
+            | Some(["by", "their", "controllers"])
+    ) {
+        return Ok(None);
+    }
+
+    if !matches!(words[0], "each" | "all") {
+        return Ok(None);
+    }
+    let Some(object_start) = word_view.token_index_for_word_index(1) else {
+        return Ok(None);
+    };
+    let Some(be_verb_start) = word_view.token_index_for_word_index(sacrificed_idx - 1) else {
+        return Ok(None);
+    };
+    let object_tokens = trim_commas(&tokens[object_start..be_verb_start]);
+    if object_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let filter = parse_object_filter(&object_tokens, false)?;
+    Ok(Some(EffectAst::ForEachObject {
+        filter,
+        effects: vec![EffectAst::subject_verb_sacrifice(
+            PlayerAst::ItsController,
+            ObjectFilter::tagged(TagKey::from(IT_TAG)),
+            1,
+            None,
+        )],
+    }))
+}
+
 pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
     if tokens.is_empty() {
         return Err(CardTextError::ParseError("empty effect clause".to_string()));
@@ -984,6 +1030,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     }
 
     if let Some(effect) = parse_has_base_power_toughness_clause(tokens)? {
+        return Ok(effect);
+    }
+
+    if let Some(effect) = parse_passive_sacrifice_by_controller_clause(tokens)? {
         return Ok(effect);
     }
 

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -147,6 +147,7 @@ pub enum DelayedTriggerSpec {
     AttacksAndIsntBlocked(ObjectFilter),
     AttacksOneOrMore(ObjectFilter),
     Blocks(ObjectFilter),
+    BlocksOneOrMore(ObjectFilter),
     LeavesBattlefield(ObjectFilter),
     Dies(ObjectFilter),
     DealsCombatDamageToPlayer {

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -68,6 +68,9 @@ pub enum TriggerKind {
     Blocks {
         filter: ObjectFilter,
     },
+    BlocksOneOrMore {
+        filter: ObjectFilter,
+    },
     ThisBecomesBlocked,
     ThisBecomesBlockedByObject {
         filter: ObjectFilter,
@@ -487,6 +490,9 @@ impl Trigger {
     }
     pub fn blocks(filter: ObjectFilter) -> Self {
         Self::typed("blocks", TriggerKind::Blocks { filter })
+    }
+    pub fn blocks_one_or_more(filter: ObjectFilter) -> Self {
+        Self::typed("blocks_one_or_more", TriggerKind::BlocksOneOrMore { filter })
     }
     pub fn this_becomes_blocked() -> Self {
         Self::typed("this_becomes_blocked", TriggerKind::ThisBecomesBlocked)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -30777,6 +30777,31 @@ fn parse_goblin_kites_strictly_and_renders_delayed_coin_flip_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn tide_of_war_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Tide of War");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(
+        rendered,
+        "Whenever one or more creatures block, flip a coin. If you win the flip, each blocking creature is sacrificed by its controller. If you lose the flip, each blocked creature is sacrificed by its controller."
+    );
+    assert!(
+        debug.contains("BlocksTrigger")
+            && debug.contains("one_or_more: true")
+            && debug.contains("FlipCoinEffect")
+            && debug.contains("Happened")
+            && debug.contains("DidNotHappen")
+            && debug.contains("ForEachObject")
+            && debug.contains("blocking: true")
+            && debug.contains("blocked: true")
+            && debug.contains("SacrificeTargetEffect"),
+        "expected Tide of War to structurally model its one-or-more block trigger and both coin-flip sacrifice branches, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_object_filter_with_entered_since_last_turn_ended_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Premature Burial Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -19464,6 +19464,27 @@ pub(super) fn describe_for_each_devotion_damage(
     ))
 }
 
+fn describe_for_each_sacrifice_by_controller(
+    for_each: &crate::effects::ForEachObject,
+) -> Option<String> {
+    let [effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let sacrifice = effect.downcast_ref::<crate::effects::SacrificeTargetEffect>()?;
+    let target = sacrifice.target.base();
+    let sacrifices_iterated = matches!(target, ChooseSpec::Iterated)
+        || matches!(target, ChooseSpec::Tagged(tag) if tag.as_str() == "__it__");
+    if !sacrifices_iterated {
+        return None;
+    }
+
+    let description = for_each.filter.description();
+    let filter_text = strip_indefinite_article(&description);
+    Some(format!(
+        "Each {filter_text} is sacrificed by its controller"
+    ))
+}
+
 pub(super) fn describe_tap_then_damage_for_tapped_this_way(
     with_id: &crate::effects::WithIdEffect,
     deal: &crate::effects::DealDamageEffect,
@@ -28638,6 +28659,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_for_each_devotion_damage(for_each) {
+            return compact;
+        }
+        if let Some(compact) = describe_for_each_sacrifice_by_controller(for_each) {
             return compact;
         }
         if let Some(compact) = describe_for_each_prevent_combat_damage_unless_pays(for_each) {

--- a/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
@@ -587,6 +587,9 @@ pub fn apply_blocker_declarations(
         return Err(ResponseError::InvalidBlockers(err.to_string()).into());
     }
 
+    // Block triggers can depend on the complete set of blockers declared together.
+    game.combat = Some(combat.clone());
+
     // Emit block triggers (per declaration).
     for (blocker, attacker) in &pairs {
         let event_provenance = game

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -4,7 +4,7 @@ use crate::ability::AbilityKind;
 use crate::card::{CardBuilder, LinkedFaceLayout, PowerToughness, PtValue};
 use crate::cards::builders::CardDefinitionBuilder;
 use crate::cards::definitions::emrakul_the_promised_end;
-use crate::combat_state::AttackTarget;
+use crate::combat_state::{AttackTarget, CombatState};
 use crate::decision::{AutoPassDecisionMaker, DecisionMaker, SelectFirstDecisionMaker};
 use crate::effect::RestrictionExt as _;
 use crate::effect::{Effect, EventValueSpec, Until, Value};
@@ -36,6 +36,188 @@ fn setup_three_player_game() -> GameState {
         ],
         20,
     )
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn tide_of_war_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(78_606), "Tide of War")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Whenever one or more creatures block, flip a coin. If you win the flip, each blocking creature is sacrificed by its controller. If you lose the flip, each blocked creature is sacrificed by its controller.",
+        )
+        .expect("Tide of War should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_tide_of_war_creature(
+    game: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_tide_of_war_combat_state(
+    game: &mut GameState,
+    attacker: ObjectId,
+    blocker: ObjectId,
+    defending_player: PlayerId,
+) {
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: AttackTarget::Player(defending_player),
+    });
+    combat.blockers.insert(attacker, vec![blocker]);
+    game.combat = Some(combat);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_tide_of_war_trigger(
+    game: &mut GameState,
+    tide_id: ObjectId,
+    controller: PlayerId,
+    attacker: ObjectId,
+    blocker: ObjectId,
+) {
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    let tide = tide_of_war_definition();
+    let triggered = tide
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Tide of War should have one triggered ability");
+    let blocker_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(blocker).expect("blocking creature should exist"),
+        game,
+    );
+    let attacker_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(attacker).expect("blocked creature should exist"),
+        game,
+    );
+    let trigger_event = TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureBlockedEvent::with_snapshots(
+            blocker,
+            attacker,
+            blocker_snapshot,
+            attacker_snapshot,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx =
+        ExecutionContext::new_default(tide_id, controller).with_triggering_event(trigger_event);
+    for effect in triggered.effects.flattened_default_effects() {
+        execute_effect(game, effect, &mut ctx).expect("Tide of War trigger effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tide_of_war_queues_once_when_multiple_creatures_block() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let tide = tide_of_war_definition();
+    let _ = game.create_object_from_definition(&tide, alice, Zone::Battlefield);
+    let attacker_one = create_tide_of_war_creature(&mut game, "Blocked Attacker One", bob);
+    let attacker_two = create_tide_of_war_creature(&mut game, "Blocked Attacker Two", bob);
+    let blocker_one = create_tide_of_war_creature(&mut game, "Blocking Creature One", alice);
+    let blocker_two = create_tide_of_war_creature(&mut game, "Blocking Creature Two", alice);
+
+    let mut combat = CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker_one,
+        target: AttackTarget::Player(alice),
+    });
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker_two,
+        target: AttackTarget::Player(alice),
+    });
+    let mut trigger_queue = TriggerQueue::new();
+
+    apply_blocker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[
+            BlockerDeclaration {
+                blocker: blocker_one,
+                blocking: attacker_one,
+            },
+            BlockerDeclaration {
+                blocker: blocker_two,
+                blocking: attacker_two,
+            },
+        ],
+        alice,
+    )
+    .expect("Tide of War blockers should be legal");
+
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Tide of War should trigger once for one or more creatures blocking"
+    );
+    assert_eq!(
+        trigger_queue.entries[0].ability.trigger.display(),
+        "Whenever one or more creatures block"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tide_of_war_win_flip_sacrifices_blocking_creatures_only() {
+    let mut game = setup_game();
+    game.set_random_seed(2);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let tide = tide_of_war_definition();
+    let tide_id = game.create_object_from_definition(&tide, alice, Zone::Battlefield);
+    let attacker = create_tide_of_war_creature(&mut game, "Blocked Attacker", bob);
+    let blocker = create_tide_of_war_creature(&mut game, "Blocking Creature", alice);
+    let noncombat = create_tide_of_war_creature(&mut game, "Noncombat Creature", alice);
+    put_tide_of_war_combat_state(&mut game, attacker, blocker, alice);
+
+    resolve_tide_of_war_trigger(&mut game, tide_id, alice, attacker, blocker);
+
+    assert!(game.battlefield.contains(&attacker));
+    assert!(!game.battlefield.contains(&blocker));
+    assert!(game.battlefield.contains(&noncombat));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tide_of_war_lose_flip_sacrifices_blocked_creatures_only() {
+    let mut game = setup_game();
+    game.set_random_seed(7);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let tide = tide_of_war_definition();
+    let tide_id = game.create_object_from_definition(&tide, alice, Zone::Battlefield);
+    let attacker = create_tide_of_war_creature(&mut game, "Blocked Attacker", bob);
+    let blocker = create_tide_of_war_creature(&mut game, "Blocking Creature", alice);
+    let noncombat = create_tide_of_war_creature(&mut game, "Noncombat Creature", bob);
+    put_tide_of_war_combat_state(&mut game, attacker, blocker, alice);
+
+    resolve_tide_of_war_trigger(&mut game, tide_id, alice, attacker, blocker);
+
+    assert!(!game.battlefield.contains(&attacker));
+    assert!(game.battlefield.contains(&blocker));
+    assert!(game.battlefield.contains(&noncombat));
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/triggers/combat/blocks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/blocks.rs
@@ -10,11 +10,46 @@ use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
 #[derive(Debug, Clone, PartialEq)]
 pub struct BlocksTrigger {
     pub filter: ObjectFilter,
+    pub one_or_more: bool,
 }
 
 impl BlocksTrigger {
     pub fn new(filter: ObjectFilter) -> Self {
-        Self { filter }
+        Self {
+            filter,
+            one_or_more: false,
+        }
+    }
+
+    pub fn one_or_more(filter: ObjectFilter) -> Self {
+        Self {
+            filter,
+            one_or_more: true,
+        }
+    }
+
+    fn is_first_matching_blocker_this_combat(
+        &self,
+        blocker: crate::ids::ObjectId,
+        ctx: &TriggerContext,
+    ) -> bool {
+        let Some(combat) = ctx.game.combat.as_ref() else {
+            return true;
+        };
+        let Some(first_matching) = combat
+            .blockers
+            .values()
+            .flat_map(|blockers| blockers.iter().copied())
+            .filter(|blocker_id| {
+                ctx.game
+                    .object(*blocker_id)
+                    .is_some_and(|obj| self.filter.matches(obj, &ctx.filter_ctx, ctx.game))
+            })
+            .min_by_key(|id| id.0)
+        else {
+            return true;
+        };
+        first_matching == blocker
     }
 }
 
@@ -28,12 +63,28 @@ impl TriggerMatcher for BlocksTrigger {
         };
         if let Some(obj) = ctx.game.object(e.blocker) {
             self.filter.matches(obj, &ctx.filter_ctx, ctx.game)
+                && (!self.one_or_more
+                    || self.is_first_matching_blocker_this_combat(e.blocker, ctx))
         } else {
             false
         }
     }
 
     fn display(&self) -> String {
+        if self.one_or_more {
+            let mut subject = self.filter.description();
+            if let Some(stripped) = subject.strip_prefix("a ") {
+                subject = stripped.to_string();
+            } else if let Some(stripped) = subject.strip_prefix("an ") {
+                subject = stripped.to_string();
+            }
+            if subject == "creature" {
+                subject = "creatures".to_string();
+            } else if let Some(rest) = subject.strip_prefix("creature ") {
+                subject = format!("creatures {rest}");
+            }
+            return format!("Whenever one or more {subject} block");
+        }
         format!("Whenever {} blocks", self.filter.description())
     }
 }

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -554,6 +554,11 @@ impl Trigger {
         Self::new(BlocksTrigger::new(filter))
     }
 
+    /// Create a "when one or more [filter] block" trigger.
+    pub fn blocks_one_or_more(filter: ObjectFilter) -> Self {
+        Self::new(BlocksTrigger::one_or_more(filter))
+    }
+
     /// Create a "when this creature becomes blocked" trigger.
     pub fn this_becomes_blocked() -> Self {
         Self::new(ThisBecomesBlockedTrigger)

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -149,6 +149,9 @@ pub(crate) fn interpret_trigger_model(
             crate::triggers::Trigger::this_blocks_object(filter)
         }
         TriggerKind::Blocks { filter } => crate::triggers::Trigger::blocks(filter),
+        TriggerKind::BlocksOneOrMore { filter } => {
+            crate::triggers::Trigger::blocks_one_or_more(filter)
+        }
         TriggerKind::ThisBecomesBlocked => crate::triggers::Trigger::this_becomes_blocked(),
         TriggerKind::ThisBecomesBlockedByObject { filter } => {
             crate::triggers::Trigger::this_becomes_blocked_by_object(filter)
@@ -509,6 +512,9 @@ impl super::Trigger {
                 Self::attacks_one_or_more(filter)
             }
             ironsmith_core::DelayedTriggerSpec::Blocks(filter) => Self::blocks(filter),
+            ironsmith_core::DelayedTriggerSpec::BlocksOneOrMore(filter) => {
+                Self::blocks_one_or_more(filter)
+            }
             ironsmith_core::DelayedTriggerSpec::LeavesBattlefield(filter) => {
                 Self::leaves_battlefield(filter)
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tide of War
Initial parse error:
```
could not find verb in effect clause (clause: 'each blocking creature is sacrificed by its controller'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'each blocking creature is sacrificed by its controller'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0daf2be7f6a74d3c8
Branch: codex/aws-card-fix-tide-of-war
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0023
