### PR TITLE
Fix Ironsmith parse failure: Boss's Chauffeur

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -6,7 +6,7 @@ use crate::cards::builders::{
 use crate::color::ColorSet;
 use crate::effect::{EventValueSpec, Value};
 use crate::static_abilities::{Anthem, AnthemCountExpression, AnthemValue, StaticAbility};
-use crate::target::{ObjectFilter, PlayerFilter};
+use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype, Supertype};
 use crate::zone::Zone;
 use ironsmith_core::ValueSurfaceHint;
@@ -22,8 +22,9 @@ use super::super::token_primitives::{
     find_index as find_token_index, str_split_once_char, str_starts_with_char,
 };
 use super::super::util::{
-    is_article, parse_card_type, parse_color, parse_number, parse_subtype_flexible,
-    parse_target_phrase, parse_value, token_index_for_word_index, trim_commas,
+    is_article, parse_card_type, parse_color, parse_counter_type_word, parse_number,
+    parse_subtype_flexible, parse_target_phrase, parse_value, source_choose_spec_for_surface,
+    source_reference_surface_for_words, token_index_for_word_index, trim_commas,
     value_contains_unbound_x,
 };
 use super::clause_pattern_helpers::{ClauseShape, clause_shape, extract_subject_player};
@@ -178,6 +179,25 @@ const CREATE_TOKEN_OR_TOKENS_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["token"], &["tokens"]]);
 const CREATE_FOR_EACH_WORDS: &[&str] = &["for", "each"];
 const CREATE_FOR_EACH_PATTERN: ClauseShape<'static> = clause_shape!(exact & CREATE_FOR_EACH_WORDS);
+const CREATE_COUNTER_OR_COUNTERS_WORD_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["counter"], &["counters"]]);
+const CREATE_SOURCE_COUNTER_LEADING_WORD_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["a"], &["an"], &["one"], &["another"]]);
+const CREATE_ON_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["on"]);
+const CREATE_SOURCE_COUNTER_REFERENCE_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["it"],
+            &["this"],
+            &["this", "card"],
+            &["this", "creature"],
+            &["this", "permanent"],
+            &["this", "source"],
+            &["this", "artifact"],
+            &["this", "land"],
+            &["this", "enchantment"],
+        ]
+);
 const CREATE_TOKEN_GETS_FOR_EACH_WORDS: &[&str] =
     &["this", "token", "gets", "+1/+1", "for", "each"];
 const CREATE_TOKEN_GETS_FOR_EACH_PATTERN: ClauseShape<'static> =
@@ -1302,7 +1322,54 @@ fn parse_create_for_each_player_condition(
     Ok(Some((filter, predicate)))
 }
 
+fn parse_create_for_each_counter_count(tokens: &[OwnedLexToken]) -> Option<Value> {
+    let words = token_word_refs(tokens);
+    let mut idx = 0usize;
+    if words
+        .get(idx)
+        .is_some_and(|word| CREATE_SOURCE_COUNTER_LEADING_WORD_PATTERN.matches_word(word))
+    {
+        idx += 1;
+    }
+
+    let counter_type = words
+        .get(idx)
+        .and_then(|word| parse_counter_type_word(word));
+    if counter_type.is_some() {
+        idx += 1;
+    }
+
+    if !words
+        .get(idx)
+        .is_some_and(|word| CREATE_COUNTER_OR_COUNTERS_WORD_PATTERN.matches_word(word))
+        || !words
+            .get(idx + 1)
+            .is_some_and(|word| CREATE_ON_WORD_PATTERN.matches_word(word))
+    {
+        return None;
+    }
+
+    let reference = &words[idx + 2..];
+    if CREATE_SOURCE_COUNTER_REFERENCE_PATTERN.matches_words(reference) {
+        return Some(match counter_type {
+            Some(counter_type) => Value::CountersOnSource(counter_type),
+            None => Value::CountersOn(Box::new(ChooseSpec::Source), None),
+        });
+    }
+
+    source_reference_surface_for_words(reference).map(|surface| {
+        Value::CountersOn(
+            Box::new(source_choose_spec_for_surface(surface)),
+            counter_type,
+        )
+    })
+}
+
 pub(crate) fn parse_create_for_each_dynamic_count(tokens: &[OwnedLexToken]) -> Option<Value> {
+    if let Some(value) = parse_create_for_each_counter_count(tokens) {
+        return Some(value.with_surface_hint(ValueSurfaceHint::ForEach));
+    }
+
     if grammar::words_match_any_prefix(
         tokens,
         &[

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -143,6 +143,31 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Boss's Chauffeur");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains(
+            "This creature enters with a number of +1/+1 counters on it equal to one plus the number of other creatures you control."
+        ),
+        "Boss's Chauffeur should render the equal-to ETB counter count, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature."
+        ),
+        "Boss's Chauffeur should render its Alliance trigger, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "When this creature dies, create a 1/1 green and white Citizen creature token for each +1/+1 counter on it."
+        ),
+        "Boss's Chauffeur should render token creation for each +1/+1 counter on it, got {rendered}"
+    );
+}
+
+#[test]
 fn commander_liara_portyr_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Commander Liara Portyr");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -21922,6 +21922,16 @@ pub(super) fn describe_create_for_each_count(value: &Value) -> Option<String> {
         }
         Value::CreaturesDiedThisTurn => Some("creature that died this turn".to_string()),
         Value::SourceRegeneratedThisTurnCount => Some("time it regenerated this turn".to_string()),
+        Value::CountersOnSource(counter_type) => Some(format!(
+            "{} counter on it",
+            describe_counter_type(*counter_type)
+        )),
+        Value::CountersOn(spec, Some(counter_type)) => Some(format!(
+            "{} counter on {}",
+            describe_counter_type(*counter_type),
+            describe_choose_spec(spec)
+        )),
+        Value::CountersOn(spec, None) => Some(format!("counter on {}", describe_choose_spec(spec))),
         _ => None,
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -20462,6 +20462,194 @@ fn parsed_dies_token_count_uses_source_lki_after_prior_counter_trigger() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn boss_s_chauffeur_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(671_495), "Boss's Chauffeur")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf, Subtype::Citizen])
+        .power_toughness(PowerToughness::fixed(0, 0))
+        .parse_text(
+            "This creature enters with a number of +1/+1 counters on it equal to one plus the number of other creatures you control.\n\
+             Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature.\n\
+             When this creature dies, create a 1/1 green and white Citizen creature token for each +1/+1 counter on it.",
+        )
+        .expect("Boss's Chauffeur should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn plus_one_counters(game: &GameState, object_id: ObjectId) -> u32 {
+    game.object(object_id)
+        .expect("object should exist")
+        .counters
+        .get(&crate::object::CounterType::PlusOnePlusOne)
+        .copied()
+        .unwrap_or(0)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn citizen_token_count(game: &GameState) -> usize {
+    game.battlefield
+        .iter()
+        .filter(|id| game.object(**id).is_some_and(|object| object.name == "Citizen"))
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_boss_s_chauffeur_onto_battlefield(
+    game: &mut GameState,
+    definition: &crate::cards::CardDefinition,
+    controller: PlayerId,
+) -> ObjectId {
+    let object_id = game.create_object_from_definition(definition, controller, Zone::Hand);
+    game.move_object_with_etb_processing(object_id, Zone::Battlefield)
+        .expect("Boss's Chauffeur should move onto the battlefield")
+        .new_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_plain_creature_onto_battlefield(
+    game: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let object_id = game.create_object_from_card(&card, controller, Zone::Hand);
+    game.move_object_with_etb_processing(object_id, Zone::Battlefield)
+        .expect("test creature should move onto the battlefield")
+        .new_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn boss_s_chauffeur_enters_with_one_plus_other_creatures_you_control() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let chauffeur = boss_s_chauffeur_definition();
+
+    create_creature(&mut game, "Alice Creature One", alice, 2, 2);
+    create_creature(&mut game, "Alice Creature Two", alice, 2, 2);
+    create_creature(&mut game, "Bob Creature", bob, 2, 2);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("no Boss's Chauffeur triggers should exist before it enters");
+    assert!(game.stack_is_empty());
+
+    let chauffeur_id = put_boss_s_chauffeur_onto_battlefield(&mut game, &chauffeur, alice);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Boss's Chauffeur should not trigger on itself entering");
+
+    assert!(
+        game.stack_is_empty(),
+        "Boss's Chauffeur's Alliance trigger should not count its own enter event"
+    );
+    assert_eq!(
+        plus_one_counters(&game, chauffeur_id),
+        3,
+        "Boss's Chauffeur should enter with one plus Alice's two other creatures, ignoring itself and Bob's creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn boss_s_chauffeur_alliance_triggers_only_for_another_creature_you_control() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let chauffeur = boss_s_chauffeur_definition();
+    let chauffeur_id = put_boss_s_chauffeur_onto_battlefield(&mut game, &chauffeur, alice);
+
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Boss's Chauffeur should not trigger on itself entering");
+    assert!(game.stack_is_empty());
+    assert_eq!(plus_one_counters(&game, chauffeur_id), 1);
+
+    put_plain_creature_onto_battlefield(&mut game, "Opponent Creature", bob);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("opponent creature enter should not create an Alliance trigger");
+    assert!(
+        game.stack_is_empty(),
+        "Boss's Chauffeur should not trigger for a creature an opponent controls"
+    );
+    assert_eq!(plus_one_counters(&game, chauffeur_id), 1);
+
+    put_plain_creature_onto_battlefield(&mut game, "Alice Followup Creature", alice);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Alice's other creature should create an Alliance trigger");
+    assert!(
+        !game.stack_is_empty(),
+        "Boss's Chauffeur should trigger for another creature Alice controls"
+    );
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("Alliance trigger should resolve");
+    }
+
+    assert_eq!(
+        plus_one_counters(&game, chauffeur_id),
+        2,
+        "Boss's Chauffeur should get one +1/+1 counter from the Alliance trigger"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn boss_s_chauffeur_dies_creates_citizens_for_each_plus_one_counter_on_it() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let chauffeur = boss_s_chauffeur_definition();
+
+    create_creature(&mut game, "Alice Creature One", alice, 2, 2);
+    create_creature(&mut game, "Alice Creature Two", alice, 2, 2);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("setup creatures should not create Boss's Chauffeur triggers");
+    assert!(game.stack_is_empty());
+
+    let chauffeur_id = put_boss_s_chauffeur_onto_battlefield(&mut game, &chauffeur, alice);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Boss's Chauffeur should not trigger on itself entering");
+    assert_eq!(plus_one_counters(&game, chauffeur_id), 3);
+
+    put_plain_creature_onto_battlefield(&mut game, "Alice Followup Creature", alice);
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Alliance trigger should stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("Alliance trigger should resolve");
+    }
+    assert_eq!(plus_one_counters(&game, chauffeur_id), 4);
+
+    game.move_object_by_effect(chauffeur_id, Zone::Graveyard)
+        .expect("Boss's Chauffeur should die");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Boss's Chauffeur dies trigger should stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("dies trigger should resolve");
+    }
+
+    assert_eq!(
+        citizen_token_count(&game),
+        4,
+        "Boss's Chauffeur should create one Citizen token for each +1/+1 counter it had using source LKI"
+    );
+}
+
 #[test]
 fn test_resolution_uses_source_lki_for_source_owner() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -122,6 +122,15 @@ fn enters_with_counters_where_x_value(count: &Value) -> Option<String> {
     prefers_where_x.then(|| describe_value(count))
 }
 
+fn describe_enters_with_counters_equal_to_value(count: &Value) -> String {
+    let value = describe_value(count);
+    if let Some(rest) = value.strip_prefix("1 plus ") {
+        format!("one plus {rest}")
+    } else {
+        value
+    }
+}
+
 fn describe_discard_filter_card_phrase(filter: &ObjectFilter) -> String {
     let mut phrase = filter.description().trim().to_string();
     if phrase.is_empty() {
@@ -1118,6 +1127,12 @@ impl StaticAbilityKind for EntersWithCounters {
         if let Some(where_x_value) = enters_with_counters_where_x_value(&self.count) {
             return format!(
                 "Enters the battlefield with X {counter} counters on it, where X is {where_x_value}"
+            );
+        }
+        if self.count.has_surface_hint(ValueSurfaceHint::EqualTo) {
+            return format!(
+                "Enters the battlefield with a number of {counter} counters on it equal to {}",
+                describe_enters_with_counters_equal_to_value(&self.count)
             );
         }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Boss's Chauffeur
Initial parse error:
```
unsupported target phrase (clause: '+1/+1 counter on it'); oracle-only fallback also failed: unsupported target phrase (clause: '+1/+1 counter on it')
```

Current worker: i-0caf5f7525779a8b3
Branch: codex/aws-card-fix-boss-s-chauffeur
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0037
