### PR TITLE
Fix Ironsmith parse failure: Frodo, Adventurous Hobbit

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -195,6 +195,23 @@ const MELD_ATTACKING_OWN_CONTROL_TAIL_PATTERN: ClauseShape<'static> = clause_sha
 );
 const YOU_ATTACKED_THIS_TURN_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["you", "attacked", "this", "turn"]);
+const SOURCE_IS_YOUR_RING_BEARER_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["this", "is", "your", "ring", "bearer"],
+            &["this", "creature", "is", "your", "ring", "bearer"],
+        ]
+);
+const RING_HAS_TEMPTED_YOU_PREFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(
+        prefix_any
+            & [
+                &["ring", "has", "tempted", "you"],
+                &["the", "ring", "has", "tempted", "you"],
+            ]
+    );
+const TIMES_THIS_GAME_TAIL_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["times", "this", "game"], &["time", "this", "game"]]);
 const TRIGGERING_OBJECT_HAD_TO_ATTACK_THIS_COMBAT_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -925,6 +942,60 @@ fn parse_source_exiled_with_counter_predicate(
             count,
         }),
     ))
+}
+
+fn parse_source_is_your_ring_bearer_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if SOURCE_IS_YOUR_RING_BEARER_PATTERN.matches_words(words) {
+        Some(PredicateAst::SourceIsRingBearer {
+            player: PlayerAst::You,
+        })
+    } else {
+        None
+    }
+}
+
+fn parse_ring_has_tempted_you_this_game_predicate(
+    words: &[&str],
+    tokens: &[OwnedLexToken],
+) -> Option<PredicateAst> {
+    if !RING_HAS_TEMPTED_YOU_PREFIX_PATTERN.matches_words(words) {
+        return None;
+    }
+    let count_start = if words.first() == Some(&"the") { 5 } else { 4 };
+    let (count, used) = parse_number(tokens.get(count_start..)?)?;
+    let tail = words.get(count_start + used..)?;
+    if tail.len() == 5 && OR_MORE_PREFIX_PATTERN.matches_words(&tail[..2]) {
+        if TIMES_THIS_GAME_TAIL_PATTERN.matches_words(&tail[2..]) {
+            return Some(PredicateAst::PlayerRingTemptedThisGameOrMore {
+                player: PlayerAst::You,
+                count,
+            });
+        }
+    }
+    None
+}
+
+fn parse_ring_bearer_temptation_predicate(
+    words: &[&str],
+    tokens: &[OwnedLexToken],
+) -> Option<PredicateAst> {
+    if let Some(predicate) = parse_source_is_your_ring_bearer_predicate(words) {
+        return Some(predicate);
+    }
+    if let Some(predicate) = parse_ring_has_tempted_you_this_game_predicate(words, tokens) {
+        return Some(predicate);
+    }
+
+    let and_idx = find_index(words, |word| AND_WORD_PATTERN.matches_word(word))?;
+    let left_words = &words[..and_idx];
+    let right_words = &words[and_idx + 1..];
+    if left_words.is_empty() || right_words.is_empty() {
+        return None;
+    }
+    let left = parse_source_is_your_ring_bearer_predicate(left_words)?;
+    let right =
+        parse_ring_has_tempted_you_this_game_predicate(right_words, &tokens[and_idx + 1..])?;
+    Some(PredicateAst::And(Box::new(left), Box::new(right)))
 }
 
 fn parse_stack_object_targets_only_source_predicate(filtered: &[&str]) -> Option<PredicateAst> {
@@ -3855,6 +3926,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         return Ok(predicate);
     }
 
+    if let Some(predicate) = parse_ring_bearer_temptation_predicate(&filtered, tokens) {
+        return Ok(predicate);
+    }
+
     if let Some(predicate) = parse_player_status_predicate(&filtered) {
         return Ok(predicate);
     }
@@ -4641,6 +4716,31 @@ mod tests {
 
             assert_eq!(parsed, expected, "{text}");
         }
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_supports_ring_bearer_temptation_gate() -> Result<(), CardTextError> {
+        let tokens = lex_line(
+            "If this is your Ring-bearer and the Ring has tempted you two or more times this game",
+            0,
+        )?;
+        let predicate_tokens = predicate_tokens_after_if(&tokens);
+
+        let parsed = parse_predicate(&predicate_tokens)?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::And(
+                Box::new(PredicateAst::SourceIsRingBearer {
+                    player: PlayerAst::You,
+                }),
+                Box::new(PredicateAst::PlayerRingTemptedThisGameOrMore {
+                    player: PlayerAst::You,
+                    count: 2,
+                })
+            )
+        );
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -410,6 +410,17 @@ pub(crate) fn compile_condition_from_predicate_ast(
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerHasCitysBlessing { player }
         }
+        PredicateAst::SourceIsRingBearer { player } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::SourceIsRingBearer { player }
+        }
+        PredicateAst::PlayerRingTemptedThisGameOrMore { player, count } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::PlayerRingTemptedThisGameOrMore {
+                player,
+                count: *count,
+            }
+        }
         PredicateAst::PlayerCompletedDungeon {
             player,
             dungeon_name,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -475,6 +475,13 @@ pub(crate) enum PredicateAst {
     PlayerHasCitysBlessing {
         player: PlayerAst,
     },
+    SourceIsRingBearer {
+        player: PlayerAst,
+    },
+    PlayerRingTemptedThisGameOrMore {
+        player: PlayerAst,
+        count: u32,
+    },
     PlayerCompletedDungeon {
         player: PlayerAst,
         dungeon_name: Option<String>,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -687,6 +687,13 @@ pub enum Condition {
     PlayerHasCitysBlessing {
         player: PlayerFilter,
     },
+    SourceIsRingBearer {
+        player: PlayerFilter,
+    },
+    PlayerRingTemptedThisGameOrMore {
+        player: PlayerFilter,
+        count: u32,
+    },
     PlayerCommittedCrimeThisTurn {
         player: PlayerFilter,
     },

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -42716,6 +42716,48 @@ fn assert_oracle_card_fails_strict(name: &str) {
 }
 
 #[test]
+fn frodo_adventurous_hobbit_strict_parser_and_compiled_text_regression() {
+    let oracle = oracle_text_by_name()
+        .get("Frodo, Adventurous Hobbit")
+        .expect("missing Frodo, Adventurous Hobbit oracle text")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Frodo, Adventurous Hobbit")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Frodo, Adventurous Hobbit should parse strictly");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Frodo, Adventurous Hobbit should parse its attack trigger strictly"
+    );
+    assert!(
+        ability_debug.contains("RingTemptsYouEffect")
+            && ability_debug.contains("ConditionalEffect")
+            && ability_debug.contains("SourceIsRingBearer")
+            && ability_debug.contains("PlayerRingTemptedThisGameOrMore")
+            && ability_debug.contains("DrawCardsEffect"),
+        "expected Ring temptation plus Ring-bearer draw gate, got {ability_debug}"
+    );
+    assert!(
+        rendered_lower.contains(
+            "if frodo is your ring-bearer and the ring has tempted you two or more times this game"
+        ) && rendered_lower.contains("draw a card"),
+        "expected Frodo's Ring-bearer temptation gate to render, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("unsupported predicate")
+            && !rendered_lower.contains("unsupported effect"),
+        "Frodo should compile without unsupported fallbacks, got {rendered}"
+    );
+}
+
+#[test]
 fn martyr_of_spores_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Martyr of Spores");
     let rendered = canonical_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1085,11 +1085,7 @@ pub(super) fn substitute_legendary_source_reference(
         return line.to_string();
     }
 
-    let source_name = if lower.starts_with("whenever this creature attacks") {
-        card.name.as_str()
-    } else {
-        card.name.split(',').next().unwrap_or(&card.name).trim()
-    };
+    let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
     if source_name.is_empty() {
         return line.to_string();
     }

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11499,6 +11499,17 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 )
             }
         }
+        Condition::SourceIsRingBearer { player } => format!(
+            "this creature is {} Ring-bearer",
+            describe_possessive_player_filter(player)
+        ),
+        Condition::PlayerRingTemptedThisGameOrMore { player, count } => {
+            let count_text = small_number_word(*count).unwrap_or_else(|| count.to_string());
+            format!(
+                "the Ring has tempted {} {count_text} or more times this game",
+                describe_player_filter(player)
+            )
+        }
         Condition::PlayerHadLandEnterBattlefieldThisTurn { player } => {
             format!(
                 "{} had a land enter the battlefield under {} control this turn",

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -223,6 +223,70 @@ mod tests {
     }
 
     #[test]
+    fn frodo_ring_bearer_threshold_condition_requires_bearer_and_two_temptations() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = game.players[0].id;
+        let bob = game.players[1].id;
+        let frodo = CardBuilder::new(CardId::from_raw(71_571), "Frodo, Adventurous Hobbit")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 3))
+            .build();
+        let other_creature = CardBuilder::new(CardId::from_raw(71_572), "Other Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        let source = game.create_object_from_card(&frodo, alice, Zone::Battlefield);
+        let other_source = game.create_object_from_card(&other_creature, alice, Zone::Battlefield);
+        let condition = Condition::And(
+            Box::new(Condition::SourceIsRingBearer {
+                player: PlayerFilter::You,
+            }),
+            Box::new(Condition::PlayerRingTemptedThisGameOrMore {
+                player: PlayerFilter::You,
+                count: 2,
+            }),
+        );
+        let ctx = ExecutionContext::new_default(source, alice);
+
+        game.set_ring_bearer(alice, source);
+        game.increment_ring_temptations(bob);
+        game.increment_ring_temptations(bob);
+        assert!(
+            !evaluate_condition(&game, &condition, &ctx)
+                .expect("opponent temptations should evaluate cleanly"),
+            "Frodo's draw gate must use its controller's Ring temptation count"
+        );
+
+        game.increment_ring_temptations(alice);
+        assert!(
+            !evaluate_condition(&game, &condition, &ctx)
+                .expect("one temptation should evaluate cleanly"),
+            "Frodo's draw gate must stay false before the Ring has tempted you twice"
+        );
+
+        game.increment_ring_temptations(alice);
+        assert!(
+            evaluate_condition(&game, &condition, &ctx)
+                .expect("two temptations should evaluate cleanly"),
+            "Frodo's draw gate should be true once he is your Ring-bearer and you have two temptations"
+        );
+
+        game.set_ring_bearer(alice, other_source);
+        assert!(
+            !evaluate_condition(&game, &condition, &ctx)
+                .expect("different Ring-bearer should evaluate cleanly"),
+            "Frodo's draw gate must require the source itself to be your Ring-bearer"
+        );
+
+        game.clear_ring_bearer(alice);
+        assert!(
+            !evaluate_condition(&game, &condition, &ctx)
+                .expect("missing Ring-bearer should evaluate cleanly"),
+            "Frodo's draw gate must stay false when the source is no longer your Ring-bearer"
+        );
+    }
+
+    #[test]
     fn evaluate_player_has_no_opponent_with_more_life_than_allows_ties() {
         let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
         let alice = game.players[0].id;
@@ -965,6 +1029,16 @@ fn evaluate_condition_shared_core(
             game.player(*player)
                 .is_some_and(|p| p.graveyard.len() >= *count),
         ),
+        Condition::SourceIsRingBearer { player } => Some(
+            matching_condition_players_simple(game, ctx.controller, player)
+                .into_iter()
+                .any(|player_id| game.current_ring_bearer(player_id) == Some(ctx.source)),
+        ),
+        Condition::PlayerRingTemptedThisGameOrMore { player, count } => Some(
+            matching_condition_players_simple(game, ctx.controller, player)
+                .into_iter()
+                .any(|player_id| game.ring_temptations(player_id) >= *count),
+        ),
         Condition::YouControlCommander => {
             if let Some(player) = game.player(ctx.controller) {
                 let commanders = player.get_commanders();
@@ -1133,6 +1207,8 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::PlayerIsMonarch { .. } => {}
         Condition::PlayerHasInitiative { .. } => {}
         Condition::PlayerHasCitysBlessing { .. } => {}
+        Condition::SourceIsRingBearer { .. } => {}
+        Condition::PlayerRingTemptedThisGameOrMore { .. } => {}
         Condition::PlayerCommittedCrimeThisTurn { .. } => {}
         Condition::PlayerRolledResultThisTurn { .. } => {}
         Condition::PlayerCompletedDungeon { .. } => {}
@@ -1942,6 +2018,8 @@ pub fn evaluate_condition_external(
         | Condition::SameColorManaSpentToCastThisSpellAtLeast(_)
         | Condition::ColorsOfManaSpentToCastThisSpellOrMore(_)
         | Condition::PlayerGraveyardHasCardsAtLeast { .. }
+        | Condition::SourceIsRingBearer { .. }
+        | Condition::PlayerRingTemptedThisGameOrMore { .. }
         | Condition::ValueComparison { .. }
         | Condition::YouControlCommander
         | Condition::ThisAbilityResolvedThisTurnExactly(_)
@@ -2673,6 +2751,8 @@ fn evaluate_condition_simple(
         | Condition::SameColorManaSpentToCastThisSpellAtLeast(_)
         | Condition::ColorsOfManaSpentToCastThisSpellOrMore(_)
         | Condition::PlayerGraveyardHasCardsAtLeast { .. }
+        | Condition::SourceIsRingBearer { .. }
+        | Condition::PlayerRingTemptedThisGameOrMore { .. }
         | Condition::ValueComparison { .. }
         | Condition::YouControlCommander
         | Condition::ThisAbilityResolvedThisTurnExactly(_)
@@ -3789,6 +3869,8 @@ fn evaluate_condition(
         | Condition::SameColorManaSpentToCastThisSpellAtLeast(_)
         | Condition::ColorsOfManaSpentToCastThisSpellOrMore(_)
         | Condition::PlayerGraveyardHasCardsAtLeast { .. }
+        | Condition::SourceIsRingBearer { .. }
+        | Condition::PlayerRingTemptedThisGameOrMore { .. }
         | Condition::YouControlCommander
         | Condition::ThisAbilityResolvedThisTurnExactly(_)
         | Condition::Not(_)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Frodo, Adventurous Hobbit
Initial parse error:
```
unsupported predicate (predicate: 'this is your ring bearer and ring has tempted you two or more times this game'); oracle-only fallback also failed: unsupported predicate (predicate: 'this is your ring bearer and ring has tempted you two or more times this game')
```

Current worker: i-0a9efeeb9909f53f0
Branch: codex/aws-card-fix-frodo-adventurous-hobbit
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0044
