### PR TITLE
Fix Ironsmith parse failure: Colfenor's Urn

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -116,6 +116,13 @@ const CONTROL_OR_CONTROLLED_WORD_PATTERN: ClauseShape<'static> =
 const CARD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["card"]);
 const CARD_OR_CARDS_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["card"], &["cards"]]);
+const BEEN_EXILED_WITH_THIS_SOURCE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["been", "exiled", "with", "this"],
+            &["exiled", "with", "this"],
+        ]
+);
 const IN_YOUR_GRAVEYARD_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -2001,6 +2008,45 @@ fn parse_counted_objects_have_counter_predicate(words: &[&str]) -> Option<Predic
     })
 }
 
+fn parse_counted_source_exiled_objects_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if words.len() < 7 {
+        return None;
+    }
+    let (comparison, used) = predicate_quantity_prefix(words)?;
+    let (operator, count) = comparison_to_value_comparison_operator(comparison)?;
+    let have_idx = find_index(words, |word| HAS_OR_HAVE_WORD_PATTERN.matches_word(word))?;
+    if have_idx <= used {
+        return None;
+    }
+    let object_words = &words[used..have_idx];
+    let tail_words = &words[have_idx + 1..];
+    if object_words.is_empty() || !BEEN_EXILED_WITH_THIS_SOURCE_PREFIX_PATTERN.matches_words(tail_words)
+    {
+        return None;
+    }
+
+    let object_tokens = crate::runtime_backend::lexer::synthetic_word_tokens(object_words);
+    let mut filter = if object_words
+        .iter()
+        .all(|word| CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+    {
+        ObjectFilter::default()
+    } else {
+        parse_object_filter(&object_tokens, false).ok()?
+    };
+    filter.zone = Some(Zone::Exile);
+    filter.tagged_constraints.push(TaggedObjectConstraint {
+        tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+        relation: TaggedOpbjectRelation::IsTaggedObject,
+    });
+
+    Some(PredicateAst::ValueComparison {
+        left: Value::Count(filter),
+        operator,
+        right: Value::Fixed(count),
+    })
+}
+
 fn parse_happily_style_conjoined_predicate(words: &[&str]) -> Option<PredicateAst> {
     let cleaned = word_refs_except(words, &[","]);
     let words = cleaned.as_slice();
@@ -2247,6 +2293,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_counted_objects_have_counter_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_counted_source_exiled_objects_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -155,6 +155,57 @@ fn is_then_that_player_shuffles_sentence(tokens: &[OwnedLexToken]) -> bool {
     ])
 }
 
+fn is_if_you_do_return_source_exiled_cards_sentence(tokens: &[OwnedLexToken]) -> bool {
+    let words = crate::runtime_backend::util::non_article_token_word_refs(tokens);
+    if words.len() < 7 || words.get(0..5) != Some(&["if", "you", "do", "return", "those"]) {
+        return false;
+    }
+    if words.get(5) != Some(&"cards") || words.get(6) != Some(&"to") {
+        return false;
+    }
+    words.iter().any(|word| *word == "battlefield")
+        && words
+            .iter()
+            .any(|word| matches!(*word, "owner" | "owners" | "owner's" | "owners'"))
+        && words.iter().any(|word| *word == "control")
+}
+
+fn sacrifice_effect_targets_tagged_it(effect: &EffectAst) -> bool {
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action:
+            SubjectVerbActionAst::Sacrifice {
+                filter,
+                count,
+                target,
+            },
+        ..
+    }) = effect
+    else {
+        return false;
+    };
+    *count == 1
+        && target.is_none()
+        && filter.tagged_constraints.len() == 1
+        && filter.tagged_constraints[0].tag.as_str() == crate::cards::builders::IT_TAG
+        && filter.tagged_constraints[0].relation == TaggedOpbjectRelation::IsTaggedObject
+}
+
+fn sacrifice_effect_targets_source(effect: &EffectAst) -> bool {
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action:
+            SubjectVerbActionAst::Sacrifice {
+                filter,
+                count,
+                target,
+            },
+        ..
+    }) = effect
+    else {
+        return false;
+    };
+    *count == 1 && target.is_none() && filter.source
+}
+
 fn rule_matches_sentence_head(heads: &[&str], tokens: &[OwnedLexToken]) -> bool {
     if heads.is_empty() {
         return true;
@@ -302,6 +353,45 @@ fn pre_rule_library_shuffle_followups(
     }
 
     Ok(None)
+}
+
+fn pre_rule_return_source_exiled_cards_if_source_sacrificed(
+    state: &mut SentenceDispatchState<'_>,
+    _sentences: &[SentenceInput],
+    _sentence_idx: usize,
+    sentence_tokens: &[OwnedLexToken],
+) -> Result<Option<PreParseFollowupResult>, CardTextError> {
+    if !is_if_you_do_return_source_exiled_cards_sentence(sentence_tokens) {
+        return Ok(None);
+    }
+
+    let Some(previous) = state.effects.last_mut() else {
+        return Ok(None);
+    };
+    if sacrifice_effect_targets_tagged_it(previous) {
+        *previous = EffectAst::subject_verb_sacrifice(
+            PlayerAst::You,
+            ObjectFilter::source(),
+            1,
+            None,
+        );
+    } else if !sacrifice_effect_targets_source(previous) {
+        return Ok(None);
+    }
+
+    state.effects.push(EffectAst::IfResult {
+        predicate: IfResultPredicate::Did,
+        effects: vec![EffectAst::subject_verb_return_all_to_battlefield(
+            ObjectFilter::tagged(crate::tag::SOURCE_EXILED_TAG).in_zone(Zone::Exile),
+            false,
+            false,
+            ReturnControllerAst::Owner,
+        )],
+    });
+    Ok(Some(PreParseFollowupResult::Handled {
+        consumed_sentences: 1,
+        route: Some("subject-verb verb=Return subject=source-exiled recognizer=source-sacrifice-followup"),
+    }))
 }
 
 fn pre_rule_future_zone_replacement_followup(
@@ -1176,6 +1266,12 @@ const PRE_PARSE_SUBJECT_VERB_FOLLOWUP_RULES: &[SubjectVerbFollowupRuleDef] = &[
         priority: 55,
         heads: &["if"],
         run: pre_rule_exile_this_way_followup,
+    },
+    SubjectVerbFollowupRuleDef {
+        id: "source-exiled-return-if-sacrificed",
+        priority: 55,
+        heads: &["if"],
+        run: pre_rule_return_source_exiled_cards_if_source_sacrificed,
     },
     SubjectVerbFollowupRuleDef {
         id: "milled-this-way",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -51448,6 +51448,42 @@ fn debug_surface_keeps_complex_source_text_regressions() {
 }
 
 #[test]
+fn colfenors_urn_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Colfenor's Urn");
+    let rendered = debug_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported"),
+        "Colfenor's Urn should strictly parse without unsupported output, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever a creature with toughness 4 or greater is put into your graveyard from the battlefield, you may exile it."
+        ),
+        "expected Colfenor's Urn death trigger text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("if three or more cards have been exiled with this artifact"),
+        "expected source-linked exile count condition, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "sacrifice it. If you do, return those cards to the battlefield under their owners' control"
+        ),
+        "expected source sacrifice and source-linked return text, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("ValueComparison")
+            && ability_debug.contains("__source_exiled__")
+            && ability_debug.contains("SacrificeTargetEffect")
+            && ability_debug.contains("target: Source")
+            && ability_debug.contains("ReturnAllToBattlefieldEffect"),
+        "expected Colfenor's Urn to structurally count and return cards exiled with its source, got {ability_debug}"
+    );
+}
+
+#[test]
 fn necromentia_counts_only_cards_exiled_from_hand_this_way() {
     struct NecromentiaDecisionMaker;
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -21,6 +21,25 @@ pub(super) fn with_effect_render_depth<F: FnOnce() -> String>(render: F) -> Stri
     })
 }
 
+fn is_source_exiled_count_filter(filter: &ObjectFilter) -> bool {
+    if filter.zone != Some(Zone::Exile)
+        || !filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+        })
+    {
+        return false;
+    }
+
+    let mut base = filter.clone();
+    base.zone = None;
+    base.tagged_constraints.retain(|constraint| {
+        !(constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG)
+    });
+    base == ObjectFilter::default()
+}
+
 pub(super) fn describe_player_filter(filter: &PlayerFilter) -> String {
     match filter {
         PlayerFilter::You => "you".to_string(),
@@ -12251,6 +12270,17 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                     }
                 };
                 return format!("{subject} drawn {count_text} or more cards this turn");
+            }
+            if let (
+                Value::Count(filter),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                Value::Fixed(count),
+            ) = (left, operator, right)
+                && is_source_exiled_count_filter(filter)
+            {
+                let count_text = small_number_word(*count as u32)
+                    .unwrap_or_else(|| count.to_string());
+                return format!("{count_text} or more cards have been exiled with this permanent");
             }
             if let (
                 Value::Count(filter),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -951,6 +951,43 @@ fn describe_exile_it_then_return_all_to_battlefield(
     ))
 }
 
+fn describe_source_sacrifice_then_return_source_exiled(
+    first: &Effect,
+    second: &Effect,
+) -> Option<String> {
+    let with_id = first.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let sacrifice = with_id
+        .effect
+        .downcast_ref::<crate::effects::SacrificeTargetEffect>()?;
+    if !matches!(sacrifice.target, ChooseSpec::Source) {
+        return None;
+    }
+
+    let if_effect = second.downcast_ref::<crate::effects::IfEffect>()?;
+    if if_effect.condition != with_id.id
+        || if_effect.predicate != EffectPredicate::Happened
+        || !if_effect.else_.is_empty()
+    {
+        return None;
+    }
+    let [return_effect] = if_effect.then.as_slice() else {
+        return None;
+    };
+    let return_all = return_effect.downcast_ref::<crate::effects::ReturnAllToBattlefieldEffect>()?;
+    if !is_source_exiled_cards_filter(&return_all.filter)
+        || return_all.tapped
+        || return_all.face_down
+        || return_all.battlefield_controller != crate::effects::BattlefieldController::Owner
+    {
+        return None;
+    }
+
+    Some(
+        "sacrifice it. If you do, return those cards to the battlefield under their owners' control"
+            .to_string(),
+    )
+}
+
 fn describe_prevention_follow_up_target(target: &ChooseSpec) -> &'static str {
     let described = describe_choose_spec(target);
     if described.contains("creature") {
@@ -6630,6 +6667,12 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if filtered.len() == 2
         && let Some(compact) =
             describe_exile_it_then_return_all_to_battlefield(filtered[0], filtered[1])
+    {
+        return compact;
+    }
+    if filtered.len() == 2
+        && let Some(compact) =
+            describe_source_sacrifice_then_return_source_exiled(filtered[0], filtered[1])
     {
         return compact;
     }
@@ -16207,6 +16250,42 @@ fn describe_trigger_surface_with_frequency(
         if !chapter_text.is_empty() && chapter_text.len() == chapters.len() {
             return chapter_text.join(", ");
         }
+    }
+
+    if let Some(zone_change) = triggered
+        .trigger
+        .downcast_ref::<crate::triggers::zone_changes::ZoneChangeTrigger>()
+        && zone_change.player == crate::triggers::zone_changes::PlayerRelation::Any
+        && zone_change.count_mode == crate::triggers::zone_changes::CountMode::Each
+        && zone_change.from
+            == crate::triggers::zone_changes::ZonePattern::Specific(Zone::Battlefield)
+        && zone_change.to == crate::triggers::zone_changes::ZonePattern::Specific(Zone::Graveyard)
+        && zone_change.object_filter.owner == Some(PlayerFilter::You)
+    {
+        let mut filter = zone_change.object_filter.clone();
+        filter.owner = None;
+        let subject = with_indefinite_article(&filter.description());
+        return format!(
+            "Whenever {subject} is put into your graveyard from the battlefield"
+        );
+    }
+
+    if triggered
+        .trigger
+        .downcast_ref::<crate::triggers::phase_step::BeginningOfEndStepTrigger>()
+        .is_some_and(|trigger| trigger.player == PlayerFilter::Any)
+        && triggered.intervening_if.as_ref().is_some_and(|condition| {
+            matches!(
+                condition,
+                Condition::ValueComparison {
+                    left: Value::Count(filter),
+                    operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                    ..
+                } if is_source_exiled_cards_filter(filter)
+            )
+        })
+    {
+        return "At the beginning of the end step".to_string();
     }
 
     let mut trigger_surface = triggered.trigger.display();

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -527,6 +527,20 @@ fn evaluate_value_comparison(
     right: &Value,
 ) -> bool {
     let mut ctx = ExecutionContext::new_default(source, controller);
+    let source_exiled = game
+        .get_exiled_with_source_links(source)
+        .iter()
+        .filter_map(|id| {
+            game.object(*id).map(|obj| {
+                crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+                    obj, game,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    if !source_exiled.is_empty() {
+        ctx.set_tagged_objects(crate::tag::SOURCE_EXILED_TAG, source_exiled);
+    }
     let Ok(left_value) = resolve_value(game, left, &mut ctx) else {
         return false;
     };

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -114,6 +114,55 @@ fn graveyard_scroll_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn colfenors_urn_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(696_471), "Colfenor's Urn")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Whenever a creature with toughness 4 or greater is put into your graveyard from the battlefield, you may exile it.\n\
+             At the beginning of the end step, if three or more cards have been exiled with this artifact, sacrifice it. If you do, return those cards to the battlefield under their owner's control.",
+        )
+        .expect("Colfenor's Urn should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn vanilla_creature_definition(
+    card_id: u32,
+    name: &str,
+    power: i32,
+    toughness: i32,
+) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(card_id), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_colfenor_end_step_trigger_on_stack(game: &mut GameState) -> usize {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(game, &mut trigger_queue);
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Colfenor's Urn end-step trigger processing should succeed");
+    game.stack.len()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn count_named_objects_in_zone(game: &GameState, zone: Zone, name: &str) -> usize {
+    game.objects_in_zone(zone)
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| object.name == name)
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn activated_ability_count(game: &GameState, object_id: ObjectId) -> usize {
     game.calculated_characteristics(object_id)
         .expect("object should have calculated characteristics")
@@ -121,6 +170,133 @@ fn activated_ability_count(game: &GameState, object_id: ObjectId) -> usize {
         .iter()
         .filter(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
         .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn colfenors_urn_death_trigger_exiles_only_toughness_four_or_greater_creatures() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let urn = colfenors_urn_definition();
+    let urn_id = game.create_object_from_definition(&urn, alice, Zone::Battlefield);
+
+    let small = vanilla_creature_definition(696_472, "Small Creature", 3, 3);
+    let large = vanilla_creature_definition(696_473, "Large Creature", 4, 4);
+    let small_id = game.create_object_from_definition(&small, alice, Zone::Battlefield);
+    let large_id = game.create_object_from_definition(&large, alice, Zone::Battlefield);
+
+    game.move_object_by_effect(small_id, Zone::Graveyard)
+        .expect("small creature should move to graveyard");
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        0,
+        "Colfenor's Urn should not trigger for toughness below four"
+    );
+
+    game.move_object_by_effect(large_id, Zone::Graveyard)
+        .expect("large creature should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Colfenor's Urn should trigger for a creature with toughness four or greater"
+    );
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Colfenor's Urn death trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Colfenor's Urn death trigger should resolve");
+
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Large Creature"),
+        1,
+        "accepting Colfenor's Urn optional trigger should exile the large creature card"
+    );
+    assert_eq!(
+        game.get_exiled_with_source_links(urn_id).len(),
+        1,
+        "the exiled card should be linked to Colfenor's Urn as cards exiled with it"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn colfenors_urn_end_step_requires_three_source_exiled_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let urn = colfenors_urn_definition();
+    let urn_id = game.create_object_from_definition(&urn, alice, Zone::Battlefield);
+    let card = vanilla_creature_definition(696_474, "Exiled Creature", 2, 2);
+    let unrelated_id = game.create_object_from_definition(&card, alice, Zone::Exile);
+
+    for idx in 0..2 {
+        let card_id = game.create_object_from_definition(&card, alice, Zone::Exile);
+        game.add_exiled_with_source_link(urn_id, card_id);
+        assert_eq!(
+            game.get_exiled_with_source_links(urn_id).len(),
+            idx + 1,
+            "test setup should link exiled cards to Colfenor's Urn"
+        );
+    }
+
+    assert_eq!(
+        put_colfenor_end_step_trigger_on_stack(&mut game),
+        0,
+        "Colfenor's Urn should not count unrelated exiled cards toward its threshold"
+    );
+    assert_eq!(
+        game.object(unrelated_id).expect("unrelated card exists").zone,
+        Zone::Exile,
+        "unrelated exiled cards should remain exiled below the source-linked threshold"
+    );
+    assert_eq!(
+        game.object(urn_id).expect("urn exists").zone,
+        Zone::Battlefield,
+        "below threshold Colfenor's Urn should remain on the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn colfenors_urn_end_step_sacrifices_and_returns_source_exiled_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let urn = colfenors_urn_definition();
+    let urn_id = game.create_object_from_definition(&urn, alice, Zone::Battlefield);
+    let card = vanilla_creature_definition(696_475, "Exiled Creature", 2, 2);
+    let unrelated_id = game.create_object_from_definition(&card, alice, Zone::Exile);
+    let mut exiled = Vec::new();
+
+    for _ in 0..3 {
+        let card_id = game.create_object_from_definition(&card, alice, Zone::Exile);
+        game.add_exiled_with_source_link(urn_id, card_id);
+        exiled.push(card_id);
+    }
+
+    assert_eq!(
+        put_colfenor_end_step_trigger_on_stack(&mut game),
+        1,
+        "Colfenor's Urn should trigger once when three cards have been exiled with it"
+    );
+    resolve_stack_entry(&mut game).expect("Colfenor's Urn end-step trigger should resolve");
+
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Graveyard, "Colfenor's Urn"),
+        1,
+        "Colfenor's Urn should sacrifice itself when the threshold trigger resolves"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Battlefield, "Exiled Creature"),
+        exiled.len(),
+        "only cards exiled with Colfenor's Urn should return to the battlefield"
+    );
+    assert_eq!(
+        game.object(unrelated_id).expect("unrelated card exists").zone,
+        Zone::Exile,
+        "unrelated exiled cards should not return with Colfenor's Urn"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Colfenor's Urn
Initial parse error:
```
unsupported predicate (predicate: 'three or more cards have been exiled with this artifact'); oracle-only fallback also failed: unsupported predicate (predicate: 'three or more cards have been exiled with this artifact')
```

Current worker: i-0d1171a9220510c1f
Branch: codex/aws-card-fix-colfenor-s-urn
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0043
