### PR TITLE
Fix Ironsmith parse failure: Last Night Together

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -76,6 +76,30 @@ mod next_turn_cant;
 type ClauseDispatchCompatWords<'a> = TokenWordView<'a>;
 
 const PREVENT_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["prevent"]);
+const ONLY_CHOSEN_CREATURES_CAN_ATTACK_DURING_THAT_COMBAT_PHASE_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any
+        &[
+            &[
+                "only", "the", "chosen", "creatures", "can", "attack", "during", "that",
+                "combat", "phase",
+            ],
+            &[
+                "only", "chosen", "creatures", "can", "attack", "during", "that", "combat",
+                "phase",
+            ],
+        ]);
+const ONLY_CHOSEN_CREATURES_CAN_BLOCK_DURING_THAT_COMBAT_PHASE_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any
+        &[
+            &[
+                "only", "the", "chosen", "creatures", "can", "block", "during", "that",
+                "combat", "phase",
+            ],
+            &[
+                "only", "chosen", "creatures", "can", "block", "during", "that", "combat",
+                "phase",
+            ],
+        ]);
 const CONTROL_PLAYER_SUBJECT_PATTERNS: &[&[&str]] = &[
     &["you"],
     &["that", "player"],
@@ -1322,6 +1346,28 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         return Ok(EffectAst::subject_verb_emit_keyword_action(
             crate::events::KeywordActionKind::ChaosEnsues,
             1,
+        ));
+    }
+
+    if ONLY_CHOSEN_CREATURES_CAN_ATTACK_DURING_THAT_COMBAT_PHASE_PATTERN.matches_words(&clause_words)
+    {
+        return Ok(EffectAst::subject_verb_cant(
+            crate::effect::Restriction::attack(
+                ObjectFilter::creature().not_tagged(TagKey::from(IT_TAG)),
+            ),
+            Until::EndOfCombat,
+            None,
+        ));
+    }
+
+    if ONLY_CHOSEN_CREATURES_CAN_BLOCK_DURING_THAT_COMBAT_PHASE_PATTERN.matches_words(&clause_words)
+    {
+        return Ok(EffectAst::subject_verb_cant(
+            crate::effect::Restriction::block(
+                ObjectFilter::creature().not_tagged(TagKey::from(IT_TAG)),
+            ),
+            Until::EndOfCombat,
+            None,
         ));
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57118,6 +57118,153 @@ fn parse_full_throttle_two_additional_combats() {
 }
 
 #[test]
+fn last_night_together_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Last Night Together");
+
+    let def = parse_oracle_card_definition("Last Night Together");
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.spell_effect);
+
+    assert!(
+        rendered.contains("Choose two target creatures")
+            && rendered.contains("Put two +1/+1 counters on each of them")
+            && rendered.contains("They gain vigilance, indestructible, and haste until end of turn")
+            && rendered.contains("After this main phase, there is an additional combat phase")
+            && rendered.contains("Only the chosen creatures can attack during that combat phase"),
+        "expected Last Night Together compiled text to preserve the full chosen-creature combat restriction, got {rendered}"
+    );
+    assert!(
+        debug.contains("AdditionalPhasesEffect")
+            && debug.contains("CantEffect")
+            && debug.contains("EndOfCombat"),
+        "expected Last Night Together to lower to additional combat plus end-of-combat attack restriction, got {debug}"
+    );
+}
+
+#[test]
+fn last_night_together_runtime_limits_attackers_to_chosen_creatures_for_that_combat() {
+    let def = parse_oracle_card_definition("Last Night Together");
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let chosen_one = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(71_001), "Chosen One")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let chosen_two = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(71_002), "Chosen Two")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let unchosen = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(71_003), "Unchosen Bear")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    for creature in [chosen_one, chosen_two, unchosen] {
+        game.remove_summoning_sickness(creature);
+        game.tap(creature);
+    }
+
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Last Night Together should have a spell effect")
+        .flattened_default_effects();
+    let target_spec = effects[0]
+        .0
+        .get_target_spec()
+        .expect("Last Night Together should start with target selection")
+        .clone();
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(chosen_one),
+            crate::effects::ResolvedTarget::Object(chosen_two),
+        ])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: target_spec,
+            range: 0..2,
+        }]);
+    ctx.snapshot_targets(&game);
+
+    for effect in effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx).unwrap_or_else(|err| {
+            panic!("Last Night Together effect should resolve: {err:?}; effect={effect:?}")
+        });
+    }
+
+    assert_eq!(
+        game.turn_store.additional_phases,
+        vec![crate::game_state::Phase::Combat],
+        "Last Night Together should insert an additional combat phase"
+    );
+    for chosen in [chosen_one, chosen_two] {
+        assert!(!game.is_tapped(chosen), "chosen creatures should be untapped");
+        assert_eq!(
+            game.counter_count(chosen, crate::object::CounterType::PlusOnePlusOne),
+            2,
+            "chosen creatures should get two +1/+1 counters"
+        );
+        assert!(game.object_has_static_ability_id(chosen, StaticAbilityId::Vigilance));
+        assert!(game.object_has_static_ability_id(chosen, StaticAbilityId::Indestructible));
+        assert!(game.object_has_static_ability_id(chosen, StaticAbilityId::Haste));
+        assert!(game.can_attack(chosen), "chosen creatures should be allowed to attack");
+    }
+    assert!(
+        !game.can_attack(unchosen),
+        "unchosen creatures should be prohibited from attacking during that combat"
+    );
+
+    crate::turn::advance_phase(&mut game).expect("advance to the inserted combat phase");
+    assert_eq!(game.turn.phase, crate::game_state::Phase::Combat);
+    assert!(!game.can_attack(unchosen));
+
+    let late_unchosen = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(71_004), "Late Unchosen Bear")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.remove_summoning_sickness(late_unchosen);
+    game.update_cant_effects();
+    assert!(
+        !game.can_attack(late_unchosen),
+        "creatures that enter before that combat are still not chosen and cannot attack"
+    );
+
+    game.turn.step = None;
+    crate::turn::advance_phase(&mut game).expect("advance out of the restricted combat phase");
+    game.update_cant_effects();
+    assert!(
+        game.can_attack(unchosen),
+        "the chosen-creatures-only restriction should expire after that combat phase"
+    );
+    assert!(
+        game.can_attack(late_unchosen),
+        "late unchosen creatures should be able to attack after the restricted combat ends"
+    );
+}
+
+#[test]
 fn parse_must_be_blocked_each_combat_this_turn_if_able() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Must Be Blocked Variant")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14503,6 +14503,30 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             continue;
         }
         if idx + 1 < filtered.len()
+            && let Some(for_each) = filtered[idx].downcast_ref::<crate::effects::ForEachObject>()
+            && let Some(tagged) = filtered[idx + 1].downcast_ref::<crate::effects::TaggedEffect>()
+            && let Some(compact) =
+                describe_for_each_chosen_put_counters_then_gain_keywords(for_each, tagged)
+        {
+            parts.push(compact);
+            idx += 2;
+            continue;
+        }
+        if idx + 1 < filtered.len()
+            && let Some(additional_phases) = filtered[idx]
+                .downcast_ref::<crate::effects::AdditionalPhasesEffect>()
+            && let Some(cant) = filtered[idx + 1].downcast_ref::<crate::effects::CantEffect>()
+            && let Some(compact) =
+                describe_additional_combat_then_chosen_attack_or_block_restriction(
+                    additional_phases,
+                    cant,
+                )
+        {
+            parts.push(compact);
+            idx += 2;
+            continue;
+        }
+        if idx + 1 < filtered.len()
             && let Some(tagged) = filtered[idx].downcast_ref::<crate::effects::TaggedEffect>()
             && let Some(cant) = filtered[idx + 1].downcast_ref::<crate::effects::CantEffect>()
             && let Some(compact) = describe_tagged_target_then_cant_restriction(tagged, cant)
@@ -21003,6 +21027,114 @@ pub(super) fn describe_choose_then_cant_pile_restriction(
         }
     };
     Some(sentence)
+}
+
+pub(super) fn describe_additional_combat_then_chosen_attack_or_block_restriction(
+    additional_phases: &crate::effects::AdditionalPhasesEffect,
+    cant: &crate::effects::CantEffect,
+) -> Option<String> {
+    if additional_phases.phases != [crate::effects::AdditionalPhase::Combat]
+        || cant.duration != crate::effect::Until::EndOfCombat
+    {
+        return None;
+    }
+
+    let (filter, verb) = match &cant.restriction {
+        crate::effect::Restriction::Attack(filter) => (filter, "attack"),
+        crate::effect::Restriction::Block(filter) => (filter, "block"),
+        _ => return None,
+    };
+    let references_chosen_tag = filter.tagged_constraints.iter().all(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::IsNotTaggedObject
+    }) && filter.tagged_constraints.iter().any(|constraint| {
+        let tag = constraint.tag.as_str();
+        matches!(tag, "__it__" | "it")
+            || tag.starts_with("targeted_")
+            || tag.starts_with("untapped_")
+    });
+    if !references_chosen_tag {
+        return None;
+    }
+    let mut base_filter = filter.clone();
+    base_filter.tagged_constraints.clear();
+    if base_filter != ObjectFilter::creature() {
+        return None;
+    }
+
+    Some(format!(
+        "After this main phase, there is an additional combat phase. Only the chosen creatures can {verb} during that combat phase"
+    ))
+}
+
+pub(super) fn describe_for_each_chosen_put_counters_then_gain_keywords(
+    for_each: &crate::effects::ForEachObject,
+    tagged: &crate::effects::TaggedEffect,
+) -> Option<String> {
+    let tag = for_each.filter.tagged_constraints.iter().find_map(|constraint| {
+        (constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject)
+            .then_some(&constraint.tag)
+    })?;
+    let [put_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let put = put_effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if !matches!(put.target, ChooseSpec::Iterated) || put.target_count.is_some() || put.distributed
+    {
+        return None;
+    }
+
+    let apply = tagged
+        .effect
+        .downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if apply.until != crate::effect::Until::EndOfTurn
+        || apply.condition.is_some()
+        || !apply.runtime_modifications.is_empty()
+        || !matches!(apply.target_spec.as_ref(), Some(ChooseSpec::Tagged(found)) if found == tag)
+    {
+        return None;
+    }
+
+    fn keyword_label(ability: &crate::static_abilities::StaticAbility) -> Option<String> {
+        Some(
+            match ability.id() {
+                crate::static_abilities::StaticAbilityId::Flying => "flying",
+                crate::static_abilities::StaticAbilityId::FirstStrike => "first strike",
+                crate::static_abilities::StaticAbilityId::DoubleStrike => "double strike",
+                crate::static_abilities::StaticAbilityId::Deathtouch => "deathtouch",
+                crate::static_abilities::StaticAbilityId::Haste => "haste",
+                crate::static_abilities::StaticAbilityId::Hexproof => "hexproof",
+                crate::static_abilities::StaticAbilityId::Indestructible => "indestructible",
+                crate::static_abilities::StaticAbilityId::Lifelink => "lifelink",
+                crate::static_abilities::StaticAbilityId::Menace => "menace",
+                crate::static_abilities::StaticAbilityId::Reach => "reach",
+                crate::static_abilities::StaticAbilityId::Trample => "trample",
+                crate::static_abilities::StaticAbilityId::Vigilance => "vigilance",
+                _ => return None,
+            }
+            .to_string(),
+        )
+    }
+
+    let mut keywords = Vec::new();
+    let Some(crate::continuous::Modification::AddAbility(ability)) = &apply.modification else {
+        return None;
+    };
+    keywords.push(keyword_label(ability)?);
+    for modification in &apply.additional_modifications {
+        let crate::continuous::Modification::AddAbility(ability) = modification else {
+            return None;
+        };
+        keywords.push(keyword_label(ability)?);
+    }
+    if keywords.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "Put {} on each of them. They gain {} until end of turn",
+        describe_put_counter_phrase(&put.amount, put.counter_type),
+        join_with_and(&keywords),
+    ))
 }
 
 pub(super) fn describe_tagged_target_then_cant_restriction(

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -813,24 +813,51 @@ pub(crate) trait RestrictionExt {
         controller: crate::ids::PlayerId,
         source: Option<crate::ids::ObjectId>,
         iterated_player: Option<crate::ids::PlayerId>,
-    );
-}
+    ) {
+        self.apply_with_tagged_objects(
+            game,
+            tracker,
+            controller,
+            source,
+            iterated_player,
+            &std::collections::HashMap::new(),
+        );
+    }
 
-impl RestrictionExt for Restriction {
-    fn apply(
+    fn apply_with_tagged_objects(
         &self,
         game: &mut crate::game_state::GameState,
         tracker: &mut crate::game_state::CantEffectTracker,
         controller: crate::ids::PlayerId,
         source: Option<crate::ids::ObjectId>,
         iterated_player: Option<crate::ids::PlayerId>,
+        tagged_objects: &std::collections::HashMap<
+            TagKey,
+            Vec<crate::snapshot::ObjectSnapshot>,
+        >,
+    );
+}
+
+impl RestrictionExt for Restriction {
+    fn apply_with_tagged_objects(
+        &self,
+        game: &mut crate::game_state::GameState,
+        tracker: &mut crate::game_state::CantEffectTracker,
+        controller: crate::ids::PlayerId,
+        source: Option<crate::ids::ObjectId>,
+        iterated_player: Option<crate::ids::PlayerId>,
+        tagged_objects: &std::collections::HashMap<
+            TagKey,
+            Vec<crate::snapshot::ObjectSnapshot>,
+        >,
     ) {
         use crate::game_loop::player_matches_filter_with_combat;
 
         let combat = game.combat.as_ref();
         let ctx = game
             .filter_context_for_combat(controller, source, None, None)
-            .with_iterated_player(iterated_player);
+            .with_iterated_player(iterated_player)
+            .with_tagged_objects(tagged_objects);
         let player_matches_restriction_filter =
             |player_id, filter: &crate::target::PlayerFilter| {
                 filter.matches_player(player_id, &ctx)

--- a/crates/ironsmith-runtime/src/effects/composition/tag_matching_objects.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/tag_matching_objects.rs
@@ -20,6 +20,9 @@ fn effect_zones(effect: &TagMatchingObjectsEffect) -> Vec<Zone> {
             zones.push(*zone);
         }
     }
+    if zones.is_empty() {
+        zones.push(Zone::Battlefield);
+    }
     zones
 }
 
@@ -126,5 +129,34 @@ mod tests {
             .get_tagged_all("matched")
             .expect("tagged snapshots should be stored");
         assert_eq!(tagged.len(), 2);
+    }
+
+    #[test]
+    fn tags_matching_objects_on_battlefield_when_no_zone_is_specified() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let creature_id = game.create_object_from_card(
+            &make_card("Battlefield Bear"),
+            alice,
+            Zone::Battlefield,
+        );
+
+        let source = game.new_object_id();
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let effect = TagMatchingObjectsEffect::new(ObjectFilter::creature(), "matched");
+
+        let outcome = effect
+            .execute(&mut game, &mut ctx)
+            .expect("effect resolves");
+        let crate::effect::OutcomeValue::Objects(ids) = outcome.value else {
+            panic!("expected tagged object ids");
+        };
+        assert_eq!(ids, vec![creature_id]);
+
+        let tagged = ctx
+            .get_tagged_all("matched")
+            .expect("tagged snapshots should be stored");
+        assert_eq!(tagged.len(), 1);
+        assert_eq!(tagged[0].object_id, creature_id);
     }
 }

--- a/crates/ironsmith-runtime/src/effects/restrictions.rs
+++ b/crates/ironsmith-runtime/src/effects/restrictions.rs
@@ -122,6 +122,12 @@ fn collapse_filter_to_current_matching_objects(
     }
 }
 
+fn filter_has_not_tagged_constraint(filter: &ObjectFilter) -> bool {
+    filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::IsNotTaggedObject
+    })
+}
+
 fn normalize_restriction_for_resolution(
     restriction: &Restriction,
     ctx: &ExecutionContext,
@@ -137,18 +143,24 @@ fn normalize_restriction_for_resolution(
         Restriction::MustBeBlocked(filter) => Restriction::must_be_blocked(
             collapse_filter_to_current_matching_objects(filter, ctx, game),
         ),
-        Restriction::Attack(filter) => Restriction::attack(
-            collapse_filter_to_current_matching_objects(filter, ctx, game),
-        ),
+        Restriction::Attack(filter) if filter_has_not_tagged_constraint(filter) => {
+            Restriction::attack(filter.clone())
+        }
+        Restriction::Attack(filter) => {
+            Restriction::attack(collapse_filter_to_current_matching_objects(filter, ctx, game))
+        }
         Restriction::AttackPlayerOrPlaneswalkersControlledBy { attackers, player } => {
             Restriction::attack_player_or_planeswalkers_controlled_by(
                 collapse_filter_to_current_matching_objects(attackers, ctx, game),
                 player.clone(),
             )
         }
-        Restriction::Block(filter) => Restriction::block(
-            collapse_filter_to_current_matching_objects(filter, ctx, game),
-        ),
+        Restriction::Block(filter) if filter_has_not_tagged_constraint(filter) => {
+            Restriction::block(filter.clone())
+        }
+        Restriction::Block(filter) => {
+            Restriction::block(collapse_filter_to_current_matching_objects(filter, ctx, game))
+        }
         _ => restriction.clone(),
     }
 }
@@ -198,12 +210,13 @@ impl EffectExecutor for CantEffect {
                 );
             }
         } else {
-            game.add_restriction_effect(
+            game.add_restriction_effect_with_tagged_objects(
                 restriction,
                 self.duration.clone(),
                 ctx.source,
                 ctx.controller,
                 ctx.iteration.iterated_player,
+                ctx.tagged_objects.clone(),
             );
         }
         game.update_cant_effects();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -692,6 +692,7 @@ pub struct RestrictionEffectInstance {
     pub controller: PlayerId,
     pub source: ObjectId,
     pub iterated_player: Option<PlayerId>,
+    pub tagged_objects: HashMap<crate::tag::TagKey, Vec<ObjectSnapshot>>,
     pub duration: crate::effect::Until,
     pub expires_end_of_turn: u32,
     pub consumed_next_untap: bool,
@@ -2727,6 +2728,25 @@ impl GameState {
         controller: PlayerId,
         iterated_player: Option<PlayerId>,
     ) {
+        self.add_restriction_effect_with_tagged_objects(
+            restriction,
+            duration,
+            source,
+            controller,
+            iterated_player,
+            HashMap::new(),
+        );
+    }
+
+    pub fn add_restriction_effect_with_tagged_objects(
+        &mut self,
+        restriction: crate::effect::Restriction,
+        duration: crate::effect::Until,
+        source: ObjectId,
+        controller: PlayerId,
+        iterated_player: Option<PlayerId>,
+        tagged_objects: HashMap<crate::tag::TagKey, Vec<ObjectSnapshot>>,
+    ) {
         let expires_end_of_turn = match duration {
             crate::effect::Until::EndOfTurn => self.turn.turn_number,
             crate::effect::Until::Forever => u32::MAX,
@@ -2740,6 +2760,7 @@ impl GameState {
                 controller,
                 source,
                 iterated_player,
+                tagged_objects,
                 duration,
                 expires_end_of_turn,
                 consumed_next_untap: false,
@@ -3015,6 +3036,12 @@ impl GameState {
             !matches!(effect.duration, crate::effect::Until::EndOfTurn)
                 || effect.expires_end_of_turn > current_turn
         });
+    }
+
+    pub fn cleanup_restrictions_end_of_combat(&mut self) {
+        self.effect_store
+            .restriction_effects
+            .retain(|effect| !matches!(effect.duration, crate::effect::Until::EndOfCombat));
     }
 
     pub fn cleanup_granted_mana_abilities_end_of_turn(&mut self) {
@@ -6053,12 +6080,13 @@ impl GameState {
 
         let mut restriction_tracker = CantEffectTracker::default();
         for effect in active_restrictions {
-            effect.restriction.apply(
+            effect.restriction.apply_with_tagged_objects(
                 self,
                 &mut restriction_tracker,
                 effect.controller,
                 Some(effect.source),
                 effect.iterated_player,
+                &effect.tagged_objects,
             );
         }
         self.effect_store.cant_effects.merge(restriction_tracker);

--- a/crates/ironsmith-runtime/src/turn.rs
+++ b/crates/ironsmith-runtime/src/turn.rs
@@ -167,6 +167,7 @@ pub fn advance_phase(game: &mut GameState) -> Result<(), TurnError> {
     }
 
     let current_phase = game.turn.phase;
+    let leaving_combat = matches!(current_phase, Phase::Combat);
 
     if let Some(mut next) = if !game.turn_store.additional_phases.is_empty() {
         Some(game.turn_store.additional_phases.remove(0))
@@ -203,6 +204,9 @@ pub fn advance_phase(game: &mut GameState) -> Result<(), TurnError> {
         {
             next = Phase::NextMain;
         }
+        if leaving_combat {
+            game.cleanup_restrictions_end_of_combat();
+        }
         game.turn.phase = next;
         if matches!(next, Phase::Combat) {
             game.mark_combat_phase_started();
@@ -211,6 +215,9 @@ pub fn advance_phase(game: &mut GameState) -> Result<(), TurnError> {
         game.turn.priority_player = Some(game.turn.active_player);
         Ok(())
     } else {
+        if leaving_combat {
+            game.cleanup_restrictions_end_of_combat();
+        }
         // End of turn - advance to next player
         game.next_turn();
         Ok(())

--- a/crates/ironsmith-runtime/src/turn_runner.rs
+++ b/crates/ironsmith-runtime/src/turn_runner.rs
@@ -1149,6 +1149,10 @@ fn check_first_strike(game: &GameState, combat: &CombatState) -> bool {
 }
 
 fn next_runner_state_after_phase(game: &mut GameState, normal_next: TurnState) -> TurnState {
+    if matches!(game.turn.phase, Phase::Combat) {
+        game.cleanup_restrictions_end_of_combat();
+    }
+
     let next_phase = if !game.turn_store.additional_phases.is_empty() {
         Some(game.turn_store.additional_phases.remove(0))
     } else if game.turn_store.additional_phase_continuation.is_some() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Last Night Together
Initial parse error:
```
could not find verb in effect clause (clause: 'only the chosen creatures can attack during that combat phase'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'only the chosen creatures can attack during that combat phase'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-015b0f240d8152c14
Branch: codex/aws-card-fix-last-night-together
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0037
