### PR TITLE
Fix Ironsmith parse failure: Guff Rewrites History

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -499,6 +499,98 @@ pub(crate) fn classify_statement_line_family_lexed(
         .collect::<Vec<_>>();
     if matches!(
         sentences.as_slice(),
+        [first, second, third, fourth]
+            if sentence_words_match(
+                first,
+                &[
+                    "for",
+                    "each",
+                    "player",
+                    "choose",
+                    "target",
+                    "nonenchantment",
+                    "nonland",
+                    "permanent",
+                    "that",
+                    "player",
+                    "controls",
+                ],
+            ) && sentence_words_match(
+                second,
+                &[
+                    "those",
+                    "permanents",
+                    "owners",
+                    "shuffle",
+                    "them",
+                    "into",
+                    "their",
+                    "libraries",
+                ],
+            ) && sentence_words_match(
+                third,
+                &[
+                    "each",
+                    "player",
+                    "who",
+                    "controlled",
+                    "one",
+                    "of",
+                    "those",
+                    "permanents",
+                    "exiles",
+                    "cards",
+                    "from",
+                    "the",
+                    "top",
+                    "of",
+                    "their",
+                    "library",
+                    "until",
+                    "they",
+                    "exile",
+                    "a",
+                    "nonland",
+                    "card",
+                    "then",
+                    "puts",
+                    "the",
+                    "rest",
+                    "on",
+                    "the",
+                    "bottom",
+                    "of",
+                    "their",
+                    "library",
+                    "in",
+                    "a",
+                    "random",
+                    "order",
+                ],
+            ) && sentence_words_match(
+                fourth,
+                &[
+                    "each",
+                    "player",
+                    "may",
+                    "cast",
+                    "the",
+                    "nonland",
+                    "card",
+                    "they",
+                    "exiled",
+                    "without",
+                    "paying",
+                    "its",
+                    "mana",
+                    "cost",
+                ],
+            )
+    ) {
+        return Some(StatementLineFamily::Generic);
+    }
+    if matches!(
+        sentences.as_slice(),
         [first, second, third]
             if sentence_words_match(first, &["exile", "target", "nonland", "permanent"])
                 && sentence_words_match(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -240,6 +240,19 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 filter: resolve_it_tag(filter, &refs)?,
             }
         }
+        PredicateAst::PlayerControlledTaggedObjectSnapshot {
+            player,
+            tag,
+            filter,
+        } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            let resolved_tag = resolve_it_tag_key(tag, &refs)?;
+            Condition::PlayerControlledTaggedObjectSnapshot {
+                player,
+                tag: resolved_tag,
+                filter: resolve_it_tag(filter, &refs)?,
+            }
+        }
         PredicateAst::PlayerControls { player, filter } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             let resolved = resolve_it_tag(filter, &refs)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -21,6 +21,9 @@ fn bind_explicit_tag_to_player_tagged_predicate(
     let mut bound = predicate.clone();
     if let PredicateAst::PlayerTaggedObjectMatches {
         tag: predicate_tag, ..
+    }
+    | PredicateAst::PlayerControlledTaggedObjectSnapshot {
+        tag: predicate_tag, ..
     } = &mut bound
         && predicate_tag.as_str() == IT_TAG
     {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1485,12 +1485,25 @@ fn compile_subject_verb_effect(
         SubjectVerbActionAst::ShuffleObjectsIntoLibrary { target } => {
             let (spec, mut choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
-            let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
-            for choice in subject.into_choices() {
-                push_choice(&mut choices, choice);
-            }
-            let mut effect =
-                Effect::shuffle_objects_into_library(spec.clone(), subject.into_player_filter());
+            let player_filter = if matches!(player, PlayerAst::ItsOwner | PlayerAst::ItsController)
+                && let TargetAst::Tagged(tag, _) = target
+            {
+                let resolved_tag = resolve_it_tag_key(tag, &current_reference_env(ctx))?;
+                match player {
+                    PlayerAst::ItsOwner => PlayerFilter::OwnerOf(ObjectRef::tagged(resolved_tag)),
+                    PlayerAst::ItsController => {
+                        PlayerFilter::ControllerOf(ObjectRef::tagged(resolved_tag))
+                    }
+                    _ => unreachable!(),
+                }
+            } else {
+                let subject = resolve_subject_verb_subject(role, player, ctx, true, true, true)?;
+                for choice in subject.into_choices() {
+                    push_choice(&mut choices, choice);
+                }
+                subject.into_player_filter()
+            };
+            let mut effect = Effect::shuffle_objects_into_library(spec.clone(), player_filter);
             let id = ctx.next_effect_id();
             ctx.last_effect_id = Some(id);
             effect = Effect::with_id(id.0, effect);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -317,6 +317,7 @@ pub(crate) fn effect_references_tag(effect: &EffectAst, tag: &str) -> bool {
         } => {
             matches!(predicate, PredicateAst::TaggedMatches(t, _) if t.as_str() == tag)
                 || matches!(predicate, PredicateAst::PlayerTaggedObjectMatches { tag: t, .. } if t.as_str() == tag)
+                || matches!(predicate, PredicateAst::PlayerControlledTaggedObjectSnapshot { tag: t, .. } if t.as_str() == tag)
                 || matches!(
                     predicate,
                     PredicateAst::TargetMatches(filter) if filter_references_tag(filter, tag)
@@ -1106,6 +1107,10 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
                 || matches!(
                     predicate,
                     PredicateAst::PlayerTaggedObjectMatches { tag: t, .. } if t.as_str() == IT_TAG
+                )
+                || matches!(
+                    predicate,
+                    PredicateAst::PlayerControlledTaggedObjectSnapshot { tag: t, .. } if t.as_str() == IT_TAG
                 )
                 || matches!(
                     predicate,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -399,6 +399,11 @@ pub(crate) enum PredicateAst {
         tag: TagKey,
         filter: ObjectFilter,
     },
+    PlayerControlledTaggedObjectSnapshot {
+        player: PlayerAst,
+        tag: TagKey,
+        filter: ObjectFilter,
+    },
     PlayerTaggedObjectEnteredBattlefieldThisTurn {
         player: PlayerAst,
         tag: TagKey,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -3293,7 +3293,8 @@ fn bind_unresolved_it_in_predicate(predicate: &mut PredicateAst, seed_tag: &TagK
             replacements
         }
         PredicateAst::TaggedWasCast(tag) => bind_unresolved_it_in_tag(tag, seed_tag),
-        PredicateAst::PlayerTaggedObjectMatches { tag, filter, .. } => {
+        PredicateAst::PlayerTaggedObjectMatches { tag, filter, .. }
+        | PredicateAst::PlayerControlledTaggedObjectSnapshot { tag, filter, .. } => {
             bind_unresolved_it_in_tag(tag, seed_tag)
                 + bind_unresolved_it_in_filter(filter, seed_tag)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
@@ -4,9 +4,10 @@ pub(crate) mod pairs;
 pub(crate) mod quads;
 pub(crate) mod triples;
 use crate::cards::builders::{
-    CardTextError, EffectAst, IfResultPredicate, ObjectFilter, OwnedLexToken, PlayerAst,
-    PredicateAst, ReturnControllerAst, SubjectVerbActionAst, SubjectVerbEffectAst,
-    SubjectVerbRoleAst, SubjectVerbSubjectAst, TagKey, TargetAst,
+    CardTextError, EffectAst, IfResultPredicate, LibraryBottomOrderAst, LibraryConsultModeAst,
+    LibraryConsultStopRuleAst, ObjectFilter, OwnedLexToken, PlayerAst, PredicateAst,
+    ReturnControllerAst, SubjectVerbActionAst, SubjectVerbEffectAst, SubjectVerbRoleAst,
+    SubjectVerbSubjectAst, TagKey, TargetAst, TextSpan,
 };
 use crate::effect::{EventValueSpec, Value};
 use crate::mana::ManaSymbol;
@@ -19,6 +20,7 @@ use crate::runtime_backend::util::{
     mana_pips_from_token, non_article_token_word_refs, trim_commas,
 };
 use crate::target::PlayerFilter;
+use crate::types::CardType;
 use crate::zone::Zone;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -362,6 +364,172 @@ pub(crate) fn parse_each_player_repeat_pay_life_tokens_sequence(
                     granted_abilities: Vec::new(),
                 },
             )],
+        },
+    ]))
+}
+
+pub(crate) fn parse_each_player_choose_target_shuffle_consult_cast(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let first = LexedClause::new(sentences[sentence_idx].lowered()).trimmed();
+    if first.word_refs()
+        != [
+            "for",
+            "each",
+            "player",
+            "choose",
+            "target",
+            "nonenchantment",
+            "nonland",
+            "permanent",
+            "that",
+            "player",
+            "controls",
+        ]
+    {
+        return Ok(None);
+    }
+
+    let second = LexedClause::new(sentences[sentence_idx + 1].lowered()).trimmed();
+    if second.word_refs()
+        != [
+            "those",
+            "permanents",
+            "owners",
+            "shuffle",
+            "them",
+            "into",
+            "their",
+            "libraries",
+        ]
+    {
+        return Ok(None);
+    }
+
+    let third = LexedClause::new(sentences[sentence_idx + 2].lowered()).trimmed();
+    if third.word_refs()
+        != [
+            "each",
+            "player",
+            "who",
+            "controlled",
+            "one",
+            "of",
+            "those",
+            "permanents",
+            "exiles",
+            "cards",
+            "from",
+            "the",
+            "top",
+            "of",
+            "their",
+            "library",
+            "until",
+            "they",
+            "exile",
+            "a",
+            "nonland",
+            "card",
+            "then",
+            "puts",
+            "the",
+            "rest",
+            "on",
+            "the",
+            "bottom",
+            "of",
+            "their",
+            "library",
+            "in",
+            "a",
+            "random",
+            "order",
+        ]
+    {
+        return Ok(None);
+    }
+
+    let fourth = LexedClause::new(sentences[sentence_idx + 3].lowered()).trimmed();
+    if fourth.word_refs()
+        != [
+            "each",
+            "player",
+            "may",
+            "cast",
+            "the",
+            "nonland",
+            "card",
+            "they",
+            "exiled",
+            "without",
+            "paying",
+            "its",
+            "mana",
+            "cost",
+        ]
+    {
+        return Ok(None);
+    }
+
+    let chosen_permanents_tag = TagKey::from(effect_sentences::IT_TAG);
+    let all_exiled_tag = TagKey::from("mass_polymorph_exiled_cards");
+    let nonland_exiled_tag = TagKey::from("mass_polymorph_nonland_card");
+
+    let mut target_filter = ObjectFilter::permanent().controlled_by(PlayerFilter::IteratedPlayer);
+    target_filter.excluded_card_types.push(CardType::Enchantment);
+    target_filter.excluded_card_types.push(CardType::Land);
+
+    let eligible_player = PredicateAst::PlayerTaggedObjectMatches {
+        player: PlayerAst::That,
+        tag: chosen_permanents_tag.clone(),
+        filter: ObjectFilter::default(),
+    };
+
+    Ok(Some(vec![
+        EffectAst::ForEachPlayer {
+            effects: vec![EffectAst::subject_verb_target_only(TargetAst::Object(
+                target_filter,
+                Some(TextSpan::synthetic()),
+                None,
+            ))],
+        },
+        EffectAst::subject_verb_shuffle_objects_into_library(
+            PlayerAst::ItsOwner,
+            TargetAst::Tagged(chosen_permanents_tag.clone(), None),
+        ),
+        EffectAst::ForEachPlayer {
+            effects: vec![EffectAst::Conditional {
+                predicate: eligible_player,
+                if_true: vec![
+                    EffectAst::subject_verb_consult_top_of_library(
+                        PlayerAst::That,
+                        LibraryConsultModeAst::Exile,
+                        ObjectFilter::nonland(),
+                        LibraryConsultStopRuleAst::FirstMatch,
+                        all_exiled_tag.clone(),
+                        nonland_exiled_tag.clone(),
+                    ),
+                    EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+                        all_exiled_tag,
+                        Some(nonland_exiled_tag.clone()),
+                        LibraryBottomOrderAst::Random,
+                        PlayerAst::That,
+                    ),
+                    EffectAst::May {
+                        effects: vec![EffectAst::subject_verb_cast_tagged(
+                            nonland_exiled_tag,
+                            PlayerAst::That,
+                            false,
+                            false,
+                            true,
+                            None,
+                        )],
+                    },
+                ],
+                if_false: Vec::new(),
+            }],
         },
     ]))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
@@ -481,7 +481,7 @@ pub(crate) fn parse_each_player_choose_target_shuffle_consult_cast(
     target_filter.excluded_card_types.push(CardType::Enchantment);
     target_filter.excluded_card_types.push(CardType::Land);
 
-    let eligible_player = PredicateAst::PlayerTaggedObjectMatches {
+    let eligible_player = PredicateAst::PlayerControlledTaggedObjectSnapshot {
         player: PlayerAst::That,
         tag: chosen_permanents_tag.clone(),
         filter: ObjectFilter::default(),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -137,6 +137,10 @@ fn first_word_each(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
     sentence_head_word_is(sentences, sentence_idx, "each")
 }
 
+fn first_word_each_or_for(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
+    sentence_head_word_in(sentences, sentence_idx, &["each", "for"])
+}
+
 fn first_word_target(sentences: &[SentenceInput], sentence_idx: usize) -> bool {
     sentence_head_word_is(sentences, sentence_idx, "target")
 }
@@ -219,6 +223,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         predicate: first_word_look,
         parser:
             generic_subject_verb_sequences::quads::parse_look_at_top_may_reveal_match_bargain_battlefield_else_hand_then_shuffle,
+    },
+    SequenceRuleDef {
+        name: "each-player-choose-target-shuffle-consult-cast",
+        feature_tag: Some("mass-polymorph-consult-cast"),
+        priority: 427,
+        consumed_sentences: 4,
+        predicate: first_word_each_or_for,
+        parser: generic_subject_verb_sequences::parse_each_player_choose_target_shuffle_consult_cast,
     },
     SequenceRuleDef {
         name: "choose-land-or-nonland-consult-hand-bottom",

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -825,6 +825,11 @@ pub enum Condition {
         tag: TagKey,
         filter: ObjectFilter,
     },
+    PlayerControlledTaggedObjectSnapshot {
+        player: PlayerFilter,
+        tag: TagKey,
+        filter: ObjectFilter,
+    },
     PlayerTaggedObjectEnteredBattlefieldThisTurn {
         player: PlayerFilter,
         tag: TagKey,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39668,6 +39668,139 @@ fn guff_rewrites_history_runtime_skips_player_whose_target_is_gone() {
     );
 }
 
+#[test]
+fn guff_rewrites_history_runtime_uses_previous_controller_for_stolen_permanent() {
+    fn card(name: &str, card_types: Vec<CardType>) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(card_types)
+            .build()
+    }
+
+    let def = parse_oracle_card_definition("Guff Rewrites History");
+    let spell_effect = def
+        .spell_effect
+        .clone()
+        .expect("Guff Rewrites History should have a spell effect");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    game.set_random_seed(31);
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let bob_owned_stolen_permanent = game.create_object_from_card(
+        &card("Borrowed Bob Idol", vec![CardType::Artifact]),
+        bob,
+        Zone::Battlefield,
+    );
+    game.set_current_controller(bob_owned_stolen_permanent, alice);
+    let bob_permanent = game.create_object_from_card(
+        &card("Bob Idol", vec![CardType::Artifact]),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_card(
+        &card("Alice Island", vec![CardType::Land]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Alice Free Spell", vec![CardType::Sorcery]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Bob Island", vec![CardType::Land]),
+        bob,
+        Zone::Library,
+    );
+    let bob_spell = game.create_object_from_card(
+        &card("Bob Free Spell", vec![CardType::Sorcery]),
+        bob,
+        Zone::Library,
+    );
+
+    let target_requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        &spell_effect,
+        alice,
+        Some(source),
+        None,
+    );
+    assert_eq!(target_requirements.len(), 2);
+    assert_eq!(
+        target_requirements[0].legal_targets,
+        vec![crate::game_state::Target::Object(bob_owned_stolen_permanent)],
+        "Alice should target the Bob-owned permanent she currently controls"
+    );
+    assert_eq!(
+        target_requirements[1].legal_targets,
+        vec![crate::game_state::Target::Object(bob_permanent)],
+        "Bob should target the permanent he currently controls"
+    );
+    let target_assignments = vec![
+        crate::game_state::TargetAssignment {
+            spec: target_requirements[0].spec.clone(),
+            range: 0..1,
+        },
+        crate::game_state::TargetAssignment {
+            spec: target_requirements[1].spec.clone(),
+            range: 1..2,
+        },
+    ];
+
+    game.move_object_by_effect(bob_permanent, Zone::Graveyard)
+        .expect("Bob's own target should move away before resolution");
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(bob_owned_stolen_permanent),
+            crate::effects::ResolvedTarget::Object(bob_permanent),
+        ])
+        .with_target_assignments(target_assignments.clone());
+    let events = crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &spell_effect,
+        None,
+        &target_assignments,
+    )
+    .expect("Guff Rewrites History should resolve with the stolen permanent target");
+
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "only the previous controller of the moved permanent should cast"
+    );
+    assert!(
+        game.stack.iter().any(|entry| entry.controller == alice),
+        "Alice controlled the Bob-owned permanent before it moved, so Alice should consult and cast"
+    );
+    assert!(
+        !game.stack.iter().any(|entry| entry.controller == bob),
+        "Bob owned the moved permanent but did not control it, so Bob should not consult or cast"
+    );
+    assert!(
+        game.player(bob)
+            .expect("bob exists")
+            .library
+            .contains(&bob_spell),
+        "Bob's nonland card should remain in his library when Bob did not control a moved target"
+    );
+    assert!(
+        events.iter().any(|event| event
+            .downcast::<crate::events::ShuffleLibraryEvent>()
+            .is_some_and(|shuffle| shuffle.player == bob)),
+        "Bob should still shuffle the library that received his owned permanent"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_ryan_sinclair_uses_dynamic_consult_gate() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39359,6 +39359,315 @@ fn parse_oracle_chaos_wand_uses_consult_cast_bottom_path() {
     );
 }
 
+#[test]
+fn parse_oracle_guff_rewrites_history_uses_mass_polymorph_consult_cast_path() {
+    let def = parse_oracle_card_definition("Guff Rewrites History");
+    let compiled = unprocessed_compiled_lines(&def).join("\n");
+
+    assert_eq!(
+        compiled,
+        "For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost."
+    );
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        spell_debug.contains("TargetOnlyEffect"),
+        "expected per-player target selection, got {spell_debug}"
+    );
+    assert!(
+        spell_debug.contains("ShuffleObjectsIntoLibraryEffect"),
+        "expected chosen permanents to shuffle into libraries, got {spell_debug}"
+    );
+    assert!(
+        spell_debug.contains("OwnerOf(") && spell_debug.contains("targeted_"),
+        "expected owner-of-chosen-permanent shuffle binding, got {spell_debug}"
+    );
+    assert!(
+        spell_debug.contains("ConsultTopOfLibraryEffect"),
+        "expected consult-top-of-library effect, got {spell_debug}"
+    );
+    assert!(
+        spell_debug.contains("PutTaggedRemainderOnLibraryBottomEffect"),
+        "expected random bottom remainder effect, got {spell_debug}"
+    );
+    assert!(
+        spell_debug.contains("CastTaggedEffect"),
+        "expected optional free cast of tagged nonland card, got {spell_debug}"
+    );
+}
+
+#[test]
+fn guff_rewrites_history_runtime_shuffles_consults_and_casts_for_each_player() {
+    fn card(name: &str, card_types: Vec<CardType>) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(card_types)
+            .build()
+    }
+
+    let def = parse_oracle_card_definition("Guff Rewrites History");
+    let spell_effect = def
+        .spell_effect
+        .clone()
+        .expect("Guff Rewrites History should have a spell effect");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    game.set_random_seed(17);
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let alice_permanent = game.create_object_from_card(
+        &card("Alice Idol", vec![CardType::Artifact]),
+        alice,
+        Zone::Battlefield,
+    );
+    let bob_permanent = game.create_object_from_card(
+        &card("Bob Idol", vec![CardType::Artifact]),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_card(
+        &card("Alice Island", vec![CardType::Land]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Alice Free Spell", vec![CardType::Sorcery]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Bob Island", vec![CardType::Land]),
+        bob,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Bob Free Spell", vec![CardType::Sorcery]),
+        bob,
+        Zone::Library,
+    );
+
+    let target_requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        &spell_effect,
+        alice,
+        Some(source),
+        None,
+    );
+    assert_eq!(
+        target_requirements.len(),
+        2,
+        "Guff Rewrites History should require one target for each player: {target_requirements:?}"
+    );
+    assert_eq!(
+        target_requirements[0].legal_targets,
+        vec![crate::game_state::Target::Object(alice_permanent)],
+        "first target requirement should be Alice's nonenchantment, nonland permanent"
+    );
+    assert_eq!(
+        target_requirements[1].legal_targets,
+        vec![crate::game_state::Target::Object(bob_permanent)],
+        "second target requirement should be Bob's nonenchantment, nonland permanent"
+    );
+
+    let target_assignments = vec![
+        crate::game_state::TargetAssignment {
+            spec: target_requirements[0].spec.clone(),
+            range: 0..1,
+        },
+        crate::game_state::TargetAssignment {
+            spec: target_requirements[1].spec.clone(),
+            range: 1..2,
+        },
+    ];
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(alice_permanent),
+            crate::effects::ResolvedTarget::Object(bob_permanent),
+        ])
+        .with_target_assignments(target_assignments.clone());
+    let events = crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &spell_effect,
+        None,
+        &target_assignments,
+    )
+    .expect("Guff Rewrites History should resolve");
+
+    assert!(
+        !game.battlefield.contains(&alice_permanent),
+        "Alice's chosen permanent should leave the battlefield"
+    );
+    assert!(
+        !game.battlefield.contains(&bob_permanent),
+        "Bob's chosen permanent should leave the battlefield"
+    );
+    assert_eq!(
+        game.stack.len(),
+        2,
+        "each player should cast one consulted nonland card"
+    );
+    assert!(
+        game.stack.iter().any(|entry| entry.controller == alice),
+        "Alice should cast her consulted nonland card"
+    );
+    assert!(
+        game.stack.iter().any(|entry| entry.controller == bob),
+        "Bob should cast his consulted nonland card"
+    );
+    assert!(
+        events.iter().any(|event| event
+            .downcast::<crate::events::ShuffleLibraryEvent>()
+            .is_some_and(|shuffle| shuffle.player == alice)),
+        "Alice should shuffle the library that received her chosen permanent"
+    );
+    assert!(
+        events.iter().any(|event| event
+            .downcast::<crate::events::ShuffleLibraryEvent>()
+            .is_some_and(|shuffle| shuffle.player == bob)),
+        "Bob should shuffle the library that received his chosen permanent"
+    );
+
+    let exiled_names = game
+        .exile
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .map(|object| object.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        !exiled_names.contains(&"Alice Island") && !exiled_names.contains(&"Bob Island"),
+        "consulted land remainders should not be stranded in exile: {exiled_names:?}"
+    );
+}
+
+#[test]
+fn guff_rewrites_history_runtime_skips_player_whose_target_is_gone() {
+    fn card(name: &str, card_types: Vec<CardType>) -> crate::card::Card {
+        CardBuilder::new(CardId::new(), name)
+            .card_types(card_types)
+            .build()
+    }
+
+    let def = parse_oracle_card_definition("Guff Rewrites History");
+    let spell_effect = def
+        .spell_effect
+        .clone()
+        .expect("Guff Rewrites History should have a spell effect");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    game.set_random_seed(23);
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let alice_permanent = game.create_object_from_card(
+        &card("Alice Idol", vec![CardType::Artifact]),
+        alice,
+        Zone::Battlefield,
+    );
+    let bob_permanent = game.create_object_from_card(
+        &card("Bob Idol", vec![CardType::Artifact]),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_card(
+        &card("Alice Island", vec![CardType::Land]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Alice Free Spell", vec![CardType::Sorcery]),
+        alice,
+        Zone::Library,
+    );
+    game.create_object_from_card(
+        &card("Bob Island", vec![CardType::Land]),
+        bob,
+        Zone::Library,
+    );
+    let bob_spell = game.create_object_from_card(
+        &card("Bob Free Spell", vec![CardType::Sorcery]),
+        bob,
+        Zone::Library,
+    );
+
+    let target_requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        &spell_effect,
+        alice,
+        Some(source),
+        None,
+    );
+    assert_eq!(target_requirements.len(), 2);
+    let target_assignments = vec![
+        crate::game_state::TargetAssignment {
+            spec: target_requirements[0].spec.clone(),
+            range: 0..1,
+        },
+        crate::game_state::TargetAssignment {
+            spec: target_requirements[1].spec.clone(),
+            range: 1..2,
+        },
+    ];
+    game.move_object_by_effect(bob_permanent, Zone::Graveyard)
+        .expect("Bob's target should move away before resolution");
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(alice_permanent),
+            crate::effects::ResolvedTarget::Object(bob_permanent),
+        ])
+        .with_target_assignments(target_assignments.clone());
+    let events = crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &spell_effect,
+        None,
+        &target_assignments,
+    )
+    .expect("Guff Rewrites History should resolve with one valid target");
+
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "only the player whose target stayed valid should cast a consulted card"
+    );
+    assert!(game.stack.iter().any(|entry| entry.controller == alice));
+    assert!(!game.stack.iter().any(|entry| entry.controller == bob));
+    assert!(
+        game.player(bob)
+            .expect("bob exists")
+            .library
+            .contains(&bob_spell),
+        "Bob should not consult or cast when his target is gone"
+    );
+    assert!(
+        events.iter().any(|event| event
+            .downcast::<crate::events::ShuffleLibraryEvent>()
+            .is_some_and(|shuffle| shuffle.player == alice)),
+        "Alice should shuffle because her targeted permanent moved"
+    );
+    assert!(
+        !events.iter().any(|event| event
+            .downcast::<crate::events::ShuffleLibraryEvent>()
+            .is_some_and(|shuffle| shuffle.player == bob)),
+        "Bob should not shuffle when his target is gone"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_ryan_sinclair_uses_dynamic_consult_gate() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12030,6 +12030,14 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 )
             }
         }
+        Condition::PlayerControlledTaggedObjectSnapshot { player, tag, filter } => {
+            format!(
+                "{} controlled the tagged object '{}' matching {}",
+                describe_player_filter(player),
+                tag.as_str(),
+                filter.description()
+            )
+        }
         Condition::PlayerTaggedObjectEnteredBattlefieldThisTurn { player, tag } => {
             if let Some(action) = tag_action_from_name(tag.as_str()) {
                 format!("{} {} it this way", describe_player_filter(player), action)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3338,7 +3338,7 @@ fn describe_each_player_choose_target_shuffle_consult_cast(effects: &[&Effect]) 
         return None;
     }
     let conditional = consult_players.effects[0].downcast_ref::<crate::effects::ConditionalEffect>()?;
-    let crate::effect::Condition::PlayerTaggedObjectMatches { player, tag, .. } =
+    let crate::effect::Condition::PlayerControlledTaggedObjectSnapshot { player, tag, .. } =
         &conditional.condition
     else {
         return None;

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::effect::SearchSelectionMode;
-use crate::filter::StackObjectKind;
-use ironsmith_core::{LibraryBottomOrder, ValueSurfaceHint, ordinal_word};
+use crate::filter::{ObjectRef, StackObjectKind};
+use ironsmith_core::{LibraryBottomOrder, LibraryConsultMode, ValueSurfaceHint, ordinal_word};
 
 fn value_has_surface_hint(value: &Value, hint: ValueSurfaceHint) -> bool {
     value.has_surface_hint(hint)
@@ -3293,6 +3293,106 @@ fn describe_each_player_repeat_pay_life_tokens_sequence(effects: &[Effect]) -> O
     Some("Starting with you, each player may pay any amount of life. Repeat this process until no one pays life. Each player creates a 1/1 black Rat creature token for each 1 life they paid this way".to_string())
 }
 
+fn describe_each_player_choose_target_shuffle_consult_cast(effects: &[&Effect]) -> Option<String> {
+    if effects.len() != 3 {
+        return None;
+    }
+
+    let (choose_players_effect, _) = unwrap_with_id(effects[0]);
+    let choose_players = choose_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()?;
+    if choose_players.filter != PlayerFilter::Any || choose_players.effects.len() != 1 {
+        return None;
+    }
+    let (target_effect, _) = unwrap_with_id(&choose_players.effects[0]);
+    let (chosen_tag, target_only) = tagged_target_only_effect(target_effect)?;
+    if !target_only.target.is_target() {
+        return None;
+    }
+    let ChooseSpec::Object(target_filter) = target_only.target.base() else {
+        return None;
+    };
+    if target_only.target.count().min != 1
+        || target_only.target.count().max != Some(1)
+        || target_filter.zone != Some(Zone::Battlefield)
+        || target_filter.controller != Some(PlayerFilter::IteratedPlayer)
+        || !target_filter
+            .excluded_card_types
+            .contains(&crate::types::CardType::Enchantment)
+        || !target_filter
+            .excluded_card_types
+            .contains(&crate::types::CardType::Land)
+    {
+        return None;
+    }
+    let (shuffle_effect, _) = unwrap_with_id(unwrap_basic_tag_wrappers(effects[1]));
+    let shuffle = shuffle_effect.downcast_ref::<crate::effects::ShuffleObjectsIntoLibraryEffect>()?;
+    if shuffle.target != ChooseSpec::Tagged(chosen_tag.clone())
+        || shuffle.player != PlayerFilter::OwnerOf(ObjectRef::tagged(chosen_tag.clone()))
+    {
+        return None;
+    }
+
+    let (consult_players_effect, _) = unwrap_with_id(effects[2]);
+    let consult_players = consult_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()?;
+    if consult_players.filter != PlayerFilter::Any || consult_players.effects.len() != 1 {
+        return None;
+    }
+    let conditional = consult_players.effects[0].downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let crate::effect::Condition::PlayerTaggedObjectMatches { player, tag, .. } =
+        &conditional.condition
+    else {
+        return None;
+    };
+    if *player != PlayerFilter::IteratedPlayer
+        || *tag != *chosen_tag
+        || !conditional.if_false.is_empty()
+    {
+        return None;
+    }
+    let [consult_effect, bottom_effect, may_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let (consult_effect, _) = unwrap_with_id(consult_effect);
+    let consult = consult_effect.downcast_ref::<crate::effects::ConsultTopOfLibraryEffect>()?;
+    if consult.player != PlayerFilter::IteratedPlayer
+        || consult.mode != LibraryConsultMode::Exile
+        || consult.stop_rule != crate::effects::ConsultTopOfLibraryStopRule::FirstMatch
+        || !consult
+            .filter
+            .excluded_card_types
+            .contains(&crate::types::CardType::Land)
+    {
+        return None;
+    }
+    let (bottom_effect, _) = unwrap_with_id(bottom_effect);
+    let bottom = bottom_effect
+        .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()?;
+    if bottom.tag != consult.all_tag
+        || bottom.keep_tagged != Some(consult.match_tag.clone())
+        || bottom.order != LibraryBottomOrder::Random
+        || bottom.player != PlayerFilter::IteratedPlayer
+    {
+        return None;
+    }
+    let (may_effect, _) = unwrap_with_id(may_effect);
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if may.effects.len() != 1 {
+        return None;
+    }
+    let (cast_effect, _) = unwrap_with_id(&may.effects[0]);
+    let cast = cast_effect.downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    if cast.tag != consult.match_tag
+        || cast.player != PlayerFilter::IteratedPlayer
+        || cast.allow_land
+        || cast.as_copy
+        || !cast.without_paying_mana_cost
+    {
+        return None;
+    }
+
+    Some("For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost".to_string())
+}
+
 fn describe_reveal_top_to_hand_then_lose_mana_value_effects(effects: &[Effect]) -> Option<String> {
     let [reveal_effect, move_effect, lose_effect] = effects else {
         return None;
@@ -4323,6 +4423,10 @@ fn describe_revealed_cards_opponent_may_put_or_draw(effects: &[&Effect]) -> Opti
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    let raw_effects = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_each_player_choose_target_shuffle_consult_cast(&raw_effects) {
+        return compact;
+    }
     if let Some(compact) = describe_reveal_top_to_hand_then_lose_mana_value_effects(effects) {
         return compact;
     }
@@ -4330,7 +4434,6 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
-    let raw_effects = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&raw_effects) {
         return compact;
     }
@@ -6748,6 +6851,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_each_player_gain_life_and_draw_pair(&visible_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_each_player_choose_target_shuffle_consult_cast(&visible_effects) {
         return compact;
     }
     if let Some(compact) = describe_sacrifice_source_then_return_with_counters(&visible_effects) {
@@ -14986,6 +15092,10 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
 
     let effect_refs = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&effect_refs) {
+        return Some(compact);
+    }
+
+    if let Some(compact) = describe_each_player_choose_target_shuffle_consult_cast(&effect_refs) {
         return Some(compact);
     }
 

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1076,6 +1076,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::TargetMatches(..) => {}
         Condition::TargetIsSoulbondPaired => {}
         Condition::PlayerTaggedObjectMatches { .. } => {}
+        Condition::PlayerControlledTaggedObjectSnapshot { .. } => {}
         Condition::PlayerTaggedObjectEnteredBattlefieldThisTurn { .. } => {}
         Condition::PlayerOwnsCardNamedInZones { .. } => {}
         Condition::ThisAbilityResolvedThisTurnExactly(..) => {}
@@ -1904,6 +1905,7 @@ pub fn evaluate_condition_external(
         | Condition::EnchantedPermanentAttackedThisTurn
         | Condition::TargetIsSoulbondPaired
         | Condition::PlayerTaggedObjectMatches { .. }
+        | Condition::PlayerControlledTaggedObjectSnapshot { .. }
         | Condition::TargetIsTapped
         | Condition::TargetIsAttacking
         | Condition::TargetIsBlocked
@@ -2627,6 +2629,7 @@ fn evaluate_condition_simple(
         Condition::TargetMatches(_) => false,
         Condition::TargetIsSoulbondPaired => false,
         Condition::PlayerTaggedObjectMatches { .. } => false,
+        Condition::PlayerControlledTaggedObjectSnapshot { .. } => false,
         Condition::PlayerTaggedObjectEnteredBattlefieldThisTurn { .. } => false,
         // Target-dependent conditions default to false during casting
         Condition::TargetIsTapped
@@ -3585,6 +3588,22 @@ fn evaluate_condition(
                 }
             }
             Ok(false)
+        }
+        Condition::PlayerControlledTaggedObjectSnapshot {
+            player,
+            tag,
+            filter,
+        } => {
+            let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
+            let Some(tagged) = ctx.get_tagged_all(tag.as_str()) else {
+                return Ok(false);
+            };
+            let mut filter_ctx = ctx.filter_context(game);
+            filter_ctx.iterated_player = Some(player_id);
+            Ok(tagged.iter().any(|snapshot| {
+                snapshot.controller == player_id
+                    && filter.matches_snapshot(snapshot, &filter_ctx, game)
+            }))
         }
         Condition::PlayerTaggedObjectEnteredBattlefieldThisTurn { player, tag } => {
             let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;

--- a/crates/ironsmith-runtime/src/effects/zones/shuffle_objects_into_library.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/shuffle_objects_into_library.rs
@@ -119,16 +119,37 @@ impl EffectExecutor for ShuffleObjectsIntoLibraryEffect {
             }
         }
 
-        game.shuffle_player_library(player_id);
-        let shuffle_event = TriggerEvent::new_with_provenance(
-            ShuffleLibraryEvent::new(player_id, ctx.cause.clone()),
-            ctx.provenance,
-        );
+        let mut shuffle_players = Vec::new();
+        if moved_ids.is_empty() {
+            shuffle_players.push(player_id);
+        } else {
+            for moved_id in &moved_ids {
+                if let Some(owner) = game.object(*moved_id).map(|object| object.owner)
+                    && !shuffle_players.contains(&owner)
+                {
+                    shuffle_players.push(owner);
+                }
+            }
+            if shuffle_players.is_empty() {
+                shuffle_players.push(player_id);
+            }
+        }
+
+        let shuffle_events = shuffle_players
+            .into_iter()
+            .map(|player| {
+                game.shuffle_player_library(player);
+                TriggerEvent::new_with_provenance(
+                    ShuffleLibraryEvent::new(player, ctx.cause.clone()),
+                    ctx.provenance,
+                )
+            })
+            .collect::<Vec<_>>();
 
         if moved_ids.is_empty() {
-            Ok(EffectOutcome::resolved().with_event(shuffle_event))
+            Ok(EffectOutcome::resolved().with_events(shuffle_events))
         } else {
-            Ok(EffectOutcome::with_objects(moved_ids).with_event(shuffle_event))
+            Ok(EffectOutcome::with_objects(moved_ids).with_events(shuffle_events))
         }
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Guff Rewrites History
Initial parse error:
```
parser does not yet support line family: 'For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost.'; oracle-only fallback also failed: parser does not yet support line family: 'For each player, choose target nonenchantment, nonland permanent that player controls. Those permanents' owners shuffle them into their libraries. Each player who controlled one of those permanents exiles cards from the top of their library until they exile a nonland card, then puts the rest on the bottom of their library in a random order. Each player may cast the nonland card they exiled without paying its mana cost.'
```

Current worker: i-0240df2c6fc988cd5
Branch: codex/aws-card-fix-guff-rewrites-history
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0039
