### PR TITLE
Fix Ironsmith parse failure: Pendant of Prosperity

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -26,6 +26,7 @@ pub enum PlayerAst {
     ThatPlayerOrTargetController,
     ItsController,
     ItsOwner,
+    SourceOwner,
     Implicit,
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2714,6 +2714,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_choose_creature_type_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_named_options_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_player_as_enters_line),
+        single_static_ability_ast_rule!(parse_enters_under_opponent_control_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_color_as_becomes_attached_line),
         single_static_ability_ast_rule!(parse_enchanted_land_is_chosen_type_line),
         single_static_ability_ast_rule!(parse_source_is_chosen_type_in_addition_line),
@@ -5487,6 +5488,64 @@ pub(crate) fn parse_choose_player_as_enters_line(
     Ok(Some(StaticAbility::choose_player_as_enters(format!(
         "As {display_subject} enters, choose a player."
     ))))
+}
+
+pub(crate) fn parse_enters_under_opponent_control_as_enters_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let (idx, display_subject) = if words
+        .first()
+        .is_some_and(|word| THIS_WORD_PATTERN.matches_word(word))
+    {
+        let Some(kind) = words.get(1) else {
+            return Ok(None);
+        };
+        let Some((_, display)) = AS_ENTERS_STANDARD_SUBJECTS_WITH_AURA
+            .iter()
+            .find(|(subject_kind, _)| subject_kind == kind)
+        else {
+            return Ok(None);
+        };
+        (2usize, *display)
+    } else {
+        let Some(enter_idx) = words
+            .iter()
+            .position(|word| ENTERS_WORD_PATTERN.matches_word(word))
+        else {
+            return Ok(None);
+        };
+        if source_reference_surface_for_words(&words[..enter_idx]).is_none() {
+            return Ok(None);
+        }
+        (enter_idx, "this")
+    };
+
+    if !words
+        .get(idx)
+        .is_some_and(|word| ENTERS_WORD_PATTERN.matches_word(word))
+    {
+        return Ok(None);
+    }
+    let tail = &words[idx + 1..];
+    if tail
+        != [
+            "under", "the", "control", "of", "an", "opponent", "of", "your", "choice",
+        ]
+    {
+        return Ok(None);
+    }
+
+    let mut chars = display_subject.chars();
+    let subject = match chars.next() {
+        Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+        None => display_subject.to_string(),
+    };
+    Ok(Some(
+        StaticAbility::enters_under_opponent_control_as_enters(format!(
+            "{subject} enters under the control of an opponent of your choice."
+        )),
+    ))
 }
 
 pub(crate) fn parse_damage_redirect_to_source_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1838,7 +1838,7 @@ fn player_filter_for_turn_value(player: PlayerAst) -> Option<PlayerFilter> {
         PlayerAst::ThatPlayerOrTargetController => {
             Some(PlayerFilter::TargetPlayerOrControllerOfTarget)
         }
-        PlayerAst::ItsController | PlayerAst::ItsOwner => None,
+        PlayerAst::ItsController | PlayerAst::ItsOwner | PlayerAst::SourceOwner => None,
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -3291,7 +3291,7 @@ pub(crate) fn parse_subject(tokens: &[OwnedLexToken]) -> SubjectAst {
             .last()
             .is_some_and(|word| OWNER_WORD_PATTERN.matches_word(word))
     {
-        return SubjectAst::Player(PlayerAst::ItsOwner);
+        return SubjectAst::Player(PlayerAst::SourceOwner);
     }
     if ITS_OR_THEIR_CONTROLLER_SUFFIX_PATTERN.matches_words(slice) {
         return SubjectAst::Player(PlayerAst::ItsController);

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -95,6 +95,7 @@ pub(crate) fn resolve_non_target_player_filter(
                 Ok(PlayerFilter::OwnerOf(ObjectRef::Target))
             }
         }
+        PlayerAst::SourceOwner => Ok(PlayerFilter::OwnerOf(ObjectRef::tagged(IT_TAG))),
         PlayerAst::Implicit => {
             if refs.iterated_player
                 && refs

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -1078,7 +1078,7 @@ fn player_filter_for_life_reference(player: PlayerAst) -> Option<PlayerFilter> {
         PlayerAst::MostLifeTied => Some(PlayerFilter::MostLifeTied),
         PlayerAst::LowestLifeTied => Some(PlayerFilter::LowestLifeTied),
         PlayerAst::ThatPlayerOrTargetController => None,
-        PlayerAst::ItsController | PlayerAst::ItsOwner => None,
+        PlayerAst::ItsController | PlayerAst::ItsOwner | PlayerAst::SourceOwner => None,
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -1089,7 +1089,8 @@ fn player_filter_for_set_life_total_reference(player: PlayerAst) -> Option<Playe
         PlayerAst::LowestLifeTied => Some(PlayerFilter::LowestLifeTied),
         PlayerAst::ThatPlayerOrTargetController
         | PlayerAst::ItsController
-        | PlayerAst::ItsOwner => None,
+        | PlayerAst::ItsOwner
+        | PlayerAst::SourceOwner => None,
     }
 }
 

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -156,6 +156,7 @@ pub enum StaticAbilityId {
     ChooseColorAsEnters,
     ChooseColorAsBecomesAttached,
     ChoosePlayerAsEnters,
+    EntersUnderOpponentControlAsEnters,
     ChooseCardNameAsEnters,
     ChooseBasicLandTypeAsEnters,
     ChooseLandTypeAsEnters,
@@ -416,6 +417,7 @@ impl StaticAbilityId {
             | ChooseColorAsEnters
             | ChooseColorAsBecomesAttached
             | ChoosePlayerAsEnters
+            | EntersUnderOpponentControlAsEnters
             | ChooseCardNameAsEnters
             | ChooseBasicLandTypeAsEnters
             | ChooseLandTypeAsEnters

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -381,6 +381,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         condition: Option<Condition>,
     },
     ChoosePlayerAsEnters(String),
+    EntersUnderOpponentControlAsEnters(String),
     ChooseCardNameAsEnters(String),
     ChooseCreatureTypeAsEnters(String),
     ChooseNamedOptionAsEnters {
@@ -1180,6 +1181,9 @@ where
             },
             StaticAbilityPayload::ChoosePlayerAsEnters(display) => {
                 StaticAbilityPayload::ChoosePlayerAsEnters(display)
+            }
+            StaticAbilityPayload::EntersUnderOpponentControlAsEnters(display) => {
+                StaticAbilityPayload::EntersUnderOpponentControlAsEnters(display)
             }
             StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
                 StaticAbilityPayload::ChooseCardNameAsEnters(display)
@@ -3185,6 +3189,14 @@ impl<
             id: Some(StaticAbilityId::ChoosePlayerAsEnters),
             label: display.clone(),
             payload: StaticAbilityPayload::ChoosePlayerAsEnters(display),
+        }
+    }
+    pub fn enters_under_opponent_control_as_enters(display: impl Into<String>) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::EntersUnderOpponentControlAsEnters),
+            label: display.clone(),
+            payload: StaticAbilityPayload::EntersUnderOpponentControlAsEnters(display),
         }
     }
     pub fn choose_card_name_as_enters(display: impl Into<String>) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -957,6 +957,7 @@ pub(crate) enum PlayerAst {
     ThatPlayerOrTargetController,
     ItsController,
     ItsOwner,
+    SourceOwner,
     Implicit,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5145,6 +5145,39 @@ fn test_parse_choose_player_as_enters_without_placeholder() {
     );
 }
 
+#[test]
+fn pendant_of_prosperity_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Pendant of Prosperity");
+    let def = parse_oracle_card_definition("Pendant of Prosperity");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.abilities.iter().any(|ability| matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::EntersUnderOpponentControlAsEnters
+        )),
+        "Pendant of Prosperity should model its opponent-control as-enters ability, got {ability_debug}"
+    );
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Activated(_))),
+        "Pendant of Prosperity should keep its activated ability, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "This artifact enters under the control of an opponent of your choice."
+        ),
+        "expected opponent-control clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("This artifact's owner draws a card"),
+        "expected owner draw clause in compiled text, got {rendered}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_enchanted_land_is_chosen_type_without_placeholder() {

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -44,6 +44,7 @@ pub fn compiled_text_lines(def: &CardDefinition) -> Vec<String> {
     normalize_ast_surface_lines(debug_compiled_lines(def))
         .into_iter()
         .map(|line| substitute_legendary_source_reference(&line, &def.card, ""))
+        .map(|line| substitute_source_owner_reference(&line, def))
         .map(|line| substitute_kicked_draw_source_reference(&line, def))
         .map(normalize_scored_compiled_line)
         .collect()
@@ -53,6 +54,7 @@ pub fn unprocessed_compiled_lines(def: &CardDefinition) -> Vec<String> {
     normalize_ast_surface_lines(debug_compiled_lines(def))
         .into_iter()
         .map(|line| substitute_legendary_source_reference(&line, &def.card, ""))
+        .map(|line| substitute_source_owner_reference(&line, def))
         .map(normalize_unprocessed_compiled_line)
         .collect()
 }
@@ -124,6 +126,46 @@ fn substitute_kicked_draw_source_reference(line: &str, def: &CardDefinition) -> 
         "This spell was kicked",
         &format!("{source_name} was kicked"),
     )
+}
+
+fn source_type_noun(def: &CardDefinition) -> &'static str {
+    if def.card.card_types.contains(&CardType::Artifact) {
+        "artifact"
+    } else if def.card.card_types.contains(&CardType::Creature) {
+        "creature"
+    } else if def.card.card_types.contains(&CardType::Enchantment) {
+        "enchantment"
+    } else if def.card.card_types.contains(&CardType::Land) {
+        "land"
+    } else if def.card.card_types.contains(&CardType::Planeswalker) {
+        "planeswalker"
+    } else if def.card.card_types.contains(&CardType::Battle) {
+        "battle"
+    } else {
+        "permanent"
+    }
+}
+
+fn substitute_source_owner_reference(line: &str, def: &CardDefinition) -> String {
+    let noun = source_type_noun(def);
+    line.replace(
+        "then this object's owner may put a land card from this object's owner's hand",
+        "then that player may put a land card from their hand",
+    )
+    .replace(
+        "Then this object's owner may put a land card from this object's owner's hand",
+        "Then that player may put a land card from their hand",
+    )
+    .replace(
+        "this object's owner may put a land card from this object's owner's hand",
+        "that player may put a land card from their hand",
+    )
+    .replace(
+        "This object's owner may put a land card from this object's owner's hand",
+        "That player may put a land card from their hand",
+    )
+    .replace("This object's owner", &format!("This {noun}'s owner"))
+    .replace("this object's owner", &format!("this {noun}'s owner"))
 }
 
 fn normalize_unprocessed_compiled_line(line: String) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -113,6 +113,9 @@ pub(super) fn describe_player_filter(filter: &PlayerFilter) -> String {
             "its controller".to_string()
         }
         PlayerFilter::OwnerOf(crate::target::ObjectRef::Target) => "its owner".to_string(),
+        PlayerFilter::OwnerOf(crate::target::ObjectRef::Tagged(tag)) if tag.as_str() == "__it__" => {
+            "this object's owner".to_string()
+        }
         PlayerFilter::ControllerOf(_) => "that object's controller".to_string(),
         PlayerFilter::OwnerOf(_) => "that object's owner".to_string(),
         PlayerFilter::AliasedOwnerOf(_) | PlayerFilter::AliasedControllerOf(_) => {
@@ -1968,6 +1971,30 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
         .replace(" and gains this creature cant ", " and can't ")
         .replace(" and gains this permanent can't ", " and can't ")
         .replace(" and gains this permanent cant ", " and can't ");
+    normalized = normalized
+        .replace("Draw a card, you may", "Draw a card, then you may")
+        .replace("draw a card, you may", "draw a card, then you may");
+    normalized = normalized
+        .replace(
+            "onto the battlefield, this object's owner draws",
+            "onto the battlefield. This object's owner draws",
+        )
+        .replace(
+            "onto the battlefield, this artifact's owner draws",
+            "onto the battlefield. This artifact's owner draws",
+        )
+        .replace(
+            "onto the battlefield, this creature's owner draws",
+            "onto the battlefield. This creature's owner draws",
+        )
+        .replace(
+            "onto the battlefield, this enchantment's owner draws",
+            "onto the battlefield. This enchantment's owner draws",
+        )
+        .replace(
+            "onto the battlefield, this permanent's owner draws",
+            "onto the battlefield. This permanent's owner draws",
+        );
     normalized = normalized.replace(
         "Tap target creature or planeswalker. choose it. activated abilities of that permanent can't be activated this turn",
         "Tap target creature or planeswalker. Its activated abilities can't be activated this turn",

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2208,6 +2208,14 @@ fn resolve_controller_of(
         ObjectRef::Tagged(tag) => {
             if let Some(snapshot) = ctx.get_tagged(tag) {
                 Ok(snapshot.controller)
+            } else if tag.as_str() == "__it__" {
+                if let Some(obj) = game.object(ctx.source) {
+                    Ok(game.controller_of(obj))
+                } else if let Some(snapshot) = ctx.source_snapshot.as_ref() {
+                    Ok(snapshot.controller)
+                } else {
+                    Err(ExecutionError::TagNotFound(tag.to_string()))
+                }
             } else {
                 Err(ExecutionError::TagNotFound(tag.to_string()))
             }
@@ -2243,6 +2251,14 @@ fn resolve_owner_of(
         ObjectRef::Tagged(tag) => {
             if let Some(snapshot) = ctx.get_tagged(tag) {
                 Ok(snapshot.owner)
+            } else if tag.as_str() == "__it__" {
+                if let Some(obj) = game.object(ctx.source) {
+                    Ok(obj.owner)
+                } else if let Some(snapshot) = ctx.source_snapshot.as_ref() {
+                    Ok(snapshot.owner)
+                } else {
+                    Err(ExecutionError::TagNotFound(tag.to_string()))
+                }
             } else {
                 Err(ExecutionError::TagNotFound(tag.to_string()))
             }

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2710,31 +2710,71 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
     let mut object_etb_effects: Vec<ReplacementEffect> = Vec::new();
     let mut copy_choice_effects: Vec<ReplacementEffect> = Vec::new();
 
-    if let Some(obj) = game.object(object) {
-        if let Some(loyalty) = obj.base_loyalty
+    let mut controller_override = None;
+    let object_static_context = game.object(object).map(|obj| {
+        let controller = game.controller_of(obj);
+        let base_loyalty = obj.base_loyalty;
+        let current_static_abilities = {
+            let view = crate::derived_view::DerivedGameView::new(game);
+            view.static_abilities_rc(object)
+                .map(|abilities| abilities.as_ref().clone())
+                .unwrap_or_else(|| {
+                    obj.abilities
+                        .iter()
+                        .filter_map(|ability| match &ability.kind {
+                            AbilityKind::Static(s) => Some(s.clone()),
+                            _ => None,
+                        })
+                        .collect()
+                })
+        };
+        (controller, base_loyalty, current_static_abilities)
+    });
+
+    if let Some((controller, base_loyalty, current_static_abilities)) = object_static_context {
+        if let Some(loyalty) = base_loyalty
             && loyalty > 0
         {
             // Planeswalkers intrinsically enter with loyalty counters equal to
             // their printed loyalty. Model this as ETB counters so replacement
             // effects can modify it (e.g., Doubling Season).
-            let loyalty = loyalty_after_compleated_life_payment(obj, loyalty);
+            let loyalty = game
+                .object(object)
+                .map(|obj| loyalty_after_compleated_life_payment(obj, loyalty))
+                .unwrap_or(loyalty);
             enters_with_counters.push((CounterType::Loyalty, loyalty));
         }
-        let controller = game.controller_of(obj);
-        let view = crate::derived_view::DerivedGameView::new(game);
-        let current_static_abilities = view
-            .static_abilities_rc(object)
-            .map(|abilities| abilities.as_ref().clone())
-            .unwrap_or_else(|| {
-                obj.abilities
-                    .iter()
-                    .filter_map(|ability| match &ability.kind {
-                        AbilityKind::Static(s) => Some(s.clone()),
-                        _ => None,
-                    })
-                    .collect()
-            });
         for s in &current_static_abilities {
+            if s.enters_under_opponent_control_as_enters().is_some() {
+                let opponents = game
+                    .players
+                    .iter()
+                    .filter(|player| player.id != controller && player.is_in_game())
+                    .map(|player| player.id)
+                    .collect::<Vec<_>>();
+                if !opponents.is_empty() {
+                    let display_options = opponents
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(idx, player_id)| {
+                            game.player(*player_id).map(|player| {
+                                crate::decisions::spec::DisplayOption::new(
+                                    idx,
+                                    player.name.clone(),
+                                )
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    let choice_spec = crate::decisions::specs::ChoiceSpec::single(
+                        object,
+                        display_options,
+                    );
+                    let mut chosen = make_decision(game, dm, controller, Some(object), choice_spec);
+                    if let Some(chosen_idx) = chosen.pop().filter(|idx| *idx < opponents.len()) {
+                        controller_override = Some(opponents[chosen_idx]);
+                    }
+                }
+            }
             // Check for unified replacement effects
             if let Some(effect) = s.generate_replacement_effect(object, controller) {
                 object_etb_effects.push(effect);
@@ -2818,7 +2858,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
             added_subtypes: Vec::new(),
             added_abilities: Vec::new(),
             set_base_power_toughness: None,
-            controller_override: None,
+            controller_override,
         },
         etb_event_provenance,
     );

--- a/crates/ironsmith-runtime/src/game_loop/choose_player_tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/choose_player_tests.rs
@@ -44,6 +44,20 @@ fn parse_sorcery_definition(name: &str, oracle_text: &str) -> crate::cards::Card
         .unwrap_or_else(|err| panic!("{name} should parse: {err:?}"))
 }
 
+fn parse_artifact_definition(name: &str, oracle_text: &str) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Artifact])
+        .parse_text(oracle_text)
+        .unwrap_or_else(|err| panic!("{name} should parse: {err:?}"))
+}
+
+fn pendant_of_prosperity_definition() -> crate::cards::CardDefinition {
+    parse_artifact_definition(
+        "Pendant of Prosperity",
+        "This artifact enters under the control of an opponent of your choice.\n{2}, {T}: Draw a card, then you may put a land card from your hand onto the battlefield. This artifact's owner draws a card, then that player may put a land card from their hand onto the battlefield.",
+    )
+}
+
 fn register_spell_cast_this_turn_for_test(
     game: &mut GameState,
     spell_id: ObjectId,
@@ -162,6 +176,7 @@ struct ScriptedDecisionMaker {
     option_matches: VecDeque<String>,
     object_matches: VecDeque<String>,
     color_matches: VecDeque<String>,
+    boolean_choices: VecDeque<bool>,
 }
 
 impl ScriptedDecisionMaker {
@@ -173,6 +188,23 @@ impl ScriptedDecisionMaker {
         option_matches: &[&str],
         object_matches: &[&str],
         color_matches: &[&str],
+    ) -> Self {
+        Self::with_colors_and_booleans(option_matches, object_matches, color_matches, &[])
+    }
+
+    fn with_booleans(
+        option_matches: &[&str],
+        object_matches: &[&str],
+        boolean_choices: &[bool],
+    ) -> Self {
+        Self::with_colors_and_booleans(option_matches, object_matches, &[], boolean_choices)
+    }
+
+    fn with_colors_and_booleans(
+        option_matches: &[&str],
+        object_matches: &[&str],
+        color_matches: &[&str],
+        boolean_choices: &[bool],
     ) -> Self {
         Self {
             option_matches: option_matches
@@ -187,11 +219,20 @@ impl ScriptedDecisionMaker {
                 .iter()
                 .map(|value| value.to_ascii_lowercase())
                 .collect(),
+            boolean_choices: boolean_choices.iter().copied().collect(),
         }
     }
 }
 
 impl DecisionMaker for ScriptedDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.boolean_choices.pop_front().unwrap_or(false)
+    }
+
     fn decide_options(
         &mut self,
         _game: &GameState,
@@ -327,6 +368,118 @@ fn order_of_succession_skips_player_when_next_player_has_no_creature() {
 
     assert_eq!(game.current_controller(alice_creature), Some(bob));
     assert_eq!(game.current_controller(bob_creature), Some(cara));
+}
+
+#[test]
+fn pendant_of_prosperity_enters_under_chosen_opponent_control() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let pendant = pendant_of_prosperity_definition();
+    let mut dm = ScriptedDecisionMaker::new(&["Charlie"], &[]);
+
+    let pendant_id = move_definition_to_battlefield_with_dm(&mut game, &pendant, alice, &mut dm);
+
+    let object = game.object(pendant_id).expect("Pendant should exist");
+    assert_eq!(object.owner, alice);
+    assert_eq!(game.current_controller(pendant_id), Some(charlie));
+    assert_ne!(game.current_controller(pendant_id), Some(bob));
+}
+
+#[test]
+fn pendant_of_prosperity_cannot_enter_under_its_controllers_control_choice() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let pendant = pendant_of_prosperity_definition();
+    let mut dm = ScriptedDecisionMaker::new(&["Alice"], &[]);
+
+    let pendant_id = move_definition_to_battlefield_with_dm(&mut game, &pendant, alice, &mut dm);
+
+    assert_eq!(game.current_controller(pendant_id), Some(bob));
+}
+
+#[test]
+fn pendant_of_prosperity_activation_draws_for_controller_and_owner_and_puts_lands() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let pendant = pendant_of_prosperity_definition();
+    let mut dm = ScriptedDecisionMaker::new(&["Bob"], &[]);
+    let pendant_id = move_definition_to_battlefield_with_dm(&mut game, &pendant, alice, &mut dm);
+
+    let bob_draw = CardBuilder::new(CardId::new(), "Bob Draw").build();
+    let alice_draw = CardBuilder::new(CardId::new(), "Alice Draw").build();
+    let bob_land = CardBuilder::new(CardId::new(), "Bob Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let alice_land = CardBuilder::new(CardId::new(), "Alice Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    game.create_object_from_card(&bob_draw, bob, Zone::Library);
+    game.create_object_from_card(&alice_draw, alice, Zone::Library);
+    game.create_object_from_card(&bob_land, bob, Zone::Hand);
+    game.create_object_from_card(&alice_land, alice, Zone::Hand);
+
+    game.player_mut(bob)
+        .expect("Bob should exist")
+        .mana_pool
+        .add(ManaSymbol::Green, 2);
+    let ability_index = game
+        .object(pendant_id)
+        .expect("Pendant should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Pendant should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(&game, bob)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == pendant_id && *idx == ability_index
+            )
+        })
+        .expect("Bob should be able to activate Pendant");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    game.turn.active_player = bob;
+    state.reset_for_new_priority_window(&mut game);
+    let mut resolve_dm =
+        ScriptedDecisionMaker::with_booleans(&[], &["Bob Land", "Alice Land"], &[true, true]);
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut resolve_dm,
+    )
+    .expect("Pendant activation should be placed on the stack");
+
+    assert!(
+        game.is_tapped(pendant_id),
+        "Pendant should tap to pay its activation cost"
+    );
+
+    resolve_stack_entry_with(&mut game, &mut resolve_dm)
+        .expect("Pendant activation should resolve");
+
+    let count_named = |game: &GameState, owner: PlayerId, zone: Zone, name: &str| {
+        game.objects_in_zone(zone)
+            .into_iter()
+            .filter(|id| {
+                game.object(*id)
+                    .is_some_and(|object| object.owner == owner && object.name == name)
+            })
+            .count()
+    };
+    assert_eq!(count_named(&game, bob, Zone::Hand, "Bob Draw"), 1);
+    assert_eq!(count_named(&game, alice, Zone::Hand, "Alice Draw"), 1);
+    assert_eq!(count_named(&game, bob, Zone::Battlefield, "Bob Land"), 1);
+    assert_eq!(count_named(&game, alice, Zone::Battlefield, "Alice Land"), 1);
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -6,6 +6,7 @@ use super::{
     ChooseBasicLandTypeAsEntersSpec, ChooseCardNameAsEntersSpec, ChooseColorAsBecomesAttachedSpec,
     ChooseColorAsEntersSpec, ChooseCreatureTypeAsEntersSpec, ChooseLandTypeAsEntersSpec,
     ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
+    EntersUnderOpponentControlAsEntersSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
     ConditionalSpellKeywordSpec, EnterAsCopyAsEntersSpec, GraveyardCountMetric,
     PowerToughnessChoiceOption, StaticAbility, StaticAbilityId, StaticAbilityKind,
@@ -1499,6 +1500,34 @@ impl StaticAbilityKind for ChoosePlayerAsEnters {
 
     fn player_choice_as_enters(&self) -> Option<ChoosePlayerAsEntersSpec> {
         Some(ChoosePlayerAsEntersSpec)
+    }
+}
+
+/// "This permanent enters under the control of an opponent of your choice."
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntersUnderOpponentControlAsEnters {
+    pub display: String,
+}
+
+impl EntersUnderOpponentControlAsEnters {
+    pub fn new(display: String) -> Self {
+        Self { display }
+    }
+}
+
+impl StaticAbilityKind for EntersUnderOpponentControlAsEnters {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::EntersUnderOpponentControlAsEnters
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn enters_under_opponent_control_as_enters(
+        &self,
+    ) -> Option<EntersUnderOpponentControlAsEntersSpec> {
+        Some(EntersUnderOpponentControlAsEntersSpec)
     }
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -627,6 +627,13 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Returns info for "this enters under an opponent's control" abilities.
+    fn enters_under_opponent_control_as_enters(
+        &self,
+    ) -> Option<EntersUnderOpponentControlAsEntersSpec> {
+        None
+    }
+
     /// Returns info for "as this enters, choose a card name" abilities.
     fn card_name_choice_as_enters(&self) -> Option<ChooseCardNameAsEntersSpec> {
         None
@@ -953,6 +960,10 @@ pub struct ChooseColorAsBecomesAttachedSpec;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChoosePlayerAsEntersSpec;
 
+/// Spec for "this enters under an opponent's control" abilities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct EntersUnderOpponentControlAsEntersSpec;
+
 /// Spec for "as this enters, choose a card name" abilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChooseCardNameAsEntersSpec;
@@ -1106,6 +1117,12 @@ impl StaticAbility {
 
     pub fn player_choice_as_enters(&self) -> Option<ChoosePlayerAsEntersSpec> {
         self.0.player_choice_as_enters()
+    }
+
+    pub fn enters_under_opponent_control_as_enters(
+        &self,
+    ) -> Option<EntersUnderOpponentControlAsEntersSpec> {
+        self.0.enters_under_opponent_control_as_enters()
     }
 
     pub fn card_name_choice_as_enters(&self) -> Option<ChooseCardNameAsEntersSpec> {
@@ -2652,6 +2669,10 @@ impl StaticAbility {
 
     pub fn choose_player_as_enters(display: String) -> Self {
         Self::new(ChoosePlayerAsEnters::new(display))
+    }
+
+    pub fn enters_under_opponent_control_as_enters_static(display: String) -> Self {
+        Self::new(EntersUnderOpponentControlAsEnters::new(display))
     }
 
     pub fn choose_card_name_as_enters(display: String) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1172,6 +1172,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ChoosePlayerAsEnters(display) => {
                 StaticAbility::choose_player_as_enters(display.clone())
             }
+            ironsmith_core::StaticAbilityPayload::EntersUnderOpponentControlAsEnters(display) => {
+                StaticAbility::enters_under_opponent_control_as_enters_static(display.clone())
+            }
             ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
                 StaticAbility::choose_card_name_as_enters(display.clone())
             }
@@ -1863,6 +1866,16 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ChoosePlayerAsEnters(_)
         )
         .then_some(super::ChoosePlayerAsEntersSpec)
+    }
+
+    fn enters_under_opponent_control_as_enters(
+        &self,
+    ) -> Option<super::EntersUnderOpponentControlAsEntersSpec> {
+        matches!(
+            self.payload(),
+            ironsmith_core::StaticAbilityPayload::EntersUnderOpponentControlAsEnters(_)
+        )
+        .then_some(super::EntersUnderOpponentControlAsEntersSpec)
     }
 
     fn card_name_choice_as_enters(&self) -> Option<super::ChooseCardNameAsEntersSpec> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pendant of Prosperity
Initial parse error:
```
parser does not yet support line family: 'This artifact enters under the control of an opponent of your choice.'; oracle-only fallback also failed: parser does not yet support line family: 'This artifact enters under the control of an opponent of your choice.'
```

Current worker: i-04c65a6729856ddbf
Branch: codex/aws-card-fix-pendant-of-prosperity
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0030
