### PR TITLE
Fix Ironsmith parse failure: Akuta, Born of Ash

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -96,7 +96,6 @@ const LIFE_TOTAL_AT_LEAST_STARTING_PATTERN: ClauseShape<'static> = clause_shape!
         ]
 );
 const OR_MORE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["or", "more"]);
-const HAS_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["has"]);
 const HAS_OR_HAVE_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["has"], &["have"]]);
 const HAD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["had"]);
@@ -3162,7 +3161,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
-        && HAS_WORD_PATTERN.matches_word_at(&filtered, subject_len)
+        && HAS_OR_HAVE_WORD_PATTERN.matches_word_at(&filtered, subject_len)
         && matches!(
             &filtered[subject_len + 1..],
             ["more", "card", "in", "hand", "than", "you"]
@@ -3179,7 +3178,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
-        && HAS_WORD_PATTERN.matches_word_at(&filtered, subject_len)
+        && HAS_OR_HAVE_WORD_PATTERN.matches_word_at(&filtered, subject_len)
         && matches!(
             &filtered[subject_len + 1..],
             [
@@ -3190,6 +3189,25 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
                 "more", "card", "in", "their", "hand", "than", "each", "other", "player",
             ] | [
                 "more", "cards", "in", "their", "hand", "than", "each", "other", "player",
+            ]
+        )
+    {
+        return Ok(PredicateAst::PlayerHasMoreCardsInHandThanEachOtherPlayer { player });
+    }
+
+    if let Some((player, subject_len)) = parse_comparison_player_subject(&filtered)
+        && matches!(player, PlayerAst::You)
+        && HAS_OR_HAVE_WORD_PATTERN.matches_word_at(&filtered, subject_len)
+        && matches!(
+            &filtered[subject_len + 1..],
+            [
+                "more", "card", "in", "hand", "than", "each", "opponent"
+            ] | [
+                "more", "cards", "in", "hand", "than", "each", "opponent"
+            ] | [
+                "more", "card", "in", "their", "hand", "than", "each", "opponent",
+            ] | [
+                "more", "cards", "in", "their", "hand", "than", "each", "opponent",
             ]
         )
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5739,11 +5739,14 @@ fn compile_subject_verb_effect(
 
             let tag = ctx.next_tag("sacrificed");
             ctx.last_object_tag = Some(tag.clone());
-            let choose = Effect::choose_objects(
-                resolved_filter,
-                *count as usize,
-                chooser.clone(),
-                tag.clone(),
+            let choose = Effect::new(
+                crate::effects::ChooseObjectsEffect::new(
+                    resolved_filter,
+                    *count as usize,
+                    chooser.clone(),
+                    tag.clone(),
+                )
+                .in_zone(Zone::Battlefield),
             );
             let sacrifice =
                 Effect::sacrifice_player(ObjectFilter::tagged(tag), *count, chooser.clone());

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -608,6 +608,8 @@ fn rewrite_lower_parsed_ability_internal(
             };
             let (lowered, parsed_intervening_if) =
                 materialize_prepared_triggered_effects(&prepared)?;
+            let returns_source_from_graveyard =
+                resolution_program_returns_source_from_graveyard_to_battlefield(&lowered.effects);
             rewrite_validate_iterated_player_bindings_in_lowered_effects(
                 &lowered,
                 trigger_binds_player_reference_context(&trigger),
@@ -621,6 +623,15 @@ fn rewrite_lower_parsed_ability_internal(
             triggered.effects = lowered.effects;
             triggered.choices = lowered.choices;
             triggered.intervening_if = intervening_if;
+            if returns_source_from_graveyard
+                && parsed
+                    .runtime()
+                    .functional_zones
+                    .iter()
+                    .all(|zone| *zone == Zone::Battlefield)
+            {
+                parsed.runtime_mut().functional_zones = vec![Zone::Graveyard];
+            }
             return Ok(parsed);
         }
         return Ok(parsed);
@@ -644,6 +655,31 @@ fn rewrite_lower_parsed_ability_internal(
     activated.choices = lowered.choices;
     mark_activated_mana_output_if_needed(activated);
     Ok(parsed)
+}
+
+fn resolution_program_returns_source_from_graveyard_to_battlefield(
+    program: &crate::resolution::ResolutionProgram,
+) -> bool {
+    program
+        .flattened_default_effects()
+        .iter()
+        .any(effect_returns_source_from_graveyard_to_battlefield)
+}
+
+fn effect_returns_source_from_graveyard_to_battlefield(effect: &Effect) -> bool {
+    if let Some(return_effect) =
+        effect.downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()
+    {
+        return matches!(return_effect.target.unhinted(), ChooseSpec::Source);
+    }
+    if let Some(if_effect) = effect.downcast_ref::<crate::effects::IfEffect>() {
+        return if_effect
+            .then
+            .iter()
+            .chain(if_effect.else_.iter())
+            .any(effect_returns_source_from_graveyard_to_battlefield);
+    }
+    false
 }
 
 fn mark_activated_mana_output_if_needed(activated: &mut crate::ability::ActivatedAbility) {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -1302,6 +1302,22 @@ fn rewrite_structure_predicate_parses_you_have_one_or_fewer_cards_in_hand() {
 }
 
 #[test]
+fn rewrite_structure_predicate_parses_you_have_more_cards_in_hand_than_each_opponent() {
+    let text = "you have more cards in hand than each opponent";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify predicate text");
+
+    let predicate = super::parse_predicate_lexed(&lexed)
+        .expect("predicate should parse for each-opponent hand comparison");
+
+    assert_eq!(
+        predicate,
+        crate::cards::builders::PredicateAst::PlayerHasMoreCardsInHandThanEachOtherPlayer {
+            player: crate::cards::builders::PlayerAst::You,
+        }
+    );
+}
+
+#[test]
 fn rewrite_structure_if_tail_parser_extracts_predicate() {
     let tokens = lex_line("if it's white", 0).expect("rewrite lexer should classify if tail");
     let predicate = super::grammar::structure::parse_trailing_if_predicate_lexed(&tokens)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -53005,6 +53005,38 @@ fn parse_sokenzan_renegade_keeps_unique_hand_leader_upkeep_trigger() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_akuta_born_of_ash_keeps_each_opponent_hand_gate_and_sacrifice_return() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Akuta, Born of Ash")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Haste\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may sacrifice a Swamp. If you do, return Akuta from your graveyard to the battlefield.",
+        )
+        .expect("Akuta, Born of Ash should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Haste")
+            && rendered.contains("if you have more cards in hand than each opponent")
+            && rendered.contains("you may sacrifice a Swamp")
+            && rendered.contains("If you do, return Akuta from your graveyard to the battlefield")
+            && !rendered.contains("unsupported"),
+        "expected Akuta's hand gate and sacrifice-return text to render cleanly, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("PlayerHasMoreCardsInHandThanEachOtherPlayer { player: You }")
+            && debug.contains("Sacrifice")
+            && debug.contains("ReturnFromGraveyardToBattlefieldEffect")
+            && debug.contains("functional_zones: [Graveyard]"),
+        "expected Akuta to lower the each-opponent hand gate and graveyard return, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_wild_dogs_keeps_unique_life_leader_upkeep_trigger() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Wild Dogs")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11352,6 +11352,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             )
         }
         Condition::PlayerHasMoreCardsInHandThanEachOtherPlayer { player } => {
+            if *player == PlayerFilter::You {
+                return "you have more cards in hand than each opponent".to_string();
+            }
             format!(
                 "{} has more cards in hand than each other player",
                 describe_player_filter(player)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -24034,6 +24034,212 @@ fn arden_angel_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn akuta_born_of_ash_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_390), "Akuta, Born of Ash")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(3, 2))
+        .parse_text(
+            "Haste\nAt the beginning of your upkeep, if you have more cards in hand than each opponent, you may sacrifice a Swamp. If you do, return Akuta from your graveyard to the battlefield.",
+        )
+        .expect("Akuta, Born of Ash should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_hand_filler(game: &mut GameState, controller: PlayerId, name: &str) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Hand)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_test_swamp(game: &mut GameState, controller: PlayerId) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), "Test Swamp")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Swamp])
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn set_akuta_upkeep(game: &mut GameState, active_player: PlayerId) {
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = active_player;
+    game.turn.priority_player = Some(active_player);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn akuta_born_of_ash_upkeep_trigger_requires_more_cards_than_each_opponent() {
+    let mut game = setup_three_player_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let akuta = akuta_born_of_ash_definition();
+    game.create_object_from_definition(&akuta, alice, Zone::Graveyard);
+    create_hand_filler(&mut game, alice, "Alice Card");
+    create_hand_filler(&mut game, bob, "Bob Card");
+    set_akuta_upkeep(&mut game, alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Akuta should not trigger when its controller is tied with an opponent for cards in hand"
+    );
+
+    create_hand_filler(&mut game, alice, "Alice Extra Card");
+    create_hand_filler(&mut game, charlie, "Charlie Card One");
+    create_hand_filler(&mut game, charlie, "Charlie Card Two");
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Akuta should not trigger unless its controller has more cards than every opponent"
+    );
+
+    create_hand_filler(&mut game, alice, "Alice Third Card");
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Akuta should trigger when its controller has more cards in hand than each opponent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn akuta_born_of_ash_rechecks_hand_condition_on_resolution() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let akuta = akuta_born_of_ash_definition();
+    let akuta_id = game.create_object_from_definition(&akuta, alice, Zone::Graveyard);
+    let akuta_stable_id = game.object(akuta_id).expect("Akuta exists").stable_id;
+    let swamp_id = create_test_swamp(&mut game, alice);
+    create_hand_filler(&mut game, alice, "Alice Card One");
+    create_hand_filler(&mut game, alice, "Alice Card Two");
+    create_hand_filler(&mut game, bob, "Bob Card");
+    set_akuta_upkeep(&mut game, alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Akuta should trigger");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Akuta upkeep trigger should go on the stack");
+
+    create_hand_filler(&mut game, bob, "Bob Second Card");
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Akuta trigger should resolve without effect when its condition becomes false");
+
+    let akuta_after = game
+        .find_object_by_stable_id(akuta_stable_id)
+        .expect("Akuta should still be trackable after resolving");
+    assert!(
+        game.object(akuta_after)
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "Akuta's intervening-if condition should be checked again at resolution"
+    );
+    assert!(
+        game.object(swamp_id)
+            .is_some_and(|object| object.zone == Zone::Battlefield),
+        "a false resolution-time hand condition should not sacrifice the Swamp"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn akuta_born_of_ash_sacrifices_swamp_and_returns_from_graveyard_when_accepted() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let akuta = akuta_born_of_ash_definition();
+    let akuta_id = game.create_object_from_definition(&akuta, alice, Zone::Graveyard);
+    let akuta_stable_id = game.object(akuta_id).expect("Akuta exists").stable_id;
+    let swamp_id = create_test_swamp(&mut game, alice);
+    let swamp_stable_id = game.object(swamp_id).expect("Swamp exists").stable_id;
+    create_hand_filler(&mut game, alice, "Alice Card One");
+    create_hand_filler(&mut game, alice, "Alice Card Two");
+    create_hand_filler(&mut game, bob, "Bob Card");
+    set_akuta_upkeep(&mut game, alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Akuta should trigger");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Akuta upkeep trigger should go on the stack");
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Akuta trigger should resolve");
+
+    let returned_akuta = game
+        .find_object_by_stable_id(akuta_stable_id)
+        .expect("Akuta should still be trackable after returning");
+    assert!(
+        game.object(returned_akuta)
+            .is_some_and(|object| object.zone == Zone::Battlefield),
+        "accepting Akuta's optional sacrifice should return it from the graveyard"
+    );
+    let sacrificed_swamp = game
+        .find_object_by_stable_id(swamp_stable_id)
+        .expect("sacrificed Swamp should still be trackable");
+    assert!(
+        game.object(sacrificed_swamp)
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "Akuta's accepted branch should sacrifice a Swamp"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn akuta_born_of_ash_declining_swamp_sacrifice_leaves_it_in_graveyard() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let akuta = akuta_born_of_ash_definition();
+    let akuta_id = game.create_object_from_definition(&akuta, alice, Zone::Graveyard);
+    let akuta_stable_id = game.object(akuta_id).expect("Akuta exists").stable_id;
+    let swamp_id = create_test_swamp(&mut game, alice);
+    create_hand_filler(&mut game, alice, "Alice Card One");
+    create_hand_filler(&mut game, alice, "Alice Card Two");
+    create_hand_filler(&mut game, bob, "Bob Card");
+    set_akuta_upkeep(&mut game, alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(trigger_queue.entries.len(), 1, "Akuta should trigger");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Akuta upkeep trigger should go on the stack");
+    let mut dm = AutoPassDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Akuta trigger should resolve");
+
+    let akuta_after = game
+        .find_object_by_stable_id(akuta_stable_id)
+        .expect("Akuta should still be trackable after resolving");
+    assert!(
+        game.object(akuta_after)
+            .is_some_and(|object| object.zone == Zone::Graveyard),
+        "declining the optional sacrifice should leave Akuta in the graveyard"
+    );
+    assert!(
+        game.object(swamp_id)
+            .is_some_and(|object| object.zone == Zone::Battlefield),
+        "declining the optional sacrifice should leave the Swamp on the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn arden_angel_upkeep_roll_one_returns_from_graveyard_to_battlefield() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Akuta, Born of Ash
Initial parse error:
```
unsupported predicate (predicate: 'you have more cards in hand than each opponent'); oracle-only fallback also failed: unsupported predicate (predicate: 'you have more cards in hand than each opponent')
```

Current worker: i-06ce8d41e146501df
Branch: codex/aws-card-fix-akuta-born-of-ash
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0023
