### PR TITLE
Fix Ironsmith parse failure: Jetmir's Fixer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -186,6 +186,10 @@ const COST_PAID_INSTEAD_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["cost", "was", "paid"], &["cost", "wasnt", "paid"]]);
 const COST_NOT_PAID_INSTEAD_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["cost", "was", "not", "paid"]);
+const MANA_FROM_TREASURE_SPENT_TO_ACTIVATE_THIS_ABILITY_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & [
+        "mana", "from", "treasure", "was", "spent", "to", "activate", "this", "ability"
+    ]);
 const GETS_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["gets"]);
 const MORE_VOTES_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["more", "votes"]);
 const MORE_VOTES_OR_TIED_TAIL_PATTERN: ClauseShape<'static> =
@@ -3670,6 +3674,11 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
     if THAT_WAS_KICKED_PATTERN.matches_words(&filtered) {
         return Ok(PredicateAst::TargetWasKicked);
+    }
+    if MANA_FROM_TREASURE_SPENT_TO_ACTIVATE_THIS_ABILITY_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::ThisSpellPaidLabel(
+            "ManaFromTreasure".to_string(),
+        ));
     }
 
     if YOU_HAVE_FULL_PARTY_PATTERN.matches_words(&filtered) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -175,7 +175,16 @@ fn jetmirs_fixer_strict_parser_and_compiled_text_regression() {
     );
 }
 
-fn resolve_jetmirs_fixer_activation(use_treasure_mana: bool) -> crate::game_state::GameState {
+#[derive(Clone, Copy)]
+enum JetmirsFixerManaScenario {
+    DirectNonTreasure,
+    DirectTreasure,
+    PreFloatedTreasure,
+}
+
+fn resolve_jetmirs_fixer_activation(
+    scenario: JetmirsFixerManaScenario,
+) -> crate::game_state::GameState {
     use crate::decision::{GameProgress, LegalAction, SelectFirstDecisionMaker};
     use crate::game_loop::{PriorityLoopState, PriorityResponse, apply_priority_response_with_dm};
     use crate::game_state::Phase;
@@ -203,26 +212,53 @@ fn resolve_jetmirs_fixer_activation(use_treasure_mana: bool) -> crate::game_stat
 
     let def = jetmirs_fixer_definition_for_test();
     let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
-    if use_treasure_mana {
-        game.create_object_from_definition(
-            &crate::cards::tokens::treasure_token_definition(),
-            alice,
-            Zone::Battlefield,
-        );
-        game.create_object_from_definition(
-            &crate::cards::definitions::basic_forest(),
-            alice,
-            Zone::Battlefield,
-        );
-    } else {
-        game.player_mut(alice)
-            .expect("Alice should exist")
-            .mana_pool
-            .add(ManaSymbol::Red, 1);
-        game.player_mut(alice)
-            .expect("Alice should exist")
-            .mana_pool
-            .add(ManaSymbol::Green, 1);
+    match scenario {
+        JetmirsFixerManaScenario::DirectNonTreasure => {
+            game.create_object_from_definition(
+                &crate::cards::definitions::basic_mountain(),
+                alice,
+                Zone::Battlefield,
+            );
+            game.create_object_from_definition(
+                &crate::cards::definitions::basic_forest(),
+                alice,
+                Zone::Battlefield,
+            );
+        }
+        JetmirsFixerManaScenario::DirectTreasure => {
+            game.create_object_from_definition(
+                &crate::cards::tokens::treasure_token_definition(),
+                alice,
+                Zone::Battlefield,
+            );
+            game.create_object_from_definition(
+                &crate::cards::definitions::basic_forest(),
+                alice,
+                Zone::Battlefield,
+            );
+        }
+        JetmirsFixerManaScenario::PreFloatedTreasure => {
+            let treasure = game.create_object_from_definition(
+                &crate::cards::tokens::treasure_token_definition(),
+                alice,
+                Zone::Battlefield,
+            );
+            game.create_object_from_definition(
+                &crate::cards::definitions::basic_forest(),
+                alice,
+                Zone::Battlefield,
+            );
+            let mut prefloat_decision_maker = SelectFirstDecisionMaker;
+            crate::special_actions::perform_activate_mana_ability_restricted_colors_with_events(
+                &mut game,
+                alice,
+                treasure,
+                0,
+                Some(vec![crate::color::Color::Red]),
+                &mut prefloat_decision_maker,
+            )
+            .expect("Treasure should pre-float red mana");
+        }
     }
 
     let ability_index = def
@@ -287,7 +323,7 @@ fn resolve_jetmirs_fixer_activation(use_treasure_mana: bool) -> crate::game_stat
 
 #[test]
 fn jetmirs_fixer_activation_without_treasure_mana_gives_temporary_plus_one_plus_one() {
-    let game = resolve_jetmirs_fixer_activation(false);
+    let game = resolve_jetmirs_fixer_activation(JetmirsFixerManaScenario::DirectNonTreasure);
     let fixer = game
         .battlefield
         .iter()
@@ -308,8 +344,8 @@ fn jetmirs_fixer_activation_without_treasure_mana_gives_temporary_plus_one_plus_
 }
 
 #[test]
-fn jetmirs_fixer_activation_with_treasure_mana_puts_counter_instead() {
-    let game = resolve_jetmirs_fixer_activation(true);
+fn jetmirs_fixer_activation_with_direct_treasure_mana_puts_counter_instead() {
+    let game = resolve_jetmirs_fixer_activation(JetmirsFixerManaScenario::DirectTreasure);
     let fixer = game
         .battlefield
         .iter()
@@ -323,7 +359,33 @@ fn jetmirs_fixer_activation_with_treasure_mana_puts_counter_instead() {
     assert_eq!(
         game.counter_count(fixer, crate::object::CounterType::PlusOnePlusOne),
         1,
-        "Treasure-mana activation should put a +1/+1 counter on Jetmir's Fixer"
+        "direct Treasure-mana activation should put a +1/+1 counter on Jetmir's Fixer"
+    );
+    assert_eq!(
+        game.calculated_power(fixer),
+        Some(3),
+        "instead branch should not also apply the temporary +1/+1 effect"
+    );
+    assert_eq!(game.calculated_toughness(fixer), Some(3));
+}
+
+#[test]
+fn jetmirs_fixer_activation_with_pre_floated_treasure_mana_puts_counter_instead() {
+    let game = resolve_jetmirs_fixer_activation(JetmirsFixerManaScenario::PreFloatedTreasure);
+    let fixer = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Jetmir's Fixer")
+        })
+        .expect("Jetmir's Fixer remains on battlefield");
+
+    assert_eq!(
+        game.counter_count(fixer, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "pre-floated Treasure mana should put a +1/+1 counter on Jetmir's Fixer"
     );
     assert_eq!(
         game.calculated_power(fixer),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -315,6 +315,19 @@ fn resolve_jetmirs_fixer_activation(
     )
     .expect("Jetmir's Fixer should pay the second colored pip and go on the stack");
 
+    let stack_entry = game.stack.last().expect("activation should be on the stack");
+    let should_have_treasure_label = matches!(
+        scenario,
+        JetmirsFixerManaScenario::DirectTreasure | JetmirsFixerManaScenario::PreFloatedTreasure
+    );
+    assert_eq!(
+        stack_entry
+            .optional_costs_paid
+            .was_paid_label("ManaFromTreasure"),
+        should_have_treasure_label,
+        "Treasure-mana payment label should match the selected payment source"
+    );
+
     crate::game_loop::resolve_stack_entry(&mut game)
         .expect("Jetmir's Fixer activation should resolve");
     game.refresh_continuous_state();

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -142,6 +142,197 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
     );
 }
 
+fn jetmirs_fixer_definition_for_test() -> CardDefinition {
+    let oracle = oracle_text_by_name()
+        .get("Jetmir's Fixer")
+        .expect("missing oracle text for Jetmir's Fixer")
+        .clone();
+    CardDefinitionBuilder::new(CardId::new(), "Jetmir's Fixer")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red], vec![ManaSymbol::Green]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Cat, Subtype::Warrior])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(oracle)
+        .expect("Jetmir's Fixer should parse strictly")
+}
+
+#[test]
+fn jetmirs_fixer_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Jetmir's Fixer");
+    let def = jetmirs_fixer_definition_for_test();
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+
+    assert!(
+        rendered.contains(
+            "If mana from a Treasure was spent to activate this ability, put a +1/+1 counter on this creature instead"
+        ),
+        "expected Treasure-mana activation clause in compiled text, got {rendered}"
+    );
+    assert!(
+        debug.contains("ManaFromTreasure") && debug.contains("PutCountersEffect"),
+        "expected paid-label condition and +1/+1 counter branch, got {debug}"
+    );
+}
+
+fn resolve_jetmirs_fixer_activation(use_treasure_mana: bool) -> crate::game_state::GameState {
+    use crate::decision::{GameProgress, LegalAction, SelectFirstDecisionMaker};
+    use crate::game_loop::{PriorityLoopState, PriorityResponse, apply_priority_response_with_dm};
+    use crate::game_state::Phase;
+    use crate::tests::test_helpers::setup_two_player_game;
+    use crate::triggers::TriggerQueue;
+
+    fn assert_needs_pip_payment(progress: GameProgress, context: &str) {
+        assert!(
+            matches!(
+                progress,
+                GameProgress::NeedsDecisionCtx(
+                    crate::decisions::context::DecisionContext::SelectOptions(_)
+                )
+            ),
+            "expected {context} to ask for a mana-pip payment"
+        );
+    }
+
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let def = jetmirs_fixer_definition_for_test();
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    if use_treasure_mana {
+        game.create_object_from_definition(
+            &crate::cards::tokens::treasure_token_definition(),
+            alice,
+            Zone::Battlefield,
+        );
+        game.create_object_from_definition(
+            &crate::cards::definitions::basic_forest(),
+            alice,
+            Zone::Battlefield,
+        );
+    } else {
+        game.player_mut(alice)
+            .expect("Alice should exist")
+            .mana_pool
+            .add(ManaSymbol::Red, 1);
+        game.player_mut(alice)
+            .expect("Alice should exist")
+            .mana_pool
+            .add(ManaSymbol::Green, 1);
+    }
+
+    let ability_index = def
+        .abilities
+        .iter()
+        .enumerate()
+        .find_map(|(idx, ability)| match &ability.kind {
+            AbilityKind::Activated(_) => Some(idx),
+            _ => None,
+        })
+        .expect("Jetmir's Fixer should have an activated ability");
+
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source: id, ability_index: idx }
+                    if *id == source && *idx == ability_index
+            )
+        })
+        .expect("Jetmir's Fixer activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    state.auto_choose_single_pip_payment = false;
+    let mut decision_maker = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut decision_maker,
+    )
+    .expect("Jetmir's Fixer activation should start paying mana");
+    assert_needs_pip_payment(progress, "the first colored pip");
+
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::ManaPipPayment(0),
+        &mut decision_maker,
+    )
+    .expect("Jetmir's Fixer should pay the first colored pip");
+    assert_needs_pip_payment(progress, "the second colored pip");
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::ManaPipPayment(0),
+        &mut decision_maker,
+    )
+    .expect("Jetmir's Fixer should pay the second colored pip and go on the stack");
+
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Jetmir's Fixer activation should resolve");
+    game.refresh_continuous_state();
+    game
+}
+
+#[test]
+fn jetmirs_fixer_activation_without_treasure_mana_gives_temporary_plus_one_plus_one() {
+    let game = resolve_jetmirs_fixer_activation(false);
+    let fixer = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Jetmir's Fixer")
+        })
+        .expect("Jetmir's Fixer remains on battlefield");
+
+    assert_eq!(
+        game.counter_count(fixer, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "ordinary activation should not put a +1/+1 counter on Jetmir's Fixer"
+    );
+    assert_eq!(game.calculated_power(fixer), Some(3));
+    assert_eq!(game.calculated_toughness(fixer), Some(3));
+}
+
+#[test]
+fn jetmirs_fixer_activation_with_treasure_mana_puts_counter_instead() {
+    let game = resolve_jetmirs_fixer_activation(true);
+    let fixer = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Jetmir's Fixer")
+        })
+        .expect("Jetmir's Fixer remains on battlefield");
+
+    assert_eq!(
+        game.counter_count(fixer, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Treasure-mana activation should put a +1/+1 counter on Jetmir's Fixer"
+    );
+    assert_eq!(
+        game.calculated_power(fixer),
+        Some(3),
+        "instead branch should not also apply the temporary +1/+1 effect"
+    );
+    assert_eq!(game.calculated_toughness(fixer), Some(3));
+}
+
 #[test]
 fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Commander Liara Portyr");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11502,6 +11502,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             if label.eq_ignore_ascii_case("CastDuringYourMainPhase") {
                 return "you cast this spell during your main phase".to_string();
             }
+            if label.eq_ignore_ascii_case("ManaFromTreasure") {
+                return "mana from a Treasure was spent to activate this ability".to_string();
+            }
             format!("this spell's {} cost was paid", label.to_ascii_lowercase())
         }
         Condition::YouHaveFullParty => "you have a full party".to_string(),

--- a/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
@@ -129,6 +129,9 @@ pub(crate) fn credit_mana_symbols_from_context<I>(
         player_id,
         symbols,
         Some(ctx.source),
+        ctx.source_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.subtypes.clone()),
         &ctx.mana.mana_usage_restrictions,
         ctx.mana.mana_source_chosen_creature_type,
     );
@@ -139,16 +142,26 @@ fn credit_mana_symbols_with_context<I>(
     player_id: PlayerId,
     symbols: I,
     source: Option<ObjectId>,
+    source_subtypes: Option<Vec<Subtype>>,
     restrictions: &[crate::ability::ManaUsageRestriction],
     source_chosen_creature_type: Option<Subtype>,
 ) where
     I: IntoIterator<Item = ManaSymbol>,
 {
+    let source_subtypes = source_subtypes
+        .or_else(|| {
+            source.and_then(|source| game.object(source).map(|object| object.subtypes.clone()))
+        })
+        .unwrap_or_default();
     if let Some(player) = game.player_mut(player_id) {
         for symbol in symbols {
             if restrictions.is_empty() {
                 if let Some(source) = source {
-                    player.add_unrestricted_mana_from_source(symbol, source);
+                    player.add_unrestricted_mana_from_source_with_subtypes(
+                        symbol,
+                        source,
+                        source_subtypes.clone(),
+                    );
                 } else {
                     player.mana_pool.add(symbol, 1);
                 }
@@ -177,6 +190,9 @@ pub(crate) fn credit_repeated_mana_symbol_from_context(
         symbol,
         count,
         Some(ctx.source),
+        ctx.source_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.subtypes.clone()),
         &ctx.mana.mana_usage_restrictions,
         ctx.mana.mana_source_chosen_creature_type,
     );
@@ -188,6 +204,7 @@ fn credit_repeated_mana_symbol_with_context(
     symbol: ManaSymbol,
     count: u32,
     source: Option<ObjectId>,
+    source_subtypes: Option<Vec<Subtype>>,
     restrictions: &[crate::ability::ManaUsageRestriction],
     source_chosen_creature_type: Option<Subtype>,
 ) {
@@ -196,6 +213,7 @@ fn credit_repeated_mana_symbol_with_context(
         player_id,
         std::iter::repeat_n(symbol, count as usize),
         source,
+        source_subtypes,
         restrictions,
         source_chosen_creature_type,
     );

--- a/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
@@ -147,7 +147,11 @@ fn credit_mana_symbols_with_context<I>(
     if let Some(player) = game.player_mut(player_id) {
         for symbol in symbols {
             if restrictions.is_empty() {
-                player.mana_pool.add(symbol, 1);
+                if let Some(source) = source {
+                    player.add_unrestricted_mana_from_source(symbol, source);
+                } else {
+                    player.mana_pool.add(symbol, 1);
+                }
             } else {
                 player.add_restricted_mana(crate::ability::RestrictedManaUnit {
                     symbol,

--- a/crates/ironsmith-runtime/src/effects/mana/empty_mana_pool.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/empty_mana_pool.rs
@@ -28,8 +28,7 @@ impl EffectExecutor for EmptyManaPoolEffect {
         let Some(player) = game.player_mut(player_id) else {
             return Err(ExecutionError::InvalidTarget);
         };
-        player.mana_pool.empty();
-        player.restricted_mana.clear();
+        player.empty_mana_pool();
         Ok(EffectOutcome::default())
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -1014,7 +1014,7 @@ pub fn apply_priority_response_with_dm(
                         if let Some(player_obj) = game.player_mut(player) {
                             for symbol in &mana_to_add {
                                 if mana_usage_restrictions.is_empty() {
-                                    player_obj.mana_pool.add(*symbol, 1);
+                                    player_obj.add_unrestricted_mana_from_source(*symbol, *source);
                                 } else {
                                     player_obj.add_restricted_mana(
                                         crate::ability::RestrictedManaUnit {

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -991,6 +991,14 @@ pub fn apply_priority_response_with_dm(
                         });
 
                 if can_pay_mana {
+                    let source_snapshot = game
+                        .object(*source)
+                        .map(|object| ObjectSnapshot::from_object(object, game));
+                    let source_subtypes = source_snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.subtypes.clone())
+                        .unwrap_or_default();
+
                     // Pay all costs immediately
                     let mut cost_ctx = CostContext::new(*source, player, &mut *decision_maker)
                         .with_reason(crate::costs::PaymentReason::ActivateManaAbility)
@@ -1014,7 +1022,11 @@ pub fn apply_priority_response_with_dm(
                         if let Some(player_obj) = game.player_mut(player) {
                             for symbol in &mana_to_add {
                                 if mana_usage_restrictions.is_empty() {
-                                    player_obj.add_unrestricted_mana_from_source(*symbol, *source);
+                                    player_obj.add_unrestricted_mana_from_source_with_subtypes(
+                                        *symbol,
+                                        *source,
+                                        source_subtypes.clone(),
+                                    );
                                 } else {
                                     player_obj.add_restricted_mana(
                                         crate::ability::RestrictedManaUnit {
@@ -1028,16 +1040,13 @@ pub fn apply_priority_response_with_dm(
                                 }
                             }
                         }
-                        let snapshot = game
-                            .object(*source)
-                            .map(|obj| ObjectSnapshot::from_object(obj, game));
                         let event = crate::events::ManaAddedEvent::new(
                             *source,
                             player,
                             player,
                             mana_to_add.clone(),
                         )
-                        .with_snapshot(snapshot)
+                        .with_snapshot(source_snapshot.clone())
                         .into_trigger_event();
                         queue_triggers_from_event(game, trigger_queue, event, false);
                     }
@@ -1050,6 +1059,9 @@ pub fn apply_priority_response_with_dm(
                             .with_mana_source_chosen_creature_type(
                                 mana_source_chosen_creature_type,
                             );
+                        if let Some(snapshot) = source_snapshot.clone() {
+                            ctx = ctx.with_source_snapshot(snapshot);
+                        }
                         if let Some(x) = x_value_from_costs {
                             ctx = ctx.with_x(x);
                         }

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -3338,6 +3338,7 @@ pub(super) fn continue_activation(
             // Auto-select deterministic pip choices when possible.
             if let Some(auto_choice) = preferred_auto_pip_choice(state, &options) {
                 let action = options[auto_choice].action.clone();
+                let uses_treasure_source = mana_payment_action_uses_treasure_source(game, &action);
                 let pip_paid = execute_pip_payment_action(
                     game,
                     trigger_queue,
@@ -3350,6 +3351,9 @@ pub(super) fn continue_activation(
                     &mut pending.payment_trace,
                     None,
                 )?;
+                if pip_paid && uses_treasure_source {
+                    pending.optional_costs_paid.mark_label_paid("ManaFromTreasure");
+                }
                 queue_mana_ability_event_for_action(
                     game,
                     trigger_queue,
@@ -3401,6 +3405,7 @@ pub(super) fn continue_activation(
                     .with_provenance(pending.provenance)
                     .with_source_info(pending.source_stable_id, pending.source_name.clone())
                     .with_source_snapshot(pending.source_snapshot.clone())
+                    .with_optional_costs_paid(pending.optional_costs_paid.clone())
                     .with_chosen_modes(pending.chosen_modes.clone())
                     .with_mana_usage_restrictions(
                         pending.mana_usage_restrictions.clone(),

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1821,6 +1821,7 @@ pub(super) fn continue_spell_cast_mana_payment(
             &mut *decision_maker,
             &mut pending.payment_trace,
             Some(&mut pending.mana_spent_to_cast),
+            None,
         )?;
         queue_mana_ability_event_for_action(
             game,
@@ -3338,7 +3339,6 @@ pub(super) fn continue_activation(
             // Auto-select deterministic pip choices when possible.
             if let Some(auto_choice) = preferred_auto_pip_choice(state, &options) {
                 let action = options[auto_choice].action.clone();
-                let uses_treasure_source = mana_payment_action_uses_treasure_source(game, &action);
                 let pip_paid = execute_pip_payment_action(
                     game,
                     trigger_queue,
@@ -3350,10 +3350,8 @@ pub(super) fn continue_activation(
                     &mut *decision_maker,
                     &mut pending.payment_trace,
                     None,
+                    Some(&mut pending.optional_costs_paid),
                 )?;
-                if pip_paid && uses_treasure_source {
-                    pending.optional_costs_paid.mark_label_paid("ManaFromTreasure");
-                }
                 queue_mana_ability_event_for_action(
                     game,
                     trigger_queue,

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -1212,6 +1212,17 @@ pub(super) fn record_activation_mana_ability_payment(
     let _ = ability_index;
 }
 
+pub(super) fn mana_payment_action_uses_treasure_source(
+    game: &GameState,
+    action: &ManaPipPaymentAction,
+) -> bool {
+    let ManaPipPaymentAction::ActivateManaAbility { source_id, .. } = action else {
+        return false;
+    };
+    game.object(*source_id)
+        .is_some_and(|object| object.subtypes.contains(&crate::types::Subtype::Treasure))
+}
+
 /// Execute a pip payment action.
 /// Execute a pip payment action.
 /// Returns true if the pip was actually paid (mana consumed or life paid),
@@ -2236,6 +2247,7 @@ pub(super) fn apply_pip_payment_response_activation(
     }
 
     let action = &options[choice].action;
+    let uses_treasure_source = mana_payment_action_uses_treasure_source(game, action);
 
     // Execute the payment action
     let pip_paid = execute_pip_payment_action(
@@ -2250,6 +2262,9 @@ pub(super) fn apply_pip_payment_response_activation(
         &mut pending.payment_trace,
         None,
     )?;
+    if pip_paid && uses_treasure_source {
+        pending.optional_costs_paid.mark_label_paid("ManaFromTreasure");
+    }
     queue_mana_ability_event_for_action(
         game,
         trigger_queue,

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -653,6 +653,7 @@ pub(super) fn add_any_color_pool_options(
 pub(super) struct SpentManaInfo {
     symbol: crate::mana::ManaSymbol,
     source: ObjectId,
+    source_subtypes: Vec<crate::types::Subtype>,
     source_chosen_creature_type: Option<crate::types::Subtype>,
     restrictions: Vec<crate::ability::ManaUsageRestriction>,
 }
@@ -908,11 +909,18 @@ pub(super) fn spend_pool_symbol(
                 unit.symbol == symbol && restricted_unit_is_payable(game, unit, payment_source)
             })
             .min_by_key(|(_, unit)| restricted_unit_priority(game, unit, payment_source))
-            .map(|(idx, unit)| (idx, restricted_unit_priority(game, unit, payment_source)))
+            .map(|(idx, unit)| {
+                let priority = restricted_unit_priority(game, unit, payment_source);
+                let source_subtypes = game
+                    .object(unit.source)
+                    .map(|object| object.subtypes.clone())
+                    .unwrap_or_default();
+                (idx, priority, source_subtypes)
+            })
     });
 
     let player_obj = game.player_mut(player)?;
-    if let Some((idx, priority)) = payable_restricted
+    if let Some((idx, priority, source_subtypes)) = payable_restricted
         && !(unrestricted_available && priority >= 2)
     {
         if !player_obj.mana_pool.remove(symbol, 1) {
@@ -922,18 +930,23 @@ pub(super) fn spend_pool_symbol(
         return Some(SpentManaInfo {
             symbol,
             source: unit.source,
+            source_subtypes,
             source_chosen_creature_type: unit.source_chosen_creature_type,
             restrictions: unit.restrictions,
         });
     }
 
     if unrestricted_available && player_obj.mana_pool.remove(symbol, 1) {
-        let source = player_obj
-            .remove_unrestricted_mana_source(symbol)
-            .unwrap_or(ObjectId::from_raw(0));
+        let source = player_obj.remove_unrestricted_mana_source(symbol);
         return Some(SpentManaInfo {
             symbol,
-            source,
+            source: source
+                .as_ref()
+                .map(|source| source.source)
+                .unwrap_or(ObjectId::from_raw(0)),
+            source_subtypes: source
+                .map(|source| source.source_subtypes)
+                .unwrap_or_default(),
             source_chosen_creature_type: None,
             restrictions: Vec::new(),
         });
@@ -1215,18 +1228,13 @@ pub(super) fn record_activation_mana_ability_payment(
     let _ = ability_index;
 }
 
-pub(super) fn mana_payment_action_uses_treasure_source(
-    game: &GameState,
-    action: &ManaPipPaymentAction,
-) -> bool {
-    let ManaPipPaymentAction::ActivateManaAbility { source_id, .. } = action else {
-        return false;
-    };
-    game.object(*source_id)
-        .is_some_and(|object| object.subtypes.contains(&crate::types::Subtype::Treasure))
-}
-
 fn spent_mana_uses_treasure_source(game: &GameState, spent: &SpentManaInfo) -> bool {
+    if spent
+        .source_subtypes
+        .contains(&crate::types::Subtype::Treasure)
+    {
+        return true;
+    }
     game.object(spent.source)
         .is_some_and(|object| object.subtypes.contains(&crate::types::Subtype::Treasure))
 }
@@ -2045,6 +2053,14 @@ pub(super) fn execute_pending_mana_ability(
     use crate::costs::CostContext;
     use crate::effects::ExecutionContext;
 
+    let source_snapshot = game
+        .object(pending.source)
+        .map(|object| ObjectSnapshot::from_object(object, game));
+    let source_subtypes = source_snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.subtypes.clone())
+        .unwrap_or_default();
+
     // Pay the mana cost
     if !game.try_pay_mana_cost_with_reason(
         pending.activator,
@@ -2073,7 +2089,11 @@ pub(super) fn execute_pending_mana_ability(
         if let Some(player_obj) = game.player_mut(pending.activator) {
             for symbol in &pending.mana_to_add {
                 if pending.mana_usage_restrictions.is_empty() {
-                    player_obj.add_unrestricted_mana_from_source(*symbol, pending.source);
+                    player_obj.add_unrestricted_mana_from_source_with_subtypes(
+                        *symbol,
+                        pending.source,
+                        source_subtypes.clone(),
+                    );
                 } else {
                     player_obj.add_restricted_mana(crate::ability::RestrictedManaUnit {
                         symbol: *symbol,
@@ -2084,16 +2104,13 @@ pub(super) fn execute_pending_mana_ability(
                 }
             }
         }
-        let snapshot = game
-            .object(pending.source)
-            .map(|obj| ObjectSnapshot::from_object(obj, game));
         let event = crate::events::ManaAddedEvent::new(
             pending.source,
             pending.activator,
             pending.activator,
             pending.mana_to_add.clone(),
         )
-        .with_snapshot(snapshot)
+        .with_snapshot(source_snapshot.clone())
         .into_trigger_event();
         queue_triggers_from_event(game, trigger_queue, event, false);
     }
@@ -2104,6 +2121,9 @@ pub(super) fn execute_pending_mana_ability(
             .with_provenance(pending.provenance)
             .with_mana_usage_restrictions(pending.mana_usage_restrictions.clone())
             .with_mana_source_chosen_creature_type(pending.mana_source_chosen_creature_type);
+        if let Some(snapshot) = source_snapshot.clone() {
+            ctx = ctx.with_source_snapshot(snapshot);
+        }
         let emitted_events = crate::game_loop::execute_resolution_program(
             game,
             &mut ctx,

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -928,9 +928,12 @@ pub(super) fn spend_pool_symbol(
     }
 
     if unrestricted_available && player_obj.mana_pool.remove(symbol, 1) {
+        let source = player_obj
+            .remove_unrestricted_mana_source(symbol)
+            .unwrap_or(ObjectId::from_raw(0));
         return Some(SpentManaInfo {
             symbol,
-            source: ObjectId::from_raw(0),
+            source,
             source_chosen_creature_type: None,
             restrictions: Vec::new(),
         });
@@ -1223,6 +1226,23 @@ pub(super) fn mana_payment_action_uses_treasure_source(
         .is_some_and(|object| object.subtypes.contains(&crate::types::Subtype::Treasure))
 }
 
+fn spent_mana_uses_treasure_source(game: &GameState, spent: &SpentManaInfo) -> bool {
+    game.object(spent.source)
+        .is_some_and(|object| object.subtypes.contains(&crate::types::Subtype::Treasure))
+}
+
+fn mark_spent_mana_labels(
+    game: &GameState,
+    spent: &SpentManaInfo,
+    optional_costs_paid: Option<&mut OptionalCostsPaid>,
+) {
+    if spent_mana_uses_treasure_source(game, spent)
+        && let Some(paid) = optional_costs_paid
+    {
+        paid.mark_label_paid("ManaFromTreasure");
+    }
+}
+
 /// Execute a pip payment action.
 /// Execute a pip payment action.
 /// Returns true if the pip was actually paid (mana consumed or life paid),
@@ -1238,6 +1258,7 @@ pub(super) fn execute_pip_payment_action(
     decision_maker: &mut impl DecisionMaker,
     payment_trace: &mut Vec<CostStep>,
     mut mana_spent_to_cast: Option<&mut ManaPool>,
+    mut optional_costs_paid: Option<&mut OptionalCostsPaid>,
 ) -> Result<bool, GameLoopError> {
     match action {
         ManaPipPaymentAction::UseFromPool(symbol) => {
@@ -1250,6 +1271,7 @@ pub(super) fn execute_pip_payment_action(
             if let Some(spent) = mana_spent_to_cast.as_deref_mut() {
                 track_spent_mana_symbol(spent, spent_info.symbol);
             }
+            mark_spent_mana_labels(game, &spent_info, optional_costs_paid.as_deref_mut());
             apply_spent_mana_bonuses(game, source, &spent_info);
             record_pip_payment_action(payment_trace, action);
             Ok(true) // Pip was paid
@@ -1300,6 +1322,7 @@ pub(super) fn execute_pip_payment_action(
                 if let Some(spent) = mana_spent_to_cast.as_deref_mut() {
                     track_spent_mana_symbol(spent, spent_info.symbol);
                 }
+                mark_spent_mana_labels(game, &spent_info, optional_costs_paid.as_deref_mut());
                 apply_spent_mana_bonuses(game, source, &spent_info);
                 record_pip_payment_action(
                     payment_trace,
@@ -2050,7 +2073,7 @@ pub(super) fn execute_pending_mana_ability(
         if let Some(player_obj) = game.player_mut(pending.activator) {
             for symbol in &pending.mana_to_add {
                 if pending.mana_usage_restrictions.is_empty() {
-                    player_obj.mana_pool.add(*symbol, 1);
+                    player_obj.add_unrestricted_mana_from_source(*symbol, pending.source);
                 } else {
                     player_obj.add_restricted_mana(crate::ability::RestrictedManaUnit {
                         symbol: *symbol,
@@ -2247,8 +2270,6 @@ pub(super) fn apply_pip_payment_response_activation(
     }
 
     let action = &options[choice].action;
-    let uses_treasure_source = mana_payment_action_uses_treasure_source(game, action);
-
     // Execute the payment action
     let pip_paid = execute_pip_payment_action(
         game,
@@ -2261,10 +2282,8 @@ pub(super) fn apply_pip_payment_response_activation(
         &mut *decision_maker,
         &mut pending.payment_trace,
         None,
+        Some(&mut pending.optional_costs_paid),
     )?;
-    if pip_paid && uses_treasure_source {
-        pending.optional_costs_paid.mark_label_paid("ManaFromTreasure");
-    }
     queue_mana_ability_event_for_action(
         game,
         trigger_queue,
@@ -2368,6 +2387,7 @@ pub(super) fn apply_pip_payment_response_cast(
         &mut *decision_maker,
         &mut pending.payment_trace,
         Some(&mut pending.mana_spent_to_cast),
+        None,
     )?;
     perf.execute_payment_ms = execute_started_at.elapsed_ms();
     let queue_event_started_at = crate::perf::PerfTimer::start();
@@ -5298,6 +5318,7 @@ mod priority_mana_tests {
             &mut dm,
             &mut payment_trace,
             Some(&mut mana_spent),
+            None,
         )
         .expect("mana ability activation during pip payment should succeed");
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_state.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_state.rs
@@ -655,6 +655,9 @@ pub struct PendingActivation {
     pub display_mana_pips: Vec<Vec<crate::mana::ManaSymbol>>,
     /// Ordered trace of cost payments performed so far.
     pub payment_trace: Vec<CostStep>,
+    /// Labels satisfied by the activation payment, used by resolution-time "was spent"
+    /// checks.
+    pub optional_costs_paid: OptionalCostsPaid,
     /// True after activating a mana ability that is not undo-safe while paying
     /// this activation's mana costs.
     pub undo_locked_by_mana: bool,
@@ -734,6 +737,7 @@ impl PendingActivation {
             mana_cost_to_pay,
             display_mana_pips: Vec::new(),
             payment_trace,
+            optional_costs_paid: OptionalCostsPaid::default(),
             undo_locked_by_mana: false,
             remaining_mana_pips: Vec::new(),
             remaining_cost_steps,

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -7409,8 +7409,7 @@ impl GameState {
     /// Called at the end of each step and phase per MTG rules.
     pub fn empty_mana_pools(&mut self) {
         for player in &mut self.players {
-            player.mana_pool.empty();
-            player.restricted_mana.clear();
+            player.empty_mana_pool();
         }
     }
 

--- a/crates/ironsmith-runtime/src/player.rs
+++ b/crates/ironsmith-runtime/src/player.rs
@@ -14,6 +14,12 @@ pub struct ManaPool {
     pub colorless: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManaPoolSource {
+    pub symbol: ManaSymbol,
+    pub source: ObjectId,
+}
+
 impl ManaPool {
     pub fn new() -> Self {
         Self::default()
@@ -593,6 +599,7 @@ pub struct Player {
     pub starting_life: i32,
     pub life: i32,
     pub mana_pool: ManaPool,
+    pub mana_pool_sources: Vec<ManaPoolSource>,
     pub restricted_mana: Vec<crate::ability::RestrictedManaUnit>,
     pub poison_counters: u32,
     pub energy_counters: u32,
@@ -640,6 +647,7 @@ impl Player {
             starting_life,
             life: starting_life,
             mana_pool: ManaPool::new(),
+            mana_pool_sources: Vec::new(),
             restricted_mana: Vec::new(),
             poison_counters: 0,
             energy_counters: 0,
@@ -695,6 +703,34 @@ impl Player {
     pub fn add_restricted_mana(&mut self, unit: crate::ability::RestrictedManaUnit) {
         self.mana_pool.add(unit.symbol, 1);
         self.restricted_mana.push(unit);
+    }
+
+    pub fn add_unrestricted_mana_from_source(&mut self, symbol: ManaSymbol, source: ObjectId) {
+        self.mana_pool.add(symbol, 1);
+        self.mana_pool_sources
+            .push(ManaPoolSource { symbol, source });
+    }
+
+    pub fn remove_unrestricted_mana_source(&mut self, symbol: ManaSymbol) -> Option<ObjectId> {
+        let tracked = self
+            .mana_pool_sources
+            .iter()
+            .filter(|unit| unit.symbol == symbol)
+            .count() as u32;
+        if self.mana_pool.amount(symbol) > tracked {
+            return None;
+        }
+        let index = self
+            .mana_pool_sources
+            .iter()
+            .position(|unit| unit.symbol == symbol)?;
+        Some(self.mana_pool_sources.remove(index).source)
+    }
+
+    pub fn empty_mana_pool(&mut self) {
+        self.mana_pool.empty();
+        self.mana_pool_sources.clear();
+        self.restricted_mana.clear();
     }
 
     /// Returns the combat damage this player has taken from a commander.

--- a/crates/ironsmith-runtime/src/player.rs
+++ b/crates/ironsmith-runtime/src/player.rs
@@ -1,5 +1,6 @@
 use crate::ids::{ObjectId, PlayerId};
 use crate::mana::ManaSymbol;
+use crate::types::Subtype;
 use rand::{SeedableRng, rngs::StdRng};
 use std::collections::HashMap;
 
@@ -18,6 +19,7 @@ pub struct ManaPool {
 pub struct ManaPoolSource {
     pub symbol: ManaSymbol,
     pub source: ObjectId,
+    pub source_subtypes: Vec<Subtype>,
 }
 
 impl ManaPool {
@@ -706,12 +708,27 @@ impl Player {
     }
 
     pub fn add_unrestricted_mana_from_source(&mut self, symbol: ManaSymbol, source: ObjectId) {
-        self.mana_pool.add(symbol, 1);
-        self.mana_pool_sources
-            .push(ManaPoolSource { symbol, source });
+        self.add_unrestricted_mana_from_source_with_subtypes(symbol, source, Vec::new());
     }
 
-    pub fn remove_unrestricted_mana_source(&mut self, symbol: ManaSymbol) -> Option<ObjectId> {
+    pub fn add_unrestricted_mana_from_source_with_subtypes(
+        &mut self,
+        symbol: ManaSymbol,
+        source: ObjectId,
+        source_subtypes: Vec<Subtype>,
+    ) {
+        self.mana_pool.add(symbol, 1);
+        self.mana_pool_sources.push(ManaPoolSource {
+            symbol,
+            source,
+            source_subtypes,
+        });
+    }
+
+    pub fn remove_unrestricted_mana_source(
+        &mut self,
+        symbol: ManaSymbol,
+    ) -> Option<ManaPoolSource> {
         let tracked = self
             .mana_pool_sources
             .iter()
@@ -724,7 +741,7 @@ impl Player {
             .mana_pool_sources
             .iter()
             .position(|unit| unit.symbol == symbol)?;
-        Some(self.mana_pool_sources.remove(index).source)
+        Some(self.mana_pool_sources.remove(index))
     }
 
     pub fn empty_mana_pool(&mut self) {

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -1601,11 +1601,16 @@ pub(crate) fn perform_activate_mana_ability_restricted_colors_with_events(
         let x_value_from_costs = cost_summary.x_value;
         drop(cost_ctx);
 
-        // Add mana to player's pool
+        // Add mana to player's pool. Keep the source type snapshot from before
+        // costs were paid, since mana sources like Treasure can sacrifice themselves.
         if let Some(player_data) = game.player_mut(player) {
             for symbol in mana.iter().copied() {
                 if mana_usage_restrictions.is_empty() {
-                    player_data.add_unrestricted_mana_from_source(symbol, permanent_id);
+                    player_data.add_unrestricted_mana_from_source_with_subtypes(
+                        symbol,
+                        permanent_id,
+                        source_snapshot.subtypes.clone(),
+                    );
                 } else {
                     player_data.add_restricted_mana(crate::ability::RestrictedManaUnit {
                         symbol,
@@ -1627,6 +1632,7 @@ pub(crate) fn perform_activate_mana_ability_restricted_colors_with_events(
         // Execute additional effects if present (for complex mana abilities like Ancient Tomb)
         if !effects.is_empty() {
             let mut effect_ctx = ExecutionContext::new(permanent_id, player, decision_maker)
+                .with_source_snapshot(source_snapshot.clone())
                 .with_mana_color_restriction(mana_color_restriction.clone())
                 .with_mana_usage_restrictions(mana_usage_restrictions)
                 .with_mana_source_chosen_creature_type(source_chosen_creature_type);

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -1605,7 +1605,7 @@ pub(crate) fn perform_activate_mana_ability_restricted_colors_with_events(
         if let Some(player_data) = game.player_mut(player) {
             for symbol in mana.iter().copied() {
                 if mana_usage_restrictions.is_empty() {
-                    player_data.mana_pool.add(symbol, 1);
+                    player_data.add_unrestricted_mana_from_source(symbol, permanent_id);
                 } else {
                     player_data.add_restricted_mana(crate::ability::RestrictedManaUnit {
                         symbol,

--- a/crates/ironsmith-runtime/src/turn.rs
+++ b/crates/ironsmith-runtime/src/turn.rs
@@ -611,7 +611,7 @@ pub fn execute_cleanup_step(game: &mut GameState) {
 
     // Empty mana pool
     if let Some(player) = game.player_mut(active_player) {
-        player.mana_pool.empty();
+        player.empty_mana_pool();
     }
 
     // Remove all damage marked on creatures and clear regeneration shields


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jetmir's Fixer
Initial parse error:
```
unsupported predicate (predicate: 'mana from treasure was spent to activate this ability'); oracle-only fallback also failed: unsupported predicate (predicate: 'mana from treasure was spent to activate this ability')
```

Current worker: i-032140f351d8206ba
Branch: codex/aws-card-fix-jetmir-s-fixer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0025
