### PR TITLE
Fix Ironsmith parse failure: Discover the Impossible

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/quads.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/quads.rs
@@ -4,8 +4,9 @@ use super::super::super::dispatch_entry::{
     parse_if_you_dont_put_card_from_among_them_into_your_hand,
 };
 use crate::cards::builders::{
-    CardTextError, EffectAst, ObjectFilter, PlayerAst, PredicateAst, SubjectVerbActionAst,
-    SubjectVerbEffectAst, SubjectVerbRoleAst, TagKey, TargetAst,
+    CardTextError, EffectAst, IfResultPredicate, LibraryBottomOrderAst, ObjectFilter, PlayerAst,
+    PredicateAst, ReturnControllerAst, SubjectVerbActionAst, SubjectVerbEffectAst,
+    SubjectVerbRoleAst, TagKey, TargetAst,
 };
 use crate::effect::ChoiceCount;
 use crate::filter::TaggedObjectConstraint;
@@ -13,8 +14,10 @@ use crate::runtime_backend::effect_sentences;
 use crate::runtime_backend::effect_sentences::SentenceInput;
 use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use crate::runtime_backend::front_end::lexer::{LexedClause, OwnedLexToken};
+use crate::runtime_backend::object_filters::parse_object_filter_lexed;
 use crate::runtime_backend::util::{
-    helper_tag_for_tokens, parse_choice_count_token_prefix_consumed,
+    helper_tag_for_tokens, non_article_token_word_refs, parse_choice_count_token_prefix_consumed,
+    trim_commas,
 };
 use crate::target::TaggedOpbjectRelation;
 use crate::zone::Zone;
@@ -129,6 +132,28 @@ const OTHERWISE_PUT_REVEALED_CARDS_INTO_HAND_PATTERN: ClauseShape<'static> = cla
         ]
 );
 
+const EXILE_ONE_LOOKED_CARD_FACE_DOWN_REST_BOTTOM_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix & ["exile", "one", "of", "them", "face", "down"];
+    contains_phrases & [&["put", "rest"], &["bottom", "of", "your", "library"]]
+);
+
+const CAST_EXILED_CARD_FREE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact & [
+        "you", "may", "cast", "exiled", "card", "without", "paying", "its", "mana", "cost"
+    ]
+);
+
+const IF_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["if"]);
+
+const EXILED_CARD_HAND_FOLLOWUP_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["if", "you", "don't", "put", "that", "card", "into", "your", "hand"],
+            &["if", "you", "dont", "put", "that", "card", "into", "your", "hand"],
+            &["if", "you", "do", "not", "put", "that", "card", "into", "your", "hand"],
+        ]
+);
+
 fn named_revealed_card_filter(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
     let clause = LexedClause::new(tokens);
     if !NAMED_REVEALED_THIS_WAY_PATTERN.matches(clause) {
@@ -165,6 +190,53 @@ fn otherwise_puts_that_card_into_hand(tokens: &[OwnedLexToken]) -> bool {
 fn then_shuffle(tokens: &[OwnedLexToken]) -> bool {
     let clause = LexedClause::new(tokens).trimmed();
     THEN_SHUFFLE_PATTERN.matches(clause)
+}
+
+fn exiles_one_looked_card_face_down_and_bottoms_rest(tokens: &[OwnedLexToken]) -> bool {
+    let trimmed = trim_commas(tokens);
+    let words = non_article_token_word_refs(&trimmed);
+    EXILE_ONE_LOOKED_CARD_FACE_DOWN_REST_BOTTOM_PATTERN.matches_words(&words)
+}
+
+fn parse_exiled_card_cast_filter(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<ObjectFilter>, CardTextError> {
+    let trimmed = trim_commas(tokens);
+    let words = non_article_token_word_refs(&trimmed);
+    let Some(if_word_idx) = IF_WORD_PATTERN.find_word(&words) else {
+        return Ok(None);
+    };
+    if !CAST_EXILED_CARD_FREE_PREFIX_PATTERN.matches_words(&words[..if_word_idx]) {
+        return Ok(None);
+    }
+
+    let clause = LexedClause::new(&trimmed);
+    let Some(condition_token_idx) = clause.token_index_for_word_index(if_word_idx + 1) else {
+        return Ok(None);
+    };
+    let mut condition = trim_commas(&trimmed[condition_token_idx..]);
+    if let Some(first) = condition.first().and_then(|token| token.as_word())
+        && matches!(first, "it's" | "its" | "it" | "that" | "that's")
+    {
+        condition = trim_commas(&condition[1..]);
+    }
+    if let Some(first) = condition.first().and_then(|token| token.as_word())
+        && first == "card"
+    {
+        condition = trim_commas(&condition[1..]);
+    }
+
+    let mut filter = parse_object_filter_lexed(&condition, false)?;
+    if filter.zone == Some(Zone::Stack) {
+        filter.zone = None;
+    }
+    Ok(Some(filter))
+}
+
+fn puts_exiled_card_into_hand_if_not_cast(tokens: &[OwnedLexToken]) -> bool {
+    let trimmed = trim_commas(tokens);
+    let words = LexedClause::new(&trimmed).word_refs();
+    EXILED_CARD_HAND_FOLLOWUP_PATTERN.matches_words(&words)
 }
 
 fn parse_may_reveal_up_to_from_looked_cards(
@@ -359,6 +431,78 @@ pub(crate) fn parse_look_at_top_may_reveal_match_bargain_battlefield_else_hand_t
             PlayerAst::You,
             SubjectVerbActionAst::ShuffleLibrary,
         ),
+    ]))
+}
+
+pub(crate) fn parse_look_at_top_exile_one_rest_bottom_cast_else_hand(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Some((player, count, reveal_top)) =
+        effect_sentences::parse_top_cards_view_sentence(sentences[sentence_idx].lowered())
+    else {
+        return Ok(None);
+    };
+    if reveal_top {
+        return Ok(None);
+    }
+    if !exiles_one_looked_card_face_down_and_bottoms_rest(sentences[sentence_idx + 1].lowered()) {
+        return Ok(None);
+    }
+    let Some(cast_filter) = parse_exiled_card_cast_filter(sentences[sentence_idx + 2].lowered())?
+    else {
+        return Ok(None);
+    };
+    if !puts_exiled_card_into_hand_if_not_cast(sentences[sentence_idx + 3].lowered()) {
+        return Ok(None);
+    }
+
+    let looked_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "looked");
+    let exiled_tag = helper_tag_for_tokens(sentences[sentence_idx + 1].lowered(), "exiled");
+    let mut choice_filter = ObjectFilter::tagged(looked_tag.clone());
+    choice_filter.zone = Some(Zone::Library);
+
+    Ok(Some(vec![
+        EffectAst::subject_verb_look_at_top_cards(player, count, looked_tag.clone()),
+        EffectAst::ChooseObjects {
+            filter: choice_filter,
+            count: ChoiceCount::exactly(1),
+            count_value: None,
+            player,
+            tag: exiled_tag.clone(),
+        },
+        EffectAst::subject_verb_exile(TargetAst::Tagged(exiled_tag.clone(), None), true),
+        EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+            looked_tag,
+            Some(exiled_tag.clone()),
+            LibraryBottomOrderAst::Random,
+            player,
+        ),
+        EffectAst::May {
+            effects: vec![EffectAst::Conditional {
+                predicate: PredicateAst::TaggedMatches(exiled_tag.clone(), cast_filter),
+                if_true: vec![EffectAst::subject_verb_cast_tagged(
+                    exiled_tag.clone(),
+                    player,
+                    false,
+                    false,
+                    true,
+                    None,
+                )],
+                if_false: Vec::new(),
+            }],
+        },
+        EffectAst::IfResult {
+            predicate: IfResultPredicate::DidNot,
+            effects: vec![EffectAst::subject_verb_move_to_zone(
+                TargetAst::Tagged(exiled_tag, None),
+                Zone::Hand,
+                false,
+                ReturnControllerAst::Preserve,
+                false,
+                None,
+            )],
+        },
     ]))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -203,6 +203,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         parser: generic_subject_verb_sequences::quads::parse_look_at_top_put_counted_into_hand_rest_bottom_with_kicker_override,
     },
     SequenceRuleDef {
+        name: "look-at-top-exile-one-rest-bottom-cast-else-hand",
+        feature_tag: Some("looked-card-exile-cast-else-hand"),
+        priority: 430,
+        consumed_sentences: 4,
+        predicate: first_word_look,
+        parser: generic_subject_verb_sequences::quads::parse_look_at_top_exile_one_rest_bottom_cast_else_hand,
+    },
+    SequenceRuleDef {
         name: "look-at-top-may-put-match-onto-battlefield-if-not-put-into-hand-rest-bottom",
         feature_tag: Some("looked-cards-battlefield-or-hand"),
         priority: 429,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -12,6 +12,7 @@ use crate::effects::{
     TagTriggeringObjectEffect, TaggedEffect, TargetOnlyEffect, UntapEffect, WithIdEffect,
 };
 use crate::filter::ObjectFilterExt;
+use crate::ids::StableId;
 use crate::object::AuraAttachmentFilter;
 use crate::static_abilities::StaticAbilityId;
 use crate::target::{ChooseSpec, ObjectRef, PlayerFilter, SourceReferenceSurface};
@@ -40365,6 +40366,257 @@ fn parse_oracle_warp_world_strict_parse_and_render_regression() {
     assert!(
         !rendered.contains("tagged '") && !rendered.contains("tagged object"),
         "expected Warp World to avoid internal tagged-object markers, got {rendered}"
+    );
+}
+
+#[test]
+fn parse_oracle_discover_the_impossible_strict_parse_and_render_regression() {
+    let def = parse_oracle_card_definition("Discover the Impossible");
+
+    let debug = format!("{def:#?}").to_ascii_lowercase();
+    assert!(
+        debug.contains("lookattopcardseffect")
+            && debug.contains("chooseobjectseffect")
+            && debug.contains("exileeffect")
+            && debug.contains("puttaggedremainderonlibrarybottomeffect")
+            && debug.contains("casttaggedeffect")
+            && debug.contains("conditionaleffect")
+            && debug.contains("didnothappen"),
+        "expected Discover the Impossible to compile to look/choose/exile/remainder/conditional-cast/fallback-hand effects, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "Look at the top five cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost if it's an instant spell with mana value 2 or less. If you don't, put that card into your hand."
+    );
+    assert!(
+        !rendered.contains("tagged '") && !rendered.contains("tagged object"),
+        "Discover the Impossible rendered text should not leak internal tagged-object markers: {rendered}"
+    );
+}
+
+fn discover_the_impossible_definition() -> CardDefinition {
+    parse_oracle_card_definition("Discover the Impossible")
+}
+
+fn one_mana_instant_card(id: u32, name: &str) -> crate::card::Card {
+    instant_card_with_mana_value(id, name, 1)
+}
+
+fn three_mana_instant_card(id: u32, name: &str) -> crate::card::Card {
+    instant_card_with_mana_value(id, name, 3)
+}
+
+fn instant_card_with_mana_value(id: u32, name: &str, mana_value: u8) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(
+            mana_value,
+        )]))
+        .build()
+}
+
+fn one_mana_creature_card(id: u32, name: &str) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(1)]))
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build()
+}
+
+fn resolve_discover_the_impossible_with<D: crate::decision::DecisionMaker>(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    decision_maker: &mut D,
+) {
+    let discover = discover_the_impossible_definition();
+    let source_id = game.create_object_from_definition(&discover, controller, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(source_id, controller));
+    crate::game_loop::resolve_stack_entry_with(game, decision_maker)
+        .expect("Discover the Impossible should resolve");
+}
+
+fn discover_test_zones_by_stable(
+    game: &crate::game_state::GameState,
+    stable_ids: &[StableId],
+) -> Vec<String> {
+    stable_ids
+        .iter()
+        .map(|&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .map(|object| format!("{}:{:?}", object.name, object.zone))
+                .unwrap_or_else(|| format!("{stable_id:?}:missing"))
+        })
+        .collect()
+}
+
+#[test]
+fn discover_the_impossible_casts_chosen_small_instant_and_bottoms_rest() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let mut library_stables = Vec::new();
+    for idx in 0..5 {
+        let card = one_mana_instant_card(90_100 + idx, &format!("Discover Instant {idx}"));
+        let id = game.create_object_from_card(&card, alice, Zone::Library);
+        library_stables.push(game.object(id).expect("library card exists").stable_id);
+    }
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    resolve_discover_the_impossible_with(&mut game, alice, &mut dm);
+
+    let cast_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Stack)
+        })
+        .count();
+    let bottomed_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Library)
+        })
+        .count();
+    assert_eq!(
+        cast_count,
+        1,
+        "one selected small instant should be cast from exile; zones={:?}",
+        discover_test_zones_by_stable(&game, &library_stables)
+    );
+    assert_eq!(
+        bottomed_count, 4,
+        "the four unchosen looked-at cards should remain in the library as the bottomed rest"
+    );
+}
+
+#[test]
+fn discover_the_impossible_declined_cast_puts_exiled_card_into_hand() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let mut library_stables = Vec::new();
+    for idx in 0..5 {
+        let card = one_mana_instant_card(
+            90_200 + idx,
+            &format!("Declined Discover Instant {idx}"),
+        );
+        let id = game.create_object_from_card(&card, alice, Zone::Library);
+        library_stables.push(game.object(id).expect("library card exists").stable_id);
+    }
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    resolve_discover_the_impossible_with(&mut game, alice, &mut dm);
+
+    let hand_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Hand)
+        })
+        .count();
+    let library_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Library)
+        })
+        .count();
+    assert_eq!(
+        hand_count,
+        1,
+        "declining the free cast should put that card into hand; zones={:?}",
+        discover_test_zones_by_stable(&game, &library_stables)
+    );
+    assert_eq!(
+        library_count, 4,
+        "declining should still bottom the unchosen cards"
+    );
+}
+
+#[test]
+fn discover_the_impossible_noninstant_choice_goes_to_hand_not_stack() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let mut library_stables = Vec::new();
+    for idx in 0..5 {
+        let card = one_mana_creature_card(90_300 + idx, &format!("Discover Creature {idx}"));
+        let id = game.create_object_from_card(&card, alice, Zone::Library);
+        library_stables.push(game.object(id).expect("library card exists").stable_id);
+    }
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    resolve_discover_the_impossible_with(&mut game, alice, &mut dm);
+
+    let stack_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Stack)
+        })
+        .count();
+    let hand_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Hand)
+        })
+        .count();
+    assert_eq!(stack_count, 0, "a noninstant exiled card should not be cast");
+    assert_eq!(
+        hand_count,
+        1,
+        "a chosen noninstant should move to hand through the if-you-don't branch; zones={:?}",
+        discover_test_zones_by_stable(&game, &library_stables)
+    );
+}
+
+#[test]
+fn discover_the_impossible_large_instant_choice_goes_to_hand_not_stack() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let mut library_stables = Vec::new();
+    for idx in 0..5 {
+        let card = three_mana_instant_card(90_400 + idx, &format!("Discover Large Instant {idx}"));
+        let id = game.create_object_from_card(&card, alice, Zone::Library);
+        library_stables.push(game.object(id).expect("library card exists").stable_id);
+    }
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    resolve_discover_the_impossible_with(&mut game, alice, &mut dm);
+
+    let stack_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Stack)
+        })
+        .count();
+    let hand_count = library_stables
+        .iter()
+        .filter(|&&stable_id| {
+            game.find_object_by_stable_id(stable_id)
+                .and_then(|id| game.object(id))
+                .is_some_and(|object| object.zone == Zone::Hand)
+        })
+        .count();
+    assert_eq!(
+        stack_count, 0,
+        "an instant above the mana-value limit should not be cast"
+    );
+    assert_eq!(
+        hand_count,
+        1,
+        "an instant above the mana-value limit should move to hand through the if-you-don't branch; zones={:?}",
+        discover_test_zones_by_stable(&game, &library_stables)
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1257,6 +1257,119 @@ fn describe_hideaway_effects(effects: &[&Effect]) -> Option<String> {
     ))
 }
 
+fn describe_look_exile_one_rest_bottom_cast_else_hand(effects: &[&Effect]) -> Option<String> {
+    let [look_effect, choose_effect, exile_effect, rest_effect, may_effect, fallback_effect] =
+        effects
+    else {
+        return None;
+    };
+    let look = look_effect.downcast_ref::<crate::effects::LookAtTopCardsEffect>()?;
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let exile = exile_effect.downcast_ref::<crate::effects::ExileEffect>()?;
+    let rest =
+        rest_effect.downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()?;
+    let with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let may = with_id.effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let if_effect = fallback_effect.downcast_ref::<crate::effects::IfEffect>()?;
+
+    if look.player != PlayerFilter::You
+        || look.reveal
+        || !choose.count.is_single()
+        || choose.chooser != PlayerFilter::You
+        || choose_primary_zone(choose) != Some(Zone::Library)
+        || !choose.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag == look.tag
+        })
+        || !matches!(exile.spec.base(), ChooseSpec::Tagged(tag) if tag == &choose.tag)
+        || !exile.face_down
+        || rest.tag != look.tag
+        || rest.keep_tagged.as_ref() != Some(&choose.tag)
+        || rest.player != PlayerFilter::You
+        || rest.order != LibraryBottomOrder::Random
+        || may.decider.is_some()
+        || if_effect.condition != with_id.id
+        || if_effect.predicate != EffectPredicate::DidNotHappen
+        || !if_effect.else_.is_empty()
+    {
+        return None;
+    }
+
+    let [conditional_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let Condition::TaggedObjectMatches(condition_tag, filter) = &conditional.condition else {
+        return None;
+    };
+    let [cast_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    if !conditional.if_false.is_empty() {
+        return None;
+    }
+    let cast = cast_effect.downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    if condition_tag != &choose.tag
+        || cast.tag != choose.tag
+        || cast.player != PlayerFilter::You
+        || cast.allow_land
+        || cast.as_copy
+        || !cast.without_paying_mana_cost
+        || cast.cost_reduction.is_some()
+    {
+        return None;
+    }
+
+    let [hand_effect] = if_effect.then.as_slice() else {
+        return None;
+    };
+    let hand_move = unwrap_basic_tag_wrappers(hand_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if hand_move.zone != Zone::Hand
+        || !matches!(hand_move.target.base(), ChooseSpec::Tagged(tag) if tag == &choose.tag)
+    {
+        return None;
+    }
+
+    let (count_text, noun, _) = describe_look_count_and_noun(&look.count);
+    let condition_text = describe_exiled_card_cast_condition(filter)?;
+    Some(format!(
+        "Look at the top {count_text} {noun} of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. You may cast the exiled card without paying its mana cost if {condition_text}. If you don't, put that card into your hand"
+    ))
+}
+
+fn describe_exiled_card_cast_condition(filter: &ObjectFilter) -> Option<String> {
+    let mut display_filter = filter.clone();
+    display_filter.zone = None;
+    display_filter.has_mana_cost = false;
+    if display_filter.card_types.len() == 1 {
+        let card_type = display_filter.card_types[0].to_string().to_ascii_lowercase();
+        let spell_text = with_indefinite_article(&format!("{card_type} spell"));
+        let mana_value = display_filter.mana_value.clone();
+        let mut remaining_filter = display_filter.clone();
+        remaining_filter.card_types.clear();
+        remaining_filter.mana_value = None;
+        if remaining_filter == ObjectFilter::default() {
+            match mana_value.as_ref() {
+                Some(crate::filter::Comparison::LessThanOrEqual(value)) => {
+                    return Some(format!(
+                        "it's {spell_text} with mana value {value} or less"
+                    ));
+                }
+                Some(crate::filter::Comparison::LessThanOrEqualExpr(value)) => {
+                    return Some(format!(
+                        "it's {spell_text} with mana value {} or less",
+                        describe_value(value)
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+    let desc = strip_indefinite_article(&display_filter.description()).to_ascii_lowercase();
+    Some(format!("it's {}", with_indefinite_article(&desc)))
+}
+
 fn describe_exile_targets_opponent_piles_return_chosen(effects: &[&Effect]) -> Option<String> {
     let [
         exile_effect,
@@ -6473,6 +6586,11 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
     if filtered.len() == 4
         && let Some(compact) = describe_hideaway_effects(&filtered)
+    {
+        return compact;
+    }
+    if filtered.len() == 6
+        && let Some(compact) = describe_look_exile_one_rest_bottom_cast_else_hand(&filtered)
     {
         return compact;
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Discover the Impossible
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-0e10c2823b6ac38de
Branch: codex/aws-card-fix-discover-the-impossible
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
