### PR TITLE
Fix Ironsmith parse failure: Cheering Fanatic

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
@@ -531,9 +531,13 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
         .or_else(|| word_slice_find_word(clause_words.as_slice(), "costs"))?;
     let less_idx = word_slice_find_word(clause_words.as_slice(), "less")?;
 
+    let has_you_cast = word_slice_contains_phrase(&clause_words, &["you", "cast"]);
+    let has_chosen_name = word_slice_contains_phrase(&clause_words, &["with", "chosen", "name"])
+        || word_slice_contains_phrase(&clause_words, &["with", "the", "chosen", "name"]);
+
     if cost_idx <= spell_idx
         || less_idx <= cost_idx
-        || !word_slice_contains_phrase(&clause_words, &["you", "cast"])
+        || (!has_you_cast && !has_chosen_name)
         || !word_slice_contains_phrase(&clause_words, &["this", "turn"])
         || clause_words.get(less_idx + 1).copied() != Some("to")
         || clause_words.get(less_idx + 2).copied() != Some("cast")
@@ -560,9 +564,17 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
     }
 
     let mut filter = crate::runtime_backend::parse_spell_filter_lexed(&subject_tokens);
-    filter.cast_by = Some(PlayerFilter::You);
+    let player = if has_you_cast {
+        filter.cast_by = Some(PlayerFilter::You);
+        PlayerAst::You
+    } else {
+        PlayerAst::Any
+    };
 
     let between_words = &clause_words[spell_idx + 1..cost_idx];
+    if has_chosen_name {
+        filter.name = Some("{chosen name}".to_string());
+    }
     if word_slice_contains_phrase(between_words, &["from", "exile"]) {
         filter.zone = Some(Zone::Exile);
     } else if word_slice_contains_phrase(between_words, &["from", "your", "graveyard"]) {
@@ -575,13 +587,13 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
         && used == reduction_tokens.len()
     {
         Some(EffectAst::subject_verb_reduce_next_spell_cost_this_turn(
-            PlayerAst::You,
+            player,
             filter,
             mana_reduction,
         ))
     } else {
         Some(EffectAst::subject_verb_reduce_matching_spell_cost_this_turn(
-            PlayerAst::You,
+            player,
             filter,
             reduction,
         ))

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41995,6 +41995,57 @@ fn assert_oracle_card_parses_strict(name: &str) {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cheering_fanatic_strict_parser_renders_chosen_name_cost_reduction() {
+    let def = parse_oracle_card_definition("Cheering Fanatic");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Cheering Fanatic should have an attack trigger");
+
+    assert_eq!(
+        triggered.trigger.display(),
+        "Whenever this creature attacks",
+        "Cheering Fanatic should trigger from attacking"
+    );
+
+    let effects = triggered.effects.flattened_default_effects();
+    assert!(
+        effects.iter().any(|effect| effect
+            .downcast_ref::<crate::effects::ChooseCardNameEffect>()
+            .is_some()),
+        "Cheering Fanatic should choose a card name before granting the cost reduction"
+    );
+    let reduction = effects
+        .iter()
+        .find_map(|effect| {
+            effect.downcast_ref::<crate::effects::GrantNextSpellCostReductionEffect>()
+        })
+        .expect("Cheering Fanatic should grant a temporary matching-spell cost reduction");
+    assert_eq!(reduction.player, PlayerFilter::Any);
+    assert_eq!(reduction.filter.name.as_deref(), Some("{chosen name}"));
+    assert_eq!(reduction.filter.cast_by, None);
+    assert!(reduction.applies_to_all_matching_this_turn);
+    assert!(
+        matches!(reduction.generic_reduction, Some(Value::Fixed(1))),
+        "Cheering Fanatic should reduce matching spells by one generic mana, got {:?}",
+        reduction.generic_reduction
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("spells with the chosen name cost {1} less to cast this turn"),
+        "Cheering Fanatic should render the chosen-name temporary cost reduction, got {rendered}"
+    );
+}
+
 fn assert_oracle_card_fails_strict(name: &str) {
     let oracle = oracle_text_by_name()
         .get(name)

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -135,6 +135,23 @@ pub(super) fn describe_cast_limit_spell_filter(filter: &ObjectFilter) -> String 
     if filter == &ObjectFilter::default() {
         return "spell".to_string();
     }
+    if filter.name.as_deref() == Some("{chosen name}") {
+        let mut base = filter.clone();
+        base.name = None;
+        if base == ObjectFilter::default() {
+            return "spell with the chosen name".to_string();
+        }
+    }
+    if filter.tagged_constraints.len() == 1
+        && filter.tagged_constraints[0].tag.as_str() == "__chosen_name__"
+        && filter.tagged_constraints[0].relation == TaggedOpbjectRelation::SameNameAsTagged
+    {
+        let mut base = filter.clone();
+        base.tagged_constraints.clear();
+        if base == ObjectFilter::default() {
+            return "spell with the chosen name".to_string();
+        }
+    }
     if filter == &ObjectFilter::default().without_type(CardType::Creature) {
         return "noncreature spell".to_string();
     }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -34989,7 +34989,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 .generic_reduction
                 .as_ref()
                 .map(|value| match value {
-                    Value::Fixed(amount) => (amount.to_string(), String::new()),
+                    Value::Fixed(amount) => (format!("{{{amount}}}"), String::new()),
                     Value::X => ("{X}".to_string(), String::new()),
                     _ => (
                         "{X}".to_string(),
@@ -35019,6 +35019,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             } else {
                 format!("{spell_text} spells")
             };
+            if grant_next_spell_cost_reduction.filter.cast_by.is_none()
+                && grant_next_spell_cost_reduction.filter.zone.is_none()
+            {
+                return format!(
+                    "{} cost {} less to cast this turn{}",
+                    plural_spell_text, reduction, where_suffix,
+                );
+            }
             return format!(
                 "{} this turn cost {} less to cast{}",
                 plural_spell_text, reduction, where_suffix,

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -3097,7 +3097,22 @@ pub(crate) fn apply_spell_cost_modifiers(
         if effect.player != player || effect.is_expired(current_turn) {
             continue;
         }
-        if spell_matches_filter(game, spell, player, &effect.filter, &ctx, casting_method) {
+        let temporary_ctx = with_source_exiled_tagged_objects(
+            game,
+            FilterContext::new(player)
+                .with_source(effect.source)
+                .with_active_player(game.turn.active_player)
+                .with_opponents(opponents_of(game, player)),
+            effect.source,
+        );
+        if spell_matches_filter(
+            game,
+            spell,
+            player,
+            &effect.filter,
+            &temporary_ctx,
+            casting_method,
+        ) {
             if let Some(generic_reduction) = &effect.generic_reduction {
                 let amount = resolve_cost_modifier_value(game, player, spell, generic_reduction);
                 if amount > 0 {

--- a/crates/ironsmith-runtime/src/effects/player/grant_next_spell_cost_reduction.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_next_spell_cost_reduction.rs
@@ -2,7 +2,7 @@
 
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
-use crate::effects::helpers::{resolve_player_filter, resolve_value};
+use crate::effects::helpers::{resolve_player_filter_to_list, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 
@@ -14,7 +14,8 @@ impl EffectExecutor for GrantNextSpellCostReductionEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        let player = resolve_player_filter(game, &self.player, ctx)?;
+        let players =
+            resolve_player_filter_to_list(game, &self.player, &ctx.filter_context(game), ctx)?;
         if self.applies_to_all_matching_this_turn {
             let amount = self
                 .generic_reduction
@@ -23,20 +24,24 @@ impl EffectExecutor for GrantNextSpellCostReductionEffect {
                 .transpose()?
                 .unwrap_or(0)
                 .max(0);
-            game.add_temporary_matching_spell_cost_reduction_this_turn(
-                player,
-                ctx.source,
-                self.filter.clone(),
-                crate::effect::Value::Fixed(amount),
-            );
+            for player in players {
+                game.add_temporary_matching_spell_cost_reduction_this_turn(
+                    player,
+                    ctx.source,
+                    self.filter.clone(),
+                    crate::effect::Value::Fixed(amount),
+                );
+            }
         } else {
-            game.add_temporary_spell_cost_reduction(
-                player,
-                ctx.source,
-                self.filter.clone(),
-                self.reduction.clone(),
-                1,
-            );
+            for player in players {
+                game.add_temporary_spell_cost_reduction(
+                    player,
+                    ctx.source,
+                    self.filter.clone(),
+                    self.reduction.clone(),
+                    1,
+                );
+            }
         }
         Ok(EffectOutcome::resolved())
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -32971,6 +32971,105 @@ fn commander_liara_portyr_runtime_has_no_reduction_without_attacked_players() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cheering_fanatic_runtime_reduces_only_spells_with_chosen_name_this_turn() {
+    struct ChooseLightningBoltName;
+
+    impl DecisionMaker for ChooseLightningBoltName {
+        fn decide_text(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::TextInputContext,
+        ) -> String {
+            "Lightning Bolt".to_string()
+        }
+    }
+
+    fn generic_spell(name: &str) -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), name)
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .card_types(vec![CardType::Sorcery])
+            .with_spell_effect(vec![Effect::draw(1)])
+            .build()
+    }
+
+    fn effective_cost_text(game: &GameState, player: PlayerId, spell_id: ObjectId) -> String {
+        let spell = game.object(spell_id).expect("spell should exist");
+        crate::decision::calculate_effective_mana_cost(
+            game,
+            player,
+            spell,
+            spell.mana_cost.as_ref().expect("spell mana cost"),
+        )
+        .to_oracle()
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let cheering = CardDefinitionBuilder::new(CardId::from_raw(56_400), "Cheering Fanatic")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Goblin])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "Whenever this creature attacks, choose a card name. \
+             Spells with the chosen name cost {1} less to cast this turn.",
+        )
+        .expect("Cheering Fanatic should parse for runtime regression");
+    let triggered = cheering
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Cheering Fanatic should have an attack trigger");
+    let cheering_id = game.create_object_from_definition(&cheering, alice, Zone::Battlefield);
+
+    let lightning = generic_spell("Lightning Bolt");
+    let other_spell = generic_spell("Giant Growth");
+    let alice_lightning = game.create_object_from_definition(&lightning, alice, Zone::Hand);
+    let bob_lightning = game.create_object_from_definition(&lightning, bob, Zone::Hand);
+    let alice_other = game.create_object_from_definition(&other_spell, alice, Zone::Hand);
+
+    let mut decision_maker = ChooseLightningBoltName;
+    let mut ctx = crate::effects::ExecutionContext::new_default(cheering_id, alice)
+        .with_decision_maker(&mut decision_maker);
+    for effect in triggered.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Cheering Fanatic attack trigger effect should resolve");
+    }
+
+    assert_eq!(
+        effective_cost_text(&game, alice, alice_lightning),
+        "{1}",
+        "the chosen Lightning Bolt should cost one less for Cheering Fanatic's controller"
+    );
+    assert_eq!(
+        effective_cost_text(&game, bob, bob_lightning),
+        "{1}",
+        "Cheering Fanatic's unqualified cost reduction should apply to other players too"
+    );
+    assert_eq!(
+        effective_cost_text(&game, alice, alice_other),
+        "{2}",
+        "spells without the chosen name should not be reduced"
+    );
+
+    game.turn.turn_number += 1;
+    game.cleanup_temporary_spell_cost_reductions_end_of_turn();
+    assert_eq!(
+        effective_cost_text(&game, alice, alice_lightning),
+        "{2}",
+        "Cheering Fanatic's reduction should expire after this turn"
+    );
+}
+
 #[test]
 fn test_face_down_cast_matches_panoptic_filter_and_enters_battlefield_face_down() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cheering Fanatic
Initial parse error:
```
could not find verb in effect clause (clause: 'spells with the chosen name cost 1 less to cast this turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'spells with the chosen name cost 1 less to cast this turn'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0c317e2a804ea9adc
Branch: codex/aws-card-fix-cheering-fanatic
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0032
