### PR TITLE
Fix Ironsmith parse failure: Thunder Brute

### DIFF
--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -128,6 +128,7 @@ pub enum KeywordAction {
     UmbraArmor,
     Landwalk(LandwalkKind),
     Bloodthirst(u32),
+    Tribute(u32),
     Rampage(u32),
     Bushido(u32),
     Changeling,
@@ -235,6 +236,7 @@ impl KeywordAction {
                 | Self::UmbraArmor
                 | Self::Landwalk(_)
                 | Self::Bloodthirst(_)
+                | Self::Tribute(_)
                 | Self::Rampage(_)
                 | Self::Bushido(_)
                 | Self::Changeling
@@ -390,6 +392,7 @@ impl KeywordAction {
             Self::UmbraArmor => "Umbra armor".to_string(),
             Self::Landwalk(kind) => kind.display(),
             Self::Bloodthirst(amount) => format!("Bloodthirst {amount}"),
+            Self::Tribute(amount) => format!("Tribute {amount}"),
             Self::Rampage(amount) => format!("Rampage {amount}"),
             Self::Bushido(amount) => format!("Bushido {amount}"),
             Self::Changeling => "Changeling".to_string(),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -1146,6 +1146,9 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
     {
         return Some(action);
     }
+    if let Some(action) = parse_numeric_keyword_action(&words, "tribute", KeywordAction::Tribute) {
+        return Some(action);
+    }
     if let Some(action) = parse_numeric_keyword_action(&words, "afflict", KeywordAction::Afflict) {
         return Some(action);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -470,6 +470,9 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
         if let Some(action) = parse_count_keyword("bloodthirst", KeywordAction::Bloodthirst) {
             return Some(action);
         }
+        if let Some(action) = parse_count_keyword("tribute", KeywordAction::Tribute) {
+            return Some(action);
+        }
         if let Some(action) = parse_count_keyword("rampage", KeywordAction::Rampage) {
             return Some(action);
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -141,6 +141,7 @@ pub(crate) fn static_ability_for_keyword_action(action: KeywordAction) -> Option
             }
         }),
         KeywordAction::Bloodthirst(amount) => Some(StaticAbility::bloodthirst(amount)),
+        KeywordAction::Tribute(amount) => Some(StaticAbility::tribute(amount)),
         KeywordAction::Rampage(amount) => {
             Some(StaticAbility::keyword_marker(format!("rampage {amount}")))
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -502,6 +502,15 @@ const GIFT_NOT_PROMISED_PATTERN: ClauseShape<'static> = clause_shape!(
             &["gift", "was", "not", "promised"],
         ]
 );
+const TRIBUTE_WAS_PAID_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["tribute", "was", "paid"]);
+const TRIBUTE_WASNT_PAID_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["tribute", "wasnt", "paid"],
+            &["tribute", "was", "not", "paid"],
+        ]
+);
 const COST_WAS_PAID_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["cost", "was", "paid"]);
 const COST_WASNT_PAID_TAIL_PATTERN: ClauseShape<'static> =
@@ -3618,6 +3627,14 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     if GIFT_NOT_PROMISED_PATTERN.matches_words(&filtered) {
         return Ok(PredicateAst::Not(Box::new(
             PredicateAst::ThisSpellPaidLabel("Gift".to_string()),
+        )));
+    }
+    if TRIBUTE_WAS_PAID_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::ThisSpellPaidLabel("Tribute".to_string()));
+    }
+    if TRIBUTE_WASNT_PAID_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::Not(Box::new(
+            PredicateAst::ThisSpellPaidLabel("Tribute".to_string()),
         )));
     }
     if filtered.len() >= 4

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -924,6 +924,7 @@ pub(crate) fn rewrite_static_ability_for_keyword_action(
             }
         }),
         KeywordAction::Bloodthirst(amount) => Some(StaticAbility::bloodthirst(amount)),
+        KeywordAction::Tribute(amount) => Some(StaticAbility::tribute(amount)),
         KeywordAction::Rampage(amount) => {
             Some(StaticAbility::keyword_marker(format!("rampage {amount}")))
         }

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -34,6 +34,7 @@ pub enum StaticAbilityId {
     CantBeBlockedAsLongAsDefendingPlayerControlsCardType,
     CantBeBlockedAsLongAsDefendingPlayerControlsCardTypes,
     Bloodthirst,
+    Tribute,
     Daybound,
     Nightbound,
     DayNightStartsDayAsEnters,
@@ -294,6 +295,7 @@ impl StaticAbilityId {
             | CantBeBlockedAsLongAsDefendingPlayerControlsCardType
             | CantBeBlockedAsLongAsDefendingPlayerControlsCardTypes
             | Bloodthirst
+            | Tribute
             | Daybound
             | Nightbound
             | DayNightStartsDayAsEnters
@@ -553,6 +555,7 @@ impl StaticAbilityId {
                 | Flanking
                 | Landwalk
                 | Bloodthirst
+                | Tribute
                 | Morph
                 | Disguise
                 | Megamorph

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -491,6 +491,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     },
     Landwalk(LandwalkKind),
     Bloodthirst(u32),
+    Tribute(u32),
     PreventDamageToSelfRemoveCounter {
         counter_type: CounterType,
         amount: u32,
@@ -1426,6 +1427,7 @@ where
             StaticAbilityPayload::Bloodthirst(amount) => {
                 StaticAbilityPayload::Bloodthirst(amount)
             }
+            StaticAbilityPayload::Tribute(amount) => StaticAbilityPayload::Tribute(amount),
             StaticAbilityPayload::PreventDamageToSelfRemoveCounter {
                 counter_type,
                 amount,
@@ -2367,6 +2369,13 @@ impl<
             id: Some(StaticAbilityId::Bloodthirst),
             label: format!("bloodthirst {amount}"),
             payload: StaticAbilityPayload::Bloodthirst(amount),
+        }
+    }
+    pub fn tribute(amount: u32) -> Self {
+        Self {
+            id: Some(StaticAbilityId::Tribute),
+            label: format!("tribute {amount}"),
+            payload: StaticAbilityPayload::Tribute(amount),
         }
     }
     pub fn krrik_black_mana_may_be_paid_with_life() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -582,6 +582,7 @@ pub(crate) enum KeywordAction {
     UmbraArmor,
     Landwalk(crate::static_abilities::LandwalkKind),
     Bloodthirst(u32),
+    Tribute(u32),
     Rampage(u32),
     Bushido(u32),
     Changeling,
@@ -688,6 +689,7 @@ impl KeywordAction {
                 | Self::UmbraArmor
                 | Self::Landwalk(_)
                 | Self::Bloodthirst(_)
+                | Self::Tribute(_)
                 | Self::Rampage(_)
                 | Self::Bushido(_)
                 | Self::Changeling
@@ -842,6 +844,7 @@ impl KeywordAction {
             Self::UmbraArmor => "Umbra armor".to_string(),
             Self::Landwalk(kind) => kind.display(),
             Self::Bloodthirst(amount) => format!("Bloodthirst {amount}"),
+            Self::Tribute(amount) => format!("Tribute {amount}"),
             Self::Rampage(amount) => format!("Rampage {amount}"),
             Self::Bushido(amount) => format!("Bushido {amount}"),
             Self::Changeling => "Changeling".to_string(),
@@ -1748,6 +1751,7 @@ impl CardDefinitionBuilder {
                 self.with_ability(Ability::static_ability(ability))
             }
             KeywordAction::Bloodthirst(amount) => self.bloodthirst(amount),
+            KeywordAction::Tribute(amount) => self.tribute(amount),
             KeywordAction::Rampage(amount) => self.rampage(amount),
             KeywordAction::Bushido(amount) => self.bushido(amount),
             KeywordAction::Changeling => {
@@ -3820,6 +3824,13 @@ impl CardDefinitionBuilder {
     /// the battlefield with N +1/+1 counters on it."
     pub fn bloodthirst(self, amount: u32) -> Self {
         self.with_ability(Ability::static_ability(StaticAbility::bloodthirst(amount)))
+    }
+
+    /// Add tribute N.
+    ///
+    /// Tribute means "As this creature enters, an opponent may put N +1/+1 counters on it."
+    pub fn tribute(self, amount: u32) -> Self {
+        self.with_ability(Ability::static_ability(StaticAbility::tribute(amount)))
     }
 
     /// Add rampage N.

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10756,6 +10756,76 @@ fn thunder_brute_etb_does_not_trigger_when_tribute_paid() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn thunder_brute_tribute_uses_controller_chosen_opponent() {
+    struct ChooseCharlieThenAccept {
+        chose_opponent: bool,
+        prompted_chosen_opponent: bool,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseCharlieThenAccept {
+        fn decide_options(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            assert_eq!(ctx.player, PlayerId::from_index(0));
+            self.chose_opponent = true;
+            let charlie = ctx
+                .options
+                .iter()
+                .find(|option| option.description == "Charlie")
+                .expect("Charlie should be a tribute opponent option");
+            vec![charlie.index]
+        }
+
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            self.prompted_chosen_opponent = ctx.player == PlayerId::from_index(2);
+            self.prompted_chosen_opponent
+        }
+    }
+
+    let def = parse_oracle_card_definition("Thunder Brute");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let stack_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = ChooseCharlieThenAccept {
+        chose_opponent: false,
+        prompted_chosen_opponent: false,
+    };
+
+    let result = game
+        .move_object_with_etb_processing_with_dm(stack_id, Zone::Battlefield, &mut dm)
+        .expect("Thunder Brute should enter the battlefield");
+    let thunder_brute_id = result.new_id;
+
+    assert!(dm.chose_opponent, "controller should choose a tribute opponent");
+    assert!(
+        dm.prompted_chosen_opponent,
+        "chosen opponent should receive the tribute payment choice"
+    );
+    assert_eq!(
+        game.counter_count(thunder_brute_id, crate::object::CounterType::PlusOnePlusOne),
+        3,
+        "Thunder Brute should get counters when the chosen opponent accepts tribute"
+    );
+    assert!(
+        game.object(thunder_brute_id)
+            .expect("Thunder Brute exists")
+            .optional_costs_paid
+            .was_paid_label("Tribute"),
+        "tribute should be marked paid when the chosen opponent accepts"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_disturb_keyword_line_compiles_to_alternative_cast() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Disturb Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10596,6 +10596,166 @@ fn test_rix_maadi_reveler_etb_uses_spectacle_branch_when_paid() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn thunder_brute_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Thunder Brute");
+    let def = parse_oracle_card_definition("Thunder Brute");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("Tribute")
+            && debug.contains("Tribute(3)")
+            && debug.contains("ThisSpellPaidLabel")
+            && !debug.contains("KeywordMarker")
+            && !debug.contains("KeywordFallbackText")
+            && !debug.contains("RuleFallbackText")
+            && !debug.contains("UnsupportedParserLine"),
+        "expected Thunder Brute to lower tribute and its paid condition without unsupported placeholders, got {debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Tribute 3")
+            && rendered.contains("When this creature enters, if tribute wasn't paid")
+            && rendered.contains("it gains haste until end of turn"),
+        "expected Thunder Brute compiled text to preserve tribute and the unpaid branch, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunder_brute_etb_grants_haste_when_tribute_not_paid() {
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::tests::test_helpers::setup_two_player_game;
+
+    struct DeclineTribute;
+    impl crate::decision::DecisionMaker for DeclineTribute {}
+
+    let def = parse_oracle_card_definition("Thunder Brute");
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let stack_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = DeclineTribute;
+    let result = game
+        .move_object_with_etb_processing_with_dm(stack_id, Zone::Battlefield, &mut dm)
+        .expect("Thunder Brute should enter the battlefield");
+    let thunder_brute_id = result.new_id;
+
+    assert_eq!(
+        game.counter_count(thunder_brute_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Thunder Brute should not get tribute counters when the opponent declines"
+    );
+    assert!(
+        !game
+            .object(thunder_brute_id)
+            .expect("Thunder Brute exists")
+            .optional_costs_paid
+            .was_paid_label("Tribute"),
+        "tribute should not be marked paid when the opponent declines"
+    );
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(thunder_brute_id).expect("Thunder Brute exists"),
+        &game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            thunder_brute_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    assert_eq!(
+        triggered.len(),
+        1,
+        "Thunder Brute should trigger when tribute was not paid"
+    );
+
+    let entry = &triggered[0];
+    let mut ctx = ExecutionContext::new_default(thunder_brute_id, alice)
+        .with_triggering_event(entry.triggering_event.clone());
+    for effect in &entry.ability.effects {
+        execute_effect(&mut game, effect, &mut ctx).expect("Thunder Brute ETB should resolve");
+    }
+
+    assert!(
+        game.current_has_static_ability_id(thunder_brute_id, StaticAbilityId::Haste),
+        "Thunder Brute should gain haste until end of turn when tribute was not paid"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thunder_brute_etb_does_not_trigger_when_tribute_paid() {
+    use crate::tests::test_helpers::setup_two_player_game;
+
+    struct AcceptTribute;
+    impl crate::decision::DecisionMaker for AcceptTribute {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+    }
+
+    let def = parse_oracle_card_definition("Thunder Brute");
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let graveyard_id = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    let mut dm = AcceptTribute;
+    let result = game
+        .move_object_with_etb_processing_with_dm(graveyard_id, Zone::Battlefield, &mut dm)
+        .expect("Thunder Brute should enter the battlefield");
+    let thunder_brute_id = result.new_id;
+
+    assert_eq!(
+        game.counter_count(thunder_brute_id, crate::object::CounterType::PlusOnePlusOne),
+        3,
+        "Thunder Brute should enter with three tribute counters when the opponent accepts"
+    );
+    assert!(
+        game.object(thunder_brute_id)
+            .expect("Thunder Brute exists")
+            .optional_costs_paid
+            .was_paid_label("Tribute"),
+        "tribute should be marked paid when the opponent accepts"
+    );
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(thunder_brute_id).expect("Thunder Brute exists"),
+        &game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            thunder_brute_id,
+            Zone::Graveyard,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    assert!(
+        triggered.is_empty(),
+        "Thunder Brute should not trigger when tribute was paid"
+    );
+    assert!(
+        !game.current_has_static_ability_id(thunder_brute_id, StaticAbilityId::Haste),
+        "Thunder Brute should not gain haste when tribute was paid"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_disturb_keyword_line_compiles_to_alternative_cast() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Disturb Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10953,6 +10953,7 @@ fn describe_source_condition_static_ability(
         Flanking => Some("flanking"),
         Landwalk => Some("landwalk"),
         Bloodthirst => Some("bloodthirst"),
+        Tribute => Some("tribute"),
         Morph => Some("morph"),
         Disguise => Some("disguise"),
         Megamorph => Some("megamorph"),
@@ -11498,6 +11499,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             }
             if label.eq_ignore_ascii_case("bargain") {
                 return "this spell was bargained".to_string();
+            }
+            if label.eq_ignore_ascii_case("tribute") {
+                return "tribute was paid".to_string();
             }
             if label.eq_ignore_ascii_case("CastDuringYourMainPhase") {
                 return "you cast this spell during your main phase".to_string();
@@ -12379,6 +12383,10 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 "no permanents left the battlefield this turn".to_string()
             } else if let Condition::CardsInHandOrMore(1) = inner.as_ref() {
                 "you have no cards in hand".to_string()
+            } else if let Condition::ThisSpellPaidLabel(label) = inner.as_ref()
+                && label.eq_ignore_ascii_case("tribute")
+            {
+                "tribute wasn't paid".to_string()
             } else if let Condition::PlayerControls { player, filter } = inner.as_ref() {
                 let subject = describe_player_filter(player);
                 let mut described_filter = filter.clone();

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -108,27 +108,22 @@ pub(super) fn apply_trait_replacement(
         }
 
         ReplacementAction::Tribute { count, .. } => {
-            let Some(opponent) = game
-                .players
-                .iter()
-                .filter(|player| player.is_in_game() && player.id != effect.controller)
-                .map(|player| player.id)
-                .min_by_key(|player| player.0)
-            else {
+            let opponents = super::tribute_opponents(game, effect.controller);
+            if opponents.is_empty() {
                 return TraitApplyResult::Unchanged(event);
             };
-            let source_name = game
-                .object(effect.source)
-                .map(|object| object.name.clone())
-                .unwrap_or_else(|| "this creature".to_string());
-            let mut bool_ctx = crate::decisions::context::BooleanContext::new(
-                opponent,
-                Some(effect.source),
-                format!("Put {count} +1/+1 counters on {source_name}? (Tribute {count})"),
-            );
-            bool_ctx = bool_ctx.with_source_name(source_name);
+            let decision_ctx = if opponents.len() == 1 {
+                super::tribute_boolean_context(game, effect.source, opponents[0], *count)
+            } else {
+                super::tribute_opponent_choice_context(
+                    game,
+                    effect.source,
+                    effect.controller,
+                    &opponents,
+                )
+            };
             TraitApplyResult::NeedsInteraction {
-                decision_ctx: crate::decisions::context::DecisionContext::Boolean(bool_ctx),
+                decision_ctx,
                 redirect_zone: Zone::Battlefield,
                 effect_id: effect.id,
                 object_id: effect.source,

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -107,6 +107,36 @@ pub(super) fn apply_trait_replacement(
             }
         }
 
+        ReplacementAction::Tribute { count, .. } => {
+            let Some(opponent) = game
+                .players
+                .iter()
+                .filter(|player| player.is_in_game() && player.id != effect.controller)
+                .map(|player| player.id)
+                .min_by_key(|player| player.0)
+            else {
+                return TraitApplyResult::Unchanged(event);
+            };
+            let source_name = game
+                .object(effect.source)
+                .map(|object| object.name.clone())
+                .unwrap_or_else(|| "this creature".to_string());
+            let mut bool_ctx = crate::decisions::context::BooleanContext::new(
+                opponent,
+                Some(effect.source),
+                format!("Put {count} +1/+1 counters on {source_name}? (Tribute {count})"),
+            );
+            bool_ctx = bool_ctx.with_source_name(source_name);
+            TraitApplyResult::NeedsInteraction {
+                decision_ctx: crate::decisions::context::DecisionContext::Boolean(bool_ctx),
+                redirect_zone: Zone::Battlefield,
+                effect_id: effect.id,
+                object_id: effect.source,
+                filter: None,
+                destinations: None,
+            }
+        }
+
         ReplacementAction::Redirect { target, which } => {
             let modified = apply_trait_redirect(game, &event, target, which, effect.controller);
             match modified {
@@ -717,7 +747,7 @@ fn apply_trait_enter_untapped(event: &Event) -> Option<Event> {
     }
 }
 
-fn apply_trait_enter_with_counters(
+pub(super) fn apply_trait_enter_with_counters(
     event: &Event,
     counter_type: CounterType,
     count: u32,

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -35,13 +35,18 @@ use application::{
 };
 
 fn apply_tribute_response(
+    game: &GameState,
     event: Event,
     response: &InteractiveReplacementResponse,
+    source: ObjectId,
+    controller: PlayerId,
     counter_type: CounterType,
     count: u32,
     paid_label: &str,
     paid_labels: &mut Vec<String>,
+    dm: &mut dyn DecisionMaker,
 ) -> Event {
+    let response = resolve_tribute_response(game, response, source, controller, count, dm);
     if !matches!(response, InteractiveReplacementResponse::Accept) {
         return event;
     }
@@ -52,6 +57,101 @@ fn apply_tribute_response(
         paid_labels.push(paid_label.to_string());
     }
     apply_trait_enter_with_counters(&event, counter_type, count, &[], &[]).unwrap_or(event)
+}
+
+pub(super) fn tribute_opponents(game: &GameState, controller: PlayerId) -> Vec<PlayerId> {
+    let mut opponents = game
+        .players
+        .iter()
+        .filter(|player| player.is_in_game() && player.id != controller)
+        .map(|player| player.id)
+        .collect::<Vec<_>>();
+    opponents.sort_by_key(|player| player.0);
+    opponents
+}
+
+fn tribute_source_name(game: &GameState, source: ObjectId) -> String {
+    game.object(source)
+        .map(|object| object.name.clone())
+        .unwrap_or_else(|| "this creature".to_string())
+}
+
+pub(super) fn tribute_boolean_context(
+    game: &GameState,
+    source: ObjectId,
+    opponent: PlayerId,
+    count: u32,
+) -> crate::decisions::context::DecisionContext {
+    let source_name = tribute_source_name(game, source);
+    let bool_ctx = crate::decisions::context::BooleanContext::new(
+        opponent,
+        Some(source),
+        format!("Put {count} +1/+1 counters on {source_name}? (Tribute {count})"),
+    )
+    .with_source_name(source_name);
+    crate::decisions::context::DecisionContext::Boolean(bool_ctx)
+}
+
+pub(super) fn tribute_opponent_choice_context(
+    game: &GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    opponents: &[PlayerId],
+) -> crate::decisions::context::DecisionContext {
+    let source_name = tribute_source_name(game, source);
+    let options = opponents
+        .iter()
+        .enumerate()
+        .map(|(index, opponent)| {
+            let name = game
+                .player(*opponent)
+                .map(|player| player.name.clone())
+                .unwrap_or_else(|| format!("Player {}", opponent.index() + 1));
+            crate::decisions::context::SelectableOption::new(index, name)
+        })
+        .collect();
+    crate::decisions::context::DecisionContext::SelectOptions(
+        crate::decisions::context::SelectOptionsContext::new(
+            controller,
+            Some(source),
+            format!("Choose an opponent for {source_name}'s tribute"),
+            options,
+            1,
+            1,
+        ),
+    )
+}
+
+fn resolve_tribute_response(
+    game: &GameState,
+    response: &InteractiveReplacementResponse,
+    source: ObjectId,
+    controller: PlayerId,
+    count: u32,
+    dm: &mut dyn DecisionMaker,
+) -> InteractiveReplacementResponse {
+    let InteractiveReplacementResponse::Options(selected) = response else {
+        return response.clone();
+    };
+    let opponents = tribute_opponents(game, controller);
+    let Some(opponent) = selected
+        .first()
+        .and_then(|index| opponents.get(*index))
+        .copied()
+        .or_else(|| opponents.first().copied())
+    else {
+        return InteractiveReplacementResponse::Decline;
+    };
+    let crate::decisions::context::DecisionContext::Boolean(ctx) =
+        tribute_boolean_context(game, source, opponent, count)
+    else {
+        return InteractiveReplacementResponse::Decline;
+    };
+    if dm.decide_boolean(game, &ctx) {
+        InteractiveReplacementResponse::Accept
+    } else {
+        InteractiveReplacementResponse::Decline
+    }
 }
 
 fn replacement_effect_choice_description(game: &GameState, effect: &ReplacementEffect) -> String {
@@ -3084,12 +3184,16 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                         } = &chosen_effect.replacement
                         {
                             current_event = apply_tribute_response(
+                                game,
                                 current_event,
                                 &response,
+                                chosen_effect.source,
+                                chosen_effect.controller,
                                 *counter_type,
                                 *count,
                                 paid_label,
                                 &mut paid_labels,
+                                dm,
                             );
                             continue;
                         }
@@ -3159,12 +3263,16 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                     .map(|effect| effect.replacement)
                 {
                     current_event = apply_tribute_response(
+                        game,
                         *event,
                         &response,
+                        object_id,
+                        controller,
                         counter_type,
                         count,
                         &paid_label,
                         &mut paid_labels,
+                        dm,
                     );
                     continue;
                 }

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -29,7 +29,30 @@ use crate::replacement::{
 };
 use crate::types::CardType;
 use crate::zone::Zone;
-use application::{apply_trait_enter_tapped, apply_trait_replacement, find_matching_cards_in_hand};
+use application::{
+    apply_trait_enter_tapped, apply_trait_enter_with_counters, apply_trait_replacement,
+    find_matching_cards_in_hand,
+};
+
+fn apply_tribute_response(
+    event: Event,
+    response: &InteractiveReplacementResponse,
+    counter_type: CounterType,
+    count: u32,
+    paid_label: &str,
+    paid_labels: &mut Vec<String>,
+) -> Event {
+    if !matches!(response, InteractiveReplacementResponse::Accept) {
+        return event;
+    }
+    if !paid_labels
+        .iter()
+        .any(|existing| existing.eq_ignore_ascii_case(paid_label))
+    {
+        paid_labels.push(paid_label.to_string());
+    }
+    apply_trait_enter_with_counters(&event, counter_type, count, &[], &[]).unwrap_or(event)
+}
 
 fn replacement_effect_choice_description(game: &GameState, effect: &ReplacementEffect) -> String {
     match &effect.replacement {
@@ -2088,6 +2111,8 @@ pub struct EtbEventResult {
     pub set_base_power_toughness: Option<(i32, i32)>,
     /// If set, the controller to use as the object enters.
     pub controller_override: Option<crate::ids::PlayerId>,
+    /// Keyword payment labels set by as-enters replacements.
+    pub paid_labels: Vec<String>,
     /// An interactive replacement that requires player input.
     ///
     /// If present, the caller must:
@@ -2823,6 +2848,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
         etb_event_provenance,
     );
     let mut state = TraitEventProcessingState::default();
+    let mut paid_labels = Vec::new();
 
     loop {
         let copy_choice_consumed = copy_choice_effects
@@ -2896,6 +2922,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                         added_abilities: etb.added_abilities.clone(),
                         set_base_power_toughness: etb.set_base_power_toughness,
                         controller_override: etb.controller_override,
+                        paid_labels,
                         interactive_replacement: None,
                     };
                 }
@@ -3050,6 +3077,22 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                             _ => InteractiveReplacementResponse::Decline,
                         };
                         state.mark_applied(effect_id);
+                        if let ReplacementAction::Tribute {
+                            counter_type,
+                            count,
+                            paid_label,
+                        } = &chosen_effect.replacement
+                        {
+                            current_event = apply_tribute_response(
+                                current_event,
+                                &response,
+                                *counter_type,
+                                *count,
+                                paid_label,
+                                &mut paid_labels,
+                            );
+                            continue;
+                        }
                         let interactive_result = continue_interactive_replacement(
                             game,
                             &response,
@@ -3108,6 +3151,23 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                     _ => InteractiveReplacementResponse::Decline,
                 };
                 state.mark_applied(effect_id);
+                if let Some(ReplacementAction::Tribute {
+                    counter_type,
+                    count,
+                    paid_label,
+                }) = find_effect_for_choice(game, &current_additional_effects, effect_id)
+                    .map(|effect| effect.replacement)
+                {
+                    current_event = apply_tribute_response(
+                        *event,
+                        &response,
+                        counter_type,
+                        count,
+                        &paid_label,
+                        &mut paid_labels,
+                    );
+                    continue;
+                }
                 let interactive_result = continue_interactive_replacement(
                     game,
                     &response,

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -4729,6 +4729,7 @@ fn describe_filter_static_ability(ability_id: StaticAbilityId) -> Option<&'stati
         Flanking => Some("flanking"),
         Landwalk => Some("landwalk"),
         Bloodthirst => Some("bloodthirst"),
+        Tribute => Some("tribute"),
         Morph => Some("morph"),
         Disguise => Some("disguise"),
         Megamorph => Some("megamorph"),

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -4458,6 +4458,14 @@ impl GameState {
             }
         }
 
+        if !result.paid_labels.is_empty() {
+            if let Some(obj) = self.object_mut(new_id) {
+                for label in &result.paid_labels {
+                    obj.optional_costs_paid.mark_label_paid(label);
+                }
+            }
+        }
+
         for linked_old_id in &result.linked_exile_with_entering {
             if self.object(*linked_old_id).is_none() {
                 continue;

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -139,6 +139,13 @@ pub enum ReplacementAction {
         added_abilities: Vec<Ability>,
     },
 
+    /// As this enters, an opponent may put counters on it and mark a keyword paid.
+    Tribute {
+        counter_type: CounterType,
+        count: u32,
+        paid_label: String,
+    },
+
     /// Enter tapped
     EnterTapped,
 

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1053,6 +1053,49 @@ impl ReplacementMatcher for ThisWouldEnterWithBloodthirstMatcher {
     }
 }
 
+/// Tribute N.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Tribute {
+    pub amount: u32,
+}
+
+impl Tribute {
+    pub const fn new(amount: u32) -> Self {
+        Self { amount }
+    }
+}
+
+impl StaticAbilityKind for Tribute {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::Tribute
+    }
+
+    fn display(&self) -> String {
+        format!("Tribute {}", self.amount)
+    }
+
+    fn is_keyword(&self) -> bool {
+        true
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            ThisWouldEnterBattlefieldMatcher,
+            ReplacementAction::Tribute {
+                counter_type: CounterType::PlusOnePlusOne,
+                count: self.amount,
+                paid_label: "Tribute".to_string(),
+            },
+        ))
+    }
+}
+
 /// Enters the battlefield with counters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EntersWithCounters {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -1943,6 +1943,10 @@ impl StaticAbility {
         Self::new(Bloodthirst::new(amount))
     }
 
+    pub fn tribute(amount: u32) -> Self {
+        Self::new(Tribute::new(amount))
+    }
+
     pub fn morph(cost: crate::cost::TotalCost) -> Self {
         Self::new(Morph::new(cost))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -313,6 +313,7 @@ impl StaticAbilityModelInterpreter {
                 | StaticAbilityId::ReadAhead
                 | StaticAbilityId::Unleash
                 | StaticAbilityId::Bloodthirst
+                | StaticAbilityId::Tribute
                 | StaticAbilityId::Protection
                 | StaticAbilityId::Ward
                 | StaticAbilityId::Landwalk
@@ -1408,6 +1409,7 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::Bloodthirst(amount) => {
                 StaticAbility::bloodthirst(*amount)
             }
+            ironsmith_core::StaticAbilityPayload::Tribute(amount) => StaticAbility::tribute(*amount),
             ironsmith_core::StaticAbilityPayload::PreventDamageToSelfRemoveCounter {
                 counter_type,
                 amount,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thunder Brute
Initial parse error:
```
card ability compiled to unsupported static ability fallback KeywordFallbackText: Tribute 3; oracle-only fallback also failed: card ability compiled to unsupported static ability fallback KeywordFallbackText: Tribute 3
```

Current worker: i-0f5e6bc9caafcf431
Branch: codex/aws-card-fix-thunder-brute
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
