### PR TITLE
Fix Ironsmith parse failure: Captain America, First Avenger

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1116,6 +1116,10 @@ impl Effect {
         Self::new(crate::effects::AttachObjectsEffect::new(objects, target))
     }
 
+    pub fn unattach_objects(objects: crate::target::ChooseSpec) -> Self {
+        Self::new(crate::effects::UnattachObjectsEffect::new(objects))
+    }
+
     pub fn transform(target: crate::target::ChooseSpec) -> Self {
         Self::new(crate::effects::TransformEffect::new(target))
     }

--- a/crates/ironsmith-compiler/src/effects/mod.rs
+++ b/crates/ironsmith-compiler/src/effects/mod.rs
@@ -81,7 +81,7 @@ pub use ironsmith_core::{
     TagMatchingObjectsEffect, TagTriggeringDamageTargetEffect, TagTriggeringObjectEffect,
     TagTriggeringSourceEffect, TaggedEffect as CoreTaggedEffect, TaggedLeavesAbilitySource,
     TakeInitiativeEffect, TapEffect, TargetOnlyEffect, TicketCountersEffect, TransformEffect,
-    UnearthEffect, UnlessActionEffect, UnlessPaysEffect, UntapEffect,
+    UnearthEffect, UnattachObjectsEffect, UnlessActionEffect, UnlessPaysEffect, UntapEffect,
     VariableCasualtyPlaneswalkerCopyEffect, VentureIntoDungeonEffect, WinTheGameEffect,
     WithIdEffect as CoreWithIdEffect,
 };

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -352,13 +352,18 @@ pub(super) fn run_max_speed_labeled_line_family(
         split_activation_text_tokens_lexed(&activation_line.tokens)
     {
         let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
-        match parse_activation_cost_tokens_rewrite(&cost_tokens) {
+        let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+            &ctx.preprocessed.builder,
+            ctx.line,
+            cost_tokens.clone(),
+        )?;
+        match parse_activation_cost_tokens_rewrite(&normalized_cost_tokens) {
             Ok(cost) => {
                 return Ok(Some(LineDispatchResult::single(
                     RewriteLineCst::Activated(ActivatedLineCst {
                         info: ctx.line.info.clone(),
                         cost,
-                        cost_parse_tokens: cost_tokens,
+                        cost_parse_tokens: normalized_cost_tokens,
                         effect_text,
                         effect_parse_tokens,
                         presentation_label: None,
@@ -726,13 +731,18 @@ pub(super) fn run_station_line_family(
             ctx.line.info.raw_line
         )));
     };
-    let cost = parse_activation_cost_tokens_rewrite(&cost_tokens)?;
+    let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+        &ctx.preprocessed.builder,
+        ctx.line,
+        cost_tokens.clone(),
+    )?;
+    let cost = parse_activation_cost_tokens_rewrite(&normalized_cost_tokens)?;
     let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
 
     let mut lines = vec![RewriteLineCst::Activated(ActivatedLineCst {
         info: ctx.line.info.clone(),
         cost,
-        cost_parse_tokens: cost_tokens,
+        cost_parse_tokens: normalized_cost_tokens,
         effect_text,
         effect_parse_tokens,
         presentation_label: None,
@@ -833,12 +843,17 @@ pub(super) fn run_station_threshold_line_family(
     if let Some((cost_tokens, effect_parse_tokens)) =
         split_activation_text_tokens_lexed(&body_line.tokens)
     {
-        let cost = parse_activation_cost_tokens_rewrite(&cost_tokens)?;
+        let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+            &ctx.preprocessed.builder,
+            ctx.line,
+            cost_tokens.clone(),
+        )?;
+        let cost = parse_activation_cost_tokens_rewrite(&normalized_cost_tokens)?;
         let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
         lines.push(RewriteLineCst::Activated(ActivatedLineCst {
             info: ctx.line.info.clone(),
             cost,
-            cost_parse_tokens: cost_tokens,
+            cost_parse_tokens: normalized_cost_tokens,
             effect_text,
             effect_parse_tokens,
             presentation_label: None,
@@ -1180,13 +1195,18 @@ pub(super) fn run_activation_line_family(
             );
         }
         let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
-        match parse_activation_cost_tokens_rewrite(&cost_tokens) {
+        let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+            &ctx.preprocessed.builder,
+            ctx.line,
+            cost_tokens.clone(),
+        )?;
+        match parse_activation_cost_tokens_rewrite(&normalized_cost_tokens) {
             Ok(cost) => {
                 return Ok(Some(LineDispatchResult::single(
                     RewriteLineCst::Activated(ActivatedLineCst {
                         info: ctx.line.info.clone(),
                         cost,
-                        cost_parse_tokens: cost_tokens,
+                        cost_parse_tokens: normalized_cost_tokens,
                         effect_text,
                         effect_parse_tokens,
                         presentation_label,
@@ -1588,11 +1608,16 @@ fn try_parse_trailing_keyword_activation_dispatch(
         )));
     };
     let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
-    let cost = parse_activation_cost_tokens_rewrite(&cost_tokens)?;
+    let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+        builder,
+        line,
+        cost_tokens.clone(),
+    )?;
+    let cost = parse_activation_cost_tokens_rewrite(&normalized_cost_tokens)?;
     let activated = RewriteLineCst::Activated(ActivatedLineCst {
         info: suffix_line.info.clone(),
         cost,
-        cost_parse_tokens: cost_tokens,
+        cost_parse_tokens: normalized_cost_tokens,
         effect_text,
         effect_parse_tokens,
         presentation_label: Some(label.trim().to_string()),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -690,6 +690,7 @@ fn looks_like_activation_cost_prefix(tokens: &[OwnedLexToken]) -> bool {
             | "remove"
             | "put"
             | "return"
+            | "unattach"
     )
 }
 
@@ -2637,8 +2638,10 @@ fn is_named_ability_label(label: &str) -> bool {
             | "stunning strike"
             | "teleport"
             | "trance"
+            | "throw ..."
             | "valiant"
             | "waterbend"
+            | "... catch"
     )
 }
 
@@ -2652,8 +2655,24 @@ fn looks_like_ability_word_label(
     !label_tokens.is_empty()
         && !label_tokens
             .iter()
-            .any(|token| matches!(token.kind, TokenKind::Period | TokenKind::Colon))
+            .any(|token| matches!(token.kind, TokenKind::Colon))
         && token_word_refs(label_tokens).len() <= 4
+}
+
+fn normalize_activation_cost_tokens_for_builder(
+    builder: &CardDefinitionBuilder,
+    line: &PreprocessedLine,
+    cost_tokens: Vec<OwnedLexToken>,
+) -> Result<Vec<OwnedLexToken>, CardTextError> {
+    let cost_text = render_token_slice(&cost_tokens);
+    if !normalized_line_mentions_source_alias(builder, cost_text.as_str()) {
+        return Ok(cost_tokens);
+    }
+    let Some(rewritten) = normalize_named_source_sentence_for_builder(builder, cost_text.as_str())
+    else {
+        return Ok(cost_tokens);
+    };
+    Ok(rewrite_line_normalized(line, rewritten.as_str())?.tokens)
 }
 
 fn rewrite_line_normalized(
@@ -2963,13 +2982,18 @@ fn try_parse_labeled_line_dispatch(
     if prefer_activation
         && let Some((cost_tokens, effect_parse_tokens, effect_text)) = labeled_activation.clone()
     {
-        match parse_activation_cost_tokens_rewrite(&cost_tokens) {
+        let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+            &preprocessed.builder,
+            line,
+            cost_tokens.clone(),
+        )?;
+        match parse_activation_cost_tokens_rewrite(&normalized_cost_tokens) {
             Ok(cost) => {
                 return Ok(Some(LineDispatchResult::single(
                     RewriteLineCst::Activated(ActivatedLineCst {
                         info: line.info.clone(),
                         cost,
-                        cost_parse_tokens: cost_tokens,
+                        cost_parse_tokens: normalized_cost_tokens,
                         effect_text,
                         effect_parse_tokens,
                         presentation_label: Some(label.trim().to_string()),
@@ -3051,13 +3075,18 @@ fn try_parse_labeled_line_dispatch(
     }
 
     if let Some((cost_tokens, effect_parse_tokens, effect_text)) = labeled_activation {
-        match parse_activation_cost_tokens_rewrite(&cost_tokens) {
+        let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+            &preprocessed.builder,
+            line,
+            cost_tokens.clone(),
+        )?;
+        match parse_activation_cost_tokens_rewrite(&normalized_cost_tokens) {
             Ok(cost) => {
                 return Ok(Some(LineDispatchResult::single(
                     RewriteLineCst::Activated(ActivatedLineCst {
                         info: line.info.clone(),
                         cost,
-                        cost_parse_tokens: cost_tokens,
+                        cost_parse_tokens: normalized_cost_tokens,
                         effect_text,
                         effect_parse_tokens,
                         presentation_label: Some(label.trim().to_string()),
@@ -3486,11 +3515,16 @@ pub(crate) fn parse_document_cst(
                         )));
                     };
                     let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
-                    let cost = parse_activation_cost_tokens_rewrite(&cost_tokens)?;
+                    let normalized_cost_tokens = normalize_activation_cost_tokens_for_builder(
+                        &preprocessed.builder,
+                        line,
+                        cost_tokens.clone(),
+                    )?;
+                    let cost = parse_activation_cost_tokens_rewrite(&normalized_cost_tokens)?;
                     let cst = RewriteLineCst::Activated(ActivatedLineCst {
                         info: suffix_line.info.clone(),
                         cost,
-                        cost_parse_tokens: cost_tokens,
+                        cost_parse_tokens: normalized_cost_tokens,
                         effect_text,
                         effect_parse_tokens,
                         presentation_label: Some(label.trim().to_string()),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -764,8 +764,28 @@ fn split_label_prefix_lexed(
         return None;
     }
     let (label_tokens, body_tokens) = split_em_dash_label_prefix_tokens(tokens)?;
-    let label = render_token_slice(label_tokens).trim().to_string();
+    let label = render_label_prefix_tokens(label_tokens);
     (!label.is_empty()).then_some((label, label_tokens, body_tokens))
+}
+
+fn render_label_prefix_tokens(tokens: &[OwnedLexToken]) -> String {
+    let rendered = render_token_slice(tokens);
+    let trimmed = rendered.trim();
+    if tokens
+        .first()
+        .is_some_and(|token| token.kind == TokenKind::Period)
+    {
+        let rest = trimmed.trim_start_matches('.').trim_start();
+        return format!("... {rest}").trim().to_string();
+    }
+    if tokens
+        .last()
+        .is_some_and(|token| token.kind == TokenKind::Period)
+    {
+        let rest = trimmed.trim_end_matches('.').trim_end();
+        return format!("{rest} ...").trim().to_string();
+    }
+    trimmed.to_string()
 }
 
 fn trigger_presentation_label_from_line_tokens(tokens: &[OwnedLexToken]) -> Option<String> {
@@ -778,7 +798,10 @@ fn trigger_presentation_label_from_line_tokens(tokens: &[OwnedLexToken]) -> Opti
 
 fn is_nonkeyword_choice_labeled_line(line: &PreprocessedLine) -> bool {
     split_label_prefix_lexed(&line.tokens)
-        .is_some_and(|(label, _, _)| !preserve_keyword_prefix_for_parse(label.as_str()))
+        .is_some_and(|(label, _, _)| {
+            !preserve_keyword_prefix_for_parse(label.as_str())
+                && !is_named_ability_label(label.as_str())
+        })
 }
 
 fn labeled_choice_block_has_peer(items: &[PreprocessedItem], idx: usize) -> bool {
@@ -2615,6 +2638,7 @@ fn is_named_ability_label(label: &str) -> bool {
             | "bigby's hand"
             | "body-print"
             | "boast"
+            | "catch"
             | "cohort"
             | "devouring monster"
             | "diana"
@@ -2638,6 +2662,7 @@ fn is_named_ability_label(label: &str) -> bool {
             | "stunning strike"
             | "teleport"
             | "trance"
+            | "throw"
             | "throw ..."
             | "valiant"
             | "waterbend"

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -831,6 +831,52 @@ fn parse_sacrifice_segment_tokens(
     })
 }
 
+fn parse_unattach_segment_tokens(
+    tokens: &[OwnedLexToken],
+) -> Result<ActivationCostSegmentCst, CardTextError> {
+    let raw = render_lower_lexed_tokens(tokens);
+    let words = LeafCompatWords::new(tokens);
+    let lowered = words.to_word_refs();
+    let tail = lowered.get(1..).unwrap_or_default();
+
+    let mut idx = 0usize;
+    let mut count = 1u32;
+    if let Some((parsed, consumed_words)) = parse_count_prefix_words(tail) {
+        count = parsed;
+        idx = consumed_words;
+    } else if LEAF_A_OR_AN_WORD_PATTERN.matches_first_word(tail) {
+        idx = 1;
+    }
+
+    let filter_end = tail
+        .iter()
+        .position(|word| LEAF_FROM_WORD_PATTERN.matches_word(word))
+        .unwrap_or(tail.len());
+    if filter_end <= idx {
+        return Err(CardTextError::ParseError(format!(
+            "rewrite unattach parser missing filter in '{raw}'"
+        )));
+    }
+
+    let from_tail = &tail[filter_end..];
+    if !from_tail.is_empty()
+        && !from_tail.get(1..).is_some_and(is_source_reference_words)
+    {
+        return Err(CardTextError::ParseError(format!(
+            "rewrite unattach parser only supports unattach-from-source costs in '{raw}'"
+        )));
+    }
+
+    let filter_text = tail[idx..filter_end].join(" ");
+    if filter_text.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "rewrite unattach parser missing filter in '{raw}'"
+        )));
+    }
+
+    Ok(ActivationCostSegmentCst::UnattachChosen { count, filter_text })
+}
+
 fn parse_tap_chosen_segment_tokens(
     tokens: &[OwnedLexToken],
 ) -> Result<ActivationCostSegmentCst, CardTextError> {
@@ -1328,6 +1374,7 @@ fn parse_activation_cost_segment_tokens(
         "discard" => Some(parse_discard_segment_tokens(tokens)),
         "mill" => Some(parse_mill_segment_tokens(tokens)),
         "sacrifice" => Some(parse_sacrifice_segment_tokens(tokens)),
+        "unattach" => Some(parse_unattach_segment_tokens(tokens)),
         "tap" if word_slice_contains_word(&lowered, "untapped") => {
             Some(parse_tap_chosen_segment_tokens(tokens))
         }
@@ -1733,6 +1780,7 @@ fn starts_new_activation_cost_segment_tokens(tokens: &[OwnedLexToken]) -> bool {
                 | "discard"
                 | "mill"
                 | "sacrifice"
+                | "unattach"
                 | "exile"
                 | "return"
                 | "put"
@@ -2076,9 +2124,6 @@ pub(crate) fn lower_activation_cost_cst(
                     filter_text.trim().to_string()
                 };
                 let mut filter = parse_filter_text(normalized_filter_text.as_str(), false)?;
-                if filter.controller.is_none() {
-                    filter.controller = Some(PlayerFilter::You);
-                }
                 if filter.zone.is_none() {
                     filter.zone = Some(crate::zone::Zone::Battlefield);
                 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -102,6 +102,10 @@ pub(crate) enum ActivationCostSegmentCst {
         filter_text: String,
         other: bool,
     },
+    UnattachChosen {
+        count: u32,
+        filter_text: String,
+    },
     ExileSelf,
     ExileSelfFromGraveyard,
     ExileFromHand {
@@ -2063,6 +2067,32 @@ pub(crate) fn lower_activation_cost_cst(
                     Effect::sacrifice(ObjectFilter::tagged(tag), *count)
                 };
                 costs.push(Cost::validated_effect(sacrifice));
+            }
+            ActivationCostSegmentCst::UnattachChosen { count, filter_text } => {
+                flush_pending_mana(&mut costs, &mut pending_mana_pips);
+                let normalized_filter_text = if *count == 1 {
+                    strip_single_choice_article_from_filter_text(filter_text)
+                } else {
+                    filter_text.trim().to_string()
+                };
+                let mut filter = parse_filter_text(normalized_filter_text.as_str(), false)?;
+                if filter.controller.is_none() {
+                    filter.controller = Some(PlayerFilter::You);
+                }
+                if filter.zone.is_none() {
+                    filter.zone = Some(crate::zone::Zone::Battlefield);
+                }
+                let tag = format!("unattach_cost_{return_tag_id}");
+                return_tag_id += 1;
+                costs.push(Cost::validated_effect(Effect::choose_objects(
+                    filter,
+                    ChoiceCount::exactly(*count as usize),
+                    PlayerFilter::You,
+                    tag.clone(),
+                )));
+                costs.push(Cost::validated_effect(Effect::unattach_objects(
+                    crate::target::ChooseSpec::tagged(tag),
+                )));
             }
             ActivationCostSegmentCst::ExileSelf => {
                 flush_pending_mana(&mut costs, &mut pending_mana_pips);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2896,6 +2896,7 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         &["that", "permanents", "mana", "value"],
         &["that", "equipment", "mana", "value"],
         &["that", "equipment's", "mana", "value"],
+        &["that", "equipments", "mana", "value"],
         &["that", "object", "mana", "value"],
         &["that", "object's", "mana", "value"],
         &["that", "objects", "mana", "value"],

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -51,6 +51,7 @@ use std::collections::HashMap;
 
 const SACRIFICE_COST_TAG_PREFIX: &str = "sacrifice_cost_";
 const EXILE_COST_TAG_PREFIX: &str = "exile_cost_";
+const UNATTACH_COST_TAG_PREFIX: &str = "unattach_cost_";
 
 #[derive(Clone)]
 struct SourceReferenceAlias {
@@ -1646,6 +1647,21 @@ pub(crate) fn find_last_exile_cost_choice_tag(mana_cost: &TotalCost) -> Option<T
     found
 }
 
+pub(crate) fn find_first_unattach_cost_choice_tag(mana_cost: &TotalCost) -> Option<TagKey> {
+    for cost in mana_cost.costs() {
+        let Some(effect) = cost.effect_ref() else {
+            continue;
+        };
+        let Some(choose) = effect.downcast_ref::<crate::effects::ChooseObjectsEffect>() else {
+            continue;
+        };
+        if is_unattach_cost_choice_tag(&choose.tag) {
+            return Some(choose.tag.clone());
+        }
+    }
+    None
+}
+
 fn tag_has_prefix(tag: &TagKey, prefix: &str) -> bool {
     tag.as_str().strip_prefix(prefix).is_some()
 }
@@ -1656,6 +1672,10 @@ fn is_sacrifice_cost_choice_tag(tag: &TagKey) -> bool {
 
 fn is_exile_cost_choice_tag(tag: &TagKey) -> bool {
     tag_has_prefix(tag, EXILE_COST_TAG_PREFIX)
+}
+
+fn is_unattach_cost_choice_tag(tag: &TagKey) -> bool {
+    tag_has_prefix(tag, UNATTACH_COST_TAG_PREFIX)
 }
 
 pub(crate) fn value_contains_unbound_x(value: &Value) -> bool {
@@ -2874,6 +2894,8 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         &["that", "permanent", "mana", "value"],
         &["that", "permanent's", "mana", "value"],
         &["that", "permanents", "mana", "value"],
+        &["that", "equipment", "mana", "value"],
+        &["that", "equipment's", "mana", "value"],
         &["that", "object", "mana", "value"],
         &["that", "object's", "mana", "value"],
         &["that", "objects", "mana", "value"],

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/token_primitives.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/token_primitives.rs
@@ -472,9 +472,7 @@ pub(crate) fn split_em_dash_label_prefix_tokens<'a>(
     })?;
     let label_tokens = &tokens[..split_idx];
     let body_tokens = &tokens[split_idx + 1..];
-    if label_tokens.is_empty()
-        || body_tokens.is_empty()
-        || contains_token_kind(label_tokens, TokenKind::Period)
+    if label_tokens.is_empty() || body_tokens.is_empty() || label_has_disallowed_period(label_tokens)
     {
         return None;
     }
@@ -485,6 +483,29 @@ pub(crate) fn split_em_dash_label_prefix_tokens<'a>(
     }
 
     Some((label_tokens, body_tokens))
+}
+
+fn label_has_disallowed_period(tokens: &[OwnedLexToken]) -> bool {
+    if !contains_token_kind(tokens, TokenKind::Period) {
+        return false;
+    }
+
+    let Some(first_non_period) = tokens
+        .iter()
+        .position(|token| token.kind != TokenKind::Period)
+    else {
+        return true;
+    };
+    let Some(last_non_period) = tokens
+        .iter()
+        .rposition(|token| token.kind != TokenKind::Period)
+    else {
+        return true;
+    };
+
+    tokens[first_non_period..=last_non_period]
+        .iter()
+        .any(|token| token.kind == TokenKind::Period)
 }
 
 pub(crate) fn split_em_dash_label_prefix<'a>(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -3,6 +3,7 @@ use super::super::ir::RewriteActivatedLine;
 use super::*;
 use crate::effect::Effect;
 use crate::object::CounterType;
+use crate::runtime_backend::util::find_first_unattach_cost_choice_tag;
 use ironsmith_core::TotalCostKind;
 
 fn activated_effect_may_be_mana_ability_lexed(tokens: &[OwnedLexToken]) -> bool {
@@ -737,6 +738,7 @@ fn lower_rewrite_activated_to_chunk_impl(
             )?;
             let reference_imports = find_first_sacrifice_cost_choice_tag(&normalized_cost)
                 .or_else(|| find_last_exile_cost_choice_tag(&normalized_cost))
+                .or_else(|| find_first_unattach_cost_choice_tag(&normalized_cost))
                 .map(ReferenceImports::with_last_object_tag)
                 .unwrap_or_default();
             let mut parsed = ParsedAbility {
@@ -799,6 +801,7 @@ fn lower_rewrite_activated_to_chunk_impl(
     )?;
     let reference_imports = find_first_sacrifice_cost_choice_tag(&normalized_cost)
         .or_else(|| find_last_exile_cost_choice_tag(&normalized_cost))
+        .or_else(|| find_first_unattach_cost_choice_tag(&normalized_cost))
         .map(ReferenceImports::with_last_object_tag)
         .unwrap_or_default();
     let mut parsed = ParsedAbility {
@@ -898,6 +901,9 @@ fn activated_line_has_exhaust_label(line: &RewriteActivatedLine) -> bool {
 }
 
 fn activated_presentation_display_label(label: &str) -> Option<&'static str> {
+    if label.eq_ignore_ascii_case("Throw ...") {
+        return Some("Throw ...");
+    }
     let label_tokens = lex_line(label, 0).ok();
     let label_words = label_tokens
         .as_deref()

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/activated_lowering.rs
@@ -629,11 +629,19 @@ fn lower_rewrite_activated_to_chunk_impl(
     let normalized_cost =
         bind_activated_x_definition_to_mana_cost(line.cost.clone(), x_definition_value);
     let ability_text = rewrite_activated_display_text(line);
-    let additional_activation_restrictions = if activated_line_has_exhaust_label(line) {
+    let presentation_display = line
+        .presentation_label
+        .as_deref()
+        .or(line.chosen_option_label.as_deref())
+        .and_then(activated_presentation_display_label);
+    let mut additional_activation_restrictions = if activated_line_has_exhaust_label(line) {
         vec!["Activate each exhaust ability only once.".to_string()]
     } else {
         Vec::new()
     };
+    if let Some(display) = presentation_display {
+        additional_activation_restrictions.push(format!("__ironsmith_activation_label:{display}"));
+    }
     if contains_token_word_sequence(&effect_parse_tokens, ADD_X_MANA_PHRASE)
         && !tokens_mention_phrase(original_effect_parse_tokens, WHERE_X_IS_PHRASE)
         && !activation_cost_defines_x_for_mana_ability(&normalized_cost)
@@ -901,7 +909,7 @@ fn activated_line_has_exhaust_label(line: &RewriteActivatedLine) -> bool {
 }
 
 fn activated_presentation_display_label(label: &str) -> Option<&'static str> {
-    if label.eq_ignore_ascii_case("Throw ...") {
+    if label.eq_ignore_ascii_case("Throw ...") || label.eq_ignore_ascii_case("Throw") {
         return Some("Throw ...");
     }
     let label_tokens = lex_line(label, 0).ok();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -14,8 +14,6 @@ const DAMAGE_EACH_OPPONENT_HAND_SIZE_PATTERN: ClauseShape<'static> = clause_shap
     prefix &["damage", "to", "each", "opponent", "equal", "to"];
     contains_words &["number", "cards", "hand"]
 );
-const DIVIDED_DAMAGE_PATTERN: ClauseShape<'static> =
-    clause_shape!(contains_words & ["divided", "among"]);
 const DAMAGE_TO_EACH_OPPONENT_HAND_SIZE_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["number", "cards", "hand"]);
 const COMBAT_TARGET_WORD_PATTERN: ClauseShape<'static> = clause_shape!(contains_words & ["target"]);
@@ -83,6 +81,13 @@ fn combat_words_start_with_shape(words: &[&str], shape: &ClauseShape<'static>) -
 
 fn combat_find_exact_window(words: &[&str], width: usize, shape: ClauseShape<'static>) -> Option<usize> {
     find_window_by(words, width, |window| shape.matches_words(window))
+}
+
+fn is_divided_damage_clause(words: &[&str]) -> bool {
+    let Some(divided_idx) = words.iter().position(|word| *word == "divided") else {
+        return false;
+    };
+    words[divided_idx + 1..].iter().any(|word| *word == "among")
 }
 
 pub(crate) fn parse_attach_object_phrase(
@@ -252,7 +257,7 @@ pub(crate) fn parse_deal_damage(tokens: &[OwnedLexToken]) -> Result<EffectAst, C
             )],
         });
     }
-    if DIVIDED_DAMAGE_PATTERN.matches_words(&clause_words) {
+    if is_divided_damage_clause(&clause_words) {
         if let Some((value, used)) = parse_value(tokens) {
             return parse_divided_damage_with_amount(tokens, value, used);
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -256,6 +256,9 @@ pub(crate) fn parse_deal_damage(tokens: &[OwnedLexToken]) -> Result<EffectAst, C
         if let Some((value, used)) = parse_value(tokens) {
             return parse_divided_damage_with_amount(tokens, value, used);
         }
+        if let Some(effect) = parse_divided_damage_equal_to_amount(tokens)? {
+            return Ok(effect);
+        }
         return Err(CardTextError::ParseError(format!(
             "unsupported divided-damage distribution clause (clause: '{}')",
             clause_words.join(" ")
@@ -294,6 +297,38 @@ pub(crate) fn parse_deal_damage(tokens: &[OwnedLexToken]) -> Result<EffectAst, C
     Err(CardTextError::ParseError(format!(
         "missing damage amount (clause: '{}')",
         clause_words.join(" ")
+    )))
+}
+
+fn parse_divided_damage_equal_to_amount(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<EffectAst>, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !matches!(words.as_slice(), ["damage", "equal", "to", ..]) {
+        return Ok(None);
+    }
+    let Some(divided_word_idx) = words.iter().position(|word| *word == "divided") else {
+        return Ok(None);
+    };
+    let Some(divided_token_idx) = token_index_for_word_index(tokens, divided_word_idx) else {
+        return Ok(None);
+    };
+    let amount_tokens = trim_commas(&tokens[3..divided_token_idx]);
+    let Some((amount, used)) = parse_value(&amount_tokens) else {
+        return Err(CardTextError::ParseError(format!(
+            "missing divided-damage amount (clause: '{}')",
+            words.join(" ")
+        )));
+    };
+    if used != amount_tokens.len() {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported divided-damage amount (clause: '{}')",
+            words.join(" ")
+        )));
+    }
+    let target = parse_divided_damage_target(&tokens[divided_token_idx..])?;
+    Ok(Some(EffectAst::subject_verb_distributed_damage(
+        amount, target,
     )))
 }
 

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -5534,6 +5534,17 @@ impl AttachObjectsEffect {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct UnattachObjectsEffect {
+    pub objects: ChooseSpec,
+}
+
+impl UnattachObjectsEffect {
+    pub fn new(objects: ChooseSpec) -> Self {
+        Self { objects }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct RevealTopEffect {
     pub player: PlayerFilter,
     pub tag: Option<TagKey>,

--- a/crates/ironsmith-core/src/lib.rs
+++ b/crates/ironsmith-core/src/lib.rs
@@ -136,7 +136,7 @@ pub use effect::{
     ShuffleLibraryEffect, ShuffleObjectsIntoLibraryEffect, SkipCombatPhasesEffect,
     SkipCombatPhasesThisTurnEffect, SkipDrawStepEffect, SkipMainPhasesThisTurnEffect,
     SkipNextCombatPhaseThisTurnEffect, SkipTurnEffect, SneakCostEffect, SoulbondPairEffect,
-    SupportEffect, SurveilEffect, SuspectEffect, TagAttachedToSourceEffect,
+    SupportEffect, SurveilEffect, SuspectEffect, TagAttachedToSourceEffect, UnattachObjectsEffect,
     TagMatchingObjectsEffect, TagTriggeringDamageTargetEffect, TagTriggeringObjectEffect,
     TagTriggeringSourceEffect, TaggedEffect, TaggedLeavesAbilitySource, TakeInitiativeEffect,
     TapEffect, TargetOnlyEffect, TicketCountersEffect, TransformEffect, UnearthEffect,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -58855,3 +58855,250 @@ fn pardic_firecat_does_not_count_for_non_spell_flame_burst_effect_source() {
         "Pardic Firecat should count only for effects from spells named Flame Burst"
     );
 }
+
+#[test]
+fn captain_america_first_avenger_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Captain America, First Avenger");
+
+    let def = parse_oracle_card_definition("Captain America, First Avenger");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Throw...")
+            && rendered.contains("Unattach an Equipment from this creature")
+            && rendered.contains("that Equipment's mana value")
+            && rendered.contains("divided as you choose among one, two, or three targets")
+            && rendered.contains("... Catch")
+            && rendered.contains("attach up to one target Equipment you control"),
+        "expected Captain America's Throw/Catch labels and distributed-damage text, got {rendered}"
+    );
+    let activated = captain_america_throw_ability(&def);
+    let damage_effect = activated
+        .effects
+        .flattened_default_effects()
+        .iter()
+        .find(|effect| captain_america_distributed_damage(effect).is_some())
+        .expect("Throw should have a distributed damage effect");
+    let damage = captain_america_distributed_damage(damage_effect)
+        .expect("Throw should lower through a distributed damage effect");
+    let target_count = damage_effect
+        .0
+        .get_target_count()
+        .expect("distributed damage should expose target count");
+    assert_eq!(target_count.min, 1);
+    assert_eq!(target_count.max, Some(3));
+    assert!(
+        ability_debug.contains("UnattachObjectsEffect")
+            && format!("{:?}", damage.amount).contains("ManaValueOf"),
+        "expected Captain America to lower to unattach cost plus mana-value distributed damage, got {ability_debug}"
+    );
+}
+
+fn captain_america_distributed_damage(
+    effect: &crate::effect::Effect,
+) -> Option<&crate::effects::DealDistributedDamageEffect> {
+    effect
+        .downcast_ref::<crate::effects::DealDistributedDamageEffect>()
+        .or_else(|| {
+            effect
+                .downcast_ref::<crate::effects::TaggedEffect>()
+                .and_then(|tagged| {
+                    tagged
+                        .effect
+                        .downcast_ref::<crate::effects::DealDistributedDamageEffect>()
+                })
+        })
+}
+
+fn captain_america_throw_ability(def: &CardDefinition) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated
+                    .effects
+                    .flattened_default_effects()
+                    .iter()
+                    .any(|effect| captain_america_distributed_damage(effect).is_some()) =>
+            {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("Captain America should have its Throw activated ability")
+}
+
+fn create_attached_test_equipment(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    host: ObjectId,
+) -> ObjectId {
+    let equipment = CardDefinitionBuilder::new(CardId::from_raw(72_001), "Vibranium Shield")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .build();
+    let equipment_id =
+        game.create_object_from_definition(&equipment, controller, Zone::Battlefield);
+    game.object_mut(equipment_id)
+        .expect("test Equipment should exist")
+        .attached_to = Some(crate::object::AttachmentTarget::Object(host));
+    game.object_mut(host)
+        .expect("Captain America should exist")
+        .attachments
+        .push(equipment_id);
+    equipment_id
+}
+
+fn pay_captain_america_throw_costs(
+    game: &mut crate::game_state::GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    activated: &crate::ability::ActivatedAbility,
+    equipment: Option<ObjectId>,
+) -> Result<
+    std::collections::HashMap<crate::tag::TagKey, Vec<crate::snapshot::ObjectSnapshot>>,
+    crate::cost::CostPaymentError,
+> {
+    game.player_mut(controller)
+        .expect("controller should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 3);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut cost_ctx = crate::costs::CostContext::new(source, controller, &mut dm);
+    if let Some(equipment) = equipment {
+        cost_ctx.pre_chosen_cards = vec![equipment];
+    }
+
+    for cost in activated.mana_cost.costs() {
+        cost.pay(game, &mut cost_ctx)?;
+    }
+
+    Ok(cost_ctx.tagged_objects)
+}
+
+#[test]
+fn captain_america_throw_unattaches_equipment_and_deals_its_mana_value_divided_damage() {
+    struct DivideDamageBetweenPlayers {
+        first_player: PlayerId,
+        second_player: PlayerId,
+    }
+
+    impl crate::decision::DecisionMaker for DivideDamageBetweenPlayers {
+        fn decide_distribute(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::DistributeContext,
+        ) -> Vec<(crate::game_state::Target, u32)> {
+            assert_eq!(ctx.total, 4, "damage total should be the Equipment's mana value");
+            assert_eq!(ctx.min_per_target, 1);
+            vec![
+                (crate::game_state::Target::Player(self.first_player), 1),
+                (crate::game_state::Target::Player(self.second_player), 3),
+            ]
+        }
+    }
+
+    let def = parse_oracle_card_definition("Captain America, First Avenger");
+    let activated = captain_america_throw_ability(&def);
+    let damage_effect = activated
+        .effects
+        .flattened_default_effects()
+        .iter()
+        .find(|effect| captain_america_distributed_damage(effect).is_some())
+        .expect("Throw should have a distributed damage effect");
+    let target_count = damage_effect
+        .0
+        .get_target_count()
+        .expect("distributed damage should expose target count");
+    assert_eq!(target_count.min, 1);
+    assert_eq!(target_count.max, Some(3));
+
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+        ],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let captain_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let shield_id = create_attached_test_equipment(&mut game, alice, captain_id);
+
+    let tagged_objects = pay_captain_america_throw_costs(
+        &mut game,
+        captain_id,
+        alice,
+        activated,
+        Some(shield_id),
+    )
+    .expect("Throw costs should be payable with three mana and attached Equipment");
+    assert!(
+        tagged_objects
+            .values()
+            .any(|snapshots| snapshots.iter().any(|snapshot| snapshot.name == "Vibranium Shield")),
+        "paying the unattach cost should remember the Equipment for the damage amount"
+    );
+    assert_eq!(
+        game.object(shield_id)
+            .expect("Equipment should still exist")
+            .attached_to,
+        None,
+        "paying the Throw cost should unattach the Equipment"
+    );
+    assert!(
+        !game
+            .object(captain_id)
+            .expect("Captain America should still exist")
+            .attachments
+            .contains(&shield_id),
+        "paying the Throw cost should remove the Equipment from Captain America's attachments"
+    );
+
+    let mut dm = DivideDamageBetweenPlayers {
+        first_player: bob,
+        second_player: charlie,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(captain_id, alice, &mut dm)
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Player(bob),
+            crate::effects::ResolvedTarget::Player(charlie),
+        ])
+        .with_tagged_objects(tagged_objects);
+    crate::effects::execute_effect(&mut game, damage_effect, &mut ctx)
+        .expect("Throw distributed damage should resolve");
+
+    assert_eq!(
+        game.life_total(bob),
+        19,
+        "one damage should be assigned to the first player target"
+    );
+    assert_eq!(
+        game.life_total(charlie),
+        17,
+        "three damage should be assigned to the second player target"
+    );
+
+    let mut game_without_equipment = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let empty_captain =
+        game_without_equipment.create_object_from_definition(&def, alice, Zone::Battlefield);
+    assert!(
+        pay_captain_america_throw_costs(
+            &mut game_without_equipment,
+            empty_captain,
+            alice,
+            activated,
+            None,
+        )
+        .is_err(),
+        "Throw should not be payable without an Equipment attached to Captain America"
+    );
+}

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2896,11 +2896,27 @@ fn describe_choose_each_basic_land_type_then_destroy(effects: &[&Effect]) -> Opt
 
 fn describe_distributed_damage_target(target: &ChooseSpec) -> String {
     match target {
+        ChooseSpec::WithCount(inner, count)
+            if matches!(inner.as_ref(), ChooseSpec::AnyTarget)
+                && count.min == 1
+                && count.max == Some(3) =>
+        {
+            "one, two, or three targets".to_string()
+        }
         ChooseSpec::WithCount(inner, count) if !inner.is_target() => {
             describe_choose_spec(&ChooseSpec::target(inner.as_ref().clone()).with_count(*count))
         }
         _ => describe_choose_spec(target),
     }
+}
+
+fn describe_distributed_damage_amount(value: &Value) -> String {
+    if let Value::ManaValueOf(spec) = value
+        && matches!(spec.as_ref(), ChooseSpec::Tagged(tag) if tag.as_str().starts_with("unattach_cost_"))
+    {
+        return "that Equipment's mana value".to_string();
+    }
+    describe_value(value)
 }
 
 fn describe_for_each_tagged_shuffle_into_owner_library(
@@ -15955,7 +15971,7 @@ pub(super) fn describe_inline_ability_with_self_subject(
                 }
                 line.push_str(&clause);
             }
-            if line.is_empty() {
+            let line = if line.is_empty() {
                 "an activated ability".to_string()
             } else if activated.is_exhaust_ability() {
                 format!(
@@ -15964,9 +15980,65 @@ pub(super) fn describe_inline_ability_with_self_subject(
                 )
             } else {
                 normalize_ability_self_reference_surface(&line, self_subject)
+            };
+            if let Some(label) = activated_presentation_label(activated)
+                && !line.starts_with(label)
+            {
+                format!("{label} — {line}")
+            } else {
+                line
             }
         }
     }
+}
+
+fn activated_presentation_label(activated: &crate::ability::ActivatedAbility) -> Option<&str> {
+    activated
+        .additional_restrictions
+        .iter()
+        .find_map(|restriction| restriction.strip_prefix("__ironsmith_activation_label:"))
+        .or_else(|| inferred_throw_activation_label(activated))
+}
+
+fn inferred_throw_activation_label(
+    activated: &crate::ability::ActivatedAbility,
+) -> Option<&'static str> {
+    let unattach_tag = activated
+        .mana_cost
+        .costs()
+        .iter()
+        .filter_map(|cost| cost.effect_ref())
+        .find_map(|effect| {
+            effect
+                .downcast_ref::<crate::effects::UnattachObjectsEffect>()
+                .and_then(|unattach| match unattach.objects.base() {
+                    ChooseSpec::Tagged(tag) => Some(tag.as_str()),
+                    _ => None,
+                })
+        })?;
+
+    activated
+        .effects
+        .flattened_default_effects()
+        .iter()
+        .any(|effect| effect_is_distributed_damage_from_tag(effect, unattach_tag))
+        .then_some("Throw ...")
+}
+
+fn effect_is_distributed_damage_from_tag(effect: &Effect, tag: &str) -> bool {
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return effect_is_distributed_damage_from_tag(tagged.effect.as_ref(), tag);
+    }
+
+    effect
+        .downcast_ref::<crate::effects::DealDistributedDamageEffect>()
+        .is_some_and(|damage| {
+            matches!(
+                &damage.amount,
+                crate::effect::Value::ManaValueOf(spec)
+                    if matches!(spec.as_ref(), ChooseSpec::Tagged(amount_tag) if amount_tag.as_str() == tag)
+            )
+        })
 }
 
 fn describe_granted_ability_phrase(ability: &Ability, self_subject: &str) -> String {
@@ -16666,6 +16738,11 @@ fn apply_triggered_presentation_label(
     if label.is_empty() || label.starts_with("__ironsmith_") || line.starts_with(label) {
         return line;
     }
+    let label = if label.eq_ignore_ascii_case("catch") {
+        "... Catch"
+    } else {
+        label
+    };
     format!("{label} — {line}")
 }
 
@@ -30356,9 +30433,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     }
     if let Some(distributed) = effect.downcast_ref::<crate::effects::DealDistributedDamageEffect>()
     {
+        let amount = describe_distributed_damage_amount(&distributed.amount);
+        if amount.contains("mana value") {
+            return format!(
+                "Deal damage equal to {amount} divided as you choose among {}",
+                describe_distributed_damage_target(&distributed.target)
+            );
+        }
         return format!(
             "Deal {} damage divided as you choose among {}",
-            describe_value(&distributed.amount),
+            amount,
             describe_distributed_damage_target(&distributed.target)
         );
     }
@@ -36180,6 +36264,9 @@ pub(super) fn collect_activation_restriction_clauses(
         if raw.starts_with(STATION_THRESHOLD_RESTRICTION_PREFIX) {
             continue;
         }
+        if raw.starts_with("__ironsmith_activation_label:") {
+            continue;
+        }
         if raw
             .to_ascii_lowercase()
             .contains("exhaust ability only once")
@@ -39324,7 +39411,8 @@ pub(super) fn describe_ability(
             }
             let is_grandeur = is_grandeur_activation_cost(activated);
             let is_exhaust = activated.is_exhaust_ability();
-            let mut line = if is_grandeur || is_exhaust {
+            let has_presentation_label = activated_presentation_label(activated).is_some();
+            let mut line = if is_grandeur || is_exhaust || has_presentation_label {
                 String::new()
             } else {
                 format!("Activated ability {index}")
@@ -39404,6 +39492,10 @@ pub(super) fn describe_ability(
             }
             if is_exhaust {
                 line = format!("Exhaust — {line}");
+            } else if let Some(label) = activated_presentation_label(activated)
+                && !line.starts_with(label)
+            {
+                line = format!("{label} — {line}");
             }
             line = normalize_ability_self_reference_surface(&line, subject);
             line = normalize_graveyard_source_return_surface(&line, ability);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -19515,6 +19515,19 @@ fn describe_cost_component_parts(costs: &[crate::costs::Cost]) -> Vec<String> {
             && let Some(choose) = costs[idx]
                 .effect_ref()
                 .and_then(|effect| effect.downcast_ref::<crate::effects::ChooseObjectsEffect>())
+            && let Some(unattach) = costs[idx + 1]
+                .effect_ref()
+                .and_then(|effect| effect.downcast_ref::<crate::effects::UnattachObjectsEffect>())
+            && let Some(compact) = describe_choose_then_unattach_cost(choose, unattach)
+        {
+            parts.push(normalize_cost_phrase(&compact));
+            idx += 2;
+            continue;
+        }
+        if idx + 1 < costs.len()
+            && let Some(choose) = costs[idx]
+                .effect_ref()
+                .and_then(|effect| effect.downcast_ref::<crate::effects::ChooseObjectsEffect>())
             && let Some(return_to_hand) = costs[idx + 1]
                 .effect_ref()
                 .and_then(|effect| effect.downcast_ref::<crate::effects::ReturnToHandEffect>())
@@ -19528,6 +19541,36 @@ fn describe_cost_component_parts(costs: &[crate::costs::Cost]) -> Vec<String> {
         idx += 1;
     }
     parts
+}
+
+fn describe_choose_then_unattach_cost(
+    choose: &crate::effects::ChooseObjectsEffect,
+    unattach: &crate::effects::UnattachObjectsEffect,
+) -> Option<String> {
+    if choose.is_search
+        || choose.chooser != PlayerFilter::You
+        || choose_primary_zone(choose) != Some(Zone::Battlefield)
+        || !matches!(unattach.objects.base(), ChooseSpec::Tagged(tag) if tag.as_str() == choose.tag.as_str())
+    {
+        return None;
+    }
+
+    let exact = choose.count.max.filter(|max| *max == choose.count.min)?;
+    if exact == 0 {
+        return None;
+    }
+    let noun = choose.filter.description();
+    if exact == 1 {
+        return Some(format!(
+            "Unattach {} from this source",
+            with_indefinite_article(&noun)
+        ));
+    }
+    let count = number_word(exact as i32).unwrap_or_else(|| exact.to_string());
+    Some(format!(
+        "Unattach {count} {} from this source",
+        pluralize_noun_phrase(&noun)
+    ))
 }
 
 fn describe_choose_then_return_to_hand_cost(

--- a/crates/ironsmith-runtime/src/costs/cost_effect.rs
+++ b/crates/ironsmith-runtime/src/costs/cost_effect.rs
@@ -176,6 +176,45 @@ fn tagged_move_to_zone_cost_precheck(
     }
 }
 
+fn tagged_unattach_cost_precheck(
+    effect: &Effect,
+    game: &GameState,
+    ctx: &CostContext,
+) -> Option<Result<(), CostPaymentError>> {
+    let unattach = effect.downcast_ref::<crate::effects::UnattachObjectsEffect>()?;
+    let tag = match unattach.objects.base() {
+        crate::target::ChooseSpec::Tagged(tag) => tag,
+        crate::target::ChooseSpec::Object(filter) => tagged_selection_tag(filter)?,
+        _ => return None,
+    };
+
+    let Some(chosen) = ctx.tagged_objects.get(tag.as_str()) else {
+        return Some(Err(CostPaymentError::Other(
+            "unattach cost has no chosen object".to_string(),
+        )));
+    };
+    if chosen.is_empty() {
+        return Some(Err(CostPaymentError::Other(
+            "unattach cost has no chosen object".to_string(),
+        )));
+    }
+
+    let valid = chosen.iter().any(|snapshot| {
+        game.find_object_by_stable_id(snapshot.stable_id)
+            .and_then(|id| game.object(id))
+            .is_some_and(|object| {
+                object.attached_to.and_then(|target| target.object_id()) == Some(ctx.source)
+            })
+    });
+    if valid {
+        Some(Ok(()))
+    } else {
+        Some(Err(CostPaymentError::Other(
+            "chosen object is not attached to this source".to_string(),
+        )))
+    }
+}
+
 fn simple_exile_from_hand_filter(
     filter: &crate::filter::ObjectFilter,
 ) -> Option<Option<crate::color::ColorSet>> {
@@ -222,6 +261,8 @@ impl CostPayer for CostEffect {
         if let Some(result) = tagged_sacrifice_cost_precheck(&self.effect, game, ctx) {
             result?;
         } else if let Some(result) = tagged_move_to_zone_cost_precheck(&self.effect, ctx) {
+            result?;
+        } else if let Some(result) = tagged_unattach_cost_precheck(&self.effect, game, ctx) {
             result?;
         } else {
             self.can_pay(game, ctx)?;

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -2838,6 +2838,12 @@ impl Effect {
         Self::new(AttachObjectsEffect::new(objects, target))
     }
 
+    /// Create an effect that unattaches one or more attached objects.
+    pub fn unattach_objects(objects: ChooseSpec) -> Self {
+        use crate::effects::UnattachObjectsEffect;
+        Self::new(UnattachObjectsEffect::new(objects))
+    }
+
     /// Create a "mill N cards" effect.
     pub fn mill(count: impl Into<Value>) -> Self {
         use crate::effects::MillEffect;

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -694,6 +694,10 @@ where
     {
         return Ok(converted);
     }
+    if let Some(converted) = clone_direct_effect::<M, crate::effects::UnattachObjectsEffect>(&effect)
+    {
+        return Ok(converted);
+    }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::SequenceEffect<M::Effect>>(&effect) {
         return Ok(Effect::new(crate::effects::SequenceEffect::new(
             convert_effects(payload.effects.iter().cloned(), hooks)?,

--- a/crates/ironsmith-runtime/src/effects/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/mod.rs
@@ -160,7 +160,7 @@ pub use permanents::{
     NinjutsuCostEffect, NinjutsuEffect, PhaseInEffect, PhaseOutEffect, PutStickerEffect,
     ReconfigureEffect, RegenerateEffect, RenownEffect, SaddleCostEffect, SneakCostEffect,
     SoulbondPairEffect, SuspectEffect, TapEffect, TransformEffect, UmbraArmorEffect, UnearthEffect,
-    UntapEffect,
+    UnattachObjectsEffect, UntapEffect,
 };
 pub use player::{
     AdditionalLandPlaysEffect, AdditionalPhase, AdditionalPhasesEffect, BecomeMonarchEffect,

--- a/crates/ironsmith-runtime/src/effects/permanents/mod.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/mod.rs
@@ -39,6 +39,7 @@ mod tap;
 mod transform;
 mod umbra_armor;
 mod unearth;
+mod unattach_objects;
 mod untap;
 
 pub(crate) fn attachment_can_attach_to_target(
@@ -225,4 +226,5 @@ pub use tap::TapEffect;
 pub use transform::{ConvertEffect, TransformEffect};
 pub use umbra_armor::UmbraArmorEffect;
 pub use unearth::UnearthEffect;
+pub use unattach_objects::UnattachObjectsEffect;
 pub use untap::UntapEffect;

--- a/crates/ironsmith-runtime/src/effects/permanents/unattach_objects.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/unattach_objects.rs
@@ -1,0 +1,83 @@
+//! Unattach arbitrary objects from their current attachments.
+
+use crate::costs::PaymentReason;
+use crate::effect::EffectOutcome;
+use crate::effects::helpers::resolve_objects_for_effect;
+use crate::effects::{CostExecutableEffect, CostValidationError, EffectExecutor};
+use crate::effects::{ExecutionContext, ExecutionError};
+use crate::game_state::GameState;
+use crate::ids::{ObjectId, PlayerId};
+use crate::target::ChooseSpec;
+
+pub use ironsmith_core::UnattachObjectsEffect;
+
+impl EffectExecutor for UnattachObjectsEffect {
+    fn execute(
+        &self,
+        game: &mut GameState,
+        ctx: &mut ExecutionContext,
+    ) -> Result<EffectOutcome, ExecutionError> {
+        let object_ids = resolve_objects_for_effect(game, ctx, &self.objects)?;
+        let mut count = 0;
+        for object_id in object_ids {
+            let Some(object) = game.object_mut(object_id) else {
+                continue;
+            };
+            if object.attached_to.take().is_some() {
+                count += 1;
+            }
+        }
+        Ok(EffectOutcome::count(count))
+    }
+
+    fn decision_related_object_specs(&self) -> Vec<ChooseSpec> {
+        vec![self.objects.clone()]
+    }
+
+    fn as_cost_executable(&self) -> Option<&dyn CostExecutableEffect> {
+        Some(self)
+    }
+
+    fn cost_description(&self) -> Option<String> {
+        Some("Unattach the chosen object".to_string())
+    }
+}
+
+impl CostExecutableEffect for UnattachObjectsEffect {
+    fn can_execute_as_cost(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Result<(), CostValidationError> {
+        CostExecutableEffect::can_execute_as_cost_with_reason(
+            self,
+            game,
+            source,
+            controller,
+            PaymentReason::Other,
+        )
+    }
+
+    fn can_execute_as_cost_with_reason(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        _controller: PlayerId,
+        _reason: PaymentReason,
+    ) -> Result<(), CostValidationError> {
+        match self.objects.base() {
+            ChooseSpec::Tagged(_) => Ok(()),
+            ChooseSpec::SpecificObject(id) => game
+                .object(*id)
+                .filter(|object| object.attached_to.and_then(|target| target.object_id()) == Some(source))
+                .map(|_| ())
+                .ok_or_else(|| {
+                    CostValidationError::Other(
+                        "chosen object is not attached to this source".to_string(),
+                    )
+                }),
+            _ => Ok(()),
+        }
+    }
+}

--- a/crates/ironsmith-runtime/src/effects/permanents/unattach_objects.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/unattach_objects.rs
@@ -20,10 +20,7 @@ impl EffectExecutor for UnattachObjectsEffect {
         let object_ids = resolve_objects_for_effect(game, ctx, &self.objects)?;
         let mut count = 0;
         for object_id in object_ids {
-            let Some(object) = game.object_mut(object_id) else {
-                continue;
-            };
-            if object.attached_to.take().is_some() {
+            if game.detach_object_from_current_target(object_id) {
                 count += 1;
             }
         }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Captain America, First Avenger
Initial parse error:
```
parser does not yet support line family: 'Throw ... — {3}, Unattach an Equipment from Captain America: He deals damage equal to that Equipment's mana value divided as you choose among one, two, or three targets.'; oracle-only fallback also failed: parser does not yet support line family: 'Throw... — {3}, Unattach an Equipment from Captain America: He deals damage equal to that Equipment's mana value divided as you choose among one, two, or three targets.'
```

Current worker: i-0b7582ac149603aee
Branch: codex/aws-card-fix-captain-america-first-avenger
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0044
