### PR TITLE
Fix Ironsmith parse failure: Sage of Hours

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -1038,7 +1038,9 @@ fn bind_relative_iterated_player_in_value_to_player_filter(
             bind_relative_iterated_player_in_value_to_player_filter(left, player_filter);
             bind_relative_iterated_player_in_value_to_player_filter(right, player_filter);
         }
-        Value::Scaled(inner, _) | Value::HalfRoundedDown(inner) => {
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner) => {
             bind_relative_iterated_player_in_value_to_player_filter(inner, player_filter);
         }
         Value::Min(left, right) => {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -374,8 +374,9 @@ pub(crate) fn value_references_tag(value: &Value, tag: &str) -> bool {
         Value::Add(left, right) => {
             value_references_tag(left, tag) || value_references_tag(right, tag)
         }
-        Value::Scaled(value, _) => value_references_tag(value, tag),
-        Value::HalfRoundedDown(value) => value_references_tag(value, tag),
+        Value::Scaled(value, _)
+        | Value::DividedRoundedDown(value, _)
+        | Value::HalfRoundedDown(value) => value_references_tag(value, tag),
         Value::Count(filter) | Value::CountScaled(filter, _) => filter
             .tagged_constraints
             .iter()
@@ -493,7 +494,9 @@ pub(crate) fn value_references_event_derived_amount(value: &Value) -> bool {
             value_references_event_derived_amount(left)
                 || value_references_event_derived_amount(right)
         }
-        Value::Scaled(value, _) | Value::HalfRoundedDown(value) => {
+        Value::Scaled(value, _)
+        | Value::DividedRoundedDown(value, _)
+        | Value::HalfRoundedDown(value) => {
             value_references_event_derived_amount(value)
         }
         _ => false,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -40,7 +40,9 @@ fn activation_cost_defines_x_for_mana_ability(cost: &TotalCost) -> bool {
 
         match value {
             Value::X | Value::XTimes(_) => true,
-            Value::Scaled(inner, _) | Value::HalfRoundedDown(inner) => value_uses_x(inner),
+            Value::Scaled(inner, _)
+            | Value::DividedRoundedDown(inner, _)
+            | Value::HalfRoundedDown(inner) => value_uses_x(inner),
             Value::Add(left, right) => value_uses_x(left) || value_uses_x(right),
             _ => false,
         }
@@ -122,7 +124,9 @@ fn bind_event_amount_to_cost_x(value: &mut crate::effect::Value) {
             bind_event_amount_to_cost_x(left);
             bind_event_amount_to_cost_x(right);
         }
-        Value::Scaled(inner, _) | Value::HalfRoundedDown(inner) => {
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner) => {
             bind_event_amount_to_cost_x(inner);
         }
         Value::SurfaceHinted { value, .. } => bind_event_amount_to_cost_x(value),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -88,6 +88,20 @@ fn default_trigger_last_object_tag(trigger: &TriggerSpec) -> Option<&'static str
     }
 }
 
+fn spell_cast_trigger_targets_source(trigger: &TriggerSpec) -> bool {
+    match trigger {
+        TriggerSpec::WithIntro { trigger, .. } => spell_cast_trigger_targets_source(trigger),
+        TriggerSpec::SpellCast {
+            filter: Some(filter),
+            ..
+        } => filter
+            .targets_object
+            .as_deref()
+            .is_some_and(|target_filter| target_filter.source),
+        _ => false,
+    }
+}
+
 fn retarget_it_target_to_source(target: &mut TargetAst) {
     match target {
         TargetAst::Tagged(tag, span) if tag.as_str() == IT_TAG => {
@@ -292,6 +306,12 @@ pub(crate) fn rewrite_prepare_effects_with_trigger_context_for_lowering(
     {
         retarget_phase_step_it_targets_to_source(&mut normalized);
     }
+    if let Some(trigger) = trigger
+        && spell_cast_trigger_targets_source(trigger)
+        && !has_phase_step_it_prelude
+    {
+        retarget_phase_step_it_targets_to_source(&mut normalized);
+    }
     let default_last_object_tag = if imports.last_object_tag.is_none()
         && !has_local_target_prelude
         && (effects_reference_it_tag(&normalized) || effects_reference_its_controller(&normalized))
@@ -432,6 +452,9 @@ pub(crate) fn rewrite_prepare_triggered_effects_for_lowering(
         );
     }
     if phase_step_trigger_has_no_object_reference(&trigger) && !has_phase_step_it_prelude {
+        retarget_phase_step_it_targets_to_source(&mut body_effects);
+    }
+    if spell_cast_trigger_targets_source(&trigger) && !has_phase_step_it_prelude {
         retarget_phase_step_it_targets_to_source(&mut body_effects);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1452,7 +1452,9 @@ fn value_references_only_other_number_metric(value: &Value) -> bool {
             value_references_only_other_number_metric(left)
                 || value_references_only_other_number_metric(right)
         }
-        Value::Scaled(value, _) | Value::HalfRoundedDown(value) => {
+        Value::Scaled(value, _)
+        | Value::DividedRoundedDown(value, _)
+        | Value::HalfRoundedDown(value) => {
             value_references_only_other_number_metric(value)
         }
         _ => false,
@@ -2275,7 +2277,9 @@ fn resolve_effect_result_value(
             resolve_effect_result_value(left, state)?;
             resolve_effect_result_value(right, state)?;
         }
-        Value::Scaled(inner, _) | Value::HalfRoundedDown(inner) => {
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner) => {
             resolve_effect_result_value(inner, state)?;
         }
         Value::SurfaceHinted { value, .. } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -330,6 +330,45 @@ fn starts_like_create_fragment_lexed(tokens: &[OwnedLexToken]) -> bool {
     starts_like_count && CHAIN_TOKEN_OR_TOKENS_PATTERN.matches_words(&words)
 }
 
+fn is_for_each_counter_group_removed_this_way_prefix_lexed(tokens: &[OwnedLexToken]) -> bool {
+    let words = token_word_refs(tokens);
+    if !matches!(words.as_slice(), ["for", "each", ..] | ["each", ..]) {
+        return false;
+    }
+    let count_start = if words.first() == Some(&"each") { 1 } else { 2 };
+    let Some((_group_size, used_tokens)) = parse_number_from_lexed(&tokens[count_start..]) else {
+        return false;
+    };
+    let after_count = count_start + used_tokens;
+    let Some(counter_word_idx) = words
+        .iter()
+        .enumerate()
+        .skip(after_count)
+        .find_map(|(idx, word)| matches!(*word, "counter" | "counters").then_some(idx))
+    else {
+        return false;
+    };
+
+    words.get(counter_word_idx + 1..counter_word_idx + 4) == Some(&["removed", "this", "way"])
+        && words.len() == counter_word_idx + 4
+}
+
+fn merge_for_each_counter_group_segments_lexed(
+    segments: Vec<Vec<OwnedLexToken>>,
+) -> Vec<Vec<OwnedLexToken>> {
+    let mut merged = Vec::new();
+    let mut iter = segments.into_iter().peekable();
+    while let Some(mut segment) = iter.next() {
+        if is_for_each_counter_group_removed_this_way_prefix_lexed(&segment)
+            && let Some(next) = iter.next()
+        {
+            segment.extend(next);
+        }
+        merged.push(segment);
+    }
+    merged
+}
+
 pub(super) fn parse_effect_chain_rule_lexed(
     view: &LexClauseView<'_>,
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
@@ -1032,6 +1071,7 @@ pub(crate) fn parse_effect_chain_inner_lexed(
     .collect();
     segments = expand_segments_with_comma_action_clauses_lexed(segments);
     segments = expand_segments_with_multi_create_clauses_lexed(segments);
+    segments = merge_for_each_counter_group_segments_lexed(segments);
     let mut carried_context: Option<CarryContext> = None;
     let leading_duration = leading_duration_for_followup_carry(tokens);
     let mut carried_duration: Option<Until> = leading_duration.clone();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -631,6 +631,56 @@ fn parse_for_each_prevent_damage_clause(
     Ok(Some(EffectAst::ForEachObject { filter, effects }))
 }
 
+fn parse_for_each_counter_group_removed_this_way_clause(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let words = ClauseDispatchCompatWords::new(tokens).to_word_refs();
+    if !matches!(words.as_slice(), ["for", "each", ..] | ["each", ..]) {
+        return Ok(None);
+    }
+
+    let count_start = if words.first() == Some(&"each") { 1 } else { 2 };
+    let Some((group_size, used_tokens)) = parse_number(&tokens[count_start..]) else {
+        return Ok(None);
+    };
+    if group_size == 0 {
+        return Err(CardTextError::ParseError(format!(
+            "counter group size must be positive (clause: '{}')",
+            words.join(" ")
+        )));
+    }
+
+    let after_count = count_start + used_tokens;
+    let Some(counter_word_idx) = words
+        .iter()
+        .enumerate()
+        .skip(after_count)
+        .find_map(|(idx, word)| matches!(*word, "counter" | "counters").then_some(idx))
+    else {
+        return Ok(None);
+    };
+    if words.get(counter_word_idx + 1..counter_word_idx + 4) != Some(&["removed", "this", "way"])
+    {
+        return Ok(None);
+    }
+
+    let tail_word_idx = counter_word_idx + 4;
+    let tail_token_idx = token_index_for_word_index(tokens, tail_word_idx).unwrap_or(tokens.len());
+    let tail_tokens = trim_commas(&tokens[tail_token_idx..]);
+    if tail_tokens.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing effect after counter group clause (clause: '{}')",
+            words.join(" ")
+        )));
+    }
+
+    let effects = parse_effect_chain_with_subject_verb_primitives(&tail_tokens)?;
+    Ok(Some(EffectAst::RepeatEffects {
+        count: Value::DividedRoundedDown(Box::new(Value::X), group_size as i32),
+        effects,
+    }))
+}
+
 fn parse_cast_any_number_from_among_tagged_clause(tokens: &[OwnedLexToken]) -> Option<EffectAst> {
     let clause_word_view = ClauseDispatchCompatWords::new(tokens);
     let clause_words = clause_word_view.to_word_refs();
@@ -795,6 +845,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
     let clause_words = clause_word_view.to_word_refs();
 
     if let Some(effect) = parse_for_each_prevent_damage_clause(tokens)? {
+        return Ok(effect);
+    }
+
+    if let Some(effect) = parse_for_each_counter_group_removed_this_way_clause(tokens)? {
         return Ok(effect);
     }
 

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -2477,6 +2477,12 @@ fn describe_comparison(cmp: &Comparison) -> String {
             Value::CountScaled(filter, factor) => {
                 format!("{factor} times the number of {}", filter.description())
             }
+            Value::DividedRoundedDown(value, divisor) => {
+                format!(
+                    "{} divided by {divisor}, rounded down",
+                    describe_value_expr(value)
+                )
+            }
             Value::LandsEnteredBattlefieldThisTurn(player) => {
                 format!(
                     "the number of lands that entered the battlefield under {:?}'s control this turn",

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -55,6 +55,7 @@ pub enum Value {
     X,
     XTimes(i32),
     Scaled(Box<Value>, i32),
+    DividedRoundedDown(Box<Value>, i32),
     HalfRoundedDown(Box<Value>),
     Count(ObjectFilter),
     CountScaled(ObjectFilter, i32),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31229,6 +31229,31 @@ fn parse_aura_barbs_attached_target_contraction_keeps_second_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn sage_of_hours_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Sage of Hours");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Heroic")
+            && rendered.contains("Whenever you cast a spell that targets this creature"),
+        "Sage of Hours should preserve its heroic trigger in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("For each five counters removed this way, you take an extra turn after this one"),
+        "Sage of Hours should render the counter-group extra-turn clause, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("RemoveAnyCountersFromSourceEffect")
+            && abilities_debug.contains("RepeatEffectsEffect")
+            && abilities_debug.contains("DividedRoundedDown")
+            && abilities_debug.contains("ExtraTurnEffect"),
+        "Sage of Hours should lower removed-counter groups into repeated extra turns, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_for_each_of_x_target_permanents_builds_choose_then_for_each_tagged() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Doppelgang Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8061,6 +8061,9 @@ pub(crate) fn describe_value(value: &Value) -> String {
                 format!("{factor} times {}", describe_value(value))
             }
         }
+        Value::DividedRoundedDown(value, divisor) => {
+            format!("{} divided by {divisor}, rounded down", describe_value(value))
+        }
         Value::Min(left, right) => {
             format!("the lesser of {} and {}", describe_value(left), describe_value(right))
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -35371,6 +35371,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 repeated
             );
         }
+        if let Value::DividedRoundedDown(value, divisor) = &repeat.count
+            && matches!(value.as_ref(), Value::X)
+            && *divisor > 0
+        {
+            let group = small_number_word(*divisor as u32).unwrap_or_else(|| divisor.to_string());
+            return format!("For each {group} counters removed this way, {repeated}");
+        }
         return format!(
             "Repeat {} {} times",
             repeated,

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -2946,6 +2946,17 @@ fn resolve_value_direct(
                 game,
             ) * *multiplier
         }
+        Value::DividedRoundedDown(value, divisor) => resolve_value_direct(
+            value,
+            objects,
+            effects,
+            battlefield,
+            commanders,
+            source,
+            controller,
+            game,
+        )
+        .div_euclid(*divisor),
         Value::Min(left, right) => resolve_value_direct(
             left,
             objects,
@@ -4025,6 +4036,9 @@ fn resolve_value_with_context(
         }
         Value::Scaled(value, multiplier) => {
             resolve_value_with_context(value, ctx, source, controller) * *multiplier
+        }
+        Value::DividedRoundedDown(value, divisor) => {
+            resolve_value_with_context(value, ctx, source, controller).div_euclid(*divisor)
         }
         Value::Min(left, right) => resolve_value_with_context(left, ctx, source, controller)
             .min(resolve_value_with_context(right, ctx, source, controller)),

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -516,6 +516,13 @@ fn evaluate_value(
                 _ => ValueEval::Unknown,
             }
         }
+        Value::DividedRoundedDown(value, divisor) => {
+            let value = evaluate_value(value, source, effect_controller, baseline, objects, game);
+            match value {
+                ValueEval::Scalar(value) if *divisor != 0 => ValueEval::Scalar(value.div_euclid(*divisor)),
+                _ => ValueEval::Unknown,
+            }
+        }
         Value::CreatureTypesAmong(filter) => {
             let mut seen = std::collections::HashSet::new();
             for (id, chars) in baseline {
@@ -710,6 +717,10 @@ fn evaluate_source_scalar_value(
         Value::Add(left, right) => Some(
             evaluate_source_scalar_value(left, source_power, source_toughness)?
                 + evaluate_source_scalar_value(right, source_power, source_toughness)?,
+        ),
+        Value::DividedRoundedDown(value, divisor) if *divisor != 0 => Some(
+            evaluate_source_scalar_value(value, source_power, source_toughness)?
+                .div_euclid(*divisor),
         ),
         Value::HalfRoundedDown(value) => {
             Some(evaluate_source_scalar_value(value, source_power, source_toughness)?.div_euclid(2))
@@ -1301,8 +1312,9 @@ fn value_references_pt(value: &Value) -> bool {
         Value::Add(left, right) | Value::Min(left, right) => {
             value_references_pt(left) || value_references_pt(right)
         }
-        Value::Scaled(value, _) => value_references_pt(value),
-        Value::HalfRoundedDown(value) => value_references_pt(value),
+        Value::Scaled(value, _)
+        | Value::DividedRoundedDown(value, _)
+        | Value::HalfRoundedDown(value) => value_references_pt(value),
 
         // EffectValue could reference P/T from a prior effect
         Value::EffectValue(_) | Value::EffectValueOffset(_, _) => true,
@@ -1863,7 +1875,9 @@ fn value_is_independent_count_or_fixed(value: &Value) -> bool {
         Value::Min(left, right) => {
             value_is_independent_count_or_fixed(left) && value_is_independent_count_or_fixed(right)
         }
-        Value::HalfRoundedDown(value) => value_is_independent_count_or_fixed(value),
+        Value::DividedRoundedDown(value, _) | Value::HalfRoundedDown(value) => {
+            value_is_independent_count_or_fixed(value)
+        }
         _ => false,
     }
 }

--- a/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
@@ -87,7 +87,9 @@ fn value_mentions_iterated_player(value: &crate::effect::Value) -> bool {
         crate::effect::Value::Add(left, right) => {
             value_mentions_iterated_player(left) || value_mentions_iterated_player(right)
         }
-        crate::effect::Value::Scaled(inner, _) | crate::effect::Value::HalfRoundedDown(inner) => {
+        crate::effect::Value::Scaled(inner, _)
+        | crate::effect::Value::DividedRoundedDown(inner, _)
+        | crate::effect::Value::HalfRoundedDown(inner) => {
             value_mentions_iterated_player(inner)
         }
         crate::effect::Value::Count(filter)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -449,6 +449,14 @@ pub fn resolve_value(
             .ok_or_else(|| ExecutionError::UnresolvableValue("X value not set".to_string())),
 
         Value::Scaled(value, multiplier) => Ok(resolve_value(game, value, ctx)? * *multiplier),
+        Value::DividedRoundedDown(value, divisor) => {
+            if *divisor == 0 {
+                return Err(ExecutionError::UnresolvableValue(
+                    "division by zero in dynamic value".to_string(),
+                ));
+            }
+            Ok(resolve_value(game, value, ctx)?.div_euclid(*divisor))
+        }
         Value::Min(left, right) => {
             Ok(resolve_value(game, left, ctx)?.min(resolve_value(game, right, ctx)?))
         }

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -832,6 +832,10 @@ fn resolve_filter_comparison_rhs_value(
             resolve_filter_comparison_rhs_value(inner, game, ctx, stack_entry)
                 .map(|value| value * multiplier)
         }
+        Value::DividedRoundedDown(inner, divisor) if *divisor != 0 => {
+            resolve_filter_comparison_rhs_value(inner, game, ctx, stack_entry)
+                .map(|value| value.div_euclid(*divisor))
+        }
         Value::Min(left, right) => Some(
             resolve_filter_comparison_rhs_value(left, game, ctx, stack_entry)?.min(
                 resolve_filter_comparison_rhs_value(right, game, ctx, stack_entry)?,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14748,6 +14748,173 @@ fn magma_mine_activated_ability_uses_current_pressure_counter_count_when_zero() 
     );
 }
 
+fn sage_of_hours_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(994_200), "Sage of Hours")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "Heroic — Whenever you cast a spell that targets this creature, put a +1/+1 counter on it.\n\
+             Remove all +1/+1 counters from this creature: For each five counters removed this way, take an extra turn after this one.",
+        )
+        .expect("Sage of Hours should parse for runtime tests")
+}
+
+fn sage_of_hours_extra_turn_ability_index(game: &GameState, sage_id: ObjectId) -> usize {
+    game.object(sage_id)
+        .expect("Sage of Hours should exist")
+        .abilities
+        .iter()
+        .position(|ability| {
+            if let AbilityKind::Activated(activated) = &ability.kind {
+                format!("{:?}", activated.effects).contains("ExtraTurnEffect")
+            } else {
+                false
+            }
+        })
+        .expect("Sage of Hours should have an extra-turn activated ability")
+}
+
+fn activate_sage_of_hours_extra_turn_ability(counter_count: u32) -> GameState {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let sage_def = sage_of_hours_definition();
+    let sage_id = game.create_object_from_definition(&sage_def, alice, Zone::Battlefield);
+    game.add_counters(
+        sage_id,
+        crate::object::CounterType::PlusOnePlusOne,
+        counter_count,
+    )
+    .expect("+1/+1 counters should be addable to Sage of Hours");
+
+    let ability_index = sage_of_hours_extra_turn_ability_index(&game, sage_id);
+    let activate_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == sage_id && *idx == ability_index
+            )
+        })
+        .expect("Sage of Hours activation should be legal");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Sage of Hours activation should be put on the stack");
+
+    assert_eq!(
+        game.counter_count(sage_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Sage of Hours activation cost should remove all +1/+1 counters"
+    );
+    resolve_stack_entry(&mut game).expect("Sage of Hours activation should resolve");
+    game
+}
+
+#[test]
+fn sage_of_hours_activation_takes_one_extra_turn_per_five_removed_counters() {
+    let game = activate_sage_of_hours_extra_turn_ability(10);
+    let alice = PlayerId::from_index(0);
+
+    assert_eq!(
+        game.turn_store.extra_turns,
+        vec![alice, alice],
+        "ten removed counters should schedule two extra turns for Sage of Hours controller"
+    );
+}
+
+#[test]
+fn sage_of_hours_activation_below_five_removed_counters_takes_no_extra_turns() {
+    let game = activate_sage_of_hours_extra_turn_ability(4);
+
+    assert!(
+        game.turn_store.extra_turns.is_empty(),
+        "fewer than five removed counters should not schedule an extra turn"
+    );
+}
+
+fn queue_spell_cast_targeting(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    caster: PlayerId,
+    target: ObjectId,
+) {
+    let spell = CardBuilder::new(CardId::from_raw(994_201), "Sage Targeting Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let spell_id = game.create_object_from_card(&spell, caster, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(spell_id, caster).with_targets(vec![Target::Object(target)]),
+    );
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, caster, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(game, trigger_queue, event, false);
+}
+
+#[test]
+fn sage_of_hours_heroic_adds_counter_when_your_spell_targets_it() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let sage_def = sage_of_hours_definition();
+    let sage_id = game.create_object_from_definition(&sage_def, alice, Zone::Battlefield);
+    let mut trigger_queue = TriggerQueue::new();
+
+    queue_spell_cast_targeting(&mut game, &mut trigger_queue, alice, sage_id);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Sage of Hours should trigger when Alice casts a spell targeting it"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Sage of Hours heroic trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Sage of Hours heroic trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(sage_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Sage of Hours heroic trigger should add a +1/+1 counter"
+    );
+}
+
+#[test]
+fn sage_of_hours_heroic_does_not_trigger_for_spell_targeting_another_creature() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let sage_def = sage_of_hours_definition();
+    game.create_object_from_definition(&sage_def, alice, Zone::Battlefield);
+    let other_id = create_creature(&mut game, "Other Target", alice, 1, 1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    queue_spell_cast_targeting(&mut game, &mut trigger_queue, alice, other_id);
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Sage of Hours should not trigger when the spell targets a different creature"
+    );
+}
+
 #[test]
 fn molten_hydra_activated_damage_uses_number_of_removed_plus1_counters() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sage of Hours
Initial parse error:
```
unsupported target phrase (clause: 'five'); oracle-only fallback also failed: unsupported target phrase (clause: 'five')
```

Current worker: i-0e2243fbf7c7d1147
Branch: codex/aws-card-fix-sage-of-hours
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0037
