### PR TITLE
Fix Ironsmith parse failure: Circuits Act

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -166,6 +166,7 @@ fn compile_effect_inner(
         ));
     }
     if let EffectAst::RepeatEffects { count, effects } = effect {
+        let resolved_count = resolve_value_it_tag(count, &current_reference_env(ctx))?;
         let mut compiled_effects = Vec::new();
         let mut choices = Vec::new();
         for child in effects {
@@ -174,7 +175,7 @@ fn compile_effect_inner(
             choices.append(&mut child_choices);
         }
         return Ok((
-            vec![Effect::repeat_effects(count.clone(), compiled_effects)],
+            vec![Effect::repeat_effects(resolved_count, compiled_effects)],
             choices,
         ));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -880,6 +880,10 @@ pub(crate) fn effect_references_event_derived_amount(effect: &EffectAst) -> bool
                     _ => false,
                 }
         }
+        EffectAst::RepeatEffects { count, effects } => {
+            value_references_event_derived_amount(count)
+                || effects.iter().any(effect_references_event_derived_amount)
+        }
         _ => {
             let mut references = false;
             for_each_nested_effects(effect, true, |nested| {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -5718,10 +5718,6 @@ impl EffectAst {
         )
     }
 
-    pub(crate) fn subject_verb_roll_die(player: PlayerAst, sides: u32) -> Self {
-        Self::subject_verb_roll_die_with_die_text(player, sides, None)
-    }
-
     pub(crate) fn subject_verb_roll_die_with_die_text(
         player: PlayerAst,
         sides: u32,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1412,6 +1412,9 @@ fn effect_can_supply_event_derived_amount_for(effect: &EffectAst, consumer: &Eff
     if !effect_references_event_derived_amount(consumer) {
         return false;
     }
+    if effect_references_only_distinct_numbers_metric(consumer) {
+        return effect_can_supply_distinct_numbers_metric(effect);
+    }
     if effect_references_only_other_number_metric(consumer) {
         return matches!(
             effect,
@@ -1422,6 +1425,56 @@ fn effect_can_supply_event_derived_amount_for(effect: &EffectAst, consumer: &Eff
         );
     }
     true
+}
+
+fn effect_can_supply_distinct_numbers_metric(effect: &EffectAst) -> bool {
+    match effect {
+        EffectAst::RepeatEffects { effects, .. } => {
+            effects.iter().any(effect_can_supply_distinct_numbers_metric)
+        }
+        EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action:
+                SubjectVerbActionAst::RollDie { .. }
+                | SubjectVerbActionAst::RollDiceChooseResult { .. },
+            ..
+        }) => true,
+        _ => false,
+    }
+}
+
+fn effect_references_only_distinct_numbers_metric(effect: &EffectAst) -> bool {
+    let mut saw_distinct_numbers = false;
+    let mut saw_other_event_value = false;
+    visit_effect_values(effect, &mut |value| {
+        if value_references_only_distinct_numbers_metric(value) {
+            saw_distinct_numbers = true;
+        } else if value_references_event_derived_amount(value) {
+            saw_other_event_value = true;
+        }
+    });
+    saw_distinct_numbers && !saw_other_event_value
+}
+
+fn value_references_only_distinct_numbers_metric(value: &Value) -> bool {
+    match value {
+        Value::SurfaceHinted { value, .. } => value_references_only_distinct_numbers_metric(value),
+        Value::PendingEffectMetric {
+            metric: EffectMetric::DistinctNumbers,
+            ..
+        }
+        | Value::PendingEffectMetricOffset {
+            metric: EffectMetric::DistinctNumbers,
+            ..
+        } => true,
+        Value::Add(left, right) | Value::Min(left, right) => {
+            value_references_only_distinct_numbers_metric(left)
+                || value_references_only_distinct_numbers_metric(right)
+        }
+        Value::Scaled(value, _) | Value::HalfRoundedDown(value) => {
+            value_references_only_distinct_numbers_metric(value)
+        }
+        _ => false,
+    }
 }
 
 fn effect_references_only_other_number_metric(effect: &EffectAst) -> bool {
@@ -1464,6 +1517,7 @@ fn visit_effect_values(effect: &EffectAst, visit: &mut impl FnMut(&Value)) {
         EffectAst::SubjectVerb(subject_verb) => {
             visit_subject_verb_action_values(&subject_verb.action, visit);
         }
+        EffectAst::RepeatEffects { count, .. } => visit(count),
         _ => {}
     }
     for_each_nested_effects(effect, true, |nested| {
@@ -3724,6 +3778,69 @@ mod tests {
             }
             other => panic!("expected draw effect, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn annotate_effect_sequence_binds_distinct_numbers_only_to_prior_dice_results() {
+        let effects = vec![
+            EffectAst::RepeatEffects {
+                count: Value::Fixed(3),
+                effects: vec![EffectAst::subject_verb_roll_die_with_die_text(
+                    PlayerAst::Implicit,
+                    6,
+                    Some("six-sided die".to_string()),
+                )],
+            },
+            EffectAst::RepeatEffects {
+                count: Value::PendingEffectMetric {
+                    source: EffectMetricSource::Outcome,
+                    metric: EffectMetric::DistinctNumbers,
+                },
+                effects: vec![EffectAst::subject_verb(
+                    SubjectVerbRoleAst::AffectedPlayer,
+                    PlayerAst::You,
+                    SubjectVerbActionAst::Draw {
+                        count: Value::Fixed(1),
+                    },
+                )],
+            },
+        ];
+
+        let annotated = annotate_effect_sequence(
+            &effects,
+            &ModelReferenceImports::default(),
+            EffectReferenceResolutionConfig::default(),
+            IdGenContext::default(),
+        )
+        .expect("annotate dice distinct-results sequence");
+
+        assert_eq!(annotated.effects[0].assigned_effect_id, Some(EffectId(0)));
+        assert_eq!(
+            annotated.effects[1].in_env.last_effect_id,
+            ModelRefState::Known(EffectId(0))
+        );
+
+        let non_dice_effects = vec![
+            EffectAst::subject_verb(
+                SubjectVerbRoleAst::AffectedPlayer,
+                PlayerAst::You,
+                SubjectVerbActionAst::Draw {
+                    count: Value::Fixed(1),
+                },
+            ),
+            effects[1].clone(),
+        ];
+        let annotated = annotate_effect_sequence(
+            &non_dice_effects,
+            &ModelReferenceImports::default(),
+            EffectReferenceResolutionConfig::default(),
+            IdGenContext::default(),
+        )
+        .expect("annotate non-dice distinct-results sequence");
+        assert_eq!(
+            annotated.effects[1].in_env.last_effect_id,
+            ModelRefState::Unknown
+        );
     }
 
     #[test]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -8,6 +8,7 @@ use crate::static_abilities::StaticAbilityId;
 use crate::target::{ObjectFilter, PlayerFilter};
 use crate::zone::Zone;
 use crate::{ChoiceCount, Supertype};
+use ironsmith_core::{EffectMetric, EffectMetricSource};
 
 use super::super::activation_and_restrictions::activation_restriction_clauses::starts_with_target_indicator;
 use super::super::activation_and_restrictions::trigger_subject_filters::title_case_token_word;
@@ -653,6 +654,7 @@ const ODD_EVEN_RESULT_PREFIXES: &[&[&str]] = &[
     &["for", "each", "odd", "result"],
     &["for", "each", "even", "result"],
 ];
+const DIFFERENT_RESULT_PREFIX: &[&str] = &["for", "each", "different", "result"];
 
 const ODD_RESULT_VALUES_D6: &[i32] = &[1, 3, 5];
 const EVEN_RESULT_VALUES_D6: &[i32] = &[2, 4, 6];
@@ -2562,7 +2564,11 @@ pub(crate) fn parse_keyword_mechanic_clause(
             }
             return Ok(Some(EffectAst::RepeatEffects {
                 count,
-                effects: vec![EffectAst::subject_verb_roll_die(PlayerAst::Implicit, 6)],
+                effects: vec![EffectAst::subject_verb_roll_die_with_die_text(
+                    PlayerAst::Implicit,
+                    6,
+                    Some("six-sided die".to_string()),
+                )],
             }));
         }
         return Err(CardTextError::ParseError(format!(
@@ -2596,6 +2602,34 @@ pub(crate) fn parse_keyword_mechanic_clause(
         let effect = parse_effect_with_verb(verb, None, &tail_tokens[1..])?;
         return Ok(Some(EffectAst::IfResult {
             predicate: IfResultPredicate::Value(predicate),
+            effects: vec![effect],
+        }));
+    }
+
+    if let Some(tail_clause) = clause.strip_prefix_clause(DIFFERENT_RESULT_PREFIX) {
+        let mut tail_clause = tail_clause.trimmed();
+        while CLAUSE_THEN_OR_YOU_WORD_PATTERN.matches_clause_first_word(tail_clause) {
+            tail_clause = tail_clause.from(1).trimmed();
+        }
+        let tail_tokens = tail_clause.tokens();
+        let Some((verb, verb_idx)) = find_verb(tail_tokens) else {
+            return Err(CardTextError::ParseError(format!(
+                "missing action after different-result clause (clause: '{}')",
+                clause_text
+            )));
+        };
+        if verb_idx != 0 {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported different-result action prefix (clause: '{}')",
+                clause_text
+            )));
+        }
+        let effect = parse_effect_with_verb(verb, None, &tail_tokens[1..])?;
+        return Ok(Some(EffectAst::RepeatEffects {
+            count: Value::PendingEffectMetric {
+                source: EffectMetricSource::Outcome,
+                metric: EffectMetric::DistinctNumbers,
+            },
             effects: vec![effect],
         }));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -14243,3 +14243,22 @@ fn clown_car_parses_roll_x_six_sided_dice_with_odd_even_result_clauses() {
         "expected repeat roll plus odd/even result branches for Clown Car, got {debug}"
     );
 }
+
+#[test]
+fn circuits_act_parses_roll_three_dice_with_different_result_clause() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Circuits Act")
+        .parse_text(
+            "Roll three six-sided dice. For each different result, create a 1/1 white Clown Robot artifact creature token.",
+        )
+        .expect("Circuits Act text should parse");
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("RepeatEffects")
+            && debug.contains("RollDieEffect")
+            && debug.contains("DistinctNumbers")
+            && debug.contains("CreateToken")
+            && debug.contains("Clown")
+            && debug.contains("Robot"),
+        "expected roll-three-dice plus different-result token creation for Circuits Act, got {debug}"
+    );
+}

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -35,6 +35,7 @@ pub enum EffectMetric {
     GreatestPlayerCount,
     IteratedPlayerCount,
     OtherNumber,
+    DistinctNumbers,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6568,7 +6568,7 @@ fn test_parse_clown_car_compiled_text_keeps_odd_even_branches_and_token_identity
         .join(" ")
         .to_ascii_lowercase();
     assert!(
-        rendered.contains("roll") && rendered.contains("d6"),
+        rendered.contains("roll") && (rendered.contains("d6") || rendered.contains("six-sided")),
         "expected roll clause in compiled text, got {rendered}"
     );
     assert!(
@@ -6589,6 +6589,43 @@ fn test_parse_clown_car_compiled_text_keeps_odd_even_branches_and_token_identity
     assert!(
         rendered.contains("+1/+1 counter") && rendered.contains("this vehicle"),
         "expected even-result +1/+1 counter branch in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_circuits_act_counts_different_die_results_for_tokens() {
+    let def = parse_oracle_card_definition("Circuits Act");
+
+    let spell_debug = format!("{:?}", def.spell_effect);
+    assert!(
+        spell_debug.contains("RepeatEffects")
+            && spell_debug.contains("RollDieEffect")
+            && spell_debug.contains("DistinctNumbers")
+            && spell_debug.contains("CreateToken")
+            && spell_debug.contains("Clown")
+            && spell_debug.contains("Robot"),
+        "expected Circuits Act to roll three dice and create tokens for distinct results, got {spell_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("roll three") && rendered.contains("six-sided dice"),
+        "expected Circuits Act compiled text to keep the three-dice roll, got {rendered}"
+    );
+    assert!(
+        rendered.contains("for each different result"),
+        "expected Circuits Act compiled text to keep the different-result clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("1/1")
+            && rendered.contains("white")
+            && rendered.contains("clown")
+            && rendered.contains("robot")
+            && rendered.contains("artifact creature token"),
+        "expected Circuits Act compiled text to keep the Clown Robot token payload, got {rendered}"
     );
 }
 
@@ -46812,6 +46849,7 @@ strict_parse_card_test!(strict_parse_blast_zone, "Blast Zone");
 strict_parse_card_test!(strict_parse_bridge_from_below, "Bridge from Below");
 strict_parse_card_test!(strict_parse_cabal_ritual, "Cabal Ritual");
 strict_parse_card_test!(strict_parse_cavern_of_souls, "Cavern of Souls");
+strict_parse_card_test!(strict_parse_circuits_act, "Circuits Act");
 strict_parse_card_test!(strict_parse_clown_car, "Clown Car");
 strict_parse_card_test!(strict_parse_encroaching_mycosynth, "Encroaching Mycosynth");
 strict_parse_card_test!(strict_parse_escaped_null, "Escaped Null");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8026,6 +8026,7 @@ fn describe_effect_metric_value(
         }
         crate::effect::EffectMetric::IteratedPlayerCount => "that many".to_string(),
         crate::effect::EffectMetric::OtherNumber => "the other result".to_string(),
+        crate::effect::EffectMetric::DistinctNumbers => "the number of different results".to_string(),
     };
     match offset {
         Some(0) | None => base,

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -35279,6 +35279,43 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 repeated
             );
         }
+        if matches!(
+            repeat.count.unhinted(),
+            Value::EffectMetric {
+                metric: crate::effect::EffectMetric::DistinctNumbers,
+                ..
+            } | Value::PendingEffectMetric {
+                metric: crate::effect::EffectMetric::DistinctNumbers,
+                ..
+            }
+        ) {
+            return format!("For each different result, {repeated}");
+        }
+        if repeat.effects.len() == 1
+            && let Some(roll_die) = repeat.effects[0].downcast_ref::<crate::effects::RollDieEffect>()
+        {
+            let player = describe_player_filter(&roll_die.player);
+            let count_text = match repeat.count.unhinted() {
+                Value::Fixed(n) => number_word(*n).unwrap_or_else(|| n.to_string()),
+                other => describe_value(other),
+            };
+            let die_text = roll_die
+                .die_text
+                .as_deref()
+                .map(|text| {
+                    text.strip_suffix(" die")
+                        .map(|base| format!("{base} dice"))
+                        .unwrap_or_else(|| text.to_string())
+                })
+                .unwrap_or_else(|| format!("d{}", roll_die.sides));
+            if player == "you" {
+                return format!("Roll {count_text} {die_text}");
+            }
+            return format!(
+                "{player} {} {count_text} {die_text}",
+                player_verb(&player, "roll", "rolls"),
+            );
+        }
         return format!(
             "Repeat {} {} times",
             repeated,

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -360,6 +360,16 @@ fn resolve_effect_metric(
                 _ => None,
             })
             .unwrap_or(0),
+        EffectMetric::DistinctNumbers => outcome
+            .execution_facts
+            .iter()
+            .filter_map(|fact| match fact {
+                crate::effect::ExecutionFact::ChosenNumber(value)
+                | crate::effect::ExecutionFact::OtherNumber(value) => Some(*value),
+                _ => None,
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .len() as i32,
     };
 
     Ok(resolved)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -24249,6 +24249,77 @@ fn clown_car_etb_applies_odd_even_result_branches_per_die_for_x_rolls() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn circuits_act_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Circuits Act")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Roll three six-sided dice. For each different result, create a 1/1 white Clown Robot artifact creature token.",
+        )
+        .expect("Circuits Act should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_circuits_act_with_rolls(rolls: &[u32]) -> usize {
+    use crate::effects::{ExecutionContext, execute_effect};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    for roll in rolls {
+        game.force_next_die_roll(*roll);
+    }
+
+    let circuits_act = circuits_act_definition();
+    let source_id = game.create_object_from_definition(&circuits_act, alice, Zone::Stack);
+    let spell_effect = circuits_act
+        .spell_effect
+        .as_ref()
+        .expect("Circuits Act should have spell effects");
+    let mut ctx = ExecutionContext::new_default(source_id, alice);
+    for effect in spell_effect {
+        execute_effect(&mut game, effect, &mut ctx)
+            .expect("Circuits Act spell effect should resolve");
+    }
+
+    game.battlefield
+        .iter()
+        .filter(|&&id| {
+            game.object(id).is_some_and(|obj| {
+                obj.name == "Clown"
+                    && game.controller_of(obj) == alice
+                    && obj.card_types.contains(&CardType::Artifact)
+                    && obj.card_types.contains(&CardType::Creature)
+                    && obj.subtypes.contains(&Subtype::Clown)
+                    && obj.subtypes.contains(&Subtype::Robot)
+            })
+        })
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn circuits_act_creates_tokens_for_each_distinct_die_result() {
+    assert_eq!(
+        resolve_circuits_act_with_rolls(&[1, 1, 1]),
+        1,
+        "three matching results should create one Clown Robot token"
+    );
+    assert_eq!(
+        resolve_circuits_act_with_rolls(&[1, 2, 1]),
+        2,
+        "duplicate results should not create an extra token for the repeated result"
+    );
+    assert_eq!(
+        resolve_circuits_act_with_rolls(&[1, 2, 3]),
+        3,
+        "three different results should create three Clown Robot tokens"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn complaints_clerk_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), "Complaints Clerk")
         .card_types(vec![CardType::Creature])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Circuits Act
Initial parse error:
```
unsupported target phrase (clause: 'different result'); oracle-only fallback also failed: unsupported target phrase (clause: 'different result')
```

Current worker: i-0277afb3da97199a7
Branch: codex/aws-card-fix-circuits-act
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0033
