### PR TITLE
Fix Ironsmith parse failure: Lae'zel's Acrobatics

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1718,6 +1718,16 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
         return Ok(None);
     }
 
+    if let Some(effect) = parse_cast_with_prefixed_mana_value_limit(
+        rest_tokens,
+        &normalized_words,
+        lead.player,
+        from_idx,
+        parse_simple_spell_type_list_filter_tokens,
+    )? {
+        return Ok(Some(effect));
+    }
+
     if let Some(without_idx) = normalized_words
         .iter()
         .position(|word| word.as_str() == "without")
@@ -1739,6 +1749,9 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
                 return Ok(None);
             };
             let filter_tokens = trim_lexed_commas(&rest_tokens[..filter_end]);
+            if token_slice_first_is_any(filter_tokens, &["target"]) {
+                return Ok(None);
+            }
             let Some(mut filter) = parse_simple_spell_type_list_filter_tokens(filter_tokens)
                 .or(parse_permission_subject_filter_tokens_lexed(filter_tokens)?)
             else {
@@ -1758,16 +1771,6 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
                 ),
             ));
         }
-    }
-
-    if let Some(effect) = parse_cast_with_prefixed_mana_value_limit(
-        rest_tokens,
-        &normalized_words,
-        lead.player,
-        from_idx,
-        parse_simple_spell_type_list_filter_tokens,
-    )? {
-        return Ok(Some(effect));
     }
 
     let normalized_tail = &normalized_words[from_idx..];

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1492,9 +1492,14 @@ pub(super) fn run_statement_probe_line_family(
         && !is_can_block_additional_creatures_static_line(&ctx.line.tokens)
         && let Some(statement_line) = parse_statement_line_cst(ctx.line)?
     {
+        let (statement_line, next_idx) = extend_statement_line_with_result_followups(
+            &ctx.preprocessed.items,
+            ctx.idx,
+            statement_line,
+        );
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Statement(statement_line),
-            ctx.idx + 1,
+            next_idx,
         )));
     }
     Ok(None)
@@ -1536,7 +1541,12 @@ pub(super) fn run_statement_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     Ok(parse_statement_line_cst(ctx.line)?.map(|statement_line| {
-        LineDispatchResult::single(RewriteLineCst::Statement(statement_line), ctx.idx + 1)
+        let (statement_line, next_idx) = extend_statement_line_with_result_followups(
+            &ctx.preprocessed.items,
+            ctx.idx,
+            statement_line,
+        );
+        LineDispatchResult::single(RewriteLineCst::Statement(statement_line), next_idx)
     }))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -159,9 +159,9 @@ use line_dispatch::{LineDispatchResult, dispatch_standard_line_cst};
 #[cfg(test)]
 use statement_cst_support::looks_like_statement_line;
 use statement_cst_support::{
-    extend_triggered_line_with_result_followups, looks_like_statement_line_lexed,
-    normalize_statement_parse_groups_lexed, parse_colon_nonactivation_statement_fallback,
-    parse_statement_line_cst,
+    extend_statement_line_with_result_followups, extend_triggered_line_with_result_followups,
+    looks_like_statement_line_lexed, normalize_statement_parse_groups_lexed,
+    parse_colon_nonactivation_statement_fallback, parse_statement_line_cst,
 };
 use unsupported::diagnose_known_unsupported_rewrite_line;
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -167,6 +167,16 @@ fn is_trigger_result_followup_line(line: &PreprocessedLine) -> bool {
     structure::split_leading_result_prefix_lexed(&line.tokens).is_some()
 }
 
+fn is_numeric_result_followup_line(line: &PreprocessedLine) -> bool {
+    matches!(line.tokens.first().map(|token| token.kind), Some(TokenKind::Number))
+        && matches!(
+            line.tokens.get(1).map(|token| token.kind),
+            Some(TokenKind::Dash | TokenKind::EmDash)
+        )
+        && matches!(line.tokens.get(2).map(|token| token.kind), Some(TokenKind::Number))
+        && line.tokens.iter().any(|token| token.kind == TokenKind::Pipe)
+}
+
 fn append_joined_line_tokens(target: &mut Vec<OwnedLexToken>, extra: &[OwnedLexToken]) {
     if extra.is_empty() {
         return;
@@ -208,6 +218,35 @@ pub(super) fn extend_triggered_line_with_result_followups(
     }
 
     (triggered, next_idx)
+}
+
+pub(super) fn extend_statement_line_with_result_followups(
+    items: &[PreprocessedItem],
+    idx: usize,
+    mut statement: StatementLineCst,
+) -> (StatementLineCst, usize) {
+    let mut next_idx = idx + 1;
+
+    while let Some(PreprocessedItem::Line(line)) = items.get(next_idx) {
+        if !is_numeric_result_followup_line(line) {
+            break;
+        }
+
+        let followup_text = render_token_slice(&line.tokens).trim().to_string();
+        if !statement.text.is_empty() {
+            statement.text.push('\n');
+        }
+        statement.text.push_str(followup_text.as_str());
+        append_joined_line_tokens(&mut statement.parse_tokens, &line.tokens);
+
+        next_idx += 1;
+    }
+
+    if next_idx != idx + 1 {
+        statement.parse_groups = normalize_statement_parse_groups_lexed(&statement.parse_tokens);
+    }
+
+    (statement, next_idx)
 }
 
 fn looks_like_statement_line_tokens(tokens: &[OwnedLexToken]) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/unsupported.rs
@@ -385,6 +385,11 @@ pub(super) fn diagnose_known_unsupported_rewrite_line(
         "planeswalker",
     ]) {
         "unsupported creature-token/player/planeswalker target clause"
+    } else if ctx.has_prefix(&["target", "face", "down"])
+        || ctx.has_prefix(&["target", "face-down"])
+        || ctx.has_prefix(&["target", "facedown"])
+    {
+        "unsupported face-down clause"
     } else if ctx.first_word() == Some("villainous") {
         "unsupported villainous-choice clause"
     } else if ctx.has_prefix(&["copy", "target", "spell"]) && ctx.contains_word("legendary") {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -18,10 +18,13 @@ use super::super::effect_ast_traversal::{
 };
 use super::super::grammar::filters::parse_spell_filter_with_grammar_entrypoint_lexed as parse_spell_filter_lexed;
 use super::super::grammar::primitives::{self as grammar, TokenWordView};
+use super::super::grammar::structure::{
+    LeadingResultPrefixKind, split_leading_result_prefix_lexed,
+};
 use super::super::keyword_static::parse_value_binding_clause;
 use super::super::lexer::{
     LexStream, LexedClause, OwnedLexToken, TokenKind, contains_token_word_sequence, lex_line,
-    split_lexed_sentences, token_slice_at_is,
+    split_lexed_sentences, token_slice_at_is, trim_lexed_commas,
 };
 use super::super::object_filters::{
     is_comparison_or_delimiter, parse_object_filter, parse_object_filter_lexed,
@@ -1095,6 +1098,17 @@ pub(super) fn parse_if_you_dont_sentence(
 fn parse_effect_sentences_from_sentence_inputs(
     sentences: Vec<SentenceInput>,
 ) -> Result<Vec<EffectAst>, CardTextError> {
+    fn starts_with_numeric_result_prefix(tokens: &[OwnedLexToken]) -> bool {
+        let tokens = trim_lexed_commas(tokens);
+        matches!(tokens.first().map(|token| token.kind), Some(TokenKind::Number))
+            && matches!(
+                tokens.get(1).map(|token| token.kind),
+                Some(TokenKind::Dash | TokenKind::EmDash)
+            )
+            && matches!(tokens.get(2).map(|token| token.kind), Some(TokenKind::Number))
+            && tokens.iter().any(|token| token.kind == TokenKind::Pipe)
+    }
+
     fn where_x_value_from_tokens(tokens: &[OwnedLexToken]) -> Option<Value> {
         let word_view = TokenWordView::new(tokens);
         let words = word_view.word_refs();
@@ -1127,6 +1141,36 @@ fn parse_effect_sentences_from_sentence_inputs(
         }
         let sentence_text = crate::runtime_backend::token_word_refs(sentence).join(" ");
         let _sentence_scope = parse_trace::scope(format!("effect sentence: \"{}\"", sentence_text));
+
+        if let Some(prefix) = split_leading_result_prefix_lexed(sentence) {
+            let mut row_sentences = vec![SentenceInput::from_lexed(prefix.trailing_tokens)];
+            let mut consumed_sentences = 1usize;
+            if starts_with_numeric_result_prefix(sentence) {
+                while sentence_idx + consumed_sentences < sentences.len() {
+                    let next = sentences[sentence_idx + consumed_sentences].lowered();
+                    if split_leading_result_prefix_lexed(next).is_some() {
+                        break;
+                    }
+                    row_sentences.push(SentenceInput::from_lexed(next));
+                    consumed_sentences += 1;
+                }
+            }
+
+            let row_effects = parse_effect_sentences_from_sentence_inputs(row_sentences)?;
+            effects.push(match prefix.kind {
+                LeadingResultPrefixKind::If => EffectAst::IfResult {
+                    predicate: prefix.predicate,
+                    effects: row_effects,
+                },
+                LeadingResultPrefixKind::When => EffectAst::WhenResult {
+                    predicate: prefix.predicate,
+                    effects: row_effects,
+                },
+            });
+            carried_context = None;
+            sentence_idx += consumed_sentences;
+            continue;
+        }
 
         if let Some(mut matched) = try_parse_subject_verb_sequence_rule(&sentences, sentence_idx)? {
             let stage = if let Some(feature_tag) = matched.feature_tag {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -1142,18 +1142,18 @@ fn parse_effect_sentences_from_sentence_inputs(
         let sentence_text = crate::runtime_backend::token_word_refs(sentence).join(" ");
         let _sentence_scope = parse_trace::scope(format!("effect sentence: \"{}\"", sentence_text));
 
-        if let Some(prefix) = split_leading_result_prefix_lexed(sentence) {
+        if starts_with_numeric_result_prefix(sentence)
+            && let Some(prefix) = split_leading_result_prefix_lexed(sentence)
+        {
             let mut row_sentences = vec![SentenceInput::from_lexed(prefix.trailing_tokens)];
             let mut consumed_sentences = 1usize;
-            if starts_with_numeric_result_prefix(sentence) {
-                while sentence_idx + consumed_sentences < sentences.len() {
-                    let next = sentences[sentence_idx + consumed_sentences].lowered();
-                    if split_leading_result_prefix_lexed(next).is_some() {
-                        break;
-                    }
-                    row_sentences.push(SentenceInput::from_lexed(next));
-                    consumed_sentences += 1;
+            while sentence_idx + consumed_sentences < sentences.len() {
+                let next = sentences[sentence_idx + consumed_sentences].lowered();
+                if starts_with_numeric_result_prefix(next) {
+                    break;
                 }
+                row_sentences.push(SentenceInput::from_lexed(next));
+                consumed_sentences += 1;
             }
 
             let row_effects = parse_effect_sentences_from_sentence_inputs(row_sentences)?;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/return_exchange.rs
@@ -230,6 +230,37 @@ pub(crate) fn parse_return(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
         tokens
     };
 
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if let Some(then_idx) = words
+        .windows(2)
+        .position(|window| window == ["then", "exile"])
+        && let Some(then_token_idx) = token_index_for_word_index(tokens, then_idx)
+    {
+        let return_tokens = trim_commas(&tokens[..then_token_idx]);
+        let exile_tokens = trim_commas(&tokens[then_token_idx + 1..]);
+        if !return_tokens.is_empty()
+            && exile_tokens
+                .first()
+                .is_some_and(|token| token.parser_text().eq_ignore_ascii_case("exile"))
+        {
+            let mut target_tokens = trim_commas(&exile_tokens[1..]);
+            if target_tokens
+                .last()
+                .is_some_and(|token| token.parser_text().eq_ignore_ascii_case("again"))
+            {
+                target_tokens = trim_commas(&target_tokens[..target_tokens.len() - 1]);
+            }
+            if !target_tokens.is_empty() {
+                return Ok(EffectAst::Sequence {
+                    effects: vec![
+                        parse_return(&return_tokens)?,
+                        EffectAst::subject_verb_exile(parse_target_phrase(&target_tokens)?, false),
+                    ],
+                });
+            }
+        }
+    }
+
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     if grammar::contains_word(tokens, "unless") {
         return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6786,6 +6786,48 @@ fn test_parse_aberrant_mind_sorcerer_rolls_and_branch_ranges() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_parse_lae_zels_acrobatics_roll_table_and_return_sequence() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Lae'zel's Acrobatics")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Exile all nontoken creatures you control, then roll a d20.\n1—9 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10—20 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
+        )
+        .expect("Lae'zel's Acrobatics should parse strictly");
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(debug.contains("RollDieEffect"), "{debug}");
+    assert!(
+        debug.contains("BetweenInclusive(1, 9)")
+            && debug.contains("BetweenInclusive(10, 20)"),
+        "expected both d20 result branches, got {debug}"
+    );
+    assert!(
+        debug.contains("ScheduleDelayedTriggerEffect")
+            && debug.contains("MoveToZoneEffect")
+            && debug.contains("zone: Exile"),
+        "expected delayed returns plus 10-20 re-exile sequence, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Lae'zel's Acrobatics") || def.card.name == "Lae'zel's Acrobatics",
+        "card-specific regression should name Lae'zel's Acrobatics"
+    );
+    assert!(
+        rendered.contains("Exile all nontoken creatures you control, then roll a d20")
+            && rendered.contains("1—9 | Return those cards")
+            && rendered.contains("10—20 | Return those cards")
+            && rendered.contains("then exile them again"),
+        "expected d20 table and re-exile wording in compiled text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_arden_angel_rolls_four_sided_die_and_returns_itself_from_graveyard() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Arden Angel")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3216,6 +3216,7 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     describe_roll_choose_destroy_create_structural(effects)
+        .or_else(|| describe_d20_exile_return_table(effects))
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
@@ -3231,6 +3232,147 @@ fn unwrap_with_id(effect: &Effect) -> (&Effect, Option<crate::effect::EffectId>)
         return (&with_id.effect, Some(with_id.id));
     }
     (effect, None)
+}
+
+fn describe_d20_exile_return_table(effects: &[Effect]) -> Option<String> {
+    let [exile_effect, roll_effect, low_branch_effect, high_branch_effect] = effects else {
+        return None;
+    };
+
+    let tagged_exile = exile_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let exile = tagged_exile
+        .effect
+        .downcast_ref::<crate::effects::ExileEffect>()?;
+    if exile.face_down {
+        return None;
+    }
+
+    let (roll_unwrapped, roll_id) = unwrap_with_id(roll_effect);
+    let roll = roll_unwrapped.downcast_ref::<crate::effects::RollDieEffect>()?;
+    let roll_id = roll_id?;
+    if roll.sides != 20 || roll.player != PlayerFilter::You {
+        return None;
+    }
+
+    let low_branch = result_range_if_effect(low_branch_effect, roll_id, 1, 9)?;
+    let high_branch = result_range_if_effect(high_branch_effect, roll_id, 10, 20)?;
+    let [low_delayed_return] = low_branch.then.as_slice() else {
+        return None;
+    };
+    if !is_delayed_owner_battlefield_return_for_tag(low_delayed_return, &tagged_exile.tag) {
+        return None;
+    }
+
+    let [high_return, high_exile, high_delayed_return] = high_branch.then.as_slice() else {
+        return None;
+    };
+    if !is_owner_battlefield_return_for_tag(high_return, &tagged_exile.tag)
+        || !is_exile_move_for_tag(high_exile, &tagged_exile.tag)
+        || !is_delayed_owner_battlefield_return_for_tag_or_source_exiled(
+            high_delayed_return,
+            &tagged_exile.tag,
+        )
+    {
+        return None;
+    }
+
+    let exile_text = describe_effect(exile_effect);
+    let roll_text = lowercase_first(&describe_effect(roll_effect));
+    Some(format!(
+        "{exile_text}, then {roll_text}.\n1—9 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10—20 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step"
+    ))
+}
+
+fn result_range_if_effect(
+    effect: &Effect,
+    condition: crate::effect::EffectId,
+    min: i32,
+    max: i32,
+) -> Option<&crate::effects::IfEffect> {
+    let (effect, _) = unwrap_with_id(effect);
+    let if_effect = effect.downcast_ref::<crate::effects::IfEffect>()?;
+    if if_effect.condition != condition || !if_effect.else_.is_empty() {
+        return None;
+    }
+    match &if_effect.predicate {
+        EffectPredicate::Value(Comparison::BetweenInclusive(found_min, found_max))
+            if *found_min == min && *found_max == max =>
+        {
+            Some(if_effect)
+        }
+        _ => None,
+    }
+}
+
+fn is_owner_battlefield_return_for_tag(effect: &Effect, tag: &crate::TagKey) -> bool {
+    let Some(move_to_zone) = unwrap_basic_tag_wrappers(effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()
+    else {
+        return false;
+    };
+    move_to_zone.zone == Zone::Battlefield
+        && move_to_zone.battlefield_controller == crate::effects::BattlefieldController::Owner
+        && !move_to_zone.enters_tapped
+        && !move_to_zone.enters_attacking
+        && !move_to_zone.enters_face_down
+        && matches!(move_to_zone.target.base(), ChooseSpec::Tagged(found) if found == tag)
+}
+
+fn is_exile_move_for_tag(effect: &Effect, tag: &crate::TagKey) -> bool {
+    if let Some(exile) = unwrap_basic_tag_wrappers(effect)
+        .downcast_ref::<crate::effects::ExileEffect>()
+    {
+        return !exile.face_down
+            && matches!(exile.spec.base(), ChooseSpec::Tagged(found) if found == tag);
+    }
+    unwrap_basic_tag_wrappers(effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()
+        .is_some_and(|move_to_zone| {
+            move_to_zone.zone == Zone::Exile
+                && matches!(move_to_zone.target.base(), ChooseSpec::Tagged(found) if found == tag)
+        })
+}
+
+fn is_delayed_owner_battlefield_return_for_tag(effect: &Effect, tag: &crate::TagKey) -> bool {
+    delayed_owner_battlefield_return_tag(effect)
+        .is_some_and(|found| found.as_str() == tag.as_str())
+}
+
+fn is_delayed_owner_battlefield_return_for_tag_or_source_exiled(
+    effect: &Effect,
+    tag: &crate::TagKey,
+) -> bool {
+    delayed_owner_battlefield_return_tag(effect).is_some_and(|found| {
+        found.as_str() == tag.as_str() || found.as_str() == crate::tag::SOURCE_EXILED_TAG
+    })
+}
+
+fn delayed_owner_battlefield_return_tag(effect: &Effect) -> Option<&crate::TagKey> {
+    let schedule = effect.downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()?;
+    if !schedule.one_shot || schedule.start_next_turn || schedule.until_end_of_turn {
+        return None;
+    }
+    let trigger_text = schedule.trigger.display().to_ascii_lowercase();
+    if !trigger_text.contains("end step") {
+        return None;
+    }
+    let [move_effect] = schedule.effects.as_ref() else {
+        return None;
+    };
+    let move_to_zone = unwrap_basic_tag_wrappers(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Battlefield
+        || move_to_zone.battlefield_controller != crate::effects::BattlefieldController::Owner
+        || move_to_zone.enters_tapped
+        || move_to_zone.enters_attacking
+        || move_to_zone.enters_face_down
+    {
+        return None;
+    }
+    match move_to_zone.target.base() {
+        ChooseSpec::Tagged(tag) => Some(tag),
+        _ => None,
+    }
 }
 
 fn describe_each_player_repeat_pay_life_tokens_sequence(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -14,7 +14,7 @@ use crate::events::zones::EnterBattlefieldEvent;
 use crate::execute_cleanup_step;
 use crate::filter::ObjectFilterExt as _;
 use crate::game_state::Phase;
-use crate::ids::{CardId, ObjectId};
+use crate::ids::{CardId, ObjectId, StableId};
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::ObjectKind;
 use crate::static_abilities::StaticAbility;
@@ -17339,6 +17339,180 @@ fn valiant_endeavor_first_result_choice_uses_second_result_for_tokens() {
         knight_count, 2,
         "choosing the first die result should create tokens equal to the second result"
     );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn lae_zels_acrobatics_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(274_432), "Lae'zel's Acrobatics")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Exile all nontoken creatures you control, then roll a d20.\n1—9 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10—20 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
+        )
+        .expect("Lae'zel's Acrobatics should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn lae_zels_blink_probe_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(274_433), "Lae'zel Blink Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text("When this creature enters, you gain 1 life.")
+        .expect("Lae'zel Blink Probe should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_lae_zels_token_creature(game: &mut GameState, owner: PlayerId) -> StableId {
+    let id = game.new_object_id();
+    let token = crate::object::Object::new_token(
+        id,
+        owner,
+        "Lae'zel Token Probe".to_string(),
+        vec![CardType::Creature],
+        Vec::new(),
+        Some(1),
+        Some(1),
+        crate::color::ColorSet::WHITE,
+    );
+    let stable = token.stable_id;
+    game.add_object(token);
+    stable
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn zone_for_stable(game: &GameState, stable: StableId) -> Zone {
+    let id = game
+        .find_object_by_stable_id(stable)
+        .expect("object should be tracked by stable id");
+    game.object(id).expect("object should exist").zone
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn object_id_for_stable(game: &GameState, stable: StableId) -> ObjectId {
+    game.find_object_by_stable_id(stable)
+        .expect("object should be tracked by stable id")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_lae_zels_acrobatics_roll(roll: u32) -> (GameState, StableId, StableId, PlayerId) {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let spell = lae_zels_acrobatics_definition();
+    let probe = lae_zels_blink_probe_definition();
+    let spell_source = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    let probe_id = game.create_object_from_definition(&probe, alice, Zone::Battlefield);
+    let probe_stable = game
+        .object(probe_id)
+        .expect("probe creature should exist")
+        .stable_id;
+    let token_stable = create_lae_zels_token_creature(&mut game, alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    while !game.stack_is_empty() {
+        resolve_stack_entry(&mut game).expect("setup triggers should resolve cleanly");
+    }
+
+    game.force_next_die_roll(roll);
+    let mut decisions = AutoPassDecisionMaker;
+    let mut ctx = ExecutionContext::new(spell_source, alice, &mut decisions);
+    execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        spell
+            .spell_effect
+            .as_ref()
+            .expect("Lae'zel's Acrobatics should have a spell effect"),
+        None,
+        &[],
+    )
+    .expect("Lae'zel's Acrobatics spell effect should resolve");
+
+    (game, probe_stable, token_stable, alice)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_lae_zels_next_end_step(game: &mut GameState) {
+    let mut trigger_queue = TriggerQueue::new();
+    let end_step_event = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(game.turn.active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(game, &end_step_event) {
+        trigger_queue.add(trigger);
+    }
+    put_triggers_on_stack(game, &mut trigger_queue).expect("put delayed Lae'zel return on stack");
+    while !game.stack_is_empty() {
+        resolve_stack_entry(game).expect("resolve delayed Lae'zel return");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn lae_zels_acrobatics_low_roll_returns_nontokens_only_at_next_end_step() {
+    let (mut game, probe_stable, token_stable, alice) = resolve_lae_zels_acrobatics_roll(5);
+
+    assert_eq!(
+        zone_for_stable(&game, probe_stable),
+        Zone::Exile,
+        "Lae'zel's Acrobatics low roll should leave the nontoken creature exiled"
+    );
+    assert_eq!(
+        zone_for_stable(&game, token_stable),
+        Zone::Battlefield,
+        "Lae'zel's Acrobatics should not exile token creatures"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").life, 20);
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("low roll should not put a pre-end-step ETB trigger on stack");
+    assert!(
+        game.stack_is_empty(),
+        "low roll should not return the creature before the next end step"
+    );
+
+    resolve_lae_zels_next_end_step(&mut game);
+    assert_eq!(
+        zone_for_stable(&game, probe_stable),
+        Zone::Battlefield,
+        "Lae'zel's Acrobatics low roll should return the nontoken creature at the next end step"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn lae_zels_acrobatics_high_roll_returns_then_reexiles_before_next_end_step() {
+    let (mut game, probe_stable, token_stable, alice) = resolve_lae_zels_acrobatics_roll(17);
+
+    let current_probe_id = object_id_for_stable(&game, probe_stable);
+    assert!(
+        current_probe_id.0 >= probe_stable.0.0 + 4,
+        "Lae'zel's Acrobatics high roll should return and re-exile the creature before the delayed return"
+    );
+    assert_eq!(
+        zone_for_stable(&game, probe_stable),
+        Zone::Exile,
+        "Lae'zel's Acrobatics high roll should re-exile the returned nontoken creature"
+    );
+    assert_eq!(
+        zone_for_stable(&game, token_stable),
+        Zone::Battlefield,
+        "Lae'zel's Acrobatics high roll should still ignore token creatures"
+    );
+
+    resolve_lae_zels_next_end_step(&mut game);
+    assert_eq!(
+        zone_for_stable(&game, probe_stable),
+        Zone::Battlefield,
+        "Lae'zel's Acrobatics high roll should return the re-exiled creature at the next end step"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").life, 20);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Lae'zel's Acrobatics
Initial parse error:
```
missing prior effect for if clause; oracle-only fallback also failed: missing prior effect for if clause
```

Current worker: i-0647747a8a1bcfcf9
Branch: codex/aws-card-fix-lae-zel-s-acrobatics
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T121724Z-controller-dev-loop-wave0001
