### PR TITLE
Fix Ironsmith parse failure: Grand Master of Flowers

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -898,6 +898,50 @@ fn anthem_find_slash_word(words: &[&str]) -> Option<usize> {
         .position(|word| crate::string_primitives::contains_char(word, '/'))
 }
 
+fn is_source_pronoun_contracted_be_word(word: &str) -> bool {
+    matches!(
+        word,
+        "it's" | "it’s" | "its" | "he's" | "he’s" | "hes" | "she's" | "she’s" | "shes"
+    )
+}
+
+fn parse_static_be_subject_and_condition(
+    tokens: &[OwnedLexToken],
+    be_idx: usize,
+) -> Result<Option<(Option<crate::ConditionExpr>, AnthemSubjectAst, bool)>, CardTextError> {
+    let contracted_source_subject = tokens[be_idx]
+        .as_word()
+        .is_some_and(is_source_pronoun_contracted_be_word);
+    if contracted_source_subject && token_slice_starts_with(tokens, &["as", "long", "as"]) {
+        let condition_tokens = trim_commas(&tokens[3..be_idx]);
+        if condition_tokens.is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some((
+            Some(parse_static_condition_clause(&condition_tokens)?),
+            AnthemSubjectAst::Source,
+            false,
+        )));
+    }
+
+    let (condition, subject_start) = match parse_anthem_prefix_condition(tokens, be_idx) {
+        Ok(parsed) => parsed,
+        Err(_) => return Ok(None),
+    };
+    let subject_tokens = trim_commas(&tokens[subject_start..be_idx]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+    let subject = match parse_anthem_subject(&subject_tokens) {
+        Ok(subject) => subject,
+        Err(_) => return Ok(None),
+    };
+    let attached_subject = crate::runtime_backend::token_word_refs(&subject_tokens)
+        .first()
+        .is_some_and(|word| ENCHANTED_OR_EQUIPPED_WORD_PATTERN.matches_word(word));
+    Ok(Some((condition, subject, attached_subject)))
+}
+
 
 fn first_spell_each_turn_subject(filter_words: &[&str]) -> Option<AnthemSubjectAst> {
     FIRST_SPELL_EACH_TURN_SUBJECT_PATTERN
@@ -2757,6 +2801,10 @@ pub(crate) fn parse_static_condition_clause(
         ));
     }
 
+    if let Some(condition) = parse_source_counter_static_condition(&tokens) {
+        return Ok(condition);
+    }
+
     if let Some(condition) = parse_cards_in_hand_static_condition(&tokens) {
         return Ok(condition);
     }
@@ -3514,6 +3562,38 @@ fn parse_cards_in_hand_static_condition(tokens: &[OwnedLexToken]) -> Option<crat
         }
         _ => None,
     }
+}
+
+fn parse_source_counter_static_condition(tokens: &[OwnedLexToken]) -> Option<crate::ConditionExpr> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    let count_start_idx = match clause_words.as_slice() {
+        ["this", "has", ..] | ["it", "has", ..] => 2,
+        ["this", "creature", "has", ..]
+        | ["this", "planeswalker", "has", ..]
+        | ["this", "permanent", "has", ..] => 3,
+        _ => return None,
+    };
+
+    let count_tokens = tokens.get(count_start_idx..)?;
+    let (comparison, used) = parse_static_quantity_prefix(count_tokens, false).ok()?;
+    let count = comparison_to_at_least_threshold(&comparison)?;
+    let rest_tokens = count_tokens.get(used..)?;
+    let rest_words = crate::runtime_backend::token_word_refs(rest_tokens);
+    let counter_idx = find_index(&rest_words, |word| {
+        COUNTER_OR_COUNTERS_WORD_PATTERN.matches_word(word)
+    })?;
+    if counter_idx == 0 {
+        return None;
+    }
+    let counter_type = parse_counter_type_from_tokens(&rest_tokens[..=counter_idx])?;
+    if !ON_SOURCE_COUNTER_TAIL_PATTERN.matches_words(&rest_words[counter_idx + 1..]) {
+        return None;
+    }
+
+    Some(crate::ConditionExpr::SourceHasCounterAtLeast {
+        counter_type,
+        count,
+    })
 }
 
 fn parse_life_total_static_condition(tokens: &[OwnedLexToken]) -> Option<crate::ConditionExpr> {
@@ -7175,7 +7255,9 @@ pub(crate) fn parse_filter_has_granted_ability_line(
         let (mut condition, subject_start) = match parse_anthem_prefix_condition(tokens, has_idx) {
             Ok(parsed) => parsed,
             Err(err) => {
-                deferred_error.get_or_insert(err);
+                if !(token_slice_starts_with(tokens, &["as", "long", "as"]) && has_idx <= 4) {
+                    deferred_error.get_or_insert(err);
+                }
                 continue;
             }
         };

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -942,7 +942,8 @@ const THE_BATTLEFIELD_PREFIX_PATTERN: ClauseShape<'static> =
 const BATTLEFIELD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["battlefield"]);
 const CHOOSE_CARD_NAME_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["choose", "a", "card", "name"]);
-const SOURCE_IT_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["it"]);
+const SOURCE_IT_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["it"], &["he"], &["she"]]);
 const CHOICE_OR_PATTERN: ClauseShape<'static> = clause_shape!(contains_words & ["or"]);
 const AS_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["as"]);
 const THIS_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["this"]);
@@ -2759,6 +2760,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         },
         multi_static_ability_ast_passthrough_rule!(
             parse_has_base_power_toughness_and_granted_keywords_static_line
+        ),
+        multi_static_ability_ast_passthrough_rule!(
+            parse_subject_is_pt_creature_with_granted_abilities_line
         ),
         multi_static_ability_ast_passthrough_rule!(
             parse_subject_is_subtype_with_base_pt_and_granted_abilities_line
@@ -8376,6 +8380,95 @@ pub(crate) fn parse_filter_is_pt_creature_in_addition_and_has_line(
     )))
 }
 
+pub(crate) fn parse_subject_is_pt_creature_with_granted_abilities_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
+    let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    let Some(be_idx) = find_index(tokens, |token| {
+        IS_OR_ARE_WORD_PATTERN.matches_token(token)
+            || token
+                .as_word()
+                .is_some_and(is_source_pronoun_contracted_be_word)
+    }) else {
+        return Ok(None);
+    };
+    let Some(with_idx) = find_index(&tokens[be_idx + 1..], |token| {
+        WITH_WORD_PATTERN.matches_token(token)
+    })
+    .map(|offset| be_idx + 1 + offset) else {
+        return Ok(None);
+    };
+    let Some((condition, subject, attached_subject)) =
+        parse_static_be_subject_and_condition(tokens, be_idx)?
+    else {
+        return Ok(None);
+    };
+
+    let before_with = trim_commas(&tokens[be_idx + 1..with_idx]);
+    if before_with.is_empty() {
+        return Ok(None);
+    }
+    let before_with_words = crate::runtime_backend::token_word_refs(&before_with);
+    let before_with_words = strip_leading_article_word_refs(&before_with_words);
+    if before_with_words.len() < 3 {
+        return Ok(None);
+    }
+    let (power, toughness) = match parse_pt_modifier(before_with_words[0]) {
+        Ok(parsed) => parsed,
+        Err(_) => return Ok(None),
+    };
+    let Some(creature_idx) = find_index(&before_with_words, |word| {
+        STATIC_CREATURE_OR_CREATURES_WORD_PATTERN.matches_word(word)
+    }) else {
+        return Ok(None);
+    };
+    if creature_idx == 0 || creature_idx + 1 != before_with_words.len() {
+        return Ok(None);
+    }
+    let mut subtypes = Vec::new();
+    for word in &before_with_words[1..creature_idx] {
+        if is_article(word) {
+            continue;
+        }
+        let Some(subtype) = parse_subtype_word(word) else {
+            return Ok(None);
+        };
+        subtypes.push(subtype);
+    }
+
+    let ability_tokens = trim_commas(&tokens[with_idx + 1..]);
+    let Some(granted_tail) =
+        parse_heterogeneous_granted_tail(&ability_tokens, &clause_words, attached_subject)?
+    else {
+        return Ok(None);
+    };
+
+    let filter = anthem_subject_filter(&subject);
+    let mut result = vec![
+        wrap_conditioned_animation_static_ability(
+            StaticAbility::set_card_types(filter.clone(), vec![CardType::Creature]),
+            &condition,
+        ),
+        wrap_conditioned_animation_static_ability(
+            StaticAbility::set_base_power_toughness(filter.clone(), power, toughness),
+            &condition,
+        ),
+    ];
+    if !subtypes.is_empty() {
+        result.push(wrap_conditioned_animation_static_ability(
+            StaticAbility::set_creature_subtypes(filter.clone(), subtypes),
+            &condition,
+        ));
+    }
+    result.extend(lower_granted_tail_for_anthem_subject(
+        &subject,
+        &condition,
+        granted_tail,
+    ));
+
+    Ok(Some(result))
+}
+
 pub(crate) fn parse_subject_is_subtype_with_base_pt_and_granted_abilities_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
@@ -8388,8 +8481,12 @@ pub(crate) fn parse_subject_is_subtype_with_base_pt_and_granted_abilities_line(
     } else {
         tokens
     };
-    let Some(be_idx) = find_index(tokens, |token| IS_OR_ARE_WORD_PATTERN.matches_token(token))
-    else {
+    let Some(be_idx) = find_index(tokens, |token| {
+        IS_OR_ARE_WORD_PATTERN.matches_token(token)
+            || token
+                .as_word()
+                .is_some_and(is_source_pronoun_contracted_be_word)
+    }) else {
         return Ok(None);
     };
     let Some(with_idx) = find_index(&tokens[be_idx + 1..], |token| {
@@ -8399,21 +8496,11 @@ pub(crate) fn parse_subject_is_subtype_with_base_pt_and_granted_abilities_line(
         return Ok(None);
     };
 
-    let (_condition, subject_start) = match parse_anthem_prefix_condition(tokens, be_idx) {
-        Ok(parsed) => parsed,
-        Err(_) => return Ok(None),
-    };
-    let subject_tokens = trim_commas(&tokens[subject_start..be_idx]);
-    if subject_tokens.is_empty() {
+    let Some((_condition, subject, attached_subject)) =
+        parse_static_be_subject_and_condition(tokens, be_idx)?
+    else {
         return Ok(None);
-    }
-    let subject = match parse_anthem_subject(&subject_tokens) {
-        Ok(subject) => subject,
-        Err(_) => return Ok(None),
     };
-    let attached_subject = crate::runtime_backend::token_word_refs(&subject_tokens)
-        .first()
-        .is_some_and(|word| ENCHANTED_OR_EQUIPPED_WORD_PATTERN.matches_word(word));
 
     let type_tokens = trim_commas(&tokens[be_idx + 1..with_idx]);
     if type_tokens.is_empty() {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/naming_and_reference.rs
@@ -818,13 +818,63 @@ pub(super) fn try_apply_without_clause_tail(
     filter: &mut ObjectFilter,
     words: &[&str],
 ) -> Option<usize> {
-    if let Some((constraint, consumed)) = parse_filter_keyword_constraint_words(words) {
+    let mut consumed = 0usize;
+    let mut applied_keyword = false;
+    while consumed < words.len() {
+        while consumed < words.len()
+            && matches!(words[consumed], "," | "or" | "and")
+        {
+            consumed += 1;
+        }
+        if let Some((ability, used)) = parse_without_static_ability_keyword(&words[consumed..]) {
+            if !slice_contains(filter.excluded_static_abilities.as_slice(), &ability) {
+                filter.excluded_static_abilities.push(ability);
+            }
+            consumed += used;
+            applied_keyword = true;
+            continue;
+        }
+        let Some((constraint, used)) = parse_filter_keyword_constraint_words(&words[consumed..])
+        else {
+            break;
+        };
         apply_filter_keyword_constraint(filter, constraint, true);
+        consumed += used;
+        applied_keyword = true;
+    }
+    if applied_keyword {
         return Some(consumed);
     }
     if let Some((counter_constraint, consumed)) = parse_filter_counter_constraint_words(words) {
         filter.without_counter = Some(counter_constraint);
         return Some(consumed);
+    }
+
+    None
+}
+
+fn parse_without_static_ability_keyword(
+    words: &[&str],
+) -> Option<(crate::static_abilities::StaticAbilityId, usize)> {
+    use crate::static_abilities::StaticAbilityId;
+
+    if words.get(0..2) == Some(&["first", "strike"]) {
+        return Some((StaticAbilityId::FirstStrike, 2));
+    }
+    if words
+        .first()
+        .is_some_and(|word| matches!(*word, "first-strike" | "firststrike"))
+    {
+        return Some((StaticAbilityId::FirstStrike, 1));
+    }
+    if words.get(0..2) == Some(&["double", "strike"]) {
+        return Some((StaticAbilityId::DoubleStrike, 2));
+    }
+    if words
+        .first()
+        .is_some_and(|word| matches!(*word, "double-strike" | "doublestrike"))
+    {
+        return Some((StaticAbilityId::DoubleStrike, 1));
     }
 
     None

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1900,10 +1900,16 @@ impl ObjectFilter {
         for marker in &self.ability_markers {
             parts.push(format!("with {}", marker.to_ascii_lowercase()));
         }
-        for ability in &self.excluded_static_abilities {
-            if let Some(label) = describe_filter_static_ability(*ability) {
-                parts.push(format!("without {}", label));
-            }
+        let excluded_static_ability_labels = self
+            .excluded_static_abilities
+            .iter()
+            .filter_map(|ability| describe_filter_static_ability(*ability))
+            .collect::<Vec<_>>();
+        if !excluded_static_ability_labels.is_empty() {
+            parts.push(format!(
+                "without {}",
+                join_filter_labels_or(&excluded_static_ability_labels)
+            ));
         }
         for marker in &self.excluded_ability_markers {
             parts.push(format!("without {}", marker.to_ascii_lowercase()));
@@ -2414,6 +2420,20 @@ fn describe_counter_constraint(constraint: CounterConstraint) -> String {
         CounterConstraint::Any => "a counter".to_string(),
         CounterConstraint::Typed(counter_type) => {
             format!("a {} counter", counter_type.description())
+        }
+    }
+}
+
+fn join_filter_labels_or(labels: &[&str]) -> String {
+    match labels {
+        [] => String::new(),
+        [only] => (*only).to_string(),
+        [first, second] => format!("{first} or {second}"),
+        _ => {
+            let mut text = labels[..labels.len() - 1].join(", ");
+            text.push_str(", or ");
+            text.push_str(labels[labels.len() - 1]);
+            text
         }
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41971,6 +41971,74 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn grand_master_of_flowers_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Grand Master of Flowers");
+    let def = parse_oracle_card_definition("Grand Master of Flowers");
+    let ability_debug = format!("{:#?}", def.abilities);
+    assert!(
+        ability_debug.contains("SourceHasCounterAtLeast")
+            && ability_debug.contains("Loyalty")
+            && ability_debug.contains("SetCardTypes")
+            && ability_debug.contains("SetBasePowerToughness")
+            && ability_debug.contains("SetCreatureSubtypes")
+            && ability_debug.contains("Flying")
+            && ability_debug.contains("Indestructible")
+            && ability_debug.contains("FirstStrike")
+            && ability_debug.contains("DoubleStrike")
+            && ability_debug.contains("Vigilance"),
+        "Grand Master of Flowers should structurally model the seven-loyalty Dragon God animation, got {ability_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("as long as this has seven or more loyalty counters on it")
+            && rendered.contains("7/7 dragon god creature")
+            && rendered.contains("flying and indestructible")
+            && rendered.contains("target creature without first strike, double strike, or vigilance can't attack or block until your next turn"),
+        "compiled text should preserve Grand Master's conditional animation and target restriction clauses, got {rendered}"
+    );
+}
+
+#[test]
+fn grand_master_of_flowers_animation_depends_on_loyalty_counter_threshold() {
+    let def = parse_oracle_card_definition("Grand Master of Flowers");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let grand_master = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert!(
+        !game.calculated_card_types(grand_master).contains(&CardType::Creature),
+        "Grand Master should not be a creature below seven loyalty counters"
+    );
+    assert_eq!(game.calculated_power(grand_master), None);
+    assert_eq!(game.calculated_toughness(grand_master), None);
+    assert!(
+        !game.object_has_static_ability_id(grand_master, StaticAbilityId::Flying)
+            && !game.object_has_static_ability_id(grand_master, StaticAbilityId::Indestructible),
+        "Grand Master should not have creature keywords below the threshold"
+    );
+
+    game.add_counters(grand_master, crate::object::CounterType::Loyalty, 7)
+        .expect("add loyalty counters");
+
+    assert!(
+        game.calculated_card_types(grand_master).contains(&CardType::Creature),
+        "Grand Master should become a creature at seven loyalty counters"
+    );
+    assert_eq!(game.calculated_power(grand_master), Some(7));
+    assert_eq!(game.calculated_toughness(grand_master), Some(7));
+    let subtypes = game.calculated_subtypes(grand_master);
+    assert!(subtypes.contains(&Subtype::Dragon) && subtypes.contains(&Subtype::God));
+    assert!(game.object_has_static_ability_id(grand_master, StaticAbilityId::Flying));
+    assert!(game.object_has_static_ability_id(
+        grand_master,
+        StaticAbilityId::Indestructible
+    ));
+}
+
+#[test]
 fn death_in_heaven_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Death in Heaven");
     let def = parse_oracle_card_definition("Death in Heaven");

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -259,7 +259,9 @@ fn parse_conditional_subject_predicate(line: &str) -> Option<ConditionalSubjectP
 
 fn is_creature_addition_predicate(predicate: &str) -> bool {
     let lower = predicate.trim().to_ascii_lowercase();
-    lower == "a creature in addition to its other types"
+    lower == "creature"
+        || lower == "a creature"
+        || lower == "a creature in addition to its other types"
         || lower == "creature in addition to its other types"
         || lower == "creatures in addition to their other types"
 }
@@ -522,6 +524,14 @@ fn conditioned_subject_key(subject: &str) -> String {
     let lower = subject.trim().to_ascii_lowercase();
     if let Some(rest) = lower.strip_prefix("each creature ") {
         return format!("creatures {rest}");
+    }
+    if lower.starts_with("this ") {
+        if let Some(stripped) = lower.strip_suffix(" creature") {
+            return stripped.to_string();
+        }
+        if let Some(stripped) = lower.strip_suffix(" source") {
+            return stripped.to_string();
+        }
     }
     lower
 }
@@ -1350,7 +1360,7 @@ pub(super) fn merge_subject_animation_lines(lines: Vec<String>) -> Vec<String> {
                 let Some(next) = parse_conditional_subject_predicate(&lines[idx + consumed]) else {
                     break;
                 };
-                if !start.subject.eq_ignore_ascii_case(&next.subject)
+                if !conditioned_subjects_equivalent(&start.subject, &next.subject)
                     || !start.condition.eq_ignore_ascii_case(&next.condition)
                 {
                     break;
@@ -1422,16 +1432,37 @@ pub(super) fn merge_subject_animation_lines(lines: Vec<String>) -> Vec<String> {
                     .as_deref()
                     .unwrap_or_else(|| start.subject.as_str());
                 if !plural_subject {
-                    let mut combined = format!(
-                        "{condition}, {subject} is {} {replacement_subtypes}",
-                        indefinite_article_for_phrase(&replacement_subtypes)
-                    );
-                    if let Some(pt) = base_pt {
-                        combined.push_str(" with base power and toughness ");
-                        combined.push_str(&pt);
+                    let subject = lowercase_first(subject);
+                    let replacement_subtypes = replacement_subtypes.replace(" and ", " ");
+                    let started_as_creature = is_creature_addition_predicate(&start.predicate);
+                    let mut combined = if started_as_creature {
+                        if let Some(pt) = base_pt {
+                            format!(
+                                "{condition}, {subject} is {} {pt} {replacement_subtypes} creature",
+                                indefinite_article_for_phrase(&pt)
+                            )
+                        } else {
+                            format!(
+                                "{condition}, {subject} is {} {replacement_subtypes} creature",
+                                indefinite_article_for_phrase(&replacement_subtypes)
+                            )
+                        }
+                    } else {
+                        let mut text = format!(
+                            "{condition}, {subject} is {} {replacement_subtypes}",
+                            indefinite_article_for_phrase(&replacement_subtypes)
+                        );
+                        if let Some(pt) = base_pt {
+                            text.push_str(" with base power and toughness ");
+                            text.push_str(&pt);
+                        }
+                        text
+                    };
+                    if combined.contains(" a 8") || combined.contains(" a 11") {
+                        combined = combined.replacen(" a ", " an ", 1);
                     }
                     if !granted_predicates.is_empty() {
-                        combined.push_str(" and has ");
+                        combined.push_str(" with ");
                         combined.push_str(&join_with_and(&granted_predicates));
                     }
                     merged.push(combined);

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3770,10 +3770,16 @@ impl ObjectFilterExt for ObjectFilter {
         for marker in &self.ability_markers {
             parts.push(format!("with {}", marker.to_ascii_lowercase()));
         }
-        for ability in &self.excluded_static_abilities {
-            if let Some(label) = describe_filter_static_ability(*ability) {
-                parts.push(format!("without {}", label));
-            }
+        let excluded_static_ability_labels = self
+            .excluded_static_abilities
+            .iter()
+            .filter_map(|ability| describe_filter_static_ability(*ability))
+            .collect::<Vec<_>>();
+        if !excluded_static_ability_labels.is_empty() {
+            parts.push(format!(
+                "without {}",
+                join_filter_labels_or(&excluded_static_ability_labels)
+            ));
         }
         for marker in &self.excluded_ability_markers {
             parts.push(format!("without {}", marker.to_ascii_lowercase()));
@@ -4686,6 +4692,21 @@ fn describe_counter_constraint(constraint: CounterConstraint) -> String {
         CounterConstraint::Any => "a counter".to_string(),
         CounterConstraint::Typed(counter_type) => {
             format!("a {} counter", counter_type.description())
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn join_filter_labels_or(labels: &[&str]) -> String {
+    match labels {
+        [] => String::new(),
+        [only] => (*only).to_string(),
+        [first, second] => format!("{first} or {second}"),
+        _ => {
+            let mut text = labels[..labels.len() - 1].join(", ");
+            text.push_str(", or ");
+            text.push_str(labels[labels.len() - 1]);
+            text
         }
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -584,10 +584,13 @@ fn spell_grant_subject_text(filter: &ObjectFilter) -> Option<String> {
 }
 
 fn subject_verb_and_possessive(subject: &str) -> (&'static str, &'static str) {
-    let singular = subject.starts_with("enchanted ")
-        || subject.starts_with("equipped ")
-        || subject.starts_with("this ")
-        || subject.starts_with("that ");
+    let lower = subject.to_ascii_lowercase();
+    let singular = lower == "this"
+        || lower == "that"
+        || lower.starts_with("enchanted ")
+        || lower.starts_with("equipped ")
+        || lower.starts_with("this ")
+        || lower.starts_with("that ");
     if singular {
         ("is", "its")
     } else {
@@ -939,6 +942,20 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         }
         crate::ConditionExpr::SourceIsMonstrous => {
             "as long as this creature is monstrous".to_string()
+        }
+        crate::ConditionExpr::SourceHasCounterAtLeast {
+            counter_type,
+            count,
+        } => {
+            let count_text = number_word_u32(*count).unwrap_or_else(|| count.to_string());
+            format!(
+                "as long as this has {count_text} or more {} counters on it",
+                counter_type.description()
+            )
+        }
+        crate::ConditionExpr::SourceHasCountersAtLeast(count) => {
+            let count_text = number_word_u32(*count).unwrap_or_else(|| count.to_string());
+            format!("as long as this has {count_text} or more counters on it")
         }
         crate::ConditionExpr::SourceDevouredCreaturesOrMore(count) => {
             if *count == 1 {
@@ -2572,11 +2589,18 @@ impl StaticAbilityKind for SetBasePowerToughnessForFilter {
     }
 
     fn display(&self) -> String {
-        let subject = pluralized_subject_text(&self.filter);
-        let singular = subject.starts_with("enchanted ")
-            || subject.starts_with("equipped ")
-            || subject.starts_with("this ")
-            || subject.starts_with("that ");
+        let subject = if self.filter.source {
+            "this".to_string()
+        } else {
+            pluralized_subject_text(&self.filter)
+        };
+        let subject_lower = subject.to_ascii_lowercase();
+        let singular = subject_lower.starts_with("enchanted ")
+            || subject_lower.starts_with("equipped ")
+            || subject_lower == "this"
+            || subject_lower == "that"
+            || subject_lower.starts_with("this ")
+            || subject_lower.starts_with("that ");
         let verb = if singular { "has" } else { "have" };
         let mut text = format!(
             "{subject} {verb} base power and toughness {}/{}",
@@ -3176,17 +3200,29 @@ impl StaticAbilityKind for RemoveCardTypesForFilter {
 pub struct SetCardTypesForFilter {
     pub filter: ObjectFilter,
     pub card_types: Vec<CardType>,
+    pub condition: Option<crate::ConditionExpr>,
 }
 
 impl SetCardTypesForFilter {
     pub fn new(filter: ObjectFilter, card_types: Vec<CardType>) -> Self {
-        Self { filter, card_types }
+        Self {
+            filter,
+            card_types,
+            condition: None,
+        }
+    }
+
+    pub fn with_condition(mut self, condition: crate::ConditionExpr) -> Self {
+        self.condition = Some(condition);
+        self
     }
 }
 
 impl PartialEq for SetCardTypesForFilter {
     fn eq(&self, other: &Self) -> bool {
-        self.filter == other.filter && self.card_types == other.card_types
+        self.filter == other.filter
+            && self.card_types == other.card_types
+            && self.condition == other.condition
     }
 }
 
@@ -3196,7 +3232,11 @@ impl StaticAbilityKind for SetCardTypesForFilter {
     }
 
     fn display(&self) -> String {
-        let subject = pluralized_subject_text(&self.filter);
+        let subject = if self.filter.source {
+            "this".to_string()
+        } else {
+            pluralized_subject_text(&self.filter)
+        };
         let (verb, _) = subject_verb_and_possessive(&subject);
         let types = self
             .card_types
@@ -3210,7 +3250,16 @@ impl StaticAbilityKind for SetCardTypesForFilter {
                 }
             })
             .collect::<Vec<_>>();
-        format!("{subject} {verb} {}", join_with_and(&types))
+        let mut text = format!("{subject} {verb} {}", join_with_and(&types));
+        if let Some(condition) = &self.condition {
+            text.push(' ');
+            text.push_str(&describe_static_condition(condition));
+        }
+        text
+    }
+
+    fn with_static_condition(&self, condition: crate::ConditionExpr) -> Option<StaticAbility> {
+        Some(StaticAbility::new(self.clone().with_condition(condition)))
     }
 
     fn generate_effects(
@@ -3219,7 +3268,7 @@ impl StaticAbilityKind for SetCardTypesForFilter {
         controller: PlayerId,
         _game: &GameState,
     ) -> Vec<ContinuousEffect> {
-        vec![
+        vec![effect_with_optional_static_condition(
             ContinuousEffect::new(
                 source,
                 controller,
@@ -3227,7 +3276,8 @@ impl StaticAbilityKind for SetCardTypesForFilter {
                 Modification::SetCardTypes(self.card_types.clone()),
             )
             .with_source_type(EffectSourceType::StaticAbility),
-        ]
+            &self.condition,
+        )]
     }
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Grand Master of Flowers
Initial parse error:
```
missing condition after leading 'as long as' clause (clause: 'as long as this has seven or more loyalty counters on him he's a 7/7 dragon god creature with flying and indestructible'); oracle-only fallback also failed: missing condition after leading 'as long as' clause (clause: 'as long as this has seven or more loyalty counters on him he's a 7/7 dragon god creature with flying and indestructible')
```

Current worker: i-07ee3de6a177a5e10
Branch: codex/aws-card-fix-grand-master-of-flowers
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
