### PR TITLE
Fix Ironsmith parse failure: Archon of Coronation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -277,6 +277,17 @@ const PLAYER_GET_POISON_COUNTERS_TAIL_PATTERN: ClauseShape<'static> = clause_sha
 const PLAYER_CAST_MORE_THAN_ONE_SPELL_EACH_TURN_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["cast", "more", "than", "one", "spell", "each", "turn"]);
 const BE_PREVENTED_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["be", "prevented"]);
+const DAMAGE_CAUSE_YOU_LOSE_LIFE_TAIL_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix & ["cause", "you", "to", "lose", "life"]);
+const DAMAGE_CAUSE_PLAYERS_LOSE_LIFE_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["cause", "players", "to", "lose", "life"],
+            &["cause", "each", "player", "to", "lose", "life"],
+        ]
+);
+const DAMAGE_CAUSE_THAT_PLAYER_LOSE_LIFE_TAIL_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix & ["cause", "that", "player", "to", "lose", "life"]);
 const ATTACK_YOU_OR_PLANESWALKERS_YOU_CONTROL_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["attack", "you", "or", "planeswalkers", "you", "control"]);
 const BE_BLOCKED_EXCEPT_BY_PREFIX_PATTERN: ClauseShape<'static> =
@@ -533,6 +544,24 @@ fn player_negated_restriction_from_tail(
         Some(Restriction::cast_spells_matching(
             player,
             ObjectFilter::spell(),
+        ))
+    } else {
+        None
+    }
+}
+
+fn damage_cause_life_loss_restriction_from_tail(
+    words: &[&str],
+) -> Option<crate::effect::Restriction> {
+    use crate::effect::Restriction;
+
+    if DAMAGE_CAUSE_YOU_LOSE_LIFE_TAIL_PATTERN.matches_words(words) {
+        Some(Restriction::damage_cause_life_loss(PlayerFilter::You))
+    } else if DAMAGE_CAUSE_PLAYERS_LOSE_LIFE_TAIL_PATTERN.matches_words(words) {
+        Some(Restriction::damage_cause_life_loss(PlayerFilter::Any))
+    } else if DAMAGE_CAUSE_THAT_PLAYER_LOSE_LIFE_TAIL_PATTERN.matches_words(words) {
+        Some(Restriction::damage_cause_life_loss(
+            PlayerFilter::IteratedPlayer,
         ))
     } else {
         None
@@ -1684,6 +1713,14 @@ pub(crate) fn parse_negated_object_restriction_clause(
     {
         return Ok(Some(ParsedCantRestriction {
             restriction: Restriction::prevent_damage(),
+            target: None,
+        }));
+    }
+    if DAMAGE_RESTRICTION_SUBJECT_PATTERN.matches_words(&subject_words)
+        && let Some(restriction) = damage_cause_life_loss_restriction_from_tail(&remainder_words)
+    {
+        return Ok(Some(ParsedCantRestriction {
+            restriction,
             target: None,
         }));
     }

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -274,6 +274,7 @@ pub enum Restriction {
     DrawExtraCards(PlayerFilter),
     PoisonCounters(PlayerFilter),
     LoseLife(PlayerFilter),
+    DamageCauseLifeLoss(PlayerFilter),
     ChangeLifeTotal(PlayerFilter),
     LoseGame(PlayerFilter),
     WinGame(PlayerFilter),
@@ -475,6 +476,10 @@ impl Restriction {
 
     pub fn lose_life(filter: PlayerFilter) -> Self {
         Self::LoseLife(filter)
+    }
+
+    pub fn damage_cause_life_loss(filter: PlayerFilter) -> Self {
+        Self::DamageCauseLifeLoss(filter)
     }
 
     pub fn change_life_total(filter: PlayerFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -143,6 +143,33 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn archon_of_coronation_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Archon of Coronation");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Archon of Coronation should parse its enters trigger strictly"
+    );
+    assert!(
+        ability_debug.contains("BecomeMonarchEffect")
+            && ability_debug.contains("DamageCauseLifeLoss")
+            && ability_debug.contains("PlayerIsMonarch"),
+        "expected monarch trigger and conditional damage-life-loss restriction, got {ability_debug}"
+    );
+    assert!(
+        rendered_lower.contains("you become the monarch")
+            && rendered_lower.contains("damage doesn't cause you to lose life")
+            && rendered_lower.contains("as long as you're the monarch"),
+        "expected Archon compiled text to preserve monarch and damage-life-loss clauses, got {rendered}"
+    );
+}
+
+#[test]
 fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Commander Liara Portyr");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10309,6 +10309,17 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
         crate::effect::Restriction::LoseLife(filter) => {
             format!("{} can't lose life", describe_player_set_filter(filter))
         }
+        crate::effect::Restriction::DamageCauseLifeLoss(filter) => match filter {
+            PlayerFilter::You => "damage doesn't cause you to lose life".to_string(),
+            PlayerFilter::Any => "damage doesn't cause players to lose life".to_string(),
+            PlayerFilter::IteratedPlayer => {
+                "damage doesn't cause that player to lose life".to_string()
+            }
+            _ => format!(
+                "damage doesn't cause {} to lose life",
+                describe_player_filter(filter)
+            ),
+        },
         crate::effect::Restriction::ChangeLifeTotal(filter) => {
             format!(
                 "{} can't have life total changed",

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -953,6 +953,13 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::DamageCauseLifeLoss(filter) => {
+                for player in &game.players {
+                    if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
+                        tracker.damage_cant_cause_life_loss.insert(player.id);
+                    }
+                }
+            }
             Restriction::ChangeLifeTotal(filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -318,6 +318,69 @@ fn lost_monarch_of_ifnir_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn archon_of_coronation_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(559_764), "Archon of Coronation")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .flying()
+        .parse_text(
+            "When this creature enters, you become the monarch.\n\
+             As long as you're the monarch, damage doesn't cause you to lose life.",
+        )
+        .expect("Archon of Coronation should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn deal_test_combat_damage_to_player(
+    game: &mut GameState,
+    source: ObjectId,
+    player: PlayerId,
+    amount: u32,
+) -> CombatDamageEvent {
+    let cause = crate::events::cause::EventCause::combat_damage(source);
+    let processed = crate::events::processing::process_damage_assignments_with_event(
+        game,
+        source,
+        crate::events::DamageTarget::Player(player),
+        amount,
+        true,
+        cause.clone(),
+    );
+    let keywords = crate::rules::damage::source_damage_keywords(game, source, None);
+    let mut damage_dealt = 0u32;
+    let mut life_lost = 0u32;
+    for assignment in processed.assignments {
+        let applied = crate::rules::damage::apply_processed_damage_assignment(
+            game,
+            source,
+            assignment.target,
+            assignment.amount,
+            keywords,
+            cause.clone(),
+        );
+        assert!(applied.applied, "combat damage assignment should apply");
+        damage_dealt = damage_dealt.saturating_add(assignment.amount);
+        life_lost = life_lost.saturating_add(applied.life_lost);
+    }
+
+    CombatDamageEvent {
+        source,
+        target: DamageEventTarget::Player(player),
+        amount: damage_dealt,
+        life_lost,
+        result: DamageResult {
+            damage_dealt,
+            ..DamageResult::default()
+        },
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn create_typed_creature(
     game: &mut GameState,
     name: &str,
@@ -6530,6 +6593,121 @@ fn test_monarch_changes_when_creature_deals_combat_damage_to_monarch() {
         game.monarch,
         Some(alice),
         "the attacking creature's controller should become the monarch"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn archon_of_coronation_enters_trigger_makes_controller_the_monarch() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let archon = archon_of_coronation_definition();
+    let archon_id = game.create_object_from_definition(&archon, alice, Zone::Battlefield);
+    let event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            archon_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        if trigger.source == archon_id {
+            trigger_queue.add(trigger);
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Archon of Coronation should trigger when it enters"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Archon of Coronation enters trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Archon of Coronation enters trigger should resolve");
+
+    assert_eq!(
+        game.monarch,
+        Some(alice),
+        "Archon of Coronation's controller should become the monarch"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn archon_of_coronation_monarch_takes_damage_without_losing_life_and_still_loses_monarch() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let archon = archon_of_coronation_definition();
+    game.create_object_from_definition(&archon, alice, Zone::Battlefield);
+    let attacker = create_creature(&mut game, "Archon Challenger", bob, 3, 3);
+    game.monarch = Some(alice);
+    game.update_cant_effects();
+
+    assert!(
+        game.can_lose_life(alice),
+        "Archon should not stop non-damage life loss"
+    );
+    assert_eq!(
+        game.lose_life(alice, 2),
+        2,
+        "non-damage life loss should still happen while Archon's controller is monarch"
+    );
+    let life_before_damage = game.player(alice).expect("alice exists").life;
+
+    let event = deal_test_combat_damage_to_player(&mut game, attacker, alice, 3);
+    assert_eq!(event.life_lost, 0, "combat damage should not cause life loss");
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        life_before_damage,
+        "damage should be dealt without reducing the monarch's life total"
+    );
+
+    generate_damage_triggers(&mut game, &[event], &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "combat damage still dealt to the monarch should queue the transfer trigger"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("monarch transfer trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("monarch transfer trigger should resolve");
+
+    assert_eq!(
+        game.monarch,
+        Some(bob),
+        "combat damage to the monarch should still make the attacker's controller the monarch"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn archon_of_coronation_nonmonarch_controller_still_loses_life_to_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let archon = archon_of_coronation_definition();
+    game.create_object_from_definition(&archon, alice, Zone::Battlefield);
+    let attacker = create_creature(&mut game, "Archon Challenger", bob, 3, 3);
+    game.monarch = Some(bob);
+    game.update_cant_effects();
+    let life_before_damage = game.player(alice).expect("alice exists").life;
+
+    let event = deal_test_combat_damage_to_player(&mut game, attacker, alice, 3);
+
+    assert_eq!(
+        event.life_lost, 3,
+        "Archon should not stop damage-caused life loss when its controller is not monarch"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        life_before_damage - 3,
+        "nonmonarch Archon controller should lose life from damage normally"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -644,6 +644,9 @@ pub struct CantEffectTracker {
     /// Players who can't lose life.
     pub cant_lose_life: HashSet<PlayerId>,
 
+    /// Players whose damage dealt to them does not cause life loss.
+    pub damage_cant_cause_life_loss: HashSet<PlayerId>,
+
     /// Players who can't lose the game.
     /// Example: Platinum Angel
     pub cant_lose_game: HashSet<PlayerId>,
@@ -891,6 +894,8 @@ impl CantEffectTracker {
         self.life_total_cant_change
             .extend(other.life_total_cant_change);
         self.cant_lose_life.extend(other.cant_lose_life);
+        self.damage_cant_cause_life_loss
+            .extend(other.damage_cant_cause_life_loss);
         self.cant_lose_game.extend(other.cant_lose_game);
         self.cant_win_game.extend(other.cant_win_game);
         self.cant_become_monarch.extend(other.cant_become_monarch);
@@ -935,6 +940,7 @@ impl CantEffectTracker {
         self.damage_cant_be_prevented = false;
         self.life_total_cant_change.clear();
         self.cant_lose_life.clear();
+        self.damage_cant_cause_life_loss.clear();
         self.cant_lose_game.clear();
         self.cant_win_game.clear();
         self.cant_become_monarch.clear();
@@ -954,6 +960,11 @@ impl CantEffectTracker {
     /// Check if a player can lose life (not from damage).
     pub fn can_lose_life(&self, player: PlayerId) -> bool {
         !self.cant_lose_life.contains(&player) && !self.life_total_cant_change.contains(&player)
+    }
+
+    /// Check if damage dealt to a player can cause that player to lose life.
+    pub fn can_damage_cause_life_loss(&self, player: PlayerId) -> bool {
+        self.can_lose_life(player) && !self.damage_cant_cause_life_loss.contains(&player)
     }
 
     /// Check if a player's life total can change (Platinum Emperion, etc.).
@@ -3069,6 +3080,13 @@ impl GameState {
     /// Can the player lose life (not from damage)?
     pub fn can_lose_life(&self, player: PlayerId) -> bool {
         self.effect_store.cant_effects.can_lose_life(player)
+    }
+
+    /// Can damage dealt to the player cause life loss?
+    pub fn can_damage_cause_life_loss(&self, player: PlayerId) -> bool {
+        self.effect_store
+            .cant_effects
+            .can_damage_cause_life_loss(player)
     }
 
     /// Can the player's life total change?

--- a/crates/ironsmith-runtime/src/rules/damage.rs
+++ b/crates/ironsmith-runtime/src/rules/damage.rs
@@ -141,8 +141,12 @@ pub(crate) fn apply_processed_damage_assignment(
             if game.player(player_id).is_none() {
                 return AppliedDamageAssignment::default();
             }
-            // Damage is still dealt even when life total can't change; track only actual life lost.
-            let life_lost = game.lose_life(player_id, amount);
+            // Damage is still dealt even when a replacement/restriction stops the life loss.
+            let life_lost = if game.can_damage_cause_life_loss(player_id) {
+                game.lose_life(player_id, amount)
+            } else {
+                0
+            };
             AppliedDamageAssignment {
                 applied: true,
                 life_lost,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Archon of Coronation
Initial parse error:
```
unsupported negated restriction tail (clause: 'damage doesn't cause you to lose life'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'damage doesn't cause you to lose life')
```

Current worker: i-0a089ff995a1eda0c
Branch: codex/aws-card-fix-archon-of-coronation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0037
