### PR TITLE
Fix Ironsmith parse failure: Nezumi Graverobber // Nighteyes the Desecrator

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -114,6 +114,8 @@ const CONTROL_POSSESSIVE_WORD_PATTERN: ClauseShape<'static> =
 const IN_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["in"]);
 const INSTEAD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["instead"]);
 const GRAVEYARD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["graveyard"]);
+const IN_THAT_GRAVEYARD_TAIL_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["in", "that", "graveyard"]);
 const MORE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["more"]);
 const OTHER_OR_ANOTHER_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["another"], &["other"]]);
@@ -2241,6 +2243,19 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if let Some(predicate) = parse_graveyard_threshold_predicate(&filtered)? {
         return Ok(predicate);
+    }
+
+    if filtered.len() == 6
+        && NO_WORD_PATTERN.matches_word(filtered[0])
+        && CARD_OR_CARDS_WORD_PATTERN.matches_word(filtered[1])
+        && IS_OR_ARE_WORD_PATTERN.matches_word(filtered[2])
+        && IN_THAT_GRAVEYARD_TAIL_PATTERN.matches_words(&filtered[3..])
+    {
+        return Ok(PredicateAst::ValueComparison {
+            left: Value::CardsInGraveyard(PlayerFilter::OwnerOf(ObjectRef::Target)),
+            operator: crate::effect::ValueComparisonOperator::Equal,
+            right: Value::Fixed(0),
+        });
     }
 
     if let Some(predicate) = parse_card_in_your_graveyard_predicate(&filtered) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42009,6 +42009,30 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn nezumi_graverobber_strict_parser_and_compiled_text_regression() {
+    const NAME: &str = "Nezumi Graverobber // Nighteyes the Desecrator";
+
+    assert_oracle_card_parses_strict(NAME);
+    let def = parse_oracle_card_definition(NAME);
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "{1}{B}: Exile target card from an opponent's graveyard. If no cards are in that graveyard, flip this creature"
+        ),
+        "expected Nezumi Graverobber to render the empty-that-graveyard flip clause, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("CardsInGraveyard")
+            && debug.contains("OwnerOf")
+            && debug.contains("Target")
+            && debug.contains("FlipEffect"),
+        "expected Nezumi Graverobber to lower the target owner's empty graveyard check and flip structurally, got {debug}"
+    );
+}
+
+#[test]
 fn death_in_heaven_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Death in Heaven");
     let def = parse_oracle_card_definition("Death in Heaven");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12206,6 +12206,14 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 );
             }
             if let (
+                Value::CardsInGraveyard(PlayerFilter::OwnerOf(crate::target::ObjectRef::Target)),
+                crate::effect::ValueComparisonOperator::Equal,
+                Value::Fixed(0),
+            ) = (left, operator, right)
+            {
+                return "no cards are in that graveyard".to_string();
+            }
+            if let (
                 Value::MaxCardsDrawnThisTurn(player),
                 crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
                 Value::Fixed(count),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -4134,6 +4134,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
     }
+    if let Some(compact) = describe_exile_target_then_flip_if_that_graveyard_empty(effects) {
+        return compact;
+    }
 
     let raw_effects = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&raw_effects) {
@@ -14741,6 +14744,65 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     cleanup_decompiled_text(&text)
+}
+
+fn describe_exile_target_then_flip_if_that_graveyard_empty(effects: &[Effect]) -> Option<String> {
+    fn unwrap_effect(effect: &Effect) -> &Effect {
+        if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+            return unwrap_effect(&tagged.effect);
+        }
+        if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+            return unwrap_effect(&tag_all.effect);
+        }
+        if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+            return unwrap_effect(with_id.effect.as_ref());
+        }
+        effect
+    }
+
+    let [move_effect, conditional_effect] = effects else {
+        return None;
+    };
+    let move_to_zone = unwrap_effect(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Exile
+        || !matches!(move_to_zone.target.unhinted(), ChooseSpec::Target(_))
+    {
+        return None;
+    }
+
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() {
+        return None;
+    }
+    let [flip_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let flip = flip_effect.downcast_ref::<crate::effects::FlipEffect>()?;
+    if !matches!(flip.target.unhinted(), ChooseSpec::Source) {
+        return None;
+    }
+    if !matches!(
+        &conditional.condition,
+        crate::effect::Condition::ValueComparison {
+            left: Value::CardsInGraveyard(PlayerFilter::OwnerOf(crate::target::ObjectRef::Target)),
+            operator: crate::effect::ValueComparisonOperator::Equal,
+            right: Value::Fixed(0),
+        }
+    ) {
+        return None;
+    }
+
+    let exile_text = describe_effect(move_effect)
+        .trim()
+        .trim_end_matches('.')
+        .to_string();
+    if exile_text.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{exile_text}. If no cards are in that graveyard, flip this creature"
+    ))
 }
 
 fn normalize_haunting_echoes_text(text: &str) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1933,6 +1933,241 @@ fn keeper_of_the_flame_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn nezumi_graverobber_pair_definitions() -> (
+    crate::cards::CardDefinition,
+    crate::cards::CardDefinition,
+) {
+    let front_id = CardId::from_raw(222_366);
+    let back_id = CardId::from_raw(222_367);
+
+    let front = CardDefinitionBuilder::new(front_id, "Nezumi Graverobber")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Rat, Subtype::Rogue])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .other_face(back_id)
+        .other_face_name("Nighteyes the Desecrator")
+        .linked_face_layout(LinkedFaceLayout::TransformLike)
+        .parse_text(
+            "{1}{B}: Exile target card from an opponent's graveyard. If no cards are in that graveyard, flip this creature.",
+        )
+        .expect("Nezumi Graverobber should parse for runtime tests");
+    let back = CardDefinitionBuilder::new(back_id, "Nighteyes the Desecrator")
+        .card_types(vec![CardType::Creature])
+        .supertypes(vec![Supertype::Legendary])
+        .subtypes(vec![Subtype::Rat, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(4, 2))
+        .other_face(front_id)
+        .other_face_name("Nezumi Graverobber")
+        .linked_face_layout(LinkedFaceLayout::TransformLike)
+        .parse_text(
+            "{4}{B}: Put target creature card from a graveyard onto the battlefield under your control.",
+        )
+        .expect("Nighteyes the Desecrator should parse for runtime tests");
+
+    (front, back)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn register_nezumi_graverobber_pair(game: &mut GameState) -> crate::cards::CardDefinition {
+    let (front, back) = nezumi_graverobber_pair_definitions();
+    game.register_linked_face_definition(&front);
+    game.register_linked_face_definition(&back);
+    front
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_graveyard_instant(game: &mut GameState, name: &str, owner: PlayerId) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Instant])
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Graveyard)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_graveyard_creature(game: &mut GameState, name: &str, owner: PlayerId) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Graveyard)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn object_id_in_zone_named(game: &GameState, zone: Zone, name: &str) -> Option<ObjectId> {
+    game.objects_in_zone(zone).into_iter().find(|id| {
+        game.object(*id).is_some_and(|object| object.name == name)
+    })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_nezumi_ability_targeting(
+    game: &mut GameState,
+    controller: PlayerId,
+    source: ObjectId,
+    target: ObjectId,
+) {
+    let ability_index = game
+        .object(source)
+        .expect("Nezumi permanent should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Nezumi permanent should have an activated ability");
+    let activate_action = crate::decision::compute_legal_actions(game, controller)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility {
+                    source: action_source,
+                    ability_index: idx,
+                }
+                    if *action_source == source && *idx == ability_index
+            )
+        })
+        .expect("Nezumi activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let progress = apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Nezumi activation should start");
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected target selection for Nezumi activation, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(target)]),
+        &mut dm,
+    )
+    .expect("choosing Nezumi activation target should complete activation");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nezumi_graverobber_flips_when_target_owners_graveyard_is_empty_then_reanimates() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let front = register_nezumi_graverobber_pair(&mut game);
+    let nezumi_id = game.create_object_from_definition(&front, alice, Zone::Battlefield);
+    let target_name = "Bob's Last Card";
+    let target_card = create_graveyard_instant(&mut game, target_name, bob);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Black, 2);
+
+    activate_nezumi_ability_targeting(&mut game, alice, nezumi_id, target_card);
+    resolve_stack_entry(&mut game).expect("Nezumi Graverobber ability should resolve");
+
+    assert!(
+        object_id_in_zone_named(&game, Zone::Exile, target_name).is_some(),
+        "target card should be exiled from Bob's graveyard"
+    );
+    assert!(
+        game.player(bob).expect("Bob should exist").graveyard.is_empty(),
+        "Bob's graveyard should be empty after exiling its only card"
+    );
+    assert!(
+        game.is_flipped(nezumi_id),
+        "Nezumi Graverobber should flip when that graveyard is empty"
+    );
+    assert_eq!(
+        game.object(nezumi_id).expect("Nezumi should exist").name,
+        "Nighteyes the Desecrator"
+    );
+
+    let creature_name = "Bob's Reanimation Target";
+    let creature_card = create_graveyard_creature(&mut game, creature_name, bob);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Black, 5);
+
+    activate_nezumi_ability_targeting(&mut game, alice, nezumi_id, creature_card);
+    resolve_stack_entry(&mut game).expect("Nighteyes the Desecrator ability should resolve");
+
+    let reanimated_id = object_id_in_zone_named(&game, Zone::Battlefield, creature_name)
+        .expect("reanimated creature should be on the battlefield");
+    let reanimated = game
+        .object(reanimated_id)
+        .expect("reanimated creature should still exist");
+    assert_eq!(reanimated.zone, Zone::Battlefield);
+    assert_eq!(
+        game.controller_of(reanimated),
+        alice,
+        "Nighteyes should put the target creature card onto the battlefield under your control"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nezumi_graverobber_does_not_flip_when_that_graveyard_still_has_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let front = register_nezumi_graverobber_pair(&mut game);
+    let nezumi_id = game.create_object_from_definition(&front, alice, Zone::Battlefield);
+    let target_name = "Bob's First Card";
+    let remaining_name = "Bob's Remaining Card";
+    let target_card = create_graveyard_instant(&mut game, target_name, bob);
+    create_graveyard_instant(&mut game, remaining_name, bob);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Black, 2);
+
+    activate_nezumi_ability_targeting(&mut game, alice, nezumi_id, target_card);
+    resolve_stack_entry(&mut game).expect("Nezumi Graverobber ability should resolve");
+
+    assert!(
+        object_id_in_zone_named(&game, Zone::Exile, target_name).is_some(),
+        "target card should still be exiled"
+    );
+    assert!(
+        object_id_in_zone_named(&game, Zone::Graveyard, remaining_name).is_some(),
+        "a different card should remain in that graveyard"
+    );
+    assert!(
+        !game.is_flipped(nezumi_id),
+        "Nezumi Graverobber should not flip while that graveyard still has cards"
+    );
+    assert_eq!(
+        game.object(nezumi_id).expect("Nezumi should exist").name,
+        "Nezumi Graverobber"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn goblin_kites_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_955), "Goblin Kites")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nezumi Graverobber // Nighteyes the Desecrator
Initial parse error:
```
unsupported predicate (predicate: 'no cards are in that graveyard'); oracle-only fallback also failed: unsupported predicate (predicate: 'no cards are in that graveyard')
```

Current worker: i-0cadfba5f5ae71ff7
Branch: codex/aws-card-fix-nezumi-graverobber-nighteyes-the-desecrator
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0034
