### PR TITLE
Fix Ironsmith parse failure: Snowfall

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -126,6 +126,23 @@ const SPEND_MANA_ACTIVATE_ABILITY_PATTERN: ClauseShape<'static> = clause_shape!(
             ],
         ]
 );
+const SPEND_MANA_PAY_CUMULATIVE_UPKEEP_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &[
+                "spend", "this", "mana", "only", "to", "pay", "cumulative", "upkeep", "costs",
+            ],
+            &[
+                "spend", "this", "mana", "only", "to", "pay", "cumulative", "upkeep", "cost",
+            ],
+            &[
+                "spend", "that", "mana", "only", "to", "pay", "cumulative", "upkeep", "costs",
+            ],
+            &[
+                "spend", "that", "mana", "only", "to", "pay", "cumulative", "upkeep", "cost",
+            ],
+        ]
+);
 const ARTICLE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["a"], &["an"]]);
 const OF_THE_CHOSEN_TYPE_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["of", "the", "chosen", "type"]);
@@ -826,8 +843,20 @@ pub(crate) fn parse_mana_usage_restriction_sentence_lexed(
 ) -> Option<ManaUsageRestriction> {
     parse_legacy_mana_usage_restriction_sentence_lexed(tokens)
         .or_else(|| parse_activate_ability_mana_usage_restriction_sentence_lexed(tokens))
+        .or_else(|| parse_pay_cumulative_upkeep_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_cant_be_spent_to_cast_sentence_lexed(tokens))
         .or_else(|| parse_filter_mana_usage_restriction_sentence_lexed(tokens))
+}
+
+fn parse_pay_cumulative_upkeep_mana_usage_restriction_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ManaUsageRestriction> {
+    let words = TokenWordView::new(tokens).to_word_refs();
+    if SPEND_MANA_PAY_CUMULATIVE_UPKEEP_PATTERN.matches_words(&words) {
+        Some(ManaUsageRestriction::PayCumulativeUpkeepCosts)
+    } else {
+        None
+    }
 }
 
 fn parse_cant_be_spent_to_cast_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -552,6 +552,13 @@ const PREDICATE_REFERENCE_NOUN_WORD_PATTERN: ClauseShape<'static> = clause_shape
             &["token"],
         ]
 );
+
+fn is_predicate_reference_noun_word(word: &str) -> bool {
+    PREDICATE_REFERENCE_NOUN_WORD_PATTERN.matches_word(word)
+        || parse_card_type(word).is_some()
+        || parse_subtype_flexible(word).is_some()
+}
+
 const OR_COMPARISON_TAIL_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["more"], &["fewer"], &["less"], &["greater"], &["equal"]]);
 const ITS_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["its"], &["it's"]]);
@@ -1365,7 +1372,7 @@ fn predicate_reference_prefix<'a>(words: &'a [&'a str]) -> Option<&'a [&'a str]>
     }
     if words.len() >= 2
         && THAT_WORD_PATTERN.matches_word(words[0])
-        && PREDICATE_REFERENCE_NOUN_WORD_PATTERN.matches_word(words[1])
+        && is_predicate_reference_noun_word(words[1])
     {
         return Some(&words[..2]);
     }
@@ -3377,7 +3384,7 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         Some(1usize)
     } else if filtered.len() >= 2
         && THAT_WORD_PATTERN.matches_word_at(&filtered, 0)
-        && PREDICATE_REFERENCE_NOUN_WORD_PATTERN.matches_word_at(&filtered, 1)
+        && is_predicate_reference_noun_word(filtered[1])
     {
         Some(2usize)
     } else {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -150,19 +150,19 @@ fn compile_effect_inner(
         restrictions,
     } = effect
     {
-        let mut compiled_effects = Vec::new();
-        let mut choices = Vec::new();
-        for child in effects {
-            let (mut child_effects, mut child_choices) = compile_effect(child, ctx)?;
-            compiled_effects.append(&mut child_effects);
-            choices.append(&mut child_choices);
-        }
+        let lowered = compile_statement_effects_with_imports(
+            effects,
+            &ReferenceImports {
+                last_object_tag: ctx.last_object_tag.clone().map(TagKey::from),
+                ..ReferenceImports::default()
+            },
+        )?;
         return Ok((
             vec![Effect::mana_restricted(
-                compiled_effects,
+                lowered.effects.flattened_default_effects().to_vec(),
                 restrictions.clone(),
             )],
-            choices,
+            lowered.choices,
         ));
     }
     if let EffectAst::RepeatEffects { count, effects } = effect {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -1389,7 +1389,16 @@ fn apply_mana_usage_restriction_to_previous_effect(
         )));
     }
 
-    let wrapped = match previous {
+    let wrapped = apply_mana_usage_restriction_to_mana_effect(previous, restriction);
+    effects.push(wrapped);
+    Ok(())
+}
+
+fn apply_mana_usage_restriction_to_mana_effect(
+    effect: EffectAst,
+    restriction: crate::ability::ManaUsageRestriction,
+) -> EffectAst {
+    match effect {
         EffectAst::ManaRestricted {
             effects,
             mut restrictions,
@@ -1400,13 +1409,49 @@ fn apply_mana_usage_restriction_to_previous_effect(
                 restrictions,
             }
         }
-        previous => EffectAst::ManaRestricted {
-            effects: vec![previous],
+        EffectAst::Conditional {
+            predicate,
+            if_true,
+            if_false,
+        } => EffectAst::Conditional {
+            predicate,
+            if_true: apply_mana_usage_restriction_to_mana_effects(if_true, restriction.clone()),
+            if_false: apply_mana_usage_restriction_to_mana_effects(if_false, restriction),
+        },
+        EffectAst::SelfReplacement {
+            predicate,
+            if_true,
+            if_false,
+        } => EffectAst::SelfReplacement {
+            predicate,
+            if_true: apply_mana_usage_restriction_to_mana_effects(if_true, restriction.clone()),
+            if_false: apply_mana_usage_restriction_to_mana_effects(if_false, restriction),
+        },
+        EffectAst::Sequence { effects } => EffectAst::Sequence {
+            effects: apply_mana_usage_restriction_to_mana_effects(effects, restriction),
+        },
+        EffectAst::May { effects } => EffectAst::May {
+            effects: apply_mana_usage_restriction_to_mana_effects(effects, restriction),
+        },
+        EffectAst::MayByPlayer { player, effects } => EffectAst::MayByPlayer {
+            player,
+            effects: apply_mana_usage_restriction_to_mana_effects(effects, restriction),
+        },
+        effect => EffectAst::ManaRestricted {
+            effects: vec![effect],
             restrictions: vec![restriction],
         },
-    };
-    effects.push(wrapped);
-    Ok(())
+    }
+}
+
+fn apply_mana_usage_restriction_to_mana_effects(
+    effects: Vec<EffectAst>,
+    restriction: crate::ability::ManaUsageRestriction,
+) -> Vec<EffectAst> {
+    effects
+        .into_iter()
+        .map(|effect| apply_mana_usage_restriction_to_mana_effect(effect, restriction.clone()))
+        .collect()
 }
 
 fn effect_ast_can_produce_mana(effect: &EffectAst) -> bool {
@@ -1433,6 +1478,11 @@ fn effect_ast_can_produce_mana(effect: &EffectAst) -> bool {
                 || (!if_false.is_empty() && if_false.iter().all(effect_ast_can_produce_mana))
         }
         EffectAst::ManaRestricted { effects, .. } => {
+            !effects.is_empty() && effects.iter().all(effect_ast_can_produce_mana)
+        }
+        EffectAst::Sequence { effects }
+        | EffectAst::May { effects }
+        | EffectAst::MayByPlayer { effects, .. } => {
             !effects.is_empty() && effects.iter().all(effect_ast_can_produce_mana)
         }
         _ => false,

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -39,6 +39,7 @@ pub enum ManaUsageRestriction {
         granted_abilities: Vec<StaticAbilityId>,
     },
     ActivateAbility,
+    PayCumulativeUpkeepCosts,
 }
 
 impl Eq for ManaUsageRestriction {}

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7665,6 +7665,43 @@ fn test_parse_trigger_tap_creature_for_mana() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+const SNOWFALL_ORACLE_TEXT: &str = "Cumulative upkeep {U}\nWhenever an Island is tapped for mana, its controller may add an additional {U}. If that Island is snow, its controller may add an additional {U}{U} instead. Spend this mana only to pay cumulative upkeep costs.";
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn snowfall_strict_parser_and_compiled_text_regression() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(2537), "Snowfall")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(SNOWFALL_ORACLE_TEXT)
+        .expect("Snowfall should parse strictly");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("CumulativeUpkeepEffect")
+            && debug.contains("TapForManaTrigger")
+            && debug.contains("PayCumulativeUpkeepCosts")
+            && debug.contains("Snow"),
+        "expected Snowfall to model cumulative upkeep, tap-for-mana, snow branch, and restricted mana, got {debug}"
+    );
+    assert!(
+        !crate::cards::generated_definition_has_unimplemented_content(&def),
+        "Snowfall should not contain unsupported markers: {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("If that Island is snow")
+            && rendered.contains("{U}{U} instead")
+            && rendered.contains("Spend this mana only to pay cumulative upkeep costs"),
+        "expected Snowfall compiled text to preserve snow instead branch and spend restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_trigger_one_or_more_plus_one_counters_put_on_this_creature() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Counter Trigger One-Or-More Probe")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -109,6 +109,11 @@ pub(super) fn describe_player_filter(filter: &PlayerFilter) -> String {
         {
             "its controller".to_string()
         }
+        PlayerFilter::ControllerOf(crate::target::ObjectRef::Tagged(tag))
+            if tag.as_str() == "triggering" =>
+        {
+            "its controller".to_string()
+        }
         PlayerFilter::ControllerOf(crate::target::ObjectRef::Target) => {
             "its controller".to_string()
         }
@@ -947,6 +952,7 @@ pub(super) fn normalize_you_verb_phrase(text: &str) -> String {
         ("pays ", "pay "),
         ("loses ", "lose "),
         ("gains ", "gain "),
+        ("adds ", "add "),
         ("draws ", "draw "),
         ("puts ", "put "),
         ("discards ", "discard "),
@@ -1954,11 +1960,47 @@ fn normalize_searched_tagged_hand_followup(line: &str) -> String {
     normalized
 }
 
+fn normalize_tap_for_mana_conditional_restriction(line: &str) -> String {
+    let Some(rest) = line.strip_prefix("Whenever a player taps ") else {
+        return line.to_string();
+    };
+    let Some((object_phrase, rest)) = rest.split_once(" for mana, its controller may add ") else {
+        return line.to_string();
+    };
+    let Some((base_mana, rest)) = rest.split_once(". Spend this mana only to ") else {
+        return line.to_string();
+    };
+    let Some((restriction_tail, rest)) = rest.split_once(". If that object is ") else {
+        return line.to_string();
+    };
+    let Some((condition, rest)) = rest.split_once(", its controller may add ") else {
+        return line.to_string();
+    };
+    let Some((replacement_mana, replacement_restriction)) =
+        rest.split_once(". Spend this mana only to ")
+    else {
+        return line.to_string();
+    };
+    let replacement_restriction = replacement_restriction.trim_end_matches('.');
+    let Some(replacement_restriction) = replacement_restriction.strip_suffix(" instead") else {
+        return line.to_string();
+    };
+    if restriction_tail != replacement_restriction {
+        return line.to_string();
+    }
+
+    let object_noun = strip_leading_article(object_phrase);
+    format!(
+        "Whenever {object_phrase} is tapped for mana, its controller may add an additional {base_mana}. If that {object_noun} is {condition}, its controller may add an additional {replacement_mana} instead. Spend this mana only to {restriction_tail}"
+    )
+}
+
 pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
     let mut normalized = line.trim().to_string();
     normalized = normalize_token_quoted_ability_surfaces(&normalized);
     normalized = normalize_token_death_trigger_quote_surface(&normalized);
     normalized = normalize_searched_tagged_hand_followup(&normalized);
+    normalized = normalize_tap_for_mana_conditional_restriction(&normalized);
     normalized = normalized
         .replace(" and gains This creature can't ", " and can't ")
         .replace(" and gains This creature cant ", " and can't ")
@@ -11944,6 +11986,48 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                         "creature"
                     };
                     return is_clause(noun);
+                }
+                if filter.supertypes.len() == 1
+                    && filter.zone.is_none()
+                    && filter.controller.is_none()
+                    && filter.owner.is_none()
+                    && !filter.single_graveyard
+                    && filter.card_types.is_empty()
+                    && filter.all_card_types.is_empty()
+                    && filter.excluded_card_types.is_empty()
+                    && filter.subtypes.is_empty()
+                    && filter.excluded_subtypes.is_empty()
+                    && filter.excluded_supertypes.is_empty()
+                    && filter.colors.is_none()
+                    && filter.excluded_colors.is_empty()
+                    && !filter.colorless
+                    && !filter.multicolored
+                    && !filter.monocolored
+                    && filter.all_colors.is_none()
+                    && filter.exactly_two_colors.is_none()
+                    && filter.power.is_none()
+                    && filter.toughness.is_none()
+                    && filter.total_power_toughness.is_none()
+                    && filter.mana_value.is_none()
+                    && filter.with_counter.is_none()
+                    && filter.without_counter.is_none()
+                    && filter.name.is_none()
+                    && filter.excluded_name.is_none()
+                    && filter.tagged_constraints.is_empty()
+                    && filter.any_of.is_empty()
+                    && !filter.source
+                {
+                    let supertype = match filter.supertypes[0] {
+                        Supertype::Basic => "basic",
+                        Supertype::Legendary => "legendary",
+                        Supertype::Snow => "snow",
+                        Supertype::World => "world",
+                    };
+                    return if subject == "it" {
+                        format!("it's {supertype}")
+                    } else {
+                        format!("{subject} is {supertype}")
+                    };
                 }
                 if filter.subtypes.len() == 1
                     && filter.zone.is_none()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -35878,6 +35878,9 @@ fn describe_mana_usage_restriction(
         crate::ability::ManaUsageRestriction::ActivateAbility => {
             Some("Spend this mana only to activate abilities".to_string())
         }
+        crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts => {
+            Some("Spend this mana only to pay cumulative upkeep costs".to_string())
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/costs/payer_trait.rs
+++ b/crates/ironsmith-runtime/src/costs/payer_trait.rs
@@ -25,6 +25,8 @@ pub enum PaymentReason {
     TurnFaceUp,
     /// Paying a cost during effect or triggered-ability resolution.
     Effect,
+    /// Paying cumulative upkeep costs during cumulative-upkeep resolution.
+    CumulativeUpkeep,
     /// Paying another special-action or generic engine cost.
     #[default]
     Other,

--- a/crates/ironsmith-runtime/src/effects/composition/cumulative_upkeep.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/cumulative_upkeep.rs
@@ -136,6 +136,7 @@ fn payment_can_complete(
     let mut simulated_dm = SelectFirstDecisionMaker;
     let mut simulated_ctx = ExecutionContext::new_default(ctx.source, ctx.controller)
         .with_decision_maker(&mut simulated_dm);
+    simulated_ctx.mana.payment_reason = crate::costs::PaymentReason::CumulativeUpkeep;
 
     for _ in 0..count {
         let Ok(outcome) = execute_sequence(&mut simulated_game, &mut simulated_ctx, effects) else {
@@ -156,6 +157,8 @@ fn execute_payment_atomically(
 ) -> Result<Option<EffectOutcome>, ExecutionError> {
     let game_checkpoint = game.clone();
     let ctx_checkpoint = ExecutionContextCheckpoint::from_context(ctx);
+    let saved_reason = ctx.mana.payment_reason;
+    ctx.mana.payment_reason = crate::costs::PaymentReason::CumulativeUpkeep;
     let mut outcomes = Vec::new();
     let mut failed_to_pay = false;
     let mut execution_error = None;
@@ -185,6 +188,7 @@ fn execute_payment_atomically(
         restore_payment_checkpoint(game, ctx, game_checkpoint, ctx_checkpoint);
         return Ok(None);
     }
+    ctx.mana.payment_reason = saved_reason;
 
     Ok(Some(EffectOutcome::aggregate_summing_counts(outcomes)))
 }

--- a/crates/ironsmith-runtime/src/effects/context.rs
+++ b/crates/ironsmith-runtime/src/effects/context.rs
@@ -160,6 +160,8 @@ pub struct ManaExecutionContext {
     pub mana_usage_restrictions: Vec<crate::ability::ManaUsageRestriction>,
     /// Chosen creature type snapshot for mana produced by the source.
     pub mana_source_chosen_creature_type: Option<Subtype>,
+    /// Why mana costs paid by this effect are being paid.
+    pub payment_reason: crate::costs::PaymentReason,
 }
 
 /// Ephemeral replacement effects scoped to the current resolution path.

--- a/crates/ironsmith-runtime/src/effects/mana/pay_mana.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/pay_mana.rs
@@ -24,20 +24,21 @@ fn try_pay_interactively(
     player_id: PlayerId,
 ) -> bool {
     const MAX_PAYMENT_STEPS: usize = 32;
+    let reason = ctx.mana.payment_reason;
 
     for _ in 0..MAX_PAYMENT_STEPS {
         let adjusted_cost = game.adjust_mana_cost_for_payment_reason(
             player_id,
             Some(ctx.source),
             &effect.cost,
-            crate::costs::PaymentReason::Effect,
+            reason,
         );
         let can_pay_now = game.can_pay_mana_cost_with_reason(
             player_id,
             Some(ctx.source),
             &adjusted_cost,
             0,
-            crate::costs::PaymentReason::Effect,
+            reason,
         );
         let mana_abilities = get_available_mana_abilities(game, player_id, &mut ctx.decision_maker);
 
@@ -88,7 +89,7 @@ fn try_pay_interactively(
                     Some(ctx.source),
                     &adjusted_cost,
                     0,
-                    crate::costs::PaymentReason::Effect,
+                    reason,
                 );
             }
             return false;
@@ -104,7 +105,7 @@ fn try_pay_interactively(
                     Some(ctx.source),
                     &adjusted_cost,
                     0,
-                    crate::costs::PaymentReason::Effect,
+                    reason,
                 );
             }
             PayManaChoice::ActivateManaAbility {
@@ -127,14 +128,14 @@ fn try_pay_interactively(
         player_id,
         Some(ctx.source),
         &effect.cost,
-        crate::costs::PaymentReason::Effect,
+        reason,
     );
     game.try_pay_mana_cost_with_reason(
         player_id,
         Some(ctx.source),
         &adjusted_cost,
         0,
-        crate::costs::PaymentReason::Effect,
+        reason,
     )
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -686,6 +686,7 @@ fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRe
             ..
         } => *restrict_to_matching_spell,
         crate::ability::ManaUsageRestriction::ActivateAbility => true,
+        crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts => true,
     }
 }
 
@@ -734,6 +735,7 @@ fn restriction_bonus_applies_to_payment_source(
             cast_spell_filter_matches_payment_source(game, unit, filter, payment_source)
         }
         crate::ability::ManaUsageRestriction::ActivateAbility => false,
+        crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts => false,
     }
 }
 
@@ -799,6 +801,7 @@ pub(super) fn payment_source_matches_restriction(
             cast_spell_filter_matches_payment_source(game, unit, filter, Some(source_obj.id))
         }
         crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
+        crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts => false,
     }
 }
 
@@ -937,7 +940,8 @@ pub(super) fn apply_spent_mana_bonuses(
                 enters_with_counters,
                 granted_abilities,
             ),
-            crate::ability::ManaUsageRestriction::ActivateAbility => continue,
+            crate::ability::ManaUsageRestriction::ActivateAbility
+            | crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts => continue,
         };
 
         if grant_uncounterable || !enters_with_counters.is_empty() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -9049,6 +9049,149 @@ fn test_triggered_mana_ability_resolves_immediately_without_stack() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+const SNOWFALL_ORACLE_TEXT: &str = "Cumulative upkeep {U}\nWhenever an Island is tapped for mana, its controller may add an additional {U}. If that Island is snow, its controller may add an additional {U}{U} instead. Spend this mana only to pay cumulative upkeep costs.";
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn snowfall_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(2537), "Snowfall")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(SNOWFALL_ORACLE_TEXT)
+        .expect("Snowfall should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn snowfall_upkeep_trigger(def: &crate::cards::CardDefinition) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if format!("{triggered:?}").contains("CumulativeUpkeepEffect") =>
+            {
+                Some(triggered)
+            }
+            _ => None,
+        })
+        .expect("Snowfall should have cumulative upkeep trigger")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn test_island_card(name: &str, snow: bool) -> crate::card::Card {
+    let mut builder = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Island]);
+    if snow {
+        builder = builder.supertypes(vec![Supertype::Snow]);
+    }
+    builder.build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn trigger_snowfall_for_island(snow: bool) -> GameState {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+    let alice = PlayerId::from_index(0);
+    let snowfall = snowfall_definition();
+    game.create_object_from_definition(&snowfall, alice, Zone::Battlefield);
+    let island_card = test_island_card(if snow { "Snow Island" } else { "Island" }, snow);
+    let island_id = game.create_object_from_card(&island_card, alice, Zone::Battlefield);
+
+    queue_ability_activated_event(
+        &mut game,
+        &mut trigger_queue,
+        &mut dm,
+        island_id,
+        alice,
+        true,
+        None,
+    );
+    assert!(trigger_queue.is_empty(), "Snowfall is a triggered mana ability");
+    assert!(game.stack.is_empty(), "Snowfall mana trigger should not use the stack");
+    game
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn snowfall_nonsnow_island_adds_one_restricted_blue_mana() {
+    let game = trigger_snowfall_for_island(false);
+    let alice = PlayerId::from_index(0);
+    let player = game.player(alice).expect("alice exists");
+    assert_eq!(player.mana_pool.blue, 1, "nonsnow Island should add one blue mana");
+    assert_eq!(player.restricted_mana.len(), 1);
+    assert_eq!(
+        player.restricted_mana[0].restrictions,
+        vec![crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts]
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn snowfall_snow_island_adds_two_restricted_blue_mana_instead() {
+    let game = trigger_snowfall_for_island(true);
+    let alice = PlayerId::from_index(0);
+    let player = game.player(alice).expect("alice exists");
+    assert_eq!(player.mana_pool.blue, 2, "snow Island should use the {{U}}{{U}} instead branch");
+    assert_eq!(player.restricted_mana.len(), 2);
+    assert!(player.restricted_mana.iter().all(|unit| {
+        unit.restrictions == vec![crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts]
+    }));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn snowfall_restricted_mana_pays_cumulative_upkeep_not_spells() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let snowfall = snowfall_definition();
+    let upkeep = snowfall_upkeep_trigger(&snowfall).clone();
+    let snowfall_id = game.create_object_from_definition(&snowfall, alice, Zone::Battlefield);
+    let spell = CardBuilder::new(CardId::new(), "Blue Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let spell_id = game.create_object_from_card(&spell, alice, Zone::Stack);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .add_restricted_mana(crate::ability::RestrictedManaUnit {
+            symbol: ManaSymbol::Blue,
+            source: snowfall_id,
+            source_chosen_creature_type: None,
+            restrictions: vec![crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts],
+        });
+    assert!(
+        spend_pool_symbol(&mut game, alice, ManaSymbol::Blue, Some(spell_id)).is_none(),
+        "Snowfall mana must not be spendable on ordinary spells"
+    );
+    assert!(
+        spend_pool_symbol(&mut game, alice, ManaSymbol::Blue, Some(snowfall_id)).is_none(),
+        "Snowfall mana must not be spendable on generic costs from a cumulative-upkeep permanent"
+    );
+
+    let mut dm = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(snowfall_id, alice, &mut dm);
+    execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        snowfall_id,
+        &upkeep.effects,
+        None,
+        &[],
+    )
+    .expect("Snowfall cumulative upkeep should resolve");
+
+    assert!(game.battlefield.contains(&snowfall_id), "restricted mana should pay Snowfall's upkeep");
+    assert_eq!(game.counter_count(snowfall_id, CounterType::Age), 1);
+    let player = game.player(alice).expect("alice exists");
+    assert_eq!(player.mana_pool.blue, 0);
+    assert!(player.restricted_mana.is_empty());
+}
+
 #[test]
 fn test_mana_added_event_triggers_mana_ability_immediately() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -6532,6 +6532,8 @@ impl GameState {
             .and_then(|source| self.chosen_color_activation_mana_restriction(source, cost, reason))
         {
             self.mana_pool_restricted_to_symbol(&player.mana_pool, symbol)
+        } else if reason == crate::costs::PaymentReason::CumulativeUpkeep {
+            self.mana_pool_for_cumulative_upkeep_payment(player, source)
         } else {
             player.mana_pool.clone()
         };
@@ -6611,6 +6613,42 @@ impl GameState {
             }
             return true;
         }
+        if reason == crate::costs::PaymentReason::CumulativeUpkeep {
+            let Some(player) = self.player(payer) else {
+                return false;
+            };
+            let mut payable_pool = self.mana_pool_for_cumulative_upkeep_payment(player, source);
+            let before_payable = payable_pool.clone();
+            let (paid, life_to_pay) = payable_pool
+                .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
+                    cost,
+                    x_value,
+                    &mana_spend_policy,
+                    allow_black_life,
+                );
+            if !paid || !self.can_pay_life_with_reason(payer, life_to_pay, reason) {
+                return false;
+            }
+            if !self.consume_cumulative_upkeep_restricted_mana(
+                payer,
+                source,
+                &before_payable,
+                &payable_pool,
+            ) {
+                if let (Some(original_pool), Some(player)) = (original_pool, self.player_mut(payer)) {
+                    player.mana_pool = original_pool;
+                }
+                return false;
+            }
+            if life_to_pay > 0 && !self.pay_life(payer, life_to_pay) {
+                if let (Some(original_pool), Some(player)) = (original_pool, self.player_mut(payer)) {
+                    player.mana_pool = original_pool;
+                }
+                return false;
+            }
+            return true;
+        }
+
         let (paid, life_to_pay) = {
             let Some(player) = self.player_mut(payer) else {
                 return false;
@@ -6672,6 +6710,95 @@ impl GameState {
             self.chosen_color(source)
                 .map(crate::mana::ManaSymbol::from_color)
         })?
+    }
+
+    fn cumulative_upkeep_restricted_unit_is_payable(
+        &self,
+        unit: &crate::ability::RestrictedManaUnit,
+        source: Option<ObjectId>,
+    ) -> bool {
+        let Some(source_id) = source else {
+            return false;
+        };
+        let Some(source_obj) = self.object(source_id) else {
+            return false;
+        };
+        if source_obj.zone != Zone::Battlefield {
+            return false;
+        }
+        let has_cumulative_upkeep = source_obj.abilities.iter().any(|ability| match &ability.kind {
+            crate::ability::AbilityKind::Triggered(triggered) => triggered
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::CumulativeUpkeepEffect>()
+                        .is_some()
+                }),
+            _ => false,
+        });
+        has_cumulative_upkeep
+            && unit.restrictions.iter().all(|restriction| {
+                matches!(
+                    restriction,
+                    crate::ability::ManaUsageRestriction::PayCumulativeUpkeepCosts
+                )
+            })
+    }
+
+    fn mana_pool_for_cumulative_upkeep_payment(
+        &self,
+        player: &crate::player::Player,
+        source: Option<ObjectId>,
+    ) -> crate::player::ManaPool {
+        let mut pool = player.mana_pool.clone();
+        for unit in &player.restricted_mana {
+            if !self.cumulative_upkeep_restricted_unit_is_payable(unit, source) {
+                pool.remove(unit.symbol, 1);
+            }
+        }
+        pool
+    }
+
+    fn consume_cumulative_upkeep_restricted_mana(
+        &mut self,
+        payer: PlayerId,
+        source: Option<ObjectId>,
+        before: &crate::player::ManaPool,
+        after: &crate::player::ManaPool,
+    ) -> bool {
+        use crate::mana::ManaSymbol;
+
+        for symbol in [
+            ManaSymbol::White,
+            ManaSymbol::Blue,
+            ManaSymbol::Black,
+            ManaSymbol::Red,
+            ManaSymbol::Green,
+            ManaSymbol::Colorless,
+        ] {
+            let mut spent = before.amount(symbol).saturating_sub(after.amount(symbol));
+            while spent > 0 {
+                let restricted_idx = self.player(payer).and_then(|player| {
+                    player.restricted_mana.iter().position(|unit| {
+                        unit.symbol == symbol
+                            && self.cumulative_upkeep_restricted_unit_is_payable(unit, source)
+                    })
+                });
+                let Some(player) = self.player_mut(payer) else {
+                    return false;
+                };
+                if let Some(idx) = restricted_idx {
+                    player.restricted_mana.remove(idx);
+                }
+                if !player.mana_pool.remove(symbol, 1) {
+                    return false;
+                }
+                spent -= 1;
+            }
+        }
+        true
     }
 
     fn mana_pool_restricted_to_symbol(

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/tap_for_mana.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/tap_for_mana.rs
@@ -69,9 +69,16 @@ impl TriggerMatcher for TapForManaTrigger {
         let object_phrase = if starts_with_determiner(&object) {
             object
         } else {
-            format!("a {object}")
+            format!("{} {object}", indefinite_article(&object))
         };
         format!("Whenever {player} {verb} {object_phrase} for mana")
+    }
+}
+
+fn indefinite_article(text: &str) -> &'static str {
+    match text.chars().next().map(|ch| ch.to_ascii_lowercase()) {
+        Some('a' | 'e' | 'i' | 'o' | 'u') => "an",
+        _ => "a",
     }
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Snowfall
Initial parse error:
```
unsupported predicate (predicate: 'that island is snow'); oracle-only fallback also failed: unsupported predicate (predicate: 'that island is snow')
```

Current worker: i-0811a533027315046
Branch: codex/aws-card-fix-snowfall
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0044
