### PR TITLE
Fix Ironsmith parse failure: Gibbering Descent

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -7830,6 +7830,24 @@ pub(crate) fn parse_add_mana_that_much_value(tokens: &[OwnedLexToken]) -> Option
 pub(crate) fn parse_players_skip_upkeep_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
+    let tokens = trim_edge_punctuation(tokens);
+    let tokens = super::grammar::effects::split_labeled_effect_prefix_lexed(&tokens)
+        .unwrap_or(&tokens);
+    let words = parser_token_word_refs(tokens);
+    if token_slice_starts_with(tokens, &["skip", "your", "upkeep", "step"]) {
+        let mut ability = StaticAbility::player_skips_upkeep(crate::target::PlayerFilter::You);
+        if words.len() > 4 {
+            if words.get(4) != Some(&"if") || tokens.len() <= 5 {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported skip-upkeep tail (clause: '{}')",
+                    words.join(" ")
+                )));
+            }
+            let condition = parse_static_condition_clause(&tokens[5..])?;
+            ability = ability.with_condition(condition);
+        }
+        return Ok(Some(ability));
+    }
     if is_players_skip_upkeep_line_lexed(tokens) {
         return Ok(Some(StaticAbility::players_skip_upkeep()));
     }

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -367,6 +367,9 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     CostIncreasePerTargetBeyondFirst(u32),
     CostIncreaseManaCostPerTargetBeyondFirst(ManaCost),
     MinimumSpellTotalMana(u32),
+    PlayersSkipUpkeep {
+        player: PlayerFilter,
+    },
     ActivatedAbilityCostReduction {
         filter: ObjectFilter,
         reduction: u32,
@@ -810,6 +813,9 @@ where
         {
             let payload = match ability.payload {
             StaticAbilityPayload::None => StaticAbilityPayload::None,
+            StaticAbilityPayload::PlayersSkipUpkeep { player } => {
+                StaticAbilityPayload::PlayersSkipUpkeep { player }
+            }
             StaticAbilityPayload::Anthem(anthem) => StaticAbilityPayload::Anthem(anthem),
             StaticAbilityPayload::AttachedAbilityGrant(grant) => {
                 let grant = *grant;
@@ -3330,10 +3336,13 @@ impl<
         }
     }
     pub fn players_skip_upkeep() -> Self {
+        Self::player_skips_upkeep(PlayerFilter::Any)
+    }
+    pub fn player_skips_upkeep(player: PlayerFilter) -> Self {
         Self {
             id: Some(StaticAbilityId::PlayersSkipUpkeep),
             label: "players skip upkeep".into(),
-            payload: StaticAbilityPayload::None,
+            payload: StaticAbilityPayload::PlayersSkipUpkeep { player },
         }
     }
     pub fn legend_rule_doesnt_apply() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20936,6 +20936,33 @@ fn parse_spell_line_instead_followup_merges_non_control_predicate() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn gibbering_descent_parses_hellbent_skip_upkeep_static_line() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Gibbering Descent")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "At the beginning of each player's upkeep, that player loses 1 life and discards a card.\n\
+             Hellbent — Skip your upkeep step if you have no cards in hand.\n\
+             Madness {2}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+        )
+        .expect("Gibbering Descent should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Skip your upkeep step if you have no cards in hand"),
+        "expected hellbent skip-upkeep clause in compiled text, got {rendered}"
+    );
+    assert!(
+        def.abilities.iter().any(|ability| {
+            matches!(&ability.kind, AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::PlayersSkipUpkeep)
+        }),
+        "expected Gibbering Descent to compile a skip-upkeep static ability, got {:?}",
+        def.abilities
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_cabal_ritual_threshold_instead_compiles_to_self_replacement_branch() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Cabal Ritual Variant")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20948,7 +20948,13 @@ fn gibbering_descent_parses_hellbent_skip_upkeep_static_line() {
 
     let rendered = unprocessed_compiled_lines(&def).join(" ");
     assert!(
-        rendered.contains("Skip your upkeep step if you have no cards in hand"),
+        rendered.contains(
+            "At the beginning of each player's upkeep, that player loses 1 life and discards a card"
+        ),
+        "expected compact lose-life-and-discard trigger text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Hellbent — Skip your upkeep step if you have no cards in hand"),
         "expected hellbent skip-upkeep clause in compiled text, got {rendered}"
     );
     assert!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2241,6 +2241,32 @@ fn describe_each_player_gain_life_and_draw_pair(effects: &[&Effect]) -> Option<S
     ))
 }
 
+fn describe_player_loses_life_and_discards_pair(effects: &[&Effect]) -> Option<String> {
+    let [lose_effect, discard_effect] = effects else {
+        return None;
+    };
+    let lose = lose_effect.downcast_ref::<crate::effects::LoseLifeEffect>()?;
+    let discard = discard_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+    let ChooseSpec::Player(lose_player) = lose.player.base() else {
+        return None;
+    };
+    if lose_player != &discard.player || discard.any_number {
+        return None;
+    }
+
+    let player = describe_choose_spec(&lose.player);
+    let random_suffix = if discard.random { " at random" } else { "" };
+    Some(format!(
+        "{} {} {} and {} {}{}",
+        player,
+        player_verb(&player, "lose", "loses"),
+        describe_life_amount_phrase(&lose.amount),
+        player_verb(&player, "discard", "discards"),
+        describe_discard_count(&discard.count, discard.card_filter.as_ref()),
+        random_suffix
+    ))
+}
+
 fn describe_for_players_subject(filter: &PlayerFilter) -> Option<&'static str> {
     match filter {
         PlayerFilter::Any => Some("Each player"),
@@ -6763,6 +6789,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_each_player_gain_life_and_draw_pair(&visible_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_player_loses_life_and_discards_pair(&visible_effects) {
         return compact;
     }
     if let Some(compact) = describe_sacrifice_source_then_return_with_counters(&visible_effects) {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -6393,6 +6393,16 @@ impl GameState {
             && self.player(player).is_some()
     }
 
+    pub fn player_skips_upkeep_step(&self, player: PlayerId) -> bool {
+        self.with_active_battlefield_static_abilities(|source, controller, ability| {
+            ability
+                .skips_upkeep_for_player(self, source, controller, player)
+                .then_some(true)
+        })
+        .unwrap_or(false)
+            && self.player(player).is_some()
+    }
+
     fn object_is_land_for_cost_restrictions(&self, object_id: ObjectId) -> bool {
         let Some(object) = self.object(object_id) else {
             return false;

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -2845,8 +2845,31 @@ impl StaticAbilityKind for BuybackCostReduction {
 }
 
 /// Players skip their upkeep steps.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct PlayersSkipUpkeep;
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayersSkipUpkeep {
+    pub player: PlayerFilter,
+    pub condition: Option<crate::ConditionExpr>,
+}
+
+impl PlayersSkipUpkeep {
+    pub fn new(player: PlayerFilter) -> Self {
+        Self {
+            player,
+            condition: None,
+        }
+    }
+
+    pub fn with_condition(mut self, condition: crate::ConditionExpr) -> Self {
+        self.condition = Some(condition);
+        self
+    }
+
+    fn condition_matches(&self, game: &GameState, source: ObjectId, controller: PlayerId) -> bool {
+        self.condition.as_ref().is_none_or(|condition| {
+            super::static_condition_is_active(condition, game, source, controller)
+        })
+    }
+}
 
 impl StaticAbilityKind for PlayersSkipUpkeep {
     fn id(&self) -> StaticAbilityId {
@@ -2854,7 +2877,43 @@ impl StaticAbilityKind for PlayersSkipUpkeep {
     }
 
     fn display(&self) -> String {
-        "Players skip their upkeep steps".to_string()
+        let base = match self.player {
+            PlayerFilter::You => "Skip your upkeep step".to_string(),
+            PlayerFilter::Opponent => "Each opponent skips their upkeep step".to_string(),
+            PlayerFilter::Any => "Players skip their upkeep steps".to_string(),
+            _ => "Matching players skip their upkeep steps".to_string(),
+        };
+        if let Some(condition) = &self.condition {
+            if matches!(self.player, PlayerFilter::You)
+                && let crate::ConditionExpr::PlayerCardsInHandOrFewer {
+                    player: PlayerFilter::You,
+                    count: 0,
+                } = condition
+            {
+                return "Skip your upkeep step if you have no cards in hand".to_string();
+            }
+            let condition = super::describe_static_condition(condition);
+            format!("{base} {condition}")
+        } else {
+            base
+        }
+    }
+
+    fn with_static_condition(&self, condition: crate::ConditionExpr) -> Option<StaticAbility> {
+        Some(StaticAbility::new(self.clone().with_condition(condition)))
+    }
+
+    fn skips_upkeep_for_player(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        player: PlayerId,
+    ) -> bool {
+        self.condition_matches(game, source, controller)
+            && self
+                .player
+                .matches_player(player, &game.filter_context_for(controller, Some(source)))
     }
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -2890,7 +2890,7 @@ impl StaticAbilityKind for PlayersSkipUpkeep {
                     count: 0,
                 } = condition
             {
-                return "Skip your upkeep step if you have no cards in hand".to_string();
+                return "Hellbent — Skip your upkeep step if you have no cards in hand".to_string();
             }
             let condition = super::describe_static_condition(condition);
             format!("{base} {condition}")

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -347,6 +347,16 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         true
     }
 
+    fn skips_upkeep_for_player(
+        &self,
+        _game: &GameState,
+        _source: ObjectId,
+        _controller: PlayerId,
+        _player: PlayerId,
+    ) -> bool {
+        false
+    }
+
     // ========================================================================
     // Query methods for specific ability checks
     // These allow checking ability properties without pattern matching.
@@ -1217,6 +1227,17 @@ impl StaticAbility {
     /// Check if this ability is currently active.
     pub fn is_active(&self, game: &GameState, source: ObjectId) -> bool {
         self.0.is_active(game, source)
+    }
+
+    pub fn skips_upkeep_for_player(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        player: PlayerId,
+    ) -> bool {
+        self.0
+            .skips_upkeep_for_player(game, source, controller, player)
     }
 
     /// Generate a replacement effect for this ability.
@@ -2747,7 +2768,11 @@ impl StaticAbility {
     }
 
     pub fn players_skip_upkeep() -> Self {
-        Self::new(PlayersSkipUpkeep)
+        Self::players_skip_upkeep_for(crate::target::PlayerFilter::Any)
+    }
+
+    pub fn players_skip_upkeep_for(player: crate::target::PlayerFilter) -> Self {
+        Self::new(PlayersSkipUpkeep::new(player))
     }
 
     pub fn starting_life_bonus(amount: i32) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -859,6 +859,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::AttachedChosenLandwalkGrant(grant) => {
                 StaticAbility::attached_chosen_landwalk_grant(grant.display.clone(), grant.snow)
             }
+            ironsmith_core::StaticAbilityPayload::PlayersSkipUpkeep { player } => {
+                StaticAbility::players_skip_upkeep_for(player.clone())
+            }
             ironsmith_core::StaticAbilityPayload::Conditional { ability, condition } => {
                 let converted = StaticAbility::from_model((**ability).clone());
                 converted.with_condition(condition.clone()).unwrap_or_else(|| {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1643,6 +1643,18 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
             .unwrap_or(true)
     }
 
+    fn skips_upkeep_for_player(
+        &self,
+        game: &GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        player: PlayerId,
+    ) -> bool {
+        self.leaf_static_ability().is_some_and(|ability| {
+            ability.skips_upkeep_for_player(game, source, controller, player)
+        })
+    }
+
     fn is_keyword(&self) -> bool {
         Self::is_simple_keyword_id(self.id())
     }

--- a/crates/ironsmith-runtime/src/turn_runner.rs
+++ b/crates/ironsmith-runtime/src/turn_runner.rs
@@ -327,6 +327,12 @@ impl TurnRunner {
             }
 
             TurnState::Upkeep => {
+                if game.player_skips_upkeep_step(game.turn.active_player) {
+                    game.turn.step = Some(Step::Upkeep);
+                    game.turn.priority_player = Some(game.turn.active_player);
+                    self.state = TurnState::Draw;
+                    return Ok(TurnAction::Continue);
+                }
                 game.turn.step = Some(Step::Upkeep);
                 game.turn.priority_player = Some(game.turn.active_player);
                 drain_pending_trigger_events(game, tq);
@@ -1198,6 +1204,69 @@ mod tests {
         let object = Object::from_card(object_id, &card, owner, Zone::Battlefield);
         game.add_object(object);
         object_id
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn gibbering_descent_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Gibbering Descent")
+            .card_types(vec![CardType::Enchantment])
+            .parse_text(
+                "At the beginning of each player's upkeep, that player loses 1 life and discards a card.\n\
+                 Hellbent — Skip your upkeep step if you have no cards in hand.\n\
+                 Madness {2}{B}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+            )
+            .expect("Gibbering Descent should parse for turn-runner tests")
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn run_gibbering_descent_upkeep_with_hand_size(hand_size: usize) -> (TurnAction, TurnRunner, TriggerQueue) {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        game.turn.active_player = alice;
+        game.turn.phase = Phase::Beginning;
+        game.turn.step = Some(Step::Untap);
+        let gibbering_descent = gibbering_descent_definition();
+        game.create_object_from_definition(&gibbering_descent, alice, Zone::Battlefield);
+        for idx in 0..hand_size {
+            let card = CardBuilder::new(CardId::new(), &format!("Hand Card {idx}"))
+                .card_types(vec![CardType::Creature])
+                .build();
+            game.create_object_from_card(&card, alice, Zone::Hand);
+        }
+
+        let mut runner = TurnRunner::from_state_for_sync(TurnState::Upkeep);
+        let mut tq = TriggerQueue::new();
+        let action = runner
+            .advance(&mut game, &mut tq)
+            .expect("Gibbering Descent upkeep should advance");
+        (action, runner, tq)
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn gibbering_descent_skips_your_upkeep_when_you_have_no_cards_in_hand() {
+        let (action, runner, tq) = run_gibbering_descent_upkeep_with_hand_size(0);
+
+        assert!(matches!(action, TurnAction::Continue));
+        assert!(matches!(runner.state(), TurnState::Draw));
+        assert!(
+            tq.is_empty(),
+            "skipping the upkeep step should not queue Gibbering Descent's upkeep trigger"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn gibbering_descent_keeps_your_upkeep_when_you_have_cards_in_hand() {
+        let (action, runner, tq) = run_gibbering_descent_upkeep_with_hand_size(1);
+
+        assert!(matches!(action, TurnAction::RunPriority));
+        assert!(matches!(runner.state(), TurnState::UpkeepPriority));
+        assert_eq!(
+            tq.entries.len(),
+            1,
+            "not satisfying hellbent should queue the normal upkeep trigger"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gibbering Descent
Initial parse error:
```
parser does not yet support line family: 'Hellbent — Skip your upkeep step if you have no cards in hand.'; oracle-only fallback also failed: parser does not yet support line family: 'Hellbent — Skip your upkeep step if you have no cards in hand.'
```

Current worker: i-057b3ef57b047060e
Branch: codex/aws-card-fix-gibbering-descent
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T121724Z-controller-dev-loop-wave0001
