### PR TITLE
Fix Ironsmith parse failure: Dread Wight

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -187,6 +187,8 @@ const BEGINNING_DRAW_STEP_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "draw", "step"]);
 const BEGINNING_COMBAT_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "combat"]);
+const END_OF_COMBAT_TRIGGER_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["end", "of", "combat"], &["the", "end", "of", "combat"]]);
 const BEGINNING_FIRST_MAIN_PHASE_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "first", "main", "phase"]);
 const BEGINNING_SECOND_MAIN_PHASE_TRIGGER_PATTERN: ClauseShape<'static> =
@@ -4073,6 +4075,7 @@ pub(crate) fn parse_trigger_clause_lexed(
         _ if BEGINNING_COMBAT_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfCombat(parse_possessive_clause_player_filter(&words)),
         ),
+        _ if END_OF_COMBAT_TRIGGER_PATTERN.matches_words(&words) => Ok(TriggerSpec::EndOfCombat),
         _ => Err(CardTextError::ParseError(format!(
             "unsupported trigger clause (clause: '{}')",
             words.join(" ")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -373,6 +373,7 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::BeginningOfUpkeep(player) => Trigger::beginning_of_upkeep(player),
         TriggerSpec::BeginningOfDrawStep(player) => Trigger::beginning_of_draw_step(player),
         TriggerSpec::BeginningOfCombat(player) => Trigger::beginning_of_combat(player),
+        TriggerSpec::EndOfCombat => Trigger::end_of_combat(),
         TriggerSpec::BeginningOfEndStep(player) => Trigger::beginning_of_end_step(player),
         TriggerSpec::BeginningOfPrecombatMain(player) => {
             Trigger::beginning_of_precombat_main_phase(player)
@@ -502,6 +503,7 @@ fn trigger_binds_iterated_player(trigger: &TriggerSpec) -> bool {
         | TriggerSpec::BeginningOfUpkeep(_)
         | TriggerSpec::BeginningOfDrawStep(_)
         | TriggerSpec::BeginningOfCombat(_)
+        | TriggerSpec::EndOfCombat
         | TriggerSpec::BeginningOfEndStep(_)
         | TriggerSpec::BeginningOfPrecombatMain(_)
         | TriggerSpec::BeginningOfPostcombatMain(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime_backend::GrantedAbilityAst;
 use crate::runtime_backend::ast::{SubjectVerbEffectAst, SubjectVerbSubjectAst};
 use crate::runtime_backend::grammar::structure::{
     StatementLineFamily, classify_statement_line_family_lexed,
@@ -875,6 +876,85 @@ pub(crate) fn lower_special_rewrite_triggered_chunk(
             }],
             max_triggers_per_turn: line.max_triggers_per_turn,
         }));
+    }
+
+    let effect_sentences = split_lexed_sentences(effect_parse_tokens);
+    if effect_sentences.len() == 3 {
+        let second_words = crate::runtime_backend::token_word_refs(effect_sentences[1]);
+        if word_slice_contains_word(&second_words, "untap")
+            && word_slice_contains_word(&second_words, "counter")
+            && word_slice_contains_phrase(&second_words, &["for", "as", "long", "as"])
+        {
+            let trigger = parse_trigger_clause_lexed(trigger_parse_tokens)?;
+            let first_effects = parse_effect_sentences_lexed(effect_sentences[0])?;
+            let third_effects = parse_effect_sentences_lexed(effect_sentences[2])?;
+            let counter_parts = first_effects.iter().find_map(|effect| {
+                let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                    action:
+                        SubjectVerbActionAst::PutCountersAll {
+                            counter_type,
+                            count,
+                            filter,
+                        },
+                    ..
+                }) = effect
+                else {
+                    return None;
+                };
+                let mut source_with_counter = ObjectFilter::source();
+                source_with_counter.with_counter = Some(
+                    crate::filter::CounterConstraint::Typed(*counter_type),
+                );
+                let ability = crate::static_abilities::StaticAbility::restriction(
+                    crate::effect::Restriction::untap(ObjectFilter::source()),
+                    "This creature doesn't untap during its controller's untap step".to_string(),
+                )
+                .with_condition(crate::ConditionExpr::SourceMatches(source_with_counter));
+                Some((
+                    *counter_type,
+                    count.clone(),
+                    filter.clone(),
+                    EffectAst::subject_verb_grant_abilities_all(
+                        filter.clone(),
+                        vec![GrantedAbilityAst::StaticAbility(ability)],
+                        crate::effect::Until::Forever,
+                    ),
+                ))
+            });
+            let granted_activation = third_effects.into_iter().find_map(|effect| {
+                let EffectAst::SubjectVerb(SubjectVerbEffectAst { action, .. }) = effect else {
+                    return None;
+                };
+                match action {
+                    SubjectVerbActionAst::GrantAbilitiesAll {
+                        abilities,
+                        duration,
+                        ..
+                    }
+                    | SubjectVerbActionAst::GrantAbilitiesToTarget {
+                        abilities,
+                        duration,
+                        ..
+                    } => Some((abilities, duration)),
+                    _ => None,
+                }
+            });
+            if let (Some((counter_type, count, filter, counter_grant)), Some((abilities, duration))) =
+                (counter_parts, granted_activation)
+            {
+                let effects = vec![
+                    EffectAst::subject_verb_put_counters_all(counter_type, count, filter.clone()),
+                    EffectAst::subject_verb_tap_all(filter.clone()),
+                    counter_grant,
+                    EffectAst::subject_verb_grant_abilities_all(filter, abilities, duration),
+                ];
+                return Ok(Some(LineAst::Triggered {
+                    trigger,
+                    effects,
+                    max_triggers_per_turn: line.max_triggers_per_turn,
+                }));
+            }
+        }
     }
 
     if let Some(_amount) =

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -63,6 +63,7 @@ fn phase_step_trigger_has_no_object_reference(trigger: &TriggerSpec) -> bool {
         TriggerSpec::BeginningOfUpkeep(_)
             | TriggerSpec::BeginningOfDrawStep(_)
             | TriggerSpec::BeginningOfCombat(_)
+            | TriggerSpec::EndOfCombat
             | TriggerSpec::BeginningOfEndStep(_)
             | TriggerSpec::BeginningOfPrecombatMain(_)
             | TriggerSpec::BeginningOfPostcombatMain(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -326,6 +326,7 @@ pub(crate) enum TriggerSpec {
     BeginningOfUpkeep(PlayerFilter),
     BeginningOfDrawStep(PlayerFilter),
     BeginningOfCombat(PlayerFilter),
+    EndOfCombat,
     BeginningOfEndStep(PlayerFilter),
     BeginningOfPrecombatMain(PlayerFilter),
     BeginningOfPostcombatMain(PlayerFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41957,6 +41957,238 @@ fn assert_oracle_card_parses_strict(name: &str) {
     );
 }
 
+#[test]
+fn dread_wight_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Dread Wight");
+    let rendered = compiled_text_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Dread Wight should parse its end-of-combat trigger strictly"
+    );
+    assert!(
+        rendered.contains(
+            "At end of combat, put a paralyzation counter on each creature blocking or blocked by this creature and tap those creatures"
+        ) && rendered.contains(
+            "Each of those creatures doesn't untap during its controller's untap step for as long as it has a paralyzation counter on it"
+        ) && rendered.contains(
+            "Each of those creatures gains \"{4}: Remove a paralyzation counter from this creature\""
+        ),
+        "Dread Wight compiled text should preserve the paralyzation counter/tap/untap/granted-activation clauses, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("EndOfCombatTrigger")
+            && ability_debug.contains("PutCountersEffect")
+            && ability_debug.contains("TapEffect")
+            && ability_debug.contains("SourceMatches")
+            && ability_debug.contains("RemoveCountersEffect"),
+        "Dread Wight should lower to end-of-combat counter, tap, conditional untap restriction, and remove-counter ability effects, got {ability_debug}"
+    );
+}
+
+#[test]
+fn dread_wight_end_of_combat_paralyzes_only_creatures_in_combat_with_it() {
+    let def = parse_oracle_card_definition("Dread Wight");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Dread Wight should have a triggered ability");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let paralyzation = crate::object::CounterType::Named("paralyzation");
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let blocker_def = CardDefinitionBuilder::new(CardId::new(), "Blocking Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bystander_def = CardDefinitionBuilder::new(CardId::new(), "Bystander Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let blocker = game.create_object_from_definition(&blocker_def, bob, Zone::Battlefield);
+    let bystander = game.create_object_from_definition(&bystander_def, bob, Zone::Battlefield);
+
+    let trigger_ctx = crate::triggers::TriggerContext::for_source(source, alice, &game);
+    let end_of_combat = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::EndOfCombatEvent::new(),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        triggered.trigger.matches(&end_of_combat, &trigger_ctx),
+        "Dread Wight's trigger should fire at end of combat"
+    );
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: source,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    });
+    combat.blockers.insert(source, vec![blocker]);
+    game.combat = Some(combat);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Dread Wight end-of-combat trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(blocker, paralyzation),
+        1,
+        "the creature blocking Dread Wight should get a paralyzation counter"
+    );
+    assert!(
+        game.is_tapped(blocker),
+        "the creature blocking Dread Wight should be tapped"
+    );
+    assert_eq!(
+        game.counter_count(bystander, paralyzation),
+        0,
+        "unrelated creatures should not get paralyzation counters"
+    );
+
+    game.combat = None;
+    game.tap(bystander);
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Untap);
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    crate::turn::execute_untap_step_with(&mut game, &mut dm);
+    assert!(
+        game.is_tapped(blocker),
+        "a creature with a paralyzation counter should not untap during its controller's untap step"
+    );
+    assert!(
+        !game.is_tapped(bystander),
+        "an unaffected creature should untap normally"
+    );
+
+    let remove_counter_program = game
+        .current_characteristics(blocker)
+        .expect("blocked creature should still exist")
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::WithIdEffect>()
+                        .and_then(|with_id| {
+                            with_id
+                                .effect
+                                .downcast_ref::<crate::effects::RemoveCountersEffect>()
+                        })
+                        .is_some_and(|remove| remove.counter_type == paralyzation)
+                }) => {
+                Some(activated.effects.clone())
+            }
+            _ => None,
+        })
+        .expect("the blocked creature should gain the paralyzation counter-removal ability");
+    let mut remove_ctx = crate::effects::ExecutionContext::new_default(blocker, bob);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut remove_ctx,
+        bob,
+        blocker,
+        &remove_counter_program,
+        None,
+        &[],
+    )
+    .expect("granted remove-counter ability should resolve");
+    assert_eq!(
+        game.counter_count(blocker, paralyzation),
+        0,
+        "the granted activation should remove the paralyzation counter"
+    );
+
+    crate::turn::execute_untap_step_with(&mut game, &mut dm);
+    assert!(
+        !game.is_tapped(blocker),
+        "after its paralyzation counter is removed, the creature should untap normally"
+    );
+}
+
+#[test]
+fn dread_wight_end_of_combat_paralyzes_creatures_it_blocked() {
+    let def = parse_oracle_card_definition("Dread Wight");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Dread Wight should have a triggered ability");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let paralyzation = crate::object::CounterType::Named("paralyzation");
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let attacker_def = CardDefinitionBuilder::new(CardId::new(), "Blocked Attacker")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bystander_def = CardDefinitionBuilder::new(CardId::new(), "Bystander Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let attacker = game.create_object_from_definition(&attacker_def, bob, Zone::Battlefield);
+    let bystander = game.create_object_from_definition(&bystander_def, bob, Zone::Battlefield);
+
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    });
+    combat.blockers.insert(attacker, vec![source]);
+    game.combat = Some(combat);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Dread Wight end-of-combat trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(attacker, paralyzation),
+        1,
+        "the creature blocked by Dread Wight should get a paralyzation counter"
+    );
+    assert!(
+        game.is_tapped(attacker),
+        "the creature blocked by Dread Wight should be tapped"
+    );
+    assert_eq!(
+        game.counter_count(bystander, paralyzation),
+        0,
+        "unrelated creatures should not get paralyzation counters"
+    );
+}
+
 fn assert_oracle_card_fails_strict(name: &str) {
     let oracle = oracle_text_by_name()
         .get(name)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -510,6 +510,145 @@ fn direct_wrapped_effect_tag(effect: &Effect) -> Option<&crate::TagKey> {
         .map(|tagged| &tagged.tag)
 }
 
+fn unwrap_id_and_tag_wrappers(effect: &Effect) -> &Effect {
+    if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        return unwrap_id_and_tag_wrappers(&tag_all.effect);
+    }
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return unwrap_id_and_tag_wrappers(&tagged.effect);
+    }
+    if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+        return unwrap_id_and_tag_wrappers(with_id.effect.as_ref());
+    }
+    effect
+}
+
+fn describe_each_object_filter(filter: &ObjectFilter) -> String {
+    if filter.zone == Some(Zone::Battlefield)
+        && filter.card_types == [CardType::Creature]
+        && filter.controller.is_none()
+        && filter.in_combat_with_source
+    {
+        return "creature blocking or blocked by this creature".to_string();
+    }
+    strip_leading_article(&filter.description()).to_string()
+}
+
+fn describes_counter_conditioned_untap_restriction(
+    apply: &crate::effects::ApplyContinuousEffect,
+    filter: &ObjectFilter,
+    counter_type: CounterType,
+) -> bool {
+    if !matches!(
+        &apply.target,
+        crate::continuous::EffectTarget::Filter(candidate) if candidate == filter
+    )
+        || apply.target_spec.is_some()
+        || apply.until != Until::Forever
+        || apply.condition.is_some()
+        || !apply.additional_modifications.is_empty()
+        || !apply.runtime_modifications.is_empty()
+    {
+        return false;
+    }
+    let Some(crate::continuous::Modification::AddAbility(ability)) = &apply.modification else {
+        return false;
+    };
+    let Some((crate::effect::Restriction::Untap(restricted), condition)) =
+        ability.rule_restriction_parts()
+    else {
+        return false;
+    };
+    let mut source_with_counter = ObjectFilter::source();
+    source_with_counter.with_counter = Some(crate::filter::CounterConstraint::Typed(counter_type));
+    restricted == &ObjectFilter::source()
+        && matches!(condition, Some(crate::ConditionExpr::SourceMatches(filter)) if filter == &source_with_counter)
+        && ability
+            .display()
+            .contains("doesn't untap during its controller's untap step")
+}
+
+fn activated_remove_counter_ability_display(
+    ability: &Ability,
+    counter_type: CounterType,
+) -> Option<String> {
+    let AbilityKind::Activated(activated) = &ability.kind else {
+        return None;
+    };
+    if !activated.choices.is_empty() {
+        return None;
+    }
+    let [effect] = activated.effects.flattened_default_effects() else {
+        return None;
+    };
+    let remove = unwrap_id_and_tag_wrappers(effect)
+        .downcast_ref::<crate::effects::RemoveCountersEffect>()?;
+    if remove.counter_type == counter_type
+        && remove.count == Value::Fixed(1)
+        && matches!(remove.target.base(), ChooseSpec::Source)
+    {
+        Some(describe_inline_ability(ability))
+    } else {
+        None
+    }
+}
+
+fn describe_counter_lockdown_grant_effects(effects: &[Effect]) -> Option<String> {
+    let [put_effect, tap_effect, restriction_effect, activation_effect] = effects else {
+        return None;
+    };
+    let for_each = put_effect.downcast_ref::<crate::effects::ForEachObject>()?;
+    let [inner_put_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let put = inner_put_effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.amount != Value::Fixed(1)
+        || put.target_count.is_some()
+        || put.distributed
+        || !matches!(put.target.base(), ChooseSpec::Iterated)
+    {
+        return None;
+    }
+
+    let tap = tap_effect.downcast_ref::<crate::effects::TapEffect>()?;
+    if !matches!(&tap.target, ChooseSpec::All(filter) if filter == &for_each.filter) {
+        return None;
+    }
+
+    let restriction = restriction_effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if !describes_counter_conditioned_untap_restriction(
+        restriction,
+        &for_each.filter,
+        put.counter_type,
+    ) {
+        return None;
+    }
+
+    let activation = activation_effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if !matches!(
+        &activation.target,
+        crate::continuous::EffectTarget::Filter(candidate) if candidate == &for_each.filter
+    )
+        || activation.target_spec.is_some()
+        || activation.until != Until::Forever
+        || activation.condition.is_some()
+        || !activation.additional_modifications.is_empty()
+        || !activation.runtime_modifications.is_empty()
+    {
+        return None;
+    }
+    let Some(crate::continuous::Modification::AddAbilityGeneric(ability)) = &activation.modification
+    else {
+        return None;
+    };
+    let remove_ability = activated_remove_counter_ability_display(ability, put.counter_type)?;
+    let counter = describe_counter_type(put.counter_type);
+    let subject = describe_each_object_filter(&for_each.filter);
+    Some(format!(
+        "put a {counter} counter on each {subject} and tap those creatures. Each of those creatures doesn't untap during its controller's untap step for as long as it has a {counter} counter on it. Each of those creatures gains \"{remove_ability}\""
+    ))
+}
+
 fn describe_spell_mastery_reanimation_effects(effects: &[&Effect]) -> Option<String> {
     let [move_effect, conditional_effect] = effects else {
         return None;
@@ -4128,6 +4267,9 @@ fn describe_revealed_cards_opponent_may_put_or_draw(effects: &[&Effect]) -> Opti
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_counter_lockdown_grant_effects(effects) {
+        return compact;
+    }
     if let Some(compact) = describe_reveal_top_to_hand_then_lose_mana_value_effects(effects) {
         return compact;
     }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -297,6 +297,12 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    fn rule_restriction_parts(
+        &self,
+    ) -> Option<(&crate::effect::Restriction, Option<&crate::ConditionExpr>)> {
+        None
+    }
+
     /// Clone this ability into a boxed trait object.
     fn clone_box(&self) -> Box<dyn StaticAbilityKind> {
         StaticAbilityKindClone::clone_boxed(self)
@@ -1177,6 +1183,12 @@ impl StaticAbility {
 
     pub fn with_condition(&self, condition: crate::ConditionExpr) -> Option<Self> {
         self.0.with_static_condition(condition)
+    }
+
+    pub fn rule_restriction_parts(
+        &self,
+    ) -> Option<(&crate::effect::Restriction, Option<&crate::ConditionExpr>)> {
+        self.0.rule_restriction_parts()
     }
 
     /// Generate continuous effects for this ability.

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1601,6 +1601,12 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
         self.leaf_static_ability()?.with_condition(condition)
     }
 
+    fn rule_restriction_parts(
+        &self,
+    ) -> Option<(&crate::effect::Restriction, Option<&crate::ConditionExpr>)> {
+        self.leaf_static_ability()?.rule_restriction_parts()
+    }
+
     fn generate_effects(
         &self,
         source: ObjectId,

--- a/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/restrictions.rs
@@ -591,6 +591,12 @@ impl StaticAbilityKind for RuleRestriction {
         Some(StaticAbility::new(self.clone().with_condition(condition)))
     }
 
+    fn rule_restriction_parts(
+        &self,
+    ) -> Option<(&crate::effect::Restriction, Option<&crate::ConditionExpr>)> {
+        Some((&self.restriction, self.condition.as_ref()))
+    }
+
     fn is_active(&self, game: &GameState, source: ObjectId) -> bool {
         let Some(condition) = &self.condition else {
             return true;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dread Wight
Initial parse error:
```
unsupported triggered line: 'At end of combat, put a paralyzation counter on each creature blocking or blocked by this creature and tap those creatures. Each of those creatures doesn't untap during its controller's untap step for as long as it has a paralyzation counter on it. Each of those creatures gains "{4}: Remove a paralyzation counter from this creature."'; oracle-only fallback also failed: unsupported triggered line: 'At end of combat, put a paralyzation counter on each creature blocking or blocked by this creature and tap those creatures. Each of those creatures doesn't untap during its controller's untap step for as long as it has a paralyzation counter on it. Each of those creatures gains "{4}: Remove a paralyzation counter from this creature."'
```

Current worker: i-0eaf115bb7c28c5f1
Branch: codex/aws-card-fix-dread-wight
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
