### PR TITLE
Fix Ironsmith parse failure: Pardic Firecat

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3024,6 +3024,63 @@ fn parse_static_ability_ast_line_lowered(
     Ok(None)
 }
 
+fn title_case_count_as_card_name(words: &[&str]) -> String {
+    words
+        .iter()
+        .filter(|word| !word.is_empty())
+        .map(|word| {
+            let mut chars = word.chars();
+            if let Some(first) = chars.next() {
+                let mut out = first.to_ascii_uppercase().to_string();
+                out.push_str(chars.as_str());
+                out
+            } else {
+                String::new()
+            }
+        })
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn parse_count_as_card_named_for_spell_effect_line(
+    words: &[&str],
+) -> Option<StaticAbility> {
+    const GRAVEYARD_PREFIXES: &[&[&str]] = &[
+        &["if", "this", "card", "is", "in", "a", "graveyard"],
+        &["if", "this", "card", "is", "in", "your", "graveyard"],
+    ];
+    if !GRAVEYARD_PREFIXES
+        .iter()
+        .any(|prefix| words.starts_with(prefix))
+    {
+        return None;
+    }
+
+    let effects_idx = word_slice_find_phrase_start(words, &["effects", "from", "spells", "named"])?;
+    let spell_name_start = effects_idx + 4;
+    let count_idx = word_slice_find_word(words.get(spell_name_start..).unwrap_or_default(), "count")?
+        + spell_name_start;
+    let spell_name_words = words.get(spell_name_start..count_idx)?;
+    if spell_name_words.is_empty()
+        || !words
+            .get(count_idx..count_idx + 6)
+            .is_some_and(|tail| tail == ["count", "it", "as", "a", "card", "named"])
+    {
+        return None;
+    }
+
+    let counted_name_words = words.get(count_idx + 6..)?;
+    if counted_name_words.is_empty() {
+        return None;
+    }
+
+    Some(StaticAbility::count_as_card_named_for_spell_effect(
+        title_case_count_as_card_name(spell_name_words),
+        title_case_count_as_card_name(counted_name_words),
+    ))
+}
+
 fn parse_static_ability_ast_line_early_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
@@ -3076,6 +3133,9 @@ fn parse_static_ability_ast_line_early_lexed(
     }
 
     let words = parser_token_word_refs(tokens);
+    if let Some(ability) = parse_count_as_card_named_for_spell_effect_line(&words) {
+        return Ok(Some(vec![ability.into()]));
+    }
     if SOURCE_CAN_BLOCK_PREFIX_PATTERN.matches_words(&words) {
         let mut idx = 4usize;
         if words

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -312,6 +312,10 @@ const STATIC_ZONE_HINT_PHRASES: &[(&[&str], Zone)] = &[
         Zone::Graveyard,
     ),
     (
+        &["this", "card", "is", "in", "a", "graveyard"],
+        Zone::Graveyard,
+    ),
+    (
         &["this", "creature", "is", "in", "your", "graveyard"],
         Zone::Graveyard,
     ),

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -119,6 +119,7 @@ pub enum StaticAbilityId {
     GrantObjectAbilityForFilter,
     SetColors,
     SetName,
+    CountAsCardNamedForSpellEffect,
     MakeColorless,
     AddSupertypes,
     RemoveSupertypes,
@@ -379,6 +380,7 @@ impl StaticAbilityId {
             | GrantObjectAbilityForFilter
             | SetColors
             | SetName
+            | CountAsCardNamedForSpellEffect
             | MakeColorless
             | AddSupertypes
             | RemoveSupertypes

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -258,6 +258,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         filter: ObjectFilter,
         name: String,
     },
+    CountAsCardNamedForSpellEffect {
+        spell_name: String,
+        counted_name: String,
+    },
     AddSupertypes {
         filter: ObjectFilter,
         supertypes: Vec<Supertype>,
@@ -975,6 +979,13 @@ where
             StaticAbilityPayload::SetName { filter, name } => {
                 StaticAbilityPayload::SetName { filter, name }
             }
+            StaticAbilityPayload::CountAsCardNamedForSpellEffect {
+                spell_name,
+                counted_name,
+            } => StaticAbilityPayload::CountAsCardNamedForSpellEffect {
+                spell_name,
+                counted_name,
+            },
             StaticAbilityPayload::AddSupertypes { filter, supertypes } => {
                 StaticAbilityPayload::AddSupertypes { filter, supertypes }
             }
@@ -2839,6 +2850,23 @@ impl<
             id: Some(StaticAbilityId::SetName),
             label: format!("set name {name}"),
             payload: StaticAbilityPayload::SetName { filter, name },
+        }
+    }
+    pub fn count_as_card_named_for_spell_effect(
+        spell_name: impl Into<String>,
+        counted_name: impl Into<String>,
+    ) -> Self {
+        let spell_name = spell_name.into();
+        let counted_name = counted_name.into();
+        Self {
+            id: Some(StaticAbilityId::CountAsCardNamedForSpellEffect),
+            label: format!(
+                "If this card is in a graveyard, effects from spells named {spell_name} count it as a card named {counted_name}."
+            ),
+            payload: StaticAbilityPayload::CountAsCardNamedForSpellEffect {
+                spell_name,
+                counted_name,
+            },
         }
     }
     pub fn soulbond_shared_power_toughness(power: i32, toughness: i32) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57803,3 +57803,92 @@ fn fatespinner_combat_phase_choice_skips_only_that_players_combat_phase_this_tur
     crate::turn::advance_phase(&mut game).expect("additional combat phase should be skipped");
     assert_eq!(game.turn.phase, crate::game_state::Phase::NextMain);
 }
+
+#[test]
+fn pardic_firecat_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Pardic Firecat");
+    let def = parse_oracle_card_definition("Pardic Firecat");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    let count_as_ability = def
+        .abilities
+        .iter()
+        .find(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::CountAsCardNamedForSpellEffect
+        ))
+        .expect("Pardic Firecat should compile its Flame Burst graveyard count-as ability");
+
+    assert!(
+        count_as_ability.functions_in(&Zone::Graveyard),
+        "Pardic Firecat's count-as ability should function in graveyards"
+    );
+    assert!(
+        !count_as_ability.functions_in(&Zone::Battlefield),
+        "Pardic Firecat's count-as ability should not function on the battlefield"
+    );
+    assert!(
+        rendered.contains(
+            "If this card is in a graveyard, effects from spells named Flame Burst count it as a card named Flame Burst."
+        ),
+        "expected Pardic Firecat compiled text to preserve the Flame Burst count-as clause, got {rendered}"
+    );
+}
+
+fn resolve_flame_burst_with_pardic_firecat_in_zones(
+    flame_burst_source_zone: Zone,
+    pardic_zone: Zone,
+) -> i32 {
+    let flame_burst = parse_oracle_card_definition("Flame Burst");
+    let pardic_firecat = parse_oracle_card_definition("Pardic Firecat");
+    let mut game = crate::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.create_object_from_definition(&flame_burst, alice, Zone::Graveyard);
+    game.create_object_from_definition(&pardic_firecat, alice, pardic_zone);
+    let source = game.create_object_from_definition(&flame_burst, alice, flame_burst_source_zone);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    for effect in flame_burst
+        .spell_effect
+        .as_ref()
+        .expect("Flame Burst should have a spell effect")
+    {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Flame Burst damage should resolve");
+    }
+
+    game.life_total(bob)
+}
+
+#[test]
+fn pardic_firecat_in_graveyard_counts_for_flame_burst_damage() {
+    let bob_life = resolve_flame_burst_with_pardic_firecat_in_zones(Zone::Stack, Zone::Graveyard);
+    assert_eq!(
+        bob_life, 16,
+        "Flame Burst should deal 4 damage with one Flame Burst and Pardic Firecat in graveyards"
+    );
+}
+
+#[test]
+fn pardic_firecat_on_battlefield_does_not_count_for_flame_burst_damage() {
+    let bob_life = resolve_flame_burst_with_pardic_firecat_in_zones(Zone::Stack, Zone::Battlefield);
+    assert_eq!(
+        bob_life, 17,
+        "Flame Burst should deal only 3 damage when Pardic Firecat is not in a graveyard"
+    );
+}
+
+#[test]
+fn pardic_firecat_does_not_count_for_non_spell_flame_burst_effect_source() {
+    let bob_life =
+        resolve_flame_burst_with_pardic_firecat_in_zones(Zone::Battlefield, Zone::Graveyard);
+    assert_eq!(
+        bob_life, 17,
+        "Pardic Firecat should count only for effects from spells named Flame Burst"
+    );
+}

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -365,6 +365,66 @@ fn resolve_effect_metric(
     Ok(resolved)
 }
 
+fn normalize_count_as_name(name: &str) -> String {
+    name.chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect()
+}
+
+fn count_as_names_match(lhs: &str, rhs: &str) -> bool {
+    lhs.eq_ignore_ascii_case(rhs) || normalize_count_as_name(lhs) == normalize_count_as_name(rhs)
+}
+
+fn source_spell_name_for_count_as(game: &GameState, ctx: &ExecutionContext<'_>) -> Option<String> {
+    if let Some(object) = game.object(ctx.source) {
+        return (object.zone == Zone::Stack).then(|| object.name.clone());
+    }
+
+    let snapshot = ctx.source_snapshot.as_ref()?;
+    (snapshot.zone == Zone::Stack).then(|| snapshot.name.clone())
+}
+
+fn count_as_card_named_for_spell_effect_bonus(
+    game: &GameState,
+    filter: &crate::filter::ObjectFilter,
+    ctx: &ExecutionContext<'_>,
+    filter_ctx: &crate::target::FilterContext,
+) -> usize {
+    let Some(required_name) = filter.name.as_deref() else {
+        return 0;
+    };
+    let Some(source_name) = source_spell_name_for_count_as(game, ctx) else {
+        return 0;
+    };
+
+    game.object_ids_in_deterministic_order()
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| !filter.matches_non_recursive(object, filter_ctx, game))
+        .filter(|object| {
+            object.abilities.iter().any(|ability| {
+                if !ability.functions_in(&object.zone) {
+                    return false;
+                }
+                let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
+                    return false;
+                };
+                let Some(spec) = static_ability.count_as_card_named_for_spell_effect_spec() else {
+                    return false;
+                };
+                count_as_names_match(source_name.as_str(), spec.spell_name.as_str())
+                    && count_as_names_match(required_name, spec.counted_name.as_str())
+            })
+        })
+        .filter(|object| {
+            let mut counted_object = (*object).clone();
+            counted_object.name = required_name.to_string();
+            filter.matches_non_recursive(&counted_object, filter_ctx, game)
+        })
+        .count()
+}
+
 /// Resolve a Value to a concrete i32.
 pub fn resolve_value(
     game: &GameState,
@@ -408,7 +468,8 @@ pub fn resolve_value(
                 .iter()
                 .filter_map(|&id| game.object(id))
                 .filter(|obj| filter.matches(obj, &filter_ctx, game))
-                .count();
+                .count()
+                + count_as_card_named_for_spell_effect_bonus(game, filter, ctx, &filter_ctx);
             Ok(count as i32)
         }
         Value::PlayersWhoControlMoreThanYou(filter) => {
@@ -438,7 +499,9 @@ pub fn resolve_value(
                 .iter()
                 .filter_map(|&id| game.object(id))
                 .filter(|obj| filter.matches(obj, &filter_ctx, game))
-                .count() as i32;
+                .count()
+                + count_as_card_named_for_spell_effect_bonus(game, filter, ctx, &filter_ctx);
+            let count = count as i32;
             Ok(count * *multiplier)
         }
         Value::GreatestCount(filter) => {

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -23,6 +23,14 @@ impl StaticAbility {
             .and_then(|count| count.parse::<u32>().ok())
     }
 
+    fn parse_count_as_card_named_for_spell_effect_label(label: &str) -> Option<(String, String)> {
+        let prefix = "If this card is in a graveyard, effects from spells named ";
+        let middle = " count it as a card named ";
+        let rest = label.strip_prefix(prefix)?.trim_end_matches('.');
+        let (spell_name, counted_name) = rest.split_once(middle)?;
+        Some((spell_name.to_string(), counted_name.to_string()))
+    }
+
     pub fn from_compiler_model_parts(
         id: Option<StaticAbilityId>,
         label: String,
@@ -232,6 +240,18 @@ impl StaticAbility {
             Some(StaticAbilityId::DrawReplacementDouble) => Self::draw_replacement_double(),
             Some(StaticAbilityId::DrawReplacementSkipEmptyLibrary) => {
                 Self::draw_replacement_skip_empty_library()
+            }
+            Some(StaticAbilityId::CountAsCardNamedForSpellEffect) => {
+                let (spell_name, counted_name) =
+                    Self::parse_count_as_card_named_for_spell_effect_label(&label).ok_or_else(
+                        || StaticAbilityModelConversionError {
+                            detail: format!(
+                                "id={:?}, label={label}",
+                                StaticAbilityId::CountAsCardNamedForSpellEffect
+                            ),
+                        },
+                    )?;
+                Self::count_as_card_named_for_spell_effect(spell_name, counted_name)
             }
             Some(StaticAbilityId::ExileWouldDieInstead) => {
                 Self::exile_would_die_instead(crate::target::ObjectFilter::creature())

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -7,7 +7,8 @@ use super::{
     ChooseColorAsEntersSpec, ChooseCreatureTypeAsEntersSpec, ChooseLandTypeAsEntersSpec,
     ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
-    ConditionalSpellKeywordSpec, EnterAsCopyAsEntersSpec, GraveyardCountMetric,
+    ConditionalSpellKeywordSpec, CountAsCardNamedForSpellEffectSpec, EnterAsCopyAsEntersSpec,
+    GraveyardCountMetric,
     PowerToughnessChoiceOption, StaticAbility, StaticAbilityId, StaticAbilityKind,
     ThisSpellCastRestrictionKind, TriggerDuplicationSpec, TriggerSuppressionSpec,
     text_utils::{capitalize_first, join_with_and, number_word_u32},
@@ -497,6 +498,44 @@ impl StaticAbilityKind for RevealFirstCardYouDrawEachTurn {
             card_number: 1,
             optional: self.optional,
             your_turns_only: self.your_turns_only,
+        })
+    }
+}
+
+/// "Effects from spells named N count this as a card named M."
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CountAsCardNamedForSpellEffect {
+    pub spell_name: String,
+    pub counted_name: String,
+}
+
+impl CountAsCardNamedForSpellEffect {
+    pub fn new(spell_name: String, counted_name: String) -> Self {
+        Self {
+            spell_name,
+            counted_name,
+        }
+    }
+}
+
+impl StaticAbilityKind for CountAsCardNamedForSpellEffect {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::CountAsCardNamedForSpellEffect
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "If this card is in a graveyard, effects from spells named {} count it as a card named {}.",
+            self.spell_name, self.counted_name
+        )
+    }
+
+    fn count_as_card_named_for_spell_effect_spec(
+        &self,
+    ) -> Option<CountAsCardNamedForSpellEffectSpec> {
+        Some(CountAsCardNamedForSpellEffectSpec {
+            spell_name: self.spell_name.clone(),
+            counted_name: self.counted_name.clone(),
         })
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -937,6 +937,13 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
     fn reveal_drawn_card_spec(&self) -> Option<RevealDrawnCardSpec> {
         None
     }
+
+    /// Return a graveyard count-as descriptor for effects from named spells.
+    fn count_as_card_named_for_spell_effect_spec(
+        &self,
+    ) -> Option<CountAsCardNamedForSpellEffectSpec> {
+        None
+    }
 }
 
 /// Spec for "as this enters, choose a color" abilities.
@@ -1054,6 +1061,13 @@ pub struct RevealDrawnCardSpec {
     pub your_turns_only: bool,
 }
 
+/// Spec for "effects from spells named N count this as a card named M" abilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CountAsCardNamedForSpellEffectSpec {
+    pub spell_name: String,
+    pub counted_name: String,
+}
+
 // Implement Clone for Box<dyn StaticAbilityKind>
 impl Clone for Box<dyn StaticAbilityKind> {
     fn clone(&self) -> Self {
@@ -1168,6 +1182,12 @@ impl StaticAbility {
 
     pub fn reveal_drawn_card_spec(&self) -> Option<RevealDrawnCardSpec> {
         self.0.reveal_drawn_card_spec()
+    }
+
+    pub fn count_as_card_named_for_spell_effect_spec(
+        &self,
+    ) -> Option<CountAsCardNamedForSpellEffectSpec> {
+        self.0.count_as_card_named_for_spell_effect_spec()
     }
 
     /// Get the display text for this ability.
@@ -2956,6 +2976,16 @@ impl StaticAbility {
         Self::new(RevealFirstCardYouDrawEachTurn::new(
             optional,
             your_turns_only,
+        ))
+    }
+
+    pub fn count_as_card_named_for_spell_effect(
+        spell_name: impl Into<String>,
+        counted_name: impl Into<String>,
+    ) -> Self {
+        Self::new(CountAsCardNamedForSpellEffect::new(
+            spell_name.into(),
+            counted_name.into(),
         ))
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1008,6 +1008,13 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::SetName { filter, name } => {
                 StaticAbility::set_name(filter.clone(), name.clone())
             }
+            ironsmith_core::StaticAbilityPayload::CountAsCardNamedForSpellEffect {
+                spell_name,
+                counted_name,
+            } => StaticAbility::count_as_card_named_for_spell_effect(
+                spell_name.clone(),
+                counted_name.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::AddSupertypes { filter, supertypes } => {
                 StaticAbility::add_supertypes(filter.clone(), supertypes.clone())
             }
@@ -1944,6 +1951,21 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
                 card_number: 1,
                 optional: *optional,
                 your_turns_only: *your_turns_only,
+            }),
+            _ => None,
+        }
+    }
+
+    fn count_as_card_named_for_spell_effect_spec(
+        &self,
+    ) -> Option<super::CountAsCardNamedForSpellEffectSpec> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::CountAsCardNamedForSpellEffect {
+                spell_name,
+                counted_name,
+            } => Some(super::CountAsCardNamedForSpellEffectSpec {
+                spell_name: spell_name.clone(),
+                counted_name: counted_name.clone(),
             }),
             _ => None,
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pardic Firecat
Initial parse error:
```
could not find verb in effect clause (clause: 'effects from spells named flame burst count it as a card named flame burst'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'effects from spells named flame burst count it as a card named flame burst'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-06c410ee0ac3dc150
Branch: codex/aws-card-fix-pardic-firecat
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
