### PR TITLE
Fix Ironsmith parse failure: Grisly Sigil

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -2414,6 +2414,7 @@ pub(crate) fn object_filter_specificity_score(filter: &ObjectFilter) -> usize {
     score += usize::from(filter.entered_battlefield_this_turn) * 2;
     score += usize::from(filter.entered_battlefield_controller.is_some()) * 2;
     score += usize::from(filter.was_dealt_damage_this_turn) * 2;
+    score += usize::from(filter.was_dealt_noncombat_damage_this_turn) * 2;
     score += usize::from(filter.dealt_damage_to_player_this_turn.is_some()) * 2;
     score += usize::from(!filter.excluded_card_types.is_empty()) * 2;
     score += usize::from(!filter.excluded_supertypes.is_empty()) * 2;

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -766,6 +766,23 @@ const SOURCE_DEALT_COMBAT_DAMAGE_TO_PLAYER_THIS_TURN_PATTERN: ClauseShape<'stati
             ],
         ]
 );
+const IT_WAS_DEALT_NONCOMBAT_DAMAGE_THIS_TURN_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &[
+                "it", "was", "dealt", "noncombat", "damage", "this", "turn",
+            ],
+            &[
+                "target", "was", "dealt", "noncombat", "damage", "this", "turn",
+            ],
+            &[
+                "that", "creature", "was", "dealt", "noncombat", "damage", "this", "turn",
+            ],
+            &[
+                "that", "permanent", "was", "dealt", "noncombat", "damage", "this", "turn",
+            ],
+        ]
+);
 const PLAYER_WAS_DEALT_COMBAT_DAMAGE_BY_SUBTYPE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [
@@ -4391,6 +4408,13 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if SOURCE_DEALT_COMBAT_DAMAGE_TO_PLAYER_THIS_TURN_PATTERN.matches_words(&filtered) {
         return Ok(PredicateAst::SourceDealtCombatDamageToPlayerThisTurn);
+    }
+
+    if IT_WAS_DEALT_NONCOMBAT_DAMAGE_THIS_TURN_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::ItMatches(ObjectFilter {
+            was_dealt_noncombat_damage_this_turn: true,
+            ..Default::default()
+        }));
     }
 
     if THIS_TURN_TAIL_PATTERN.matches_words(filtered.get(filtered.len().saturating_sub(2)..).unwrap_or_default())

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -418,6 +418,7 @@ pub struct ObjectFilter {
     pub entered_graveyard_from_battlefield_this_turn: bool,
     pub surveilled_this_turn: bool,
     pub was_dealt_damage_this_turn: bool,
+    pub was_dealt_noncombat_damage_this_turn: bool,
     pub dealt_damage_to_player_this_turn: Option<PlayerFilter>,
     pub drawn_this_turn: bool,
     pub power: Option<Comparison>,
@@ -2015,6 +2016,9 @@ impl ObjectFilter {
 
         if self.was_dealt_damage_this_turn {
             parts.push("that was dealt damage this turn".to_string());
+        }
+        if self.was_dealt_noncombat_damage_this_turn {
+            parts.push("that was dealt noncombat damage this turn".to_string());
         }
         if let Some(player) = &self.dealt_damage_to_player_this_turn {
             parts.push(format!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13126,6 +13126,93 @@ fn parse_oracle_final_punishment_strictly_parses_and_renders_damage_dealt_this_t
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_grisly_sigil_strictly_parses_noncombat_damage_branch() {
+    assert_oracle_card_parses_strict("Grisly Sigil");
+
+    let def = parse_oracle_card_definition("Grisly Sigil");
+    let rendered_lines = canonical_compiled_lines(&def);
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Choose target creature or planeswalker. Then if it was dealt noncombat damage this turn, Grisly Sigil deals 3 damage to it and you gain 3 life. Otherwise, Grisly Sigil deals 1 damage to it and you gain 1 life."
+                .to_string(),
+            "Casualty 1".to_string(),
+        ],
+        "expected Grisly Sigil to render its noncombat-damage conditional branch"
+    );
+
+    let spell_effect = def
+        .spell_effect
+        .as_ref()
+        .expect("Grisly Sigil should have a spell effect");
+    let effects = spell_effect.flattened_default_effects();
+    let [target_effect, conditional_effect] = effects else {
+        panic!("expected target prelude and conditional effect, got {effects:#?}");
+    };
+
+    let target_tag = target_effect
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .expect("Grisly Sigil should tag its target");
+    let target_only = target_tag
+        .effect
+        .downcast_ref::<crate::effects::TargetOnlyEffect>()
+        .expect("Grisly Sigil should target a creature or planeswalker");
+    let crate::target::ChooseSpec::Target(inner_target) = &target_only.target else {
+        panic!("expected targeted creature-or-planeswalker spec, got {target_only:#?}");
+    };
+    let crate::target::ChooseSpec::Object(target_filter) = inner_target.as_ref() else {
+        panic!("expected object target spec, got {target_only:#?}");
+    };
+    assert!(
+        target_filter.card_types.contains(&CardType::Creature)
+            && target_filter.card_types.contains(&CardType::Planeswalker),
+        "expected Grisly Sigil to structurally target a creature or planeswalker, got {target_filter:#?}"
+    );
+
+    let conditional = conditional_effect
+        .downcast_ref::<crate::effects::ConditionalEffect>()
+        .expect("Grisly Sigil should branch on the tagged target");
+    let crate::effect::Condition::TaggedObjectMatches(_, condition_filter) = &conditional.condition
+    else {
+        panic!(
+            "expected Grisly Sigil to use a tagged-object condition, got {:#?}",
+            conditional.condition
+        );
+    };
+    assert!(
+        condition_filter.was_dealt_noncombat_damage_this_turn,
+        "expected Grisly Sigil to structurally branch on prior noncombat damage, got {condition_filter:#?}"
+    );
+
+    assert!(
+        branch_has_damage_and_life_gain(&conditional.if_true, 3)
+            && branch_has_damage_and_life_gain(&conditional.if_false, 1),
+        "expected Grisly Sigil true/false branches to deal and gain 3/1, got {conditional:#?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn branch_has_damage_and_life_gain(effects: &[Effect], amount: i32) -> bool {
+    let has_damage = effects.iter().any(|effect| {
+        effect
+            .downcast_ref::<crate::effects::TaggedEffect>()
+            .and_then(|tagged| {
+                tagged
+                    .effect
+                    .downcast_ref::<crate::effects::DealDamageEffect>()
+            })
+            .is_some_and(|damage| damage.amount == crate::effect::Value::Fixed(amount))
+    });
+    let has_life_gain = effects.iter().any(|effect| {
+        effect
+            .downcast_ref::<crate::effects::GainLifeEffect>()
+            .is_some_and(|gain| gain.amount == crate::effect::Value::Fixed(amount))
+    });
+    has_damage && has_life_gain
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_one_or_more_etb_trigger_binds_that_much_to_zone_change_count() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Artillerist Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11611,7 +11611,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::TargetMatches(filter) => {
             let desc = filter.description();
             let stripped = strip_leading_article(&desc).to_ascii_lowercase();
-            if stripped == "land" {
+            if stripped == "permanent that was dealt noncombat damage this turn" {
+                "it was dealt noncombat damage this turn".to_string()
+            } else if stripped == "land" {
                 "it's a land card".to_string()
             } else if stripped == "creature" {
                 "it's a creature".to_string()
@@ -11706,6 +11708,11 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 // Keep implicit tags oracle-like: use pronouns rather than exposing tag keys.
                 if tag.as_str() == "triggering" && is_aura_only_filter(filter) {
                     return "that enchantment is an Aura".to_string();
+                }
+                if strip_leading_article(&desc)
+                    .eq_ignore_ascii_case("permanent that was dealt noncombat damage this turn")
+                {
+                    return "it was dealt noncombat damage this turn".to_string();
                 }
                 let subject = if matches!(tag.as_str(), "triggering" | "damaged") {
                     "that object"

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14890,6 +14890,21 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
         return Some(compact);
     }
 
+    if effects.len() == 2
+        && let Some(deal) = deal_damage_effect_view(&effects[0])
+        && let Some(gain) = effects[1].downcast_ref::<crate::effects::GainLifeEffect>()
+        && deal.amount == gain.amount
+        && matches!(deal.amount, Value::Fixed(_))
+        && gain.player == ChooseSpec::Player(PlayerFilter::You)
+    {
+        let damage_clause = describe_effect(&effects[0]);
+        return Some(format!(
+            "{} and you gain {} life",
+            damage_clause.trim().trim_end_matches('.'),
+            describe_value(&gain.amount)
+        ));
+    }
+
     let compact = describe_effect_list(effects);
     let compact_trimmed = compact.trim();
     if compact_trimmed

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1724,6 +1724,12 @@ impl ObjectFilterExt for ObjectFilter {
             return false;
         }
 
+        if self.was_dealt_noncombat_damage_this_turn
+            && !game.object_was_dealt_noncombat_damage_this_turn(object.id)
+        {
+            return false;
+        }
+
         if let Some(player_filter) = &self.dealt_damage_to_player_this_turn {
             let dealt_damage_to_matching_player = game.players.iter().any(|player| {
                 player.is_in_game()
@@ -3887,6 +3893,9 @@ impl ObjectFilterExt for ObjectFilter {
 
         if self.was_dealt_damage_this_turn {
             parts.push("that was dealt damage this turn".to_string());
+        }
+        if self.was_dealt_noncombat_damage_this_turn {
+            parts.push("that was dealt noncombat damage this turn".to_string());
         }
         if let Some(player) = &self.dealt_damage_to_player_this_turn {
             parts.push(format!(

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -21011,6 +21011,29 @@ fn final_punishment_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn grisly_sigil_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(90_021), "Grisly Sigil")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Black]]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Casualty 1\n\
+             Choose target creature or planeswalker. If it was dealt noncombat damage this turn, Grisly Sigil deals 3 damage to it and you gain 3 life. Otherwise, Grisly Sigil deals 1 damage to it and you gain 1 life.",
+        )
+        .expect("Grisly Sigil should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn grisly_sigil_target_spec() -> crate::target::ChooseSpec {
+    crate::target::ChooseSpec::target(crate::target::ChooseSpec::Object(
+        crate::filter::ObjectFilter {
+            zone: Some(Zone::Battlefield),
+            card_types: vec![CardType::Creature, CardType::Planeswalker],
+            ..Default::default()
+        },
+    ))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn record_player_damage_this_turn(
     game: &mut GameState,
     source: ObjectId,
@@ -21032,6 +21055,47 @@ fn record_player_damage_this_turn(
     game.player_mut(player)
         .expect("damaged player should exist")
         .life -= amount as i32;
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn record_object_damage_this_turn(
+    game: &mut GameState,
+    source: ObjectId,
+    object: ObjectId,
+    amount: u32,
+    is_combat: bool,
+) {
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            source,
+            crate::events::DamageTarget::Object(object),
+            amount,
+            is_combat,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&event);
+    game.mark_damage(object, amount);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_grisly_sigil_on_stack(
+    game: &mut GameState,
+    caster: PlayerId,
+    target: ObjectId,
+) -> ObjectId {
+    let grisly_sigil = grisly_sigil_definition();
+    let spell_id = game.create_object_from_definition(&grisly_sigil, caster, Zone::Stack);
+    game.stack.push(
+        crate::game_state::StackEntry::new(spell_id, caster)
+            .with_targets(vec![crate::game_state::Target::Object(target)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: grisly_sigil_target_spec(),
+                range: 0..1,
+            }]),
+    );
+    spell_id
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
@@ -21109,6 +21173,58 @@ fn final_punishment_makes_target_player_lose_no_life_when_they_were_not_damaged_
         game.player(bob).expect("Bob should exist").life,
         bob_life_before,
         "Final Punishment should use the target player's damage total, not damage dealt to another player"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn grisly_sigil_deals_three_and_gains_three_if_target_had_noncombat_damage_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_creature(&mut game, "Previously Singed Creature", bob, 2, 10);
+    let damage_source = ObjectId::from_raw(90_022);
+
+    record_object_damage_this_turn(&mut game, damage_source, target, 2, false);
+    put_grisly_sigil_on_stack(&mut game, alice, target);
+
+    resolve_stack_entry(&mut game).expect("Grisly Sigil should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        23,
+        "Grisly Sigil should gain 3 life when its target had noncombat damage this turn"
+    );
+    assert_eq!(
+        game.damage_on(target),
+        5,
+        "Grisly Sigil should add 3 damage to the target after prior noncombat damage"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn grisly_sigil_deals_one_and_gains_one_if_target_only_had_combat_damage_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_creature(&mut game, "Combat-Scratched Creature", bob, 2, 10);
+    let damage_source = ObjectId::from_raw(90_023);
+
+    record_object_damage_this_turn(&mut game, damage_source, target, 2, true);
+    put_grisly_sigil_on_stack(&mut game, alice, target);
+
+    resolve_stack_entry(&mut game).expect("Grisly Sigil should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").life,
+        21,
+        "Grisly Sigil should not count prior combat damage for its condition"
+    );
+    assert_eq!(
+        game.damage_on(target),
+        3,
+        "Grisly Sigil should add only 1 damage when the target lacked prior noncombat damage"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -8186,6 +8186,13 @@ impl GameState {
             .creature_was_damaged_this_turn(creature)
     }
 
+    /// Returns true if `object` was dealt noncombat damage this turn.
+    pub fn object_was_dealt_noncombat_damage_this_turn(&self, object: ObjectId) -> bool {
+        self.turn_store
+            .turn_history
+            .object_was_dealt_noncombat_damage_this_turn(object)
+    }
+
     pub fn source_dealt_combat_damage_to_player_this_turn(&self, source: ObjectId) -> bool {
         let stable_id = self.object(source).map(|obj| obj.stable_id);
         self.turn_store

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -702,6 +702,19 @@ impl TurnHistory {
         })
     }
 
+    pub fn object_was_dealt_noncombat_damage_this_turn(&self, object: ObjectId) -> bool {
+        self.projected_records().any(|record| {
+            record
+                .event
+                .downcast::<DamageEvent>()
+                .is_some_and(|event| {
+                    !event.is_combat
+                        && matches!(event.target, crate::events::DamageTarget::Object(target) if target == object)
+                        && event.amount > 0
+                })
+        })
+    }
+
     pub fn creature_blocked_this_turn(&self, creature: ObjectId) -> bool {
         self.projected_records().any(|record| {
             record


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Grisly Sigil
Initial parse error:
```
unsupported predicate (predicate: 'it was dealt noncombat damage this turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'it was dealt noncombat damage this turn')
```

Current worker: i-0975bc22667b402ca
Branch: codex/aws-card-fix-grisly-sigil
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0038
