### PR TITLE
Fix Ironsmith parse failure: Mind's Dilation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -540,7 +540,9 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
             if *caster == PlayerFilter::Any {
                 Some(PlayerFilter::IteratedPlayer)
             } else {
-                Some(caster.clone())
+                Some(PlayerFilter::ControllerOf(ObjectRef::tagged(TagKey::from(
+                    "triggering",
+                ))))
             }
         }
         TriggerSpec::SpellCopied { copier, .. } => {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -54702,6 +54702,38 @@ fn mindleech_mass_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn minds_dilation_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Mind's Dilation");
+
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert_eq!(def.card.name, "Mind's Dilation");
+    assert!(
+        abilities_debug.contains("SpellCastTrigger")
+            && abilities_debug.contains("exact_spells_this_turn: Some(1)")
+            && abilities_debug.contains("ControllerOf(Tagged(TagKey(\"triggering\")))")
+            && abilities_debug.contains("ChooseObjectsEffect")
+            && abilities_debug.contains("ConditionalEffect")
+            && abilities_debug.contains("CastTaggedEffect")
+            && abilities_debug.contains(crate::tag::SOURCE_EXILED_TAG),
+        "expected Mind's Dilation to lower to first-spell trigger, triggering-player library exile, and conditional free cast, got {abilities_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("whenever an opponent casts their first spell each turn")
+            && rendered_lower.contains("that player exiles the top card of their library")
+            && rendered_lower.contains("if it's a nonland card, you may cast it without paying its mana cost"),
+        "expected Mind's Dilation compiled text to preserve the triggering-player nonland free-cast clause, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("tagged object") && !rendered_lower.contains("tagged '"),
+        "Mind's Dilation compiled text should not expose internal tagged references, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn villainous_wealth_runtime_casts_only_exiled_nonland_spells_with_mana_value_at_most_x() {
     let def = parse_oracle_card_definition("Villainous Wealth");
     let spell = def

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3191,6 +3191,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_exile_then_free_cast_while_exiled_structural(effects))
+        .or_else(|| describe_choose_top_exile_then_conditional_cast_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_choose_name_target_mills_conditional_draw(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
@@ -3761,6 +3762,97 @@ fn describe_choose_top_exile_then_play_structural(effects: &[Effect]) -> Option<
     let verb = if grant.allow_land { "play" } else { "cast" };
     Some(format!(
         "Exile the top card of your library. You may {verb} that card this turn"
+    ))
+}
+
+fn describe_choose_top_exile_then_conditional_cast_structural(
+    effects: &[Effect],
+) -> Option<String> {
+    fn is_nonland_card_filter(filter: &ObjectFilter) -> bool {
+        if filter.excluded_card_types.as_slice() != [CardType::Land] {
+            return false;
+        }
+        let mut base = filter.clone();
+        base.excluded_card_types.clear();
+        base.zone = None;
+        base == ObjectFilter::default()
+    }
+
+    fn choose_subject(chooser: &PlayerFilter) -> (String, String) {
+        if matches!(chooser, PlayerFilter::You) {
+            return ("you".to_string(), "your".to_string());
+        }
+        if matches!(
+            chooser,
+            PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(tag))
+                if tag.as_str() == "triggering"
+        ) {
+            return ("that player".to_string(), "their".to_string());
+        }
+        (
+            describe_player_filter(chooser),
+            describe_possessive_player_filter(chooser),
+        )
+    }
+
+    let [choose_effect, exile_effect, conditional_effect] = effects else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let exile = exile_effect.downcast_ref::<crate::effects::ExileEffect>()?;
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if choose.is_search
+        || choose_primary_zone(choose) != Some(Zone::Library)
+        || choose.filter.owner.as_ref() != Some(&choose.chooser)
+        || !choose.top_only
+        || choose_exact_count(choose) != Some(1)
+        || !matches!(exile.spec.base(), ChooseSpec::Tagged(tag) if tag == &choose.tag)
+        || exile.face_down
+        || !conditional.if_false.is_empty()
+    {
+        return None;
+    }
+
+    let Condition::TaggedObjectMatches(condition_tag, filter) = &conditional.condition else {
+        return None;
+    };
+    if condition_tag != &choose.tag && condition_tag.as_str() != crate::tag::SOURCE_EXILED_TAG {
+        return None;
+    }
+    if !is_nonland_card_filter(filter) {
+        return None;
+    }
+
+    let [may_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let [cast_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let cast = cast_effect.downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    if cast.tag != choose.tag && cast.tag.as_str() != crate::tag::SOURCE_EXILED_TAG {
+        return None;
+    }
+    if cast.player != PlayerFilter::You
+        || cast.allow_land
+        || cast.as_copy
+        || !cast.without_paying_mana_cost
+    {
+        return None;
+    }
+
+    let (subject, possessive) = choose_subject(&choose.chooser);
+    let exile_sentence = if subject == "you" {
+        "Exile the top card of your library".to_string()
+    } else {
+        format!(
+            "{subject} {} the top card of {possessive} library",
+            player_verb(&subject, "exile", "exiles")
+        )
+    };
+    Some(format!(
+        "{exile_sentence}. If it's a nonland card, you may cast it without paying its mana cost"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/effects/zones/exile.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/exile.rs
@@ -77,6 +77,12 @@ fn exile_object(
                             }
                         }
                         game.add_exiled_with_source_link(ctx.source, new_id);
+                        if let Some(object) = game.object(new_id) {
+                            ctx.tag_object(
+                                crate::tag::SOURCE_EXILED_TAG,
+                                ObjectSnapshot::from_object(object, game),
+                            );
+                        }
                     }
                 }
                 return Ok(None);
@@ -253,6 +259,12 @@ impl EffectExecutor for ExileEffect {
                                 }
                                 if result.final_zone == Zone::Exile {
                                     game.add_exiled_with_source_link(ctx.source, new_id);
+                                    if let Some(object) = game.object(new_id) {
+                                        ctx.tag_object(
+                                            crate::tag::SOURCE_EXILED_TAG,
+                                            ObjectSnapshot::from_object(object, game),
+                                        );
+                                    }
                                 }
                             }
                             Ok(true)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -73,6 +73,21 @@ fn the_eternity_elevator_threshold_ability_index(def: &crate::cards::CardDefinit
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn minds_dilation_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(658_545), "Mind's Dilation")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Whenever an opponent casts their first spell each turn, that player exiles the top card of their library. If it's a nonland card, you may cast it without paying its mana cost.",
+        )
+        .expect("Mind's Dilation should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn the_eternity_elevator_threshold_mana_requires_twenty_charge_counters() {
     let mut game = setup_game();
@@ -4905,6 +4920,230 @@ fn resolve_triggered_ability_from_spell_cast(
         crate::effects::execute_effect(game, effect, &mut ctx)
             .expect("Quandrix Apprentice trigger should resolve");
     }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn queue_minds_dilation_spell_cast(
+    game: &mut GameState,
+    caster: PlayerId,
+    trigger_queue: &mut TriggerQueue,
+) -> ObjectId {
+    let spell_id = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Triggering Probe Spell")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+            .card_types(vec![CardType::Instant])
+            .build(),
+        caster,
+        Zone::Stack,
+    );
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, caster, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(game, trigger_queue, event, false);
+    spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn minds_dilation_first_opponent_spell_exiles_that_players_top_nonland_and_casts_it() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let minds_dilation = minds_dilation_definition();
+    game.create_object_from_definition(&minds_dilation, alice, Zone::Battlefield);
+
+    let charlie_top = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Charlie's Top Card")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        charlie,
+        Zone::Library,
+    );
+    let charlie_top_stable = game
+        .object(charlie_top)
+        .expect("Charlie's library card should exist")
+        .stable_id;
+    let bob_top = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Bob's Exiled Spell")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    let bob_top_stable = game
+        .object(bob_top)
+        .expect("Bob's library card should exist")
+        .stable_id;
+
+    let mut trigger_queue = TriggerQueue::new();
+    queue_minds_dilation_spell_cast(&mut game, bob, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Mind's Dilation should trigger for an opponent's first spell each turn"
+    );
+
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Mind's Dilation trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Mind's Dilation trigger should resolve");
+
+    let cast_id = game
+        .find_object_by_stable_id(bob_top_stable)
+        .expect("Bob's exiled nonland card should still exist");
+    let cast_object = game
+        .object(cast_id)
+        .expect("Bob's exiled nonland card should be on stack");
+    assert_eq!(cast_object.zone, Zone::Stack);
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| entry.object_id == cast_id && entry.controller == alice),
+        "Alice should cast Bob's exiled nonland card without paying its mana cost"
+    );
+
+    let charlie_id = game
+        .find_object_by_stable_id(charlie_top_stable)
+        .expect("Charlie's library card should still exist");
+    assert_eq!(
+        game.object(charlie_id).expect("Charlie's card should exist").zone,
+        Zone::Library,
+        "Mind's Dilation should exile the triggering player's top card, not another opponent's"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn minds_dilation_declined_may_cast_leaves_nonland_card_exiled() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let minds_dilation = minds_dilation_definition();
+    game.create_object_from_definition(&minds_dilation, alice, Zone::Battlefield);
+    let bob_top = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Declined Exiled Spell")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .card_types(vec![CardType::Sorcery])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    let bob_top_stable = game
+        .object(bob_top)
+        .expect("Bob's library card should exist")
+        .stable_id;
+
+    let mut trigger_queue = TriggerQueue::new();
+    queue_minds_dilation_spell_cast(&mut game, bob, &mut trigger_queue);
+    let mut dm = AutoPassDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Mind's Dilation trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Mind's Dilation trigger should resolve");
+
+    let exiled_id = game
+        .find_object_by_stable_id(bob_top_stable)
+        .expect("Bob's declined nonland card should still exist");
+    assert_eq!(
+        game.object(exiled_id)
+            .expect("Bob's declined nonland card should exist")
+            .zone,
+        Zone::Exile,
+        "declining the optional cast should leave the nonland card in exile"
+    );
+    assert!(
+        game.stack.is_empty(),
+        "declining the optional cast should not put the exiled card on the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn minds_dilation_land_card_is_exiled_but_not_cast() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let minds_dilation = minds_dilation_definition();
+    game.create_object_from_definition(&minds_dilation, alice, Zone::Battlefield);
+    let bob_top = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Exiled Island")
+            .card_types(vec![CardType::Land])
+            .subtypes(vec![Subtype::Island])
+            .build(),
+        bob,
+        Zone::Library,
+    );
+    let bob_top_stable = game
+        .object(bob_top)
+        .expect("Bob's library land should exist")
+        .stable_id;
+
+    let mut trigger_queue = TriggerQueue::new();
+    queue_minds_dilation_spell_cast(&mut game, bob, &mut trigger_queue);
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Mind's Dilation trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Mind's Dilation trigger should resolve");
+
+    let exiled_id = game
+        .find_object_by_stable_id(bob_top_stable)
+        .expect("Bob's exiled land should still exist");
+    assert_eq!(
+        game.object(exiled_id)
+            .expect("Bob's exiled land should exist")
+            .zone,
+        Zone::Exile,
+        "Mind's Dilation should exile a land top card"
+    );
+    assert!(
+        game.stack.is_empty(),
+        "Mind's Dilation should not cast a land card from exile"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn minds_dilation_ignores_second_spell_by_same_opponent_that_turn() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let minds_dilation = minds_dilation_definition();
+    game.create_object_from_definition(&minds_dilation, alice, Zone::Battlefield);
+
+    let mut first_queue = TriggerQueue::new();
+    queue_minds_dilation_spell_cast(&mut game, bob, &mut first_queue);
+    assert_eq!(first_queue.entries.len(), 1);
+
+    let mut second_queue = TriggerQueue::new();
+    queue_minds_dilation_spell_cast(&mut game, bob, &mut second_queue);
+    assert_eq!(
+        second_queue.entries.len(),
+        0,
+        "Mind's Dilation should trigger only for an opponent's first spell each turn"
+    );
 }
 
 struct DeclineOptionalTriggerTargetsDecisionMaker {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mind's Dilation
Initial parse error:
```
compiled text contains internal marker: tagged-object-reference
```

Current worker: i-0f9c85338c2315b2d
Branch: codex/aws-card-fix-mind-s-dilation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0034
