### PR TITLE
Fix Ironsmith parse failure: Sigarda's Splendor

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1331,6 +1331,10 @@ impl Effect {
         Self::new(crate::effects::GainLifeEffect::new(amount.into(), target))
     }
 
+    pub fn note_life_total() -> Self {
+        Self::new(crate::effects::NoteLifeTotalEffect)
+    }
+
     pub fn lose_the_game() -> Self {
         Self::new(crate::effects::LoseTheGameEffect::you())
     }

--- a/crates/ironsmith-compiler/src/effects/mod.rs
+++ b/crates/ironsmith-compiler/src/effects/mod.rs
@@ -45,7 +45,7 @@ pub use ironsmith_core::{
     MillEffect, ModifyPowerToughnessEffect, ModifyPowerToughnessForEachEffect, MonstrosityEffect,
     MoveAllCountersEffect, MoveCountersEffect, MoveOneCounterEffect, MoveToLibraryNthFromTopEffect,
     MoveToLibraryTopOrBottomChoiceEffect, MoveToZoneEffect, NewTargetRestriction,
-    NinjutsuCostEffect, NinjutsuEffect, OpenAttractionEffect, PayAnyEnergyEffect,
+    NinjutsuCostEffect, NinjutsuEffect, NoteLifeTotalEffect, OpenAttractionEffect, PayAnyEnergyEffect,
     PayAnyLifeEffect, PayEnergyEffect, PayManaEffect, PhaseInEffect, PhaseOutEffect,
     PoisonCountersEffect, PopulateEffect,
     PreventAllCombatDamageEffect, PreventAllDamageEffect,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2690,6 +2690,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_choose_creature_type_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_named_options_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_player_as_enters_line),
+        single_static_ability_ast_rule!(parse_note_life_total_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_color_as_becomes_attached_line),
         single_static_ability_ast_rule!(parse_enchanted_land_is_chosen_type_line),
         single_static_ability_ast_rule!(parse_source_is_chosen_type_in_addition_line),
@@ -4332,6 +4333,24 @@ pub(crate) fn parse_choose_card_name_as_enters_line(
 
     Ok(Some(StaticAbility::choose_card_name_as_enters(format!(
         "As {display_subject} enters, choose a card name."
+    ))))
+}
+
+pub(crate) fn parse_note_life_total_as_enters_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let words = parser_token_word_refs(tokens);
+    let Some((idx, display_subject)) =
+        parse_as_enters_choice_subject_words(&words, AS_ENTERS_STANDARD_SUBJECTS_WITH_AURA)
+    else {
+        return Ok(None);
+    };
+    if words.get(idx..) != Some(&["note", "your", "life", "total"][..]) {
+        return Ok(None);
+    }
+
+    Ok(Some(StaticAbility::note_life_total_as_enters(format!(
+        "As {display_subject} enters, note your life total."
     ))))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1952,6 +1952,37 @@ fn parse_life_total_at_least_starting_predicate(words: &[&str]) -> Option<Predic
     None
 }
 
+fn parse_life_total_at_least_last_noted_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if !matches!(
+        words,
+        [
+            "your",
+            "life",
+            "total",
+            "is",
+            "greater",
+            "than",
+            "or",
+            "equal",
+            "to",
+            "last",
+            "noted",
+            "life",
+            "total",
+            "for",
+            "this",
+            "permanent" | "enchantment" | "artifact" | "creature" | "land",
+        ]
+    ) {
+        return None;
+    }
+    Some(PredicateAst::ValueComparison {
+        left: Value::LifeTotal(PlayerFilter::You),
+        operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+        right: Value::LastNotedLifeTotal,
+    })
+}
+
 fn parse_counted_objects_have_counter_predicate(words: &[&str]) -> Option<PredicateAst> {
     if words.len() < 7 {
         return None;
@@ -2239,6 +2270,9 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_life_total_at_least_starting_predicate(&filtered) {
+        return Ok(predicate);
+    }
+    if let Some(predicate) = parse_life_total_at_least_last_noted_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -633,6 +633,8 @@ fn is_statement_verb_word(word: &str) -> bool {
             | "loses"
             | "mill"
             | "mills"
+            | "note"
+            | "notes"
             | "put"
             | "puts"
             | "return"

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -805,6 +805,7 @@ fn compile_subject_verb_effect(
                 .push(resolved_tag.as_str().to_string());
             Ok((effects, choices))
         }
+        SubjectVerbActionAst::NoteLifeTotal => Ok((vec![Effect::note_life_total()], Vec::new())),
         SubjectVerbActionAst::ChooseSpellCastHistory {
             cast_by,
             filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -630,6 +630,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::ChooseCreatureType { .. }
         | SubjectVerbActionAst::ChooseCardName { .. }
         | SubjectVerbActionAst::ChoosePlayer { .. }
+        | SubjectVerbActionAst::NoteLifeTotal
         | SubjectVerbActionAst::AddMana { .. }
         | SubjectVerbActionAst::ExchangeLifeTotals { .. }
         | SubjectVerbActionAst::ExchangeTextBoxes { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -819,6 +819,7 @@ pub(crate) enum SubjectVerbActionAst {
         random: bool,
         exclude_previous_choices: usize,
     },
+    NoteLifeTotal,
     ChooseSpellCastHistory {
         cast_by: PlayerAst,
         filter: ObjectFilter,
@@ -1891,6 +1892,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("random", random)
                 .field("exclude_previous_choices", exclude_previous_choices)
                 .finish(),
+            Self::NoteLifeTotal => f.write_str("NoteLifeTotal"),
             Self::ChooseSpellCastHistory {
                 cast_by,
                 filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -335,6 +335,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::ChooseCreatureType { .. }
             | SubjectVerbActionAst::ChooseCardName { .. }
             | SubjectVerbActionAst::ChoosePlayer { .. }
+            | SubjectVerbActionAst::NoteLifeTotal
             | SubjectVerbActionAst::AddMana { .. }
             | SubjectVerbActionAst::ExchangeLifeTotals { .. }
             | SubjectVerbActionAst::ExchangeTextBoxes { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1968,6 +1968,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::ChooseCreatureType { .. }
             | SubjectVerbActionAst::ChooseCardName { .. }
             | SubjectVerbActionAst::ChoosePlayer { .. }
+            | SubjectVerbActionAst::NoteLifeTotal
             | SubjectVerbActionAst::AddMana { .. }
             | SubjectVerbActionAst::ExchangeLifeTotals { .. }
             | SubjectVerbActionAst::ExchangeTextBoxes { .. }
@@ -2472,6 +2473,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             | SubjectVerbActionAst::ChooseCardType { .. }
             | SubjectVerbActionAst::ChooseNamedOption { .. }
             | SubjectVerbActionAst::ChooseCreatureType { .. }
+            | SubjectVerbActionAst::NoteLifeTotal
             | SubjectVerbActionAst::AddManaColorsAmong { .. }
             | SubjectVerbActionAst::AddManaImprintedColors
             | SubjectVerbActionAst::DoubleManaPool

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -1662,6 +1662,13 @@ fn trailing_if_predicate_supported(predicate: &PredicateAst) -> bool {
             | PredicateAst::PlayerHasMoreCardsInHandThanYou { .. }
             | PredicateAst::PlayerHasCardTypesInGraveyardOrMore { .. }
     ) || matches!(predicate, PredicateAst::TaggedMatches(tag, _) if tag.as_str() == ENCHANTED_TAG_NAME)
+        || matches!(
+            predicate,
+            PredicateAst::ValueComparison {
+                right: Value::LastNotedLifeTotal,
+                ..
+            }
+        )
 }
 
 pub(crate) fn is_beginning_of_end_step_words(words: &[&str]) -> bool {
@@ -2360,6 +2367,7 @@ fn subject_verb_player_action_player_mut(effect: &mut EffectAst) -> Option<&mut 
                 | SubjectVerbActionAst::ChooseCreatureType { .. }
                 | SubjectVerbActionAst::ChooseCardName { .. }
                 | SubjectVerbActionAst::ChoosePlayer { .. }
+                | SubjectVerbActionAst::NoteLifeTotal
                 | SubjectVerbActionAst::AddMana { .. }
                 | SubjectVerbActionAst::AddManaScaled { .. }
                 | SubjectVerbActionAst::AddManaAnyColor { .. }
@@ -2435,6 +2443,7 @@ fn subject_verb_player_action_player(effect: &EffectAst) -> Option<PlayerAst> {
                 | SubjectVerbActionAst::ChooseCreatureType { .. }
                 | SubjectVerbActionAst::ChooseCardName { .. }
                 | SubjectVerbActionAst::ChoosePlayer { .. }
+                | SubjectVerbActionAst::NoteLifeTotal
                 | SubjectVerbActionAst::AddMana { .. }
                 | SubjectVerbActionAst::AddManaScaled { .. }
                 | SubjectVerbActionAst::AddManaAnyColor { .. }
@@ -2914,5 +2923,6 @@ pub(crate) enum Verb {
     Detain,
     Goad,
     Suspect,
+    Note,
     End,
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -929,6 +929,7 @@ pub(crate) fn parse_verb_first_clause(
         "detain" => Verb::Detain,
         "goad" => Verb::Goad,
         "suspect" => Verb::Suspect,
+        "note" => Verb::Note,
         "look" => Verb::Look,
         "end" => Verb::End,
         _ => return Ok(None),

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2501,6 +2501,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::ChooseCreatureType { .. }
             | SubjectVerbActionAst::ChooseCardName { .. }
             | SubjectVerbActionAst::ChoosePlayer { .. }
+            | SubjectVerbActionAst::NoteLifeTotal
             | SubjectVerbActionAst::AddMana { .. }
             | SubjectVerbActionAst::ExchangeLifeTotals { .. }
             | SubjectVerbActionAst::ExchangeTextBoxes { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -268,8 +268,24 @@ pub(crate) fn parse_effect_with_verb(
         Verb::Detain => parse_detain(tokens),
         Verb::Goad => parse_goad(tokens),
         Verb::Suspect => parse_suspect(tokens),
+        Verb::Note => parse_note(tokens),
         Verb::End => parse_end(tokens, subject),
     }
+}
+
+fn parse_note(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.as_slice() == ["your", "life", "total"] {
+        return Ok(subject_verb_player_resource_effect(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::You,
+            SubjectVerbActionAst::NoteLifeTotal,
+        ));
+    }
+    Err(CardTextError::ParseError(format!(
+        "unsupported note clause: '{}'",
+        words.join(" ")
+    )))
 }
 
 fn parse_take(

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -548,6 +548,9 @@ impl DrawCardsEffect {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NoteLifeTotalEffect;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TargetOnlyEffect {
     pub target: ChooseSpec,

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -2507,6 +2507,7 @@ fn describe_comparison(cmp: &Comparison) -> String {
             }
             Value::Speed(player) => format!("{player:?}'s speed"),
             Value::StartingLifeTotal(player) => format!("{player:?}'s starting life total"),
+            Value::LastNotedLifeTotal => "last noted life total".to_string(),
             Value::ThisAbilityResolvedThisTurnCount => {
                 "the number of times this ability has resolved this turn".to_string()
             }

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -106,7 +106,7 @@ pub use effect::{
     MillEffect, ModifyPowerToughnessEffect, ModifyPowerToughnessForEachEffect, MonstrosityEffect,
     MoveAllCountersEffect, MoveCountersEffect, MoveOneCounterEffect, MoveToLibraryNthFromTopEffect,
     MoveToLibraryTopOrBottomChoiceEffect, MoveToZoneEffect, NewTargetRestriction,
-    NinjutsuCostEffect, NinjutsuEffect, OpenAttractionEffect, PayAnyEnergyEffect,
+    NinjutsuCostEffect, NinjutsuEffect, NoteLifeTotalEffect, OpenAttractionEffect, PayAnyEnergyEffect,
     PayAnyLifeEffect, PayEnergyEffect, PayManaEffect, PhaseInEffect, PhaseOutEffect,
     PlayerControlDuration, PlayerControlStart,
     PoisonCountersEffect, PopulateEffect, PreventAllCombatDamageEffect, PreventAllDamageEffect,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -157,6 +157,7 @@ pub enum StaticAbilityId {
     ChooseColorAsEnters,
     ChooseColorAsBecomesAttached,
     ChoosePlayerAsEnters,
+    NoteLifeTotalAsEnters,
     ChooseCardNameAsEnters,
     ChooseBasicLandTypeAsEnters,
     ChooseLandTypeAsEnters,
@@ -418,6 +419,7 @@ impl StaticAbilityId {
             | ChooseColorAsEnters
             | ChooseColorAsBecomesAttached
             | ChoosePlayerAsEnters
+            | NoteLifeTotalAsEnters
             | ChooseCardNameAsEnters
             | ChooseBasicLandTypeAsEnters
             | ChooseLandTypeAsEnters

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -385,6 +385,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         condition: Option<Condition>,
     },
     ChoosePlayerAsEnters(String),
+    NoteLifeTotalAsEnters(String),
     ChooseCardNameAsEnters(String),
     ChooseCreatureTypeAsEnters(String),
     ChooseNamedOptionAsEnters {
@@ -1191,6 +1192,9 @@ where
             },
             StaticAbilityPayload::ChoosePlayerAsEnters(display) => {
                 StaticAbilityPayload::ChoosePlayerAsEnters(display)
+            }
+            StaticAbilityPayload::NoteLifeTotalAsEnters(display) => {
+                StaticAbilityPayload::NoteLifeTotalAsEnters(display)
             }
             StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
                 StaticAbilityPayload::ChooseCardNameAsEnters(display)
@@ -3216,6 +3220,14 @@ impl<
             id: Some(StaticAbilityId::ChoosePlayerAsEnters),
             label: display.clone(),
             payload: StaticAbilityPayload::ChoosePlayerAsEnters(display),
+        }
+    }
+    pub fn note_life_total_as_enters(display: impl Into<String>) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::NoteLifeTotalAsEnters),
+            label: display.clone(),
+            payload: StaticAbilityPayload::NoteLifeTotalAsEnters(display),
         }
     }
     pub fn choose_card_name_as_enters(display: impl Into<String>) -> Self {

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -163,6 +163,7 @@ pub enum Value {
     DraftNotedHighestNumber {
         card_name: String,
     },
+    LastNotedLifeTotal,
     CountersOnSource(CounterType),
     CountersOn(Box<ChooseSpec>, Option<CounterType>),
     TaggedCount,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -3151,6 +3151,173 @@ fn happily_ever_after_keeps_life_draw_and_win_gate() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sigardas_splendor_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Sigarda's Splendor");
+
+    let def = parse_oracle_card_definition("Sigarda's Splendor");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+
+    assert!(
+        rendered.contains("As this enchantment enters, note your life total."),
+        "expected as-enters note text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "if your life total is greater than or equal to the last noted life total for this enchantment"
+        ) && rendered.contains("Note your life total."),
+        "expected conditional upkeep draw plus note update, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever you cast a white spell, you gain 1 life."),
+        "expected white spell life-gain trigger text, got {rendered}"
+    );
+    assert!(
+        debug.contains("NoteLifeTotalAsEnters")
+            && debug.contains("NoteLifeTotalEffect")
+            && debug.contains("LastNotedLifeTotal")
+            && debug.contains("ConditionalEffect"),
+        "expected Sigarda's Splendor to model note, compare, conditional draw, and note update, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sigardas_splendor_notes_life_and_draws_conditionally_at_runtime() {
+    fn sigarda_upkeep_trigger(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
+        def.abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered)
+                    if triggered.trigger.display().to_ascii_lowercase().contains("upkeep") =>
+                {
+                    Some(triggered)
+                }
+                _ => None,
+            })
+            .expect("Sigarda's Splendor should have an upkeep trigger")
+    }
+
+    fn add_library_card(game: &mut crate::game_state::GameState, player: PlayerId, name: &str) {
+        let filler = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .build();
+        game.create_object_from_definition(&filler, player, Zone::Library);
+    }
+
+    fn resolve_upkeep_trigger(
+        game: &mut crate::game_state::GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        triggered: &crate::ability::TriggeredAbility,
+    ) {
+        let mut ctx = crate::effects::ExecutionContext::new_default(source, controller);
+        for effect in triggered.effects.flattened_default_effects() {
+            crate::effects::execute_effect(game, effect, &mut ctx)
+                .expect("Sigarda's Splendor upkeep trigger should resolve");
+        }
+    }
+
+    let def = parse_oracle_card_definition("Sigarda's Splendor");
+    let upkeep = sigarda_upkeep_trigger(&def);
+    let alice = PlayerId::from_index(0);
+
+    let mut equal_game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let equal_sigarda = equal_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    add_library_card(&mut equal_game, alice, "Sigarda Equal Branch Draw");
+    assert_eq!(
+        equal_game.noted_life_total_for_source(equal_sigarda),
+        Some(20),
+        "as-enters ability should note the controller's current life total"
+    );
+
+    resolve_upkeep_trigger(&mut equal_game, equal_sigarda, alice, upkeep);
+    assert_eq!(
+        equal_game.player(alice).expect("alice exists").hand.len(),
+        1,
+        "upkeep trigger should draw when life is at least the noted life total"
+    );
+    assert_eq!(
+        equal_game.noted_life_total_for_source(equal_sigarda),
+        Some(20),
+        "upkeep trigger should note the current life total after resolving"
+    );
+
+    let mut lower_game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let lower_sigarda = lower_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    add_library_card(&mut lower_game, alice, "Sigarda Lower Branch Draw");
+    lower_game.lose_life(alice, 1);
+
+    resolve_upkeep_trigger(&mut lower_game, lower_sigarda, alice, upkeep);
+    assert_eq!(
+        lower_game.player(alice).expect("alice exists").hand.len(),
+        0,
+        "upkeep trigger should not draw when life is below the noted life total"
+    );
+    assert_eq!(
+        lower_game.noted_life_total_for_source(lower_sigarda),
+        Some(19),
+        "upkeep trigger should still update the noted life total when the draw branch is false"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sigardas_splendor_gains_life_when_controller_casts_white_spell() {
+    fn spell_cast_event(spell: ObjectId, caster: PlayerId) -> crate::triggers::TriggerEvent {
+        crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::spells::SpellCastEvent::new(spell, caster, Zone::Hand),
+            crate::provenance::ProvNodeId::default(),
+        )
+    }
+
+    let def = parse_oracle_card_definition("Sigarda's Splendor");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let sigarda_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let blue_spell = CardDefinitionBuilder::new(CardId::new(), "Blue Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let blue_spell_id = game.create_object_from_definition(&blue_spell, alice, Zone::Stack);
+    let blue_event = spell_cast_event(blue_spell_id, alice);
+    assert!(
+        crate::triggers::check_triggers(&game, &blue_event)
+            .into_iter()
+            .all(|entry| entry.source != sigarda_id),
+        "Sigarda's Splendor should not trigger for nonwhite spells"
+    );
+
+    let white_spell = CardDefinitionBuilder::new(CardId::new(), "White Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::White]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let white_spell_id = game.create_object_from_definition(&white_spell, alice, Zone::Stack);
+    let white_event = spell_cast_event(white_spell_id, alice);
+    let triggered = crate::triggers::check_triggers(&game, &white_event);
+    let entry = triggered
+        .iter()
+        .find(|entry| entry.source == sigarda_id)
+        .expect("Sigarda's Splendor should trigger when its controller casts a white spell");
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(sigarda_id, alice, &mut dm)
+        .with_triggering_event(entry.triggering_event.clone());
+    for effect in &entry.ability.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Sigarda's Splendor white-spell trigger should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        21,
+        "controller should gain 1 life from Sigarda's Splendor's white-spell trigger"
+    );
+}
+
 #[test]
 fn test_creature_with_etb() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "ETB Creature")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8474,6 +8474,7 @@ pub(crate) fn describe_value(value: &Value) -> String {
             "the highest number you noted for cards named {}",
             title_case_card_name_fragment(card_name)
         ),
+        Value::LastNotedLifeTotal => "the last noted life total for this permanent".to_string(),
         Value::EffectValue(_) => "X".to_string(),
         Value::EffectValueOffset(_, offset) => {
             if *offset == 0 {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33827,6 +33827,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             describe_value(&set_life.amount)
         );
     }
+    if effect
+        .downcast_ref::<crate::effects::NoteLifeTotalEffect>()
+        .is_some()
+    {
+        return "Note your life total".to_string();
+    }
     if let Some(pay_mana) = effect.downcast_ref::<crate::effects::PayManaEffect>() {
         let player = describe_choose_spec(&pay_mana.player);
         return format!(

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4392,6 +4392,7 @@ fn resolve_value_with_context(
         | Value::ManaValueOf(_)
         | Value::LifeTotal(_)
         | Value::LifeTotalDifference(_)
+        | Value::LastNotedLifeTotal
         | Value::Speed(_)
         | Value::StartingLifeTotal(_)
         | Value::HalfLifeTotalRoundedUp(_)

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1360,6 +1360,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::ManaValueOf(_)
         | Value::LifeTotal(_)
         | Value::LifeTotalDifference(_)
+        | Value::LastNotedLifeTotal
         | Value::Speed(_)
         | Value::StartingLifeTotal(_)
         | Value::HalfLifeTotalRoundedUp(_)

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -1529,6 +1529,11 @@ impl Effect {
         Self::new(DrawCardsEffect::you(count))
     }
 
+    pub fn note_life_total() -> Self {
+        use crate::effects::NoteLifeTotalEffect;
+        Self::new(NoteLifeTotalEffect)
+    }
+
     /// Create a "target player draws N cards" effect.
     pub fn target_draws(count: impl Into<Value>, player: PlayerFilter) -> Self {
         use crate::effects::DrawCardsEffect;

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1359,6 +1359,9 @@ where
             payload.player.clone(),
         )));
     }
+    if M::downcast_ref::<ironsmith_core::NoteLifeTotalEffect>(&effect).is_some() {
+        return Ok(Effect::note_life_total());
+    }
     if let Some(converted) = clone_direct_effect::<M, crate::effects::IncreaseSpeedEffect>(&effect)
     {
         return Ok(converted);

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1528,6 +1528,12 @@ pub fn resolve_value(
             .try_into()
             .unwrap_or(i32::MAX)),
 
+        Value::LastNotedLifeTotal => game.noted_life_total_for_source(ctx.source).ok_or_else(|| {
+                ExecutionError::UnresolvableValue(
+                    "last noted life total is not available for this source".to_string(),
+                )
+            }),
+
         Value::EffectValue(effect_id) => {
             let outcome = ctx
                 .get_outcome(*effect_id)

--- a/crates/ironsmith-runtime/src/effects/life/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/life/mod.rs
@@ -9,9 +9,11 @@
 mod exchange_life_totals;
 mod gain_life;
 mod lose_life;
+mod note_life_total;
 mod set_life_total;
 
 pub use exchange_life_totals::ExchangeLifeTotalsEffect;
 pub use gain_life::GainLifeEffect;
 pub use lose_life::LoseLifeEffect;
+pub use note_life_total::NoteLifeTotalEffect;
 pub use set_life_total::SetLifeTotalEffect;

--- a/crates/ironsmith-runtime/src/effects/life/note_life_total.rs
+++ b/crates/ironsmith-runtime/src/effects/life/note_life_total.rs
@@ -1,0 +1,17 @@
+use crate::effect::{EffectOutcome, OutcomeStatus};
+use crate::effects::{EffectExecutor, ExecutionContext, ExecutionError};
+use crate::game_state::GameState;
+pub use ironsmith_core::NoteLifeTotalEffect;
+
+impl EffectExecutor for NoteLifeTotalEffect {
+    fn execute(
+        &self,
+        game: &mut GameState,
+        ctx: &mut ExecutionContext,
+    ) -> Result<EffectOutcome, ExecutionError> {
+        let Some(life_total) = game.note_life_total_for_source(ctx.source, ctx.controller) else {
+            return Ok(EffectOutcome::from_status(OutcomeStatus::Impossible));
+        };
+        Ok(EffectOutcome::count(life_total))
+    }
+}

--- a/crates/ironsmith-runtime/src/effects/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/mod.rs
@@ -144,7 +144,7 @@ pub use delayed::{
     ExileTaggedWhenSourceLeavesEffect, SacrificeSourceWhenTaggedLeavesEffect,
     ScheduleDelayedTriggerEffect, ScheduleEffectsWhenTaggedLeavesEffect, TaggedLeavesAbilitySource,
 };
-pub use life::{ExchangeLifeTotalsEffect, GainLifeEffect, LoseLifeEffect, SetLifeTotalEffect};
+pub use life::{ExchangeLifeTotalsEffect, GainLifeEffect, LoseLifeEffect, NoteLifeTotalEffect, SetLifeTotalEffect};
 pub use mana::{
     AddColorlessManaEffect, AddManaEffect, AddManaFromCommanderColorIdentityEffect,
     AddManaOfAnyColorEffect, AddManaOfAnyOneColorEffect, AddManaOfChosenColorEffect,

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -2024,6 +2024,9 @@ pub struct GameState {
     /// Highest pregame draft-note number recorded by a player for a named card.
     pub draft_noted_highest_numbers: HashMap<(PlayerId, String), u32>,
 
+    /// Last life total noted for a battlefield source object.
+    pub noted_life_totals: HashMap<ObjectId, i32>,
+
     // =========================================================================
     // Battlefield State Extension Maps
     // =========================================================================
@@ -2213,6 +2216,7 @@ impl GameState {
             combat_damage_player_batch_hits: Vec::new(),
             speed_increase_triggered_this_turn: HashSet::new(),
             draft_noted_highest_numbers: HashMap::new(),
+            noted_life_totals: HashMap::new(),
             // Battlefield state extension maps
             tapped_permanents: HashSet::new(),
             summoning_sick: HashSet::new(),
@@ -2277,6 +2281,16 @@ impl GameState {
             .get(&(player, normalize_draft_note_card_name(card_name.as_ref())))
             .copied()
             .unwrap_or(0)
+    }
+
+    pub fn note_life_total_for_source(&mut self, source: ObjectId, player: PlayerId) -> Option<i32> {
+        let life_total = self.player(player)?.life;
+        self.noted_life_totals.insert(source, life_total);
+        Some(life_total)
+    }
+
+    pub fn noted_life_total_for_source(&self, source: ObjectId) -> Option<i32> {
+        self.noted_life_totals.get(&source).copied()
     }
 
     /// Creates a new game state after explicitly resetting runtime player/object IDs.
@@ -3535,6 +3549,16 @@ impl GameState {
             // effects use proper timestamp order in layers.
             self.effect_store.continuous_effects.record_entry(id);
             self.handle_day_night_object_entered(id);
+            if self.object(id).is_some_and(|object| {
+                object.abilities.iter().any(|ability| match &ability.kind {
+                    crate::ability::AbilityKind::Static(static_ability) => {
+                        static_ability.life_total_note_as_enters().is_some()
+                    }
+                    _ => false,
+                })
+            }) {
+                self.note_life_total_for_source(id, owner);
+            }
         }
         id
     }
@@ -4717,6 +4741,9 @@ impl GameState {
                         {
                             self.set_chosen_named_option(new_id, spec.options[chosen_idx].clone());
                         }
+                    }
+                    if static_ability.life_total_note_as_enters().is_some() {
+                        self.note_life_total_for_source(new_id, controller);
                     }
                 }
             }
@@ -8716,6 +8743,7 @@ impl GameState {
         self.transform_count.remove(&id);
         self.phased_out.remove(&id);
         self.imprinted_cards.remove(&id);
+        self.noted_life_totals.remove(&id);
         self.choice_store.chosen_colors.remove(&id);
         self.choice_store.chosen_basic_land_types.remove(&id);
         self.choice_store.chosen_land_types.remove(&id);

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -5,7 +5,7 @@
 use super::{
     ChooseBasicLandTypeAsEntersSpec, ChooseCardNameAsEntersSpec, ChooseColorAsBecomesAttachedSpec,
     ChooseColorAsEntersSpec, ChooseCreatureTypeAsEntersSpec, ChooseLandTypeAsEntersSpec,
-    ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
+    ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec, NoteLifeTotalAsEntersSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
     ConditionalSpellKeywordSpec, CountAsCardNamedForSpellEffectSpec, EnterAsCopyAsEntersSpec,
     GraveyardCountMetric, PowerToughnessChoiceOption, StaticAbility, StaticAbilityId,
@@ -1553,6 +1553,32 @@ impl StaticAbilityKind for ChoosePlayerAsEnters {
 
     fn player_choice_as_enters(&self) -> Option<ChoosePlayerAsEntersSpec> {
         Some(ChoosePlayerAsEntersSpec)
+    }
+}
+
+/// "As this enters, note your life total."
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoteLifeTotalAsEnters {
+    pub display: String,
+}
+
+impl NoteLifeTotalAsEnters {
+    pub fn new(display: String) -> Self {
+        Self { display }
+    }
+}
+
+impl StaticAbilityKind for NoteLifeTotalAsEnters {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::NoteLifeTotalAsEnters
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn life_total_note_as_enters(&self) -> Option<NoteLifeTotalAsEntersSpec> {
+        Some(NoteLifeTotalAsEntersSpec)
     }
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -627,6 +627,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    /// Returns info for "as this enters, note your life total" abilities.
+    fn life_total_note_as_enters(&self) -> Option<NoteLifeTotalAsEntersSpec> {
+        None
+    }
+
     /// Returns info for "as this enters, choose a card name" abilities.
     fn card_name_choice_as_enters(&self) -> Option<ChooseCardNameAsEntersSpec> {
         None
@@ -960,6 +965,10 @@ pub struct ChooseColorAsBecomesAttachedSpec;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChoosePlayerAsEntersSpec;
 
+/// Spec for "as this enters, note your life total" abilities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct NoteLifeTotalAsEntersSpec;
+
 /// Spec for "as this enters, choose a card name" abilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChooseCardNameAsEntersSpec;
@@ -1120,6 +1129,10 @@ impl StaticAbility {
 
     pub fn player_choice_as_enters(&self) -> Option<ChoosePlayerAsEntersSpec> {
         self.0.player_choice_as_enters()
+    }
+
+    pub fn life_total_note_as_enters(&self) -> Option<NoteLifeTotalAsEntersSpec> {
+        self.0.life_total_note_as_enters()
     }
 
     pub fn card_name_choice_as_enters(&self) -> Option<ChooseCardNameAsEntersSpec> {
@@ -2672,6 +2685,10 @@ impl StaticAbility {
 
     pub fn choose_player_as_enters(display: String) -> Self {
         Self::new(ChoosePlayerAsEnters::new(display))
+    }
+
+    pub fn note_life_total_as_enters(display: String) -> Self {
+        Self::new(NoteLifeTotalAsEnters::new(display))
     }
 
     pub fn choose_card_name_as_enters(display: String) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1179,6 +1179,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ChoosePlayerAsEnters(display) => {
                 StaticAbility::choose_player_as_enters(display.clone())
             }
+            ironsmith_core::StaticAbilityPayload::NoteLifeTotalAsEnters(display) => {
+                StaticAbility::note_life_total_as_enters(display.clone())
+            }
             ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
                 StaticAbility::choose_card_name_as_enters(display.clone())
             }
@@ -1572,6 +1575,12 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
             return increase.display();
         }
         self.model.label.clone()
+    }
+
+    fn life_total_note_as_enters(
+        &self,
+    ) -> Option<crate::static_abilities::NoteLifeTotalAsEntersSpec> {
+        self.leaf_static_ability()?.life_total_note_as_enters()
     }
 
     fn with_static_condition(&self, condition: crate::ConditionExpr) -> Option<StaticAbility> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sigarda's Splendor
Initial parse error:
```
parser does not yet support line family: 'As this enchantment enters, note your life total.'; oracle-only fallback also failed: parser does not yet support line family: 'As this enchantment enters, note your life total.'
```

Current worker: i-0af861757b8b1d8ea
Branch: codex/aws-card-fix-sigarda-s-splendor
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0044
