### PR TITLE
Fix Ironsmith parse failure: General's Regalia

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -151,6 +151,7 @@ pub enum RedirectNextTimeDamageDestinationAst {
     SourceObject,
     Controller,
     SourceController,
+    TargetObject,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1752,6 +1752,7 @@ fn compile_subject_verb_effect(
             source,
             target,
             destination,
+            destination_target,
             all_this_turn,
         } => {
             let source_spec = match source {
@@ -1765,29 +1766,42 @@ fn compile_subject_verb_effect(
                     )?)
                 }
             };
-            compile_effect_for_target(target, ctx, |spec| {
-                let effect = crate::effects::RedirectNextTimeDamageToSourceEffect::new(
-                    source_spec.clone(),
-                    spec,
-                );
-                let effect = match destination {
-                    crate::cards::builders::RedirectNextTimeDamageDestinationAst::SourceObject => {
-                        effect
-                    }
-                    crate::cards::builders::RedirectNextTimeDamageDestinationAst::Controller => {
-                        effect.to_controller()
-                    }
-                    crate::cards::builders::RedirectNextTimeDamageDestinationAst::SourceController => {
-                        effect.to_source_controller()
-                    }
-                };
-                let effect = if *all_this_turn {
-                    effect.all_this_turn()
-                } else {
+            let refs = current_reference_env(ctx);
+            let (protected_spec, mut choices) = resolve_target_spec_with_choices(target, &refs)?;
+            let mut effect = crate::effects::RedirectNextTimeDamageToSourceEffect::new(
+                source_spec,
+                protected_spec,
+            );
+            effect = match destination {
+                crate::cards::builders::RedirectNextTimeDamageDestinationAst::SourceObject => {
                     effect
-                };
-                Effect::new(effect)
-            })
+                }
+                crate::cards::builders::RedirectNextTimeDamageDestinationAst::Controller => {
+                    effect.to_controller()
+                }
+                crate::cards::builders::RedirectNextTimeDamageDestinationAst::SourceController => {
+                    effect.to_source_controller()
+                }
+                crate::cards::builders::RedirectNextTimeDamageDestinationAst::TargetObject => {
+                    let destination_target = destination_target.as_ref().ok_or_else(|| {
+                        CardTextError::ParseError(
+                            "missing redirected-next-time damage destination target".to_string(),
+                        )
+                    })?;
+                    let (destination_spec, destination_choices) =
+                        resolve_target_spec_with_choices(destination_target, &refs)?;
+                    for choice in destination_choices {
+                        push_choice(&mut choices, choice);
+                    }
+                    effect.to_target(destination_spec)
+                }
+            };
+            let effect = if *all_this_turn {
+                effect.all_this_turn()
+            } else {
+                effect
+            };
+            Ok((vec![Effect::new(effect)], choices))
         }
         SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { source } => {
             compile_effect_for_target(source, ctx, |spec| {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1386,6 +1386,7 @@ pub(crate) enum SubjectVerbActionAst {
         source: PreventNextTimeDamageSourceAst,
         target: TargetAst,
         destination: RedirectNextTimeDamageDestinationAst,
+        destination_target: Option<TargetAst>,
         all_this_turn: bool,
     },
     RedirectAllDamageThisTurnBySourceToSourceController {
@@ -2790,12 +2791,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 source,
                 target,
                 destination,
+                destination_target,
                 all_this_turn,
             } => f
                 .debug_struct("RedirectNextTimeDamageToSource")
                 .field("source", source)
                 .field("target", target)
                 .field("destination", destination)
+                .field("destination_target", destination_target)
                 .field("all_this_turn", all_this_turn)
                 .finish(),
             Self::RedirectAllDamageThisTurnBySourceToSourceController { source } => f
@@ -4666,6 +4669,25 @@ impl EffectAst {
                 source,
                 target,
                 destination,
+                destination_target: None,
+                all_this_turn: false,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_redirect_next_time_damage_to_target(
+        source: PreventNextTimeDamageSourceAst,
+        target: TargetAst,
+        destination_target: TargetAst,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::RedirectNextTimeDamageToSource {
+                source,
+                target,
+                destination: RedirectNextTimeDamageDestinationAst::TargetObject,
+                destination_target: Some(destination_target),
                 all_this_turn: false,
             },
         )
@@ -4683,6 +4705,7 @@ impl EffectAst {
                 source,
                 target,
                 destination,
+                destination_target: None,
                 all_this_turn: true,
             },
         )

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -2833,9 +2833,18 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 bind_unresolved_it_in_value(amount, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
             }
-            SubjectVerbActionAst::RedirectNextTimeDamageToSource { source, target, .. } => {
+            SubjectVerbActionAst::RedirectNextTimeDamageToSource {
+                source,
+                target,
+                destination_target,
+                ..
+            } => {
                 bind_unresolved_it_in_prevent_next_source(source, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
+                    + destination_target
+                        .as_mut()
+                        .map(|target| bind_unresolved_it_in_target(target, seed_tag))
+                        .unwrap_or(0)
             }
             SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController {
                 source,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -2116,6 +2116,12 @@ pub(crate) fn parse_redirect_next_damage_sentence(
             .first()
             .is_some_and(|word| CLAUSE_TARGET_WORD_PATTERN.matches_word(word))
         {
+            if destination_clause.contains_word("choice") {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported redirected-next-time damage destination (clause: '{}')",
+                    clause_text
+                )));
+            }
             (
                 RedirectNextTimeDamageDestinationAst::TargetObject,
                 Some(parse_target_phrase(destination_clause.tokens())?),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -2102,15 +2102,24 @@ pub(crate) fn parse_redirect_next_damage_sentence(
         } else {
             return Ok(None);
         };
-        let destination = if destination_clause.matches_any_words(&[
+        let (destination, destination_target) = if destination_clause.matches_any_words(&[
             &["this"],
             &["it"],
             &["this", "creature"],
             &["this", "permanent"],
         ]) {
-            RedirectNextTimeDamageDestinationAst::SourceObject
+            (RedirectNextTimeDamageDestinationAst::SourceObject, None)
         } else if destination_clause.matches_any_words(&[&["you"]]) {
-            RedirectNextTimeDamageDestinationAst::Controller
+            (RedirectNextTimeDamageDestinationAst::Controller, None)
+        } else if destination_clause
+            .word_refs()
+            .first()
+            .is_some_and(|word| CLAUSE_TARGET_WORD_PATTERN.matches_word(word))
+        {
+            (
+                RedirectNextTimeDamageDestinationAst::TargetObject,
+                Some(parse_target_phrase(destination_clause.tokens())?),
+            )
         } else {
             return Err(CardTextError::ParseError(format!(
                 "unsupported redirected-next-time damage destination (clause: '{}')",
@@ -2118,13 +2127,21 @@ pub(crate) fn parse_redirect_next_damage_sentence(
             )));
         };
 
-        return Ok(Some(vec![
+        let effect = if let Some(destination_target) = destination_target {
+            EffectAst::subject_verb_redirect_next_time_damage_to_target(
+                source,
+                target,
+                destination_target,
+            )
+        } else {
             EffectAst::subject_verb_redirect_next_time_damage_to_source(
                 source,
                 target,
                 destination,
-            ),
-        ]));
+            )
+        };
+
+        return Ok(Some(vec![effect]));
     }
 
     if !CLAUSE_THE_NEXT_PREFIX_PATTERN.matches(clause) {

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -126,6 +126,7 @@ pub enum RedirectNextTimeDamageDestination {
     SourceObject,
     Controller,
     SourceController,
+    TargetObject,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3560,6 +3561,7 @@ pub struct RedirectNextTimeDamageToSourceEffect {
     pub source: RedirectNextTimeDamageSource,
     pub target: Option<ChooseSpec>,
     pub destination: RedirectNextTimeDamageDestination,
+    pub destination_target: Option<ChooseSpec>,
     pub all_this_turn: bool,
 }
 
@@ -3569,6 +3571,7 @@ impl RedirectNextTimeDamageToSourceEffect {
             source,
             target: Some(target),
             destination: RedirectNextTimeDamageDestination::SourceObject,
+            destination_target: None,
             all_this_turn: false,
         }
     }
@@ -3578,17 +3581,26 @@ impl RedirectNextTimeDamageToSourceEffect {
             source: RedirectNextTimeDamageSource::Target(source),
             target: None,
             destination: RedirectNextTimeDamageDestination::SourceController,
+            destination_target: None,
             all_this_turn: false,
         }
     }
 
     pub fn to_controller(mut self) -> Self {
         self.destination = RedirectNextTimeDamageDestination::Controller;
+        self.destination_target = None;
         self
     }
 
     pub fn to_source_controller(mut self) -> Self {
         self.destination = RedirectNextTimeDamageDestination::SourceController;
+        self.destination_target = None;
+        self
+    }
+
+    pub fn to_target(mut self, target: ChooseSpec) -> Self {
+        self.destination = RedirectNextTimeDamageDestination::TargetObject;
+        self.destination_target = Some(target);
         self
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -1084,6 +1084,7 @@ pub(crate) enum RedirectNextTimeDamageDestinationAst {
     SourceObject,
     Controller,
     SourceController,
+    TargetObject,
 }
 
 #[cfg(any(test, ironsmith_runtime_parser_tests))]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -29442,6 +29442,30 @@ fn jade_monolith_parses_and_renders_source_damage_redirect_to_you() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn generals_regalia_parses_and_renders_redirect_to_target_creature_you_control() {
+    let def = parse_oracle_card_definition("General's Regalia");
+
+    let joined = canonical_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains(
+            "the next time a source of your choice would deal damage to you this turn, that damage is dealt to target creature you control instead"
+        ),
+        "expected General's Regalia redirect text in compiled output, got {joined}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("RedirectNextTimeDamageToSourceEffect")
+            && debug.contains("destination: TargetObject")
+            && debug.contains("destination_target: Some"),
+        "General's Regalia should lower to next-time damage redirection to a target object, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn oracles_attendants_parses_and_renders_all_damage_source_redirect_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Oracle's Attendants")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -29466,6 +29466,23 @@ fn generals_regalia_parses_and_renders_redirect_to_target_creature_you_control()
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn opponent_chosen_redirect_destination_remains_unsupported() {
+    let err = CardDefinitionBuilder::new(CardId::from_raw(1), "Nova Pentacle Variant")
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{3}, {T}: The next time a source of your choice would deal damage to you this turn, that damage is dealt to target creature of an opponent's choice instead.",
+        )
+        .expect_err("opponent-chosen destination target should remain unsupported");
+
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("unsupported redirected-next-time damage destination"),
+        "expected unsupported redirected destination error, got {err}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn oracles_attendants_parses_and_renders_all_damage_source_redirect_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Oracle's Attendants")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33886,6 +33886,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                         "that source's controller".to_string()
                     }
                 }
+                crate::effects::RedirectNextTimeDamageDestination::TargetObject => {
+                    describe_choose_spec(
+                        redirect_next_time
+                            .destination_target
+                            .as_ref()
+                            .expect("redirect-next damage destination target"),
+                    )
+                }
             };
             return if let Some(target) = &redirect_next_time.target {
                 format!(
@@ -33924,6 +33932,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 } else {
                     "that source's controller"
                 }
+            ),
+            crate::effects::RedirectNextTimeDamageDestination::TargetObject => format!(
+                "The next time {source_text} would deal damage to {} this turn, that damage is dealt to {} instead",
+                describe_choose_spec(
+                    redirect_next_time
+                        .target
+                        .as_ref()
+                        .expect("redirect-next damage target")
+                ),
+                describe_choose_spec(
+                    redirect_next_time
+                        .destination_target
+                        .as_ref()
+                        .expect("redirect-next damage destination target")
+                )
             ),
         };
     }

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1011,6 +1011,7 @@ where
                 source,
                 target: None,
                 destination: crate::effects::RedirectNextTimeDamageDestination::SourceObject,
+                destination_target: None,
                 all_this_turn: false,
             }
         };
@@ -1019,6 +1020,14 @@ where
             ironsmith_core::RedirectNextTimeDamageDestination::Controller => effect.to_controller(),
             ironsmith_core::RedirectNextTimeDamageDestination::SourceController => {
                 effect.to_source_controller()
+            }
+            ironsmith_core::RedirectNextTimeDamageDestination::TargetObject => {
+                let Some(target) = payload.destination_target.clone() else {
+                    return Err(hooks.unsupported_effect(
+                        "redirect next time damage to target object without a target".to_string(),
+                    ));
+                };
+                effect.to_target(target)
             }
         };
         let effect = if payload.all_this_turn {

--- a/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/redirect_next_time_damage_to_source.rs
@@ -2,7 +2,7 @@
 
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
-use crate::effects::helpers::resolve_objects_for_effect;
+use crate::effects::helpers::{resolve_objects_for_effect, resolve_player_from_spec};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::DamageTarget;
 use crate::events::damage::matchers::{
@@ -14,20 +14,20 @@ use crate::game_state::GameState;
 use crate::replacement::{RedirectTarget, RedirectWhich, ReplacementAction, ReplacementEffect};
 use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 
-/// Matches damage events from a constrained source to a specific object target.
+/// Matches damage events from a constrained source to a specific damage target.
 #[derive(Debug, Clone)]
-struct DamageSourceToSpecificObjectMatcher {
+struct DamageSourceToSpecificTargetMatcher {
     source: DamageSourceConstraint,
-    target: crate::ids::ObjectId,
+    target: DamageTarget,
 }
 
-impl DamageSourceToSpecificObjectMatcher {
-    fn new(source: DamageSourceConstraint, target: crate::ids::ObjectId) -> Self {
+impl DamageSourceToSpecificTargetMatcher {
+    fn new(source: DamageSourceConstraint, target: DamageTarget) -> Self {
         Self { source, target }
     }
 }
 
-impl ReplacementMatcher for DamageSourceToSpecificObjectMatcher {
+impl ReplacementMatcher for DamageSourceToSpecificTargetMatcher {
     fn matches_event(&self, event: &dyn GameEventType, ctx: &crate::events::EventContext) -> bool {
         if event.event_kind() != EventKind::Damage {
             return false;
@@ -36,7 +36,7 @@ impl ReplacementMatcher for DamageSourceToSpecificObjectMatcher {
         else {
             return false;
         };
-        if damage.target != DamageTarget::Object(self.target) {
+        if damage.target != self.target {
             return false;
         }
         match &self.source {
@@ -66,6 +66,7 @@ pub enum RedirectNextTimeDamageDestination {
     SourceObject,
     Controller,
     SourceController,
+    TargetObject,
 }
 
 /// "The next time a source of your choice would deal damage to target creature this turn,
@@ -75,6 +76,7 @@ pub struct RedirectNextTimeDamageToSourceEffect {
     pub source: RedirectNextTimeDamageSource,
     pub target: Option<ChooseSpec>,
     pub destination: RedirectNextTimeDamageDestination,
+    pub destination_target: Option<ChooseSpec>,
     pub all_this_turn: bool,
 }
 
@@ -144,6 +146,7 @@ impl RedirectNextTimeDamageToSourceEffect {
             source,
             target: Some(target),
             destination: RedirectNextTimeDamageDestination::SourceObject,
+            destination_target: None,
             all_this_turn: false,
         }
     }
@@ -153,17 +156,26 @@ impl RedirectNextTimeDamageToSourceEffect {
             source: RedirectNextTimeDamageSource::Target(source),
             target: None,
             destination: RedirectNextTimeDamageDestination::SourceController,
+            destination_target: None,
             all_this_turn: false,
         }
     }
 
     pub fn to_controller(mut self) -> Self {
         self.destination = RedirectNextTimeDamageDestination::Controller;
+        self.destination_target = None;
         self
     }
 
     pub fn to_source_controller(mut self) -> Self {
         self.destination = RedirectNextTimeDamageDestination::SourceController;
+        self.destination_target = None;
+        self
+    }
+
+    pub fn to_target(mut self, target: ChooseSpec) -> Self {
+        self.destination = RedirectNextTimeDamageDestination::TargetObject;
+        self.destination_target = Some(target);
         self
     }
 
@@ -243,17 +255,25 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
             RedirectNextTimeDamageDestination::SourceController => {
                 RedirectTarget::ToSourceController
             }
+            RedirectNextTimeDamageDestination::TargetObject => {
+                let target = self
+                    .destination_target
+                    .as_ref()
+                    .ok_or(ExecutionError::InvalidTarget)?;
+                let redirect_target = resolve_objects_for_effect(game, ctx, target)?
+                    .into_iter()
+                    .next()
+                    .ok_or(ExecutionError::InvalidTarget)?;
+                RedirectTarget::ToObject(redirect_target)
+            }
         };
 
         let replacement = if let Some(target) = &self.target {
-            let protected_target = resolve_objects_for_effect(game, ctx, target)?
-                .into_iter()
-                .next()
-                .ok_or(ExecutionError::InvalidTarget)?;
+            let protected_target = resolve_damage_target_for_effect(game, ctx, target)?;
             ReplacementEffect::with_matcher(
                 ctx.source,
                 ctx.controller,
-                DamageSourceToSpecificObjectMatcher::new(source_constraint, protected_target),
+                DamageSourceToSpecificTargetMatcher::new(source_constraint, protected_target),
                 ReplacementAction::Redirect {
                     target: redirect_target,
                     which: RedirectWhich::First,
@@ -287,15 +307,32 @@ impl EffectExecutor for RedirectNextTimeDamageToSourceEffect {
     }
 
     fn get_target_spec(&self) -> Option<&ChooseSpec> {
-        self.target.as_ref().or_else(|| match &self.source {
-            RedirectNextTimeDamageSource::Target(spec) => Some(spec),
-            _ => None,
-        })
+        self.destination_target
+            .as_ref()
+            .or(self.target.as_ref())
+            .or_else(|| match &self.source {
+                RedirectNextTimeDamageSource::Target(spec) => Some(spec),
+                _ => None,
+            })
     }
 
     fn target_description(&self) -> &'static str {
         "damage source or protected target for redirection"
     }
+}
+
+fn resolve_damage_target_for_effect(
+    game: &mut GameState,
+    ctx: &mut ExecutionContext,
+    spec: &ChooseSpec,
+) -> Result<DamageTarget, ExecutionError> {
+    if let Ok(objects) = resolve_objects_for_effect(game, ctx, spec)
+        && let Some(object) = objects.into_iter().next()
+    {
+        return Ok(DamageTarget::Object(object));
+    }
+
+    resolve_player_from_spec(game, spec, ctx).map(DamageTarget::Player)
 }
 
 #[cfg(test)]
@@ -681,6 +718,191 @@ mod tests {
 
         assert_eq!(protected_damage, 4);
         assert_eq!(controller_damage, 0);
+        assert!(!processed.replacement_prevented);
+    }
+
+    #[test]
+    fn generals_regalia_redirects_chosen_source_damage_from_you_to_target_creature_once() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+
+        let chosen_source = create_creature(&mut game, "Chosen Source", alice, 80_050);
+        let regalia_card = CardBuilder::new(CardId::from_raw(80_051), "General's Regalia")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let regalia = game.create_object_from_card(&regalia_card, alice, Zone::Battlefield);
+        let recipient = create_creature(&mut game, "Shielded Ally", alice, 80_052);
+
+        let mut decision_maker = ChooseNamedSourceDecisionMaker {
+            source_name: "Chosen Source",
+        };
+        let mut ctx = ExecutionContext::new(regalia, alice, &mut decision_maker)
+            .with_targets(vec![ResolvedTarget::Object(recipient)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::you(),
+        )
+        .to_target(ChooseSpec::target(ChooseSpec::Object(
+            ObjectFilter::creature().you_control(),
+        )))
+        .execute(&mut game, &mut ctx)
+        .expect("General's Regalia replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            chosen_source,
+            DamageTarget::Player(alice),
+            5,
+            false,
+            EventCause::effect(),
+        );
+        let alice_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(alice))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let recipient_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(recipient))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(alice_damage, 0);
+        assert_eq!(recipient_damage, 5);
+        assert!(!processed.replacement_prevented);
+
+        let second = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            chosen_source,
+            DamageTarget::Player(alice),
+            2,
+            false,
+            EventCause::effect(),
+        );
+        let second_alice_damage: u32 = second
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(alice))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let second_recipient_damage: u32 = second
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(recipient))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(second_alice_damage, 2);
+        assert_eq!(second_recipient_damage, 0);
+    }
+
+    #[test]
+    fn generals_regalia_does_not_redirect_nonchosen_source_damage_to_you() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+
+        let _chosen_source = create_creature(&mut game, "Chosen Source", alice, 80_060);
+        let other_source = create_creature(&mut game, "Other Source", alice, 80_061);
+        let regalia_card = CardBuilder::new(CardId::from_raw(80_062), "General's Regalia")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let regalia = game.create_object_from_card(&regalia_card, alice, Zone::Battlefield);
+        let recipient = create_creature(&mut game, "Shielded Ally", alice, 80_063);
+
+        let mut decision_maker = ChooseNamedSourceDecisionMaker {
+            source_name: "Chosen Source",
+        };
+        let mut ctx = ExecutionContext::new(regalia, alice, &mut decision_maker)
+            .with_targets(vec![ResolvedTarget::Object(recipient)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::you(),
+        )
+        .to_target(ChooseSpec::target(ChooseSpec::Object(
+            ObjectFilter::creature().you_control(),
+        )))
+        .execute(&mut game, &mut ctx)
+        .expect("General's Regalia replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            other_source,
+            DamageTarget::Player(alice),
+            4,
+            false,
+            EventCause::effect(),
+        );
+        let alice_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(alice))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let recipient_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(recipient))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(alice_damage, 4);
+        assert_eq!(recipient_damage, 0);
+        assert!(!processed.replacement_prevented);
+    }
+
+    #[test]
+    fn generals_regalia_only_redirects_damage_that_would_be_dealt_to_you() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let chosen_source = create_creature(&mut game, "Chosen Source", alice, 80_070);
+        let regalia_card = CardBuilder::new(CardId::from_raw(80_071), "General's Regalia")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let regalia = game.create_object_from_card(&regalia_card, alice, Zone::Battlefield);
+        let recipient = create_creature(&mut game, "Shielded Ally", alice, 80_072);
+
+        let mut decision_maker = ChooseNamedSourceDecisionMaker {
+            source_name: "Chosen Source",
+        };
+        let mut ctx = ExecutionContext::new(regalia, alice, &mut decision_maker)
+            .with_targets(vec![ResolvedTarget::Object(recipient)]);
+        RedirectNextTimeDamageToSourceEffect::new(
+            RedirectNextTimeDamageSource::Choice,
+            ChooseSpec::you(),
+        )
+        .to_target(ChooseSpec::target(ChooseSpec::Object(
+            ObjectFilter::creature().you_control(),
+        )))
+        .execute(&mut game, &mut ctx)
+        .expect("General's Regalia replacement should register");
+
+        let processed = crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            chosen_source,
+            DamageTarget::Player(bob),
+            3,
+            false,
+            EventCause::effect(),
+        );
+        let bob_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Player(bob))
+            .map(|assignment| assignment.amount)
+            .sum();
+        let recipient_damage: u32 = processed
+            .assignments
+            .iter()
+            .filter(|assignment| assignment.target == DamageTarget::Object(recipient))
+            .map(|assignment| assignment.amount)
+            .sum();
+
+        assert_eq!(bob_damage, 3);
+        assert_eq!(recipient_damage, 0);
         assert!(!processed.replacement_prevented);
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: General's Regalia
Initial parse error:
```
unsupported redirected-next-time damage destination (clause: 'the next time a source of your choice would deal damage to you this turn that damage is dealt to target creature you control instead'); oracle-only fallback also failed: unsupported redirected-next-time damage destination (clause: 'the next time a source of your choice would deal damage to you this turn that damage is dealt to target creature you control instead')
```

Current worker: i-05b35ae2614684316
Branch: codex/aws-card-fix-general-s-regalia
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0036
