### PR TITLE
Fix Ironsmith parse failure: Sail into the West

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5001,7 +5001,10 @@ fn compile_subject_verb_effect(
             let (mut spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
             let from_graveyard = target_mentions_graveyard(target);
-            if from_graveyard && format!("{spec:?}").contains("IteratedPlayer") {
+            if from_graveyard
+                && !ctx.iterated_player
+                && format!("{spec:?}").contains("IteratedPlayer")
+            {
                 replace_iterated_player_with_target_player_in_choose_spec(&mut spec);
             }
             let effect = tag_object_target_effect(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -363,6 +363,12 @@ fn statement_group_should_parse_as_effects_first(tokens: &[OwnedLexToken]) -> bo
     if linked_statement_should_stay_grouped(tokens) {
         return true;
     }
+    if matches!(
+        classify_statement_line_family_lexed(tokens),
+        Some(StatementLineFamily::Vote)
+    ) {
+        return true;
+    }
 
     let words = token_word_refs(tokens);
     if words

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -48012,6 +48012,309 @@ fn travel_through_caradhras_runtime_mines_votes_return_graveyard_cards_without_s
 }
 
 #[test]
+fn sail_into_the_west_strict_parser_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Sail into the West");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains(
+            "Will of the council — Starting with you, each player votes for return or embark"
+        ),
+        "expected will-of-the-council vote opening to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "If return gets more votes, each player returns up to two cards from their graveyard to their hand"
+        ),
+        "expected return vote branch to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "If embark gets more votes or the vote is tied, each player may discard their hand and draw seven cards"
+        ),
+        "expected embark vote branch to render, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("Unsupported effect"),
+        "Sail into the West should parse strictly without unsupported placeholders, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    let compact_debug = debug.split_whitespace().collect::<String>();
+    assert!(
+        debug.contains("VoteEffect")
+            && debug.contains("VoteOptionGetsMoreVotes")
+            && debug.contains("VoteOptionGetsMoreVotesOrTied")
+            && debug.contains("ForPlayersEffect")
+            && debug.contains("ReturnFromGraveyardToHandEffect")
+            && compact_debug.contains("owner:Some(IteratedPlayer")
+            && debug.contains("DiscardHandEffect")
+            && debug.contains("DrawCardsEffect")
+            && debug.contains("MoveToZoneEffect"),
+        "expected vote conditions, iterated-player graveyard return, optional wheel, and self-exile structurally, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct SailVoteDecisionMaker {
+    votes: Vec<usize>,
+    may_accept: HashMap<PlayerId, bool>,
+    object_choice_players: Vec<PlayerId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for SailVoteDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if !self.votes.is_empty() {
+            vec![self.votes.remove(0)]
+        } else {
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.may_accept.get(&ctx.player).copied().unwrap_or(false)
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        self.object_choice_players.push(ctx.player);
+        let max = ctx.max.unwrap_or(ctx.candidates.len()).max(ctx.min);
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .take(max)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn sail_test_card(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Sorcery])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn sail_owner_zone_names(
+    game: &crate::game_state::GameState,
+    owner: PlayerId,
+    zone: Zone,
+) -> Vec<String> {
+    let mut names = game
+        .objects_in_zone(zone)
+        .into_iter()
+        .filter_map(|id| {
+            game.object(id).and_then(|object| {
+                (object.owner == owner).then(|| object.name.clone())
+            })
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_sail_into_the_west_with_votes(
+    votes: Vec<usize>,
+    may_accept: HashMap<PlayerId, bool>,
+) -> (crate::game_state::GameState, SailVoteDecisionMaker) {
+    let def = parse_oracle_card_definition("Sail into the West");
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Sail into the West should compile to spell effects");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+    for (idx, name) in [
+        "Sail Alice Grave One",
+        "Sail Alice Grave Two",
+        "Sail Alice Grave Three",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let card = sail_test_card(92_001 + idx as u32, name);
+        game.create_object_from_definition(&card, alice, Zone::Graveyard);
+    }
+    let bob_grave = sail_test_card(92_010, "Sail Bob Grave One");
+    game.create_object_from_definition(&bob_grave, bob, Zone::Graveyard);
+
+    for (idx, owner, zone, prefix, count) in [
+        (20_u32, alice, Zone::Hand, "Sail Alice Hand", 2_u32),
+        (30_u32, bob, Zone::Hand, "Sail Bob Hand", 3_u32),
+        (40_u32, alice, Zone::Library, "Sail Alice Library", 7_u32),
+        (50_u32, bob, Zone::Library, "Sail Bob Library", 7_u32),
+    ] {
+        for n in 0..count {
+            let card = sail_test_card(92_000 + idx + n, &format!("{prefix} {}", n + 1));
+            game.create_object_from_definition(&card, owner, zone);
+        }
+    }
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = SailVoteDecisionMaker {
+        votes,
+        may_accept,
+        object_choice_players: Vec::new(),
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        program,
+        None,
+        &[],
+    )
+    .expect("Sail into the West should resolve");
+    (game, dm)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sail_into_the_west_runtime_return_votes_return_each_players_graveyard_cards_and_exile_source() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let (game, dm) = resolve_sail_into_the_west_with_votes(vec![0, 0], HashMap::new());
+
+    assert_eq!(
+        dm.object_choice_players,
+        vec![alice, bob],
+        "each player should choose cards from their own graveyard for the return branch"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Hand).len(),
+        4,
+        "Alice should keep two hand cards and return up to two graveyard cards"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Graveyard).len(),
+        1,
+        "Alice should leave the third graveyard card behind because the branch is up to two"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, bob, Zone::Hand).len(),
+        4,
+        "Bob should keep three hand cards and return his one graveyard card"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, bob, Zone::Graveyard).len(),
+        0,
+        "Bob's only graveyard card should be returned"
+    );
+    assert_eq!(
+        travel_zone_names(&game, Zone::Exile),
+        vec!["Sail into the West".to_string()],
+        "return votes should exile Sail into the West after returning cards"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Library).len(),
+        7,
+        "embark draw branch should not run when return gets more votes"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sail_into_the_west_runtime_tied_vote_runs_embark_with_each_player_may_decision() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut may_accept = HashMap::new();
+    may_accept.insert(alice, true);
+    may_accept.insert(bob, false);
+
+    let (game, dm) = resolve_sail_into_the_west_with_votes(vec![0, 1], may_accept);
+
+    assert!(
+        dm.object_choice_players.is_empty(),
+        "return branch should not ask for graveyard choices when the vote is tied"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Hand).len(),
+        7,
+        "Alice accepted the embark may choice, discarded her hand, and drew seven cards"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Library).len(),
+        0,
+        "Alice should draw seven cards from her library"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, bob, Zone::Hand).len(),
+        3,
+        "Bob declined the embark may choice and should keep his hand"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, bob, Zone::Library).len(),
+        7,
+        "Bob declined, so he should not draw cards"
+    );
+    assert!(
+        travel_zone_names(&game, Zone::Exile).is_empty(),
+        "embark branch should not exile Sail into the West"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sail_into_the_west_runtime_embark_more_votes_draws_for_accepting_players() {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut may_accept = HashMap::new();
+    may_accept.insert(alice, true);
+    may_accept.insert(bob, true);
+
+    let (game, dm) = resolve_sail_into_the_west_with_votes(vec![1, 1], may_accept);
+
+    assert!(
+        dm.object_choice_players.is_empty(),
+        "return branch should not ask for graveyard choices when embark gets more votes"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Hand).len(),
+        7,
+        "Alice should draw seven after accepting embark"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, bob, Zone::Hand).len(),
+        7,
+        "Bob should draw seven after accepting embark"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, alice, Zone::Graveyard).len(),
+        5,
+        "Alice's three graveyard cards plus two discarded hand cards should stay in graveyard"
+    );
+    assert_eq!(
+        sail_owner_zone_names(&game, bob, Zone::Graveyard).len(),
+        4,
+        "Bob's one graveyard card plus three discarded hand cards should stay in graveyard"
+    );
+}
+
+#[test]
 fn dungeon_regression_cards_render_key_mechanics() {
     let crawler = parse_oracle_card_definition("Dungeon Crawler");
     let crawler_lines = unprocessed_compiled_lines(&crawler).join(" ");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -48024,9 +48024,9 @@ fn sail_into_the_west_strict_parser_text_and_structure_regression() {
     );
     assert!(
         rendered.contains(
-            "If return gets more votes, each player returns up to two cards from their graveyard to their hand"
+            "If return gets more votes, each player returns up to two cards from their graveyard to their hand, then you exile Sail into the West"
         ),
-        "expected return vote branch to render, got {rendered}"
+        "expected return vote branch and self-exile to render inside one conditional clause, got {rendered}"
     );
     assert!(
         rendered.contains(

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -974,7 +974,8 @@ fn rewrite_spell_resolution_damage_source(def: &CardDefinition, rendered: &str) 
     }
     let rendered = rewrite_damage_phrases_for_permanent_abilities(rendered, &def.card.name, false)
         .replace("Exile this source", &format!("Exile {}", def.card.name));
-    rewrite_standalone_spell_self_exile(&rendered, &def.card.name)
+    let rendered = rewrite_standalone_spell_self_exile(&rendered, &def.card.name);
+    rewrite_inline_spell_self_exile(&rendered, &def.card.name)
 }
 
 fn rewrite_standalone_spell_self_exile(rendered: &str, card_name: &str) -> String {
@@ -990,6 +991,29 @@ fn rewrite_standalone_spell_self_exile(rendered: &str, card_name: &str) -> Strin
             after.chars().next(),
             None | Some('.') | Some(',') | Some(';')
         ) {
+            out.push_str(&replacement);
+        } else {
+            out.push_str(needle);
+        }
+        rest = after;
+    }
+
+    out.push_str(rest);
+    out
+}
+
+fn rewrite_inline_spell_self_exile(rendered: &str, card_name: &str) -> String {
+    let needle = "exile this";
+    let replacement = format!("you exile {card_name}");
+    let mut out = String::with_capacity(rendered.len() + card_name.len() + 4);
+    let mut rest = rendered;
+
+    while let Some(idx) = rest.find(needle) {
+        out.push_str(&rest[..idx]);
+        let after = &rest[idx + needle.len()..];
+        if out.ends_with("then ")
+            && matches!(after.chars().next(), None | Some('.') | Some(',') | Some(';'))
+        {
             out.push_str(&replacement);
         } else {
             out.push_str(needle);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -432,7 +432,8 @@ fn describe_named_vote_conditional_sequence(effects: &[&Effect]) -> Option<Strin
         {
             return None;
         }
-        let body = describe_effect_list(&conditional.if_true)
+        let body = describe_effect_clause_list(&conditional.if_true)
+            .unwrap_or_else(|| describe_effect_list(&conditional.if_true))
             .trim()
             .trim_end_matches('.')
             .to_string();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -388,6 +388,73 @@ fn describe_planeswalk_chaos_vote_sequence(effects: &[&Effect]) -> Option<String
     )
 }
 
+fn describe_named_vote_conditional_sequence(effects: &[&Effect]) -> Option<String> {
+    let [vote_effect, followups @ ..] = effects else {
+        return None;
+    };
+    if followups.is_empty() {
+        return None;
+    }
+
+    let vote = vote_effect.downcast_ref::<crate::effects::VoteEffect>()?;
+    let ironsmith_core::VoteChoice::NamedOptions(options) = &vote.choice else {
+        return None;
+    };
+    if vote.secret
+        || vote.controller_extra_votes != 0
+        || vote.controller_optional_extra_votes != 0
+        || options.len() < 2
+        || !options
+            .iter()
+            .all(|option| option.effects_per_vote.is_empty())
+    {
+        return None;
+    }
+
+    let option_names = options
+        .iter()
+        .map(|option| option.name.clone())
+        .collect::<Vec<_>>();
+    let mut clauses = Vec::new();
+    for effect in followups {
+        let conditional = effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        if !conditional.if_false.is_empty() {
+            return None;
+        }
+        let condition_option = match &conditional.condition {
+            Condition::VoteOptionGetsMoreVotes(option)
+            | Condition::VoteOptionGetsMoreVotesOrTied(option) => option,
+            _ => return None,
+        };
+        if !option_names
+            .iter()
+            .any(|option| option.eq_ignore_ascii_case(condition_option))
+        {
+            return None;
+        }
+        let body = describe_effect_list(&conditional.if_true)
+            .trim()
+            .trim_end_matches('.')
+            .to_string();
+        if body.is_empty() {
+            return None;
+        }
+        clauses.push(format!(
+            "If {}, {}",
+            describe_condition(&conditional.condition),
+            lowercase_first(&body)
+        ));
+    }
+
+    let mut text = format!(
+        "Will of the council — Starting with you, each player votes for {}",
+        join_with_or(&option_names)
+    );
+    text.push_str(". ");
+    text.push_str(&clauses.join(". "));
+    Some(text)
+}
+
 fn library_position_from_top_text(position: &Value, one_as_on_top: bool) -> String {
     if let Value::Fixed(value) = position
         && let Ok(value) = u32::try_from(*value)
@@ -1396,6 +1463,61 @@ fn describe_each_player_may_discard_hand_draw_commander_value(
         "Each player may discard their hand and draw cards equal to the greatest mana value of a commander they own on the battlefield or in the command zone"
             .to_string()
     })
+}
+
+fn describe_each_player_may_discard_hand_draw(
+    for_players: &crate::effects::ForPlayersEffect,
+) -> Option<String> {
+    if for_players.filter != PlayerFilter::Any {
+        return None;
+    }
+    let [may_effect] = for_players.effects.as_slice() else {
+        return None;
+    };
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may.decider.is_some() {
+        return None;
+    }
+    let [discard_effect, draw_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let discard = discard_effect.downcast_ref::<crate::effects::DiscardHandEffect>()?;
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if discard.player != PlayerFilter::IteratedPlayer
+        || draw.player != PlayerFilter::IteratedPlayer
+    {
+        return None;
+    }
+    Some(format!(
+        "Each player may discard their hand and draw {}",
+        describe_card_count(&draw.count)
+    ))
+}
+
+fn describe_each_player_return_from_graveyard_to_hand(
+    for_players: &crate::effects::ForPlayersEffect,
+) -> Option<String> {
+    if for_players.filter != PlayerFilter::Any {
+        return None;
+    }
+    let [return_effect] = for_players.effects.as_slice() else {
+        return None;
+    };
+    let return_from_gy = unwrap_basic_tag_wrappers(return_effect)
+        .downcast_ref::<crate::effects::ReturnFromGraveyardToHandEffect>()?;
+    if return_from_gy.random {
+        return None;
+    }
+    let ChooseSpec::Object(filter) = return_from_gy.target.base() else {
+        return None;
+    };
+    if filter.zone != Some(Zone::Graveyard) || filter.owner != Some(PlayerFilter::IteratedPlayer) {
+        return None;
+    }
+    let target_text = describe_choose_spec_without_graveyard_zone(&return_from_gy.target);
+    Some(format!(
+        "Each player returns {target_text} from their graveyard to their hand"
+    ))
 }
 
 #[derive(Clone, Copy)]
@@ -3048,6 +3170,9 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
             return Some(compact);
         }
         if let Some(compact) = describe_planeswalk_chaos_vote_sequence(&refs) {
+            return Some(compact);
+        }
+        if let Some(compact) = describe_named_vote_conditional_sequence(&refs) {
             return Some(compact);
         }
     }
@@ -28772,6 +28897,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(for_players) = effect.downcast_ref::<crate::effects::ForPlayersEffect>() {
+        if let Some(compact) = describe_each_player_return_from_graveyard_to_hand(for_players) {
+            return compact;
+        }
+        if let Some(compact) = describe_each_player_may_discard_hand_draw(for_players) {
+            return compact;
+        }
         if let Some(compact) =
             describe_each_player_may_discard_hand_draw_commander_value(for_players)
         {

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2611,10 +2611,11 @@ pub fn resolve_objects_for_effect_with_choice_description(
             let description = choice_description
                 .clone()
                 .unwrap_or_else(|| format!("Choose {}", filter.description()));
+            let choosing_player = ctx.iteration.iterated_player.unwrap_or(ctx.controller);
             view_hidden_candidate_objects(
                 game,
                 ctx,
-                game.controlling_player_for(ctx.controller),
+                game.controlling_player_for(choosing_player),
                 &candidates,
                 description,
                 false,
@@ -2627,10 +2628,11 @@ pub fn resolve_objects_for_effect_with_choice_description(
 
         let description =
             choice_description.unwrap_or_else(|| format!("Choose {}", filter.description()));
+        let choosing_player = ctx.iteration.iterated_player.unwrap_or(ctx.controller);
         let chosen: Vec<ObjectId> = make_decision(
             game,
             ctx.decision_maker,
-            ctx.controller,
+            choosing_player,
             Some(ctx.source),
             ChooseObjectsSpec::new(ctx.source, description, candidates.clone(), min, Some(max)),
         );


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sail into the West
Initial parse error:
```
invalid power/toughness modifier in anthem clause (clause: 'starting with you each player votes for return or embark if return gets more votes each player returns up to two cards from their graveyard to their hand then you exile this if embark gets more votes or the vote is tied each player may discard their hand and draw seven cards'); oracle-only fallback also failed: invalid power/toughness modifier in anthem clause (clause: 'starting with you each player votes for return or embark if return gets more votes each player returns up to two cards from their graveyard to their hand then you exile this if embark gets more votes or the vote is tied each player may discard their hand and draw seven cards')
```

Current worker: i-0be06acb6bbb9bd39
Branch: codex/aws-card-fix-sail-into-the-west
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0023
