### PR TITLE
Fix Ironsmith parse failure: Heavy Fog

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -19,6 +19,24 @@ fn describe_value_for_mode(value: &Value) -> String {
     }
 }
 
+fn prevention_target_from_non_choice_target(
+    target: &TargetAst,
+    ctx: &EffectLoweringContext,
+) -> Result<ironsmith_core::PreventionTarget, CardTextError> {
+    match target {
+        TargetAst::Player(PlayerFilter::You, _) => Ok(ironsmith_core::PreventionTarget::You),
+        TargetAst::Player(PlayerFilter::Any, _) => Ok(ironsmith_core::PreventionTarget::Players),
+        TargetAst::Object(filter, explicit_target_span, _) if explicit_target_span.is_none() => {
+            Ok(ironsmith_core::PreventionTarget::PermanentsMatching(
+                resolve_it_tag(filter, &current_reference_env(ctx))?,
+            ))
+        }
+        _ => Err(CardTextError::ParseError(
+            "unsupported prevent-all damage protected target with source filter".to_string(),
+        )),
+    }
+}
+
 fn resolve_tagged_top_library_condition(
     condition: &crate::ConditionExpr,
     ctx: &EffectLoweringContext,
@@ -1708,6 +1726,24 @@ fn compile_subject_verb_effect(
                     source_filter,
                     duration.clone(),
                 )],
+                Vec::new(),
+            ))
+        }
+        SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter {
+            target,
+            duration,
+            source_filter,
+        } => {
+            let target = prevention_target_from_non_choice_target(target, ctx)?;
+            let source_filter = resolve_it_tag(source_filter, &current_reference_env(ctx))?;
+            let mut damage_filter = ironsmith_core::DamageFilter::all();
+            damage_filter.from_source = Some(source_filter);
+            Ok((
+                vec![Effect::new(crate::effects::PreventAllDamageEffect::new(
+                    target,
+                    damage_filter,
+                    duration.clone(),
+                ))],
                 Vec::new(),
             ))
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -724,6 +724,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
         | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
         | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+        | SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter { .. }
         | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
         | SubjectVerbActionAst::PreventDamageToTargetPutCounters { .. }
         | SubjectVerbActionAst::PutOrRemoveCounters { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1031,6 +1031,11 @@ pub(crate) enum SubjectVerbActionAst {
         target: TargetAst,
         duration: Until,
     },
+    PreventAllDamageToTargetFromSourceFilter {
+        target: TargetAst,
+        duration: Until,
+        source_filter: ObjectFilter,
+    },
     PreventAllDamageFromSourceFilter {
         duration: Until,
         source_filter: ObjectFilter,
@@ -2211,6 +2216,16 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("PreventAllDamageToTarget")
                 .field("target", target)
                 .field("duration", duration)
+                .finish(),
+            Self::PreventAllDamageToTargetFromSourceFilter {
+                target,
+                duration,
+                source_filter,
+            } => f
+                .debug_struct("PreventAllDamageToTargetFromSourceFilter")
+                .field("target", target)
+                .field("duration", duration)
+                .field("source_filter", source_filter)
                 .finish(),
             Self::PreventAllDamageFromSourceFilter {
                 duration,
@@ -3678,6 +3693,22 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::PreventAllDamageToTarget { target, duration },
+        )
+    }
+
+    pub(crate) fn subject_verb_prevent_all_damage_to_target_from_source_filter(
+        target: TargetAst,
+        source_filter: ObjectFilter,
+        duration: Until,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter {
+                target,
+                duration,
+                source_filter,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -429,6 +429,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+            | SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { amount: None, .. }
             | SubjectVerbActionAst::Meld { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -2064,6 +2064,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+            | SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { amount: None, .. }
             | SubjectVerbActionAst::Meld { .. }
@@ -2876,6 +2877,14 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             }
             SubjectVerbActionAst::PreventAllDamageToTarget { target, .. } => {
                 bind_unresolved_it_in_target(target, seed_tag)
+            }
+            SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter {
+                target,
+                source_filter,
+                ..
+            } => {
+                bind_unresolved_it_in_target(target, seed_tag)
+                    + bind_unresolved_it_in_filter(source_filter, seed_tag)
             }
             SubjectVerbActionAst::PreventAllDamageFromSourceFilter { source_filter, .. } => {
                 bind_unresolved_it_in_filter(source_filter, seed_tag)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -473,6 +473,8 @@ const CLAUSE_PREVENT_ALL_DAMAGE_THIS_TURN_BY_PREFIX: &[&str] = &[
 ];
 const CLAUSE_PREVENT_ALL_DAMAGE_TO_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix CLAUSE_PREVENT_ALL_DAMAGE_TO_PREFIX; suffix &["this", "turn"]);
+const CLAUSE_THIS_TURN_BY_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["this", "turn", "by"]);
 const CLAUSE_PREVENT_ALL_DAMAGE_THIS_TURN_TO_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix CLAUSE_PREVENT_ALL_DAMAGE_THIS_TURN_TO_PREFIX);
 const CLAUSE_PREVENT_ALL_DAMAGE_THIS_TURN_BY_PATTERN: ClauseShape<'static> =
@@ -1631,6 +1633,42 @@ pub(crate) fn parse_prevent_all_damage_clause(
         ));
     }
 
+    if let PreventAllDamageClauseShape::TargetFirstSource {
+        prefix_len,
+        this_turn_idx,
+        by_idx,
+    } = shape
+    {
+        let target_clause = clause.between_words_trimmed(prefix_len, this_turn_idx);
+        let source_clause = clause
+            .after_words(by_idx + 1)
+            .unwrap_or_else(|| clause.from(tokens.len()))
+            .trimmed();
+        if target_clause.is_empty() || source_clause.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing prevent-all damage target or source filter (clause: '{}')",
+                clause_text
+            )));
+        }
+
+        let target = parse_target_phrase(target_clause.tokens())?;
+        let source_filter_target = parse_target_phrase(source_clause.tokens())?;
+        let TargetAst::Object(source_filter, _, _) = source_filter_target else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported prevent-all damage source filter target (clause: '{}')",
+                clause_text
+            )));
+        };
+
+        return Ok(Some(
+            EffectAst::subject_verb_prevent_all_damage_to_target_from_source_filter(
+                target,
+                source_filter,
+                Until::EndOfTurn,
+            ),
+        ));
+    }
+
     let target_clause = match shape {
         PreventAllDamageClauseShape::DurationFirstTarget { prefix_len } => clause
             .after_words(prefix_len)
@@ -1651,6 +1689,9 @@ pub(crate) fn parse_prevent_all_damage_clause(
                 clause_text
             )));
         }
+        PreventAllDamageClauseShape::TargetFirstSource { .. } => unreachable!(
+            "target-plus-source prevent-all damage clauses are handled before target-only lowering"
+        ),
     };
     if target_clause.is_empty() {
         return Err(CardTextError::ParseError(format!(
@@ -1672,6 +1713,11 @@ enum PreventAllDamageClauseShape {
     DurationFirstSource { prefix_len: usize },
     DurationFirstTarget { prefix_len: usize },
     TargetFirst { prefix_len: usize },
+    TargetFirstSource {
+        prefix_len: usize,
+        this_turn_idx: usize,
+        by_idx: usize,
+    },
 }
 
 fn classify_prevent_all_damage_clause(words: &[&str]) -> Option<PreventAllDamageClauseShape> {
@@ -1689,6 +1735,19 @@ fn classify_prevent_all_damage_clause(words: &[&str]) -> Option<PreventAllDamage
         && CLAUSE_PREVENT_ALL_DAMAGE_TO_PATTERN.matches_words(words)
     {
         return Some(PreventAllDamageClauseShape::TargetFirst { prefix_len });
+    }
+    if let Some(prefix_len) = CLAUSE_PREVENT_ALL_DAMAGE_TO_PATTERN.matched_prefix_len(words)
+        && let Some(this_turn_rel) = CLAUSE_THIS_TURN_BY_PATTERN.find_exact_window(
+            words.get(prefix_len..).unwrap_or_default(),
+            3,
+        )
+    {
+        let this_turn_idx = prefix_len + this_turn_rel;
+        return Some(PreventAllDamageClauseShape::TargetFirstSource {
+            prefix_len,
+            this_turn_idx,
+            by_idx: this_turn_idx + 2,
+        });
     }
     None
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2593,6 +2593,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::RedirectAllDamageThisTurnBySourceToSourceController { .. }
             | SubjectVerbActionAst::RedirectAllDamageThisTurnToTarget { .. }
             | SubjectVerbActionAst::PreventAllDamageToTarget { .. }
+            | SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventAllDamageFromSourceFilter { .. }
             | SubjectVerbActionAst::PreventDamageToTargetPutCounters { amount: None, .. }
             | SubjectVerbActionAst::Meld { .. }
@@ -2879,6 +2880,10 @@ pub(crate) fn replace_it_target(effect: &mut EffectAst, target: &TargetAst) {
                 ..
             }
             | SubjectVerbActionAst::PreventAllDamageToTarget {
+                target: effect_target,
+                ..
+            }
+            | SubjectVerbActionAst::PreventAllDamageToTargetFromSourceFilter {
                 target: effect_target,
                 ..
             }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18491,6 +18491,189 @@ fn parse_oracle_winds_of_qal_sisma_ferocious_prevents_only_opponents_creature_da
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_heavy_fog_strict_and_keeps_attacking_creature_prevention_clause() {
+    assert_oracle_card_parses_strict("Heavy Fog");
+    let def = parse_oracle_card_definition("Heavy Fog");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.spell_effect).to_ascii_lowercase();
+
+    assert!(
+        rendered.contains(
+            "Prevent all damage that would be dealt to you this turn by attacking creatures"
+        ),
+        "Heavy Fog compiled text should keep the attacking-creature source-filter prevention clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Cast this spell only during the declare attackers step and only if you've been attacked this step"
+        ),
+        "Heavy Fog compiled text should keep its declare-attackers cast restriction, got {rendered}"
+    );
+    assert!(
+        debug.contains("preventalldamageeffect")
+            && debug.contains("target: you")
+            && debug.contains("from_source")
+            && debug.contains("attacking: true")
+            && debug.contains("creature"),
+        "Heavy Fog should lower to a prevent-all shield to you from attacking creature sources, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn heavy_fog_cast_restriction_requires_declare_attackers_after_you_were_attacked() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Heavy Fog")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::new())
+        .parse_text(
+            "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n\
+             Prevent all damage that would be dealt to you this turn by attacking creatures.",
+        )
+        .expect("Heavy Fog text should parse for cast-restriction runtime coverage");
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let attacker = create_winds_test_creature(&mut game, "Heavy Fog Attacker", bob, 3, 3);
+
+    let spell = game.object(spell_id).expect("Heavy Fog should be in hand");
+    assert!(
+        !crate::decision::can_cast_spell(
+            &game,
+            alice,
+            spell,
+            &crate::alternative_cast::CastingMethod::Normal,
+        ),
+        "Heavy Fog should not be castable outside the declare attackers step"
+    );
+
+    game.turn.active_player = bob;
+    game.turn.phase = crate::game_state::Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: attacker,
+            target: crate::combat_state::AttackTarget::Player(bob),
+        }],
+        ..crate::combat_state::CombatState::default()
+    });
+
+    let spell = game.object(spell_id).expect("Heavy Fog should be in hand");
+    assert!(
+        !crate::decision::can_cast_spell(
+            &game,
+            alice,
+            spell,
+            &crate::alternative_cast::CastingMethod::Normal,
+        ),
+        "Heavy Fog should not be castable if Alice was not attacked this step"
+    );
+
+    game.combat
+        .as_mut()
+        .expect("combat should be present")
+        .attackers[0]
+        .target = crate::combat_state::AttackTarget::Player(alice);
+
+    let spell = game.object(spell_id).expect("Heavy Fog should be in hand");
+    assert!(
+        crate::decision::can_cast_spell(
+            &game,
+            alice,
+            spell,
+            &crate::alternative_cast::CastingMethod::Normal,
+        ),
+        "Heavy Fog should be castable during declare attackers after Alice was attacked"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_heavy_fog(game: &mut crate::game_state::GameState, controller: PlayerId) {
+    let heavy_fog = parse_oracle_card_definition("Heavy Fog");
+    let spell_id = game.create_object_from_definition(&heavy_fog, controller, Zone::Stack);
+    game.push_to_stack(crate::game_state::StackEntry::new(spell_id, controller));
+    crate::game_loop::resolve_stack_entry_with(
+        game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Heavy Fog should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn heavy_fog_prevents_only_damage_to_you_from_attacking_creatures() {
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let bob_attacker = create_winds_test_creature(&mut game, "Bob Attacker", bob, 3, 3);
+    let bob_nonattacker = create_winds_test_creature(&mut game, "Bob Nonattacker", bob, 3, 3);
+
+    resolve_heavy_fog(&mut game, alice);
+
+    let shields = game.effect_store.prevention_effects.shields();
+    assert_eq!(shields.len(), 1, "Heavy Fog should create one prevention shield");
+    assert!(
+        matches!(shields[0].protected, crate::prevention::PreventionTarget::You)
+            && shields[0].damage_filter.from_source.is_some(),
+        "Heavy Fog should protect you from a source-filtered damage set, got {:?}",
+        shields[0]
+    );
+
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: bob_attacker,
+            target: crate::combat_state::AttackTarget::Player(alice),
+        }],
+        blockers: std::iter::once((bob_attacker, Vec::new())).collect(),
+        ..crate::combat_state::CombatState::default()
+    });
+
+    let (attacking_damage_to_you, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        bob_attacker,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        attacking_damage_to_you, 0,
+        "Heavy Fog should prevent noncombat damage to you from an attacking creature"
+    );
+
+    let (nonattacking_damage_to_you, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        bob_nonattacker,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        nonattacking_damage_to_you, 3,
+        "Heavy Fog should not prevent damage from a nonattacking creature"
+    );
+
+    let (attacking_damage_to_other_player, _) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            bob_attacker,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        attacking_damage_to_other_player, 3,
+        "Heavy Fog should not prevent damage to players other than you"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_prevent_next_damage_to_any_target_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Amulet of Kroog Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18610,6 +18610,7 @@ fn heavy_fog_prevents_only_damage_to_you_from_attacking_creatures() {
     let bob = PlayerId::from_index(1);
     let bob_attacker = create_winds_test_creature(&mut game, "Bob Attacker", bob, 3, 3);
     let bob_nonattacker = create_winds_test_creature(&mut game, "Bob Nonattacker", bob, 3, 3);
+    let alice_creature = create_winds_test_creature(&mut game, "Alice Creature", alice, 2, 2);
 
     resolve_heavy_fog(&mut game, alice);
 
@@ -18669,6 +18670,19 @@ fn heavy_fog_prevents_only_damage_to_you_from_attacking_creatures() {
     assert_eq!(
         attacking_damage_to_other_player, 3,
         "Heavy Fog should not prevent damage to players other than you"
+    );
+
+    let (attacking_damage_to_permanent, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        bob_attacker,
+        crate::events::DamageTarget::Object(alice_creature),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        attacking_damage_to_permanent, 3,
+        "Heavy Fog should not prevent damage to permanents you control"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -34358,6 +34358,24 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 }
                 return format!("Prevent {damage_type} that would be dealt this turn");
             }
+            if let Some(source_phrase) = damage_type
+                .strip_prefix("all damage from ")
+                .and_then(|rest| rest.strip_suffix(" sources"))
+            {
+                let source_phrase = pluralize_noun_phrase(source_phrase);
+                return format!(
+                    "Prevent all damage that would be dealt to {protected} this turn by {source_phrase}"
+                );
+            }
+            if let Some(source_phrase) = damage_type
+                .strip_prefix("combat damage from ")
+                .and_then(|rest| rest.strip_suffix(" sources"))
+            {
+                let source_phrase = pluralize_noun_phrase(source_phrase);
+                return format!(
+                    "Prevent all combat damage that would be dealt to {protected} this turn by {source_phrase}"
+                );
+            }
             return format!(
                 "Prevent {damage_type} that would be dealt to {} this turn",
                 protected


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Heavy Fog
Initial parse error:
```
parser does not yet support line family: 'Prevent all damage that would be dealt to you this turn by attacking creatures.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all damage that would be dealt to you this turn by attacking creatures.'
```

Current worker: i-0cca18d9c7137a33a
Branch: codex/aws-card-fix-heavy-fog
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T121724Z-controller-dev-loop-wave0001
