### PR TITLE
Fix Ironsmith parse failure: Garna, Bloodfist of Keld

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42008,6 +42008,215 @@ fn assert_oracle_card_fails_strict(name: &str) {
     );
 }
 
+fn garna_bloodfist_triggered_ability(
+    def: &CardDefinition,
+) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Garna, Bloodfist of Keld should have a triggered ability")
+}
+
+fn parse_garna_bloodfist_card_definition() -> CardDefinition {
+    let info = oracle_card_info_by_name()
+        .get("Garna, Bloodfist of Keld")
+        .expect("Garna, Bloodfist of Keld should exist in cards.json");
+    CardDefinitionBuilder::new(CardId::new(), "Garna, Bloodfist of Keld")
+        .card_types(card_types_from_type_line(
+            info.type_line.as_deref().unwrap_or_default(),
+        ))
+        .supertypes(vec![Supertype::Legendary])
+        .parse_text(info.oracle_text.clone())
+        .expect("Garna, Bloodfist of Keld should parse strictly")
+}
+
+fn add_garna_draw_card(game: &mut crate::game_state::GameState, player: PlayerId) {
+    let card = crate::card::CardBuilder::new(CardId::new(), "Garna Draw Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    game.create_object_from_card(&card, player, Zone::Library);
+}
+
+fn resolve_garna_bloodfist_trigger_for_dying_creature(
+    was_attacking: bool,
+) -> crate::game_state::GameState {
+    let def = parse_oracle_card_definition("Garna, Bloodfist of Keld");
+    let triggered = garna_bloodfist_triggered_ability(&def).clone();
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let garna_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let creature_def = CardDefinitionBuilder::new(CardId::new(), "Keld Witness")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let creature_id = game.create_object_from_definition(&creature_def, alice, Zone::Battlefield);
+    add_garna_draw_card(&mut game, alice);
+
+    if was_attacking {
+        game.combat = Some(crate::combat_state::CombatState {
+            attackers: vec![crate::combat_state::AttackerInfo {
+                creature: creature_id,
+                target: crate::combat_state::AttackTarget::Player(bob),
+            }],
+            ..Default::default()
+        });
+    }
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+        game.object(creature_id)
+            .expect("dying creature should exist before moving"),
+        &game,
+    );
+    let graveyard_id = game
+        .move_object_by_effect(creature_id, Zone::Graveyard)
+        .expect("dying creature should move to graveyard");
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_results(
+            creature_id,
+            vec![graveyard_id],
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(garna_id, alice, &mut dm)
+        .with_triggering_event(event);
+    for effect in &triggered.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Garna trigger effect should resolve");
+    }
+    game
+}
+
+#[test]
+fn garna_bloodfist_of_keld_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Garna, Bloodfist of Keld");
+    let def = parse_garna_bloodfist_card_definition();
+    let rendered = compiled_text_lines(&def).join(" ");
+
+    assert!(
+        rendered.contains(
+            "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna deals 1 damage to each opponent"
+        ),
+        "expected Garna's attacking conditional and otherwise damage clause to render oracle-like, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("that object matches"),
+        "Garna rendered text should not expose tagged-object predicate internals, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("object-predicate-debug"),
+        "Garna rendered text should not expose the parser debug marker, got {rendered}"
+    );
+}
+
+#[test]
+fn garna_bloodfist_of_keld_triggers_only_for_another_creature_you_control_dying() {
+    let def = parse_oracle_card_definition("Garna, Bloodfist of Keld");
+    let triggered = garna_bloodfist_triggered_ability(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let garna_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let creature_def = CardDefinitionBuilder::new(CardId::new(), "Dying Creature")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let alice_creature =
+        game.create_object_from_definition(&creature_def, alice, Zone::Battlefield);
+    let bob_creature = game.create_object_from_definition(&creature_def, bob, Zone::Battlefield);
+
+    let ctx = crate::triggers::TriggerContext::for_source(garna_id, alice, &game);
+    let allied_snapshot =
+        crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+            game.object(alice_creature)
+                .expect("allied creature exists"),
+            &game,
+        );
+    let opposing_snapshot =
+        crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+            game.object(bob_creature)
+                .expect("opposing creature exists"),
+            &game,
+        );
+    let garna_snapshot =
+        crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+            game.object(garna_id).expect("Garna exists"),
+            &game,
+        );
+
+    let allied_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            alice_creature,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(allied_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let opposing_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            bob_creature,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(opposing_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let self_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            garna_id,
+            Zone::Battlefield,
+            Zone::Graveyard,
+            crate::events::cause::EventCause::effect(),
+            Some(garna_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert!(triggered.trigger.matches(&allied_event, &ctx));
+    assert!(!triggered.trigger.matches(&opposing_event, &ctx));
+    assert!(!triggered.trigger.matches(&self_event, &ctx));
+}
+
+#[test]
+fn garna_bloodfist_of_keld_draws_when_the_dying_creature_was_attacking() {
+    let game = resolve_garna_bloodfist_trigger_for_dying_creature(true);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    assert_eq!(game.player(alice).expect("Alice exists").hand.len(), 1);
+    assert_eq!(game.life_total(bob), 20);
+    assert_eq!(game.life_total(charlie), 20);
+}
+
+#[test]
+fn garna_bloodfist_of_keld_damages_opponents_when_the_dying_creature_was_not_attacking() {
+    let game = resolve_garna_bloodfist_trigger_for_dying_creature(false);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    assert_eq!(game.player(alice).expect("Alice exists").hand.len(), 0);
+    assert_eq!(game.life_total(alice), 20);
+    assert_eq!(game.life_total(bob), 19);
+    assert_eq!(game.life_total(charlie), 19);
+}
+
 #[test]
 fn death_in_heaven_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Death in Heaven");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1074,6 +1074,8 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(" counters on this artifact")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.starts_with("whenever this creature or another ")
+        || lower.contains(" this creature deals ")
+        || lower.contains(", this creature deals ")
         || lower.contains(": this creature gets ")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11709,89 +11709,95 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 }
                 let subject = if matches!(tag.as_str(), "triggering" | "damaged") {
                     "that object"
-	                } else {
-	                    "it"
-	                };
-	                let card_context = is_generated_internal_tag(tag.as_str())
-	                    || tag.as_str().starts_with("exiled_")
-	                    || tag.as_str().starts_with("revealed_");
-	                let is_clause = |noun_phrase: &str| {
-	                    let phrase = with_indefinite_article(noun_phrase);
-	                    if subject == "it" {
-	                        format!("it's {phrase}")
-	                    } else {
-	                        format!("{subject} is {phrase}")
-	                    }
-	                };
+                } else {
+                    "it"
+                };
+                let card_context = is_generated_internal_tag(tag.as_str())
+                    || tag.as_str().starts_with("exiled_")
+                    || tag.as_str().starts_with("revealed_");
+                let is_clause = |noun_phrase: &str| {
+                    let phrase = with_indefinite_article(noun_phrase);
+                    if subject == "it" {
+                        format!("it's {phrase}")
+                    } else {
+                        format!("{subject} is {phrase}")
+                    }
+                };
 
-	                if card_context
-	                    && !filter.card_types.is_empty()
-	                    && filter.zone.is_none()
-	                    && filter.controller.is_none()
-	                    && filter.owner.is_none()
-	                    && !filter.single_graveyard
-	                    && filter.targets_player.is_none()
-	                    && filter.targets_object.is_none()
-	                    && !filter.targets_any_of
-	                    && filter.all_card_types.is_empty()
-	                    && filter.excluded_card_types.is_empty()
-	                    && filter.subtypes.is_empty()
-	                    && !filter.type_or_subtype_union
-	                    && filter.excluded_subtypes.is_empty()
-	                    && filter.supertypes.is_empty()
-	                    && filter.excluded_supertypes.is_empty()
-	                    && filter.colors.is_none()
-	                    && filter.excluded_colors.is_empty()
-	                    && !filter.colorless
-	                    && !filter.multicolored
-	                    && !filter.monocolored
-	                    && filter.all_colors.is_none()
-	                    && filter.exactly_two_colors.is_none()
-	                    && !filter.historic
-	                    && !filter.nonhistoric
-	                    && !filter.token
-	                    && !filter.nontoken
-	                    && filter.face_down.is_none()
-	                    && !filter.other
-	                    && !filter.tapped
-	                    && !filter.untapped
-	                    && !filter.attacking
-	                    && !filter.nonattacking
-	                    && !filter.blocking
-	                    && !filter.nonblocking
-	                    && !filter.blocked
-	                    && !filter.unblocked
-	                    && !filter.entered_since_your_last_turn_ended
-	                    && filter.power.is_none()
-	                    && filter.toughness.is_none()
-	                    && filter.mana_value.is_none()
-	                    && filter.mana_value_eq_counters_on_source.is_none()
-	                    && !filter.has_mana_cost
-	                    && !filter.has_tap_activated_ability
-	                    && !filter.no_abilities
-	                    && !filter.no_x_in_cost
-	                    && !filter.has_x_in_cost
-	                    && filter.with_counter.is_none()
-	                    && filter.without_counter.is_none()
-	                    && filter.name.is_none()
-	                    && filter.excluded_name.is_none()
-	                    && filter.alternative_cast.is_none()
-	                    && filter.static_abilities.is_empty()
-	                    && filter.excluded_static_abilities.is_empty()
-	                    && filter.ability_markers.is_empty()
-	                    && filter.excluded_ability_markers.is_empty()
-	                    && !filter.is_commander
-	                    && !filter.noncommander
-	                    && filter.tagged_constraints.is_empty()
-	                    && filter.specific.is_none()
-	                    && filter.any_of.is_empty()
-	                    && !filter.source
-	                {
-	                    let words = filter
-	                        .card_types
-	                        .iter()
-	                        .map(|card_type| describe_card_type_word_local(*card_type).to_string())
-	                        .collect::<Vec<_>>();
+                if let Some(state_clause) =
+                    describe_implicit_tagged_object_state_condition(subject, filter)
+                {
+                    return state_clause;
+                }
+
+                if card_context
+                    && !filter.card_types.is_empty()
+                    && filter.zone.is_none()
+                    && filter.controller.is_none()
+                    && filter.owner.is_none()
+                    && !filter.single_graveyard
+                    && filter.targets_player.is_none()
+                    && filter.targets_object.is_none()
+                    && !filter.targets_any_of
+                    && filter.all_card_types.is_empty()
+                    && filter.excluded_card_types.is_empty()
+                    && filter.subtypes.is_empty()
+                    && !filter.type_or_subtype_union
+                    && filter.excluded_subtypes.is_empty()
+                    && filter.supertypes.is_empty()
+                    && filter.excluded_supertypes.is_empty()
+                    && filter.colors.is_none()
+                    && filter.excluded_colors.is_empty()
+                    && !filter.colorless
+                    && !filter.multicolored
+                    && !filter.monocolored
+                    && filter.all_colors.is_none()
+                    && filter.exactly_two_colors.is_none()
+                    && !filter.historic
+                    && !filter.nonhistoric
+                    && !filter.token
+                    && !filter.nontoken
+                    && filter.face_down.is_none()
+                    && !filter.other
+                    && !filter.tapped
+                    && !filter.untapped
+                    && !filter.attacking
+                    && !filter.nonattacking
+                    && !filter.blocking
+                    && !filter.nonblocking
+                    && !filter.blocked
+                    && !filter.unblocked
+                    && !filter.entered_since_your_last_turn_ended
+                    && filter.power.is_none()
+                    && filter.toughness.is_none()
+                    && filter.mana_value.is_none()
+                    && filter.mana_value_eq_counters_on_source.is_none()
+                    && !filter.has_mana_cost
+                    && !filter.has_tap_activated_ability
+                    && !filter.no_abilities
+                    && !filter.no_x_in_cost
+                    && !filter.has_x_in_cost
+                    && filter.with_counter.is_none()
+                    && filter.without_counter.is_none()
+                    && filter.name.is_none()
+                    && filter.excluded_name.is_none()
+                    && filter.alternative_cast.is_none()
+                    && filter.static_abilities.is_empty()
+                    && filter.excluded_static_abilities.is_empty()
+                    && filter.ability_markers.is_empty()
+                    && filter.excluded_ability_markers.is_empty()
+                    && !filter.is_commander
+                    && !filter.noncommander
+                    && filter.tagged_constraints.is_empty()
+                    && filter.specific.is_none()
+                    && filter.any_of.is_empty()
+                    && !filter.source
+                {
+                    let words = filter
+                        .card_types
+                        .iter()
+                        .map(|card_type| describe_card_type_word_local(*card_type).to_string())
+                        .collect::<Vec<_>>();
                     let noun_phrase = format!("{} card", join_with_or(&words));
                     return is_clause(&noun_phrase);
                 }
@@ -12459,6 +12465,34 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             format!("{} or {}", describe_condition(left), describe_condition(right))
         }
     }
+}
+
+fn describe_implicit_tagged_object_state_condition(
+    subject: &str,
+    filter: &ObjectFilter,
+) -> Option<String> {
+    let mut base = filter.clone();
+    base.attacking = false;
+    base.nonattacking = false;
+    if base != ObjectFilter::default()
+        && base != ObjectFilter::permanent()
+        && base != ObjectFilter::creature()
+    {
+        return None;
+    }
+
+    if filter.attacking {
+        return Some("it was attacking".to_string());
+    }
+    if filter.nonattacking {
+        return Some(if subject == "it" {
+            "it wasn't attacking".to_string()
+        } else {
+            "that object wasn't attacking".to_string()
+        });
+    }
+
+    None
 }
 
 fn describe_you_or_attacked_player_initiative_condition(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -31953,9 +31953,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 true_branch
             );
         }
+        let condition_text = describe_condition(&conditional.condition);
+        if condition_text == "it was attacking" {
+            return format!("{true_branch} if {condition_text}. Otherwise, {false_branch}");
+        }
         return format!(
             "If {}, {}. Otherwise, {}",
-            describe_condition(&conditional.condition),
+            condition_text,
             true_branch,
             false_branch
         );

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -3464,6 +3464,7 @@ fn evaluate_condition(
             let filter_ctx = ctx.filter_context(game);
             if let Some(tagged) = ctx.get_tagged_all(tag.as_str()) {
                 return Ok(tagged.iter().any(|snapshot| {
+                    let snapshot_matches = filter.matches_snapshot(snapshot, &filter_ctx, game);
                     let current_id = game
                         .object(snapshot.object_id)
                         .map(|object| object.id)
@@ -3471,9 +3472,9 @@ fn evaluate_condition(
                     if let Some(current_id) = current_id
                         && let Some(object) = game.object(current_id)
                     {
-                        return filter.matches(object, &filter_ctx, game);
+                        return filter.matches(object, &filter_ctx, game) || snapshot_matches;
                     }
-                    filter.matches_snapshot(snapshot, &filter_ctx, game)
+                    snapshot_matches
                 }));
             }
 

--- a/crates/ironsmith-runtime/src/effects/combat/goad.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/goad.rs
@@ -190,6 +190,7 @@ mod tests {
                 counters: std::collections::HashMap::new(),
                 is_token: false,
                 tapped: false,
+                attacking: false,
                 flipped: false,
                 face_down: false,
                 transform_count: 0,

--- a/crates/ironsmith-runtime/src/effects/composition/emit_keyword_action.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/emit_keyword_action.rs
@@ -56,6 +56,7 @@ fn snapshot_from_memory(game: &GameState, memory: &OutcomeObjectMemory) -> Objec
             counters: HashMap::new(),
             is_token: memory.is_token,
             tapped: false,
+            attacking: false,
             flipped: false,
             face_down: false,
             transform_count: 0,

--- a/crates/ironsmith-runtime/src/effects/composition/tag_triggering_object.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/tag_triggering_object.rs
@@ -478,6 +478,7 @@ mod tests {
                     counters: std::collections::HashMap::new(),
                     is_token: false,
                     tapped: false,
+                    attacking: false,
                     flipped: false,
                     face_down: false,
                     transform_count: 0,

--- a/crates/ironsmith-runtime/src/effects/player/choose_card_name.rs
+++ b/crates/ironsmith-runtime/src/effects/player/choose_card_name.rs
@@ -46,6 +46,7 @@ pub(crate) fn synthetic_chosen_name_snapshot(
         counters: std::collections::HashMap::new(),
         is_token: false,
         tapped: false,
+        attacking: false,
         flipped: false,
         face_down: false,
         transform_count: 0,

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -2783,6 +2783,12 @@ impl ObjectFilterExt for ObjectFilter {
         if self.untapped && snapshot.tapped {
             return false;
         }
+        if self.attacking && !snapshot.attacking {
+            return false;
+        }
+        if self.nonattacking && snapshot.attacking {
+            return false;
+        }
         if self.enlist_eligible && !object_is_enlist_eligible(game, snapshot.object_id) {
             return false;
         }

--- a/crates/ironsmith-runtime/src/snapshot.rs
+++ b/crates/ironsmith-runtime/src/snapshot.rs
@@ -102,6 +102,8 @@ pub struct ObjectSnapshot {
     pub is_token: bool,
     /// Whether the object was tapped.
     pub tapped: bool,
+    /// Whether the object was attacking.
+    pub attacking: bool,
     /// Whether the object was flipped.
     pub flipped: bool,
     /// Whether the object was face-down.
@@ -165,6 +167,10 @@ impl ObjectSnapshot {
             counters: obj.counters.clone(),
             is_token: obj.kind == ObjectKind::Token,
             tapped: game.is_tapped(obj.id),
+            attacking: game
+                .combat
+                .as_ref()
+                .is_some_and(|combat| crate::combat_state::is_attacking(combat, obj.id)),
             flipped: game.is_flipped(obj.id),
             face_down: game.is_face_down(obj.id),
             transform_count: game.transform_count(obj.id),
@@ -452,6 +458,7 @@ impl ObjectSnapshot {
             counters: HashMap::new(),
             is_token: false,
             tapped: false,
+            attacking: false,
             flipped: false,
             face_down: false,
             transform_count: 0,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Garna, Bloodfist of Keld
Initial parse error:
```
compiled text contains internal marker: object-predicate-debug
```

Current worker: i-0a0efd683d781ee84
Branch: codex/aws-card-fix-garna-bloodfist-of-keld
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0034
