### PR TITLE
Fix Ironsmith parse failure: Lyzolda, the Blood Witch

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3398,11 +3398,21 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
         ));
     }
 
-    if filtered.len() >= 4
-        && SACRIFICED_WORD_PATTERN.matches_word_at(&filtered, 0)
-        && WAS_WORD_PATTERN.matches_word_at(&filtered, 2)
+    let sacrificed_idx = if SACRIFICED_WORD_PATTERN.matches_word_at(&filtered, 0) {
+        Some(0usize)
+    } else if filtered.len() >= 2
+        && matches!(filtered[0], "the" | "a" | "an")
+        && SACRIFICED_WORD_PATTERN.matches_word_at(&filtered, 1)
     {
-        let sacrificed_head = filtered[1];
+        Some(1usize)
+    } else {
+        None
+    };
+    if let Some(sacrificed_idx) = sacrificed_idx
+        && filtered.len() >= sacrificed_idx + 4
+        && WAS_WORD_PATTERN.matches_word_at(&filtered, sacrificed_idx + 2)
+    {
+        let sacrificed_head = filtered[sacrificed_idx + 1];
         let subject_card_type =
             parse_card_type(sacrificed_head).filter(|card_type| is_permanent_type(*card_type));
         let subject_is_permanent =
@@ -3410,8 +3420,14 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
         if subject_is_permanent {
             let descriptor_tokens =
-                crate::runtime_backend::lexer::synthetic_word_tokens(&filtered[3..]);
-            let mut filter = parse_object_filter(&descriptor_tokens, false)?;
+                crate::runtime_backend::lexer::synthetic_word_tokens(
+                    &filtered[sacrificed_idx + 3..],
+                );
+            let mut filter = match parse_object_filter(&descriptor_tokens, false) {
+                Ok(filter) => filter,
+                Err(err) => parse_color_only_object_filter_words(&filtered[sacrificed_idx + 3..])
+                    .ok_or(err)?,
+            };
             if filter.card_types.is_empty() {
                 if let Some(card_type) = subject_card_type {
                     filter.card_types.push(card_type);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8290,6 +8290,40 @@ fn test_parse_put_counter_then_it_deals_damage_equal_to_its_power() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_lyzolda_the_blood_witch_parses_sacrificed_creature_color_branches() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Lyzolda, the Blood Witch")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Cleric])
+        .power_toughness(PowerToughness::fixed(3, 1))
+        .parse_text(
+            "{2}, Sacrifice a creature: Lyzolda deals 2 damage to any target if the sacrificed creature was red. Draw a card if the sacrificed creature was black.",
+        )
+        .expect("Lyzolda, the Blood Witch should parse strictly");
+
+    let rendered = compiled_text_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "{2}, Sacrifice a creature: Lyzolda deals 2 damage to any target if the sacrificed creature was red. Draw a card if the sacrificed creature was black."
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("sacrifice_cost_0")
+            && debug.contains("TaggedObjectMatches")
+            && debug.contains("DealDamageEffect")
+            && debug.contains("DrawCardsEffect"),
+        "expected Lyzolda to lower both sacrificed-creature color branches, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_exile_named_source_with_time_counters() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Suspend Setup Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1080,6 +1080,7 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.starts_with("whenever this creature or another ")
         || lower.contains(": this creature gets ")
+        || lower.contains(": this creature deals ")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {
         return line.to_string();

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10508,6 +10508,31 @@ fn all_magic_colors() -> crate::color::ColorSet {
         .union(crate::color::ColorSet::GREEN)
 }
 
+fn describe_sacrifice_cost_object_condition(
+    tag: &crate::tag::TagKey,
+    filter: &ObjectFilter,
+) -> Option<String> {
+    if !tag.as_str().starts_with("sacrifice_cost_") {
+        return None;
+    }
+    let colors = filter.colors?;
+    if colors.is_empty() || filter.card_types.len() != 1 {
+        return None;
+    }
+    let mut rest = filter.clone();
+    rest.colors = None;
+    rest.card_types.clear();
+    if rest != ObjectFilter::default() {
+        return None;
+    }
+
+    Some(format!(
+        "the sacrificed {} was {}",
+        describe_card_type_word_local(filter.card_types[0]),
+        describe_token_color_words(colors, false)
+    ))
+}
+
 pub(super) fn describe_comparison(cmp: &Comparison) -> String {
     match cmp {
         Comparison::GreaterThan(n) => format!("is greater than {n}"),
@@ -11732,6 +11757,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 return condition;
             }
             if let Some(condition) = describe_attached_object_type_condition(tag, filter) {
+                return condition;
+            }
+            if let Some(condition) = describe_sacrifice_cost_object_condition(tag, filter) {
                 return condition;
             }
             if tag.as_str().starts_with("countered_")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3191,6 +3191,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return Some(compact);
     }
 
+    if let Some(compact) = describe_sacrificed_object_conditional_sequence(effects) {
+        return Some(compact);
+    }
+
     if effects.len() == 3 {
         let refs = effects.iter().collect::<Vec<_>>();
         if let Some(compact) = describe_discard_hand_add_mana_draw_sequence(&refs) {
@@ -3221,6 +3225,37 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_choose_name_target_mills_conditional_draw(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_sacrificed_object_conditional_sequence(effects: &[Effect]) -> Option<String> {
+    if effects.len() < 2 {
+        return None;
+    }
+    let mut parts = Vec::with_capacity(effects.len());
+    for effect in effects {
+        let conditional = effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        if !conditional.if_false.is_empty() || conditional.if_true.is_empty() {
+            return None;
+        }
+        let condition_text = describe_condition(&conditional.condition);
+        if !condition_text.starts_with("the sacrificed ") {
+            return None;
+        }
+        let rendered = describe_effect(effect);
+        let trimmed = rendered.trim().trim_end_matches('.');
+        if trimmed.is_empty()
+            || trimmed.contains(". ")
+            || trimmed.contains(": ")
+            || trimmed.starts_with("If ")
+            || trimmed.starts_with("When ")
+            || trimmed.starts_with("Whenever ")
+            || trimmed.starts_with("At ")
+        {
+            return None;
+        }
+        parts.push(trimmed.to_string());
+    }
+    Some(parts.join(". "))
 }
 
 fn unwrap_with_id(effect: &Effect) -> (&Effect, Option<crate::effect::EffectId>) {
@@ -32321,9 +32356,20 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     describe_condition(&conditional.condition)
                 );
             }
+            let condition_text = describe_condition(&conditional.condition);
+            if condition_text.starts_with("the sacrificed ")
+                && !true_branch.contains(". ")
+                && !true_branch.contains(": ")
+                && !true_branch.starts_with("If ")
+                && !true_branch.starts_with("When ")
+                && !true_branch.starts_with("Whenever ")
+                && !true_branch.starts_with("At ")
+            {
+                return format!("{true_branch} if {condition_text}");
+            }
             return format!(
                 "If {}, {}",
-                describe_condition(&conditional.condition),
+                condition_text,
                 true_branch
             );
         }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -28814,6 +28814,198 @@ fn test_bosh_iron_golem_uses_sacrificed_artifact_mana_value_for_damage() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn run_lyzolda_the_blood_witch_sacrifice_branch(
+    colors: crate::color::ColorSet,
+    expect_damage: bool,
+    expect_draw: bool,
+) {
+    use crate::decision::LegalAction;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let lyzolda_def =
+        CardDefinitionBuilder::new(CardId::from_raw(571_572), "Lyzolda, the Blood Witch")
+            .mana_cost(ManaCost::from_pips(vec![
+                vec![ManaSymbol::Generic(1)],
+                vec![ManaSymbol::Black],
+                vec![ManaSymbol::Red],
+            ]))
+            .supertypes(vec![Supertype::Legendary])
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Human, Subtype::Cleric])
+            .power_toughness(PowerToughness::fixed(3, 1))
+            .parse_text(
+                "{2}, Sacrifice a creature: Lyzolda deals 2 damage to any target if the sacrificed creature was red. Draw a card if the sacrificed creature was black.",
+            )
+            .expect("Lyzolda, the Blood Witch should parse for runtime tests");
+
+    let lyzolda_id = game.create_object_from_definition(&lyzolda_def, alice, Zone::Battlefield);
+    let fodder_card = CardBuilder::new(CardId::new(), "Lyzolda Fodder")
+        .card_types(vec![CardType::Creature])
+        .color_indicator(colors)
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let fodder_id = game.create_object_from_card(&fodder_card, alice, Zone::Battlefield);
+    let draw_card = CardBuilder::new(CardId::new(), "Lyzolda Draw Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    game.create_object_from_card(&draw_card, alice, Zone::Library);
+
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    let ability_index = game
+        .object(lyzolda_id)
+        .expect("Lyzolda should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Lyzolda should have an activated ability");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = AutoPassDecisionMaker;
+
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::ActivateAbility {
+            source: lyzolda_id,
+            ability_index,
+        }),
+        &mut dm,
+    )
+    .expect("Lyzolda activation should start");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::Targets(_),
+        ) => {}
+        other => panic!("expected Lyzolda to ask for an any-target target first, got {other:?}"),
+    }
+
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Player(bob)]),
+        &mut dm,
+    )
+    .expect("Lyzolda should accept Bob as any target");
+
+    let cost_ctx = match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectOptions(ctx),
+        ) => ctx,
+        other => panic!("expected Lyzolda to ask for cost order after targeting, got {other:?}"),
+    };
+    let sacrifice_cost_index = cost_ctx
+        .options
+        .iter()
+        .find(|option| option.description.to_ascii_lowercase().contains("sacrifice"))
+        .map(|option| option.index)
+        .expect("expected a sacrifice cost option for Lyzolda");
+
+    let progress = apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::NextCostChoice(sacrifice_cost_index),
+        &mut dm,
+    )
+    .expect("Lyzolda should accept choosing the sacrifice cost first");
+
+    match progress {
+        crate::decision::GameProgress::NeedsDecisionCtx(
+            crate::decisions::context::DecisionContext::SelectObjects(_),
+        ) => {}
+        other => panic!("expected Lyzolda to ask which creature to sacrifice, got {other:?}"),
+    }
+
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::SacrificeTarget(fodder_id),
+        &mut dm,
+    )
+    .expect("Lyzolda should accept the sacrificed creature");
+
+    assert_eq!(game.stack.len(), 1, "Lyzolda ability should be on the stack");
+    let stack_entry = game.stack.last().expect("Lyzolda ability should be stacked");
+    let sacrificed = stack_entry
+        .tagged_objects
+        .get(&crate::tag::TagKey::from("sacrifice_cost_0"))
+        .expect("Lyzolda stack entry should remember the sacrificed creature");
+    assert_eq!(sacrificed.len(), 1);
+    assert_eq!(sacrificed[0].name, "Lyzolda Fodder");
+
+    let hand_before = game.player(alice).expect("Alice exists").hand.len();
+    resolve_stack_entry(&mut game).expect("Lyzolda ability should resolve");
+
+    let expected_bob_life = if expect_damage { 18 } else { 20 };
+    assert_eq!(
+        game.player(bob).expect("Bob exists").life,
+        expected_bob_life,
+        "red sacrificed creatures should be the only ones that make Lyzolda deal damage"
+    );
+    let hand_after = game.player(alice).expect("Alice exists").hand.len();
+    assert_eq!(
+        hand_after,
+        hand_before + usize::from(expect_draw),
+        "black sacrificed creatures should be the only ones that make Lyzolda draw"
+    );
+    let drew_fixture_card = game
+        .player(alice)
+        .expect("Alice exists")
+        .hand
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .any(|object| object.name == "Lyzolda Draw Card");
+    assert_eq!(
+        drew_fixture_card, expect_draw,
+        "Lyzolda should move a library card to hand exactly when the black branch is true"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_lyzolda_the_blood_witch_red_sacrifice_deals_damage_only() {
+    run_lyzolda_the_blood_witch_sacrifice_branch(crate::color::ColorSet::RED, true, false);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_lyzolda_the_blood_witch_black_sacrifice_draws_only() {
+    run_lyzolda_the_blood_witch_sacrifice_branch(crate::color::ColorSet::BLACK, false, true);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_lyzolda_the_blood_witch_black_red_sacrifice_damages_and_draws() {
+    run_lyzolda_the_blood_witch_sacrifice_branch(
+        crate::color::ColorSet::BLACK.union(crate::color::ColorSet::RED),
+        true,
+        true,
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_lyzolda_the_blood_witch_non_red_non_black_sacrifice_does_neither_branch() {
+    run_lyzolda_the_blood_witch_sacrifice_branch(crate::color::ColorSet::GREEN, false, false);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn maestros_ascendancy_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(92_180), "Maestros Ascendancy")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Lyzolda, the Blood Witch
Initial parse error:
```
unsupported trailing if clause in damage effect (clause: '2 damage to any target if the sacrificed creature was red'); oracle-only fallback also failed: unsupported trailing if clause in damage effect (clause: '2 damage to any target if the sacrificed creature was red')
```

Current worker: i-0e40d368d5120705b
Branch: codex/aws-card-fix-lyzolda-the-blood-witch
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260601T014325Z-controller-dev-loop-wave0047
