### PR TITLE
Fix Ironsmith parse failure: Necrotic Ooze

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -495,6 +495,15 @@ const SOURCE_IS_MONSTROUS_CONDITION_PATTERN: ClauseShape<'static> = clause_shape
             &["its", "monstrous"],
         ]
 );
+const SOURCE_IS_ON_BATTLEFIELD_CONDITION_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["this", "creature", "is", "on", "the", "battlefield"],
+            &["this", "permanent", "is", "on", "the", "battlefield"],
+            &["this", "is", "on", "the", "battlefield"],
+            &["it", "is", "on", "the", "battlefield"],
+        ]
+);
 const SOURCE_DEVOURED_CREATURES_CONDITION_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -2836,6 +2845,9 @@ pub(crate) fn parse_static_condition_clause(
     }
     if SOURCE_IS_MONSTROUS_CONDITION_PATTERN.matches_words(&clause_words) {
         return Ok(crate::ConditionExpr::SourceIsMonstrous);
+    }
+    if SOURCE_IS_ON_BATTLEFIELD_CONDITION_PATTERN.matches_words(&clause_words) {
+        return Ok(crate::ConditionExpr::SourceIsInZone(Zone::Battlefield));
     }
     if SOURCE_DEVOURED_CREATURES_CONDITION_PATTERN.matches_words(&clause_words) {
         return Ok(crate::ConditionExpr::SourceDevouredCreaturesOrMore(1));

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -10693,12 +10693,15 @@ pub(crate) fn parse_copy_activated_abilities_line(
     let Some(has_idx) = has_idx else {
         return Ok(None);
     };
+    let Some(has_token_idx) = token_index_for_word_index(tokens, has_idx) else {
+        return Ok(None);
+    };
 
-    let (condition, subject_start) = match parse_anthem_prefix_condition(tokens, has_idx) {
+    let (condition, subject_start) = match parse_anthem_prefix_condition(tokens, has_token_idx) {
         Ok(parsed) => parsed,
         Err(_) => return Ok(None),
     };
-    let subject_tokens = trim_commas(&tokens[subject_start..has_idx]);
+    let subject_tokens = trim_commas(&tokens[subject_start..has_token_idx]);
     if subject_tokens.is_empty() {
         return Ok(None);
     }
@@ -10707,7 +10710,10 @@ pub(crate) fn parse_copy_activated_abilities_line(
         Err(_) => return Ok(None),
     };
 
-    let filter_tokens = trim_edge_punctuation(&tokens[(has_idx + 5)..]);
+    let Some(filter_start_idx) = token_index_for_word_index(tokens, has_idx + 5) else {
+        return Ok(None);
+    };
+    let filter_tokens = trim_edge_punctuation(&tokens[filter_start_idx..]);
     let mut filter_tokens =
         strip_leading_token_words_any(&filter_tokens, &["all", "each"]).to_vec();
     let after_of_words = crate::runtime_backend::lexer::parser_token_word_refs(&filter_tokens);

--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -154,6 +154,8 @@ const OBJECT_FILTER_YOUR_LIBRARY_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["in", "your", "library"], &["from", "your", "library"]]);
 const OBJECT_FILTER_GRAVEYARD_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["in", "graveyard"], &["from", "graveyard"]]);
+const OBJECT_FILTER_ALL_GRAVEYARDS_SUFFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["in", "all", "graveyards"], &["from", "all", "graveyards"]]);
 const OBJECT_FILTER_HAND_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["in", "hand"], &["from", "hand"]]);
 const OBJECT_FILTER_LIBRARY_SUFFIX_PATTERN: ClauseShape<'static> =
@@ -328,6 +330,11 @@ fn parse_simple_object_filter_suffix(words: &[&str]) -> Option<(SimpleObjectFilt
             SimpleObjectFilterSuffix::OwnerZone(PlayerFilter::You, Zone::Library),
             3,
         ));
+    }
+    if tail(words, 3)
+        .is_some_and(|tail| OBJECT_FILTER_ALL_GRAVEYARDS_SUFFIX_PATTERN.matches_words(tail))
+    {
+        return Some((SimpleObjectFilterSuffix::Zone(Zone::Graveyard), 3));
     }
     if tail(words, 2)
         .is_some_and(|tail| OBJECT_FILTER_YOU_CONTROL_SUFFIX_PATTERN.matches_words(tail))

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33898,6 +33898,32 @@ Creatures you control with +1/+1 counters on them have all activated abilities o
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn necrotic_ooze_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Necrotic Ooze");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+
+    assert!(
+        ability_debug.contains("CopyActivatedAbilities")
+            && ability_debug.contains("SourceIsInZone(Battlefield)")
+            && ability_debug.contains("Graveyard")
+            && ability_debug.contains("Creature"),
+        "Necrotic Ooze should structurally model a battlefield-gated graveyard-creature activated-ability copy effect, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("as long as")
+            && rendered.contains("this creature is on the battlefield")
+            && rendered.contains("all activated abilities")
+            && rendered.contains("creature cards")
+            && rendered.contains("graveyards"),
+        "expected Necrotic Ooze compiled text to preserve the source-on-battlefield activated-ability copy clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_existing_mana_spend_as_any_color_static_patterns() {
     let lattice = CardDefinitionBuilder::new(CardId::from_raw(1), "Mycosynth Lattice Variant")
         .parse_text("Players may spend mana as though it were mana of any color.")

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -73,6 +73,42 @@ fn the_eternity_elevator_threshold_ability_index(def: &crate::cards::CardDefinit
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn necrotic_ooze_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(645_500), "Necrotic Ooze")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "As long as this creature is on the battlefield, it has all activated abilities of all creature cards in all graveyards.",
+        )
+        .expect("Necrotic Ooze should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn graveyard_sage_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(645_501), "Graveyard Sage")
+        .card_types(vec![CardType::Creature])
+        .parse_text("{T}: Draw a card.")
+        .expect("graveyard creature activated ability should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn graveyard_scroll_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(645_502), "Graveyard Scroll")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{T}: Draw a card.")
+        .expect("graveyard noncreature activated ability should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activated_ability_count(game: &GameState, object_id: ObjectId) -> usize {
+    game.calculated_characteristics(object_id)
+        .expect("object should have calculated characteristics")
+        .abilities
+        .iter()
+        .filter(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn the_eternity_elevator_threshold_mana_requires_twenty_charge_counters() {
     let mut game = setup_game();
@@ -169,6 +205,65 @@ fn the_eternity_elevator_threshold_mana_counts_current_charge_counters() {
         game.player(alice).expect("alice exists").mana_pool.green,
         23,
         "The Eternity Elevator should add X mana of one color where X is its charge counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necrotic_ooze_copies_only_graveyard_creature_activated_abilities_on_battlefield() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let ooze = necrotic_ooze_definition();
+    let sage = graveyard_sage_definition();
+    let scroll = graveyard_scroll_definition();
+
+    let ooze_id = game.create_object_from_definition(&ooze, alice, Zone::Battlefield);
+    game.create_object_from_definition(&sage, alice, Zone::Graveyard);
+    game.create_object_from_definition(&sage, bob, Zone::Graveyard);
+    game.create_object_from_definition(&sage, alice, Zone::Hand);
+    game.create_object_from_definition(&scroll, alice, Zone::Graveyard);
+    game.remove_summoning_sickness(ooze_id);
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        activated_ability_count(&game, ooze_id),
+        2,
+        "Necrotic Ooze should copy creature-card activated abilities from all graveyards and ignore noncreature or non-graveyard cards"
+    );
+
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, .. } if *source == ooze_id
+        )),
+        "Necrotic Ooze's copied activated ability should be available while it is on the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necrotic_ooze_does_not_copy_activated_abilities_outside_battlefield() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let ooze = necrotic_ooze_definition();
+    let sage = graveyard_sage_definition();
+
+    let ooze_id = game.create_object_from_definition(&ooze, alice, Zone::Graveyard);
+    game.create_object_from_definition(&sage, alice, Zone::Graveyard);
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        activated_ability_count(&game, ooze_id),
+        0,
+        "Necrotic Ooze should not copy graveyard activated abilities unless it is on the battlefield"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Necrotic Ooze
Initial parse error:
```
unsupported static condition clause (clause: 'this creature is on the battlefield'); oracle-only fallback also failed: unsupported static condition clause (clause: 'this creature is on the battlefield')
```

Current worker: i-0875eb99aab033ef3
Branch: codex/aws-card-fix-necrotic-ooze
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0035
