### PR TITLE
Fix Ironsmith parse failure: Damping Sphere

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2791,6 +2791,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_buyback_cost_reduction_line),
         single_static_ability_ast_passthrough_rule!(parse_can_be_attached_only_to_line),
         single_static_ability_ast_rule!(parse_spell_cost_increase_per_target_beyond_first_line),
+        single_static_ability_ast_rule!(parse_land_mana_two_or_more_replacement_line),
         single_static_ability_ast_rule!(parse_equip_cost_modifier_line),
         single_static_ability_ast_rule!(parse_flashback_cost_modifier_line),
         multi_static_ability_ast_rule!(parse_spell_and_player_activated_ability_cost_modifier_line),
@@ -7053,6 +7054,34 @@ pub(crate) fn parse_spells_cost_modifier_line(
     Ok(Some(StaticAbility::new(ability)))
 }
 
+fn parse_land_mana_two_or_more_replacement_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let exact = word_slice_eq(
+        &words,
+        &[
+            "if", "a", "land", "is", "tapped", "for", "two", "or", "more", "mana", "it",
+            "produces", "c", "instead", "of", "any", "other", "type", "and", "amount",
+        ],
+    );
+    let loose = words.first().is_some_and(|word| *word == "if")
+        && words.iter().any(|word| *word == "land")
+        && words.iter().any(|word| *word == "tapped")
+        && words.iter().any(|word| *word == "produces")
+        && words.iter().any(|word| *word == "instead")
+        && words
+            .windows(5)
+            .any(|window| window == ["two", "or", "more", "mana", "it"]);
+    if !exact && !loose {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        StaticAbility::lands_produce_one_colorless_instead_if_produce_two_or_more(),
+    ))
+}
+
 pub(crate) fn parse_spell_and_player_activated_ability_cost_modifier_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbility>>, CardTextError> {
@@ -7570,6 +7599,14 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
     }
     // "for each spell you've cast this turn" (and limited variants like "instant and sorcery spell")
     if let Some(player) = dynamic_spell_cast_this_turn_player(&filter_words) {
+        if filter_words.windows(8).any(|window| {
+            matches!(window[0], "other")
+                && matches!(window[1], "spell" | "spells")
+                && window[2..] == ["that", "player", "has", "cast", "this", "turn"]
+        }) {
+            return Ok(Some(Value::SpellsCastThisTurn(PlayerFilter::EffectController)));
+        }
+
         if CARD_TYPE_MARKER_PATTERN.matches_words(&filter_words) {
             let mut filter = ObjectFilter::spell();
             filter.cast_by = Some(player);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -5,6 +5,24 @@ use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseSha
 const REVEAL_THIS_CARD_FROM_HAND_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["reveal", "this", "card", "from", "your", "hand"]);
 
+const LAND_TWO_OR_MORE_MANA_REPLACEMENT_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact & [
+        "if", "a", "land", "is", "tapped", "for", "two", "or", "more", "mana", "it",
+        "produces", "c", "instead", "of", "any", "other", "type", "and", "amount"
+    ]
+);
+
+fn looks_like_land_two_or_more_mana_replacement_line(tokens: &[OwnedLexToken]) -> bool {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    LAND_TWO_OR_MORE_MANA_REPLACEMENT_PATTERN.matches_words(&words)
+        || (words.first().is_some_and(|word| *word == "if")
+            && words.iter().any(|word| *word == "land")
+            && words.iter().any(|word| *word == "tapped")
+            && words.iter().any(|word| *word == "produces")
+            && words.iter().any(|word| *word == "instead")
+            && words.windows(5).any(|window| window == ["two", "or", "more", "mana", "it"]))
+}
+
 fn join_statement_parse_sentence_group(sentences: &[Vec<OwnedLexToken>]) -> Vec<OwnedLexToken> {
     let mut joined = Vec::new();
     for sentence in sentences {
@@ -27,6 +45,9 @@ pub(super) fn parse_statement_line_cst(
 ) -> Result<Option<StatementLineCst>, CardTextError> {
     let normalized = line.info.normalized.normalized.as_str();
     if looks_like_day_night_starts_day_as_enters_static_line(&line.tokens) {
+        return Ok(None);
+    }
+    if looks_like_land_two_or_more_mana_replacement_line(&line.tokens) {
         return Ok(None);
     }
     let line_family = structure::classify_statement_line_family_lexed(&line.tokens);
@@ -56,7 +77,8 @@ pub(super) fn parse_statement_line_cst(
             ],
         ) && contains_token_word_sequence(&line.tokens, &["more", "to", "cast"]))
         || (token_slice_starts_with_any(&line.tokens, &[&["if"]])
-            && contains_token_word_sequence(&line.tokens, &["instead"]))
+            && contains_token_word_sequence(&line.tokens, &["instead"])
+            && !looks_like_land_two_or_more_mana_replacement_line(&line.tokens))
         || (token_slice_starts_with_any(&line.tokens, &[&["each"], &["all"]])
             && contains_token_word_sequence(&line.tokens, &["until", "end", "of", "turn"]))
         || looks_like_statement_line_lexed(line);

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -130,6 +130,7 @@ pub enum StaticAbilityId {
     CostIncrease,
     CostReductionManaCost,
     CostIncreaseManaCost,
+    LandsProduceOneColorlessInsteadIfProduceTwoOrMore,
     CostIncreasePerAdditionalTarget,
     CostIncreaseManaCostPerAdditionalTarget,
     AffinityForArtifacts,
@@ -390,6 +391,7 @@ impl StaticAbilityId {
             | CostIncrease
             | CostReductionManaCost
             | CostIncreaseManaCost
+            | LandsProduceOneColorlessInsteadIfProduceTwoOrMore
             | CostIncreasePerAdditionalTarget
             | CostIncreaseManaCostPerAdditionalTarget
             | AffinityForArtifacts

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3298,6 +3298,12 @@ impl<
             payload: StaticAbilityPayload::CostIncreaseManaCostPerTargetBeyondFirst(cost),
         }
     }
+    pub fn lands_produce_one_colorless_instead_if_produce_two_or_more() -> Self {
+        Self::identified(
+            StaticAbilityId::LandsProduceOneColorlessInsteadIfProduceTwoOrMore,
+            "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.",
+        )
+    }
     pub fn players_skip_upkeep() -> Self {
         Self {
             id: Some(StaticAbilityId::PlayersSkipUpkeep),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -657,6 +657,26 @@ fn stoic_sphinx_hexproof_tracks_whether_controller_cast_a_spell_this_turn() {
     );
 }
 
+#[test]
+fn damping_sphere_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Damping Sphere");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = canonical_compiled_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("LandsProduceOneColorlessInsteadIfProduceTwoOrMore"),
+        "Damping Sphere should model its land mana replacement as a static ability, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("SpellsCastThisTurn(EffectController)"),
+        "Damping Sphere should count spells cast this turn by the spell's caster, got {ability_debug}"
+    );
+    assert_eq!(
+        rendered,
+        "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn."
+    );
+}
+
 fn alacrian_armory_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
     def.abilities
         .iter()

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -3224,10 +3224,11 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
                         chosen_target_count,
                     )
                 {
-                    let amount = resolve_cost_modifier_value_for_source(
+                    let amount = resolve_battlefield_cost_modifier_value(
                         game,
                         perm_id,
                         controller,
+                        caster,
                         &reduction.reduction,
                     );
                     if amount > 0 {
@@ -3245,10 +3246,11 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
                         chosen_target_count,
                     )
                 {
-                    let amount = resolve_cost_modifier_value_for_source(
+                    let amount = resolve_battlefield_cost_modifier_value(
                         game,
                         perm_id,
                         controller,
+                        caster,
                         &increase.increase,
                     );
                     if amount > 0 {
@@ -3321,10 +3323,11 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
                         chosen_target_count,
                     )
                 {
-                    let amount = resolve_cost_modifier_value_for_source(
+                    let amount = resolve_battlefield_cost_modifier_value(
                         game,
                         perm_id,
                         controller,
+                        caster,
                         &reduction.reduction,
                     );
                     if amount > 0 {
@@ -3342,10 +3345,11 @@ pub(crate) fn apply_battlefield_spell_cost_modifiers(
                         chosen_target_count,
                     )
                 {
-                    let amount = resolve_cost_modifier_value_for_source(
+                    let amount = resolve_battlefield_cost_modifier_value(
                         game,
                         perm_id,
                         controller,
+                        caster,
                         &increase.increase,
                     );
                     if amount > 0 {
@@ -3523,6 +3527,43 @@ pub(crate) fn resolve_cost_modifier_value_for_source(
     let mut dm = SelectFirstDecisionMaker;
     let ctx = ExecutionContext::new(source, controller, &mut dm);
     resolve_value(game, value, &ctx).unwrap_or(0)
+}
+
+fn resolve_battlefield_cost_modifier_value(
+    game: &GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    caster: PlayerId,
+    value: &crate::effect::Value,
+) -> i32 {
+    match value {
+        crate::effect::Value::SpellsCastThisTurn(crate::target::PlayerFilter::EffectController) => {
+            game.turn_store.turn_history.spells_cast_by_player(caster) as i32
+        }
+        crate::effect::Value::SpellsCastThisTurnMatching {
+            player: crate::target::PlayerFilter::EffectController,
+            filter,
+            exclude_source,
+        } => {
+            let mut dm = SelectFirstDecisionMaker;
+            let ctx = ExecutionContext::new(source, controller, &mut dm);
+            let filter_ctx = ctx.filter_context(game);
+            let mut count: i32 = 0;
+            for snapshot in game.turn_store.turn_history.spell_cast_snapshot_history() {
+                if *exclude_source && snapshot.object_id == source {
+                    continue;
+                }
+                if snapshot.controller != caster {
+                    continue;
+                }
+                if filter.matches_snapshot(&snapshot, &filter_ctx, game) {
+                    count = count.saturating_add(1);
+                }
+            }
+            count
+        }
+        _ => resolve_cost_modifier_value_for_source(game, source, controller, value),
+    }
 }
 
 /// Calculate the number of cards that need to be exiled for Delve.
@@ -3883,7 +3924,12 @@ fn mana_ability_output_options(
     if let Some(output) = mana_ability.mana_output.as_ref()
         && !output.is_empty()
     {
-        return vec![output.clone()];
+        return vec![apply_land_two_or_more_mana_replacement_to_symbols(
+            game,
+            source,
+            output.clone(),
+            mana_ability.has_tap_cost(),
+        )];
     }
 
     let resolve_amount = |value: &crate::effect::Value| -> usize {
@@ -3953,6 +3999,14 @@ fn mana_ability_output_options(
 
     let outputs = outputs
         .into_iter()
+        .map(|output| {
+            apply_land_two_or_more_mana_replacement_to_symbols(
+                game,
+                source,
+                output,
+                mana_ability.has_tap_cost(),
+            )
+        })
         .filter(|output| !output.is_empty())
         .collect::<Vec<_>>();
     if outputs.is_empty() {
@@ -4604,7 +4658,12 @@ pub(crate) fn inferred_potential_mana_symbols_for_ability(
     if let Some(mana_output) = mana_ability.mana_output.as_ref()
         && !mana_output.is_empty()
     {
-        return mana_output.clone();
+        return apply_land_two_or_more_mana_replacement_to_symbols(
+            game,
+            source,
+            mana_output.clone(),
+            mana_ability.has_tap_cost(),
+        );
     }
 
     let resolve_amount = |value: &crate::effect::Value| -> usize {
@@ -4681,10 +4740,45 @@ pub(crate) fn inferred_potential_mana_symbols_for_ability(
         }
     }
 
-    if inferred.is_empty() {
+    let inferred = if inferred.is_empty() {
         mana_ability.inferred_mana_symbols(game, source, controller)
     } else {
         inferred
+    };
+    apply_land_two_or_more_mana_replacement_to_symbols(
+        game,
+        source,
+        inferred,
+        mana_ability.has_tap_cost(),
+    )
+}
+
+fn apply_land_two_or_more_mana_replacement_to_symbols(
+    game: &GameState,
+    source: ObjectId,
+    mana: Vec<ManaSymbol>,
+    tapped_for_mana: bool,
+) -> Vec<ManaSymbol> {
+    if mana.len() < 2 {
+        return mana;
+    }
+    if !tapped_for_mana {
+        return mana;
+    }
+    let view = DerivedGameView::new(game);
+    if !view.object_has_card_type(source, crate::types::CardType::Land) {
+        return mana;
+    }
+    let replacement_active = game.battlefield.iter().any(|&perm_id| {
+        view.object_has_static_ability_id(
+            perm_id,
+            crate::static_abilities::StaticAbilityId::LandsProduceOneColorlessInsteadIfProduceTwoOrMore,
+        )
+    });
+    if replacement_active {
+        vec![ManaSymbol::Colorless]
+    } else {
+        mana
     }
 }
 
@@ -5085,8 +5179,13 @@ mod tests {
     use crate::alternative_cast::CastingMethod;
     use crate::card::{CardBuilder, PowerToughness};
     use crate::cards::builders::CardDefinitionBuilder;
+    use crate::derived_view::DerivedGameView;
+    use crate::events::spells::SpellCastEvent;
     use crate::ids::{CardId, PlayerId};
     use crate::mana::{ManaCost, ManaSymbol};
+    use crate::provenance::ProvNodeId;
+    use crate::snapshot::ObjectSnapshot;
+    use crate::triggers::TriggerEvent;
     use crate::types::{CardType, Subtype};
     use crate::zone::Zone;
 
@@ -5113,6 +5212,155 @@ mod tests {
             .card_types(vec![CardType::Artifact])
             .build();
         game.create_object_from_card(&card, owner, Zone::Battlefield);
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn damping_sphere_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Damping Sphere")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text(
+                "If a land is tapped for two or more mana, it produces {C} instead of any other type and amount.\nEach spell a player casts costs {1} more to cast for each other spell that player has cast this turn.",
+            )
+            .expect("Damping Sphere should parse for runtime regression tests")
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn two_mana_land_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Damping Sphere Test Temple")
+            .card_types(vec![CardType::Land])
+            .parse_text("{T}: Add {C}{C}.")
+            .expect("test land mana ability should parse")
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn test_spell_card(name: &str, cost: u8) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(cost)]]))
+            .card_types(vec![CardType::Sorcery])
+            .build()
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn record_damping_sphere_spell_cast(game: &mut GameState, caster: PlayerId, name: &str) {
+        let card = test_spell_card(name, 1);
+        let spell_id = game.create_object_from_card(&card, caster, Zone::Stack);
+        let snapshot = ObjectSnapshot::from_object(
+            game.object(spell_id)
+                .expect("recorded spell should exist on the stack"),
+            game,
+        );
+        let event = TriggerEvent::new_with_provenance(
+            SpellCastEvent::new_with_snapshot(spell_id, caster, Zone::Hand, snapshot.clone()),
+            ProvNodeId::default(),
+        );
+        game.turn_store
+            .turn_history
+            .record_event(&event, Some(snapshot), None);
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn damping_sphere_replaces_land_mana_only_when_land_would_produce_two_or_more() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let temple_def = two_mana_land_definition();
+        let temple_id = game.create_object_from_definition(&temple_def, alice, Zone::Battlefield);
+
+        let potential_without_sphere = compute_potential_mana(&game, alice);
+        assert_eq!(potential_without_sphere.colorless, 2);
+
+        let sphere_def = damping_sphere_definition();
+        game.create_object_from_definition(&sphere_def, alice, Zone::Battlefield);
+
+        let potential_with_sphere = compute_potential_mana(&game, alice);
+        assert_eq!(
+            potential_with_sphere.colorless, 1,
+            "Damping Sphere should replace the land's two-mana output with one colorless mana"
+        );
+        assert!(
+            game.object(temple_id)
+                .expect("temple should remain on battlefield")
+                .card_types
+                .contains(&CardType::Land)
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn damping_sphere_cost_tax_counts_only_that_players_prior_spells() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let sphere_def = damping_sphere_definition();
+        game.create_object_from_definition(&sphere_def, alice, Zone::Battlefield);
+        let alice_spell =
+            game.create_object_from_card(&test_spell_card("Alice Follow-up", 2), alice, Zone::Hand);
+        let bob_spell =
+            game.create_object_from_card(&test_spell_card("Bob Follow-up", 2), bob, Zone::Hand);
+        let alice_base = game
+            .object(alice_spell)
+            .expect("Alice spell should exist")
+            .mana_cost
+            .as_ref()
+            .expect("Alice spell should have a mana cost")
+            .clone();
+
+        let view = DerivedGameView::new(&game);
+        let adjusted_first = apply_battlefield_spell_cost_modifiers(
+            &game,
+            alice,
+            game.object(alice_spell).expect("Alice spell should exist"),
+            &alice_base,
+            0,
+            &CastingMethod::Normal,
+            &view,
+        );
+        assert_eq!(adjusted_first.to_oracle(), "{2}");
+
+        record_damping_sphere_spell_cast(&mut game, bob, "Bob Prior");
+        let view = DerivedGameView::new(&game);
+        let adjusted_after_bob = apply_battlefield_spell_cost_modifiers(
+            &game,
+            alice,
+            game.object(alice_spell).expect("Alice spell should exist"),
+            &alice_base,
+            0,
+            &CastingMethod::Normal,
+            &view,
+        );
+        assert_eq!(adjusted_after_bob.to_oracle(), "{2}");
+
+        record_damping_sphere_spell_cast(&mut game, alice, "Alice Prior");
+        let view = DerivedGameView::new(&game);
+        let adjusted_after_alice = apply_battlefield_spell_cost_modifiers(
+            &game,
+            alice,
+            game.object(alice_spell).expect("Alice spell should exist"),
+            &alice_base,
+            0,
+            &CastingMethod::Normal,
+            &view,
+        );
+        assert_eq!(adjusted_after_alice.to_oracle(), "{2}{1}");
+
+        let bob_base = game
+            .object(bob_spell)
+            .expect("Bob spell should exist")
+            .mana_cost
+            .as_ref()
+            .expect("Bob spell should have a mana cost")
+            .clone();
+        let adjusted_bob = apply_battlefield_spell_cost_modifiers(
+            &game,
+            bob,
+            game.object(bob_spell).expect("Bob spell should exist"),
+            &bob_base,
+            0,
+            &CastingMethod::Normal,
+            &view,
+        );
+        assert_eq!(adjusted_bob.to_oracle(), "{2}{1}");
     }
 
     #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -5180,6 +5180,7 @@ mod tests {
     use crate::card::{CardBuilder, PowerToughness};
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::derived_view::DerivedGameView;
+    use crate::effects::{AddManaEffect, EffectExecutor, ExecutionContext};
     use crate::events::spells::SpellCastEvent;
     use crate::ids::{CardId, PlayerId};
     use crate::mana::{ManaCost, ManaSymbol};
@@ -5234,6 +5235,22 @@ mod tests {
     }
 
     #[cfg(ironsmith_runtime_parser_tests)]
+    fn one_mana_land_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Damping Sphere Test Forest")
+            .card_types(vec![CardType::Land])
+            .parse_text("{T}: Add {G}.")
+            .expect("test one-mana land ability should parse")
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn two_mana_artifact_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Damping Sphere Test Battery")
+            .card_types(vec![CardType::Artifact])
+            .parse_text("{T}: Add {C}{C}.")
+            .expect("test artifact mana ability should parse")
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
     fn test_spell_card(name: &str, cost: u8) -> crate::card::Card {
         CardBuilder::new(CardId::new(), name)
             .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(cost)]]))
@@ -5265,24 +5282,58 @@ mod tests {
         let mut game = crate::tests::test_helpers::setup_two_player_game();
         let alice = PlayerId::from_index(0);
         let temple_def = two_mana_land_definition();
+        let forest_def = one_mana_land_definition();
+        let battery_def = two_mana_artifact_definition();
         let temple_id = game.create_object_from_definition(&temple_def, alice, Zone::Battlefield);
+        game.create_object_from_definition(&forest_def, alice, Zone::Battlefield);
+        game.create_object_from_definition(&battery_def, alice, Zone::Battlefield);
 
         let potential_without_sphere = compute_potential_mana(&game, alice);
-        assert_eq!(potential_without_sphere.colorless, 2);
+        assert_eq!(potential_without_sphere.colorless, 4);
+        assert_eq!(potential_without_sphere.green, 1);
 
         let sphere_def = damping_sphere_definition();
         game.create_object_from_definition(&sphere_def, alice, Zone::Battlefield);
 
         let potential_with_sphere = compute_potential_mana(&game, alice);
         assert_eq!(
-            potential_with_sphere.colorless, 1,
-            "Damping Sphere should replace the land's two-mana output with one colorless mana"
+            potential_with_sphere.colorless, 3,
+            "Damping Sphere should replace only the land's two-mana output with one colorless mana"
+        );
+        assert_eq!(
+            potential_with_sphere.green, 1,
+            "Damping Sphere should not replace a land's one-mana output"
         );
         assert!(
             game.object(temple_id)
                 .expect("temple should remain on battlefield")
                 .card_types
                 .contains(&CardType::Land)
+        );
+
+        let temple_mana_ability_index = game
+            .object(temple_id)
+            .expect("temple should remain on battlefield")
+            .abilities
+            .iter()
+            .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+            .expect("test land should have a mana ability");
+        let mut ctx = ExecutionContext::new_default(temple_id, alice)
+            .with_ability_index(temple_mana_ability_index);
+        let outcome = AddManaEffect::you(vec![ManaSymbol::Colorless, ManaSymbol::Colorless])
+            .execute(&mut game, &mut ctx)
+            .expect("test land mana ability should execute");
+        assert_eq!(
+            outcome.value,
+            crate::effect::OutcomeValue::ManaAdded(vec![ManaSymbol::Colorless])
+        );
+        assert_eq!(
+            game.player(alice)
+                .expect("Alice should exist")
+                .mana_pool
+                .colorless,
+            1,
+            "Damping Sphere should also replace actually produced land mana"
         );
     }
 

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -5179,13 +5179,18 @@ mod tests {
     use crate::alternative_cast::CastingMethod;
     use crate::card::{CardBuilder, PowerToughness};
     use crate::cards::builders::CardDefinitionBuilder;
+    use crate::color::Color;
     use crate::derived_view::DerivedGameView;
-    use crate::effects::{AddManaEffect, EffectExecutor, ExecutionContext};
+    use crate::effect::Value;
+    use crate::effects::{
+        AddManaEffect, AddManaOfChosenColorEffect, EffectExecutor, ExecutionContext,
+    };
     use crate::events::spells::SpellCastEvent;
     use crate::ids::{CardId, PlayerId};
     use crate::mana::{ManaCost, ManaSymbol};
     use crate::provenance::ProvNodeId;
     use crate::snapshot::ObjectSnapshot;
+    use crate::target::{ObjectFilter, PlayerFilter};
     use crate::triggers::TriggerEvent;
     use crate::types::{CardType, Subtype};
     use crate::zone::Zone;
@@ -5211,6 +5216,15 @@ mod tests {
     fn create_artifact(game: &mut GameState, owner: PlayerId, name: &str) {
         let card = CardBuilder::new(CardId::new(), name)
             .card_types(vec![CardType::Artifact])
+            .build();
+        game.create_object_from_card(&card, owner, Zone::Battlefield);
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn create_creature(game: &mut GameState, owner: PlayerId, name: &str) {
+        let card = CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
             .build();
         game.create_object_from_card(&card, owner, Zone::Battlefield);
     }
@@ -5334,6 +5348,76 @@ mod tests {
                 .colorless,
             1,
             "Damping Sphere should also replace actually produced land mana"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn damping_sphere_replaces_chosen_color_land_mana_outputs() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let forest_def = one_mana_land_definition();
+        let source_id = game.create_object_from_definition(&forest_def, alice, Zone::Battlefield);
+        let sphere_def = damping_sphere_definition();
+        game.create_object_from_definition(&sphere_def, alice, Zone::Battlefield);
+        game.set_chosen_color(source_id, Color::Blue);
+
+        let mana_ability_index = game
+            .object(source_id)
+            .expect("source land should remain on battlefield")
+            .abilities
+            .iter()
+            .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+            .expect("test land should have a mana ability");
+        let mut ctx = ExecutionContext::new_default(source_id, alice)
+            .with_ability_index(mana_ability_index);
+
+        let fixed_outcome = AddManaOfChosenColorEffect::new(Value::Fixed(2), PlayerFilter::You)
+            .execute(&mut game, &mut ctx)
+            .expect("chosen-color land mana ability should execute");
+        assert_eq!(
+            fixed_outcome.value,
+            crate::effect::OutcomeValue::Count(1),
+            "Damping Sphere should replace fixed two-mana chosen-color land output"
+        );
+        assert_eq!(
+            game.player(alice)
+                .expect("Alice should exist")
+                .mana_pool
+                .colorless,
+            1
+        );
+        assert_eq!(
+            game.player(alice).expect("Alice should exist").mana_pool.blue,
+            0,
+            "the original chosen-color mana should not be credited"
+        );
+
+        game.empty_mana_pools();
+        create_creature(&mut game, alice, "Damping Sphere Test Creature A");
+        create_creature(&mut game, alice, "Damping Sphere Test Creature B");
+        let dynamic_outcome = AddManaOfChosenColorEffect::new(
+            Value::Count(ObjectFilter::creature().you_control()),
+            PlayerFilter::You,
+        )
+        .execute(&mut game, &mut ctx)
+        .expect("dynamic chosen-color land mana ability should execute");
+        assert_eq!(
+            dynamic_outcome.value,
+            crate::effect::OutcomeValue::Count(1),
+            "Damping Sphere should replace dynamic chosen-color land output of two or more mana"
+        );
+        assert_eq!(
+            game.player(alice)
+                .expect("Alice should exist")
+                .mana_pool
+                .colorless,
+            1
+        );
+        assert_eq!(
+            game.player(alice).expect("Alice should exist").mana_pool.blue,
+            0,
+            "dynamic chosen-color mana should also be fully replaced"
         );
     }
 

--- a/crates/ironsmith-runtime/src/effects/mana/add_colorless_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_colorless_mana.rs
@@ -1,6 +1,9 @@
 //! Add colorless mana effect implementation.
 
-use super::choice_helpers::{credit_repeated_mana_symbol_from_context, mana_added_value_outcome};
+use super::choice_helpers::{
+    apply_land_two_or_more_mana_replacement, credit_mana_symbols_from_context,
+    mana_added_value_outcome,
+};
 use crate::effect::{EffectOutcome, Value};
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_player_filter, resolve_value};
@@ -58,15 +61,9 @@ impl EffectExecutor for AddColorlessManaEffect {
         let player_id = resolve_player_filter(game, &self.player, ctx)?;
         let count = resolve_value(game, &self.amount, ctx)?.max(0) as u32;
 
-        credit_repeated_mana_symbol_from_context(
-            game,
-            player_id,
-            ManaSymbol::Colorless,
-            count,
-            ctx,
-        );
-
         let mana_added: Vec<ManaSymbol> = (0..count).map(|_| ManaSymbol::Colorless).collect();
+        let mana_added = apply_land_two_or_more_mana_replacement(game, ctx, mana_added);
+        credit_mana_symbols_from_context(game, player_id, mana_added.iter().copied(), ctx);
         Ok(mana_added_value_outcome(ctx, player_id, mana_added))
     }
 

--- a/crates/ironsmith-runtime/src/effects/mana/add_colorless_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_colorless_mana.rs
@@ -1,9 +1,6 @@
 //! Add colorless mana effect implementation.
 
-use super::choice_helpers::{
-    apply_land_two_or_more_mana_replacement, credit_mana_symbols_from_context,
-    mana_added_value_outcome,
-};
+use super::choice_helpers::{credit_mana_symbols_from_context, mana_added_value_outcome};
 use crate::effect::{EffectOutcome, Value};
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_player_filter, resolve_value};
@@ -62,8 +59,7 @@ impl EffectExecutor for AddColorlessManaEffect {
         let count = resolve_value(game, &self.amount, ctx)?.max(0) as u32;
 
         let mana_added: Vec<ManaSymbol> = (0..count).map(|_| ManaSymbol::Colorless).collect();
-        let mana_added = apply_land_two_or_more_mana_replacement(game, ctx, mana_added);
-        credit_mana_symbols_from_context(game, player_id, mana_added.iter().copied(), ctx);
+        let mana_added = credit_mana_symbols_from_context(game, player_id, mana_added, ctx);
         Ok(mana_added_value_outcome(ctx, player_id, mana_added))
     }
 

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana.rs
@@ -1,6 +1,9 @@
 //! Add mana effect implementation.
 
-use super::choice_helpers::{credit_mana_symbols_from_context, mana_added_value_outcome};
+use super::choice_helpers::{
+    apply_land_two_or_more_mana_replacement, credit_mana_symbols_from_context,
+    mana_added_value_outcome,
+};
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_player_filter;
@@ -34,9 +37,10 @@ impl EffectExecutor for AddManaEffect {
     ) -> Result<EffectOutcome, ExecutionError> {
         let player_id = resolve_player_filter(game, &self.player, ctx)?;
 
-        credit_mana_symbols_from_context(game, player_id, self.mana.iter().copied(), ctx);
+        let mana = apply_land_two_or_more_mana_replacement(game, ctx, self.mana.clone());
+        credit_mana_symbols_from_context(game, player_id, mana.iter().copied(), ctx);
 
-        Ok(mana_added_value_outcome(ctx, player_id, self.mana.clone()))
+        Ok(mana_added_value_outcome(ctx, player_id, mana))
     }
 
     fn producible_mana_symbols(

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana.rs
@@ -1,9 +1,6 @@
 //! Add mana effect implementation.
 
-use super::choice_helpers::{
-    apply_land_two_or_more_mana_replacement, credit_mana_symbols_from_context,
-    mana_added_value_outcome,
-};
+use super::choice_helpers::{credit_mana_symbols_from_context, mana_added_value_outcome};
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_player_filter;
@@ -37,8 +34,8 @@ impl EffectExecutor for AddManaEffect {
     ) -> Result<EffectOutcome, ExecutionError> {
         let player_id = resolve_player_filter(game, &self.player, ctx)?;
 
-        let mana = apply_land_two_or_more_mana_replacement(game, ctx, self.mana.clone());
-        credit_mana_symbols_from_context(game, player_id, mana.iter().copied(), ctx);
+        let mana = self.mana.clone();
+        let mana = credit_mana_symbols_from_context(game, player_id, mana, ctx);
 
         Ok(mana_added_value_outcome(ctx, player_id, mana))
     }

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_from_commander_color_identity.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_from_commander_color_identity.rs
@@ -50,21 +50,15 @@ impl EffectExecutor for AddManaFromCommanderColorIdentityEffect {
 
         // If colorless identity, add colorless mana
         if color_identity.is_empty() {
-            credit_repeated_mana_symbol_from_context(
+            let mana = credit_repeated_mana_symbol_from_context(
                 game,
                 player_id,
                 ManaSymbol::Colorless,
                 amount,
                 ctx,
             );
-            let mana =
-                std::iter::repeat_n(ManaSymbol::Colorless, amount as usize).collect::<Vec<_>>();
-            return Ok(mana_added_count_outcome(
-                ctx,
-                player_id,
-                mana,
-                amount as i32,
-            ));
+            let count = mana.len() as i32;
+            return Ok(mana_added_count_outcome(ctx, player_id, mana, count));
         }
 
         // Build list of available colors from identity
@@ -102,15 +96,10 @@ impl EffectExecutor for AddManaFromCommanderColorIdentityEffect {
         }
 
         let symbol = ManaSymbol::from_color(color);
-        credit_repeated_mana_symbol_from_context(game, player_id, symbol, amount, ctx);
-        let mana = std::iter::repeat_n(symbol, amount as usize).collect::<Vec<_>>();
+        let mana = credit_repeated_mana_symbol_from_context(game, player_id, symbol, amount, ctx);
+        let count = mana.len() as i32;
 
-        Ok(mana_added_count_outcome(
-            ctx,
-            player_id,
-            mana,
-            amount as i32,
-        ))
+        Ok(mana_added_count_outcome(ctx, player_id, mana, count))
     }
 
     fn producible_mana_symbols(

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_color.rs
@@ -1,8 +1,7 @@
 //! Add mana of any color effect implementation.
 
 use super::choice_helpers::{
-    apply_land_two_or_more_mana_replacement, choose_mana_colors, credit_mana_symbols_from_context,
-    mana_added_count_outcome,
+    choose_mana_colors, credit_mana_symbols_from_context, mana_added_count_outcome,
 };
 use crate::color::Color;
 use crate::effect::EffectOutcome;
@@ -67,8 +66,7 @@ impl EffectExecutor for AddManaOfAnyColorEffect {
             .into_iter()
             .map(ManaSymbol::from_color)
             .collect::<Vec<_>>();
-        let symbols = apply_land_two_or_more_mana_replacement(game, ctx, symbols);
-        credit_mana_symbols_from_context(game, player_id, symbols.iter().copied(), ctx);
+        let symbols = credit_mana_symbols_from_context(game, player_id, symbols, ctx);
 
         Ok(mana_added_count_outcome(
             ctx,

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_color.rs
@@ -1,7 +1,8 @@
 //! Add mana of any color effect implementation.
 
 use super::choice_helpers::{
-    choose_mana_colors, credit_mana_symbols_from_context, mana_added_count_outcome,
+    apply_land_two_or_more_mana_replacement, choose_mana_colors, credit_mana_symbols_from_context,
+    mana_added_count_outcome,
 };
 use crate::color::Color;
 use crate::effect::EffectOutcome;
@@ -66,13 +67,14 @@ impl EffectExecutor for AddManaOfAnyColorEffect {
             .into_iter()
             .map(ManaSymbol::from_color)
             .collect::<Vec<_>>();
+        let symbols = apply_land_two_or_more_mana_replacement(game, ctx, symbols);
         credit_mana_symbols_from_context(game, player_id, symbols.iter().copied(), ctx);
 
         Ok(mana_added_count_outcome(
             ctx,
             player_id,
-            symbols,
-            amount as i32,
+            symbols.clone(),
+            symbols.len() as i32,
         ))
     }
 

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_one_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_one_color.rs
@@ -10,7 +10,8 @@ use crate::mana::ManaSymbol;
 pub use ironsmith_core::AddManaOfAnyOneColorEffect;
 
 use super::choice_helpers::{
-    choose_mana_colors, credit_repeated_mana_symbol_from_context, mana_added_count_outcome,
+    apply_land_two_or_more_mana_replacement, choose_mana_colors, credit_mana_symbols_from_context,
+    mana_added_count_outcome,
 };
 
 /// Effect that adds mana of any ONE color to a player's mana pool.
@@ -56,14 +57,15 @@ impl EffectExecutor for AddManaOfAnyOneColorEffect {
         }
 
         let symbol = ManaSymbol::from_color(color);
-        credit_repeated_mana_symbol_from_context(game, player_id, symbol, amount, ctx);
         let mana = std::iter::repeat_n(symbol, amount as usize).collect::<Vec<_>>();
+        let mana = apply_land_two_or_more_mana_replacement(game, ctx, mana);
+        credit_mana_symbols_from_context(game, player_id, mana.iter().copied(), ctx);
 
         Ok(mana_added_count_outcome(
             ctx,
             player_id,
-            mana,
-            amount as i32,
+            mana.clone(),
+            mana.len() as i32,
         ))
     }
 

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_one_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_one_color.rs
@@ -10,8 +10,7 @@ use crate::mana::ManaSymbol;
 pub use ironsmith_core::AddManaOfAnyOneColorEffect;
 
 use super::choice_helpers::{
-    apply_land_two_or_more_mana_replacement, choose_mana_colors, credit_mana_symbols_from_context,
-    mana_added_count_outcome,
+    choose_mana_colors, credit_mana_symbols_from_context, mana_added_count_outcome,
 };
 
 /// Effect that adds mana of any ONE color to a player's mana pool.
@@ -58,8 +57,7 @@ impl EffectExecutor for AddManaOfAnyOneColorEffect {
 
         let symbol = ManaSymbol::from_color(color);
         let mana = std::iter::repeat_n(symbol, amount as usize).collect::<Vec<_>>();
-        let mana = apply_land_two_or_more_mana_replacement(game, ctx, mana);
-        credit_mana_symbols_from_context(game, player_id, mana.iter().copied(), ctx);
+        let mana = credit_mana_symbols_from_context(game, player_id, mana, ctx);
 
         Ok(mana_added_count_outcome(
             ctx,

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_chosen_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_chosen_color.rs
@@ -49,15 +49,10 @@ impl EffectExecutor for AddManaOfChosenColorEffect {
         }
 
         let symbol = ManaSymbol::from_color(selected);
-        credit_repeated_mana_symbol_from_context(game, player_id, symbol, amount, ctx);
-        let mana = std::iter::repeat_n(symbol, amount as usize).collect::<Vec<_>>();
+        let mana = credit_repeated_mana_symbol_from_context(game, player_id, symbol, amount, ctx);
+        let count = mana.len() as i32;
 
-        Ok(mana_added_count_outcome(
-            ctx,
-            player_id,
-            mana,
-            amount as i32,
-        ))
+        Ok(mana_added_count_outcome(ctx, player_id, mana, count))
     }
 
     fn producible_mana_symbols(

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_colors_among.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_colors_among.rs
@@ -34,7 +34,7 @@ impl EffectExecutor for AddManaOfColorsAmongEffect {
             return Ok(EffectOutcome::count(0));
         }
 
-        credit_mana_symbols_from_context(game, player_id, symbols.iter().copied(), ctx);
+        let symbols = credit_mana_symbols_from_context(game, player_id, symbols, ctx);
         Ok(mana_added_count_outcome(
             ctx,
             player_id,

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_imprinted_colors.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_imprinted_colors.rs
@@ -74,9 +74,10 @@ impl EffectExecutor for AddManaOfImprintedColorsEffect {
             return Ok(EffectOutcome::count(0));
         }
         let symbol = ManaSymbol::from_color(chosen_color);
-        credit_mana_symbols_from_context(game, controller, [symbol], ctx);
+        let symbols = credit_mana_symbols_from_context(game, controller, [symbol], ctx);
+        let count = symbols.len() as i32;
 
-        Ok(mana_added_count_outcome(ctx, controller, vec![symbol], 1))
+        Ok(mana_added_count_outcome(ctx, controller, symbols, count))
     }
 
     fn producible_mana_symbols(

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_land_produced_types.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_land_produced_types.rs
@@ -89,13 +89,14 @@ impl EffectExecutor for AddManaOfLandProducedTypesEffect {
             return Ok(EffectOutcome::count(0));
         }
 
-        credit_mana_symbols_from_context(game, player_id, chosen_symbols.iter().copied(), ctx);
+        let chosen_symbols = credit_mana_symbols_from_context(game, player_id, chosen_symbols, ctx);
+        let count = chosen_symbols.len() as i32;
 
         Ok(mana_added_count_outcome(
             ctx,
             player_id,
             chosen_symbols,
-            amount as i32,
+            count,
         ))
     }
 }

--- a/crates/ironsmith-runtime/src/effects/mana/add_scaled_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_scaled_mana.rs
@@ -3,7 +3,10 @@
 //! Adds a fixed mana pattern repeated by a resolved numeric value.
 //! Example: "Add {B} for each creature card in your graveyard."
 
-use super::choice_helpers::{credit_mana_symbols_from_context, mana_added_value_outcome};
+use super::choice_helpers::{
+    apply_land_two_or_more_mana_replacement, credit_mana_symbols_from_context,
+    mana_added_value_outcome,
+};
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_player_filter, resolve_value};
@@ -29,6 +32,7 @@ impl EffectExecutor for AddScaledManaEffect {
         for _ in 0..repeats {
             added.extend(self.mana.iter().copied());
         }
+        let added = apply_land_two_or_more_mana_replacement(game, ctx, added);
         credit_mana_symbols_from_context(game, player_id, added.iter().copied(), ctx);
 
         Ok(mana_added_value_outcome(ctx, player_id, added))

--- a/crates/ironsmith-runtime/src/effects/mana/add_scaled_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_scaled_mana.rs
@@ -3,10 +3,7 @@
 //! Adds a fixed mana pattern repeated by a resolved numeric value.
 //! Example: "Add {B} for each creature card in your graveyard."
 
-use super::choice_helpers::{
-    apply_land_two_or_more_mana_replacement, credit_mana_symbols_from_context,
-    mana_added_value_outcome,
-};
+use super::choice_helpers::{credit_mana_symbols_from_context, mana_added_value_outcome};
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_player_filter, resolve_value};
@@ -32,8 +29,7 @@ impl EffectExecutor for AddScaledManaEffect {
         for _ in 0..repeats {
             added.extend(self.mana.iter().copied());
         }
-        let added = apply_land_two_or_more_mana_replacement(game, ctx, added);
-        credit_mana_symbols_from_context(game, player_id, added.iter().copied(), ctx);
+        let added = credit_mana_symbols_from_context(game, player_id, added, ctx);
 
         Ok(mana_added_value_outcome(ctx, player_id, added))
     }

--- a/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
@@ -163,18 +163,20 @@ pub(crate) fn credit_mana_symbols_from_context<I>(
     player_id: PlayerId,
     symbols: I,
     ctx: &ExecutionContext,
-) where
+) -> Vec<ManaSymbol>
+where
     I: IntoIterator<Item = ManaSymbol>,
 {
     let symbols = apply_land_two_or_more_mana_replacement(game, ctx, symbols.into_iter().collect());
     credit_mana_symbols_with_context(
         game,
         player_id,
-        symbols,
+        symbols.iter().copied(),
         Some(ctx.source),
         &ctx.mana.mana_usage_restrictions,
         ctx.mana.mana_source_chosen_creature_type,
     );
+    symbols
 }
 
 fn credit_mana_symbols_with_context<I>(
@@ -209,35 +211,21 @@ pub(crate) fn credit_repeated_mana_symbol_from_context(
     symbol: ManaSymbol,
     count: u32,
     ctx: &ExecutionContext,
-) {
-    credit_repeated_mana_symbol_with_context(
+) -> Vec<ManaSymbol> {
+    let symbols = apply_land_two_or_more_mana_replacement(
+        game,
+        ctx,
+        std::iter::repeat_n(symbol, count as usize).collect(),
+    );
+    credit_mana_symbols_with_context(
         game,
         player_id,
-        symbol,
-        count,
+        symbols.iter().copied(),
         Some(ctx.source),
         &ctx.mana.mana_usage_restrictions,
         ctx.mana.mana_source_chosen_creature_type,
     );
-}
-
-fn credit_repeated_mana_symbol_with_context(
-    game: &mut GameState,
-    player_id: PlayerId,
-    symbol: ManaSymbol,
-    count: u32,
-    source: Option<ObjectId>,
-    restrictions: &[crate::ability::ManaUsageRestriction],
-    source_chosen_creature_type: Option<Subtype>,
-) {
-    credit_mana_symbols_with_context(
-        game,
-        player_id,
-        std::iter::repeat_n(symbol, count as usize),
-        source,
-        restrictions,
-        source_chosen_creature_type,
-    );
+    symbols
 }
 
 /// Choose one or more mana symbols through the decision system with stable

--- a/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
@@ -9,7 +9,49 @@ use crate::game_state::GameState;
 use crate::ids::ObjectId;
 use crate::ids::PlayerId;
 use crate::mana::ManaSymbol;
+use crate::static_abilities::StaticAbilityId;
 use crate::types::Subtype;
+
+pub(crate) fn apply_land_two_or_more_mana_replacement(
+    game: &GameState,
+    ctx: &ExecutionContext,
+    mana: Vec<ManaSymbol>,
+) -> Vec<ManaSymbol> {
+    if mana.len() < 2 {
+        return mana;
+    }
+    let view = crate::derived_view::DerivedGameView::new(game);
+    let source = ctx.source;
+    if !view.object_has_card_type(source, crate::types::CardType::Land) {
+        return mana;
+    }
+    let tapped_for_mana = ctx.ability_index.is_some_and(|idx| {
+        let Some(object) = game.object(source) else {
+            return false;
+        };
+        let Some(ability) = object.abilities.get(idx) else {
+            return false;
+        };
+        let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+            return false;
+        };
+        activated.has_tap_cost()
+    });
+    if !tapped_for_mana {
+        return mana;
+    }
+    let replacement_active = game.battlefield.iter().any(|&perm_id| {
+        view.object_has_static_ability_id(
+            perm_id,
+            StaticAbilityId::LandsProduceOneColorlessInsteadIfProduceTwoOrMore,
+        )
+    });
+    if replacement_active {
+        vec![ManaSymbol::Colorless]
+    } else {
+        mana
+    }
+}
 
 pub(crate) fn mana_added_value_outcome(
     ctx: &ExecutionContext,
@@ -124,6 +166,7 @@ pub(crate) fn credit_mana_symbols_from_context<I>(
 ) where
     I: IntoIterator<Item = ManaSymbol>,
 {
+    let symbols = apply_land_two_or_more_mana_replacement(game, ctx, symbols.into_iter().collect());
     credit_mana_symbols_with_context(
         game,
         player_id,

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -443,6 +443,22 @@ fn describe_cost_modifier_amount(amount: &Value) -> (String, Option<String>) {
                 )),
             )
         }
+        Value::SpellsCastThisTurn(PlayerFilter::EffectController) => (
+            "{1}".to_string(),
+            Some("for each other spell that player has cast this turn".to_string()),
+        ),
+        Value::SpellsCastThisTurn(player) => {
+            let subject = match player {
+                PlayerFilter::You => "you have".to_string(),
+                PlayerFilter::Opponent => "an opponent has".to_string(),
+                PlayerFilter::Any => "players have".to_string(),
+                _ => format!("{} has", describe_player_filter_for_spell_target(player)),
+            };
+            (
+                "{1}".to_string(),
+                Some(format!("for each spell {subject} cast this turn")),
+            )
+        }
         Value::Speed(player) => {
             let phrase = match player {
                 PlayerFilter::You => "your speed".to_string(),
@@ -1897,11 +1913,19 @@ impl StaticAbilityKind for CostIncrease {
             }
             return describe_cost_modifier_with_condition(line, &self.condition);
         }
-        let mut line = format!(
-            "{} cost {} more to cast",
-            describe_spell_filter(&self.filter),
-            amount_text
-        );
+        let mut line = if matches!(
+            self.increase,
+            Value::SpellsCastThisTurn(PlayerFilter::EffectController)
+        ) && self.filter == ObjectFilter::default()
+        {
+            format!("Each spell a player casts costs {amount_text} more to cast")
+        } else {
+            format!(
+                "{} cost {} more to cast",
+                describe_spell_filter(&self.filter),
+                amount_text
+            )
+        };
         if let Some(tail) = tail {
             append_cost_modifier_tail(&mut line, &tail);
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Damping Sphere
Initial parse error:
```
could not find verb in effect clause (clause: 'it produces c instead of any other type and amount'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'it produces c instead of any other type and amount'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-08cfc80c0e1d697a0
Branch: codex/aws-card-fix-damping-sphere
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0024
