### PR TITLE
Fix Ironsmith parse failure: Outwit

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/meld_and_special_subjects.rs
@@ -322,6 +322,14 @@ mod tests {
         let tokens = lex_line("spell that targets player", 0).unwrap();
 
         let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.zone, Some(Zone::Stack));
+        assert_eq!(filter.stack_kind, Some(crate::filter::StackObjectKind::Spell));
+        assert_eq!(filter.targets_player, Some(PlayerFilter::Any));
+
+        let tokens = lex_line("spell that targets a player", 0).unwrap();
+        let filter = parse_object_filter_with_grammar_entrypoint_lexed(&tokens, false).unwrap();
+        assert_eq!(filter.zone, Some(Zone::Stack));
+        assert_eq!(filter.stack_kind, Some(crate::filter::StackObjectKind::Spell));
         assert_eq!(filter.targets_player, Some(PlayerFilter::Any));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/reference_tag_stage.rs
@@ -13,7 +13,7 @@ const YOU_TARGET_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(prefix & [
 const OPPONENT_TARGET_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["opponent"], &["opponents"]]);
 const PLAYER_TARGET_PREFIX_PATTERN: ClauseShape<'static> =
-    clause_shape!(prefix_any & [&["player"], &["players"]]);
+    clause_shape!(prefix_any & [&["player"], &["players"], &["a", "player"]]);
 const OR_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["or"]);
 const UNTIL_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["until"]);
 const OTHER_OR_ANOTHER_WORD_PATTERN: ClauseShape<'static> =
@@ -1415,6 +1415,7 @@ pub(super) fn parse_object_filter_inner(
         let mut spell_filter = filter.clone();
         spell_filter.any_of.clear();
         spell_filter.zone = Some(Zone::Stack);
+        spell_filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
         spell_filter.card_types.clear();
         spell_filter.all_card_types.clear();
         spell_filter.subtypes.clear();
@@ -1438,6 +1439,7 @@ pub(super) fn parse_object_filter_inner(
         let mut spell_filter = filter.clone();
         spell_filter.any_of.clear();
         spell_filter.zone = Some(Zone::Stack);
+        spell_filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
         spell_filter.has_mana_cost = false;
         if spell_filter.card_types.is_empty()
             && spell_filter.all_card_types.is_empty()
@@ -1465,6 +1467,7 @@ pub(super) fn parse_object_filter_inner(
             filter.card_types = permanent_type_defaults.clone();
         }
         filter.zone = Some(Zone::Stack);
+        filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
     } else {
         if saw_permanent && filter.card_types.is_empty() && filter.all_card_types.is_empty() {
             filter.card_types = permanent_type_defaults.clone();
@@ -1486,6 +1489,7 @@ pub(super) fn parse_object_filter_inner(
             }
         } else if saw_spell {
             filter.zone = Some(Zone::Stack);
+            filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
         } else if saw_permanent || saw_permanent_type || saw_subtype {
             filter.zone = Some(Zone::Battlefield);
         }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7,8 +7,8 @@ use crate::compiled_text::{
 };
 use crate::effects::{
     AddManaEffect, ChooseModeEffect, ChooseObjectsEffect, ConsultTopOfLibraryEffect,
-    CreateTokenEffect, DestroyEffect, DoubleCountersEffect, DrawCardsEffect, EffectExecutor,
-    GainLifeEffect, IfEffect, MoveToZoneEffect, ReturnFromGraveyardToHandEffect,
+    CounterEffect, CreateTokenEffect, DestroyEffect, DoubleCountersEffect, DrawCardsEffect,
+    EffectExecutor, GainLifeEffect, IfEffect, MoveToZoneEffect, ReturnFromGraveyardToHandEffect,
     TagTriggeringObjectEffect, TaggedEffect, TargetOnlyEffect, UntapEffect, WithIdEffect,
 };
 use crate::filter::ObjectFilterExt;
@@ -163,6 +163,49 @@ fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
     assert_eq!(
         rendered,
         "Whenever you attack, spells you cast from exile this turn cost {X} less to cast, where X is the number of players being attacked. Exile the top X cards of your library. Until end of turn, you may cast spells from among those exiled cards."
+    );
+}
+
+#[test]
+fn outwit_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Outwit");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let counter = def
+        .spell_effect
+        .as_ref()
+        .expect("Outwit should have a spell effect")
+        .flattened_default_effects()
+        .iter()
+        .find_map(|effect| {
+            effect.downcast_ref::<CounterEffect>().or_else(|| {
+                effect
+                    .downcast_ref::<TaggedEffect>()
+                    .and_then(|tagged| tagged.effect.downcast_ref::<CounterEffect>())
+            })
+        })
+        .expect("Outwit should lower to a CounterEffect");
+
+    let ChooseSpec::Target(targeted) = counter.target.unhinted() else {
+        panic!("Outwit should target a spell, got {:?}", counter.target);
+    };
+    let ChooseSpec::Object(filter) = targeted.unhinted() else {
+        panic!("Outwit should target an object-filtered spell, got {targeted:?}");
+    };
+
+    assert_eq!(
+        filter.stack_kind,
+        Some(crate::filter::StackObjectKind::Spell),
+        "Outwit should target only spells"
+    );
+    assert_eq!(
+        filter.targets_player,
+        Some(PlayerFilter::Any),
+        "Outwit should require the target spell to target a player"
+    );
+    assert_eq!(
+        rendered,
+        "Counter target spell that targets a player.",
+        "Outwit compiled text should preserve its player-targeting spell clause"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14774,6 +14774,190 @@ fn molten_hydra_activated_damage_is_zero_when_no_counters_are_removed() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn outwit_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Outwit")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Instant])
+        .parse_text("Counter target spell that targets a player.")
+        .expect("Outwit should parse strictly for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn outwit_counter_target_spec(def: &crate::cards::CardDefinition) -> crate::target::ChooseSpec {
+    def.spell_effect
+        .as_ref()
+        .expect("Outwit should have spell effects")
+        .flattened_default_effects()
+        .iter()
+        .find_map(|effect| {
+            if let Some(counter) = effect.downcast_ref::<crate::effects::CounterEffect>() {
+                return Some(counter.target.clone());
+            }
+            effect
+                .downcast_ref::<crate::effects::TaggedEffect>()
+                .and_then(|tagged| {
+                    tagged
+                        .effect
+                        .downcast_ref::<crate::effects::CounterEffect>()
+                })
+                .map(|counter| counter.target.clone())
+        })
+        .expect("Outwit should lower to a CounterEffect")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn push_outwit_test_damage_spell(
+    game: &mut GameState,
+    controller: PlayerId,
+    targets: Vec<Target>,
+) -> ObjectId {
+    let spell = CardDefinitionBuilder::new(CardId::new(), "Lightning Probe")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Lightning Probe deals 1 damage to any target.")
+        .expect("damage spell should parse");
+    let spell_id = game.create_object_from_definition(&spell, controller, Zone::Stack);
+    let target_len = targets.len();
+    game.push_to_stack(
+        StackEntry::new(spell_id, controller)
+            .with_targets(targets)
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::AnyTarget,
+                range: 0..target_len,
+            }]),
+    );
+    spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn outwit_target_requirements_only_allow_spells_targeting_players() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let outwit = outwit_definition();
+    let creature = create_creature(&mut game, "Target Dummy", alice, 1, 1);
+
+    let player_targeting_spell =
+        push_outwit_test_damage_spell(&mut game, bob, vec![Target::Player(alice)]);
+    let creature_targeting_spell =
+        push_outwit_test_damage_spell(&mut game, bob, vec![Target::Object(creature)]);
+    let ability_source = create_creature(&mut game, "Ability Source", bob, 1, 1);
+    game.push_to_stack(
+        StackEntry::ability(ability_source, bob, vec![Effect::gain_life(1)])
+            .with_targets(vec![Target::Player(alice)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: crate::target::ChooseSpec::Player(crate::target::PlayerFilter::Any),
+                range: 0..1,
+            }]),
+    );
+
+    let target_requirements = super::targeting::extract_target_requirements(
+        &game,
+        outwit
+            .spell_effect
+            .as_ref()
+            .expect("Outwit should have spell effects")
+            .flattened_default_effects(),
+        alice,
+        None,
+    );
+
+    assert_eq!(
+        target_requirements.len(),
+        1,
+        "Outwit should require one target spell"
+    );
+    assert!(
+        target_requirements[0]
+            .legal_targets
+            .contains(&Target::Object(player_targeting_spell)),
+        "Outwit should be able to target a spell that targets a player"
+    );
+    assert!(
+        !target_requirements[0]
+            .legal_targets
+            .contains(&Target::Object(creature_targeting_spell)),
+        "Outwit should not be able to target a spell that targets only a creature"
+    );
+    assert!(
+        !target_requirements[0]
+            .legal_targets
+            .contains(&Target::Object(ability_source)),
+        "Outwit should not be able to target an ability that targets a player"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn outwit_counters_spell_targeting_any_player() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let outwit = outwit_definition();
+    let target_spec = outwit_counter_target_spec(&outwit);
+    let target_spell = push_outwit_test_damage_spell(&mut game, bob, vec![Target::Player(alice)]);
+    let outwit_id = game.create_object_from_definition(&outwit, alice, Zone::Stack);
+
+    game.push_to_stack(
+        StackEntry::new(outwit_id, alice)
+            .with_targets(vec![Target::Object(target_spell)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: target_spec,
+                range: 0..1,
+            }]),
+    );
+
+    resolve_stack_entry(&mut game).expect("Outwit should resolve");
+
+    assert!(
+        !game.stack.iter().any(|entry| entry.object_id == target_spell),
+        "Outwit should remove the player-targeting spell from the stack"
+    );
+    assert!(
+        game.player(bob)
+            .expect("Bob should exist")
+            .graveyard
+            .iter()
+            .any(|id| game
+                .object(*id)
+                .is_some_and(|object| object.name == "Lightning Probe")),
+        "Outwit should counter the targeted spell into its controller's graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn outwit_fizzles_if_target_spell_does_not_target_a_player() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let outwit = outwit_definition();
+    let target_spec = outwit_counter_target_spec(&outwit);
+    let creature = create_creature(&mut game, "Target Dummy", alice, 1, 1);
+    let creature_targeting_spell =
+        push_outwit_test_damage_spell(&mut game, bob, vec![Target::Object(creature)]);
+    let outwit_id = game.create_object_from_definition(&outwit, alice, Zone::Stack);
+
+    game.push_to_stack(
+        StackEntry::new(outwit_id, alice)
+            .with_targets(vec![Target::Object(creature_targeting_spell)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: target_spec,
+                range: 0..1,
+            }]),
+    );
+
+    resolve_stack_entry(&mut game).expect("Outwit with an illegal target should fizzle cleanly");
+
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| entry.object_id == creature_targeting_spell),
+        "Outwit should not counter a spell that targets only a creature"
+    );
+}
+
 #[test]
 fn protected_stack_spell_still_resolves_after_failed_counterspell() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Outwit
Initial parse error:
```
unsupported target phrase (clause: 'player'); oracle-only fallback also failed: unsupported target phrase (clause: 'player')
```

Current worker: i-08dd4c29841c67811
Branch: codex/aws-card-fix-outwit
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0034
