### PR TITLE
Fix Ironsmith parse failure: Damping Field

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -276,6 +276,14 @@ const PLAYER_GET_POISON_COUNTERS_TAIL_PATTERN: ClauseShape<'static> = clause_sha
 );
 const PLAYER_CAST_MORE_THAN_ONE_SPELL_EACH_TURN_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["cast", "more", "than", "one", "spell", "each", "turn"]);
+const PLAYER_UNTAP_MORE_THAN_ONE_DURING_UNTAP_STEPS_TAIL_PATTERN: ClauseShape<'static> =
+    clause_shape!(
+        prefix & ["untap", "more", "than", "one"];
+        suffix_any & [
+            &["during", "their", "untap", "step"],
+            &["during", "their", "untap", "steps"],
+        ]
+    );
 const BE_PREVENTED_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["be", "prevented"]);
 const ATTACK_YOU_OR_PLANESWALKERS_YOU_CONTROL_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["attack", "you", "or", "planeswalkers", "you", "control"]);
@@ -537,6 +545,39 @@ fn player_negated_restriction_from_tail(
     } else {
         None
     }
+}
+
+fn player_untap_more_than_one_restriction_from_tail(
+    words: &[&str],
+    tokens: &[OwnedLexToken],
+    player: PlayerFilter,
+) -> Result<Option<crate::effect::Restriction>, CardTextError> {
+    if !PLAYER_UNTAP_MORE_THAN_ONE_DURING_UNTAP_STEPS_TAIL_PATTERN.matches_words(words) {
+        return Ok(None);
+    }
+    let Some(during_idx) = words
+        .iter()
+        .position(|word| DURING_WORD_PATTERN.matches_word(word))
+    else {
+        return Ok(None);
+    };
+    if during_idx <= 4 {
+        return Ok(None);
+    }
+    let object_tokens = trim_commas(&tokens[4..during_idx]);
+    let Some(object_filter) = parse_subject_object_filter(&object_tokens)? else {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported untap-limit object filter (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        )));
+    };
+
+    Ok(Some(
+        crate::effect::Restriction::untap_more_than_one_during_untap_step_matching(
+            player,
+            object_filter,
+        ),
+    ))
 }
 
 pub(crate) fn format_negated_restriction_display(tokens: &[OwnedLexToken]) -> String {
@@ -1660,6 +1701,16 @@ pub(crate) fn parse_negated_object_restriction_clause(
     if let Some(player) = player_subject {
         if is_mana_retention_tail(&remainder_words) {
             return Ok(None);
+        }
+        if let Some(restriction) = player_untap_more_than_one_restriction_from_tail(
+            &remainder_words,
+            &remainder_tokens,
+            player.clone(),
+        )? {
+            return Ok(Some(ParsedCantRestriction {
+                restriction,
+                target: None,
+            }));
         }
         let Some(restriction) = player_negated_restriction_from_tail(&remainder_words, player)
         else {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -1155,7 +1155,8 @@ pub(crate) fn restriction_references_tag(
         | Restriction::AttackOrBlock(filter)
         | Restriction::ActivateAbilitiesOf(filter)
         | Restriction::ActivateTapAbilitiesOf(filter)
-        | Restriction::ActivateNonManaAbilitiesOf(filter) => Some(filter),
+        | Restriction::ActivateNonManaAbilitiesOf(filter)
+        | Restriction::UntapMoreThanOneDuringUntapStep(_, filter) => Some(filter),
         _ => None,
     };
     if let Some(filter) = maybe_filter {

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -423,6 +423,12 @@ pub(crate) fn resolve_restriction_it_tag(
                 resolve_it_tag(filter, refs)?,
             )
         }
+        Restriction::UntapMoreThanOneDuringUntapStep(player, filter) => {
+            Restriction::UntapMoreThanOneDuringUntapStep(
+                resolve_contextual_player_filter(player, refs)?,
+                resolve_it_tag(filter, refs)?,
+            )
+        }
         Restriction::DrawCards(player) => {
             Restriction::DrawCards(resolve_contextual_player_filter(player, refs)?)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -3341,7 +3341,8 @@ fn bind_unresolved_it_in_restriction(
         | Restriction::AttackOrBlock(filter)
         | Restriction::ActivateAbilitiesOf(filter)
         | Restriction::ActivateTapAbilitiesOf(filter)
-        | Restriction::ActivateNonManaAbilitiesOf(filter) => {
+        | Restriction::ActivateNonManaAbilitiesOf(filter)
+        | Restriction::UntapMoreThanOneDuringUntapStep(_, filter) => {
             bind_unresolved_it_in_filter(filter, seed_tag)
         }
         Restriction::BlockSpecificAttacker { blockers, attacker }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -270,6 +270,7 @@ pub enum Restriction {
     ActivateTapAbilitiesOf(ObjectFilter),
     ActivateNonManaAbilitiesOf(ObjectFilter),
     CastMoreThanOneSpellEachTurn(PlayerFilter, ObjectFilter),
+    UntapMoreThanOneDuringUntapStep(PlayerFilter, ObjectFilter),
     DrawCards(PlayerFilter),
     DrawExtraCards(PlayerFilter),
     PoisonCounters(PlayerFilter),
@@ -438,6 +439,13 @@ impl Restriction {
 
     pub fn cast_more_than_one_spell_each_turn(filter: PlayerFilter) -> Self {
         Self::cast_more_than_one_spell_each_turn_matching(filter, ObjectFilter::default())
+    }
+
+    pub fn untap_more_than_one_during_untap_step_matching(
+        filter: PlayerFilter,
+        object_filter: ObjectFilter,
+    ) -> Self {
+        Self::UntapMoreThanOneDuringUntapStep(filter, object_filter)
     }
 
     pub fn cast_more_than_one_noncreature_spell_each_turn(filter: PlayerFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -4517,6 +4517,33 @@ fn test_parse_players_cant_cast_more_than_one_spell_each_turn() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn damping_field_parses_artifact_untap_limit() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Damping Field")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text("Players can't untap more than one artifact during their untap steps.")
+        .expect("Damping Field should parse strictly");
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("RuleRestriction")
+            && debug.contains("UntapMoreThanOneDuringUntapStep")
+            && debug.contains("Any")
+            && debug.contains("Artifact"),
+        "expected Damping Field to lower to an artifact untap-step limit, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("players can't untap more than one artifact during their untap steps")
+            || rendered.contains("players cant untap more than one artifact during their untap steps"),
+        "expected Damping Field compiled text to preserve the artifact untap limit, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_canonist_style_nonartifact_cast_limit() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Canonist Variant")
         .parse_text("Each player who has cast a nonartifact spell this turn can't cast additional nonartifact spells.")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10291,6 +10291,13 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             describe_player_set_filter(filter),
             describe_cast_limit_spell_filter(spell_filter)
         ),
+        crate::effect::Restriction::UntapMoreThanOneDuringUntapStep(filter, object_filter) => {
+            format!(
+                "{} can't untap more than one {} during their untap steps",
+                describe_player_set_filter(filter),
+                object_filter.description()
+            )
+        }
         crate::effect::Restriction::DrawCards(filter) => {
             format!("{} can't draw cards", describe_player_set_filter(filter))
         }

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -925,6 +925,13 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::UntapMoreThanOneDuringUntapStep(filter, object_filter) => {
+                for player in &game.players {
+                    if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
+                        tracker.add_untap_step_limit_filter(player.id, object_filter.clone(), 1);
+                    }
+                }
+            }
             Restriction::DrawCards(filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -611,6 +611,10 @@ pub struct CantEffectTracker {
     /// without hard-coding one tracker set per variant.
     pub cant_cast_limit_filters: HashMap<PlayerId, Vec<crate::target::ObjectFilter>>,
 
+    /// Per-player untap-step limits for matching permanents.
+    /// Example: "Players can't untap more than one artifact during their untap steps."
+    pub untap_step_limit_filters: HashMap<PlayerId, Vec<(crate::target::ObjectFilter, usize)>>,
+
     /// Players who can't draw cards.
     /// Example: Notion Thief redirecting draws
     pub cant_draw: HashSet<PlayerId>,
@@ -879,6 +883,11 @@ impl CantEffectTracker {
                 self.add_cast_limit_filter(player, filter);
             }
         }
+        for (player, limits) in other.untap_step_limit_filters {
+            for (filter, limit) in limits {
+                self.add_untap_step_limit_filter(player, filter, limit);
+            }
+        }
         self.cant_draw.extend(other.cant_draw);
         self.cant_draw_extra_cards
             .extend(other.cant_draw_extra_cards);
@@ -927,6 +936,7 @@ impl CantEffectTracker {
         self.cant_activate_tap_abilities_of.clear();
         self.cant_activate_non_mana_abilities_of.clear();
         self.cant_cast_limit_filters.clear();
+        self.untap_step_limit_filters.clear();
         self.cant_draw.clear();
         self.cant_draw_extra_cards.clear();
         self.cant_get_poison_counters.clear();
@@ -1173,6 +1183,34 @@ impl CantEffectTracker {
         player: PlayerId,
     ) -> Option<&[crate::target::ObjectFilter]> {
         self.cant_cast_limit_filters.get(&player).map(Vec::as_slice)
+    }
+
+    /// Add an untap-step limit for matching permanents.
+    pub fn add_untap_step_limit_filter(
+        &mut self,
+        player: PlayerId,
+        object_filter: crate::target::ObjectFilter,
+        limit: usize,
+    ) {
+        let limits = self.untap_step_limit_filters.entry(player).or_default();
+        if !limits
+            .iter()
+            .any(|(existing_filter, existing_limit)| {
+                existing_filter == &object_filter && *existing_limit == limit
+            })
+        {
+            limits.push((object_filter, limit));
+        }
+    }
+
+    /// Get active untap-step limits for a player, if any.
+    pub fn untap_step_limits_for_player(
+        &self,
+        player: PlayerId,
+    ) -> Option<&[(crate::target::ObjectFilter, usize)]> {
+        self.untap_step_limit_filters
+            .get(&player)
+            .map(Vec::as_slice)
     }
 
     /// Check if a player can cast an additional spell matching a specific filter this turn.

--- a/crates/ironsmith-runtime/src/turn.rs
+++ b/crates/ironsmith-runtime/src/turn.rs
@@ -312,7 +312,7 @@ pub fn execute_untap_step(game: &mut GameState) {
 /// This variant prompts for optional "you may choose not to untap ..." abilities.
 pub fn execute_untap_step_with(game: &mut GameState, decision_maker: &mut impl DecisionMaker) {
     use crate::ability::AbilityKind;
-    use crate::decisions::context::BooleanContext;
+    use crate::decisions::context::{BooleanContext, SelectObjectsContext, SelectableObject};
     use crate::effect::Until;
     use crate::static_abilities::StaticAbilityId;
 
@@ -370,7 +370,7 @@ pub fn execute_untap_step_with(game: &mut GameState, decision_maker: &mut impl D
     let permanents: Vec<_> = permanents.into_iter().collect();
 
     // First pass: collect which permanents should untap
-    let should_untap: std::collections::HashSet<_> = permanents
+    let mut should_untap: std::collections::HashSet<_> = permanents
         .iter()
         .filter_map(|&id| {
             let obj = game.object(id)?;
@@ -409,6 +409,57 @@ pub fn execute_untap_step_with(game: &mut GameState, decision_maker: &mut impl D
             }
         })
         .collect();
+
+    if let Some(limits) = game
+        .effect_store
+        .cant_effects
+        .untap_step_limits_for_player(active_player)
+    {
+        for (filter, limit) in limits.to_vec() {
+            let filter_ctx = game.filter_context_for(active_player, None);
+            let mut matching: Vec<_> = should_untap
+                .iter()
+                .copied()
+                .filter(|id| game.is_tapped(*id))
+                .filter(|id| {
+                    game.object(*id).is_some_and(|object| {
+                        game.controller_of(object) == active_player
+                            && filter.matches(object, &filter_ctx, game)
+                    })
+                })
+                .collect();
+            matching.sort_unstable();
+            if matching.len() <= limit {
+                continue;
+            }
+
+            let candidates = matching
+                .iter()
+                .filter_map(|id| {
+                    game.object(*id)
+                        .map(|object| SelectableObject::new(*id, object.name.clone()))
+                })
+                .collect();
+            let choice_ctx = SelectObjectsContext::new(
+                active_player,
+                None,
+                format!("choose {limit} matching permanent(s) to untap"),
+                candidates,
+                limit,
+                Some(limit),
+            );
+            let chosen: std::collections::HashSet<_> = decision_maker
+                .decide_objects(game, &choice_ctx)
+                .into_iter()
+                .take(limit)
+                .collect();
+            for id in matching {
+                if !chosen.contains(&id) {
+                    should_untap.remove(&id);
+                }
+            }
+        }
+    }
 
     // Second pass: untap eligible permanents and remove summoning sickness from all
     for id in permanents {
@@ -700,11 +751,12 @@ mod tests {
     use super::*;
     use crate::ability::Ability;
     use crate::card::CardBuilder;
+    use crate::decision::SelectFirstDecisionMaker;
     use crate::effect::{Restriction, Until};
     use crate::ids::{CardId, ObjectId};
     use crate::object::Object;
     use crate::static_abilities::StaticAbility;
-    use crate::target::ObjectFilter;
+    use crate::target::{ObjectFilter, PlayerFilter};
     use crate::types::CardType;
     use crate::zone::Zone;
 
@@ -726,6 +778,34 @@ mod tests {
         for ability in abilities {
             obj.abilities.push(Ability::static_ability(ability));
         }
+        game.add_object(obj);
+        id
+    }
+
+    fn create_enchantment(
+        game: &mut GameState,
+        name: &str,
+        controller: PlayerId,
+        abilities: Vec<StaticAbility>,
+    ) -> ObjectId {
+        let id = game.new_object_id();
+        let card = CardBuilder::new(CardId::from_raw(id.0 as u32), name)
+            .card_types(vec![CardType::Enchantment])
+            .build();
+        let mut obj = Object::from_card(id, &card, controller, Zone::Battlefield);
+        for ability in abilities {
+            obj.abilities.push(Ability::static_ability(ability));
+        }
+        game.add_object(obj);
+        id
+    }
+
+    fn create_creature(game: &mut GameState, name: &str, controller: PlayerId) -> ObjectId {
+        let id = game.new_object_id();
+        let card = CardBuilder::new(CardId::from_raw(id.0 as u32), name)
+            .card_types(vec![CardType::Creature])
+            .build();
+        let obj = Object::from_card(id, &card, controller, Zone::Battlefield);
         game.add_object(obj);
         id
     }
@@ -843,6 +923,128 @@ mod tests {
         assert!(
             game.is_tapped(cant_untap_artifact),
             "can't-untap restriction should prevent untapping"
+        );
+    }
+
+    #[test]
+    fn damping_field_limits_controller_to_one_artifact_untap() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let _damping_field = create_enchantment(
+            &mut game,
+            "Damping Field",
+            alice,
+            vec![StaticAbility::restriction(
+                Restriction::untap_more_than_one_during_untap_step_matching(
+                    PlayerFilter::Any,
+                    ObjectFilter::artifact(),
+                ),
+                "Players can't untap more than one artifact during their untap steps.".to_string(),
+            )],
+        );
+        let first = create_artifact(&mut game, "First Relic", alice, vec![]);
+        let second = create_artifact(&mut game, "Second Relic", alice, vec![]);
+        let creature = create_creature(&mut game, "Nonartifact Companion", alice);
+        game.tap(first);
+        game.tap(second);
+        game.tap(creature);
+
+        let mut dm = SelectFirstDecisionMaker;
+        execute_untap_step_with(&mut game, &mut dm);
+
+        let untapped_artifacts = [first, second]
+            .iter()
+            .filter(|id| !game.is_tapped(**id))
+            .count();
+        assert_eq!(
+            untapped_artifacts, 1,
+            "Damping Field should allow exactly one artifact to untap"
+        );
+        assert!(
+            !game.is_tapped(creature),
+            "Damping Field should not count nonartifact permanents"
+        );
+    }
+
+    #[test]
+    fn damping_field_allows_only_artifact_to_untap() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let _damping_field = create_enchantment(
+            &mut game,
+            "Damping Field",
+            alice,
+            vec![StaticAbility::restriction(
+                Restriction::untap_more_than_one_during_untap_step_matching(
+                    PlayerFilter::Any,
+                    ObjectFilter::artifact(),
+                ),
+                "Players can't untap more than one artifact during their untap steps.".to_string(),
+            )],
+        );
+        let artifact = create_artifact(&mut game, "Only Relic", alice, vec![]);
+        game.tap(artifact);
+
+        let mut dm = SelectFirstDecisionMaker;
+        execute_untap_step_with(&mut game, &mut dm);
+
+        assert!(
+            !game.is_tapped(artifact),
+            "Damping Field should allow a player to untap one artifact"
+        );
+    }
+
+    #[test]
+    fn damping_field_does_not_limit_off_turn_untaps() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.turn.active_player = bob;
+
+        let _damping_field = create_enchantment(
+            &mut game,
+            "Damping Field",
+            alice,
+            vec![StaticAbility::restriction(
+                Restriction::untap_more_than_one_during_untap_step_matching(
+                    PlayerFilter::Any,
+                    ObjectFilter::artifact(),
+                ),
+                "Players can't untap more than one artifact during their untap steps.".to_string(),
+            )],
+        );
+        let _seedborn_like = create_artifact(
+            &mut game,
+            "Seedborn Relic",
+            alice,
+            vec![StaticAbility::untap_during_each_other_players_untap_step(
+                ObjectFilter::permanent().you_control(),
+                "Untap all permanents you control during each other player's untap step"
+                    .to_string(),
+            )],
+        );
+        let alices_first = create_artifact(&mut game, "Alice First Relic", alice, vec![]);
+        let alices_second = create_artifact(&mut game, "Alice Second Relic", alice, vec![]);
+        let bobs_first = create_artifact(&mut game, "Bob First Relic", bob, vec![]);
+        let bobs_second = create_artifact(&mut game, "Bob Second Relic", bob, vec![]);
+        for id in [alices_first, alices_second, bobs_first, bobs_second] {
+            game.tap(id);
+        }
+
+        let mut dm = SelectFirstDecisionMaker;
+        execute_untap_step_with(&mut game, &mut dm);
+
+        assert!(
+            !game.is_tapped(alices_first) && !game.is_tapped(alices_second),
+            "Damping Field should not limit Alice's Seedborn-style off-turn untaps"
+        );
+        let bobs_untapped_artifacts = [bobs_first, bobs_second]
+            .iter()
+            .filter(|id| !game.is_tapped(**id))
+            .count();
+        assert_eq!(
+            bobs_untapped_artifacts, 1,
+            "Damping Field should still limit the active player during their untap step"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Damping Field
Initial parse error:
```
unsupported player negated restriction tail (clause: 'players can't untap more than one artifact during their untap steps'); oracle-only fallback also failed: unsupported player negated restriction tail (clause: 'players can't untap more than one artifact during their untap steps')
```

Current worker: i-0cff4ab7ed15d7a11
Branch: codex/aws-card-fix-damping-field
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0027
