### PR TITLE
Fix Ironsmith parse failure: Carpet of Flowers

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -191,6 +191,8 @@ const BEGINNING_FIRST_MAIN_PHASE_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "first", "main", "phase"]);
 const BEGINNING_SECOND_MAIN_PHASE_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "second", "main", "phase"]);
+const BEGINNING_EACH_MAIN_PHASE_TRIGGER_PATTERN: ClauseShape<'static> =
+    clause_shape!(contains_words & ["beginning", "main"]; contains_any_words & [&["phase", "phases"]]; contains_words & ["each"]);
 const BEGINNING_PRECOMBAT_MAIN_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "precombat", "main"]);
 const BEGINNING_POSTCOMBAT_MAIN_TRIGGER_PATTERN: ClauseShape<'static> =
@@ -4064,6 +4066,13 @@ pub(crate) fn parse_trigger_clause_lexed(
         _ if BEGINNING_SECOND_MAIN_PHASE_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfPostcombatMain(parse_possessive_clause_player_filter(&words)),
         ),
+        _ if BEGINNING_EACH_MAIN_PHASE_TRIGGER_PATTERN.matches_words(&words) => {
+            let player = parse_possessive_clause_player_filter(&words);
+            Ok(TriggerSpec::Either(
+                Box::new(TriggerSpec::BeginningOfPrecombatMain(player.clone())),
+                Box::new(TriggerSpec::BeginningOfPostcombatMain(player)),
+            ))
+        }
         _ if BEGINNING_PRECOMBAT_MAIN_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfPrecombatMain(parse_possessive_clause_player_filter(&words)),
         ),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1237,6 +1237,32 @@ fn predicate_from_control_condition(
 }
 
 fn parse_this_ability_resolution_count_predicate(filtered: &[&str]) -> Option<PredicateAst> {
+    match filtered {
+        [
+            "you",
+            "havent",
+            "added",
+            "mana",
+            "with",
+            "this",
+            "ability",
+            "this",
+            "turn",
+        ]
+        | [
+            "you",
+            "haven't",
+            "added",
+            "mana",
+            "with",
+            "this",
+            "ability",
+            "this",
+            "turn",
+        ] => return Some(PredicateAst::ThisAbilityAddedManaThisTurnExactly(0)),
+        _ => {}
+    }
+
     let count = match filtered {
         [
             "this",

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -626,6 +626,9 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::ThisAbilityResolvedThisTurnExactly(count) => {
             Condition::ThisAbilityResolvedThisTurnExactly(*count)
         }
+        PredicateAst::ThisAbilityAddedManaThisTurnExactly(count) => {
+            Condition::ThisAbilityAddedManaThisTurnExactly(*count)
+        }
         PredicateAst::TargetSpellCastOrderThisTurn(order) => {
             Condition::TargetSpellCastOrderThisTurn(*order)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -596,6 +596,7 @@ pub(crate) enum PredicateAst {
     ThisSpellPaidLabel(String),
     TargetWasKicked,
     ThisAbilityResolvedThisTurnExactly(u32),
+    ThisAbilityAddedManaThisTurnExactly(u32),
     TargetSpellCastOrderThisTurn(u32),
     TargetSpellControllerIsPoisoned,
     TargetSpellNoManaSpentToCast,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -842,6 +842,7 @@ pub enum Condition {
         zones: Vec<Zone>,
     },
     ThisAbilityResolvedThisTurnExactly(u32),
+    ThisAbilityAddedManaThisTurnExactly(u32),
     FirstTimeThisTurn,
     MaxTimesEachTurn(u32),
     DoThisMaxTimesEachTurn(u32),

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12106,6 +12106,12 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             "this is the {} time this ability has resolved this turn",
             ordinal_number_word(*count)
         ),
+        Condition::ThisAbilityAddedManaThisTurnExactly(0) => {
+            "you haven't added mana with this ability this turn".to_string()
+        }
+        Condition::ThisAbilityAddedManaThisTurnExactly(count) => {
+            format!("this ability has added mana {count} times this turn")
+        }
         Condition::MaxTimesEachTurn(limit) => {
             format!("this ability has triggered fewer than {limit} times this turn")
         }

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -677,6 +677,7 @@ struct SharedConditionContext<'a> {
     filter_source: Option<ObjectId>,
     triggering_event: Option<&'a TriggerEvent>,
     trigger_identity: Option<TriggerIdentity>,
+    ability_index: Option<usize>,
 }
 
 fn object_matching_was_put_into_graveyard_from_battlefield_this_turn(
@@ -1067,6 +1068,18 @@ fn evaluate_condition_shared_core(
                     == *count
             }))
         }
+        Condition::ThisAbilityAddedManaThisTurnExactly(count) => Some(
+            ctx.trigger_identity
+                .map(|trigger_identity| {
+                    game.triggered_ability_mana_added_count_this_turn(ctx.source, trigger_identity)
+                })
+                .or_else(|| {
+                    ctx.ability_index.map(|ability_index| {
+                        game.activated_ability_mana_added_count_this_turn(ctx.source, ability_index)
+                    })
+                })
+                .is_some_and(|actual| actual == *count),
+        ),
         Condition::Custom(_) => Some(false),
         _ => None,
     }
@@ -1153,6 +1166,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::PlayerTaggedObjectEnteredBattlefieldThisTurn { .. } => {}
         Condition::PlayerOwnsCardNamedInZones { .. } => {}
         Condition::ThisAbilityResolvedThisTurnExactly(..) => {}
+        Condition::ThisAbilityAddedManaThisTurnExactly(..) => {}
         Condition::FirstTimeThisTurn => {}
         Condition::MaxTimesEachTurn(..) => {}
         Condition::DoThisMaxTimesEachTurn(..) => {}
@@ -1285,6 +1299,7 @@ pub fn evaluate_condition_external(
             filter_source: ctx.filter_source,
             triggering_event: ctx.triggering_event,
             trigger_identity: ctx.trigger_identity,
+            ability_index: ctx.ability_index,
         },
     ) {
         return result;
@@ -2023,6 +2038,7 @@ pub fn evaluate_condition_external(
         | Condition::ValueComparison { .. }
         | Condition::YouControlCommander
         | Condition::ThisAbilityResolvedThisTurnExactly(_)
+        | Condition::ThisAbilityAddedManaThisTurnExactly(_)
         | Condition::Not(_)
         | Condition::And(_, _)
         | Condition::Or(_, _) => unreachable!("handled before external match"),
@@ -2199,6 +2215,7 @@ fn evaluate_condition_simple(
             filter_source: Some(source),
             triggering_event: None,
             trigger_identity: None,
+            ability_index: None,
         },
     ) {
         return result;
@@ -2756,6 +2773,7 @@ fn evaluate_condition_simple(
         | Condition::ValueComparison { .. }
         | Condition::YouControlCommander
         | Condition::ThisAbilityResolvedThisTurnExactly(_)
+        | Condition::ThisAbilityAddedManaThisTurnExactly(_)
         | Condition::Not(_)
         | Condition::And(_, _)
         | Condition::Or(_, _) => {
@@ -2974,6 +2992,7 @@ fn evaluate_condition(
             filter_source: Some(ctx.source),
             triggering_event: ctx.triggering_event.as_ref(),
             trigger_identity: ctx.trigger_identity,
+            ability_index: ctx.ability_index,
         },
     ) {
         return Ok(result);
@@ -3873,6 +3892,7 @@ fn evaluate_condition(
         | Condition::PlayerRingTemptedThisGameOrMore { .. }
         | Condition::YouControlCommander
         | Condition::ThisAbilityResolvedThisTurnExactly(_)
+        | Condition::ThisAbilityAddedManaThisTurnExactly(_)
         | Condition::Not(_)
         | Condition::And(_, _)
         | Condition::Or(_, _) => {

--- a/crates/ironsmith-runtime/src/effects/runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/runtime.rs
@@ -96,6 +96,18 @@ pub fn execute_effect(
         for event in &outcome.events {
             game.stage_turn_history_event(event);
         }
+        if outcome
+            .events
+            .iter()
+            .any(|event| event.downcast::<crate::events::ManaAddedEvent>().is_some())
+        {
+            if let Some(trigger_identity) = ctx.trigger_identity {
+                game.record_triggered_ability_added_mana(ctx.source, trigger_identity);
+            }
+            if let Some(ability_index) = ctx.ability_index {
+                game.record_activated_ability_added_mana(ctx.source, ability_index);
+            }
+        }
     }
 
     Ok(outcome)

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -464,6 +464,17 @@ fn triggered_ability_resolution_turn_counter_name(
     format!("triggered_ability_resolved:{}:{}", source.0, trigger_id.0)
 }
 
+fn triggered_ability_mana_added_turn_counter_name(
+    source: ObjectId,
+    trigger_id: TriggerIdentity,
+) -> String {
+    format!("triggered_ability_mana_added:{}:{}", source.0, trigger_id.0)
+}
+
+fn activated_ability_mana_added_turn_counter_name(source: ObjectId, ability_index: usize) -> String {
+    format!("activated_ability_mana_added:{}:{}", source.0, ability_index)
+}
+
 impl TurnCounterTracker {
     pub fn increment(&mut self, key: TurnCounterKey) {
         *self.counters.entry(key).or_insert(0) += 1;
@@ -7667,6 +7678,29 @@ impl GameState {
             })
     }
 
+    /// Record that a specific triggered ability added mana this turn.
+    pub fn record_triggered_ability_added_mana(
+        &mut self,
+        source_object_id: ObjectId,
+        trigger_id: TriggerIdentity,
+    ) {
+        self.turn_store.turn_history.turn_counters.increment_named(
+            triggered_ability_mana_added_turn_counter_name(source_object_id, trigger_id),
+        );
+    }
+
+    /// Get how many times this triggered ability added mana this turn.
+    pub fn triggered_ability_mana_added_count_this_turn(
+        &self,
+        source_object_id: ObjectId,
+        trigger_id: TriggerIdentity,
+    ) -> u32 {
+        self.named_turn_counter(&triggered_ability_mana_added_turn_counter_name(
+            source_object_id,
+            trigger_id,
+        ))
+    }
+
     /// Record an event kind occurrence this turn.
     pub fn record_trigger_event_kind(&mut self, event_kind: EventKind) {
         self.turn_store
@@ -7808,6 +7842,25 @@ impl GameState {
                     ability_index,
                 ))
             })
+    }
+
+    /// Record that a specific activated ability added mana this turn.
+    pub fn record_activated_ability_added_mana(&mut self, source: ObjectId, ability_index: usize) {
+        self.turn_store.turn_history.turn_counters.increment_named(
+            activated_ability_mana_added_turn_counter_name(source, ability_index),
+        );
+    }
+
+    /// Get how many times this activated ability added mana this turn.
+    pub fn activated_ability_mana_added_count_this_turn(
+        &self,
+        source: ObjectId,
+        ability_index: usize,
+    ) -> u32 {
+        self.named_turn_counter(&activated_ability_mana_added_turn_counter_name(
+            source,
+            ability_index,
+        ))
     }
 
     /// Record that a mode index was chosen for an activated modal ability.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Carpet of Flowers
Initial parse error:
```
unsupported predicate (predicate: 'you havent added mana with this ability this turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'you havent added mana with this ability this turn')
```

Current worker: i-0510d1e766f7224ba
Branch: codex/aws-card-fix-carpet-of-flowers
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T121724Z-controller-dev-loop-wave0001
