### PR TITLE
Fix Ironsmith parse failure: Dazzling Reflection

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -141,8 +141,12 @@ pub enum RetargetModeAst<
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PreventNextTimeDamageSourceAst<Filter = crate::target::ObjectFilter> {
+pub enum PreventNextTimeDamageSourceAst<
+    Filter = crate::target::ObjectFilter,
+    Target = TargetAst<crate::target::PlayerFilter, crate::target::ObjectFilter>,
+> {
     Choice,
+    Target(Target),
     Filter(Filter),
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1585,6 +1585,13 @@ fn compile_subject_verb_effect(
                 PreventNextTimeDamageSourceAst::Choice => {
                     crate::effects::PreventNextTimeDamageSource::Choice
                 }
+                PreventNextTimeDamageSourceAst::Target(target) => {
+                    let (spec, _) = resolve_target_spec_with_choices(
+                        target,
+                        &current_reference_env(ctx),
+                    )?;
+                    crate::effects::PreventNextTimeDamageSource::Target(spec)
+                }
                 PreventNextTimeDamageSourceAst::Filter(filter) => {
                     crate::effects::PreventNextTimeDamageSource::Filter(resolve_it_tag(
                         filter,
@@ -1757,6 +1764,11 @@ fn compile_subject_verb_effect(
             let source_spec = match source {
                 PreventNextTimeDamageSourceAst::Choice => {
                     crate::effects::RedirectNextTimeDamageSource::Choice
+                }
+                PreventNextTimeDamageSourceAst::Target(_) => {
+                    return Err(CardTextError::ParseError(
+                        "target-referenced redirect damage source is unsupported".to_string(),
+                    ));
                 }
                 PreventNextTimeDamageSourceAst::Filter(filter) => {
                     crate::effects::RedirectNextTimeDamageSource::Filter(resolve_it_tag(
@@ -5926,12 +5938,47 @@ where
     let (player_filter, choices) = subject.into_parts();
     let value = per_player_partition_value_for_filter(value, &player_filter);
     let you_value = per_player_partition_value_for_filter(you_value, &PlayerFilter::You);
-    compile_player_effect_from_resolved_filter(
+    let mut prelude_effects = Vec::new();
+    let mut merged_choices = choices.clone();
+    if let Some(spec) = value_object_target_spec(&value)
+        && ctx.auto_tag_object_targets
+    {
+        let effect = tag_object_target_effect(
+            Effect::new(crate::effects::TargetOnlyEffect::new(spec.clone())),
+            &spec,
+            ctx,
+            "targeted",
+        );
+        prelude_effects.push(effect);
+        push_choice(&mut merged_choices, spec);
+    }
+    let (mut effects, choices) = compile_player_effect_from_resolved_filter(
         player_filter,
         choices,
         || build_you(you_value),
         |filter| build_other(value, filter),
-    )
+    )?;
+    prelude_effects.append(&mut effects);
+    for choice in choices {
+        push_choice(&mut merged_choices, choice);
+    }
+    Ok((prelude_effects, merged_choices))
+}
+
+fn value_object_target_spec(value: &Value) -> Option<ChooseSpec> {
+    match value {
+        Value::SurfaceHinted { value, .. } => value_object_target_spec(value),
+        Value::Add(left, right) => {
+            value_object_target_spec(left).or_else(|| value_object_target_spec(right))
+        }
+        Value::PowerOf(spec)
+        | Value::ToughnessOf(spec)
+        | Value::ManaValueOf(spec)
+        | Value::CountersOn(spec, _) => {
+            (spec.is_target() && choose_spec_targets_object(spec)).then(|| (**spec).clone())
+        }
+        _ => None,
+    }
 }
 
 fn per_player_partition_value_for_filter(value: Value, player_filter: &PlayerFilter) -> Value {

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -294,6 +294,39 @@ fn maybe_tag_target(
     Ok(())
 }
 
+fn maybe_tag_value_object_target(
+    value: &Value,
+    frame: &mut ReferenceFrame,
+    id_gen: &mut IdGenContext,
+    prefix: &str,
+) {
+    if !frame.auto_tag_object_targets {
+        return;
+    }
+    let Some(spec) = value_object_target_spec(value) else {
+        return;
+    };
+    if let Some(tag) = propagated_or_generated_object_tag(spec, id_gen, prefix) {
+        frame.last_object_tag = Some(tag);
+    }
+}
+
+fn value_object_target_spec(value: &Value) -> Option<&ChooseSpec> {
+    match value {
+        Value::SurfaceHinted { value, .. } => value_object_target_spec(value),
+        Value::Add(left, right) => {
+            value_object_target_spec(left).or_else(|| value_object_target_spec(right))
+        }
+        Value::PowerOf(spec)
+        | Value::ToughnessOf(spec)
+        | Value::ManaValueOf(spec)
+        | Value::CountersOn(spec, _) => {
+            (spec.is_target() && choose_spec_targets_object(spec)).then_some(spec.as_ref())
+        }
+        _ => None,
+    }
+}
+
 fn propagated_or_generated_object_tag(
     spec: &ChooseSpec,
     id_gen: &mut IdGenContext,
@@ -378,6 +411,9 @@ fn advance_reference_frame_for_effect(
                     if frame.auto_tag_object_targets {
                         frame.last_object_tag = Some(next_reference_tag(id_gen, "amassed"));
                     }
+                }
+                SubjectVerbActionAst::GainLife { amount } => {
+                    maybe_tag_value_object_target(amount, frame, id_gen, "targeted");
                 }
                 SubjectVerbActionAst::Explore { target } => {
                     maybe_tag_target(target, frame, id_gen, "explored")?;
@@ -3217,10 +3253,14 @@ fn bind_unresolved_it_in_prevent_next_source(
     source: &mut PreventNextTimeDamageSourceAst,
     seed_tag: &TagKey,
 ) -> usize {
-    if let PreventNextTimeDamageSourceAst::Filter(filter) = source {
-        bind_unresolved_it_in_filter(filter, seed_tag)
-    } else {
-        0
+    match source {
+        PreventNextTimeDamageSourceAst::Target(target) => {
+            bind_unresolved_it_in_target(target, seed_tag)
+        }
+        PreventNextTimeDamageSourceAst::Filter(filter) => {
+            bind_unresolved_it_in_filter(filter, seed_tag)
+        }
+        PreventNextTimeDamageSourceAst::Choice => 0,
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1717,19 +1717,25 @@ pub(crate) fn parse_prevent_next_time_damage_sentence(
         return Ok(None);
     };
     let clause_words = clause.word_refs();
-    if !CLAUSE_DEAL_DAMAGE_TO_PREFIX_PATTERN.matches_words(&clause_words[would_idx + 1..]) {
+    let damage_target_start = if CLAUSE_DEAL_DAMAGE_TO_PREFIX_PATTERN
+        .matches_words(&clause_words[would_idx + 1..])
+    {
+        would_idx + 4
+    } else if word_slice_starts_with(&clause_words[would_idx + 1..], &["deal", "damage"]) {
+        would_idx + 3
+    } else {
         return Ok(None);
-    }
+    };
 
     let this_turn_rel = CLAUSE_THIS_TURN_PATTERN
-        .find_exact_window(&clause_words[would_idx + 4..], 2)
+        .find_exact_window(&clause_words[damage_target_start..], 2)
         .ok_or_else(|| {
             CardTextError::ParseError(format!(
                 "unsupported prevent-next-time damage duration (clause: '{}')",
                 clause_text
             ))
         })?;
-    let this_turn_idx = (would_idx + 4) + this_turn_rel;
+    let this_turn_idx = damage_target_start + this_turn_rel;
 
     let tail_clause = clause
         .after_words(this_turn_idx + 2)
@@ -1755,6 +1761,18 @@ pub(crate) fn parse_prevent_next_time_damage_sentence(
 
     let source = if CLAUSE_SOURCE_OF_YOUR_CHOICE_MARKER_PATTERN.matches(source_clause) {
         PreventNextTimeDamageSourceAst::Choice
+    } else if matches!(source_words.as_slice(), ["it"] | ["that", _]) {
+        let mut filter = ObjectFilter::tagged(TagKey::from(IT_TAG));
+        if let ["that", kind] = source_words.as_slice()
+            && let Some(card_type) = parse_card_type(kind)
+        {
+            filter.card_types.push(card_type);
+        }
+        PreventNextTimeDamageSourceAst::Target(TargetAst::Object(
+            filter,
+            None,
+            span_from_tokens(source_clause.tokens()),
+        ))
     } else {
         let mut words = strip_leading_article_word_refs(&source_words).to_vec();
         if CLAUSE_SOURCE_WORD_PATTERN.matches_last_word(&words) {
@@ -1806,8 +1824,10 @@ pub(crate) fn parse_prevent_next_time_damage_sentence(
         PreventNextTimeDamageSourceAst::Filter(filter)
     };
 
-    let target_clause = clause.between_words_trimmed(would_idx + 4, this_turn_idx);
-    let target = if CLAUSE_YOU_TARGET_PATTERN.matches(target_clause) {
+    let target_clause = clause.between_words_trimmed(damage_target_start, this_turn_idx);
+    let target = if target_clause.is_empty() {
+        PreventNextTimeDamageTargetAst::AnyTarget
+    } else if CLAUSE_YOU_TARGET_PATTERN.matches(target_clause) {
         PreventNextTimeDamageTargetAst::You
     } else if CLAUSE_ANY_TARGET_PATTERN.matches(target_clause) {
         PreventNextTimeDamageTargetAst::AnyTarget

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -887,6 +887,9 @@ pub(crate) fn parse_life_equal_to_value(
         {
             return Ok(Some(value));
         }
+        if let Some(value) = parse_possessive_target_stat_value(value_tokens, &value_words) {
+            return Ok(Some(value));
+        }
 
         if let Some((value, used)) = parse_value(value_tokens)
             && used == value_tokens.len()
@@ -930,6 +933,36 @@ pub(crate) fn parse_life_equal_to_value(
         "missing life amount in equal-to clause (clause: '{}')",
         clause_words.join(" ")
     )))
+}
+
+fn parse_possessive_target_stat_value(tokens: &[OwnedLexToken], words: &[&str]) -> Option<Value> {
+    let (stat_len, constructor): (usize, fn(Box<ChooseSpec>) -> Value) = match words {
+        [.., "power"] => (1, Value::PowerOf),
+        [.., "toughness"] => (1, Value::ToughnessOf),
+        [.., "mana", "value"] => (2, Value::ManaValueOf),
+        _ => return None,
+    };
+    let target_len = tokens.len().checked_sub(stat_len)?;
+    if target_len == 0 {
+        return None;
+    }
+
+    let mut target_tokens = tokens[..target_len].to_vec();
+    let possessive = target_tokens.last_mut()?;
+    let word = possessive.as_word()?;
+    let base = word
+        .strip_suffix("'s")
+        .or_else(|| word.strip_suffix("’s"))
+        .or_else(|| word.strip_suffix("‘s"))?
+        .to_string();
+    if base.is_empty() || !possessive.replace_word(base) {
+        return None;
+    }
+
+    let target = parse_target_phrase(&target_tokens).ok()?;
+    let spec =
+        crate::runtime_backend::references::reference_helpers::choose_spec_for_target(&target);
+    Some(constructor(Box::new(spec)))
 }
 
 pub(crate) fn parse_life_amount_from_trailing(

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -105,6 +105,7 @@ pub enum ReplacementApplyMode {
 #[derive(Debug, Clone, PartialEq)]
 pub enum PreventNextTimeDamageSource {
     Choice,
+    Target(ChooseSpec),
     Filter(crate::filter_model::ObjectFilter),
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -1075,6 +1075,7 @@ pub(crate) enum RetargetModeAst {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PreventNextTimeDamageSourceAst {
     Choice,
+    Target(TargetAst),
     Filter(ObjectFilter),
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18317,6 +18317,121 @@ fn parse_oracle_cho_arrim_alchemist_strict_text_and_activation_shape() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_dazzling_reflection_strict_text_and_spell_shape() {
+    assert_oracle_card_parses_strict("Dazzling Reflection");
+    let def = parse_oracle_card_definition("Dazzling Reflection");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Dazzling Reflection should have a spell effect");
+    let debug = format!("{spell:#?}");
+    assert!(
+        debug.contains("TargetOnlyEffect")
+            && debug.contains("GainLifeEffect")
+            && debug.contains("PowerOf")
+            && debug.contains("PreventNextTimeDamageEffect"),
+        "expected Dazzling Reflection to target a creature, gain life from its power, and prevent that source's next damage, got {debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("You gain life equal to target creature's power")
+            && rendered.contains("The next time that creature would deal damage this turn, prevent that damage"),
+        "expected Dazzling Reflection compiled text to preserve target-power life gain and that-creature prevention, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dazzling_reflection_runtime_gains_target_power_and_prevents_that_creature_damage_only() {
+    fn resolve_for_target_power(power: i32) -> (i32, bool, u32, bool, u32) {
+        let def = parse_oracle_card_definition("Dazzling Reflection");
+        let spell_effect = def.spell_effect.as_ref().expect("spell effect exists");
+        let mut game =
+            crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+        let target_creature = game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(91_601), "Dazzling Target")
+                .card_types(vec![CardType::Creature])
+                .power_toughness(PowerToughness::fixed(power, 4))
+                .build(),
+            bob,
+            Zone::Battlefield,
+        );
+        let other_creature = game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(91_602), "Other Damage Source")
+                .card_types(vec![CardType::Creature])
+                .power_toughness(PowerToughness::fixed(3, 3))
+                .build(),
+            bob,
+            Zone::Battlefield,
+        );
+
+        let mut dm = crate::decision::AutoPassDecisionMaker;
+        let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+            .with_targets(vec![crate::effects::ResolvedTarget::Object(target_creature)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: ChooseSpec::target_creature(),
+                range: 0..1,
+            }]);
+        crate::game_loop::execute_resolution_program(
+            &mut game,
+            &mut ctx,
+            alice,
+            spell_source,
+            spell_effect,
+            None,
+            &[],
+        )
+        .expect("Dazzling Reflection should resolve");
+
+        let life_after_resolution = game.life_total(alice);
+        let (other_source_damage, other_source_prevented) =
+            crate::events::processing::process_damage_with_event(
+                &mut game,
+                other_creature,
+                crate::events::DamageTarget::Player(alice),
+                3,
+                false,
+                crate::events::cause::EventCause::effect(),
+            );
+        let (target_source_damage, target_source_prevented) =
+            crate::events::processing::process_damage_with_event(
+                &mut game,
+                target_creature,
+                crate::events::DamageTarget::Player(bob),
+                5,
+                false,
+                crate::events::cause::EventCause::effect(),
+            );
+
+        (
+            life_after_resolution,
+            other_source_prevented,
+            other_source_damage,
+            target_source_prevented,
+            target_source_damage,
+        )
+    }
+
+    let (life, other_prevented, other_damage, target_prevented, target_damage) =
+        resolve_for_target_power(4);
+    assert_eq!(life, 24, "Alice should gain life equal to target creature's power");
+    assert!(!other_prevented, "damage from a different creature should not be prevented");
+    assert_eq!(other_damage, 3, "nonmatching damage should still be dealt");
+    assert!(target_prevented, "damage from the targeted creature should be prevented");
+    assert_eq!(target_damage, 0, "prevented target-creature damage should be reduced to zero");
+
+    let (life, _, _, target_prevented, target_damage) = resolve_for_target_power(0);
+    assert_eq!(life, 20, "zero-power target should not increase Alice's life total");
+    assert!(target_prevented, "the prevention shield should still apply for a zero-power target");
+    assert_eq!(target_damage, 0, "zero-power branch should still prevent that creature's damage");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn cho_arrim_alchemist_runtime_prevents_chosen_source_to_you_and_gains_that_life() {
     struct ChooseNamedSourceDecisionMaker {
         source_name: &'static str,

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -28567,6 +28567,57 @@ fn describe_remove_counter_phrase(
     }
 }
 
+fn prevent_next_time_tagged_source_text_filter(
+    source: &crate::effects::PreventNextTimeDamageSource,
+) -> bool {
+    match source {
+        crate::effects::PreventNextTimeDamageSource::Target(spec) => {
+            prevent_next_time_target_source_is_tagged(spec)
+        }
+        crate::effects::PreventNextTimeDamageSource::Filter(filter) => {
+            prevent_next_time_tagged_source_text(filter).is_some()
+        }
+        crate::effects::PreventNextTimeDamageSource::Choice => false,
+    }
+}
+
+fn prevent_next_time_target_source_text(spec: &ChooseSpec) -> String {
+    match spec.base() {
+        ChooseSpec::Object(filter) => prevent_next_time_tagged_source_text(filter)
+            .unwrap_or_else(|| describe_choose_spec(spec)),
+        ChooseSpec::Tagged(_) => "that source".to_string(),
+        _ => describe_choose_spec(spec),
+    }
+}
+
+fn prevent_next_time_target_source_is_tagged(spec: &ChooseSpec) -> bool {
+    match spec.base() {
+        ChooseSpec::Object(filter) => prevent_next_time_tagged_source_text(filter).is_some(),
+        ChooseSpec::Tagged(_) => true,
+        _ => false,
+    }
+}
+
+fn prevent_next_time_tagged_source_text(filter: &ObjectFilter) -> Option<String> {
+    let has_tagged_source = filter.tagged_constraints.iter().any(|constraint| {
+        matches!(
+            constraint.relation,
+            crate::filter::TaggedOpbjectRelation::IsTaggedObject
+        )
+    });
+    if !has_tagged_source {
+        return None;
+    }
+
+    if filter.card_types.contains(&CardType::Creature) {
+        Some("that creature".to_string())
+    } else if let Some(card_type) = filter.card_types.first() {
+        Some(format!("that {}", card_type.name()))
+    } else {
+        Some("that source".to_string())
+    }
+}
+
 pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(sequence) = effect.downcast_ref::<crate::effects::SequenceEffect>() {
         if let Some(compact) = describe_reveal_until_sequence(sequence) {
@@ -33560,6 +33611,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             crate::effects::PreventNextTimeDamageSource::Choice => {
                 "a source of your choice".to_string()
             }
+            crate::effects::PreventNextTimeDamageSource::Target(spec) => {
+                prevent_next_time_target_source_text(spec)
+            }
+            crate::effects::PreventNextTimeDamageSource::Filter(filter)
+                if prevent_next_time_tagged_source_text(filter).is_some() =>
+            {
+                prevent_next_time_tagged_source_text(filter).unwrap()
+            }
             crate::effects::PreventNextTimeDamageSource::Filter(filter) => {
                 let desc = filter.description();
                 if desc.is_empty() {
@@ -33573,8 +33632,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             crate::effects::PreventNextTimeDamageTarget::AnyTarget => "any target".to_string(),
             crate::effects::PreventNextTimeDamageTarget::You => "you".to_string(),
         };
+        let omits_any_target = matches!(
+            prevent_next_time.target,
+            crate::effects::PreventNextTimeDamageTarget::AnyTarget
+        ) && prevent_next_time_tagged_source_text_filter(&prevent_next_time.source);
+        let target_clause = if omits_any_target {
+            String::new()
+        } else {
+            format!(" to {target_text}")
+        };
         let mut rendered = format!(
-            "The next time {source_text} would deal damage to {target_text} this turn, prevent that damage"
+            "The next time {source_text} would deal damage{target_clause} this turn, prevent that damage"
         );
         if prevent_next_time.reflect_damage_to_source_controller {
             rendered.push_str(

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -956,6 +956,9 @@ where
             ironsmith_core::PreventNextTimeDamageSource::Choice => {
                 crate::effects::PreventNextTimeDamageSource::Choice
             }
+            ironsmith_core::PreventNextTimeDamageSource::Target(spec) => {
+                crate::effects::PreventNextTimeDamageSource::Target(spec.clone())
+            }
             ironsmith_core::PreventNextTimeDamageSource::Filter(filter) => {
                 crate::effects::PreventNextTimeDamageSource::Filter(filter.clone())
             }

--- a/crates/ironsmith-runtime/src/effects/damage/prevent_next_time_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/prevent_next_time_damage.rs
@@ -8,6 +8,7 @@ use crate::Value;
 use crate::effect::{Effect, EffectOutcome, EventValueSpec};
 use crate::effects::DealDamageEffect;
 use crate::effects::EffectExecutor;
+use crate::effects::helpers::resolve_objects_for_effect;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::damage::matchers::{
     DamageSourceConstraint, DamageTargetConstraint, PreventableDamageConstraintMatcher,
@@ -21,6 +22,8 @@ use crate::target::{ChooseSpec, ObjectFilter, ObjectRef, PlayerFilter};
 pub enum PreventNextTimeDamageSource {
     /// Choose a specific source as the effect resolves ("a source of your choice").
     Choice,
+    /// Use an already selected target as the source ("that creature").
+    Target(ChooseSpec),
     /// Match any source that satisfies a filter ("a red source", "an artifact source", etc.).
     Filter(ObjectFilter),
 }
@@ -79,6 +82,14 @@ impl EffectExecutor for PreventNextTimeDamageEffect {
 
         let mut chosen_source = None;
         let source_constraint = match &self.source {
+            PreventNextTimeDamageSource::Target(spec) => {
+                let Some(source) = resolve_objects_for_effect(game, ctx, spec)?.into_iter().next()
+                else {
+                    return Ok(EffectOutcome::count(0));
+                };
+                chosen_source = Some(source);
+                DamageSourceConstraint::Specific(source)
+            }
             PreventNextTimeDamageSource::Filter(filter) => {
                 DamageSourceConstraint::Filter(filter.clone())
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dazzling Reflection
Initial parse error:
```
missing life amount in equal-to clause (clause: 'life equal to target creature's power'); oracle-only fallback also failed: missing life amount in equal-to clause (clause: 'life equal to target creature's power')
```

Current worker: i-0c85d54917fb4762e
Branch: codex/aws-card-fix-dazzling-reflection
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0024
