### PR TITLE
Fix Ironsmith parse failure: Debt of Loyalty

### DIFF
--- a/crates/ironsmith-compiler/src/effects/mod.rs
+++ b/crates/ironsmith-compiler/src/effects/mod.rs
@@ -56,7 +56,7 @@ pub use ironsmith_core::{
     RedirectAllDamageThisTurnToTargetEffect, RedirectNextDamageToTargetEffect,
     RedirectNextTimeDamageDestination, RedirectNextTimeDamageSource,
     RedirectNextTimeDamageToSourceEffect, ReflexiveTriggerEffect as CoreReflexiveTriggerEffect,
-    RegenerateEffect, RegisterDamagedBySourceZoneReplacementEffect,
+    RegenerateEffect as CoreRegenerateEffect, RegisterDamagedBySourceZoneReplacementEffect,
     RegisterEnterUnderControlReplacementEffect, RegisterFutureZoneReplacementEffect,
     RegisterZoneReplacementEffect, RemoveAnyCountersAmongEffect, RemoveAnyCountersFromSourceEffect,
     RemoveCountersEffect, RemoveFromCombatEffect, RemoveUpToAnyCountersEffect,
@@ -97,6 +97,7 @@ pub type LocalRewriteEffect = CoreLocalRewriteEffect<Effect>;
 pub type ManaRestrictedEffect = CoreManaRestrictedEffect<Effect>;
 pub type PreventDamageEffect = CorePreventDamageEffect<Effect>;
 pub type PreventAllDamageToTargetEffect = CorePreventAllDamageToTargetEffect<Effect>;
+pub type RegenerateEffect = CoreRegenerateEffect<Effect>;
 pub type ScheduleEffectsWhenTaggedLeavesEffect = CoreScheduleEffectsWhenTaggedLeavesEffect<Effect>;
 pub type SequenceEffect = CoreSequenceEffect<Effect>;
 pub type WithIdEffect = CoreWithIdEffect<Effect>;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5664,11 +5664,30 @@ fn compile_subject_verb_effect(
         SubjectVerbActionAst::Flip { target } => {
             compile_tagged_effect_for_target(target, ctx, "flipped", Effect::flip)
         }
-        SubjectVerbActionAst::Regenerate { target } => {
-            let (spec, choices) =
+        SubjectVerbActionAst::Regenerate {
+            target,
+            follow_up_effects,
+        } => {
+            let (spec, mut choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let mut follow_ups = Vec::new();
+            if !follow_up_effects.is_empty() {
+                let saved_last_object_tag = ctx.last_object_tag.clone();
+                ctx.last_object_tag = Some(IT_TAG.to_string());
+                let (compiled_follow_ups, follow_up_choices) = compile_effects(follow_up_effects, ctx)?;
+                follow_ups = compiled_follow_ups;
+                for choice in follow_up_choices {
+                    push_choice(&mut choices, choice);
+                }
+                ctx.last_object_tag = saved_last_object_tag;
+            }
+            let regenerate = crate::effects::RegenerateEffect::new(
+                spec.clone(),
+                crate::effect::Until::EndOfTurn,
+            )
+            .with_follow_up_effects(follow_ups);
             let effect = tag_object_target_effect(
-                Effect::regenerate(spec.clone(), crate::effect::Until::EndOfTurn),
+                Effect::new(regenerate),
                 &spec,
                 ctx,
                 "regenerated",

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -103,7 +103,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::Suspect { target }
             | SubjectVerbActionAst::RemoveFromCombat { target }
             | SubjectVerbActionAst::Flip { target }
-            | SubjectVerbActionAst::Regenerate { target }
+            | SubjectVerbActionAst::Regenerate { target, .. }
             | SubjectVerbActionAst::TapOrUntap { target }
             | SubjectVerbActionAst::PhaseOut { target }
             | SubjectVerbActionAst::PhaseIn { target }
@@ -990,6 +990,9 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
             | SubjectVerbActionAst::SwitchPowerToughness { target, .. } => {
                 target_references_tag(target, IT_TAG)
             }
+            SubjectVerbActionAst::Regenerate {
+                follow_up_effects, ..
+            } => effects_reference_it_tag(follow_up_effects),
             SubjectVerbActionAst::DestroyAll { filter, .. }
             | SubjectVerbActionAst::DestroyAllOfChosenColor { filter, .. }
             | SubjectVerbActionAst::ExileAll { filter, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1714,6 +1714,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     Regenerate {
         target: TargetAst,
+        follow_up_effects: Vec<EffectAst>,
     },
     RegenerateAll {
         filter: ObjectFilter,
@@ -3229,7 +3230,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 f.debug_tuple("RemoveFromCombat").field(target).finish()
             }
             Self::Flip { target } => f.debug_tuple("Flip").field(target).finish(),
-            Self::Regenerate { target } => f.debug_tuple("Regenerate").field(target).finish(),
+            Self::Regenerate {
+                target,
+                follow_up_effects,
+            } => f
+                .debug_struct("Regenerate")
+                .field("target", target)
+                .field("follow_up_effects", follow_up_effects)
+                .finish(),
             Self::RegenerateAll { filter } => f.debug_tuple("RegenerateAll").field(filter).finish(),
             Self::Sacrifice {
                 filter,
@@ -6573,7 +6581,24 @@ impl EffectAst {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::Regenerate { target },
+            SubjectVerbActionAst::Regenerate {
+                target,
+                follow_up_effects: Vec::new(),
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_regenerate_with_follow_up_effects(
+        target: TargetAst,
+        follow_up_effects: Vec<EffectAst>,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::Regenerate {
+                target,
+                follow_up_effects,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -598,7 +598,10 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::Flip { target } => {
                     maybe_tag_target(target, frame, id_gen, "targeted")?;
                 }
-                SubjectVerbActionAst::Regenerate { target } => {
+                SubjectVerbActionAst::Regenerate {
+                    target,
+                    follow_up_effects: _,
+                } => {
                     maybe_tag_target(target, frame, id_gen, "returned")?;
                 }
                 SubjectVerbActionAst::RegenerateAll { filter } => {
@@ -2602,7 +2605,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::Suspect { target }
             | SubjectVerbActionAst::RemoveFromCombat { target }
             | SubjectVerbActionAst::Flip { target }
-            | SubjectVerbActionAst::Regenerate { target } => {
+            | SubjectVerbActionAst::Regenerate { target, .. } => {
                 bind_unresolved_it_in_target(target, seed_tag)
             }
             SubjectVerbActionAst::ClearSuspected {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -15,7 +15,7 @@ use super::super::permission_helpers::{
 use super::super::token_primitives::find_index;
 use super::super::util::{
     parse_alternative_cast_words, parse_subject, parse_target_phrase, span_from_tokens,
-    trim_commas, words,
+    token_index_for_word_index, trim_commas, words,
 };
 use super::dispatch_entry::parse_reveal_top_count_put_all_matching_into_hand_rest_graveyard;
 use super::zone_handlers::parse_exile_top_library_clause;
@@ -2007,6 +2007,63 @@ fn parse_bid_life_for_control_bundle(tokens: &[OwnedLexToken]) -> Option<Vec<Eff
     }])
 }
 
+fn parse_regenerate_then_gain_control_if_regenerates_bundle(
+    first: &[OwnedLexToken],
+    second: &[OwnedLexToken],
+) -> Option<Vec<EffectAst>> {
+    let first_words = crate::runtime_backend::token_word_refs(first);
+    if first_words.first().copied() != Some("regenerate") || first_words.len() < 2 {
+        return None;
+    }
+    let target_start = token_index_for_word_index(first, 1)?;
+    let regenerate_target = parse_target_phrase(&first[target_start..]).ok()?;
+
+    let second_words = crate::runtime_backend::token_word_refs(second);
+    let mut idx = if second_words.first().copied() == Some("you") {
+        1
+    } else {
+        0
+    };
+    if second_words.get(idx).copied() != Some("gain")
+        || second_words.get(idx + 1).copied() != Some("control")
+    {
+        return None;
+    }
+    idx += 2;
+    if second_words.get(idx).copied() == Some("of") {
+        idx += 1;
+    }
+
+    let if_idx = second_words
+        .windows(5)
+        .position(|window| window == ["if", "it", "regenerates", "this", "way"])
+        .or_else(|| {
+            second_words.windows(6).position(|window| {
+                window == ["if", "that", "creature", "regenerates", "this", "way"]
+            })
+        })?;
+    if if_idx <= idx {
+        return None;
+    }
+
+    let target_token_start = token_index_for_word_index(second, idx)?;
+    let target_token_end = token_index_for_word_index(second, if_idx)?;
+    let control_target = parse_target_phrase(&trim_commas(
+        &second[target_token_start..target_token_end],
+    ))
+    .ok()?;
+    let follow_up = EffectAst::subject_verb_gain_control(
+        PlayerAst::Implicit,
+        control_target,
+        crate::effect::Until::Forever,
+    );
+
+    Some(vec![EffectAst::subject_verb_regenerate_with_follow_up_effects(
+        regenerate_target,
+        vec![follow_up],
+    )])
+}
+
 pub(crate) fn parse_exact_card_effect_bundle_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<Vec<EffectAst>> {
@@ -2046,6 +2103,12 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
         return Some(effects);
     }
     let sentences = split_lexed_sentences(tokens);
+    if sentences.len() == 2
+        && let Some(effects) =
+            parse_regenerate_then_gain_control_if_regenerates_bundle(sentences[0], sentences[1])
+    {
+        return Some(effects);
+    }
     if sentences.len() == 2
         && let Ok(Some(effects)) = parse_consult_then_put_matches_battlefield_rest_bottom_bundle(
             sentences[0],

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2079,7 +2079,7 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::Suspect { target }
             | SubjectVerbActionAst::RemoveFromCombat { target }
             | SubjectVerbActionAst::Flip { target }
-            | SubjectVerbActionAst::Regenerate { target }
+            | SubjectVerbActionAst::Regenerate { target, .. }
             | SubjectVerbActionAst::TapOrUntap { target }
             | SubjectVerbActionAst::PhaseOut { target }
             | SubjectVerbActionAst::PhaseIn { target }
@@ -2834,6 +2834,7 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
             }
             | SubjectVerbActionAst::Regenerate {
                 target: effect_target,
+                ..
             }
             | SubjectVerbActionAst::TapOrUntap {
                 target: effect_target,

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3909,14 +3909,19 @@ impl NinjutsuEffect {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct RegenerateEffect {
+pub struct RegenerateEffect<E = ()> {
     pub target: ChooseSpec,
     pub duration: Until,
+    pub follow_up_effects: Vec<E>,
 }
 
-impl RegenerateEffect {
+impl<E> RegenerateEffect<E> {
     pub fn new(target: ChooseSpec, duration: Until) -> Self {
-        Self { target, duration }
+        Self {
+            target,
+            duration,
+            follow_up_effects: Vec::new(),
+        }
     }
 
     pub fn source(duration: Until) -> Self {
@@ -3925,6 +3930,11 @@ impl RegenerateEffect {
 
     pub fn target_creature(duration: Until) -> Self {
         Self::new(ChooseSpec::creature(), duration)
+    }
+
+    pub fn with_follow_up_effects(mut self, effects: Vec<E>) -> Self {
+        self.follow_up_effects = effects;
+        self
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -12547,6 +12547,37 @@ fn test_parse_one_word_verb_card_name_does_not_break_clause_parsing() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_debt_of_loyalty_regenerate_control_followup() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Debt of Loyalty")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Regenerate target creature. You gain control of that creature if it regenerates this way.",
+        )
+        .expect("Debt of Loyalty should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("regenerate target creature"),
+        "expected Debt of Loyalty to render the regenerate clause, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("you gain control of that creature if it regenerates this way"),
+        "expected Debt of Loyalty to render the regenerate-this-way control clause, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("unsupported parser line fallback"),
+        "Debt of Loyalty should not rely on unsupported fallback marker: {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_render_enters_with_single_counter_uses_singular_wording() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Single Counter Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32705,13 +32705,50 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(rest) = target.strip_prefix("all ") {
             target = format!("each {rest}");
         }
-        if regenerate.duration == Until::EndOfTurn {
-            return format!("Regenerate {target}");
-        }
-        return format!(
+        let base = if regenerate.duration == Until::EndOfTurn {
+            format!("Regenerate {target}")
+        } else {
+            format!(
             "Regenerate {target} {}",
             describe_until(&regenerate.duration)
-        );
+            )
+        };
+        fn follow_up_inner(effect: &Effect) -> &Effect {
+            effect
+                .downcast_ref::<crate::effects::TaggedEffect>()
+                .map(|tagged| tagged.effect.as_ref())
+                .unwrap_or(effect)
+        }
+        if let [follow_up] = regenerate.follow_up_effects.as_slice()
+            && let Some(gain_control) = follow_up_inner(follow_up)
+                .downcast_ref::<crate::effects::GainControlEffect>()
+            && gain_control.duration == Until::Forever
+            && (matches!(&gain_control.target, ChooseSpec::Tagged(tag) if tag.as_str() == "__it__")
+                || describe_choose_spec(&gain_control.target).eq_ignore_ascii_case("it"))
+        {
+            return format!("{base}. You gain control of that creature if it regenerates this way");
+        }
+        if let [follow_up] = regenerate.follow_up_effects.as_slice()
+            && let Some(apply) = follow_up_inner(follow_up)
+                .downcast_ref::<crate::effects::ApplyContinuousEffect>()
+            && apply.until == Until::Forever
+            && apply.modification.is_none()
+            && apply.additional_modifications.is_empty()
+            && matches!(
+                apply.runtime_modifications.as_slice(),
+                [crate::effects::continuous::RuntimeModification::ChangeControllerToEffectController]
+            )
+            && matches!(&apply.target_spec, Some(ChooseSpec::Tagged(tag)) if tag.as_str() == "__it__")
+        {
+            return format!("{base}. You gain control of that creature if it regenerates this way");
+        }
+        if !regenerate.follow_up_effects.is_empty() {
+            return format!(
+                "{base}. {} if it regenerates this way",
+                describe_effect_list(&regenerate.follow_up_effects)
+            );
+        }
+        return base;
     }
     if let Some(cant) = effect.downcast_ref::<crate::effects::CantEffect>() {
         if cant.duration == Until::EndOfTurn

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -513,8 +513,12 @@ where
         };
         return Ok(Effect::new(converted));
     }
-    if let Some(converted) = clone_direct_effect::<M, crate::effects::RegenerateEffect>(&effect) {
-        return Ok(converted);
+    if let Some(payload) = M::downcast_ref::<ironsmith_core::RegenerateEffect<M::Effect>>(&effect) {
+        let follow_up_effects = convert_effects(payload.follow_up_effects.clone(), hooks)?;
+        return Ok(Effect::new(
+            crate::effects::RegenerateEffect::new(payload.target.clone(), payload.duration.clone())
+                .with_follow_up_effects(follow_up_effects),
+        ));
     }
     if let Some(converted) =
         clone_direct_effect::<M, crate::effects::AddManaFromCommanderColorIdentityEffect>(&effect)

--- a/crates/ironsmith-runtime/src/effects/permanents/regenerate.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/regenerate.rs
@@ -6,9 +6,10 @@ use crate::effects::{ExecutionContext, ExecutionError, execute_effect};
 use crate::events::permanents::matchers::RegenerationShieldMatcher;
 use crate::game_state::GameState;
 use crate::replacement::{ReplacementAction, ReplacementEffect};
+use crate::tag::TagKey;
 use crate::target::ChooseSpec;
 use crate::zone::Zone;
-pub use ironsmith_core::RegenerateEffect;
+pub type RegenerateEffect = ironsmith_core::RegenerateEffect<crate::effect::Effect>;
 
 /// Effect that regenerates a target creature.
 ///
@@ -68,15 +69,16 @@ impl EffectExecutor for RegenerateEffect {
             if !game.can_be_regenerated(target_id) {
                 continue;
             }
-            let controller = game.controller_of(obj);
+            let controller = ctx.controller;
 
-            let replacement_effects = vec![
-                Effect::tap(ChooseSpec::SpecificObject(target_id)),
+            let mut replacement_effects = vec![
+                Effect::tap(ChooseSpec::SpecificObject(target_id)).tag(TagKey::from("__it__")),
                 Effect::clear_damage(ChooseSpec::SpecificObject(target_id)),
                 Effect::new(crate::effects::RemoveFromCombatEffect::with_spec(
                     ChooseSpec::SpecificObject(target_id),
                 )),
             ];
+            replacement_effects.extend(self.follow_up_effects.clone());
 
             let matcher = RegenerationShieldMatcher::new(target_id);
             let replacement_effect = ReplacementEffect::with_matcher(

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -482,6 +482,7 @@ fn tied_replacements_are_duplicate_regeneration_shields(
                 && effect.source == first.source
                 && effect.controller == first.controller
                 && effect.priority_override == first.priority_override
+                && effect.replacement == first.replacement
                 && effect
                     .matcher
                     .as_ref()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3910,6 +3910,197 @@ fn regeneration_count_tracks_used_shields_until_cleanup() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn debt_of_loyalty_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_542), "Debt of Loyalty")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Regenerate target creature. You gain control of that creature if it regenerates this way.",
+        )
+        .expect("Debt of Loyalty should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_debt_of_loyalty_on_target(
+    game: &mut GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    target: ObjectId,
+) {
+    let debt = debt_of_loyalty_definition();
+    let [effect] = debt
+        .spell_effect
+        .as_ref()
+        .expect("Debt of Loyalty should have a spell effect")
+        .flattened_default_effects()
+    else {
+        panic!("Debt of Loyalty should lower to one regenerate effect");
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: crate::target::ChooseSpec::target(crate::target::ChooseSpec::creature()),
+            range: 0..1,
+        }]);
+    crate::effects::execute_effect(game, effect, &mut ctx)
+        .expect("Debt of Loyalty should create a regeneration shield");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn debt_of_loyalty_gains_control_when_target_regenerates_this_way() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source_card = CardBuilder::new(CardId::from_raw(74_543), "Debt of Loyalty")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let source = game.create_object_from_card(&source_card, alice, Zone::Stack);
+    let creature = create_creature(&mut game, "Debt Target", bob, 2, 2);
+
+    resolve_debt_of_loyalty_on_target(&mut game, source, alice, creature);
+    assert_eq!(
+        game.controller_of_id(creature),
+        Some(bob),
+        "Debt of Loyalty should not change control before the shield is used"
+    );
+
+    let mut dm = SelectFirstDecisionMaker;
+    let outcome = crate::events::processing::process_destroy(
+        &mut game,
+        creature,
+        Some(source),
+        &mut dm,
+    );
+
+    assert!(
+        matches!(outcome, crate::events::processing::EventOutcome::Replaced),
+        "the destroy event should be replaced by the regeneration shield, got {outcome:?}"
+    );
+    assert!(
+        game.battlefield.contains(&creature),
+        "the regenerated creature should remain on the battlefield"
+    );
+    assert!(
+        game.is_tapped(creature),
+        "the regenerated creature should be tapped by regeneration"
+    );
+    assert_eq!(
+        game.controller_of_id(creature),
+        Some(alice),
+        "Debt of Loyalty should gain control only after the target regenerates this way"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn debt_of_loyalty_does_not_gain_control_if_regeneration_shield_is_unused() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source_card = CardBuilder::new(CardId::from_raw(74_544), "Debt of Loyalty")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let source = game.create_object_from_card(&source_card, alice, Zone::Stack);
+    let creature = create_creature(&mut game, "Debt Target", bob, 2, 2);
+
+    resolve_debt_of_loyalty_on_target(&mut game, source, alice, creature);
+
+    assert_eq!(
+        game.controller_of_id(creature),
+        Some(bob),
+        "Debt of Loyalty's control change is conditional on the target actually regenerating"
+    );
+    assert!(
+        game.battlefield.contains(&creature),
+        "the target should remain on the battlefield while the shield is unused"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn debt_of_loyalty_shield_is_not_deduplicated_with_plain_regeneration() {
+    struct ChooseLastReplacementDecisionMaker {
+        replacement_choices: usize,
+    }
+
+    impl DecisionMaker for ChooseLastReplacementDecisionMaker {
+        fn decide_options(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            if ctx.description == "Choose which replacement effect to apply" {
+                self.replacement_choices += 1;
+                return ctx
+                    .options
+                    .iter()
+                    .rev()
+                    .find(|option| option.legal)
+                    .map(|option| vec![option.index])
+                    .unwrap_or_default();
+            }
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let plain_source_card = CardBuilder::new(CardId::from_raw(74_545), "Plain Regeneration")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let plain_source = game.create_object_from_card(&plain_source_card, alice, Zone::Stack);
+    let debt_source_card = CardBuilder::new(CardId::from_raw(74_546), "Debt of Loyalty")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let debt_source = game.create_object_from_card(&debt_source_card, alice, Zone::Stack);
+    let creature = create_creature(&mut game, "Debt Target", bob, 2, 2);
+
+    let plain_regeneration = Effect::regenerate(
+        crate::target::ChooseSpec::SpecificObject(creature),
+        Until::EndOfTurn,
+    );
+    let mut plain_ctx = crate::effects::ExecutionContext::new_default(plain_source, alice);
+    crate::effects::execute_effect(&mut game, &plain_regeneration, &mut plain_ctx)
+        .expect("plain regeneration should create the first shield");
+    resolve_debt_of_loyalty_on_target(&mut game, debt_source, alice, creature);
+
+    let mut dm = ChooseLastReplacementDecisionMaker {
+        replacement_choices: 0,
+    };
+    let outcome = crate::events::processing::process_destroy(
+        &mut game,
+        creature,
+        Some(plain_source),
+        &mut dm,
+    );
+
+    assert!(
+        matches!(outcome, crate::events::processing::EventOutcome::Replaced),
+        "the destroy event should be replaced by a regeneration shield, got {outcome:?}"
+    );
+    assert_eq!(
+        dm.replacement_choices, 1,
+        "non-equivalent regeneration shields must be offered as a replacement choice"
+    );
+    assert_eq!(
+        game.controller_of_id(creature),
+        Some(alice),
+        "choosing the Debt of Loyalty shield should run its control-change follow-up"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn sublime_archangel_grants_real_exalted_triggers_to_other_creatures() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Debt of Loyalty
Initial parse error:
```
parser does not yet support line family: 'Regenerate target creature. You gain control of that creature if it regenerates this way.'; oracle-only fallback also failed: parser does not yet support line family: 'Regenerate target creature. You gain control of that creature if it regenerates this way.'
```

Current worker: i-0db7882d01480e87e
Branch: codex/aws-card-fix-debt-of-loyalty
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0034
