### PR TITLE
Fix Ironsmith parse failure: The Nipton Lottery

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -104,6 +104,7 @@ const CAST_SORCERY_THIS_TURN_FILTER_PATTERN: ClauseShape<'static> = clause_shape
 const CHOSEN_OBJECT_CANT_BLOCK_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["block", "this", "turn"], &["block"]]);
 const AT_RANDOM_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["at", "random"]);
+const AT_RANDOM_SUFFIX_PATTERN: ClauseShape<'static> = clause_shape!(suffix & ["at", "random"]);
 const TAGGED_CHOICE_MOVED_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["it"], &["that", "card"], &["that", "permanent"]]);
 const BATTLEFIELD_UNDER_YOUR_CONTROL_PATTERN: ClauseShape<'static> =
@@ -248,7 +249,7 @@ pub(crate) fn parse_target_player_choose_objects_clause(
         )));
     }
 
-    let (count, stripped_choose_object_tokens) =
+    let (mut count, stripped_choose_object_tokens) =
         parse_choice_count_token_prefix(&choose_object_tokens);
     choose_object_tokens = stripped_choose_object_tokens;
     if choose_object_tokens.is_empty() {
@@ -265,6 +266,11 @@ pub(crate) fn parse_target_player_choose_objects_clause(
     }
     if find_verb(&choose_object_tokens).is_some() {
         return Ok(None);
+    }
+
+    if AT_RANDOM_SUFFIX_PATTERN.matches_words(&choose_object_words) {
+        choose_object_tokens.truncate(choose_object_tokens.len().saturating_sub(2));
+        count = count.at_random();
     }
 
     let mut choose_filter = parse_object_filter(&choose_object_tokens, false).map_err(|_| {
@@ -390,6 +396,10 @@ pub(crate) fn parse_you_choose_objects_clause(
         .is_some_and(|word| LEADING_ARTICLE_PATTERN.matches_words(&[*word]))
     {
         choose_words = choose_words[1..].to_vec();
+    }
+    if AT_RANDOM_SUFFIX_PATTERN.matches_words(&choose_words) {
+        count = count.at_random();
+        choose_words.truncate(choose_words.len().saturating_sub(2));
     }
 
     if choose_words.is_empty() {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4609,7 +4609,18 @@ fn compile_subject_verb_effect(
             filter,
             no_regeneration,
         } => {
-            let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            let mut resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            if resolved_filter.other
+                && resolved_filter.tagged_constraints.is_empty()
+                && let Some(tag) = ctx.last_object_tag.as_deref()
+            {
+                resolved_filter
+                    .tagged_constraints
+                    .push(TaggedObjectConstraint {
+                        tag: TagKey::from(tag),
+                        relation: TaggedOpbjectRelation::IsNotTaggedObject,
+                    });
+            }
             let (mut prelude, choices) = target_context_prelude_for_filter(&resolved_filter);
             let mut effect = if *no_regeneration {
                 Effect::new(crate::effects::DestroyNoRegenerationEffect::all(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -143,6 +143,33 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn the_nipton_lottery_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("The Nipton Lottery");
+    let spell_effect = def
+        .spell_effect
+        .as_ref()
+        .expect("The Nipton Lottery should compile as a sorcery spell");
+    let debug = format!("{spell_effect:#?}");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        debug.contains("ChooseObjectsEffect")
+            && debug.contains("random: true")
+            && debug.contains("ChangeControllerToEffectController")
+            && debug.contains("UntapEffect")
+            && debug.contains("Haste")
+            && debug.contains("DestroyEffect")
+            && debug.contains("IsNotTaggedObject"),
+        "The Nipton Lottery should preserve random choice, control, untap, haste, and chosen-creature exclusion for destroy effects, got {debug}"
+    );
+    assert_eq!(
+        rendered,
+        "Choose a creature at random. You gain control of that creature until end of turn. Untap it. It gains haste until end of turn. Then destroy all other creatures.",
+        "The Nipton Lottery compiled text should preserve the random-choice control sequence, got {rendered}"
+    );
+}
+
+#[test]
 fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Commander Liara Portyr");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3189,6 +3189,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     describe_roll_choose_destroy_create_structural(effects)
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
+        .or_else(|| describe_choose_gain_control_untap_haste_destroy_others(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_exile_then_free_cast_while_exiled_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
@@ -3685,6 +3686,68 @@ fn is_haste_until_eot_for_tag(
             Some(crate::continuous::Modification::AddAbility(ability))
                 if ability.id() == crate::static_abilities::StaticAbilityId::Haste
         )
+}
+
+fn simple_creature_choice_text(choose: &crate::effects::ChooseObjectsEffect) -> Option<String> {
+    let mut expected_filter = crate::filter::ObjectFilter::creature();
+    expected_filter.zone = choose.filter.zone;
+    if choose.is_search
+        || choose.count_value.is_some()
+        || !choose.count.is_single()
+        || choose_primary_zone(choose) != Some(Zone::Battlefield)
+        || choose.filter != expected_filter
+    {
+        return None;
+    }
+    Some(if choose.count.is_random() {
+        "a creature at random".to_string()
+    } else {
+        "a creature".to_string()
+    })
+}
+
+fn is_destroy_all_other_creatures(
+    destroy: &crate::effects::DestroyEffect,
+    excluded_tag: &crate::TagKey,
+) -> bool {
+    let ChooseSpec::All(filter) = &destroy.spec else {
+        return false;
+    };
+    let mut expected_filter = crate::filter::ObjectFilter::creature();
+    expected_filter.zone = filter.zone;
+    expected_filter.other = true;
+    expected_filter
+        .tagged_constraints
+        .push(crate::filter::TaggedObjectConstraint {
+            tag: excluded_tag.clone(),
+            relation: crate::filter::TaggedOpbjectRelation::IsNotTaggedObject,
+        });
+    filter == &expected_filter
+}
+
+fn describe_choose_gain_control_untap_haste_destroy_others(effects: &[Effect]) -> Option<String> {
+    let [choose_effect, control_effect, untap_effect, haste_effect, destroy_effect] = effects else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let (_, control) = tagged_apply_continuous_view(control_effect)?;
+    let (_, untap) = tagged_untap_effect_view(untap_effect)?;
+    let (_, haste) = tagged_apply_continuous_view(haste_effect)?;
+    let destroy = unwrap_basic_tag_wrappers(destroy_effect)
+        .downcast_ref::<crate::effects::DestroyEffect>()?;
+    if !is_gain_control_until_eot(control)
+        || !matches!(&control.target_spec, Some(ChooseSpec::Tagged(tag)) if tag == &choose.tag)
+        || !matches!(&untap.target, ChooseSpec::Tagged(tag) if tag == &choose.tag)
+        || !is_haste_until_eot_for_tag(haste, &choose.tag)
+        || !is_destroy_all_other_creatures(destroy, &choose.tag)
+    {
+        return None;
+    }
+
+    Some(format!(
+        "Choose {}. You gain control of that creature until end of turn. Untap it. It gains haste until end of turn. Then destroy all other creatures",
+        simple_creature_choice_text(choose)?
+    ))
 }
 
 fn describe_gain_control_untap_haste_structural(effects: &[Effect]) -> Option<String> {
@@ -22134,14 +22197,15 @@ fn describe_runtime_choice_where_clause(
 }
 
 pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEffect) -> String {
+    let random_suffix = if choose.count.is_random() { " at random" } else { "" };
     if choose.top_only {
         if let Some(exact) = choose_exact_count(choose) {
             if exact > 1 {
                 let count_text = number_word(exact as i32).unwrap_or_else(|| exact.to_string());
-                return format!("the top {count_text} cards");
+                return format!("the top {count_text} cards{random_suffix}");
             }
         }
-        return "the top card".to_string();
+        return format!("the top card{random_suffix}");
     }
 
     let filter_text = choose.filter.description();
@@ -22210,18 +22274,25 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
     };
 
     if choose.count.is_single() {
-        return format!("{}{}", with_indefinite_article(&card_desc), where_x_suffix);
+        return format!(
+            "{}{}{}",
+            with_indefinite_article(&card_desc),
+            where_x_suffix,
+            random_suffix
+        );
     }
     if let Some(runtime_count) = describe_runtime_choice_count(choose) {
         let mut selection = describe_plural_selection(runtime_count, &card_desc);
         selection.push_str(&describe_runtime_choice_where_clause(choose).unwrap_or_default());
         selection.push_str(&where_x_suffix);
+        selection.push_str(random_suffix);
         return selection;
     }
     if let Some(exact) = choose_exact_count(choose) {
         let count_text = number_word(exact as i32).unwrap_or_else(|| exact.to_string());
         let mut selection = describe_plural_selection(count_text, &card_desc);
         selection.push_str(&where_x_suffix);
+        selection.push_str(random_suffix);
         return selection;
     }
     let mut selection = describe_plural_selection(describe_choice_count(&choose.count), &card_desc);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -16974,6 +16974,134 @@ fn act_of_aggression_gains_control_untaps_and_grants_haste_until_end_of_turn() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn the_nipton_lottery_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(95_100), "The Nipton Lottery")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Choose a creature at random. You gain control of that creature until end of turn. \
+             Untap it. It gains haste until end of turn. Then destroy all other creatures.",
+        )
+        .expect("The Nipton Lottery should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_the_nipton_lottery_on_stack(game: &mut GameState, controller: PlayerId) {
+    let lottery = the_nipton_lottery_definition();
+    let spell_id = game.create_object_from_definition(&lottery, controller, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, controller));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_nipton_lottery_random_creature_survives_with_control_untap_and_haste() {
+    use crate::static_abilities::StaticAbilityId;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.set_random_seed(7);
+
+    let alice_creature = create_creature(&mut game, "Alice Lottery Entrant", alice, 2, 2);
+    let bob_creature_a = create_creature(&mut game, "Bob Lottery Entrant A", bob, 2, 2);
+    let bob_creature_b = create_creature(&mut game, "Bob Lottery Entrant B", bob, 2, 2);
+    for id in [alice_creature, bob_creature_a, bob_creature_b] {
+        game.tap(id);
+    }
+    let original_controllers = [
+        (alice_creature, alice),
+        (bob_creature_a, bob),
+        (bob_creature_b, bob),
+    ];
+
+    put_the_nipton_lottery_on_stack(&mut game, alice);
+    let random_count_before = game.irreversible_random_count();
+    resolve_stack_entry(&mut game).expect("The Nipton Lottery should resolve");
+    game.refresh_continuous_state();
+
+    assert!(
+        game.irreversible_random_count() > random_count_before,
+        "The Nipton Lottery should use the random choice path"
+    );
+    let survivors = [alice_creature, bob_creature_a, bob_creature_b]
+        .into_iter()
+        .filter(|id| game.battlefield.contains(id))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        survivors.len(),
+        1,
+        "only the randomly chosen creature should survive; battlefield survivors were {survivors:?}"
+    );
+    let survivor = survivors[0];
+    assert_eq!(
+        game.current_controller(survivor),
+        Some(alice),
+        "Alice should control the randomly chosen surviving creature until end of turn"
+    );
+    assert!(
+        !game.is_tapped(survivor),
+        "The Nipton Lottery should untap the chosen creature"
+    );
+    assert!(
+        game.object_has_static_ability_id(survivor, StaticAbilityId::Haste),
+        "The Nipton Lottery should grant haste to the chosen creature"
+    );
+
+    crate::turn::execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+    let original_controller = original_controllers
+        .iter()
+        .find_map(|(id, controller)| (*id == survivor).then_some(*controller))
+        .expect("survivor should be one of the starting creatures");
+    assert_eq!(
+        game.current_controller(survivor),
+        Some(original_controller),
+        "control change should expire at cleanup"
+    );
+    assert!(
+        !game.object_has_static_ability_id(survivor, StaticAbilityId::Haste),
+        "haste should expire at cleanup"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn the_nipton_lottery_single_creature_has_no_other_creatures_to_destroy() {
+    use crate::static_abilities::StaticAbilityId;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.set_random_seed(3);
+
+    let only_creature = create_creature(&mut game, "Only Lottery Entrant", bob, 2, 2);
+    game.tap(only_creature);
+
+    put_the_nipton_lottery_on_stack(&mut game, alice);
+    resolve_stack_entry(&mut game).expect("The Nipton Lottery should resolve with one creature");
+    game.refresh_continuous_state();
+
+    assert!(
+        game.battlefield.contains(&only_creature),
+        "the chosen creature should remain when there are no other creatures to destroy"
+    );
+    assert_eq!(
+        game.current_controller(only_creature),
+        Some(alice),
+        "Alice should gain control of the only creature until end of turn"
+    );
+    assert!(!game.is_tapped(only_creature));
+    assert!(game.object_has_static_ability_id(
+        only_creature,
+        StaticAbilityId::Haste
+    ));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn target_opponent_gains_control_keeps_player_target_visible_to_object_effect() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: The Nipton Lottery
Initial parse error:
```
compiled text dropped required semantic marker: at-random
```

Current worker: i-0a2a9fc4b4b715678
Branch: codex/aws-card-fix-the-nipton-lottery
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0034
