### PR TITLE
Fix Ironsmith parse failure: Lumengrid Augur

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1712,6 +1712,45 @@ fn parse_passive_this_way_tagged_object_predicate(
     )))
 }
 
+fn parse_active_this_way_discard_predicate(
+    filtered: &[&str],
+) -> Result<Option<PredicateAst>, CardTextError> {
+    if filtered.len() < 5 || !THIS_WAY_SUFFIX_PATTERN.matches_words(filtered) {
+        return Ok(None);
+    }
+
+    let Some((player, subject_len)) = active_discard_player_subject(filtered) else {
+        return Ok(None);
+    };
+    let Some(verb) = filtered.get(subject_len) else {
+        return Ok(None);
+    };
+    if !matches!(*verb, "discard" | "discards" | "discarded") {
+        return Ok(None);
+    }
+
+    let filter_words = &filtered[subject_len + 1..filtered.len() - 2];
+    let Some(filter) = parse_this_way_object_filter_words(filter_words) else {
+        return Ok(None);
+    };
+    Ok(Some(PredicateAst::PlayerTaggedObjectMatches {
+        player,
+        tag: TagKey::from(IT_TAG),
+        filter,
+    }))
+}
+
+fn active_discard_player_subject(words: &[&str]) -> Option<(PlayerAst, usize)> {
+    match words {
+        ["you", ..] => Some((PlayerAst::You, 1)),
+        ["that", "player" | "players", ..] => Some((PlayerAst::That, 2)),
+        ["target", "player", ..] => Some((PlayerAst::Target, 2)),
+        ["target", "opponent", ..] => Some((PlayerAst::TargetOpponent, 2)),
+        ["opponent" | "opponents", ..] => Some((PlayerAst::Opponent, 1)),
+        _ => None,
+    }
+}
+
 fn parse_repeated_if_or_predicate(
     filtered: &[&str],
 ) -> Result<Option<PredicateAst>, CardTextError> {
@@ -2199,6 +2238,9 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_passive_this_way_tagged_object_predicate(&filtered)? {
+        return Ok(predicate);
+    }
+    if let Some(predicate) = parse_active_this_way_discard_predicate(&filtered)? {
         return Ok(predicate);
     }
 
@@ -4698,6 +4740,27 @@ mod tests {
         assert_eq!(
             parsed,
             PredicateAst::TaggedMatches(TagKey::from(IT_TAG), aura_filter)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_that_player_discards_filtered_card_this_way() -> Result<(), CardTextError> {
+        let tokens = lex_line("If that player discards an artifact card this way", 0)?;
+        let predicate_tokens = predicate_tokens_after_if(&tokens);
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+        let artifact_filter_tokens = lex_line("an artifact card", 0)?;
+        let mut artifact_filter = parse_object_filter(&artifact_filter_tokens, false)?;
+        artifact_filter.zone = None;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::PlayerTaggedObjectMatches {
+                player: PlayerAst::That,
+                tag: TagKey::from(IT_TAG),
+                filter: artifact_filter,
+            }
         );
         Ok(())
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -883,6 +883,172 @@ fn whirlpool_whelm_lost_clash_returns_target_without_replacement() {
     );
 }
 
+fn lumengrid_augur_activated_ability(def: &CardDefinition) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            Some(activated)
+        })
+        .expect("Lumengrid Augur should have an activated ability")
+}
+
+struct LumengridAugurDiscardDecisionMaker {
+    card_to_discard: ObjectId,
+}
+
+impl crate::decision::DecisionMaker for LumengridAugurDiscardDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx
+            .candidates
+            .iter()
+            .any(|candidate| candidate.id == self.card_to_discard && candidate.legal)
+        {
+            vec![self.card_to_discard]
+        } else {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+}
+
+fn lumengrid_augur_test_card(name: &str, card_types: Vec<CardType>) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .build()
+}
+
+fn resolve_lumengrid_augur_discarding(
+    discarded_card_types: Vec<CardType>,
+) -> (crate::game_state::GameState, ObjectId, PlayerId) {
+    let def = parse_oracle_card_definition("Lumengrid Augur");
+    let activated = lumengrid_augur_activated_ability(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.tap(source);
+
+    let drawn = lumengrid_augur_test_card("Bob Drawn Card", vec![CardType::Creature]);
+    game.create_object_from_definition(&drawn, bob, Zone::Library);
+    let discard_card = lumengrid_augur_test_card("Bob Discarded Card", discarded_card_types);
+    let discarded = game.create_object_from_definition(&discard_card, bob, Zone::Hand);
+    let kept = lumengrid_augur_test_card("Bob Kept Card", vec![CardType::Creature]);
+    game.create_object_from_definition(&kept, bob, Zone::Hand);
+
+    let mut dm = LumengridAugurDiscardDecisionMaker {
+        card_to_discard: discarded,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: activated
+                .choices
+                .first()
+                .expect("Lumengrid Augur should target a player")
+                .clone(),
+            range: 0..1,
+        }]);
+
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Lumengrid Augur activated ability effect should resolve");
+    }
+
+    (game, source, bob)
+}
+
+#[test]
+fn lumengrid_augur_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Lumengrid Augur");
+    let def = parse_oracle_card_definition("Lumengrid Augur");
+    let activated = lumengrid_augur_activated_ability(&def);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", activated);
+    let cost_debug = format!("{:?}", activated.mana_cost);
+
+    assert!(
+        activated.has_tap_cost() && cost_debug.contains("Generic(1)"),
+        "Lumengrid Augur should keep its {{1}}, {{T}} activation cost, got {cost_debug}"
+    );
+    assert!(
+        format!("{:?}", activated.choices).contains("Player"),
+        "Lumengrid Augur should target a player, got {:?}",
+        activated.choices
+    );
+    assert_eq!(
+        rendered,
+        "{1}, {T}: Target player draws a card, then discards a card. If that player discards an artifact card this way, untap this creature.",
+        "Lumengrid Augur should render its artifact-discard untap branch"
+    );
+    assert!(
+        debug.contains("DrawCardsEffect")
+            && debug.contains("DiscardEffect")
+            && debug.contains("PlayerTaggedObjectMatches")
+            && debug.contains("Artifact")
+            && debug.contains("UntapEffect"),
+        "Lumengrid Augur should structurally lower draw-discard plus artifact-discard conditional untap, got {debug}"
+    );
+}
+
+#[test]
+fn lumengrid_augur_untaps_when_target_player_discards_artifact_card() {
+    let (game, source, bob) = resolve_lumengrid_augur_discarding(vec![CardType::Artifact]);
+
+    assert!(
+        !game.is_tapped(source),
+        "Lumengrid Augur should untap when the target player discards an artifact card this way"
+    );
+    assert!(
+        game.player(bob).is_some_and(|player| player
+            .graveyard
+            .iter()
+            .any(|id| game
+                .object(*id)
+                .is_some_and(|obj| obj.name == "Bob Discarded Card"))),
+        "the chosen artifact card should be discarded to the target player's graveyard"
+    );
+    assert!(
+        game.player(bob).is_some_and(|player| player
+            .hand
+            .iter()
+            .any(|id| game.object(*id).is_some_and(|obj| obj.name == "Bob Drawn Card"))),
+        "the target player should draw before discarding"
+    );
+}
+
+#[test]
+fn lumengrid_augur_stays_tapped_when_target_player_discards_nonartifact_card() {
+    let (game, source, bob) = resolve_lumengrid_augur_discarding(vec![CardType::Creature]);
+
+    assert!(
+        game.is_tapped(source),
+        "Lumengrid Augur should stay tapped when the target player discards a nonartifact card this way"
+    );
+    assert!(
+        game.player(bob).is_some_and(|player| player
+            .graveyard
+            .iter()
+            .any(|id| game
+                .object(*id)
+                .is_some_and(|obj| obj.name == "Bob Discarded Card"))),
+        "the chosen nonartifact card should still be discarded"
+    );
+}
+
 #[test]
 fn alacrian_armory_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Alacrian Armory");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3187,6 +3187,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     describe_roll_choose_destroy_create_structural(effects)
+        .or_else(|| describe_draw_discard_then_conditional_untap_structural(effects))
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
@@ -3409,6 +3410,59 @@ fn describe_draw_discard_then_create_structural(effects: &[Effect]) -> Option<St
     let draw_discard = describe_draw_then_discard(draw, discard)?;
     let create = describe_effect(create_effect);
     Some(format!("{}. {}", capitalize_first(&draw_discard), create))
+}
+
+fn describe_draw_discard_then_conditional_untap_structural(effects: &[Effect]) -> Option<String> {
+    let (draw_effect, discard_effect, conditional_effect) = match effects {
+        [draw_effect, discard_effect, conditional_effect] => {
+            (draw_effect, discard_effect, conditional_effect)
+        }
+        [target_effect, draw_effect, discard_effect, conditional_effect] => {
+            target_effect.downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+            (draw_effect, discard_effect, conditional_effect)
+        }
+        _ => return None,
+    };
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    let discard = unwrap_structural_effect_tag(discard_effect)
+        .downcast_ref::<crate::effects::DiscardEffect>()?;
+    let discard_tag = structural_effect_tag(discard_effect).or(discard.tag.as_ref())?;
+    let draw_discard = describe_draw_then_discard(draw, discard)?;
+
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() {
+        return None;
+    }
+    let Condition::PlayerTaggedObjectMatches {
+        player,
+        tag,
+        filter,
+    } = &conditional.condition
+    else {
+        return None;
+    };
+    if tag != discard_tag || player != &draw.player {
+        return None;
+    }
+    let [untap_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let untap = untap_effect.downcast_ref::<crate::effects::UntapEffect>()?;
+    if !matches!(untap.target.unhinted(), ChooseSpec::Source) {
+        return None;
+    }
+
+    let subject = if *player == PlayerFilter::You {
+        "you".to_string()
+    } else {
+        "that player".to_string()
+    };
+    let object_text = describe_player_tagged_object_text(tag, filter);
+    let untap_text = lowercase_first(describe_effect(untap_effect).trim_end_matches('.'));
+    Some(format!(
+        "{}. If {subject} discards {object_text} this way, {untap_text}.",
+        capitalize_first(&draw_discard)
+    ))
 }
 
 fn join_or_list(items: &[String]) -> Option<String> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Lumengrid Augur
Initial parse error:
```
unsupported predicate (predicate: 'that player discards artifact card this way'); oracle-only fallback also failed: unsupported predicate (predicate: 'that player discards artifact card this way')
```

Current worker: i-032351107549914da
Branch: codex/aws-card-fix-lumengrid-augur
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0027
