### PR TITLE
Fix Ironsmith parse failure: Celestial Dawn

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -106,7 +106,7 @@ use super::util::{
     parse_alternative_cast_words, parse_card_type, parse_color, parse_counter_type_from_tokens,
     parse_counter_type_word, parse_filter_counter_constraint_words, parse_flashback_keyword_line,
     parse_for_each_count_value_words, parse_greater_than_or_equal_quantity_prefix,
-    parse_less_than_or_equal_quantity_prefix, parse_number_word_i32,
+    parse_less_than_or_equal_quantity_prefix, parse_mana_symbol_word_flexible, parse_number_word_i32,
     parse_quantity_comparison_prefix, parse_subtype_flexible, parse_value, parse_value_expr_words,
     parse_zone_word, preserve_keyword_prefix_for_parse,
     source_reference_surface_for_possessive_words, strip_leading_article_word_refs,
@@ -10784,6 +10784,31 @@ pub(crate) fn parse_spend_mana_as_any_color_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbilityAst>, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if clause_words.len() == 25
+        && word_slice_eq(&clause_words[0..3], &["you", "may", "spend"])
+        && word_slice_eq(&clause_words[4..25], &[
+            "mana", "as", "though", "it", "were", "mana", "of", "any", "color", "you", "may",
+            "spend", "other", "mana", "only", "as", "though", "it", "were", "colorless",
+            "mana",
+        ])
+        && let Some(symbol) = parse_mana_symbol_word_flexible(clause_words[3])
+        && !matches!(symbol, ManaSymbol::Colorless)
+    {
+        let display = format!(
+            "You may spend {} mana as though it were mana of any color. You may spend other mana only as though it were colorless mana",
+            clause_words[3]
+        );
+        return Ok(Some(StaticAbilityAst::Static(
+            StaticAbility::mana_spend_permission(
+                crate::effect::ManaSpendPermission::mana_symbol_as_any_color_other_as_colorless(
+                    PlayerFilter::You,
+                    symbol,
+                ),
+                display,
+            ),
+        )));
+    }
+
     if SPEND_MANA_ANY_TYPE_CAST_PREFIX_PATTERN.matches_words(&clause_words) {
         let filter_start = 9usize;
         let filter_tokens = trim_edge_punctuation(&tokens[filter_start..]);

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -317,6 +317,8 @@ pub struct ManaSpendPermission {
     pub player: PlayerFilter,
     pub scope: ManaSpendScope,
     pub mana_source_filter: Option<ObjectFilter>,
+    pub any_color_mana_symbol: Option<ManaSymbol>,
+    pub other_mana_only_as_colorless: bool,
 }
 
 impl ManaSpendPermission {
@@ -325,6 +327,21 @@ impl ManaSpendPermission {
             player,
             scope: ManaSpendScope::AllCosts,
             mana_source_filter: None,
+            any_color_mana_symbol: None,
+            other_mana_only_as_colorless: false,
+        }
+    }
+
+    pub fn mana_symbol_as_any_color_other_as_colorless(
+        player: PlayerFilter,
+        symbol: ManaSymbol,
+    ) -> Self {
+        Self {
+            player,
+            scope: ManaSpendScope::AllCosts,
+            mana_source_filter: None,
+            any_color_mana_symbol: Some(symbol),
+            other_mana_only_as_colorless: true,
         }
     }
 
@@ -333,6 +350,8 @@ impl ManaSpendPermission {
             player,
             scope: ManaSpendScope::ActivationCostsOf(filter),
             mana_source_filter: None,
+            any_color_mana_symbol: None,
+            other_mana_only_as_colorless: false,
         }
     }
 
@@ -344,6 +363,8 @@ impl ManaSpendPermission {
             player,
             scope: ManaSpendScope::CastingSpellsWithStableIds(stable_ids),
             mana_source_filter: None,
+            any_color_mana_symbol: None,
+            other_mana_only_as_colorless: false,
         }
     }
 
@@ -352,6 +373,8 @@ impl ManaSpendPermission {
             player,
             scope: ManaSpendScope::CastingSpellsMatching(filter),
             mana_source_filter: None,
+            any_color_mana_symbol: None,
+            other_mana_only_as_colorless: false,
         }
     }
 
@@ -364,6 +387,8 @@ impl ManaSpendPermission {
             player,
             scope: ManaSpendScope::CastingSpellsMatching(filter),
             mana_source_filter: Some(mana_source_filter),
+            any_color_mana_symbol: None,
+            other_mana_only_as_colorless: false,
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -33925,6 +33925,179 @@ fn parse_existing_mana_spend_as_any_color_static_patterns() {
     );
 }
 
+#[test]
+fn celestial_dawn_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Celestial Dawn");
+    let def = parse_oracle_card_definition("Celestial Dawn");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered_lower.contains("lands you control are plains"),
+        "Celestial Dawn should render the Plains-changing static ability, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("nonland permanents you control are white. the same is true for spells you control and nonland cards you own that aren't on the battlefield"),
+        "Celestial Dawn should render the same-is-true color static ability, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("you may spend white mana as though it were mana of any color. you may spend other mana only as though it were colorless mana"),
+        "Celestial Dawn should render the white-mana spend permission and other-mana restriction, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("ManaSpendPermission")
+            && ability_debug.contains("any_color_mana_symbol: Some(White)")
+            && ability_debug.contains("other_mana_only_as_colorless: true"),
+        "Celestial Dawn should structurally lower its mana-spend rule, got {ability_debug}"
+    );
+}
+
+#[test]
+fn celestial_dawn_mana_spend_runtime_uses_white_as_any_color_only() {
+    let def = parse_oracle_card_definition("Celestial Dawn");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.update_cant_effects();
+
+    let blue_spell = CardDefinitionBuilder::new(
+        CardId::from_raw(700_900),
+        "Celestial Dawn Blue Cost Probe",
+    )
+    .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+    .card_types(vec![CardType::Sorcery])
+    .build();
+    let blue_spell_id = game.create_object_from_definition(&blue_spell, alice, Zone::Stack);
+    let blue_cost = ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]);
+
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 1);
+    let view = crate::derived_view::DerivedGameView::new(&game);
+    assert!(
+        view.can_potentially_pay_with_reason(
+            alice,
+            Some(blue_spell_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::CastSpell,
+        ),
+        "Celestial Dawn should also make the derived affordability path see white mana as usable for blue"
+    );
+    assert!(
+        game.can_pay_mana_cost(alice, Some(blue_spell_id), &blue_cost, 0),
+        "Celestial Dawn should let white mana pay a blue pip"
+    );
+    assert!(
+        game.try_pay_mana_cost(alice, Some(blue_spell_id), &blue_cost, 0),
+        "white mana should actually be spent as blue"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice exists").mana_pool.total(),
+        0,
+        "white mana should be consumed by the blue-pip payment"
+    );
+}
+
+#[test]
+fn celestial_dawn_mana_spend_runtime_treats_other_mana_as_colorless_only() {
+    let def = parse_oracle_card_definition("Celestial Dawn");
+    let alice = PlayerId::from_index(0);
+
+    let blue_cost = ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]);
+    let colorless_cost = ManaCost::from_pips(vec![vec![ManaSymbol::Colorless]]);
+    let spell = CardDefinitionBuilder::new(CardId::from_raw(700_901), "Celestial Dawn Cost Probe")
+        .mana_cost(blue_cost.clone())
+        .card_types(vec![CardType::Sorcery])
+        .build();
+
+    let mut nonwhite_for_blue = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    nonwhite_for_blue.create_object_from_definition(&def, alice, Zone::Battlefield);
+    nonwhite_for_blue.update_cant_effects();
+    let blue_spell_id = nonwhite_for_blue.create_object_from_definition(&spell, alice, Zone::Stack);
+    nonwhite_for_blue
+        .player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+    let nonwhite_view = crate::derived_view::DerivedGameView::new(&nonwhite_for_blue);
+    assert!(
+        !nonwhite_view.can_potentially_pay_with_reason(
+            alice,
+            Some(blue_spell_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::CastSpell,
+        ),
+        "Celestial Dawn should also make the derived affordability path reject nonwhite mana for colored pips"
+    );
+    assert!(
+        !nonwhite_for_blue.can_pay_mana_cost(alice, Some(blue_spell_id), &blue_cost, 0),
+        "Celestial Dawn should not let nonwhite mana pay colored pips"
+    );
+
+    let mut nonwhite_for_colorless = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    nonwhite_for_colorless.create_object_from_definition(&def, alice, Zone::Battlefield);
+    nonwhite_for_colorless.update_cant_effects();
+    let colorless_spell_id =
+        nonwhite_for_colorless.create_object_from_definition(&spell, alice, Zone::Stack);
+    nonwhite_for_colorless
+        .player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+    assert!(
+        nonwhite_for_colorless.can_pay_mana_cost(
+            alice,
+            Some(colorless_spell_id),
+            &colorless_cost,
+            0,
+        ),
+        "Celestial Dawn should let nonwhite mana be spent as colorless"
+    );
+    assert!(
+        nonwhite_for_colorless.try_pay_mana_cost(
+            alice,
+            Some(colorless_spell_id),
+            &colorless_cost,
+            0,
+        ),
+        "nonwhite mana should actually be spendable as colorless"
+    );
+
+    let mut white_for_colorless = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    white_for_colorless.create_object_from_definition(&def, alice, Zone::Battlefield);
+    white_for_colorless.update_cant_effects();
+    let white_colorless_spell_id =
+        white_for_colorless.create_object_from_definition(&spell, alice, Zone::Stack);
+    white_for_colorless
+        .player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 1);
+    assert!(
+        !white_for_colorless.can_pay_mana_cost(
+            alice,
+            Some(white_colorless_spell_id),
+            &colorless_cost,
+            0,
+        ),
+        "Celestial Dawn's white-as-any-color permission should not turn white mana into colorless mana"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_mnemonic_betrayal_temporary_any_color_cast_permission() {

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -346,6 +346,106 @@ pub(super) fn merge_same_true_type_addition_lines(lines: Vec<String>) -> Vec<Str
     merged
 }
 
+#[derive(Debug, Clone)]
+struct ColorLine {
+    subject: String,
+    verb: String,
+    color: String,
+}
+
+fn parse_color_line(line: &str) -> Option<ColorLine> {
+    let trimmed = line.trim().trim_end_matches('.');
+    let (subject, verb, predicate) = split_subject_predicate_clause(trimmed)?;
+    if !matches!(verb, "is" | "are") || !is_color_predicate(predicate) {
+        return None;
+    }
+
+    Some(ColorLine {
+        subject: normalize_nonbattlefield_owned_cards_subject(subject.trim())
+            .unwrap_or_else(|| subject.trim().to_string()),
+        verb: verb.trim().to_string(),
+        color: predicate.trim().to_string(),
+    })
+}
+
+fn is_color_predicate(predicate: &str) -> bool {
+    matches!(
+        predicate.trim().to_ascii_lowercase().as_str(),
+        "white" | "blue" | "black" | "red" | "green" | "colorless"
+    )
+}
+
+fn normalize_nonbattlefield_owned_cards_subject(subject: &str) -> Option<String> {
+    let lower = subject.to_ascii_lowercase();
+    let parts = lower.split(" or ").collect::<Vec<_>>();
+    if parts.len() != 5 {
+        return None;
+    }
+
+    let zones = ["hand", "library", "graveyard", "exile", "command zone"];
+    let mut prefix: Option<&str> = None;
+    for (part, zone) in parts.iter().zip(zones) {
+        let suffix = format!(" cards in your {zone}");
+        let current_prefix = part.strip_suffix(&suffix)?.trim();
+        if current_prefix.is_empty() {
+            return None;
+        }
+        match prefix {
+            Some(existing) if existing != current_prefix => return None,
+            Some(_) => {}
+            None => prefix = Some(current_prefix),
+        }
+    }
+
+    Some(format!(
+        "{} cards you own that aren't on the battlefield",
+        prefix?
+    ))
+}
+
+pub(super) fn merge_same_true_color_lines(lines: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::with_capacity(lines.len());
+    let mut idx = 0usize;
+
+    while idx < lines.len() {
+        let Some(first) = parse_color_line(&lines[idx]) else {
+            merged.push(lines[idx].clone());
+            idx += 1;
+            continue;
+        };
+
+        let mut same_true_subjects = Vec::new();
+        let mut consumed = 1usize;
+        while idx + consumed < lines.len() {
+            let Some(next) = parse_color_line(&lines[idx + consumed]) else {
+                break;
+            };
+            if !first.color.eq_ignore_ascii_case(&next.color)
+                || !first.verb.eq_ignore_ascii_case(&next.verb)
+            {
+                break;
+            }
+            same_true_subjects.push(lowercase_first(&next.subject));
+            consumed += 1;
+        }
+
+        if same_true_subjects.len() < 2 {
+            merged.push(lines[idx].clone());
+            idx += 1;
+            continue;
+        }
+
+        merged.push(format!(
+            "{} The same is true for {}.",
+            lines[idx].trim(),
+            join_with_and(&same_true_subjects)
+        ));
+        idx += consumed;
+    }
+
+    merged
+}
+
 fn indefinite_article_for_phrase(phrase: &str) -> &'static str {
     match phrase.chars().next().map(|ch| ch.to_ascii_lowercase()) {
         Some('a' | 'e' | 'i' | 'o' | 'u') => "an",

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -947,9 +947,11 @@ fn merge_ast_surface_lines(mut lines: Vec<String>) -> Vec<String> {
             merge_adjacent_simple_mana_add_lines(drop_redundant_spell_cost_lines(
                 merge_specific_adjacent_surface_lines(merge_lose_all_transform_lines(
                     merge_attached_transform_keyword_loss_lines(merge_blockability_lines(
-                        annotate_color_choice_exclusions(merge_same_true_type_addition_lines(
-                            merge_same_true_keyword_grant_lines(
-                                merge_subject_predicate_surface_lines(previous.clone()),
+                        annotate_color_choice_exclusions(merge_same_true_color_lines(
+                            merge_same_true_type_addition_lines(
+                                merge_same_true_keyword_grant_lines(
+                                    merge_subject_predicate_surface_lines(previous.clone()),
+                                ),
                             ),
                         )),
                     )),
@@ -1409,6 +1411,24 @@ mod tests {
             lines,
             vec![
                 "Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield."
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn repeated_color_changes_use_same_is_true_surface() {
+        let lines = merge_ast_surface_lines(vec![
+            "Nonland permanents you control are white.".to_string(),
+            "Spells you control are white.".to_string(),
+            "Nonland cards in your hand or nonland cards in your library or nonland cards in your graveyard or nonland cards in your exile or nonland cards in your command zone are white."
+                .to_string(),
+        ]);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Nonland permanents you control are white. The same is true for spells you control and nonland cards you own that aren't on the battlefield."
                     .to_string()
             ]
         );

--- a/crates/ironsmith-runtime/src/costs/mana.rs
+++ b/crates/ironsmith-runtime/src/costs/mana.rs
@@ -56,15 +56,15 @@ impl CostPayer for ManaPaymentCost {
 
         // Use the existing compute_potential_mana function
         let potential = crate::decision::compute_potential_mana(game, ctx.payer);
-        let allow_any_color = game.can_spend_mana_as_any_color(ctx.payer, Some(ctx.source));
+        let mana_spend_policy = game.mana_spend_policy(ctx.payer, Some(ctx.source));
         let allow_black_life =
             game.player_can_pay_black_with_life_for_reason(ctx.payer, Some(ctx.source), ctx.reason);
         let mut preview_pool = potential.clone();
         let (can_pay, life_to_pay) = preview_pool
-            .try_pay_tracking_life_with_any_color_and_black_life(
+            .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
                 &self.cost,
                 x_value,
-                allow_any_color,
+                &mana_spend_policy,
                 allow_black_life,
             );
         if !can_pay || !game.can_pay_life_with_reason(ctx.payer, life_to_pay, ctx.reason) {

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -1480,9 +1480,9 @@ fn mana_cost_can_be_paid_with_view(
     view: &DerivedGameView<'_>,
 ) -> bool {
     let potential = view.potential_mana(player);
-    let allow_any_color = game.can_spend_mana_as_any_color(player, Some(spell_id));
-    let allow_any_color_for_obvious =
-        allow_any_color || game.has_source_filtered_mana_spend_permission(player, Some(spell_id));
+    let mana_spend_policy = game.mana_spend_policy(player, Some(spell_id));
+    let allow_any_color_for_obvious = mana_spend_policy.has_any_color_spending()
+        || game.has_source_filtered_mana_spend_permission(player, Some(spell_id));
     let allow_black_life = view
         .player_can_pay_black_with_life_for_reason(player, crate::costs::PaymentReason::CastSpell);
     !mana_cost_is_obviously_unpayable(
@@ -1497,7 +1497,7 @@ fn mana_cost_can_be_paid_with_view(
         cost,
         0,
         crate::costs::PaymentReason::CastSpell,
-        allow_any_color,
+        &mana_spend_policy,
         allow_black_life,
         view,
     )
@@ -1992,8 +1992,8 @@ pub(crate) fn can_cast_with_cost_with_context(
 
         let affordability_started_at = PerfTimer::start();
         let potential = view.potential_mana(player);
-        let allow_any_color = game.can_spend_mana_as_any_color(player, Some(spell_id));
-        let allow_any_color_for_obvious = allow_any_color
+        let mana_spend_policy = game.mana_spend_policy(player, Some(spell_id));
+        let allow_any_color_for_obvious = mana_spend_policy.has_any_color_spending()
             || game.has_source_filtered_mana_spend_permission(player, Some(spell_id));
         let allow_black_life = view.player_can_pay_black_with_life_for_reason(
             player,
@@ -2015,7 +2015,7 @@ pub(crate) fn can_cast_with_cost_with_context(
             &adjusted,
             0,
             crate::costs::PaymentReason::CastSpell,
-            allow_any_color,
+            &mana_spend_policy,
             allow_black_life,
             view,
         ) {
@@ -3700,7 +3700,7 @@ fn can_pay_mana_cost_with_available_sources(
     cost: &crate::mana::ManaCost,
     x_value: u32,
     reason: crate::costs::PaymentReason,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
     allow_black_life: bool,
     view: &DerivedGameView<'_>,
 ) -> bool {
@@ -3723,7 +3723,7 @@ fn can_pay_mana_cost_with_available_sources(
             &sources,
             &mut vec![false; sources.len()],
             0,
-            allow_any_color,
+            mana_spend_policy,
             source,
         );
     }
@@ -3739,7 +3739,7 @@ fn can_pay_mana_cost_with_available_sources(
         &sources,
         0,
         0,
-        allow_any_color,
+        mana_spend_policy,
         source,
         &mut failed_states,
     )
@@ -4029,7 +4029,7 @@ fn can_pay_expanded_pips(
     sources: &[AvailableManaSource],
     used_sources_mask: u128,
     life_to_pay: u32,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
     payment_source: Option<ObjectId>,
     failed_states: &mut std::collections::HashSet<ManaPaymentSearchKey>,
 ) -> bool {
@@ -4057,7 +4057,7 @@ fn can_pay_expanded_pips(
                     sources,
                     used_sources_mask,
                     next_life,
-                    allow_any_color,
+                    mana_spend_policy,
                     payment_source,
                     failed_states,
                 )
@@ -4068,7 +4068,7 @@ fn can_pay_expanded_pips(
         }
 
         let mut pool_after = pool.clone();
-        if remove_mana_for_pip(&mut pool_after, symbol, allow_any_color)
+        if remove_mana_for_pip(&mut pool_after, symbol, mana_spend_policy)
             && can_pay_expanded_pips(
                 game,
                 player,
@@ -4079,7 +4079,7 @@ fn can_pay_expanded_pips(
                 sources,
                 used_sources_mask,
                 life_to_pay,
-                allow_any_color,
+                mana_spend_policy,
                 payment_source,
                 failed_states,
             )
@@ -4092,15 +4092,15 @@ fn can_pay_expanded_pips(
             if used_sources_mask & source_mask != 0 {
                 continue;
             }
-            let allow_source_any_color = allow_any_color
-                || game.can_spend_mana_as_any_color_from_mana_source(
+            let mut source_policy = mana_spend_policy.clone();
+            source_policy.allow_any_color |= game.can_spend_mana_as_any_color_from_mana_source(
                     player,
                     payment_source,
                     source.source_id,
                 );
             for output in &source.outputs {
                 if let Some(pool_from_output) =
-                    consume_output_for_pip(output, symbol, allow_source_any_color)
+                    consume_output_for_pip(output, symbol, &source_policy)
                 {
                     let mut combined_pool = pool.clone();
                     add_pool(&mut combined_pool, &pool_from_output);
@@ -4114,7 +4114,7 @@ fn can_pay_expanded_pips(
                         sources,
                         used_sources_mask | source_mask,
                         life_to_pay,
-                        allow_any_color,
+                        mana_spend_policy,
                         payment_source,
                         failed_states,
                     );
@@ -4141,7 +4141,7 @@ fn can_pay_expanded_pips_large_source_count(
     sources: &[AvailableManaSource],
     used_sources: &mut [bool],
     life_to_pay: u32,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
     payment_source: Option<ObjectId>,
 ) -> bool {
     if pip_index >= pips.len() {
@@ -4163,7 +4163,7 @@ fn can_pay_expanded_pips_large_source_count(
                     sources,
                     used_sources,
                     next_life,
-                    allow_any_color,
+                    mana_spend_policy,
                     payment_source,
                 )
             {
@@ -4173,7 +4173,7 @@ fn can_pay_expanded_pips_large_source_count(
         }
 
         let mut pool_after = pool.clone();
-        if remove_mana_for_pip(&mut pool_after, symbol, allow_any_color)
+        if remove_mana_for_pip(&mut pool_after, symbol, mana_spend_policy)
             && can_pay_expanded_pips_large_source_count(
                 game,
                 player,
@@ -4184,7 +4184,7 @@ fn can_pay_expanded_pips_large_source_count(
                 sources,
                 used_sources,
                 life_to_pay,
-                allow_any_color,
+                mana_spend_policy,
                 payment_source,
             )
         {
@@ -4195,15 +4195,15 @@ fn can_pay_expanded_pips_large_source_count(
             if used_sources[source_index] {
                 continue;
             }
-            let allow_source_any_color = allow_any_color
-                || game.can_spend_mana_as_any_color_from_mana_source(
+            let mut source_policy = mana_spend_policy.clone();
+            source_policy.allow_any_color |= game.can_spend_mana_as_any_color_from_mana_source(
                     player,
                     payment_source,
                     source.source_id,
                 );
             for output in &source.outputs {
                 if let Some(pool_from_output) =
-                    consume_output_for_pip(output, symbol, allow_source_any_color)
+                    consume_output_for_pip(output, symbol, &source_policy)
                 {
                     let mut combined_pool = pool.clone();
                     add_pool(&mut combined_pool, &pool_from_output);
@@ -4218,7 +4218,7 @@ fn can_pay_expanded_pips_large_source_count(
                         sources,
                         used_sources,
                         life_to_pay,
-                        allow_any_color,
+                        mana_spend_policy,
                         payment_source,
                     );
                     used_sources[source_index] = false;
@@ -4236,10 +4236,10 @@ fn can_pay_expanded_pips_large_source_count(
 fn consume_output_for_pip(
     output: &[ManaSymbol],
     pip: ManaSymbol,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
 ) -> Option<crate::player::ManaPool> {
     for (idx, &produced) in output.iter().enumerate() {
-        if mana_symbol_can_pay_pip(produced, pip, allow_any_color) {
+        if mana_symbol_can_pay_pip(produced, pip, mana_spend_policy) {
             let mut remainder = crate::player::ManaPool::default();
             for (other_idx, &symbol) in output.iter().enumerate() {
                 if other_idx != idx && is_payable_mana_symbol(symbol) {
@@ -4273,7 +4273,7 @@ const PAYABLE_MANA_SYMBOLS: [ManaSymbol; 6] = [
 fn remove_mana_for_pip(
     pool: &mut crate::player::ManaPool,
     pip: ManaSymbol,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
 ) -> bool {
     match pip {
         ManaSymbol::White
@@ -4281,12 +4281,23 @@ fn remove_mana_for_pip(
         | ManaSymbol::Black
         | ManaSymbol::Red
         | ManaSymbol::Green => {
-            if !allow_any_color {
-                return pool.remove(pip, 1);
+            for symbol in PAYABLE_MANA_SYMBOLS {
+                if mana_spend_policy.can_pay_symbol(symbol, pip) && pool.remove(symbol, 1) {
+                    return true;
+                }
             }
-            remove_any_payable_mana(pool)
+            false
         }
-        ManaSymbol::Colorless => pool.remove(ManaSymbol::Colorless, 1),
+        ManaSymbol::Colorless => {
+            for symbol in PAYABLE_MANA_SYMBOLS {
+                if mana_spend_policy.can_pay_symbol(symbol, ManaSymbol::Colorless)
+                    && pool.remove(symbol, 1)
+                {
+                    return true;
+                }
+            }
+            false
+        }
         ManaSymbol::Generic(_) => remove_any_payable_mana(pool),
         ManaSymbol::Snow => false,
         ManaSymbol::Life(_) | ManaSymbol::X => false,
@@ -4302,17 +4313,19 @@ fn remove_any_payable_mana(pool: &mut crate::player::ManaPool) -> bool {
     false
 }
 
-fn mana_symbol_can_pay_pip(produced: ManaSymbol, pip: ManaSymbol, allow_any_color: bool) -> bool {
+fn mana_symbol_can_pay_pip(
+    produced: ManaSymbol,
+    pip: ManaSymbol,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
+) -> bool {
     match pip {
         ManaSymbol::Generic(_) => is_payable_mana_symbol(produced),
         ManaSymbol::White
         | ManaSymbol::Blue
         | ManaSymbol::Black
         | ManaSymbol::Red
-        | ManaSymbol::Green => {
-            produced == pip || (allow_any_color && is_payable_mana_symbol(produced))
-        }
-        ManaSymbol::Colorless => produced == ManaSymbol::Colorless,
+        | ManaSymbol::Green
+        | ManaSymbol::Colorless => mana_spend_policy.can_pay_symbol(produced, pip),
         ManaSymbol::Snow | ManaSymbol::Life(_) | ManaSymbol::X => false,
     }
 }

--- a/crates/ironsmith-runtime/src/derived_view.rs
+++ b/crates/ironsmith-runtime/src/derived_view.rs
@@ -585,14 +585,14 @@ impl<'a> DerivedGameView<'a> {
         x_value: u32,
         reason: crate::costs::PaymentReason,
     ) -> bool {
-        let allow_any_color = self.game.can_spend_mana_as_any_color(player, source);
+        let mana_spend_policy = self.game.mana_spend_policy(player, source);
         let allow_black_life = self.player_can_pay_black_with_life_for_reason(player, reason);
         let mut preview_pool = self.potential_mana(player);
         let (can_pay, life_to_pay) = preview_pool
-            .try_pay_tracking_life_with_any_color_and_black_life(
+            .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
                 cost,
                 x_value,
-                allow_any_color,
+                &mana_spend_policy,
                 allow_black_life,
             );
         can_pay

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -504,16 +504,16 @@ pub(super) fn compute_spell_cast_x_bounds(
     let mut max_x = None;
 
     if pay_has_x && let Some(cost) = mana_cost_to_pay {
-        let allow_any_color = game.can_spend_mana_as_any_color(caster, Some(stack_id));
+        let mana_spend_policy = game.mana_spend_policy(caster, Some(stack_id));
         let allow_black_life = game.player_can_pay_black_with_life_for_reason(
             caster,
             Some(stack_id),
             crate::costs::PaymentReason::CastSpell,
         );
         max_x = Some(
-            compute_potential_mana(game, caster).max_x_for_cost_with_any_color_and_black_life(
+            compute_potential_mana(game, caster).max_x_for_cost_with_mana_spend_policy_and_black_life(
                 cost,
-                allow_any_color,
+                &mana_spend_policy,
                 allow_black_life,
             ),
         );
@@ -1782,7 +1782,7 @@ pub(super) fn continue_spell_cast_mana_payment(
         .map(|o| o.name.clone())
         .unwrap_or_else(|| "spell".to_string());
 
-    let allow_any_color = game.can_spend_mana_as_any_color(player_id, Some(source));
+    let mana_spend_policy = game.mana_spend_policy(player_id, Some(source));
     let allow_black_life = game.player_can_pay_black_with_life_for_reason(
         player_id,
         Some(source),
@@ -1794,7 +1794,7 @@ pub(super) fn continue_spell_cast_mana_payment(
         player_id,
         &pip,
         display_pip,
-        allow_any_color,
+        &mana_spend_policy,
         allow_black_life,
         Some(source),
         &mut *decision_maker,
@@ -1816,7 +1816,7 @@ pub(super) fn continue_spell_cast_mana_payment(
             player_id,
             Some(source),
             &pip,
-            allow_any_color,
+            &mana_spend_policy,
             &action,
             &mut *decision_maker,
             &mut pending.payment_trace,
@@ -1901,14 +1901,14 @@ pub(super) fn compute_mana_ability_payment_options(
         }
 
         // Get the mana this ability produces and check if it can help pay the cost
-        let allow_any_color = game.can_spend_mana_as_any_color(player, Some(pending.source));
+    let mana_spend_policy = game.mana_spend_policy(player, Some(pending.source));
         let can_help = if game.object(*perm_id).is_some()
             && let Some(ability) = game.current_ability(*perm_id, *ability_index)
             && let AbilityKind::Activated(mana_ability) = &ability.kind
             && mana_ability.is_runtime_mana_ability(game, *perm_id, player)
         {
             let produced = mana_ability.inferred_mana_symbols(game, *perm_id, player);
-            mana_can_help_pay_cost(&produced, &pending.mana_cost, game, player, allow_any_color)
+            mana_can_help_pay_cost(&produced, &pending.mana_cost, game, player, &mana_spend_policy)
         } else {
             // If we can't determine, include it
             true
@@ -1953,7 +1953,7 @@ pub(super) fn mana_can_help_pay_cost(
     cost: &crate::mana::ManaCost,
     game: &GameState,
     player: PlayerId,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
 ) -> bool {
     use crate::mana::ManaSymbol;
 
@@ -1977,18 +1977,19 @@ pub(super) fn mana_can_help_pay_cost(
                 | ManaSymbol::Black
                 | ManaSymbol::Red
                 | ManaSymbol::Green => {
-                    // If any-color spending is allowed, any mana helps with colored pips
-                    if allow_any_color {
-                        if !mana_produced.is_empty() {
-                            return true;
-                        }
-                    } else if mana_produced.contains(alternative) {
+                    if mana_produced
+                        .iter()
+                        .any(|symbol| mana_spend_policy.can_pay_symbol(*symbol, *alternative))
+                    {
                         return true;
                     }
                 }
                 // Colorless mana can only be paid by colorless
                 ManaSymbol::Colorless => {
-                    if mana_produced.contains(&ManaSymbol::Colorless) {
+                    if mana_produced
+                        .iter()
+                        .any(|symbol| mana_spend_policy.can_pay_symbol(*symbol, ManaSymbol::Colorless))
+                    {
                         return true;
                     }
                 }
@@ -3094,17 +3095,17 @@ pub(super) fn continue_activation(
         ActivationStage::ChoosingX => {
             // Need to choose X value first
             let mut max_x = if let Some(ref cost) = pending.mana_cost_to_pay {
-                let allow_any_color =
-                    game.can_spend_mana_as_any_color(pending.activator, Some(pending.source));
+                let mana_spend_policy =
+                    game.mana_spend_policy(pending.activator, Some(pending.source));
                 let allow_black_life = game.player_can_pay_black_with_life_for_reason(
                     pending.activator,
                     Some(pending.source),
                     crate::costs::PaymentReason::ActivateAbility,
                 );
                 compute_potential_mana(game, pending.activator)
-                    .max_x_for_cost_with_any_color_and_black_life(
+                    .max_x_for_cost_with_mana_spend_policy_and_black_life(
                         cost,
-                        allow_any_color,
+                        &mana_spend_policy,
                         allow_black_life,
                     )
                     .into()
@@ -3309,7 +3310,7 @@ pub(super) fn continue_activation(
                 .map(|o| format!("{}'s ability", o.name))
                 .unwrap_or_else(|| "ability".to_string());
 
-            let allow_any_color = game.can_spend_mana_as_any_color(player_id, Some(source));
+            let mana_spend_policy = game.mana_spend_policy(player_id, Some(source));
             let allow_black_life = game.player_can_pay_black_with_life_for_reason(
                 player_id,
                 Some(source),
@@ -3322,7 +3323,7 @@ pub(super) fn continue_activation(
                 player_id,
                 &pip,
                 display_pip,
-                allow_any_color,
+                &mana_spend_policy,
                 allow_black_life,
                 Some(source),
                 &mut *decision_maker,
@@ -3344,7 +3345,7 @@ pub(super) fn continue_activation(
                     player_id,
                     Some(source),
                     &pip,
-                    allow_any_color,
+                    &mana_spend_policy,
                     &action,
                     &mut *decision_maker,
                     &mut pending.payment_trace,

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -230,7 +230,7 @@ pub(super) fn build_pip_payment_options(
     player: PlayerId,
     pip: &[crate::mana::ManaSymbol],
     display_pip: Option<&[crate::mana::ManaSymbol]>,
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
     allow_black_life: bool,
     source_for_pip_alternatives: Option<ObjectId>,
     decision_maker: &mut impl DecisionMaker,
@@ -239,7 +239,7 @@ pub(super) fn build_pip_payment_options(
 
     let mut options = Vec::new();
     let mut index = 0;
-    let mut added_any_color_options = false;
+    let mut added_pool_symbols = Vec::new();
 
     // Get the player's mana pool
     let pool = game.player(player).map(|p| &p.mana_pool);
@@ -248,155 +248,76 @@ pub(super) fn build_pip_payment_options(
     for symbol in pip {
         match symbol {
             ManaSymbol::White => {
-                if allow_any_color {
-                    if !added_any_color_options {
-                        add_any_color_pool_options(
-                            game,
-                            player,
-                            source_for_pip_alternatives,
-                            &mut options,
-                            &mut index,
-                        );
-                        added_any_color_options = true;
-                    }
-                } else if pool_symbol_count(
+                add_policy_pool_options_for_required(
                     game,
                     player,
                     ManaSymbol::White,
                     source_for_pip_alternatives,
-                ) > 0
-                {
-                    options.push(ManaPipPaymentOption {
-                        index,
-                        description: "Use {W} from mana pool".to_string(),
-                        action: ManaPipPaymentAction::UseFromPool(ManaSymbol::White),
-                    });
-                    index += 1;
-                }
+                    mana_spend_policy,
+                    &mut options,
+                    &mut index,
+                    &mut added_pool_symbols,
+                );
             }
             ManaSymbol::Blue => {
-                if allow_any_color {
-                    if !added_any_color_options {
-                        add_any_color_pool_options(
-                            game,
-                            player,
-                            source_for_pip_alternatives,
-                            &mut options,
-                            &mut index,
-                        );
-                        added_any_color_options = true;
-                    }
-                } else if pool_symbol_count(
+                add_policy_pool_options_for_required(
                     game,
                     player,
                     ManaSymbol::Blue,
                     source_for_pip_alternatives,
-                ) > 0
-                {
-                    options.push(ManaPipPaymentOption {
-                        index,
-                        description: "Use {U} from mana pool".to_string(),
-                        action: ManaPipPaymentAction::UseFromPool(ManaSymbol::Blue),
-                    });
-                    index += 1;
-                }
+                    mana_spend_policy,
+                    &mut options,
+                    &mut index,
+                    &mut added_pool_symbols,
+                );
             }
             ManaSymbol::Black => {
-                if allow_any_color {
-                    if !added_any_color_options {
-                        add_any_color_pool_options(
-                            game,
-                            player,
-                            source_for_pip_alternatives,
-                            &mut options,
-                            &mut index,
-                        );
-                        added_any_color_options = true;
-                    }
-                } else if pool_symbol_count(
+                add_policy_pool_options_for_required(
                     game,
                     player,
                     ManaSymbol::Black,
                     source_for_pip_alternatives,
-                ) > 0
-                {
-                    options.push(ManaPipPaymentOption {
-                        index,
-                        description: "Use {B} from mana pool".to_string(),
-                        action: ManaPipPaymentAction::UseFromPool(ManaSymbol::Black),
-                    });
-                    index += 1;
-                }
+                    mana_spend_policy,
+                    &mut options,
+                    &mut index,
+                    &mut added_pool_symbols,
+                );
             }
             ManaSymbol::Red => {
-                if allow_any_color {
-                    if !added_any_color_options {
-                        add_any_color_pool_options(
-                            game,
-                            player,
-                            source_for_pip_alternatives,
-                            &mut options,
-                            &mut index,
-                        );
-                        added_any_color_options = true;
-                    }
-                } else if pool_symbol_count(
+                add_policy_pool_options_for_required(
                     game,
                     player,
                     ManaSymbol::Red,
                     source_for_pip_alternatives,
-                ) > 0
-                {
-                    options.push(ManaPipPaymentOption {
-                        index,
-                        description: "Use {R} from mana pool".to_string(),
-                        action: ManaPipPaymentAction::UseFromPool(ManaSymbol::Red),
-                    });
-                    index += 1;
-                }
+                    mana_spend_policy,
+                    &mut options,
+                    &mut index,
+                    &mut added_pool_symbols,
+                );
             }
             ManaSymbol::Green => {
-                if allow_any_color {
-                    if !added_any_color_options {
-                        add_any_color_pool_options(
-                            game,
-                            player,
-                            source_for_pip_alternatives,
-                            &mut options,
-                            &mut index,
-                        );
-                        added_any_color_options = true;
-                    }
-                } else if pool_symbol_count(
+                add_policy_pool_options_for_required(
                     game,
                     player,
                     ManaSymbol::Green,
                     source_for_pip_alternatives,
-                ) > 0
-                {
-                    options.push(ManaPipPaymentOption {
-                        index,
-                        description: "Use {G} from mana pool".to_string(),
-                        action: ManaPipPaymentAction::UseFromPool(ManaSymbol::Green),
-                    });
-                    index += 1;
-                }
+                    mana_spend_policy,
+                    &mut options,
+                    &mut index,
+                    &mut added_pool_symbols,
+                );
             }
             ManaSymbol::Colorless => {
-                if pool_symbol_count(
+                add_policy_pool_options_for_required(
                     game,
                     player,
                     ManaSymbol::Colorless,
                     source_for_pip_alternatives,
-                ) > 0
-                {
-                    options.push(ManaPipPaymentOption {
-                        index,
-                        description: "Use {C} from mana pool".to_string(),
-                        action: ManaPipPaymentAction::UseFromPool(ManaSymbol::Colorless),
-                    });
-                    index += 1;
-                }
+                    mana_spend_policy,
+                    &mut options,
+                    &mut index,
+                    &mut added_pool_symbols,
+                );
             }
             ManaSymbol::Generic(_) => {
                 // Generic can be paid with any mana in the pool
@@ -480,8 +401,8 @@ pub(super) fn build_pip_payment_options(
     if !has_pool_options || is_phyrexian {
         let mana_abilities = get_available_mana_abilities(game, player, decision_maker);
         for (perm_id, ability_index, description) in mana_abilities {
-            let allow_source_any_color = allow_any_color
-                || game.can_spend_mana_as_any_color_from_mana_source(
+            let mut source_policy = mana_spend_policy.clone();
+            source_policy.allow_any_color |= game.can_spend_mana_as_any_color_from_mana_source(
                     player,
                     source_for_pip_alternatives,
                     perm_id,
@@ -493,7 +414,7 @@ pub(super) fn build_pip_payment_options(
                 ability_index,
                 source_for_pip_alternatives,
                 pip,
-                allow_source_any_color,
+                &source_policy,
             ) {
                 options.push(ManaPipPaymentOption {
                     index,
@@ -646,6 +567,46 @@ pub(super) fn add_any_color_pool_options(
             action: ManaPipPaymentAction::UseFromPool(ManaSymbol::Colorless),
         });
         *index += 1;
+    }
+}
+
+fn add_policy_pool_options_for_required(
+    game: &GameState,
+    player: PlayerId,
+    required: crate::mana::ManaSymbol,
+    payment_source: Option<ObjectId>,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
+    options: &mut Vec<ManaPipPaymentOption>,
+    index: &mut usize,
+    added_symbols: &mut Vec<crate::mana::ManaSymbol>,
+) {
+    use crate::mana::ManaSymbol;
+
+    for symbol in [
+        ManaSymbol::White,
+        ManaSymbol::Blue,
+        ManaSymbol::Black,
+        ManaSymbol::Red,
+        ManaSymbol::Green,
+        ManaSymbol::Colorless,
+    ] {
+        if added_symbols.contains(&symbol)
+            || !mana_spend_policy.can_pay_symbol(symbol, required)
+            || pool_symbol_count(game, player, symbol, payment_source) == 0
+        {
+            continue;
+        }
+
+        options.push(ManaPipPaymentOption {
+            index: *index,
+            description: format!(
+                "Use {} from mana pool",
+                crate::mana::ManaCost::from_symbols(vec![symbol]).to_oracle()
+            ),
+            action: ManaPipPaymentAction::UseFromPool(symbol),
+        });
+        *index += 1;
+        added_symbols.push(symbol);
     }
 }
 
@@ -1024,7 +985,7 @@ pub(super) fn mana_ability_can_pay_pip(
     ability_index: usize,
     payment_source: Option<ObjectId>,
     pip: &[crate::mana::ManaSymbol],
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
 ) -> bool {
     use crate::ability::AbilityKind;
     use crate::mana::ManaSymbol;
@@ -1059,31 +1020,21 @@ pub(super) fn mana_ability_can_pay_pip(
     let produced_symbols =
         mana_ability.inferred_mana_symbols(game, perm_id, game.controller_of(obj));
 
-    let pip_has_colored = pip.iter().any(|s| {
-        matches!(
-            s,
-            ManaSymbol::White
-                | ManaSymbol::Blue
-                | ManaSymbol::Black
-                | ManaSymbol::Red
-                | ManaSymbol::Green
-        )
-    });
-
     for produced in &produced_symbols {
         for pip_symbol in pip {
             match (produced, pip_symbol) {
                 // Any mana can pay generic
                 (_, ManaSymbol::Generic(_)) => return true,
-                // Exact color matches
-                (ManaSymbol::White, ManaSymbol::White) => return true,
-                (ManaSymbol::Blue, ManaSymbol::Blue) => return true,
-                (ManaSymbol::Black, ManaSymbol::Black) => return true,
-                (ManaSymbol::Red, ManaSymbol::Red) => return true,
-                (ManaSymbol::Green, ManaSymbol::Green) => return true,
-                (ManaSymbol::Colorless, ManaSymbol::Colorless) => return true,
-                // Any-color spending: any produced mana can pay colored pips
-                _ if allow_any_color && pip_has_colored => return true,
+                (_, ManaSymbol::White)
+                | (_, ManaSymbol::Blue)
+                | (_, ManaSymbol::Black)
+                | (_, ManaSymbol::Red)
+                | (_, ManaSymbol::Green)
+                | (_, ManaSymbol::Colorless) => {
+                    if mana_spend_policy.can_pay_symbol(*produced, *pip_symbol) {
+                        return true;
+                    }
+                }
                 _ => {}
             }
         }
@@ -1131,26 +1082,35 @@ pub fn mana_ability_is_undo_safe(game: &GameState, source: ObjectId, ability_ind
 
 pub(super) fn pip_mana_color_restriction(
     pip: &[crate::mana::ManaSymbol],
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
 ) -> Option<Vec<crate::color::Color>> {
     use crate::color::Color;
     use crate::mana::ManaSymbol;
-
-    if allow_any_color {
-        return None;
-    }
 
     let mut colors = Vec::new();
     let mut has_non_colored_mana_alternative = false;
 
     for symbol in pip {
         match symbol {
-            ManaSymbol::White => colors.push(Color::White),
-            ManaSymbol::Blue => colors.push(Color::Blue),
-            ManaSymbol::Black => colors.push(Color::Black),
-            ManaSymbol::Red => colors.push(Color::Red),
-            ManaSymbol::Green => colors.push(Color::Green),
-            ManaSymbol::Colorless | ManaSymbol::Generic(_) | ManaSymbol::Snow => {
+            ManaSymbol::White
+            | ManaSymbol::Blue
+            | ManaSymbol::Black
+            | ManaSymbol::Red
+            | ManaSymbol::Green
+            | ManaSymbol::Colorless => {
+                for (produced, color) in [
+                    (ManaSymbol::White, Color::White),
+                    (ManaSymbol::Blue, Color::Blue),
+                    (ManaSymbol::Black, Color::Black),
+                    (ManaSymbol::Red, Color::Red),
+                    (ManaSymbol::Green, Color::Green),
+                ] {
+                    if mana_spend_policy.can_pay_symbol(produced, *symbol) {
+                        colors.push(color);
+                    }
+                }
+            }
+            ManaSymbol::Generic(_) | ManaSymbol::Snow => {
                 has_non_colored_mana_alternative = true;
             }
             ManaSymbol::Life(_) | ManaSymbol::X => {}
@@ -1222,7 +1182,7 @@ pub(super) fn execute_pip_payment_action(
     player: PlayerId,
     source: Option<ObjectId>,
     pip: &[crate::mana::ManaSymbol],
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
     action: &ManaPipPaymentAction,
     decision_maker: &mut impl DecisionMaker,
     payment_trace: &mut Vec<CostStep>,
@@ -1250,9 +1210,10 @@ pub(super) fn execute_pip_payment_action(
             let before_pool = game
                 .player(player)
                 .map(|player_obj| player_obj.mana_pool.clone());
-            let allow_source_any_color = allow_any_color
-                || game.can_spend_mana_as_any_color_from_mana_source(player, source, *source_id);
-            let mana_color_restriction = pip_mana_color_restriction(pip, allow_source_any_color);
+            let mut source_policy = mana_spend_policy.clone();
+            source_policy.allow_any_color |=
+                game.can_spend_mana_as_any_color_from_mana_source(player, source, *source_id);
+            let mana_color_restriction = pip_mana_color_restriction(pip, &source_policy);
             let emitted_events =
                 crate::special_actions::perform_activate_mana_ability_restricted_colors_with_events(
                 game,
@@ -1283,7 +1244,7 @@ pub(super) fn execute_pip_payment_action(
                 player,
                 source,
                 pip,
-                allow_source_any_color,
+                &source_policy,
                 &produced_symbols,
             ) {
                 if let Some(spent) = mana_spent_to_cast.as_deref_mut() {
@@ -1362,7 +1323,7 @@ pub(super) fn spend_pool_mana_for_pip(
     player: PlayerId,
     payment_source: Option<ObjectId>,
     pip: &[crate::mana::ManaSymbol],
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
     preferred_symbols: &[crate::mana::ManaSymbol],
 ) -> Option<SpentManaInfo> {
     use crate::mana::ManaSymbol;
@@ -1381,7 +1342,7 @@ pub(super) fn spend_pool_mana_for_pip(
         ) {
             continue;
         }
-        if symbol_can_pay_pip(symbol, pip, allow_any_color) && !candidates.contains(&symbol) {
+        if symbol_can_pay_pip(symbol, pip, mana_spend_policy) && !candidates.contains(&symbol) {
             candidates.push(symbol);
         }
     }
@@ -1394,7 +1355,7 @@ pub(super) fn spend_pool_mana_for_pip(
         ManaSymbol::Green,
         ManaSymbol::Colorless,
     ] {
-        if symbol_can_pay_pip(symbol, pip, allow_any_color) && !candidates.contains(&symbol) {
+        if symbol_can_pay_pip(symbol, pip, mana_spend_policy) && !candidates.contains(&symbol) {
             candidates.push(symbol);
         }
     }
@@ -1411,20 +1372,9 @@ pub(super) fn spend_pool_mana_for_pip(
 pub(super) fn symbol_can_pay_pip(
     symbol: crate::mana::ManaSymbol,
     pip: &[crate::mana::ManaSymbol],
-    allow_any_color: bool,
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
 ) -> bool {
     use crate::mana::ManaSymbol;
-
-    let has_colored_requirement = pip.iter().any(|candidate| {
-        matches!(
-            candidate,
-            ManaSymbol::White
-                | ManaSymbol::Blue
-                | ManaSymbol::Black
-                | ManaSymbol::Red
-                | ManaSymbol::Green
-        )
-    });
 
     pip.iter().any(|candidate| match candidate {
         ManaSymbol::Generic(_) | ManaSymbol::Snow => matches!(
@@ -1436,22 +1386,12 @@ pub(super) fn symbol_can_pay_pip(
                 | ManaSymbol::Green
                 | ManaSymbol::Colorless
         ),
-        ManaSymbol::White => {
-            symbol == ManaSymbol::White || (allow_any_color && has_colored_requirement)
-        }
-        ManaSymbol::Blue => {
-            symbol == ManaSymbol::Blue || (allow_any_color && has_colored_requirement)
-        }
-        ManaSymbol::Black => {
-            symbol == ManaSymbol::Black || (allow_any_color && has_colored_requirement)
-        }
-        ManaSymbol::Red => {
-            symbol == ManaSymbol::Red || (allow_any_color && has_colored_requirement)
-        }
-        ManaSymbol::Green => {
-            symbol == ManaSymbol::Green || (allow_any_color && has_colored_requirement)
-        }
-        ManaSymbol::Colorless => symbol == ManaSymbol::Colorless,
+        ManaSymbol::White
+        | ManaSymbol::Blue
+        | ManaSymbol::Black
+        | ManaSymbol::Red
+        | ManaSymbol::Green
+        | ManaSymbol::Colorless => mana_spend_policy.can_pay_symbol(symbol, *candidate),
         ManaSymbol::Life(_) | ManaSymbol::X => false,
     })
 }
@@ -1870,7 +1810,7 @@ pub(super) fn apply_mana_payment_response_mana_ability(
 
     // Get available mana abilities, excluding the one we're paying for
     // and filtered to only those that can help pay the cost
-    let allow_any_color = game.can_spend_mana_as_any_color(pending.activator, Some(pending.source));
+    let mana_spend_policy = game.mana_spend_policy(pending.activator, Some(pending.source));
     let mana_abilities: Vec<_> =
         get_available_mana_abilities(game, pending.activator, decision_maker)
             .into_iter()
@@ -1894,7 +1834,7 @@ pub(super) fn apply_mana_payment_response_mana_ability(
                         &pending.mana_cost,
                         game,
                         pending.activator,
-                        allow_any_color,
+                        &mana_spend_policy,
                     )
                 } else {
                     true // If we can't determine, include it
@@ -2210,7 +2150,7 @@ pub(super) fn apply_pip_payment_response_activation(
     let display_pip = current_display_pip(&pending.display_mana_pips, &pending.remaining_mana_pips);
 
     // Rebuild the options to get the action for this choice
-    let allow_any_color = game.can_spend_mana_as_any_color(pending.activator, Some(pending.source));
+    let mana_spend_policy = game.mana_spend_policy(pending.activator, Some(pending.source));
     let allow_black_life = game.player_can_pay_black_with_life_for_reason(
         pending.activator,
         Some(pending.source),
@@ -2221,7 +2161,7 @@ pub(super) fn apply_pip_payment_response_activation(
         pending.activator,
         &pip,
         display_pip,
-        allow_any_color,
+        &mana_spend_policy,
         allow_black_life,
         Some(pending.source),
         &mut *decision_maker,
@@ -2244,7 +2184,7 @@ pub(super) fn apply_pip_payment_response_activation(
         pending.activator,
         Some(pending.source),
         &pip,
-        allow_any_color,
+        &mana_spend_policy,
         action,
         &mut *decision_maker,
         &mut pending.payment_trace,
@@ -2303,7 +2243,7 @@ pub(super) fn apply_pip_payment_response_cast(
     let pip = pending.remaining_mana_pips[0].clone();
     let display_pip = current_display_pip(&pending.display_mana_pips, &pending.remaining_mana_pips);
 
-    let allow_any_color = game.can_spend_mana_as_any_color(pending.caster, Some(pending.spell_id));
+    let mana_spend_policy = game.mana_spend_policy(pending.caster, Some(pending.spell_id));
     let allow_black_life = game.player_can_pay_black_with_life_for_reason(
         pending.caster,
         Some(pending.spell_id),
@@ -2319,7 +2259,7 @@ pub(super) fn apply_pip_payment_response_cast(
             pending.caster,
             &pip,
             display_pip,
-            allow_any_color,
+            &mana_spend_policy,
             allow_black_life,
             Some(pending.spell_id),
             &mut *decision_maker,
@@ -2348,7 +2288,7 @@ pub(super) fn apply_pip_payment_response_cast(
         pending.caster,
         Some(pending.spell_id),
         &pip,
-        allow_any_color,
+        &mana_spend_policy,
         action,
         &mut *decision_maker,
         &mut pending.payment_trace,
@@ -4488,7 +4428,14 @@ mod priority_mana_tests {
         let treasure_id = game.create_object_from_definition(&treasure, alice, Zone::Battlefield);
 
         assert!(
-            mana_ability_can_pay_pip(&game, treasure_id, 0, None, &[ManaSymbol::Black], false),
+            mana_ability_can_pay_pip(
+                &game,
+                treasure_id,
+                0,
+                None,
+                &[ManaSymbol::Black],
+                &crate::player::ManaSpendPolicy::default(),
+            ),
             "Treasure should be considered able to pay a colored pip"
         );
     }
@@ -4701,7 +4648,7 @@ mod priority_mana_tests {
                 0,
                 Some(matching_spell_id),
                 &[ManaSymbol::Green],
-                false,
+                &crate::player::ManaSpendPolicy::default(),
             ),
             "restricted mana ability should pay for a creature spell of the chosen type"
         );
@@ -4719,7 +4666,7 @@ mod priority_mana_tests {
                 0,
                 Some(nonmatching_spell_id),
                 &[ManaSymbol::Green],
-                false,
+                &crate::player::ManaSpendPolicy::default(),
             ),
             "restricted mana ability should reject creature spells of the wrong subtype"
         );
@@ -5278,7 +5225,7 @@ mod priority_mana_tests {
             alice,
             None,
             &black_pip,
-            false,
+            &crate::player::ManaSpendPolicy::default(),
             &action,
             &mut dm,
             &mut payment_trace,
@@ -5329,7 +5276,7 @@ mod priority_mana_tests {
             alice,
             &[ManaSymbol::Black],
             Some(&[ManaSymbol::Black]),
-            false,
+            &crate::player::ManaSpendPolicy::default(),
             false,
             Some(yawgmoth_id),
             &mut dm,
@@ -5418,7 +5365,7 @@ mod priority_mana_tests {
             alice,
             &[ManaSymbol::Black],
             Some(&[ManaSymbol::Black]),
-            false,
+            &crate::player::ManaSpendPolicy::default(),
             game.player_can_pay_black_with_life_for_reason(
                 alice,
                 Some(helper_id),
@@ -5447,7 +5394,7 @@ mod priority_mana_tests {
             alice,
             &[ManaSymbol::Black],
             Some(&[ManaSymbol::Black, ManaSymbol::Life(2)]),
-            false,
+            &crate::player::ManaSpendPolicy::default(),
             true,
             None,
             &mut dm,

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -6180,7 +6180,31 @@ impl GameState {
             .mana_spend_effects
             .permissions
             .iter()
-            .any(|permission| permission.allows(self, payer, source))
+            .any(|permission| {
+                permission.allows(self, payer, source)
+                    && permission.permission.any_color_mana_symbol.is_none()
+            })
+    }
+
+    pub fn mana_spend_policy(
+        &self,
+        payer: PlayerId,
+        source: Option<ObjectId>,
+    ) -> crate::player::ManaSpendPolicy {
+        let mut policy = crate::player::ManaSpendPolicy::default();
+        for permission in &self.effect_store.mana_spend_effects.permissions {
+            if !permission.allows(self, payer, source) {
+                continue;
+            }
+            if let Some(symbol) = permission.permission.any_color_mana_symbol {
+                policy.add_symbol_as_any_color(symbol);
+            } else {
+                policy.allow_any_color = true;
+            }
+            policy.other_mana_only_as_colorless |=
+                permission.permission.other_mana_only_as_colorless;
+        }
+        policy
     }
 
     pub fn can_spend_mana_as_any_color_from_mana_source(
@@ -6451,7 +6475,7 @@ impl GameState {
             return false;
         };
 
-        let allow_any_color = self.can_spend_mana_as_any_color(payer, source);
+        let mana_spend_policy = self.mana_spend_policy(payer, source);
         let allow_black_life =
             self.player_can_pay_black_with_life_for_reason(payer, source, reason);
         let mut preview_pool = if let Some(symbol) = source
@@ -6462,10 +6486,10 @@ impl GameState {
             player.mana_pool.clone()
         };
         let (can_pay, life_to_pay) = preview_pool
-            .try_pay_tracking_life_with_any_color_and_black_life(
+            .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
                 cost,
                 x_value,
-                allow_any_color,
+                &mana_spend_policy,
                 allow_black_life,
             );
         can_pay && self.can_pay_life_with_reason(payer, life_to_pay, reason)
@@ -6497,7 +6521,7 @@ impl GameState {
         x_value: u32,
         reason: crate::costs::PaymentReason,
     ) -> bool {
-        let allow_any_color = self.can_spend_mana_as_any_color(payer, source);
+        let mana_spend_policy = self.mana_spend_policy(payer, source);
         let allow_black_life =
             self.player_can_pay_black_with_life_for_reason(payer, source, reason);
         let original_pool = self.player(payer).map(|player| player.mana_pool.clone());
@@ -6509,10 +6533,10 @@ impl GameState {
             };
             let mut restricted_pool = self.mana_pool_restricted_to_symbol(&original_pool, symbol);
             let (paid, life_to_pay) = restricted_pool
-                .try_pay_tracking_life_with_any_color_and_black_life(
+                .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
                     cost,
                     x_value,
-                    allow_any_color,
+                    &mana_spend_policy,
                     allow_black_life,
                 );
             if !paid || !self.can_pay_life_with_reason(payer, life_to_pay, reason) {
@@ -6543,10 +6567,10 @@ impl GameState {
             };
             player
                 .mana_pool
-                .try_pay_tracking_life_with_any_color_and_black_life(
+                .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
                     cost,
                     x_value,
-                    allow_any_color,
+                    &mana_spend_policy,
                     allow_black_life,
                 )
         };

--- a/crates/ironsmith-runtime/src/player.rs
+++ b/crates/ironsmith-runtime/src/player.rs
@@ -14,6 +14,63 @@ pub struct ManaPool {
     pub colorless: u32,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ManaSpendPolicy {
+    pub allow_any_color: bool,
+    pub any_color_mana_symbols: Vec<ManaSymbol>,
+    pub other_mana_only_as_colorless: bool,
+}
+
+impl ManaSpendPolicy {
+    pub fn from_any_color(allow_any_color: bool) -> Self {
+        Self {
+            allow_any_color,
+            ..Self::default()
+        }
+    }
+
+    pub fn add_symbol_as_any_color(&mut self, symbol: ManaSymbol) {
+        if !self.any_color_mana_symbols.contains(&symbol) {
+            self.any_color_mana_symbols.push(symbol);
+        }
+    }
+
+    pub(crate) fn has_any_color_spending(&self) -> bool {
+        self.allow_any_color || !self.any_color_mana_symbols.is_empty()
+    }
+
+    fn symbol_spends_as_any_color(&self, symbol: ManaSymbol) -> bool {
+        self.any_color_mana_symbols.contains(&symbol)
+            || (self.allow_any_color && !self.other_mana_only_as_colorless)
+    }
+
+    fn symbol_spends_as_colorless(&self, symbol: ManaSymbol) -> bool {
+        symbol == ManaSymbol::Colorless
+            || (self.other_mana_only_as_colorless && !self.symbol_spends_as_any_color(symbol))
+    }
+
+    pub(crate) fn can_pay_symbol(&self, symbol: ManaSymbol, required: ManaSymbol) -> bool {
+        match required {
+            ManaSymbol::White
+            | ManaSymbol::Blue
+            | ManaSymbol::Black
+            | ManaSymbol::Red
+            | ManaSymbol::Green => symbol == required || self.symbol_spends_as_any_color(symbol),
+            ManaSymbol::Colorless => self.symbol_spends_as_colorless(symbol),
+            ManaSymbol::Generic(_) | ManaSymbol::Snow => matches!(
+                symbol,
+                ManaSymbol::White
+                    | ManaSymbol::Blue
+                    | ManaSymbol::Black
+                    | ManaSymbol::Red
+                    | ManaSymbol::Green
+                    | ManaSymbol::Colorless
+            ),
+            ManaSymbol::Life(_) | ManaSymbol::X => false,
+        }
+    }
+}
+
 impl ManaPool {
     pub fn new() -> Self {
         Self::default()
@@ -313,6 +370,179 @@ impl ManaPool {
         .0
     }
 
+    pub fn try_pay_tracking_life_with_mana_spend_policy_and_black_life(
+        &mut self,
+        cost: &crate::mana::ManaCost,
+        x_value: u32,
+        policy: &ManaSpendPolicy,
+        allow_black_life: bool,
+    ) -> (bool, u32) {
+        let original_pool = self.clone();
+        let result =
+            self.try_pay_internal_with_policy(cost, x_value, false, policy, allow_black_life);
+        if result.0 {
+            return result;
+        }
+
+        *self = original_pool;
+        self.try_pay_internal_with_policy(cost, x_value, true, policy, allow_black_life)
+    }
+
+    pub fn max_x_for_cost_with_mana_spend_policy_and_black_life(
+        &self,
+        cost: &crate::mana::ManaCost,
+        policy: &ManaSpendPolicy,
+        allow_black_life: bool,
+    ) -> u32 {
+        let x_pip_count = cost
+            .pips()
+            .iter()
+            .filter(|pip| pip.iter().any(|s| matches!(s, ManaSymbol::X)))
+            .count() as u32;
+        if x_pip_count == 0 {
+            return 0;
+        }
+
+        let mut non_x_cost = Vec::new();
+        for pip in cost.pips() {
+            if !pip.iter().any(|s| matches!(s, ManaSymbol::X)) {
+                non_x_cost.push(pip.clone());
+            }
+        }
+        let mut test_pool = self.clone();
+        let non_x = crate::mana::ManaCost::from_pips(non_x_cost);
+        if !test_pool
+            .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
+                &non_x,
+                0,
+                policy,
+                allow_black_life,
+            )
+            .0
+        {
+            return 0;
+        }
+
+        test_pool.total() / x_pip_count
+    }
+
+    fn try_pay_internal_with_policy(
+        &mut self,
+        cost: &crate::mana::ManaCost,
+        x_value: u32,
+        prefer_life_for_phyrexian: bool,
+        policy: &ManaSpendPolicy,
+        allow_black_life: bool,
+    ) -> (bool, u32) {
+        let mut pips: Vec<_> = cost.pips().iter().collect();
+        pips.sort_by_key(|pip| {
+            if pip
+                .iter()
+                .any(|s| matches!(s, ManaSymbol::Generic(_) | ManaSymbol::X))
+            {
+                1
+            } else {
+                0
+            }
+        });
+
+        let mut life_to_pay = 0u32;
+        for pip in pips {
+            let is_phyrexian = pip.iter().any(|s| matches!(s, ManaSymbol::Life(_)));
+            let is_singleton_black_with_life =
+                Self::singleton_black_pip_with_life_option(pip, allow_black_life);
+            let has_life_option = is_phyrexian || is_singleton_black_with_life;
+
+            if prefer_life_for_phyrexian && has_life_option {
+                if is_singleton_black_with_life {
+                    life_to_pay += 2;
+                    continue;
+                }
+                if let Some(amount) = pip.iter().find_map(|symbol| match symbol {
+                    ManaSymbol::Life(amount) => Some(*amount as u32),
+                    _ => None,
+                }) {
+                    life_to_pay += amount;
+                    continue;
+                }
+            }
+
+            let mut paid = false;
+            for alternative in pip.iter() {
+                match alternative {
+                    ManaSymbol::White
+                    | ManaSymbol::Blue
+                    | ManaSymbol::Black
+                    | ManaSymbol::Red
+                    | ManaSymbol::Green
+                    | ManaSymbol::Colorless => {
+                        if let Some(symbol) = self.first_symbol_for(*alternative, policy)
+                            && self.remove(symbol, 1)
+                        {
+                            paid = true;
+                            break;
+                        }
+                        if *alternative == ManaSymbol::Black && is_singleton_black_with_life {
+                            life_to_pay += 2;
+                            paid = true;
+                            break;
+                        }
+                    }
+                    ManaSymbol::Generic(n) => {
+                        let needed = *n as u32;
+                        if self.total() >= needed {
+                            self.pay_generic(needed);
+                            paid = true;
+                            break;
+                        }
+                    }
+                    ManaSymbol::X => {
+                        if self.total() >= x_value {
+                            self.pay_generic(x_value);
+                            paid = true;
+                            break;
+                        }
+                    }
+                    ManaSymbol::Snow => {
+                        if self.total() > 0 {
+                            self.pay_generic(1);
+                            paid = true;
+                            break;
+                        }
+                    }
+                    ManaSymbol::Life(amount) => {
+                        life_to_pay += *amount as u32;
+                        paid = true;
+                        break;
+                    }
+                }
+            }
+
+            if !paid {
+                return (false, 0);
+            }
+        }
+
+        (true, life_to_pay)
+    }
+
+    fn first_symbol_for(
+        &self,
+        required: ManaSymbol,
+        policy: &ManaSpendPolicy,
+    ) -> Option<ManaSymbol> {
+        [
+            ManaSymbol::White,
+            ManaSymbol::Blue,
+            ManaSymbol::Black,
+            ManaSymbol::Red,
+            ManaSymbol::Green,
+            ManaSymbol::Colorless,
+        ]
+        .into_iter()
+        .find(|symbol| self.amount(*symbol) > 0 && policy.can_pay_symbol(*symbol, required))
+    }
+
     /// Internal payment implementation with configurable Phyrexian strategy.
     ///
     /// If `prefer_life_for_phyrexian` is true, Phyrexian pips are paid with life first.
@@ -498,84 +728,12 @@ impl ManaPool {
         allow_any_color: bool,
         allow_black_life: bool,
     ) -> u32 {
-        // First check if the non-X part of the cost can be paid
-        let mut test_pool = self.clone();
-
-        // Count how many X pips there are
-        let x_pip_count = cost
-            .pips()
-            .iter()
-            .filter(|pip| pip.iter().any(|s| matches!(s, ManaSymbol::X)))
-            .count() as u32;
-
-        if x_pip_count == 0 {
-            // No X in cost, X is 0
-            return 0;
-        }
-
-        // Pay non-X costs first to see what's left
-        // For max_x calculation, prefer life payment over mana to preserve mana for X
-        for pip in cost.pips() {
-            let is_x_pip = pip.iter().any(|s| matches!(s, ManaSymbol::X));
-            if is_x_pip {
-                continue; // Skip X pips for now
-            }
-
-            // First check if there's a life payment option - prefer it to save mana for X
-            let has_life_option = pip.iter().any(|s| matches!(s, ManaSymbol::Life(_)))
-                || Self::singleton_black_pip_with_life_option(pip, allow_black_life);
-            if has_life_option {
-                continue; // Can pay with life, preserving mana for X
-            }
-
-            let mut paid = false;
-            for alternative in pip {
-                match alternative {
-                    ManaSymbol::White
-                    | ManaSymbol::Blue
-                    | ManaSymbol::Black
-                    | ManaSymbol::Red
-                    | ManaSymbol::Green => {
-                        if allow_any_color {
-                            if test_pool.total() > 0 {
-                                test_pool.pay_generic(1);
-                                paid = true;
-                                break;
-                            }
-                        } else if test_pool.amount(*alternative) > 0 {
-                            test_pool.remove(*alternative, 1);
-                            paid = true;
-                            break;
-                        }
-                    }
-                    ManaSymbol::Colorless => {
-                        if test_pool.colorless > 0 {
-                            test_pool.colorless -= 1;
-                            paid = true;
-                            break;
-                        }
-                    }
-                    ManaSymbol::Generic(n) => {
-                        let needed = *n as u32;
-                        if test_pool.total() >= needed {
-                            test_pool.pay_generic(needed);
-                            paid = true;
-                            break;
-                        }
-                    }
-                    ManaSymbol::Snow | ManaSymbol::Life(_) | ManaSymbol::X => {
-                        paid = true;
-                        break;
-                    }
-                }
-            }
-            if !paid {
-                return 0; // Can't even pay the base cost
-            }
-        }
-
-        // Remaining mana can all go to X (divided by number of X pips, but usually 1)
-        test_pool.total() / x_pip_count
+        let policy = ManaSpendPolicy::from_any_color(allow_any_color);
+        self.max_x_for_cost_with_mana_spend_policy_and_black_life(
+            cost,
+            &policy,
+            allow_black_life,
+        )
     }
 
     fn singleton_black_pip_with_life_option(pip: &[ManaSymbol], allow_black_life: bool) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Celestial Dawn
Initial parse error:
```
parser does not yet support line family: 'You may spend white mana as though it were mana of any color. You may spend other mana only as though it were colorless mana.'; oracle-only fallback also failed: parser does not yet support line family: 'You may spend white mana as though it were mana of any color. You may spend other mana only as though it were colorless mana.'
```

Current worker: i-0515f32ca9803e972
Branch: codex/aws-card-fix-celestial-dawn
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0037
