### PR TITLE
Fix Ironsmith parse failure: Nowhere to Run

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -137,7 +137,7 @@ use crate::object::CounterType;
 #[allow(unused_imports)]
 use crate::static_abilities::{
     Anthem, AnthemCountExpression, AnthemValue, GrantAbility, PowerToughnessChoiceOption,
-    StaticAbility,
+    StaticAbility, StaticAbilityId,
 };
 #[allow(unused_imports)]
 use crate::target::{ChooseSpec, ChooseSpecSurfaceHint, ObjectFilter, PlayerFilter};
@@ -2673,6 +2673,8 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
             id: stringify!(parse_soulbond_shared_line),
             rule: StaticAbilityLineRuleAst::Multi(parse_soulbond_shared_line),
         },
+        single_static_ability_ast_rule!(parse_hexproof_targeting_exception_line),
+        single_static_ability_ast_rule!(parse_ward_trigger_suppression_line),
         single_static_ability_ast_rule!(parse_ward_static_ability_line),
         single_static_ability_ast_rule!(parse_skulk_rules_text_line),
         single_static_ability_ast_rule!(
@@ -3752,6 +3754,113 @@ pub(crate) fn parse_ward_static_ability_line(
     )))
 }
 
+pub(crate) fn parse_hexproof_targeting_exception_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let tokens = trim_edge_punctuation(tokens);
+    let Some((can_idx, tail_idx)) = find_token_word_sequence_span(
+        &tokens,
+        &[
+            "can",
+            "be",
+            "the",
+            "targets",
+            "of",
+            "spells",
+            "and",
+            "abilities",
+        ],
+    ) else {
+        return Ok(None);
+    };
+
+    let mut subject_end = can_idx;
+    if subject_end >= 2
+        && token_slice_at_is(&tokens, subject_end - 2, "with")
+        && token_slice_at_is(&tokens, subject_end - 1, "hexproof")
+    {
+        subject_end -= 2;
+    }
+    let subject_tokens = trim_commas(&tokens[..subject_end]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let mut source_controller = None;
+    let mut as_though_idx = tail_idx;
+    if token_slice_at_is(&tokens, as_though_idx, "you")
+        && token_slice_at_is(&tokens, as_though_idx + 1, "control")
+    {
+        source_controller = Some(PlayerFilter::You);
+        as_though_idx += 2;
+    }
+
+    let tail = &tokens[as_though_idx..];
+    if find_token_word_sequence_span(
+        tail,
+        &["as", "though", "they", "didn't", "have", "hexproof"],
+    ) != Some((0, 6))
+        && find_token_word_sequence_span(
+            tail,
+            &["as", "though", "they", "didnt", "have", "hexproof"],
+        ) != Some((0, 6))
+    {
+        return Ok(None);
+    }
+
+    let target_filter = parse_object_filter_lexed(&subject_tokens, false)?;
+    let display = parser_token_word_refs(&tokens).join(" ");
+    Ok(Some(StaticAbility::hexproof_targeting_exception(
+        target_filter,
+        source_controller,
+        display,
+    )))
+}
+
+pub(crate) fn parse_ward_trigger_suppression_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let tokens = trim_edge_punctuation(tokens);
+    if !token_slice_at_is(&tokens, 0, "ward")
+        || !token_slice_at_is(&tokens, 1, "abilities")
+        || !token_slice_at_is(&tokens, 2, "of")
+    {
+        return Ok(None);
+    }
+    let Some((dont_idx, trigger_tail_end)) = find_token_word_sequence_span(
+        &tokens,
+        &["don't", "trigger"],
+    )
+    .or_else(|| find_token_word_sequence_span(&tokens, &["dont", "trigger"]))
+    else {
+        return Ok(None);
+    };
+    if trigger_tail_end != tokens.len() {
+        return Ok(None);
+    }
+
+    let source_tokens = trim_commas(&tokens[3..dont_idx]);
+    if source_tokens.is_empty() {
+        return Ok(None);
+    }
+    let source_filter = if source_tokens.len() == 2
+        && token_slice_at_is(&source_tokens, 0, "those")
+        && token_slice_at_is(&source_tokens, 1, "creatures")
+    {
+        ObjectFilter::creature().controlled_by(PlayerFilter::Opponent)
+    } else {
+        parse_object_filter_lexed(&source_tokens, false)?
+    };
+    let display = parser_token_word_refs(&tokens).join(" ");
+
+    Ok(Some(StaticAbility::suppress_matching_triggered_abilities(
+        Some(source_filter),
+        None,
+        Some(StaticAbilityId::Ward),
+        display,
+    )))
+}
+
 pub(crate) fn parse_ward_discard_card_type_cost(tokens: &[OwnedLexToken]) -> Option<TotalCost> {
     let cost_words = crate::runtime_backend::token_word_refs(tokens);
     if !DISCARD_WORD_PATTERN.matches_first_word(&cost_words) {
@@ -4770,6 +4879,7 @@ pub(crate) fn parse_trigger_suppression_line_ast(
         StaticAbility::suppress_matching_triggered_abilities(
             source_filter,
             Some(event_matcher),
+            None,
             display,
         ),
     )))

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -25,6 +25,7 @@ pub enum StaticAbilityId {
     Trample,
     Vigilance,
     Ward,
+    HexproofTargetingException,
     Fear,
     Skulk,
     Prowess,
@@ -286,6 +287,7 @@ impl StaticAbilityId {
             | Trample
             | Vigilance
             | Ward
+            | HexproofTargetingException
             | Fear
             | Skulk
             | Prowess

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -309,6 +309,12 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     SuppressMatchingTriggeredAbilities {
         source_filter: Option<ObjectFilter>,
         event_matcher: Option<T>,
+        static_ability_id: Option<StaticAbilityId>,
+        display: String,
+    },
+    HexproofTargetingException {
+        target_filter: ObjectFilter,
+        source_controller: Option<PlayerFilter>,
         display: String,
     },
     ExertAttack {
@@ -1046,10 +1052,21 @@ where
             StaticAbilityPayload::SuppressMatchingTriggeredAbilities {
                 source_filter,
                 event_matcher,
+                static_ability_id,
                 display,
             } => StaticAbilityPayload::SuppressMatchingTriggeredAbilities {
                 source_filter,
                 event_matcher: event_matcher.map(|matcher| map_trigger(matcher)).transpose()?,
+                static_ability_id,
+                display,
+            },
+            StaticAbilityPayload::HexproofTargetingException {
+                target_filter,
+                source_controller,
+                display,
+            } => StaticAbilityPayload::HexproofTargetingException {
+                target_filter,
+                source_controller,
                 display,
             },
             StaticAbilityPayload::ExertAttack {
@@ -3145,6 +3162,7 @@ impl<
     pub fn suppress_matching_triggered_abilities(
         source_filter: Option<ObjectFilter>,
         event_matcher: Option<T>,
+        static_ability_id: Option<StaticAbilityId>,
         display: impl Into<String>,
     ) -> Self {
         let display = display.into();
@@ -3154,6 +3172,24 @@ impl<
             payload: StaticAbilityPayload::SuppressMatchingTriggeredAbilities {
                 source_filter,
                 event_matcher,
+                static_ability_id,
+                display,
+            },
+        }
+    }
+
+    pub fn hexproof_targeting_exception(
+        target_filter: ObjectFilter,
+        source_controller: Option<PlayerFilter>,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::HexproofTargetingException),
+            label: display.clone(),
+            payload: StaticAbilityPayload::HexproofTargetingException {
+                target_filter,
+                source_controller,
                 display,
             },
         }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -44404,6 +44404,134 @@ fn rebbec_architect_of_ascension_strict_parser_and_text_regression() {
     );
 }
 
+#[test]
+fn nowhere_to_run_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Nowhere to Run");
+    let def = parse_oracle_card_definition("Nowhere to Run");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let static_ids = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        static_ids.contains(&StaticAbilityId::Flash),
+        "Nowhere to Run should retain flash, got {static_ids:?}"
+    );
+    assert!(
+        static_ids.contains(&StaticAbilityId::HexproofTargetingException),
+        "Nowhere to Run should structurally model the hexproof-targeting exception, got {static_ids:?}"
+    );
+    assert!(
+        static_ids.contains(&StaticAbilityId::SuppressMatchingTriggeredAbilities),
+        "Nowhere to Run should structurally model ward-trigger suppression, got {static_ids:?}"
+    );
+    assert!(
+        rendered_lower.contains("as though they didnt have hexproof")
+            && rendered_lower.contains("ward abilities of those creatures dont trigger"),
+        "Nowhere to Run compiled text should include the hexproof and ward clauses, got {rendered}"
+    );
+}
+
+fn nowhere_to_run_runtime_source(name: &str, card_type: CardType) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![card_type])
+        .build()
+}
+
+fn nowhere_to_run_hexproof_permanent(name: &str, card_types: Vec<CardType>) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::hexproof(),
+        ))
+        .build()
+}
+
+#[test]
+fn nowhere_to_run_runtime_allows_targeting_opponents_hexproof_creatures_only() {
+    let nowhere = parse_oracle_card_definition("Nowhere to Run");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+    game.create_object_from_definition(&nowhere, alice, Zone::Battlefield);
+    let bob_hexproof_creature = nowhere_to_run_hexproof_permanent(
+        "Bob Hexproof Creature",
+        vec![CardType::Creature],
+    );
+    let bob_creature_id =
+        game.create_object_from_definition(&bob_hexproof_creature, bob, Zone::Battlefield);
+    let alice_hexproof_creature = nowhere_to_run_hexproof_permanent(
+        "Alice Hexproof Creature",
+        vec![CardType::Creature],
+    );
+    let alice_creature_id =
+        game.create_object_from_definition(&alice_hexproof_creature, alice, Zone::Battlefield);
+    let bob_hexproof_noncreature = nowhere_to_run_hexproof_permanent(
+        "Bob Hexproof Enchantment",
+        vec![CardType::Enchantment],
+    );
+    let bob_noncreature_id =
+        game.create_object_from_definition(&bob_hexproof_noncreature, bob, Zone::Battlefield);
+
+    let alice_source = nowhere_to_run_runtime_source("Alice Targeting Spell", CardType::Instant);
+    let alice_source_id = game.create_object_from_definition(&alice_source, alice, Zone::Stack);
+    let bob_source = nowhere_to_run_runtime_source("Bob Targeting Spell", CardType::Instant);
+    let bob_source_id = game.create_object_from_definition(&bob_source, bob, Zone::Stack);
+
+    assert!(
+        crate::targeting::can_target_object(&game, bob_creature_id, alice_source_id, alice)
+            .is_legal(),
+        "Nowhere to Run should let Alice target Bob's hexproof creature"
+    );
+    assert!(
+        !crate::targeting::can_target_object(&game, alice_creature_id, bob_source_id, bob)
+            .is_legal(),
+        "Nowhere to Run should not remove hexproof from Alice's own creatures"
+    );
+    assert!(
+        !crate::targeting::can_target_object(&game, bob_noncreature_id, alice_source_id, alice)
+            .is_legal(),
+        "Nowhere to Run should not remove hexproof from noncreature permanents"
+    );
+}
+
+#[test]
+fn nowhere_to_run_runtime_suppresses_ward_only_for_opponents_creatures() {
+    let nowhere = parse_oracle_card_definition("Nowhere to Run");
+    let ward_creature = parse_oracle_card_definition("Waterfall Aerialist");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+
+    game.create_object_from_definition(&nowhere, alice, Zone::Battlefield);
+    let bob_ward_creature = game.create_object_from_definition(&ward_creature, bob, Zone::Battlefield);
+    let alice_ward_creature =
+        game.create_object_from_definition(&ward_creature, alice, Zone::Battlefield);
+    let alice_source = nowhere_to_run_runtime_source("Alice Targeting Spell", CardType::Instant);
+    let bob_source = nowhere_to_run_runtime_source("Bob Targeting Spell", CardType::Instant);
+    game.create_object_from_definition(&alice_source, alice, Zone::Stack);
+    game.create_object_from_definition(&bob_source, bob, Zone::Stack);
+
+    assert!(
+        crate::targeting::collect_ward_costs(&game, &[bob_ward_creature], alice).is_empty(),
+        "Nowhere to Run should suppress ward abilities of creatures Alice's opponents control"
+    );
+    assert!(
+        !crate::targeting::collect_ward_costs(&game, &[alice_ward_creature], bob).is_empty(),
+        "Nowhere to Run should not suppress ward abilities of Alice's own creatures"
+    );
+}
+
 fn rebbec_runtime_test_card(
     name: &str,
     card_types: Vec<CardType>,

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -8,9 +8,9 @@ use super::{
     ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
     ConditionalSpellKeywordSpec, CountAsCardNamedForSpellEffectSpec, EnterAsCopyAsEntersSpec,
-    GraveyardCountMetric, PowerToughnessChoiceOption, StaticAbility, StaticAbilityId,
-    StaticAbilityKind, ThisSpellCastRestrictionKind, TriggerDuplicationSpec,
-    TriggerSuppressionSpec,
+    GraveyardCountMetric, HexproofTargetingExceptionSpec, PowerToughnessChoiceOption,
+    StaticAbility, StaticAbilityId, StaticAbilityKind, ThisSpellCastRestrictionKind,
+    TriggerDuplicationSpec, TriggerSuppressionSpec,
     text_utils::{capitalize_first, join_with_and, number_word_u32},
 };
 use crate::ability::{Ability, AbilityKind, LevelAbility};
@@ -2892,6 +2892,7 @@ impl StaticAbilityKind for CreaturesEnteringDontCauseAbilitiesToTrigger {
                 ObjectFilter::creature(),
                 None,
             )),
+            static_ability_id: None,
         })
     }
 }
@@ -2945,6 +2946,7 @@ impl StaticAbilityKind for DuplicateMatchingTriggeredAbilities {
 pub struct SuppressMatchingTriggeredAbilities {
     pub source_filter: Option<ObjectFilter>,
     pub event_matcher: Option<crate::triggers::Trigger>,
+    pub static_ability_id: Option<StaticAbilityId>,
     pub display: String,
 }
 
@@ -2952,11 +2954,13 @@ impl SuppressMatchingTriggeredAbilities {
     pub fn new(
         source_filter: Option<ObjectFilter>,
         event_matcher: Option<crate::triggers::Trigger>,
+        static_ability_id: Option<StaticAbilityId>,
         display: String,
     ) -> Self {
         Self {
             source_filter,
             event_matcher,
+            static_ability_id,
             display,
         }
     }
@@ -2975,6 +2979,46 @@ impl StaticAbilityKind for SuppressMatchingTriggeredAbilities {
         Some(TriggerSuppressionSpec {
             source_filter: self.source_filter.clone(),
             event_matcher: self.event_matcher.clone(),
+            static_ability_id: self.static_ability_id,
+        })
+    }
+}
+
+/// Matching objects can be targeted as though they did not have hexproof.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HexproofTargetingException {
+    pub target_filter: ObjectFilter,
+    pub source_controller: Option<PlayerFilter>,
+    pub display: String,
+}
+
+impl HexproofTargetingException {
+    pub fn new(
+        target_filter: ObjectFilter,
+        source_controller: Option<PlayerFilter>,
+        display: String,
+    ) -> Self {
+        Self {
+            target_filter,
+            source_controller,
+            display,
+        }
+    }
+}
+
+impl StaticAbilityKind for HexproofTargetingException {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::HexproofTargetingException
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn hexproof_targeting_exception_spec(&self) -> Option<HexproofTargetingExceptionSpec> {
+        Some(HexproofTargetingExceptionSpec {
+            target_filter: self.target_filter.clone(),
+            source_controller: self.source_controller.clone(),
         })
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -918,6 +918,10 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         None
     }
 
+    fn hexproof_targeting_exception_spec(&self) -> Option<HexproofTargetingExceptionSpec> {
+        None
+    }
+
     /// Return a "Cast this spell only ..." restriction descriptor, if any.
     fn this_spell_cast_restriction_kind(&self) -> Option<ThisSpellCastRestrictionKind> {
         None
@@ -1051,6 +1055,15 @@ pub struct TriggerDuplicationSpec {
 pub struct TriggerSuppressionSpec {
     pub source_filter: Option<crate::target::ObjectFilter>,
     pub event_matcher: Option<crate::triggers::Trigger>,
+    pub static_ability_id: Option<StaticAbilityId>,
+}
+
+/// Spec for static abilities that let matching objects be targeted as though
+/// they did not have hexproof.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HexproofTargetingExceptionSpec {
+    pub target_filter: crate::target::ObjectFilter,
+    pub source_controller: Option<crate::target::PlayerFilter>,
 }
 
 /// Spec for static abilities that reveal a card as part of a draw.
@@ -1166,6 +1179,10 @@ impl StaticAbility {
 
     pub fn trigger_suppression_spec(&self) -> Option<TriggerSuppressionSpec> {
         self.0.trigger_suppression_spec()
+    }
+
+    pub fn hexproof_targeting_exception_spec(&self) -> Option<HexproofTargetingExceptionSpec> {
+        self.0.hexproof_targeting_exception_spec()
     }
 
     pub fn this_spell_cast_restriction_kind(&self) -> Option<ThisSpellCastRestrictionKind> {
@@ -2784,11 +2801,25 @@ impl StaticAbility {
     pub fn suppress_matching_triggered_abilities(
         source_filter: Option<crate::target::ObjectFilter>,
         event_matcher: Option<crate::triggers::Trigger>,
+        static_ability_id: Option<StaticAbilityId>,
         display: String,
     ) -> Self {
         Self::new(SuppressMatchingTriggeredAbilities::new(
             source_filter,
             event_matcher,
+            static_ability_id,
+            display,
+        ))
+    }
+
+    pub fn hexproof_targeting_exception(
+        target_filter: crate::target::ObjectFilter,
+        source_controller: Option<crate::target::PlayerFilter>,
+        display: String,
+    ) -> Self {
+        Self::new(HexproofTargetingException::new(
+            target_filter,
+            source_controller,
             display,
         ))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1075,10 +1075,21 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::SuppressMatchingTriggeredAbilities {
                 source_filter,
                 event_matcher,
+                static_ability_id,
                 display,
             } => StaticAbility::suppress_matching_triggered_abilities(
                 source_filter.clone(),
                 event_matcher.clone(),
+                *static_ability_id,
+                display.clone(),
+            ),
+            ironsmith_core::StaticAbilityPayload::HexproofTargetingException {
+                target_filter,
+                source_controller,
+                display,
+            } => StaticAbility::hexproof_targeting_exception(
+                target_filter.clone(),
+                source_controller.clone(),
                 display.clone(),
             ),
             ironsmith_core::StaticAbilityPayload::ExertAttack {

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -93,7 +93,10 @@ pub(crate) fn can_target_object_with_view_and_source_snapshot(
     }
 
     // Check for hexproof (only blocks opponents)
-    if target_abilities.iter().any(|a| a.has_hexproof()) && game.controller_of(target) != caster {
+    if target_abilities.iter().any(|a| a.has_hexproof())
+        && game.controller_of(target) != caster
+        && !has_hexproof_targeting_exception(game, target_id, caster, view)
+    {
         return TargetingResult::Invalid(TargetingInvalidReason::HasHexproof);
     }
 
@@ -145,7 +148,10 @@ fn can_target_object_from_source_snapshot_with_view(
         return TargetingResult::Invalid(TargetingInvalidReason::HasShroud);
     }
 
-    if target_abilities.iter().any(|a| a.has_hexproof()) && game.controller_of(target) != caster {
+    if target_abilities.iter().any(|a| a.has_hexproof())
+        && game.controller_of(target) != caster
+        && !has_hexproof_targeting_exception(game, target_id, caster, view)
+    {
         return TargetingResult::Invalid(TargetingInvalidReason::HasHexproof);
     }
 
@@ -195,6 +201,44 @@ fn source_snapshot_matches_hexproof_from(
 ) -> bool {
     let filter_ctx = game.filter_context_for(caster, Some(source_snapshot.object_id));
     filter.matches_snapshot(source_snapshot, &filter_ctx, game)
+}
+
+fn has_hexproof_targeting_exception(
+    game: &GameState,
+    target_id: ObjectId,
+    caster: PlayerId,
+    view: &crate::derived_view::DerivedGameView<'_>,
+) -> bool {
+    let Some(target) = game.object(target_id) else {
+        return false;
+    };
+
+    for &source_id in &game.battlefield {
+        let Some(source) = game.object(source_id) else {
+            continue;
+        };
+        let Some(static_abilities) = view.static_abilities_rc(source_id) else {
+            continue;
+        };
+        let controller = game.controller_of(source);
+        let filter_ctx = game.filter_context_for(controller, Some(source_id));
+
+        for ability in static_abilities.iter() {
+            let Some(spec) = ability.hexproof_targeting_exception_spec() else {
+                continue;
+            };
+            if let Some(source_controller) = spec.source_controller
+                && !player_filter_matches_game(&source_controller, caster, game, &filter_ctx)
+            {
+                continue;
+            }
+            if spec.target_filter.matches(target, &filter_ctx, game) {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Check if a permanent has protection from a source.

--- a/crates/ironsmith-runtime/src/targeting/ward.rs
+++ b/crates/ironsmith-runtime/src/targeting/ward.rs
@@ -14,10 +14,11 @@ use crate::ability::AbilityKind;
 use crate::cost::TotalCost;
 use crate::decision::DecisionMaker;
 use crate::decisions::{WardSpec, make_decision};
+use crate::filter::ObjectFilterExt as _;
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
 use crate::special_actions::pay_total_cost_with_choice;
-use crate::static_abilities::StaticAbility;
+use crate::static_abilities::{StaticAbility, StaticAbilityId};
 
 use super::types::{PendingWardCost, WardPaymentResult};
 
@@ -36,6 +37,10 @@ pub fn get_ward_cost(
 
     // Ward only triggers when an opponent targets
     if game.controller_of(target) == caster {
+        return None;
+    }
+
+    if ward_trigger_is_suppressed(game, target_id) {
         return None;
     }
 
@@ -68,6 +73,41 @@ pub fn get_ward_cost(
     }
 
     None
+}
+
+fn ward_trigger_is_suppressed(game: &GameState, target_id: ObjectId) -> bool {
+    let Some(target) = game.object(target_id) else {
+        return false;
+    };
+    let view = crate::derived_view::DerivedGameView::new(game);
+
+    for &source_id in &game.battlefield {
+        let Some(source) = game.object(source_id) else {
+            continue;
+        };
+        let Some(static_abilities) = view.static_abilities_rc(source_id) else {
+            continue;
+        };
+        let controller = game.controller_of(source);
+        let filter_ctx = game.filter_context_for(controller, Some(source_id));
+
+        for ability in static_abilities.iter() {
+            let Some(spec) = ability.trigger_suppression_spec() else {
+                continue;
+            };
+            if spec.static_ability_id != Some(StaticAbilityId::Ward) {
+                continue;
+            }
+            if let Some(filter) = spec.source_filter.as_ref()
+                && !filter.matches(target, &filter_ctx, game)
+            {
+                continue;
+            }
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Collect all ward costs for a set of targets.

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -402,6 +402,9 @@ fn trigger_is_suppressed(
             let Some(spec) = static_ability.trigger_suppression_spec() else {
                 continue;
             };
+            if spec.static_ability_id.is_some() {
+                continue;
+            }
             if trigger_entry_matches_specs(
                 game,
                 view,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nowhere to Run
Initial parse error:
```
unsupported ward cost clause (clause: 'ward abilities of those creatures don't trigger'); oracle-only fallback also failed: unsupported ward cost clause (clause: 'ward abilities of those creatures don't trigger')
```

Current worker: i-070a02e283668e491
Branch: codex/aws-card-fix-nowhere-to-run
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T121724Z-controller-dev-loop-wave0001
