### PR TITLE
Fix Ironsmith parse failure: Sophina, Spearsage Deserter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -967,12 +967,16 @@ pub(super) fn run_partner_variant_keyword_line_family(
         return Ok(None);
     }
 
+    let visible_label = raw
+        .split_once('(')
+        .map(|(head, _)| head)
+        .unwrap_or(raw)
+        .trim()
+        .trim_end_matches('.')
+        .trim()
+        .to_string();
     let partner_line = rewrite_line_normalized(ctx.line, "Partner")?;
     if let Some(mut keyword_line) = parse_keyword_line_cst(&partner_line)? {
-        let visible_label = source_before_reminder_or_period(raw, &ctx.line.tokens)
-            .unwrap_or(raw)
-            .trim()
-            .to_string();
         keyword_line.text = visible_label;
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Keyword(keyword_line),
@@ -982,9 +986,9 @@ pub(super) fn run_partner_variant_keyword_line_family(
 
     Ok(Some(LineDispatchResult::single(
         RewriteLineCst::Static(StaticLineCst {
-            info: partner_line.info.clone(),
-            text: partner_line.info.normalized.normalized.clone(),
-            parse_tokens: partner_line.tokens.clone(),
+            info: ctx.line.info.clone(),
+            text: visible_label,
+            parse_tokens: ctx.line.tokens.clone(),
             chosen_option_label: None,
         }),
         ctx.idx + 1,
@@ -995,6 +999,12 @@ fn tokens_start_with_partner_variant_separator(tokens: &[OwnedLexToken]) -> bool
     let words = TokenWordView::new(tokens);
     if !words.starts_with(PARTNER_PREFIX) {
         return false;
+    }
+    if words.len() > PARTNER_PREFIX.len()
+        && words.get(PARTNER_PREFIX.len()) != Some("with")
+        && words.token_index_for_word_index(0) == words.token_index_for_word_index(1)
+    {
+        return true;
     }
     let Some(separator_idx) = words.token_index_after_words(PARTNER_PREFIX.len()) else {
         return false;
@@ -1234,6 +1244,7 @@ mod tests {
             "Partner—Character select",
             "Partner - Character select",
             "Partner–Character select",
+            "Partner-Friends forever",
         ] {
             let tokens = lex_line(line, 0).expect("partner variant line should lex");
             assert!(
@@ -1331,6 +1342,7 @@ fn partner_with_name_from_line(line: &PreprocessedLine) -> Option<String> {
     (!name.is_empty()).then(|| name.to_string())
 }
 
+#[cfg(test)]
 fn source_before_reminder_or_period<'a>(
     raw_line: &'a str,
     tokens: &[OwnedLexToken],

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -407,6 +407,7 @@ pub(crate) fn preserve_labeled_ability_prefix_for_parse_text(prefix: &str) -> bo
             | "harmonize"
             | "boast"
             | "modular"
+            | "partner"
             | "replicate"
             | "reinforce"
             | "renew"

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
@@ -562,9 +562,7 @@ fn replace_names_with_map(
             || next.is_some_and(|word| {
                 matches!(
                     word,
-                    b"attack"
-                        | b"attacks"
-                        | b"become"
+                    b"become"
                         | b"becomes"
                         | b"becoming"
                         | b"deal"

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -130,9 +130,9 @@ use super::restriction_support::{
 use super::token_primitives::{
     find_index, iter_contains, lexed_tokens_contain_non_prefix_instead,
     remove_copy_exception_type_removal_lexed, rewrite_followup_intro_to_if_lexed, slice_contains,
-    slice_ends_with, slice_starts_with, split_em_dash_label_prefix, str_contains, str_find,
-    str_split_once, str_split_once_char, str_strip_prefix, str_strip_suffix,
-    word_view_has_any_prefix, word_view_has_prefix,
+    slice_ends_with, slice_starts_with, split_em_dash_label_prefix,
+    split_em_dash_label_prefix_tokens, str_contains, str_find, str_split_once, str_split_once_char,
+    str_strip_prefix, str_strip_suffix, word_view_has_any_prefix, word_view_has_prefix,
 };
 use super::util::{
     classify_instead_followup_text, classify_instead_followup_tokens,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1353,8 +1353,7 @@ fn lower_rewrite_static_to_chunk_impl(
 ) -> Result<LineAst, CardTextError> {
     let chosen_option_label = effective_chosen_option_label(line.chosen_option_label.as_deref());
     if tokens_start_with_partner_dash_label(&line.parse_tokens) {
-        let visible_label = render_tokens_before_reminder_or_period(&line.parse_tokens)
-            .unwrap_or_else(|| line.text.trim().to_string());
+        let visible_label = line.text.trim().to_string();
         return wrap_chosen_option_static_chunk(
             LineAst::StaticAbility(StaticAbility::partner().with_text(visible_label).into()),
             chosen_option_label,
@@ -2105,6 +2104,9 @@ pub(crate) fn lower_keyword_special_cases(
     if let Some(chunk) = try_lower_hideaway_keyword(parse_tokens)? {
         return Ok(Some(chunk));
     }
+    if let Some(chunk) = try_lower_partner_variant_keyword(line, parse_tokens) {
+        return Ok(Some(chunk));
+    }
     if let Some(chunk) = try_lower_partner_with_tokens(parse_tokens)? {
         return Ok(Some(chunk));
     }
@@ -2115,6 +2117,21 @@ pub(crate) fn lower_keyword_special_cases(
         return Ok(Some(chunk));
     }
     Ok(None)
+}
+
+fn try_lower_partner_variant_keyword(
+    line: &RewriteKeywordLine,
+    parse_tokens: &[OwnedLexToken],
+) -> Option<LineAst> {
+    let (label_tokens, _body_tokens) = split_em_dash_label_prefix_tokens(parse_tokens)?;
+    let label_words = parser_token_word_refs(label_tokens);
+    if label_words.as_slice() != ["partner"] {
+        return None;
+    }
+
+    Some(LineAst::StaticAbility(
+        StaticAbility::partner_variant(line.text.as_str()).into(),
+    ))
 }
 
 fn try_lower_hideaway_keyword(
@@ -2253,6 +2270,7 @@ fn partner_with_name_from_tokens(tokens: &[OwnedLexToken]) -> Option<String> {
     (!name.is_empty()).then_some(name)
 }
 
+#[cfg(test)]
 fn render_tokens_before_reminder_or_period(tokens: &[OwnedLexToken]) -> Option<String> {
     let end = tokens
         .iter()
@@ -2262,6 +2280,7 @@ fn render_tokens_before_reminder_or_period(tokens: &[OwnedLexToken]) -> Option<S
     (!display.is_empty()).then_some(display)
 }
 
+#[cfg(test)]
 fn normalize_dash_label_display(display: &str) -> String {
     display
         .replace(" -", " - ")

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1615,6 +1615,34 @@ pub(crate) fn parse_investigate(
 
     let trailing = trim_commas(&tokens[used..]);
     let trailing_words = token_word_refs(&trailing);
+    if token_slice_first_is(&trailing, "for") && token_slice_at_is(&trailing, 1, "each") {
+        let filter_tokens = &trailing[2..];
+        if filter_tokens.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing filter after 'for each' in investigate clause (clause: '{}')",
+                token_word_refs(tokens).join(" ")
+            )));
+        }
+
+        let each_count = parse_investigate_for_each_count(filter_tokens)?;
+        count = match (count, each_count) {
+            (Value::Fixed(1), Value::Count(filter)) => {
+                Value::CountScaled(filter, 1).with_surface_hint(ValueSurfaceHint::ForEach)
+            }
+            (Value::Fixed(1), each_count) => each_count,
+            (Value::Fixed(multiplier), Value::Count(filter)) => {
+                Value::CountScaled(filter, multiplier)
+                    .with_surface_hint(ValueSurfaceHint::ForEach)
+            }
+            (multiplier, each_count) => {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported scaled investigate for-each clause (count: '{multiplier:?}', each: '{each_count:?}')"
+                )));
+            }
+        };
+        return Ok(EffectAst::subject_verb_investigate(player, count));
+    }
+
     if matches!(count, Value::X)
         && CREATE_TIME_OR_TIMES_WORD_PATTERN.matches_word_at(&trailing_words, 0)
         && let Some(where_idx) = CREATE_WHERE_WORD_PATTERN.find_word(&trailing_words)

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -12060,6 +12060,24 @@ fn rewrite_lexed_effect_entrypoint_supports_investigate_for_each_creatures_died(
 }
 
 #[test]
+fn rewrite_lexed_effect_entrypoint_supports_investigate_once_for_each_attacking_creature() {
+    let text = "Investigate once for each nontoken attacking creature.";
+    let lexed = lex_line(text, 0)
+        .expect("rewrite lexer should classify investigate-once-for-each effect");
+    let native = super::clause_support::parse_effect_sentences_lexed(&lexed)
+        .expect("lexed investigate-once-for-each parser should succeed");
+
+    let debug = format!("{native:?}");
+    assert!(
+        debug.contains("Investigate")
+            && debug.contains("Count")
+            && debug.contains("attacking: true")
+            && debug.contains("nontoken: true"),
+        "expected dynamic nontoken attacking creature count in investigate clause, got {debug}"
+    );
+}
+
+#[test]
 fn rewrite_cost_reduction_line_rejects_unmodeled_activate_if_condition() {
     let tokens = lex_line(
         "this ability costs 1 less to activate if you control an artifact.",

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2337,6 +2337,9 @@ impl<
     pub fn partner() -> Self {
         Self::identified(StaticAbilityId::Partner, "partner")
     }
+    pub fn partner_variant(display: impl AsRef<str>) -> Self {
+        Self::identified(StaticAbilityId::Partner, display.as_ref().trim())
+    }
     pub fn partner_with(partner_name: impl AsRef<str>) -> Self {
         Self::identified(
             StaticAbilityId::PartnerWith,

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1076,6 +1076,7 @@ pub(super) fn substitute_legendary_source_reference(
         || conditional_static_self_surface
         || lower.contains("if this land has ")
         || lower.contains(" counters on this artifact")
+        || lower.starts_with("whenever this creature attacks")
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.starts_with("whenever this creature or another ")
         || lower.contains(": this creature gets ")
@@ -1084,7 +1085,11 @@ pub(super) fn substitute_legendary_source_reference(
         return line.to_string();
     }
 
-    let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
+    let source_name = if lower.starts_with("whenever this creature attacks") {
+        card.name.as_str()
+    } else {
+        card.name.split(',').next().unwrap_or(&card.name).trim()
+    };
     if source_name.is_empty() {
         return line.to_string();
     }

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -26,7 +26,10 @@ pub(super) fn is_keyword_phrase(phrase: &str) -> bool {
     if lower.starts_with("hexproof from ") {
         return true;
     }
-    if lower.starts_with("partner with ") {
+    if lower.starts_with("partner with ")
+        || lower.starts_with("partner-")
+        || lower.starts_with("partner\u{2014}")
+    {
         return true;
     }
     if lower.starts_with("ward ") {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33361,24 +33361,24 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             (Value::Fixed(1), "you") => "Investigate".to_string(),
             (Value::Count(filter), "you") => {
                 format!(
-                    "Investigate for each {}",
+                    "Investigate once for each {}",
                     describe_for_each_count_filter(filter)
                 )
             }
             (Value::CountScaled(filter, multiplier), "you") if *multiplier == 1 => {
                 format!(
-                    "Investigate for each {}",
+                    "Investigate once for each {}",
                     describe_for_each_count_filter(filter)
                 )
             }
             (Value::Fixed(1), _) => format!("{player} investigates"),
             (Value::Fixed(amount), _) => format!("{player} investigates {amount} times"),
             (Value::Count(filter), _) => format!(
-                "{player} investigates for each {}",
+                "{player} investigates once for each {}",
                 describe_for_each_count_filter(filter)
             ),
             (Value::CountScaled(filter, multiplier), _) if *multiplier == 1 => format!(
-                "{player} investigates for each {}",
+                "{player} investigates once for each {}",
                 describe_for_each_count_filter(filter)
             ),
             _ if player == "you" => format!("Investigate {}", describe_value(&investigate.count)),
@@ -36545,7 +36545,7 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
         return Some("Partner".to_string());
     }
     if text.starts_with("partner-") || text.starts_with("partner\u{2014}") {
-        return Some(raw_text.to_string());
+        return Some(raw_text.trim_end_matches('.').to_string());
     }
     if text.starts_with("partner with ") {
         return Some(raw_text.to_string());

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1331,6 +1331,146 @@ fn clue_tokens_controlled_by(game: &GameState, player: PlayerId) -> Vec<ObjectId
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn sophina_spearsage_deserter_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(105_941), "Sophina, Spearsage Deserter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::White],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Soldier])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "Menace\nWhenever Sophina, Spearsage Deserter attacks, investigate once for each nontoken attacking creature. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this artifact: Draw a card.\")\nPartner—Friends forever (You can have two commanders if both have this ability.)",
+        )
+        .expect("Sophina, Spearsage Deserter should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sophina_spearsage_deserter_strict_parse_and_compiled_text_preserve_investigate_count() {
+    let def = sophina_spearsage_deserter_definition();
+
+    let rendered_lines = crate::compiled_text::compiled_text_lines(&def);
+    let rendered = rendered_lines.join(" ");
+    assert_eq!(
+        rendered_lines,
+        vec![
+            "Menace".to_string(),
+            "Whenever Sophina, Spearsage Deserter attacks, investigate once for each nontoken attacking creature.".to_string(),
+            "Partner—Friends forever".to_string(),
+        ],
+        "Sophina compiled text should preserve the exact attack trigger, investigate count, and Partner variant label, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("InvestigateEffect")
+            && debug.contains("Count")
+            && debug.contains("attacking: true")
+            && debug.contains("nontoken: true"),
+        "Sophina should structurally investigate for each nontoken attacking creature, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sophina_spearsage_deserter_attack_trigger_counts_nontoken_attackers_and_ignores_tokens() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let sophina = sophina_spearsage_deserter_definition();
+    let sophina_id = game.create_object_from_definition(&sophina, alice, Zone::Battlefield);
+    let nontoken_attacker = create_creature(&mut game, "Nontoken Attacker", alice, 2, 2);
+    let token_attacker = create_creature(&mut game, "Token Attacker", alice, 1, 1);
+    game.object_mut(token_attacker)
+        .expect("token attacker should exist")
+        .kind = ObjectKind::Token;
+
+    for creature in [sophina_id, nontoken_attacker, token_attacker] {
+        game.remove_summoning_sickness(creature);
+    }
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    let declarations = vec![
+        AttackerDeclaration {
+            creature: sophina_id,
+            target: AttackTarget::Player(bob),
+        },
+        AttackerDeclaration {
+            creature: nontoken_attacker,
+            target: AttackTarget::Player(bob),
+        },
+        AttackerDeclaration {
+            creature: token_attacker,
+            target: AttackTarget::Player(bob),
+        },
+    ];
+    apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("Sophina and other creatures should be able to attack");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Sophina attack trigger should go on stack");
+    assert_eq!(game.stack.len(), 1, "Sophina should create one attack trigger");
+
+    resolve_stack_entry(&mut game).expect("Sophina attack trigger should resolve");
+
+    assert_eq!(
+        clue_tokens_controlled_by(&game, alice).len(),
+        2,
+        "Sophina should investigate for Sophina and the other nontoken attacker, but not the token attacker"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sophina_spearsage_deserter_does_not_trigger_when_only_other_creatures_attack() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let sophina = sophina_spearsage_deserter_definition();
+    let sophina_id = game.create_object_from_definition(&sophina, alice, Zone::Battlefield);
+    let other_attacker = create_creature(&mut game, "Other Attacker", alice, 2, 2);
+    game.remove_summoning_sickness(sophina_id);
+    game.remove_summoning_sickness(other_attacker);
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    let declarations = vec![AttackerDeclaration {
+        creature: other_attacker,
+        target: AttackTarget::Player(bob),
+    }];
+    apply_attacker_declarations(&mut game, &mut combat, &mut trigger_queue, &declarations)
+        .expect("other creature should be able to attack without Sophina");
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("putting non-Sophina attack triggers on stack should succeed");
+
+    assert!(
+        game.stack.is_empty(),
+        "Sophina should not trigger when only another creature attacks"
+    );
+    assert_eq!(
+        clue_tokens_controlled_by(&game, alice).len(),
+        0,
+        "Sophina should not investigate without its own attack trigger"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn put_torch_the_witness_on_stack(
     game: &mut GameState,
     controller: PlayerId,

--- a/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/attacks.rs
@@ -285,6 +285,9 @@ impl TriggerMatcher for AttacksTrigger {
                 self.min_total_attackers,
             );
         }
+        if display_filter.source {
+            return format!("Whenever this creature attacks{target_tail}");
+        }
         format!(
             "Whenever {} attacks{target_tail}",
             display_filter.description()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sophina, Spearsage Deserter
Initial parse error:
```
unsupported trailing investigate clause (clause: 'once for each nontoken attacking creature'); oracle-only fallback also failed: unsupported trailing investigate clause (clause: 'once for each nontoken attacking creature')
```

Current worker: i-0eabf2da1c0038f29
Branch: codex/aws-card-fix-sophina-spearsage-deserter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0039
