### PR TITLE
Fix Ironsmith parse failure: Smoke Teller

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
@@ -96,10 +96,6 @@ const UNSUPPORTED_CONTAINS_RULES: &[UnsupportedWordRule] = &[
         message: "unsupported aura-copy attachment fanout clause",
     },
     UnsupportedWordRule {
-        phrase: &["target", "face", "down", "creature"],
-        message: "unsupported face-down clause",
-    },
-    UnsupportedWordRule {
         phrase: &[
             "with",
             "islandwalk",

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/unsupported_shapes.rs
@@ -313,6 +313,16 @@ pub(crate) fn has_face_down_clause_sentence_lexed(
         return false;
     }
 
+    if matches!(
+        words,
+        ["look", "at", "target", "face", "down", "creature"]
+            | ["look", "at", "target", "face", "down", "creatures"]
+            | ["look", "at", "target", "face", "down", "permanent"]
+            | ["look", "at", "target", "face", "down", "permanents"]
+    ) {
+        return false;
+    }
+
     let simple_exile_face_down = primitives::words_match_any_prefix(tokens, EXILE_PREFIXES)
         .is_some()
         && !primitives::contains_word(tokens, "then")

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1359,6 +1359,28 @@ fn compile_subject_verb_effect(
                 subject.into_choices(),
             ))
         }
+        SubjectVerbActionAst::LookAtTarget { target } => {
+            let (spec, choices) =
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            if !choose_spec_targets_object(&spec) {
+                return Err(CardTextError::ParseError(
+                    "look-at-target object clause requires an object target".to_string(),
+                ));
+            }
+            let tag = TagKey::from(ctx.next_tag("targeted").as_str());
+            ctx.last_object_tag = Some(tag.as_str().to_string());
+            Ok((
+                vec![
+                    Effect::new(crate::effects::TargetOnlyEffect::new(spec)).tag(tag.clone()),
+                    Effect::new(crate::effects::LookAtObjectsEffect::new(
+                        ObjectFilter::tagged(tag),
+                        PlayerFilter::You,
+                        PlayerFilter::You,
+                    )),
+                ],
+                choices,
+            ))
+        }
         SubjectVerbActionAst::PutIntoHand { object } => {
             let ObjectRefAst::Tagged(tag) = object;
             let tag = resolve_it_tag_key(tag, &current_reference_env(ctx))?;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -88,6 +88,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::Destroy { target, .. }
             | SubjectVerbActionAst::Exile { target, .. }
             | SubjectVerbActionAst::LookAtHand { target }
+            | SubjectVerbActionAst::LookAtTarget { target }
             | SubjectVerbActionAst::Counter { target }
             | SubjectVerbActionAst::CounterUnlessPays { target, .. }
             | SubjectVerbActionAst::PutCounters { target, .. }
@@ -596,6 +597,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::RevealTagged { .. }
         | SubjectVerbActionAst::RevealCardsFromHand { .. }
         | SubjectVerbActionAst::LookAtObjects { .. }
+        | SubjectVerbActionAst::LookAtTarget { .. }
         | SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { .. }
         | SubjectVerbActionAst::PutSomeIntoHandRestOnBottomOfLibrary { .. }
         | SubjectVerbActionAst::EmitKeywordAction { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -952,6 +952,9 @@ pub(crate) enum SubjectVerbActionAst {
     LookAtObjects {
         filter: ObjectFilter,
     },
+    LookAtTarget {
+        target: TargetAst,
+    },
     PutIntoHand {
         object: ObjectRefAst,
     },
@@ -2099,6 +2102,9 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("LookAtObjects")
                 .field("filter", filter)
                 .finish(),
+            Self::LookAtTarget { target } => {
+                f.debug_tuple("LookAtTarget").field(target).finish()
+            }
             Self::PutIntoHand { object } => f.debug_tuple("PutIntoHand").field(object).finish(),
             Self::MayMoveToZone { target, zone } => f
                 .debug_struct("MayMoveToZone")
@@ -5631,6 +5637,14 @@ impl EffectAst {
             SubjectVerbRoleAst::AffectedPlayer,
             player,
             SubjectVerbActionAst::LookAtObjects { filter },
+        )
+    }
+
+    pub(crate) fn subject_verb_look_at_target(target: TargetAst) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::LookAtTarget { target },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -302,6 +302,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::RevealTagged { .. }
             | SubjectVerbActionAst::RevealCardsFromHand { .. }
             | SubjectVerbActionAst::LookAtObjects { .. }
+            | SubjectVerbActionAst::LookAtTarget { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::EmitKeywordAction { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -515,6 +515,9 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::LookAtHand { target } => {
                     track_target_player(target, frame);
                 }
+                SubjectVerbActionAst::LookAtTarget { target } => {
+                    maybe_tag_target(target, frame, id_gen, "targeted")?;
+                }
                 SubjectVerbActionAst::Counter { target }
                 | SubjectVerbActionAst::CounterUnlessPays { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "countered")?;
@@ -1934,6 +1937,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::EmitKeywordAction { .. }
             | SubjectVerbActionAst::Amass { .. }
             | SubjectVerbActionAst::LookAtObjects { .. }
+            | SubjectVerbActionAst::LookAtTarget { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::Bolster { .. }
@@ -2666,6 +2670,9 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             }
             SubjectVerbActionAst::LookAtObjects { filter } => {
                 bind_unresolved_it_in_filter(filter, seed_tag)
+            }
+            SubjectVerbActionAst::LookAtTarget { target } => {
+                bind_unresolved_it_in_target(target, seed_tag)
             }
             SubjectVerbActionAst::PutIntoHand { object } => {
                 bind_unresolved_it_in_object_ref_ast(object, seed_tag)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2469,6 +2469,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::RevealTagged { .. }
             | SubjectVerbActionAst::RevealCardsFromHand { .. }
             | SubjectVerbActionAst::LookAtObjects { .. }
+            | SubjectVerbActionAst::LookAtTarget { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestIntoGraveyard { .. }
             | SubjectVerbActionAst::PutSomeIntoHandRestOnBottomOfLibrary { .. }
             | SubjectVerbActionAst::EmitKeywordAction { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -544,6 +544,17 @@ pub(crate) fn parse_look(
         return Ok(EffectAst::subject_verb_look_at_hand(target));
     }
 
+    if let Some(filter) = match hand_words.as_slice() {
+        ["target", "face", "down", "creature"]
+        | ["target", "face", "down", "creatures"] => Some(ObjectFilter::creature().face_down()),
+        ["target", "face", "down", "permanent"]
+        | ["target", "face", "down", "permanents"] => Some(ObjectFilter::permanent().face_down()),
+        _ => None,
+    } {
+        let target = TargetAst::Object(filter, span_from_tokens(&hand_tokens), None);
+        return Ok(EffectAst::subject_verb_look_at_target(target));
+    }
+
     let Some(top_idx) = find_index(&clause_tokens, |t| {
         RESOURCE_TOP_WORD_PATTERN.matches_token(t)
     }) else {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -14940,6 +14940,129 @@ fn spy_network_runtime_reorders_your_top_four_library_cards() {
     );
 }
 
+#[derive(Debug)]
+struct SmokeTellerViewCall {
+    viewer: PlayerId,
+    subject: PlayerId,
+    zone: Zone,
+    cards: Vec<ObjectId>,
+}
+
+#[derive(Debug, Default)]
+struct SmokeTellerCaptureDm {
+    calls: Vec<SmokeTellerViewCall>,
+}
+
+impl crate::decision::DecisionMaker for SmokeTellerCaptureDm {
+    fn view_cards(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        viewer: PlayerId,
+        cards: &[ObjectId],
+        ctx: &crate::decisions::context::ViewCardsContext,
+    ) {
+        self.calls.push(SmokeTellerViewCall {
+            viewer,
+            subject: ctx.subject,
+            zone: ctx.zone,
+            cards: cards.to_vec(),
+        });
+    }
+}
+
+fn smoke_teller_creature(name: &str) -> crate::card::Card {
+    crate::card::CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build()
+}
+
+fn smoke_teller_add_creature(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    name: &str,
+) -> ObjectId {
+    let card = smoke_teller_creature(name);
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+fn smoke_teller_activated_effects(def: &CardDefinition) -> &[Effect] {
+    let ability = def.abilities.first().expect("Smoke Teller activated ability");
+    let AbilityKind::Activated(activated) = &ability.kind else {
+        panic!("Smoke Teller should have an activated ability, got {ability:?}");
+    };
+    activated
+        .effects
+        .segments
+        .first()
+        .expect("Smoke Teller resolution segment")
+        .default_effects
+        .as_slice()
+}
+
+#[test]
+fn smoke_teller_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Smoke Teller");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert_eq!(rendered, "{1}{U}: Look at target face-down creature.");
+
+    let debug = format!("{:#?}", smoke_teller_activated_effects(&def));
+    assert!(debug.contains("TargetOnlyEffect"), "{debug}");
+    assert!(debug.contains("LookAtObjectsEffect"), "{debug}");
+}
+
+#[test]
+fn smoke_teller_targets_and_views_only_the_selected_face_down_creature() {
+    let def = parse_oracle_card_definition("Smoke Teller");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let face_down = smoke_teller_add_creature(&mut game, bob, "Face-Down Creature");
+    let face_up = smoke_teller_add_creature(&mut game, bob, "Face-Up Creature");
+    game.set_face_down(face_down);
+
+    let choice = def
+        .abilities
+        .first()
+        .and_then(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated.choices.first(),
+            _ => None,
+        })
+        .expect("Smoke Teller should require a target");
+    let ChooseSpec::Target(inner) = choice else {
+        panic!("Smoke Teller should use a target object choice, got {choice:?}");
+    };
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        panic!("Smoke Teller should target a filtered object, got {choice:?}");
+    };
+    let filter_ctx = crate::filter::FilterContext::default();
+    assert!(
+        filter.matches(game.object(face_down).expect("face-down object"), &filter_ctx, &game),
+        "target filter should allow face-down creatures"
+    );
+    assert!(
+        !filter.matches(game.object(face_up).expect("face-up object"), &filter_ctx, &game),
+        "target filter should reject face-up creatures"
+    );
+
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let mut dm = SmokeTellerCaptureDm::default();
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(face_down)]);
+    for effect in smoke_teller_activated_effects(&def) {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Smoke Teller target and look effects should resolve");
+    }
+
+    assert_eq!(dm.calls.len(), 1, "expected one view call, got {dm:?}");
+    assert_eq!(dm.calls[0].viewer, alice);
+    assert_eq!(dm.calls[0].subject, alice);
+    assert_eq!(dm.calls[0].zone, Zone::Battlefield);
+    assert_eq!(dm.calls[0].cards, vec![face_down]);
+    assert!(!dm.calls[0].cards.contains(&face_up));
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_keeper_of_the_mind_target_condition_survives_rendering() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1623,6 +1623,18 @@ fn is_tagged_only_filter(filter: &ObjectFilter, tag: &crate::TagKey) -> bool {
     normalized == ObjectFilter::tagged(tag.clone())
 }
 
+fn describe_target_then_look_at_tagged_object(effects: &[&Effect]) -> Option<String> {
+    let [target_effect, look_effect] = effects else {
+        return None;
+    };
+    let (target_tag, target_only) = tagged_target_only_effect(target_effect)?;
+    let look = look_effect.downcast_ref::<crate::effects::LookAtObjectsEffect>()?;
+    if look.viewer != PlayerFilter::You || !is_tagged_only_filter(&look.filter, target_tag) {
+        return None;
+    }
+    Some(format!("Look at {}", describe_choose_spec(&target_only.target)))
+}
+
 fn describe_choose_same_controller_targets_then_sacrifice_one(
     effects: &[&Effect],
 ) -> Option<String> {
@@ -14987,6 +14999,17 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
     let effect_refs = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&effect_refs) {
         return Some(compact);
+    }
+
+    if effects.len() >= 2
+        && let Some(first) = describe_target_then_look_at_tagged_object(&effect_refs[..2])
+    {
+        if effects.len() == 2 {
+            return Some(first);
+        }
+        let rest = describe_effect_clause_list(&effects[2..])
+            .unwrap_or_else(|| lowercase_first(&describe_effect_list(&effects[2..])));
+        return Some(format!("{first}. {rest}"));
     }
 
     if effects.len() >= 3


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Smoke Teller
Initial parse error:
```
unsupported face-down clause; oracle-only fallback also failed: unsupported face-down clause
```

Current worker: i-0c3d5d7f7a05c1c6e
Branch: codex/aws-card-fix-smoke-teller
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0039
