### PR TITLE
Fix Ironsmith parse failure: Overwhelming Splendor

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_costs.rs
@@ -1703,6 +1703,7 @@ pub(crate) fn parse_cant_clause(
                 | crate::effect::Restriction::SearchLibraries(_)
                 | crate::effect::Restriction::CastSpellsMatching(_, _)
                 | crate::effect::Restriction::ActivateNonManaAbilities(_)
+                | crate::effect::Restriction::ActivateNonManaNonLoyaltyAbilities(_)
                 | crate::effect::Restriction::ActivateAbilitiesOf(_)
                 | crate::effect::Restriction::ActivateTapAbilitiesOf(_)
                 | crate::effect::Restriction::ActivateNonManaAbilitiesOf(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -168,6 +168,34 @@ const ACTIVATE_ABILITIES_THAT_ARENT_MANA_TAIL_PATTERN: ClauseShape<'static> = cl
             "abilities"
         ]
 );
+const ACTIVATE_ABILITIES_THAT_ARENT_MANA_OR_LOYALTY_TAIL_PATTERN: ClauseShape<'static> =
+    clause_shape!(
+        exact_any
+            & [
+                &[
+                    "activate",
+                    "abilities",
+                    "that",
+                    "arent",
+                    "mana",
+                    "abilities",
+                    "or",
+                    "loyalty",
+                    "abilities",
+                ],
+                &[
+                    "activate",
+                    "abilities",
+                    "which",
+                    "arent",
+                    "mana",
+                    "abilities",
+                    "or",
+                    "loyalty",
+                    "abilities",
+                ],
+            ]
+    );
 const ACTIVATE_ABILITIES_OF_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["activate", "abilities", "of"]);
 const UNLESS_MANA_ABILITIES_SUFFIX_PATTERN: ClauseShape<'static> =
@@ -545,6 +573,10 @@ fn player_negated_restriction_from_tail(
             player,
             ObjectFilter::spell(),
         ))
+    } else if ACTIVATE_ABILITIES_THAT_ARENT_MANA_OR_LOYALTY_TAIL_PATTERN.matches_words(words) {
+        Some(Restriction::activate_non_mana_non_loyalty_abilities(player))
+    } else if ACTIVATE_ABILITIES_THAT_ARENT_MANA_TAIL_PATTERN.matches_words(words) {
+        Some(Restriction::activate_non_mana_abilities(player))
     } else {
         None
     }
@@ -1335,6 +1367,12 @@ pub(crate) fn parse_player_negated_restriction_clause(
     if ACTIVATE_ABILITIES_THAT_ARENT_MANA_TAIL_PATTERN.matches_words(&remainder_words) {
         return Ok(Some(ParsedCantRestriction {
             restriction: Restriction::activate_non_mana_abilities(player),
+            target,
+        }));
+    }
+    if ACTIVATE_ABILITIES_THAT_ARENT_MANA_OR_LOYALTY_TAIL_PATTERN.matches_words(&remainder_words) {
+        return Ok(Some(ParsedCantRestriction {
+            restriction: Restriction::activate_non_mana_non_loyalty_abilities(player),
             target,
         }));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/object_filters.rs
@@ -144,6 +144,8 @@ const OBJECT_FILTER_YOU_DO_NOT_CONTROL_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["you", "do", "not", "control"]);
 const OBJECT_FILTER_OPPONENT_CONTROLS_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["opponents", "control"], &["opponent", "controls"]]);
+const OBJECT_FILTER_ENCHANTED_PLAYER_CONTROLS_SUFFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["enchanted", "player", "controls"]);
 const OBJECT_FILTER_YOU_OWN_SUFFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["you", "own"]);
 const OBJECT_FILTER_YOUR_GRAVEYARD_SUFFIX_PATTERN: ClauseShape<'static> =
@@ -328,6 +330,16 @@ fn parse_simple_object_filter_suffix(words: &[&str]) -> Option<(SimpleObjectFilt
     {
         return Some((
             SimpleObjectFilterSuffix::OwnerZone(PlayerFilter::You, Zone::Library),
+            3,
+        ));
+    }
+    if tail(words, 3).is_some_and(|tail| {
+        OBJECT_FILTER_ENCHANTED_PLAYER_CONTROLS_SUFFIX_PATTERN.matches_words(tail)
+    }) {
+        return Some((
+            SimpleObjectFilterSuffix::Controller(PlayerFilter::TaggedPlayer(TagKey::from(
+                "enchanted",
+            ))),
             3,
         ));
     }
@@ -737,6 +749,31 @@ fn parse_simple_object_filter_lexed(tokens: &[OwnedLexToken], other: bool) -> Op
     Some(filter)
 }
 
+fn strip_enchanted_player_controls_suffix(
+    tokens: &[OwnedLexToken],
+) -> Option<(Vec<OwnedLexToken>, PlayerFilter)> {
+    let word_view = TokenWordView::new(tokens);
+    let words = word_view.to_word_refs();
+    if !words
+        .get(words.len().checked_sub(3)?..)
+        .is_some_and(|tail| {
+            OBJECT_FILTER_ENCHANTED_PLAYER_CONTROLS_SUFFIX_PATTERN.matches_words(tail)
+        })
+    {
+        return None;
+    }
+
+    let prefix_end = word_view.token_index_for_word_index(words.len().saturating_sub(3))?;
+    let prefix = trim_commas(&tokens[..prefix_end]);
+    if prefix.is_empty() {
+        return None;
+    }
+    Some((
+        prefix,
+        PlayerFilter::TaggedPlayer(TagKey::from("enchanted")),
+    ))
+}
+
 pub(super) fn parse_attached_reference_or_another_disjunction(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<ObjectFilter>, CardTextError> {
@@ -780,6 +817,9 @@ pub(crate) fn parse_object_filter(
     other: bool,
 ) -> Result<ObjectFilter, CardTextError> {
     let (tokens, distinct_names) = strip_object_filter_different_names_clause(tokens);
+    let (tokens, controller_suffix) = strip_enchanted_player_controls_suffix(&tokens)
+        .map(|(tokens, controller)| (tokens, Some(controller)))
+        .unwrap_or((tokens, None));
     let tokens = tokens.as_slice();
     let mut filter = if let Some(with_idx) = find_token_word(tokens, "with") {
         let base_tokens = trim_commas(&tokens[..with_idx]);
@@ -815,6 +855,10 @@ pub(crate) fn parse_object_filter(
     } else {
         super::grammar::filters::parse_object_filter_with_grammar_entrypoint(tokens, other)?
     };
+    if let Some(controller) = controller_suffix {
+        filter.controller = Some(controller);
+        filter.zone = Some(Zone::Battlefield);
+    }
     filter.distinct_names |= distinct_names;
     Ok(filter)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -417,6 +417,11 @@ pub(crate) fn resolve_restriction_it_tag(
         Restriction::ActivateNonManaAbilities(player) => Restriction::activate_non_mana_abilities(
             resolve_contextual_player_filter(player, refs)?,
         ),
+        Restriction::ActivateNonManaNonLoyaltyAbilities(player) => {
+            Restriction::activate_non_mana_non_loyalty_abilities(
+                resolve_contextual_player_filter(player, refs)?,
+            )
+        }
         Restriction::CastMoreThanOneSpellEachTurn(player, filter) => {
             Restriction::CastMoreThanOneSpellEachTurn(
                 resolve_contextual_player_filter(player, refs)?,

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1199,6 +1199,12 @@ impl ObjectFilter {
                     parts.push(describe_possessive_player_filter(ctrl));
                 }
                 PlayerFilter::ChosenPlayer => parts.push("the chosen player's".to_string()),
+                PlayerFilter::TaggedPlayer(tag) if tag.as_str() == "enchanted" => {
+                    if !has_leading_determiner {
+                        parts.insert(0, "a".to_string());
+                    }
+                    controller_suffix = Some("enchanted player controls".to_string());
+                }
                 PlayerFilter::TaggedPlayer(_) => parts.push("that player's".to_string()),
                 PlayerFilter::Teammate => parts.push("a teammate's".to_string()),
                 PlayerFilter::Defending => parts.push("the defending player's".to_string()),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -268,6 +268,7 @@ pub enum Restriction {
     CastSpellsMatching(PlayerFilter, ObjectFilter),
     CastSpellsOnlyAsSorcery(PlayerFilter),
     ActivateNonManaAbilities(PlayerFilter),
+    ActivateNonManaNonLoyaltyAbilities(PlayerFilter),
     ActivateAbilitiesOf(ObjectFilter),
     ActivateTapAbilitiesOf(ObjectFilter),
     ActivateNonManaAbilitiesOf(ObjectFilter),
@@ -428,6 +429,10 @@ impl Restriction {
 
     pub fn activate_non_mana_abilities(filter: PlayerFilter) -> Self {
         Self::ActivateNonManaAbilities(filter)
+    }
+
+    pub fn activate_non_mana_non_loyalty_abilities(filter: PlayerFilter) -> Self {
+        Self::ActivateNonManaNonLoyaltyAbilities(filter)
     }
 
     pub fn activate_abilities_of(filter: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -39199,6 +39199,41 @@ fn parse_abeyance_supports_instant_or_sorcery_cast_restriction() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_overwhelming_splendor_preserves_enchanted_player_activation_exception() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Overwhelming Splendor")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura, Subtype::Curse])
+        .parse_text(
+            "Enchant player\n\
+             Creatures enchanted player controls lose all abilities and have base power and toughness 1/1.\n\
+             Enchanted player can't activate abilities that aren't mana abilities or loyalty abilities.",
+        )
+        .expect("Overwhelming Splendor should parse");
+
+    let rendered = compiled_text_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "Creatures enchanted player controls lose all abilities and have base power and toughness 1/1"
+        ),
+        "expected enchanted-player creature controller text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Enchanted player can't activate abilities that aren't mana abilities or loyalty abilities"
+        ),
+        "expected mana-or-loyalty activation exception text, got {rendered}"
+    );
+
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("controller: Some(TaggedPlayer")
+            && abilities_debug.contains("ActivateNonManaNonLoyaltyAbilities"),
+        "expected enchanted-player controller and mana-or-loyalty activation restriction, got {abilities_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_conquerors_flail_condition_maps_attached_equipment_to_equipped() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Conqueror's Flail")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -165,6 +165,11 @@ pub(super) fn extract_base_pt_tail_for_subject(line: &str, subject: &str) -> Opt
 
 pub(super) fn normalize_global_subject_number(subject: &str) -> String {
     let trimmed = subject.trim();
+    if trimmed.eq_ignore_ascii_case("a creature enchanted player controls")
+        || trimmed.eq_ignore_ascii_case("creature enchanted player controls")
+    {
+        return "Creatures enchanted player controls".to_string();
+    }
     if trimmed.eq_ignore_ascii_case("Creature") {
         return "Creatures".to_string();
     }

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10245,6 +10245,12 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
                 describe_player_set_filter(filter)
             )
         }
+        crate::effect::Restriction::ActivateNonManaNonLoyaltyAbilities(filter) => {
+            format!(
+                "{} can't activate abilities that aren't mana abilities or loyalty abilities",
+                describe_player_set_filter(filter)
+            )
+        }
         crate::effect::Restriction::ActivateAbilitiesOf(filter) => {
             let description = filter.description();
             let subject = description

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -1,6 +1,18 @@
 use super::*;
 use crate::ability::ActivatedAbilityRuntimeExt as _;
 
+fn player_can_activate_non_mana_ability(
+    game: &GameState,
+    player: PlayerId,
+    activated: &crate::ability::ActivatedAbility,
+) -> bool {
+    if activated.is_loyalty_ability() {
+        game.can_activate_non_mana_abilities(player)
+    } else {
+        game.can_activate_non_mana_non_loyalty_abilities(player)
+    }
+}
+
 fn grant_usage_limit_allows(
     game: &GameState,
     player: PlayerId,
@@ -830,28 +842,29 @@ fn add_battlefield_actions(
                 }
             }
 
-            if game.can_activate_non_mana_abilities(player) {
-                for &ability_index in activated_ability_indices {
-                    let Some(ability) = abilities.get(ability_index) else {
-                        continue;
-                    };
-                    let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
-                        continue;
-                    };
-                    if can_activate_ability_with_restrictions_with_view(
-                        game,
-                        perm_id,
+            for &ability_index in activated_ability_indices {
+                let Some(ability) = abilities.get(ability_index) else {
+                    continue;
+                };
+                let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+                    continue;
+                };
+                if !player_can_activate_non_mana_ability(game, player, activated) {
+                    continue;
+                }
+                if can_activate_ability_with_restrictions_with_view(
+                    game,
+                    perm_id,
+                    ability_index,
+                    activated,
+                    view,
+                    Some(battlefield_ability_ctx),
+                    Some(&source_facts),
+                ) {
+                    actions.push(LegalAction::ActivateAbility {
+                        source: perm_id,
                         ability_index,
-                        activated,
-                        view,
-                        Some(battlefield_ability_ctx),
-                        Some(&source_facts),
-                    ) {
-                        actions.push(LegalAction::ActivateAbility {
-                            source: perm_id,
-                            ability_index,
-                        });
-                    }
+                    });
                 }
             }
         }
@@ -932,36 +945,37 @@ fn add_non_battlefield_ability_actions(
             }
         }
 
-        if game.can_activate_non_mana_abilities(player) {
-            let current_abilities = view.abilities_rc(source_id);
-            let abilities = current_abilities.as_deref().unwrap_or(&obj.abilities);
-            for &ability_index in ability_summary.activated_ability_indices() {
-                let Some(ability) = abilities.get(ability_index) else {
-                    continue;
-                };
-                if !ability.functions_in(&obj.zone) {
-                    continue;
-                }
-                let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
-                    continue;
-                };
-                if game.controller_of(obj) != player && !activated_allows_any_player(activated) {
-                    continue;
-                }
-                if can_activate_ability_with_restrictions_with_view(
-                    game,
-                    source_id,
+        let current_abilities = view.abilities_rc(source_id);
+        let abilities = current_abilities.as_deref().unwrap_or(&obj.abilities);
+        for &ability_index in ability_summary.activated_ability_indices() {
+            let Some(ability) = abilities.get(ability_index) else {
+                continue;
+            };
+            if !ability.functions_in(&obj.zone) {
+                continue;
+            }
+            let crate::ability::AbilityKind::Activated(activated) = &ability.kind else {
+                continue;
+            };
+            if game.controller_of(obj) != player && !activated_allows_any_player(activated) {
+                continue;
+            }
+            if !player_can_activate_non_mana_ability(game, player, activated) {
+                continue;
+            }
+            if can_activate_ability_with_restrictions_with_view(
+                game,
+                source_id,
+                ability_index,
+                activated,
+                view,
+                None,
+                None,
+            ) {
+                actions.push(LegalAction::ActivateAbility {
+                    source: source_id,
                     ability_index,
-                    activated,
-                    view,
-                    None,
-                    None,
-                ) {
-                    actions.push(LegalAction::ActivateAbility {
-                        source: source_id,
-                        ability_index,
-                    });
-                }
+                });
             }
         }
     }
@@ -1364,7 +1378,9 @@ fn activation_precheck_with_view(
         source_facts.controller
     };
 
-    if game.object(source).is_some() && !game.can_activate_non_mana_abilities(controller) {
+    if game.object(source).is_some()
+        && !player_can_activate_non_mana_ability(game, controller, activated)
+    {
         if let Some(perf_ctx) = perf_ctx {
             perf_ctx.add_precheck_ms(started_at.elapsed_ms());
         }

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -918,6 +918,15 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::ActivateNonManaNonLoyaltyAbilities(filter) => {
+                for player in &game.players {
+                    if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
+                        tracker
+                            .cant_activate_non_mana_non_loyalty_abilities
+                            .insert(player.id);
+                    }
+                }
+            }
             Restriction::ActivateAbilitiesOf(filter) => {
                 for &obj_id in &game.battlefield {
                     if let Some(obj) = game.object(obj_id)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -34882,6 +34882,142 @@ fn test_grievous_wound_stops_enchanted_player_life_gain_and_triggers_on_damage()
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn overwhelming_splendor_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Overwhelming Splendor")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura, Subtype::Curse])
+        .parse_text(
+            "Enchant player\n\
+             Creatures enchanted player controls lose all abilities and have base power and toughness 1/1.\n\
+             Enchanted player can't activate abilities that aren't mana abilities or loyalty abilities.",
+        )
+        .expect("Overwhelming Splendor should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_overwhelming_splendor_restricts_only_enchanted_player_and_preserves_exceptions() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let splendor = overwhelming_splendor_definition();
+    let splendor_id = game.create_object_from_definition(&splendor, alice, Zone::Battlefield);
+    game.object_mut(splendor_id)
+        .expect("Overwhelming Splendor should exist")
+        .attached_to = Some(crate::object::AttachmentTarget::Player(bob));
+    game.player_mut(bob)
+        .expect("bob should exist")
+        .attachments
+        .push(splendor_id);
+
+    let bob_creature = CardDefinitionBuilder::new(CardId::new(), "Bob's Prodigal Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text("{0}: Draw a card.")
+        .expect("bob creature should parse");
+    let alice_creature = CardDefinitionBuilder::new(CardId::new(), "Alice's Prodigal Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text("{0}: Draw a card.")
+        .expect("alice creature should parse");
+    let mana_rock = CardDefinitionBuilder::new(CardId::new(), "Bob's Mana Rock")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{T}: Add {C}.")
+        .expect("mana rock should parse");
+    let draw_rock = CardDefinitionBuilder::new(CardId::new(), "Bob's Draw Rock")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{0}: Draw a card.")
+        .expect("draw rock should parse");
+    let alice_draw_rock = CardDefinitionBuilder::new(CardId::new(), "Alice's Draw Rock")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{0}: Draw a card.")
+        .expect("alice draw rock should parse");
+    let planeswalker = CardDefinitionBuilder::new(CardId::new(), "Bob's Test Chandra")
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(3)
+        .parse_text("+1: Draw a card.")
+        .expect("planeswalker should parse");
+
+    let bob_creature_id = game.create_object_from_definition(&bob_creature, bob, Zone::Battlefield);
+    let alice_creature_id =
+        game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+    let mana_rock_id = game.create_object_from_definition(&mana_rock, bob, Zone::Battlefield);
+    let draw_rock_id = game.create_object_from_definition(&draw_rock, bob, Zone::Battlefield);
+    let alice_draw_rock_id =
+        game.create_object_from_definition(&alice_draw_rock, alice, Zone::Battlefield);
+    let planeswalker_id =
+        game.create_object_from_definition(&planeswalker, bob, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    let bob_creature_characteristics = game
+        .calculated_characteristics(bob_creature_id)
+        .expect("bob creature should have characteristics");
+    assert_eq!(
+        (bob_creature_characteristics.power, bob_creature_characteristics.toughness),
+        (Some(1), Some(1)),
+        "Overwhelming Splendor should set enchanted player's creatures to 1/1"
+    );
+    assert_eq!(
+        activated_ability_count(&game, bob_creature_id),
+        0,
+        "Overwhelming Splendor should remove abilities from enchanted player's creatures"
+    );
+
+    let alice_creature_characteristics = game
+        .calculated_characteristics(alice_creature_id)
+        .expect("alice creature should have characteristics");
+    assert_eq!(
+        (alice_creature_characteristics.power, alice_creature_characteristics.toughness),
+        (Some(4), Some(4)),
+        "Overwhelming Splendor should not affect non-enchanted players' creatures"
+    );
+    assert_eq!(
+        activated_ability_count(&game, alice_creature_id),
+        1,
+        "Overwhelming Splendor should not remove abilities from other players' creatures"
+    );
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+    let bob_actions = crate::decision::compute_legal_actions(&game, bob);
+    assert!(
+        bob_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateManaAbility { source, .. } if *source == mana_rock_id
+        )),
+        "Overwhelming Splendor should still allow enchanted player to activate mana abilities: {bob_actions:?}"
+    );
+    assert!(
+        !bob_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, .. } if *source == draw_rock_id
+        )),
+        "Overwhelming Splendor should stop enchanted player from activating ordinary non-mana abilities: {bob_actions:?}"
+    );
+    assert!(
+        bob_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, .. } if *source == planeswalker_id
+        )),
+        "Overwhelming Splendor should still allow enchanted player to activate loyalty abilities: {bob_actions:?}"
+    );
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    let alice_actions = crate::decision::compute_legal_actions(&game, alice);
+    assert!(
+        alice_actions.iter().any(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, .. } if *source == alice_draw_rock_id
+        )),
+        "Overwhelming Splendor should not restrict non-enchanted players' ordinary activations: {alice_actions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_kitsune_mystic_requires_two_attached_auras_for_end_step_trigger() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -590,6 +590,10 @@ pub struct CantEffectTracker {
     /// Example: Split second while a split-second spell is on the stack.
     pub cant_activate_non_mana_abilities: HashSet<PlayerId>,
 
+    /// Players who can't activate abilities except mana abilities and loyalty abilities.
+    /// Example: Overwhelming Splendor.
+    pub cant_activate_non_mana_non_loyalty_abilities: HashSet<PlayerId>,
+
     /// Permanents whose activated abilities can't be activated (including mana abilities).
     /// Example: Collector Ouphe ("Activated abilities of artifacts can't be activated.")
     pub cant_activate_abilities_of: HashSet<ObjectId>,
@@ -872,6 +876,8 @@ impl CantEffectTracker {
             .extend(other.cast_spells_only_as_sorcery);
         self.cant_activate_non_mana_abilities
             .extend(other.cant_activate_non_mana_abilities);
+        self.cant_activate_non_mana_non_loyalty_abilities
+            .extend(other.cant_activate_non_mana_non_loyalty_abilities);
         self.cant_activate_abilities_of
             .extend(other.cant_activate_abilities_of);
         self.cant_activate_tap_abilities_of
@@ -929,6 +935,8 @@ impl CantEffectTracker {
         self.cant_cast_filters.clear();
         self.cast_spells_only_as_sorcery.clear();
         self.cant_activate_non_mana_abilities.clear();
+        self.cant_activate_non_mana_non_loyalty_abilities
+            .clear();
         self.cant_activate_abilities_of.clear();
         self.cant_activate_tap_abilities_of.clear();
         self.cant_activate_non_mana_abilities_of.clear();
@@ -1119,6 +1127,14 @@ impl CantEffectTracker {
     /// Check if a player can activate non-mana abilities.
     pub fn can_activate_non_mana_abilities(&self, player: PlayerId) -> bool {
         !self.cant_activate_non_mana_abilities.contains(&player)
+    }
+
+    /// Check if a player can activate non-mana, non-loyalty abilities.
+    pub fn can_activate_non_mana_non_loyalty_abilities(&self, player: PlayerId) -> bool {
+        !self.cant_activate_non_mana_abilities.contains(&player)
+            && !self
+                .cant_activate_non_mana_non_loyalty_abilities
+                .contains(&player)
     }
 
     /// Check if activated abilities of a permanent can be activated (including mana abilities).
@@ -3343,6 +3359,13 @@ impl GameState {
         self.effect_store
             .cant_effects
             .can_activate_non_mana_abilities(player)
+    }
+
+    /// Can the player activate non-mana, non-loyalty abilities?
+    pub fn can_activate_non_mana_non_loyalty_abilities(&self, player: PlayerId) -> bool {
+        self.effect_store
+            .cant_effects
+            .can_activate_non_mana_non_loyalty_abilities(player)
     }
 
     /// Can activated abilities of this permanent be activated (including mana abilities)?


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Overwhelming Splendor
Initial parse error:
```
unsupported player negated restriction tail (clause: 'enchanted player can't activate abilities that aren't mana abilities or loyalty abilities'); oracle-only fallback also failed: unsupported player negated restriction tail (clause: 'enchanted player can't activate abilities that aren't mana abilities or loyalty abilities')
```

Current worker: i-0722ff4639cfba82f
Branch: codex/aws-card-fix-overwhelming-splendor
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0039
