### PR TITLE
Fix Ironsmith parse failure: Surtland Elementalist

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -698,22 +698,56 @@ fn permanent_spell_filter() -> ObjectFilter {
 }
 
 fn parse_simple_spell_type_list_filter_tokens(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
-    let words = token_word_refs(tokens);
-    let mut words = strip_leading_article_word_refs(&words).to_vec();
-    if words
-        .last()
-        .is_some_and(|word| SPELL_WORD_PATTERN.matches_words(&[*word]))
+    let mut start = 0;
+    if tokens
+        .first()
+        .and_then(OwnedLexToken::as_word)
+        .is_some_and(|word| matches!(word, "a" | "an" | "the"))
     {
-        words.pop();
+        start = 1;
     }
-    if words.is_empty() {
+    let mut end = tokens.len();
+    if tokens
+        .get(end.saturating_sub(1))
+        .and_then(OwnedLexToken::as_word)
+        .is_some_and(|word| SPELL_WORD_PATTERN.matches_words(&[word]))
+    {
+        end = end.saturating_sub(1);
+    }
+    if start >= end {
         return None;
     }
 
     let mut card_types = Vec::new();
-    for word in words {
+    let mut saw_or_separator = false;
+    let mut saw_separator = false;
+    let mut expect_type = true;
+    let mut saw_type = false;
+    for token in &tokens[start..end] {
+        if token.kind == TokenKind::Comma {
+            if !saw_type {
+                return None;
+            }
+            saw_separator = true;
+            expect_type = true;
+            continue;
+        }
+        let word = token.as_word()?;
+        if matches!(word, "or" | "and") {
+            if !saw_type {
+                return None;
+            }
+            if word == "or" {
+                saw_or_separator = true;
+            }
+            saw_separator = true;
+            expect_type = true;
+            continue;
+        }
+        if !expect_type {
+            return None;
+        }
         let card_type = match word {
-            "or" | "and" => continue,
             "artifact" => CardType::Artifact,
             "battle" => CardType::Battle,
             "creature" => CardType::Creature,
@@ -725,8 +759,10 @@ fn parse_simple_spell_type_list_filter_tokens(tokens: &[OwnedLexToken]) -> Optio
             _ => return None,
         };
         crate::slice_primitives::push_unique(&mut card_types, card_type);
+        saw_type = true;
+        expect_type = false;
     }
-    if card_types.is_empty() {
+    if !saw_or_separator || !saw_separator || expect_type || card_types.is_empty() {
         return None;
     }
     Some(ObjectFilter {
@@ -788,7 +824,20 @@ fn parse_permission_subject_filter_tokens_lexed(
         }));
     }
 
-    if let Ok(filter) = parse_object_filter_with_grammar_entrypoint_lexed(filter_tokens, false) {
+    if let Ok(mut filter) =
+        parse_object_filter_with_grammar_entrypoint_lexed(filter_tokens, false)
+    {
+        if filter.all_card_types.is_empty()
+            && filter.card_types.len() > 1
+            && !filter_tokens.iter().any(|token| {
+                token.kind == TokenKind::Comma
+                    || token
+                        .as_word()
+                        .is_some_and(|word| matches!(word, "and" | "or"))
+            })
+        {
+            filter.all_card_types = std::mem::take(&mut filter.card_types);
+        }
         return Ok(Some(normalize_permission_subject_filter(filter)));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -697,6 +697,44 @@ fn permanent_spell_filter() -> ObjectFilter {
     }
 }
 
+fn parse_simple_spell_type_list_filter_tokens(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    let words = token_word_refs(tokens);
+    let mut words = strip_leading_article_word_refs(&words).to_vec();
+    if words
+        .last()
+        .is_some_and(|word| SPELL_WORD_PATTERN.matches_words(&[*word]))
+    {
+        words.pop();
+    }
+    if words.is_empty() {
+        return None;
+    }
+
+    let mut card_types = Vec::new();
+    for word in words {
+        let card_type = match word {
+            "or" | "and" => continue,
+            "artifact" => CardType::Artifact,
+            "battle" => CardType::Battle,
+            "creature" => CardType::Creature,
+            "enchantment" => CardType::Enchantment,
+            "instant" => CardType::Instant,
+            "land" => CardType::Land,
+            "planeswalker" => CardType::Planeswalker,
+            "sorcery" => CardType::Sorcery,
+            _ => return None,
+        };
+        crate::slice_primitives::push_unique(&mut card_types, card_type);
+    }
+    if card_types.is_empty() {
+        return None;
+    }
+    Some(ObjectFilter {
+        card_types,
+        ..ObjectFilter::default()
+    })
+}
+
 fn parse_permission_subject_filter_tokens_lexed(
     filter_tokens: &[OwnedLexToken],
 ) -> Result<Option<ObjectFilter>, CardTextError> {
@@ -717,6 +755,9 @@ fn parse_permission_subject_filter_tokens_lexed(
         ["permanent", "spell"] | ["permanent", "spells"]
     ) {
         return Ok(Some(permanent_spell_filter()));
+    }
+    if let Some(filter) = parse_simple_spell_type_list_filter_tokens(filter_tokens) {
+        return Ok(Some(filter));
     }
     for separator in ["and", "or"] {
         let Some(split_idx) = find_token_index(filter_words.as_slice(), |word| *word == separator)
@@ -1468,50 +1509,32 @@ fn grant_spec_is_free_cast_from_hand(spec: &crate::grant::GrantSpec) -> bool {
 }
 
 fn clause_is_singular_free_cast_from_hand(clause_words: &[&str]) -> bool {
-    SINGULAR_FREE_CAST_FROM_HAND_PATTERN.matches_words(clause_words)
+    if SINGULAR_FREE_CAST_FROM_HAND_PATTERN.matches_words(clause_words) {
+        return true;
+    }
+
+    let Some(cast_idx) = clause_words.iter().position(|word| *word == "cast") else {
+        return false;
+    };
+    let after_cast = &clause_words[cast_idx + 1..];
+    let Some(from_idx) = after_cast.windows(8).position(|window| {
+        matches!(
+            window,
+            ["from", "your", "hand", "without", "paying", "its", "mana", "cost"]
+                | ["from", "your", "hand", "without", "paying", "their", "mana", "cost"]
+                | ["from", "your", "hand", "without", "paying", "their", "mana", "costs"]
+        )
+    }) else {
+        return false;
+    };
+    let subject_words = &after_cast[..from_idx];
+    subject_words.iter().any(|word| *word == "spell")
+        && !subject_words.iter().any(|word| *word == "spells")
 }
 
 fn parse_cast_with_tagged_mana_value_limit_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
-    fn parse_simple_spell_type_list_filter(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
-        let words = token_word_refs(tokens);
-        let mut words = strip_leading_article_word_refs(&words).to_vec();
-        if words
-            .last()
-            .is_some_and(|word| SPELL_WORD_PATTERN.matches_words(&[*word]))
-        {
-            words.pop();
-        }
-        if words.is_empty() {
-            return None;
-        }
-
-        let mut card_types = Vec::new();
-        for word in words {
-            let card_type = match word {
-                "or" | "and" => continue,
-                "artifact" => CardType::Artifact,
-                "battle" => CardType::Battle,
-                "creature" => CardType::Creature,
-                "enchantment" => CardType::Enchantment,
-                "instant" => CardType::Instant,
-                "land" => CardType::Land,
-                "planeswalker" => CardType::Planeswalker,
-                "sorcery" => CardType::Sorcery,
-                _ => return None,
-            };
-            crate::slice_primitives::push_unique(&mut card_types, card_type);
-        }
-        if card_types.is_empty() {
-            return None;
-        }
-        Some(ObjectFilter {
-            card_types,
-            ..ObjectFilter::default()
-        })
-    }
-
     fn parse_cast_with_prefixed_mana_value_limit(
         rest_tokens: &[OwnedLexToken],
         normalized_words: &[String],
@@ -1646,12 +1669,54 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         return Ok(None);
     }
 
+    if let Some(without_idx) = normalized_words
+        .iter()
+        .position(|word| word.as_str() == "without")
+    {
+        let without_tail = normalized_words[without_idx..]
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if from_idx + 3 == without_idx
+            && normalized_words
+                .get(from_idx + 1)
+                .is_some_and(|word| word == "your")
+            && normalized_words
+                .get(from_idx + 2)
+                .is_some_and(|word| matches!(word.as_str(), "graveyard" | "hand"))
+            && WITHOUT_PAYING_ITS_MANA_COST_PATTERN.matches_words(&without_tail)
+        {
+            let Some(filter_end) = token_index_for_word_index(rest_tokens, from_idx) else {
+                return Ok(None);
+            };
+            let filter_tokens = trim_lexed_commas(&rest_tokens[..filter_end]);
+            let Some(mut filter) = parse_simple_spell_type_list_filter_tokens(filter_tokens)
+                .or(parse_permission_subject_filter_tokens_lexed(filter_tokens)?)
+            else {
+                return Ok(None);
+            };
+            filter.owner = Some(crate::target::PlayerFilter::You);
+            let zone = if normalized_words[from_idx + 2] == "hand" {
+                Zone::Hand
+            } else {
+                Zone::Graveyard
+            };
+            return Ok(Some(
+                EffectAst::may_cast_matching_spell_without_paying_mana_cost(
+                    lead.player,
+                    filter,
+                    zone,
+                ),
+            ));
+        }
+    }
+
     if let Some(effect) = parse_cast_with_prefixed_mana_value_limit(
         rest_tokens,
         &normalized_words,
         lead.player,
         from_idx,
-        parse_simple_spell_type_list_filter,
+        parse_simple_spell_type_list_filter_tokens,
     )? {
         return Ok(Some(effect));
     }
@@ -1699,7 +1764,7 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         return Ok(None);
     };
     let filter_tokens = trim_lexed_commas(&rest_tokens[..filter_end]);
-    let Some(mut filter) = parse_simple_spell_type_list_filter(filter_tokens)
+    let Some(mut filter) = parse_simple_spell_type_list_filter_tokens(filter_tokens)
         .or(parse_permission_subject_filter_tokens_lexed(filter_tokens)?)
     else {
         return Ok(None);

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4586,6 +4586,34 @@ fn rewrite_lexed_permission_helpers_preserve_disjunctive_subject_filters_without
 }
 
 #[test]
+fn rewrite_lexed_permission_helpers_preserve_conjunctive_artifact_creature_subject_filters() {
+    let tokens = lex_line("You may cast artifact creature spells from your graveyard", 0)
+        .expect("rewrite lexer should classify artifact creature permission clause");
+
+    let parsed = super::permission_helpers::parse_permission_clause_spec_lexed(&tokens)
+        .expect("permission clause should parse")
+        .expect("permission clause should build a grant spec");
+
+    match parsed {
+        super::PermissionClauseSpec::GrantBySpec {
+            player,
+            spec,
+            lifetime,
+        } => {
+            assert_eq!(player, crate::cards::builders::PlayerAst::You);
+            assert_eq!(lifetime, super::PermissionLifetime::Static);
+            assert_eq!(spec.zone, crate::zone::Zone::Graveyard);
+            assert_eq!(spec.filter.card_types, Vec::<CardType>::new());
+            assert_eq!(
+                spec.filter.all_card_types,
+                vec![CardType::Artifact, CardType::Creature]
+            );
+        }
+        other => panic!("expected graveyard artifact creature cast grant, got {other:?}"),
+    }
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_route_free_cast_spell_filters_through_grammar_entrypoint() {
     let tokens = lex_line(
         "You may cast creature spells from your hand without paying their mana costs",

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4808,6 +4808,39 @@ fn rewrite_lexed_parse_glamdring_trigger_clause_with_damage_value_gate() {
 }
 
 #[test]
+fn rewrite_lexed_parse_surtland_elementalist_trigger_clause_without_mana_value_gate() {
+    let tokens = lex_line(
+        "Cast an instant or sorcery spell from your hand without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify Surtland Elementalist cast clause");
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("Surtland Elementalist cast clause should parse as a supported effect");
+
+    let (player, filter, zone) = match effects.as_slice() {
+        [
+            crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+                player,
+                filter,
+                zone,
+                ..
+            },
+        ] => (player, filter, zone),
+        _ => panic!("expected one-shot hand free-cast effect, got {effects:#?}"),
+    };
+
+    assert!(matches!(
+        player,
+        crate::cards::builders::PlayerAst::Implicit | crate::cards::builders::PlayerAst::You
+    ));
+    assert_eq!(*zone, crate::zone::Zone::Hand);
+    assert!(filter.card_types.contains(&crate::types::CardType::Instant));
+    assert!(filter.card_types.contains(&crate::types::CardType::Sorcery));
+    assert_eq!(filter.mana_value, None);
+}
+
+#[test]
 fn rewrite_lexed_parse_brain_in_a_jar_free_cast_clause_with_counter_value_gate() {
     let tokens = lex_line(
         "Cast an instant or sorcery spell with mana value equal to the number of charge counters on this artifact from your hand without paying its mana cost",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -22468,6 +22468,52 @@ fn parse_brain_in_a_jar_strictly_and_renders_counter_gated_free_cast() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_surtland_elementalist_strictly_and_renders_hand_free_cast() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Surtland Elementalist")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Giant, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(8, 8))
+        .parse_text(
+            "As an additional cost to cast this spell, reveal a Giant card from your hand or pay {2}.\nWhenever this creature attacks, you may cast an instant or sorcery spell from your hand without paying its mana cost.",
+        )
+        .expect("Surtland Elementalist should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("as an additional cost to cast this spell, reveal a giant card from your hand or pay {2}"),
+        "expected reveal-or-pay additional cost in compiled output, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("whenever this creature attacks, you may cast an instant or sorcery spell from your hand without paying its mana cost"),
+        "expected attack-triggered hand free-cast clause in compiled output, got {rendered}"
+    );
+
+    let ability_debug = format!("{:?}", def.abilities);
+    assert!(
+        ability_debug.contains("ThisAttacksTrigger")
+            && ability_debug.contains("MayCastMatchingSpellWithoutPayingManaCostEffect")
+            && ability_debug.contains("Instant")
+            && ability_debug.contains("Sorcery"),
+        "expected Surtland Elementalist to lower to an attack-triggered instant/sorcery free-cast effect, got {ability_debug}"
+    );
+    let cost_debug = format!("{:?}", def.additional_cost);
+    assert!(
+        cost_debug.contains("ChooseModeEffect")
+            && cost_debug.contains("RevealTaggedEffect")
+            && cost_debug.contains("Giant")
+            && cost_debug.contains("PayManaEffect"),
+        "expected Surtland Elementalist to keep reveal-or-pay additional cost structurally, got {cost_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_kentaro_static_mana_value_permission() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Kentaro Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39374,6 +39374,417 @@ fn brain_in_a_jar_ability_index(game: &GameState, brain_id: ObjectId, needle: &s
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn surtland_elementalist_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(93_100), "Surtland Elementalist")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Giant, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(8, 8))
+        .parse_text(
+            "As an additional cost to cast this spell, reveal a Giant card from your hand or pay {2}.\nWhenever this creature attacks, you may cast an instant or sorcery spell from your hand without paying its mana cost.",
+        )
+        .expect("Surtland Elementalist should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+enum SurtlandAdditionalCostMode {
+    Reveal,
+    Pay,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct SurtlandDecisionMaker {
+    cast_free_spell: bool,
+    additional_cost_mode: Option<SurtlandAdditionalCostMode>,
+    object_choice: Option<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for SurtlandDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.cast_free_spell
+    }
+
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if let Some(mode) = self.additional_cost_mode.as_ref() {
+            let needle = match mode {
+                SurtlandAdditionalCostMode::Reveal => "reveal",
+                SurtlandAdditionalCostMode::Pay => "pay {2}",
+            };
+            if let Some(option) = ctx.options.iter().find(|option| {
+                option.legal && option.description.to_ascii_lowercase().contains(needle)
+            }) {
+                return vec![option.index];
+            }
+        }
+
+        ctx.options
+            .iter()
+            .filter(|option| option.legal)
+            .map(|option| option.index)
+            .take(ctx.min)
+            .collect()
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if let Some(object_id) = self.object_choice
+            && ctx
+                .candidates
+                .iter()
+                .any(|candidate| candidate.legal && candidate.id == object_id)
+        {
+            return vec![object_id];
+        }
+
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .take(ctx.min)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn attack_with_surtland(game: &mut GameState, surtland_id: ObjectId) -> TriggerQueue {
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.remove_summoning_sickness(surtland_id);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: surtland_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("Surtland Elementalist should be able to attack");
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn stack_contains_named_object(game: &GameState, name: &str) -> bool {
+    game.stack.iter().any(|entry| {
+        game.object(entry.object_id)
+            .is_some_and(|object| object.name == name)
+    })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn finish_surtland_cast(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    state: &mut PriorityLoopState,
+    mut progress: crate::decision::GameProgress,
+    dm: &mut SurtlandDecisionMaker,
+) {
+    for _ in 0..32 {
+        if stack_contains_named_object(game, "Surtland Elementalist") {
+            return;
+        }
+        progress = match progress {
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectObjects(ctx),
+            ) => {
+                let choice = dm.object_choice.unwrap_or_else(|| {
+                    ctx.candidates
+                        .iter()
+                        .find(|candidate| candidate.legal)
+                        .expect("Surtland additional cost should have a legal object choice")
+                        .id
+                });
+                apply_priority_response_with_dm(
+                    game,
+                    trigger_queue,
+                    state,
+                    &PriorityResponse::CardCostChoice(choice),
+                    dm,
+                )
+                .expect("Surtland additional cost object choice should be accepted")
+            }
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) => {
+                let choice = dm
+                    .decide_options(game, &ctx)
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| {
+                        ctx.options
+                            .iter()
+                            .find(|option| option.legal)
+                            .expect("Surtland cast should have a legal option")
+                            .index
+                    });
+                let description = ctx.description.to_ascii_lowercase();
+                let response = if description.starts_with("choose the next cost to pay") {
+                    PriorityResponse::NextCostChoice(choice)
+                } else {
+                    PriorityResponse::ManaPayment(choice)
+                };
+                apply_priority_response_with_dm(game, trigger_queue, state, &response, dm)
+                    .expect("Surtland cast option should be accepted")
+            }
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            )
+            | crate::decision::GameProgress::Continue => return,
+            other => panic!("unexpected Surtland cast flow state: {other:?}"),
+        };
+    }
+    panic!("Surtland cast flow did not finish after repeated decisions");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn surtland_elementalist_attack_trigger_casts_matching_hand_spell_for_free() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let surtland = surtland_elementalist_definition();
+    let surtland_id = game.create_object_from_definition(&surtland, alice, Zone::Battlefield);
+    let matching_spell = CardBuilder::new(CardId::from_raw(93_101), "Surtland Matching Instant")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(9)]))
+        .build();
+    let nonmatching_type = CardBuilder::new(CardId::from_raw(93_102), "Surtland Hand Creature")
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(1)]))
+        .build();
+    let opponent_spell = CardBuilder::new(CardId::from_raw(93_103), "Opponent Surtland Instant")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(1)]))
+        .build();
+    game.create_object_from_card(&matching_spell, alice, Zone::Hand);
+    let nonmatching_id = game.create_object_from_card(&nonmatching_type, alice, Zone::Hand);
+    let opponent_spell_id = game.create_object_from_card(&opponent_spell, bob, Zone::Hand);
+
+    let mut trigger_queue = attack_with_surtland(&mut game, surtland_id);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Surtland Elementalist should trigger when it attacks"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Surtland Elementalist attack trigger should go on the stack");
+
+    let mut dm = SurtlandDecisionMaker {
+        cast_free_spell: true,
+        additional_cost_mode: None,
+        object_choice: None,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Surtland Elementalist attack trigger should resolve");
+
+    assert!(
+        stack_contains_named_object(&game, "Surtland Matching Instant"),
+        "the matching instant should be cast onto the stack without paying its mana cost"
+    );
+    assert_eq!(
+        game.object(nonmatching_id)
+            .expect("nonmatching creature should still exist")
+            .zone,
+        Zone::Hand,
+        "the trigger should not cast a non-instant, non-sorcery card"
+    );
+    assert_eq!(
+        game.object(opponent_spell_id)
+            .expect("opponent spell should still exist")
+            .zone,
+        Zone::Hand,
+        "the trigger should not cast a spell from another player's hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn surtland_elementalist_attack_trigger_can_be_declined() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    let surtland = surtland_elementalist_definition();
+    let surtland_id = game.create_object_from_definition(&surtland, alice, Zone::Battlefield);
+    let matching_spell = CardBuilder::new(CardId::from_raw(93_104), "Declined Surtland Instant")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(9)]))
+        .build();
+    let matching_id = game.create_object_from_card(&matching_spell, alice, Zone::Hand);
+
+    let mut trigger_queue = attack_with_surtland(&mut game, surtland_id);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Surtland Elementalist attack trigger should go on the stack");
+
+    let mut dm = SurtlandDecisionMaker {
+        cast_free_spell: false,
+        additional_cost_mode: None,
+        object_choice: None,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Surtland Elementalist attack trigger should resolve when declined");
+
+    assert_eq!(
+        game.object(matching_id)
+            .expect("declined spell should still exist")
+            .zone,
+        Zone::Hand,
+        "declining the may trigger should leave the matching spell in hand"
+    );
+    assert!(
+        !stack_contains_named_object(&game, "Declined Surtland Instant"),
+        "declining the may trigger should not cast the spell"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn surtland_elementalist_additional_cost_can_reveal_giant_instead_of_paying_two() {
+    use crate::decision::LegalAction;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let surtland = surtland_elementalist_definition();
+    let surtland_id = game.create_object_from_definition(&surtland, alice, Zone::Hand);
+    let giant = CardBuilder::new(CardId::from_raw(93_105), "Revealed Giant")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Giant])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let giant_id = game.create_object_from_card(&giant, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 2);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 5);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SurtlandDecisionMaker {
+        cast_free_spell: false,
+        additional_cost_mode: Some(SurtlandAdditionalCostMode::Reveal),
+        object_choice: Some(giant_id),
+    };
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id: surtland_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+        &mut dm,
+    )
+    .expect("Surtland Elementalist should cast by revealing a Giant with only its mana cost available");
+    finish_surtland_cast(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        progress,
+        &mut dm,
+    );
+
+    assert!(
+        stack_contains_named_object(&game, "Surtland Elementalist"),
+        "Surtland Elementalist should be on the stack after revealing the Giant additional cost"
+    );
+    assert_eq!(
+        game.object(giant_id)
+            .expect("revealed Giant should remain in hand")
+            .zone,
+        Zone::Hand,
+        "revealing a Giant should not move it out of hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn surtland_elementalist_additional_cost_can_pay_two_without_giant() {
+    use crate::decision::LegalAction;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let surtland = surtland_elementalist_definition();
+    let surtland_id = game.create_object_from_definition(&surtland, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 2);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 7);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SurtlandDecisionMaker {
+        cast_free_spell: false,
+        additional_cost_mode: Some(SurtlandAdditionalCostMode::Pay),
+        object_choice: None,
+    };
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id: surtland_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+        &mut dm,
+    )
+    .expect("Surtland Elementalist should cast by paying {2} with no Giant in hand");
+    finish_surtland_cast(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        progress,
+        &mut dm,
+    );
+
+    assert!(
+        stack_contains_named_object(&game, "Surtland Elementalist"),
+        "Surtland Elementalist should be on the stack after paying {{2}} additional cost"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_omniscience_grants_free_cast_from_hand_without_mana() {
     use crate::cards::definitions::lightning_bolt;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Surtland Elementalist
Initial parse error:
```
could not find verb in effect clause (clause: 'cast an instant or sorcery spell from your hand without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast an instant or sorcery spell from your hand without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-00ea021909d355170
Branch: codex/aws-card-fix-surtland-elementalist
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0043
