### PR TITLE
Fix Ironsmith parse failure: Battle for Bretagard

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -14,7 +14,7 @@ use super::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape}
 use super::grammar::primitives::{self as grammar_primitives, split_lexed_slices_on_or};
 use super::keyword_static::parse_pt_modifier;
 use super::lexer::{
-    OwnedLexToken, TokenWordView, find_token_word, token_slice_at_is,
+    OwnedLexToken, TokenWordView, find_token_word, parser_token_word_refs, token_slice_at_is,
     word_slice_contains_any_phrase, word_slice_find_phrase_start,
 };
 use super::util::{
@@ -160,6 +160,13 @@ const OBJECT_FILTER_LIBRARY_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["in", "library"], &["from", "library"]]);
 const OBJECT_FILTER_EXILE_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["in", "exile"], &["from", "exile"]]);
+const OBJECT_FILTER_DIFFERENT_NAMES_CLAUSE_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["with", "different", "names"],
+            &["that", "have", "different", "names"]
+        ]
+);
 
 fn word_slice_match<'a>(
     expected: &str,
@@ -452,6 +459,29 @@ pub(super) fn trim_vote_winner_suffix(tokens: &[OwnedLexToken]) -> (Vec<OwnedLex
     (trim_commas(&tokens[..token_end]), true)
 }
 
+fn strip_object_filter_different_names_clause(
+    tokens: &[OwnedLexToken],
+) -> (Vec<OwnedLexToken>, bool) {
+    let mut cursor = 0usize;
+    while cursor < tokens.len() {
+        for pattern_len in [3usize, 4usize] {
+            if cursor + pattern_len <= tokens.len()
+                && OBJECT_FILTER_DIFFERENT_NAMES_CLAUSE_PATTERN.matches_words(
+                    &parser_token_word_refs(&tokens[cursor..cursor + pattern_len]),
+                )
+            {
+                let mut stripped = Vec::with_capacity(tokens.len() - pattern_len);
+                stripped.extend_from_slice(&tokens[..cursor]);
+                stripped.extend_from_slice(&tokens[cursor + pattern_len..]);
+                return (trim_commas(&stripped), true);
+            }
+        }
+        cursor += 1;
+    }
+
+    (trim_commas(tokens), false)
+}
+
 pub(super) fn apply_parity_filter_phrases(words: &[&str], filter: &mut ObjectFilter) {
     if OBJECT_FILTER_ODD_MANA_VALUE_PATTERN.matches_words(words) {
         filter.mana_value_parity = Some(ParityRequirement::Odd);
@@ -742,7 +772,9 @@ pub(crate) fn parse_object_filter(
     tokens: &[OwnedLexToken],
     other: bool,
 ) -> Result<ObjectFilter, CardTextError> {
-    if let Some(with_idx) = find_token_word(tokens, "with") {
+    let (tokens, distinct_names) = strip_object_filter_different_names_clause(tokens);
+    let tokens = tokens.as_slice();
+    let mut filter = if let Some(with_idx) = find_token_word(tokens, "with") {
         let base_tokens = trim_commas(&tokens[..with_idx]);
         let tail_words = crate::runtime_backend::token_word_refs(&tokens[with_idx + 1..]);
         if !base_tokens.is_empty()
@@ -758,9 +790,8 @@ pub(crate) fn parse_object_filter(
                 other,
             )?;
             filter.without_counter = Some(counter_constraint);
-            return Ok(filter);
-        }
-        if !base_tokens.is_empty()
+            filter
+        } else if !base_tokens.is_empty()
             && let Some((counter_constraint, consumed)) =
                 parse_filter_counter_constraint_words(&tail_words)
             && consumed == tail_words.len()
@@ -770,10 +801,15 @@ pub(crate) fn parse_object_filter(
                 other,
             )?;
             filter.with_counter = Some(counter_constraint);
-            return Ok(filter);
+            filter
+        } else {
+            super::grammar::filters::parse_object_filter_with_grammar_entrypoint(tokens, other)?
         }
-    }
-    super::grammar::filters::parse_object_filter_with_grammar_entrypoint(tokens, other)
+    } else {
+        super::grammar::filters::parse_object_filter_with_grammar_entrypoint(tokens, other)?
+    };
+    filter.distinct_names |= distinct_names;
+    Ok(filter)
 }
 
 pub(crate) fn parse_object_filter_lexed(
@@ -781,7 +817,10 @@ pub(crate) fn parse_object_filter_lexed(
     other: bool,
 ) -> Result<ObjectFilter, CardTextError> {
     let (trimmed_tokens, vote_winners_only) = trim_vote_winner_suffix(tokens);
+    let (trimmed_tokens, distinct_names) =
+        strip_object_filter_different_names_clause(&trimmed_tokens);
     if let Some(mut filter) = parse_simple_object_filter_lexed(&trimmed_tokens, other) {
+        filter.distinct_names |= distinct_names;
         if vote_winners_only {
             filter = filter.match_tagged(
                 TagKey::from(VOTE_WINNERS_TAG),
@@ -790,7 +829,9 @@ pub(crate) fn parse_object_filter_lexed(
         }
         return Ok(filter);
     }
-    parse_object_filter(&trimmed_tokens, other)
+    let mut filter = parse_object_filter(&trimmed_tokens, other)?;
+    filter.distinct_names |= distinct_names;
+    Ok(filter)
 }
 
 pub(crate) fn spell_filter_has_identity(filter: &ObjectFilter) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
@@ -264,6 +264,9 @@ pub(crate) fn has_divided_evenly_clause_sentence_lexed(words: &[&str]) -> bool {
 }
 
 pub(crate) fn has_different_names_clause_sentence_lexed(words: &[&str]) -> bool {
+    if words.first().is_some_and(|word| *word == "choose") {
+        return false;
+    }
     DIFFERENT_NAMES_PATTERN.matches_words(words)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -112,8 +112,13 @@ const OR_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["or"]);
 const YOU_OR_OWN_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["you"], &["own"]]);
 const YOU_OWN_PATTERN: ClauseShape<'static> = clause_shape!(contains_phrases & [&["you", "own"]]);
-const FOR_EACH_OF_THOSE_PREFIX_PATTERN: ClauseShape<'static> =
-    clause_shape!(prefix & ["for", "each", "of", "those"]);
+const FOR_EACH_OF_THOSE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["for", "each", "of", "those"],
+            &["for", "each", "of", "them"]
+        ]
+);
 const AND_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["and"]);
 const ARTICLE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["a"], &["an"]]);
 const SEARCH_YOUR_LIBRARY_FOR_PREFIX_PATTERN: ClauseShape<'static> =
@@ -1156,7 +1161,7 @@ fn parse_reveal_from_outside_game_to_hand(
 fn parse_choose_objects_then_for_each_of_those_bundle(
     first: &[OwnedLexToken],
     second: &[OwnedLexToken],
-    third: &[OwnedLexToken],
+    third: Option<&[OwnedLexToken]>,
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
     let mut normalized_first = first.to_vec();
     for token in &mut normalized_first {
@@ -1191,11 +1196,6 @@ fn parse_choose_objects_then_for_each_of_those_bundle(
         return Ok(None);
     }
 
-    let trailing_effects = effect_sentences::parse_effect_sentence_lexed(third)?;
-    if trailing_effects.is_empty() {
-        return Ok(None);
-    }
-
     let mut combined = vec![EffectAst::ChooseObjects {
         filter,
         count,
@@ -1207,7 +1207,13 @@ fn parse_choose_objects_then_for_each_of_those_bundle(
         tag: choose_tag,
         effects: loop_body_effects,
     });
-    combined.extend(trailing_effects);
+    if let Some(third) = third {
+        let trailing_effects = effect_sentences::parse_effect_sentence_lexed(third)?;
+        if trailing_effects.is_empty() {
+            return Ok(None);
+        }
+        combined.extend(trailing_effects);
+    }
     Ok(Some(combined))
 }
 
@@ -2090,8 +2096,14 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
         && let Ok(Some(effects)) = parse_choose_objects_then_for_each_of_those_bundle(
             sentences[0],
             sentences[1],
-            sentences[2],
+            Some(sentences[2]),
         )
+    {
+        return Some(effects);
+    }
+    if sentences.len() == 2
+        && let Ok(Some(effects)) =
+            parse_choose_objects_then_for_each_of_those_bundle(sentences[0], sentences[1], None)
     {
         return Some(effects);
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36985,6 +36985,44 @@ fn parse_oracle_elemental_teachings_divvy_surface_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_battle_for_bretagard_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Battle for Bretagard");
+    let rendered = debug_compiled_lines(&def).join(" ").to_ascii_lowercase();
+
+    assert!(
+        rendered.contains(
+            "choose any number of artifact tokens and/or creature tokens you control with different names. for each of them, create a token that's a copy of it"
+        ),
+        "expected Battle for Bretagard chapter III to render its distinct-name token-copy choice, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("ChooseObjectsEffect")
+            && debug.contains("distinct_names: true")
+            && debug.contains("token: true")
+            && debug.contains("ForEachTaggedEffect")
+            && debug.contains("CreateTokenCopyEffect"),
+        "expected Battle for Bretagard to preserve a structural distinct-name token choice and per-object copy, got {debug}"
+    );
+
+    let oracle = oracle_text_by_name()
+        .get("Battle for Bretagard")
+        .expect("missing Battle for Bretagard oracle text");
+    let rendered_lines = debug_compiled_lines(&def);
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_card_semantics_scored(
+            "Battle for Bretagard",
+            oracle,
+            &rendered_lines,
+            crate::semantic_compare::report_embedding_config(),
+        );
+    assert!(similarity >= 0.99, "expected >=0.99 similarity, got {similarity}");
+    assert!(!mismatch, "expected no semantic mismatch, got {rendered}");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_split_the_spoils_divvy_uses_splitter_then_opponent_choice() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Split the Spoils")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -20798,7 +20798,9 @@ pub(super) fn describe_choose_then_for_each_copy(
     }
     let create_copy =
         for_each.effects[0].downcast_ref::<crate::effects::CreateTokenCopyEffect>()?;
-    if !matches!(create_copy.target, ChooseSpec::Tagged(ref tag) if tag == &choose.tag) {
+    if !matches!(create_copy.target, ChooseSpec::Iterated)
+        && !matches!(create_copy.target, ChooseSpec::Tagged(ref tag) if tag == &choose.tag)
+    {
         return None;
     }
     if create_copy.controller != PlayerFilter::You
@@ -20822,13 +20824,31 @@ pub(super) fn describe_choose_then_for_each_copy(
         return None;
     }
 
-    let selected = describe_choose_spec(
-        &ChooseSpec::target(ChooseSpec::Object(choose.filter.clone())).with_count(choose.count),
-    );
-    Some(format!(
-        "For each of {selected}, create {} tokens that are copies of that permanent",
-        describe_value(&create_copy.count)
-    ))
+    let selected = if choose.count.min == 0
+        && choose.count.max.is_none()
+        && !choose.count.dynamic_x
+        && !choose.count.up_to_x
+        && !choose.count.random
+        && choose.filter.token
+        && choose.filter.distinct_names
+        && choose.filter.controller == Some(PlayerFilter::You)
+        && choose.filter.card_types.len() == 2
+        && choose.filter.card_types.contains(&CardType::Artifact)
+        && choose.filter.card_types.contains(&CardType::Creature)
+    {
+        "any number of artifact tokens and/or creature tokens you control with different names"
+            .to_string()
+    } else {
+        describe_choose_spec(&ChooseSpec::Object(choose.filter.clone()).with_count(choose.count))
+    };
+    let copy_action = match create_copy.count {
+        Value::Fixed(1) => "create a token that's a copy of it".to_string(),
+        _ => format!(
+            "create {} tokens that are copies of it",
+            describe_value(&create_copy.count)
+        ),
+    };
+    Some(format!("Choose {selected}. For each of them, {copy_action}"))
 }
 
 pub(super) fn describe_choose_then_cant_pile_restriction(

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1751,6 +1751,24 @@ fn tom_bombadil_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn battle_for_bretagard_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_929), "Battle for Bretagard")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Saga])
+        .from_text_with_metadata(
+            "I — Create a 1/1 white Human Warrior creature token.\n\
+             II — Create a 1/1 green Elf Warrior creature token.\n\
+             III — Choose any number of artifact tokens and/or creature tokens you control with different names. For each of them, create a token that's a copy of it.",
+        )
+        .expect("Battle for Bretagard should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn interface_ace_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_925), "Interface Ace")
         .mana_cost(ManaCost::from_pips(vec![
@@ -44321,6 +44339,114 @@ fn tom_bombadil_strict_parser_and_compiled_text_regression() {
         triggered.intervening_if,
         Some(crate::ConditionExpr::MaxTimesEachTurn(1))
     ));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn battle_for_bretagard_chapters_create_and_copy_distinct_named_tokens() {
+    struct SelectAllObjects;
+
+    impl DecisionMaker for SelectAllObjects {
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .collect()
+        }
+    }
+
+    fn count_controlled_named_tokens(game: &GameState, controller: PlayerId, name: &str) -> usize {
+        game.battlefield
+            .iter()
+            .filter(|&&id| {
+                game.object(id).is_some_and(|object| {
+                    object.name == name
+                        && matches!(object.kind, ObjectKind::Token)
+                        && game.controller_of(object) == controller
+                })
+            })
+            .count()
+    }
+
+    fn resolve_next_chapter(
+        game: &mut GameState,
+        trigger_queue: &mut TriggerQueue,
+        saga_id: ObjectId,
+        dm: &mut SelectAllObjects,
+    ) {
+        add_lore_counter_and_check_chapters(game, saga_id, trigger_queue);
+        put_triggers_on_stack_with_dm(game, trigger_queue, dm)
+            .expect("Battle for Bretagard chapter trigger should go on the stack");
+        resolve_stack_entry_with_dm_and_triggers(game, dm, trigger_queue)
+            .expect("Battle for Bretagard chapter trigger should resolve");
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectAllObjects;
+
+    let battle_id = game.create_object_from_definition(
+        &battle_for_bretagard_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    resolve_next_chapter(&mut game, &mut trigger_queue, battle_id, &mut dm);
+    assert_eq!(count_controlled_named_tokens(&game, alice, "Human"), 1);
+
+    resolve_next_chapter(&mut game, &mut trigger_queue, battle_id, &mut dm);
+    assert_eq!(count_controlled_named_tokens(&game, alice, "Elf"), 1);
+
+    let treasure = CardDefinitionBuilder::new(CardId::from_raw(72_930), "Treasure")
+        .token()
+        .card_types(vec![CardType::Artifact])
+        .build();
+    for controller in [alice, alice, bob] {
+        let treasure_id =
+            game.create_object_from_definition(&treasure, controller, Zone::Battlefield);
+        game.object_mut(treasure_id)
+            .expect("Treasure token should exist")
+            .kind = ObjectKind::Token;
+    }
+    create_creature(&mut game, "Nontoken Guard", alice, 2, 2);
+
+    resolve_next_chapter(&mut game, &mut trigger_queue, battle_id, &mut dm);
+
+    assert_eq!(
+        count_controlled_named_tokens(&game, alice, "Human"),
+        2,
+        "chapter III should copy the Human token chosen from chapter I"
+    );
+    assert_eq!(
+        count_controlled_named_tokens(&game, alice, "Elf"),
+        2,
+        "chapter III should copy the Elf token chosen from chapter II"
+    );
+    assert_eq!(
+        count_controlled_named_tokens(&game, alice, "Treasure"),
+        3,
+        "chapter III should copy only one of two same-named Treasure tokens"
+    );
+    assert_eq!(
+        count_controlled_named_tokens(&game, bob, "Treasure"),
+        1,
+        "chapter III should not choose or copy opponents' tokens"
+    );
+    assert!(
+        game.battlefield.iter().all(|&id| {
+            game.object(id).is_none_or(|object| {
+                object.name != "Nontoken Guard" || !matches!(object.kind, ObjectKind::Token)
+            })
+        }),
+        "the nontoken creature should not be copied by the token-only choice"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Battle for Bretagard
Initial parse error:
```
unsupported different-names selection clause (clause: 'choose any number of artifact tokens and or creature tokens you control with different names') [rule=different-names]; oracle-only fallback also failed: unsupported different-names selection clause (clause: 'choose any number of artifact tokens and or creature tokens you control with different names') [rule=different-names]
```

Current worker: i-0b0826daf7fe0554c
Branch: codex/aws-card-fix-battle-for-bretagard
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
