### PR TITLE
Fix Ironsmith parse failure: Ornitharch

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_families.rs
@@ -58,6 +58,7 @@ pub(super) enum KeywordDispatchHint {
     Transmute,
     CastThisSpellOnly,
     Gift,
+    Tribute,
     Warp,
     Exploit,
 }
@@ -95,6 +96,12 @@ mod additional_costs {
             hints: &[KeywordDispatchHint::Gift],
             matches: registry::matches_gift,
             lower: registry::lower_gift,
+        },
+        KeywordLineRule {
+            cst_kind: super::super::cst::KeywordLineKindCst::Tribute,
+            hints: &[KeywordDispatchHint::Tribute],
+            matches: registry::matches_tribute,
+            lower: registry::lower_tribute,
         },
     ];
 }
@@ -387,6 +394,9 @@ pub(super) fn parse_keyword_dispatch_hint(tokens: &[OwnedLexToken]) -> Option<Ke
     let word_view = TokenWordView::new(tokens);
     let word_refs = word_view.to_word_refs();
     let first = word_refs.first().copied()?;
+    if first == "tribute" {
+        return Some(KeywordDispatchHint::Tribute);
+    }
     if BASIC_LANDCYCLING_FALLBACK_PATTERN.matches_words(&word_refs) {
         return Some(KeywordDispatchHint::Cycling);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -12,7 +12,7 @@ use super::cst::{KeywordLineCst, KeywordLineKindCst};
 use super::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use super::grammar::abilities::{
     additional_cost_tail_tokens_lexed, is_additional_cost_choice_line_lexed,
-    is_standard_gift_keyword_tokens_lexed,
+    is_standard_gift_keyword_tokens_lexed, is_tribute_keyword_tokens_lexed,
 };
 use super::grammar::primitives::{self as grammar, TokenWordView};
 use super::ir::RewriteKeywordLine;
@@ -27,6 +27,7 @@ use super::lexer::{
 };
 use super::lower::{
     lower_exert_attack_keyword_line, lower_gift_keyword_line, lower_keyword_special_cases,
+    lower_tribute_keyword_line,
 };
 use super::preprocess::PreprocessedLine;
 use super::token_primitives::{
@@ -672,6 +673,20 @@ pub(super) fn lower_gift(
     _tokens: &[OwnedLexToken],
 ) -> Result<LineAst, CardTextError> {
     lower_gift_keyword_line(line)
+}
+
+pub(super) fn matches_tribute(
+    _line: &PreprocessedLine,
+    tokens: &[OwnedLexToken],
+) -> Result<bool, CardTextError> {
+    Ok(is_tribute_keyword_tokens_lexed(tokens))
+}
+
+pub(super) fn lower_tribute(
+    line: &RewriteKeywordLine,
+    _tokens: &[OwnedLexToken],
+) -> Result<LineAst, CardTextError> {
+    lower_tribute_keyword_line(line)
 }
 
 pub(super) fn lower_warp(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -69,6 +69,7 @@ pub(crate) enum KeywordLineKindCst {
     Evoke,
     CastThisSpellOnly,
     Gift,
+    Tribute,
     Epic,
     Warp,
     ExertAttack,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -1476,6 +1476,22 @@ pub(crate) fn is_standard_gift_keyword_tokens_lexed(tokens: &[OwnedLexToken]) ->
     .any(|phrase| primitives::words_match_prefix(head_tokens, phrase).is_some())
 }
 
+pub(crate) fn is_tribute_keyword_tokens_lexed(tokens: &[OwnedLexToken]) -> bool {
+    let head_tokens = tokens
+        .iter()
+        .position(|token| token.kind == TokenKind::LParen)
+        .map(|idx| &tokens[..idx])
+        .unwrap_or(tokens);
+    let words = TokenWordView::new(head_tokens).to_word_refs();
+    if words.first().copied() != Some("tribute") {
+        return false;
+    }
+    matches!(
+        parse_number_words(words.get(1..).unwrap_or_default()),
+        Some((_, 1))
+    )
+}
+
 pub(crate) fn additional_cost_tail_tokens_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<&[OwnedLexToken]> {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -295,6 +295,15 @@ const GIFT_NOT_PROMISED_PATTERN: ClauseShape<'static> = clause_shape!(
             &["gift", "was", "not", "promised"],
         ]
 );
+const TRIBUTE_PAID_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["tribute", "was", "paid"]);
+const TRIBUTE_NOT_PAID_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["tribute", "wasnt", "paid"],
+            &["tribute", "was", "not", "paid"],
+        ]
+);
 const COST_WAS_PAID_TAIL_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["cost", "was", "paid"]);
 const COST_WASNT_PAID_TAIL_PATTERN: ClauseShape<'static> =
@@ -3275,6 +3284,14 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     if GIFT_NOT_PROMISED_PATTERN.matches_words(&filtered) {
         return Ok(PredicateAst::Not(Box::new(
             PredicateAst::ThisSpellPaidLabel("Gift".to_string()),
+        )));
+    }
+    if TRIBUTE_PAID_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::ThisSpellPaidLabel("Tribute".to_string()));
+    }
+    if TRIBUTE_NOT_PAID_PATTERN.matches_words(&filtered) {
+        return Ok(PredicateAst::Not(Box::new(
+            PredicateAst::ThisSpellPaidLabel("Tribute".to_string()),
         )));
     }
     if filtered.len() >= 4

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -47,6 +47,7 @@ pub(crate) use parser_semantic_lowering::{
     lower_exert_attack_keyword_line, lower_gift_keyword_line, lower_keyword_special_cases,
     lower_rewrite_statement_token_groups_to_chunks, lower_rewrite_static_to_chunk,
     lower_rewrite_triggered_to_chunk,
+    lower_tribute_keyword_line,
 };
 pub(crate) use parser_semantic_lowering::{
     lower_special_rewrite_triggered_chunk, try_lower_optional_behold_additional_cost,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1984,6 +1984,54 @@ pub(crate) fn lower_gift_keyword_line(line: &RewriteKeywordLine) -> Result<LineA
     })
 }
 
+pub(crate) fn lower_tribute_keyword_line(
+    line: &RewriteKeywordLine,
+) -> Result<LineAst, CardTextError> {
+    let head_tokens = line
+        .parse_tokens
+        .iter()
+        .position(|token| token.kind == TokenKind::LParen)
+        .map(|idx| &line.parse_tokens[..idx])
+        .unwrap_or(line.parse_tokens.as_slice());
+    let words = parser_token_word_refs(head_tokens);
+    if words.first().copied() != Some("tribute") {
+        return Err(CardTextError::ParseError(format!(
+            "rewrite keyword lowering could not parse tribute line '{}'",
+            line.info.raw_line
+        )));
+    }
+    let (count, used) = crate::runtime_backend::front_end::shared::util::parse_number(
+        head_tokens.get(1..).unwrap_or_default(),
+    )
+    .ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "rewrite keyword lowering could not parse tribute count '{}'",
+            line.info.raw_line
+        ))
+    })?;
+    if used != 1 {
+        return Err(CardTextError::ParseError(format!(
+            "rewrite keyword lowering found unsupported tribute count shape '{}'",
+            line.info.raw_line
+        )));
+    }
+
+    let tribute = StaticAbility::tribute(count);
+    let counters = StaticAbility::enters_with_counters_if_condition(
+        crate::object::CounterType::PlusOnePlusOne,
+        crate::effect::Value::Fixed(count as i32),
+        crate::ConditionExpr::ThisSpellPaidLabel("Tribute".to_string()),
+        "tribute was paid".to_string(),
+    );
+
+    Ok(LineAst::Multiple(vec![
+        LineAst::StaticAbilities(vec![
+            crate::cards::builders::StaticAbilityAst::Static(tribute),
+            crate::cards::builders::StaticAbilityAst::Static(counters),
+        ]),
+    ]))
+}
+
 #[derive(Clone, Copy)]
 enum StandardGiftVariant {
     Card,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -201,6 +201,7 @@ pub enum StaticAbilityId {
     EntersTappedUnlessCondition,
     EnterWithCounters,
     EnterWithCountersIfCondition,
+    Tribute,
     ShuffleIntoLibraryFromGraveyard,
     AllPermanentsEnterTapped,
     EnterTappedForFilter,
@@ -462,6 +463,7 @@ impl StaticAbilityId {
             | EntersTappedUnlessCondition
             | EnterWithCounters
             | EnterWithCountersIfCondition
+            | Tribute
             | ShuffleIntoLibraryFromGraveyard
             | AllPermanentsEnterTapped
             | EnterTappedForFilter
@@ -555,6 +557,7 @@ impl StaticAbilityId {
                 | Flanking
                 | Landwalk
                 | Bloodthirst
+                | Tribute
                 | Morph
                 | Disguise
                 | Megamorph

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -495,6 +495,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     },
     Landwalk(LandwalkKind),
     Bloodthirst(u32),
+    Tribute(u32),
     PreventDamageToSelfRemoveCounter {
         counter_type: CounterType,
         amount: u32,
@@ -1437,6 +1438,7 @@ where
             StaticAbilityPayload::Bloodthirst(amount) => {
                 StaticAbilityPayload::Bloodthirst(amount)
             }
+            StaticAbilityPayload::Tribute(amount) => StaticAbilityPayload::Tribute(amount),
             StaticAbilityPayload::PreventDamageToSelfRemoveCounter {
                 counter_type,
                 amount,
@@ -2381,6 +2383,13 @@ impl<
             id: Some(StaticAbilityId::Bloodthirst),
             label: format!("bloodthirst {amount}"),
             payload: StaticAbilityPayload::Bloodthirst(amount),
+        }
+    }
+    pub fn tribute(amount: u32) -> Self {
+        Self {
+            id: Some(StaticAbilityId::Tribute),
+            label: format!("Tribute {amount}"),
+            payload: StaticAbilityPayload::Tribute(amount),
         }
     }
     pub fn krrik_black_mana_may_be_paid_with_life() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40615,6 +40615,52 @@ fn ornitharch_paid_tribute_enters_with_counters_and_skips_birds() {
 }
 
 #[test]
+fn ornitharch_tribute_controller_chooses_which_opponent_is_prompted() {
+    let def = parse_oracle_card_definition("Ornitharch");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut decision_maker =
+        OrnitharchTributeDecisionMaker::new_with_chosen_opponent(charlie, true);
+
+    let result = game
+        .move_object_with_etb_processing_with_dm(source, Zone::Battlefield, &mut decision_maker)
+        .expect("Ornitharch should enter the battlefield");
+
+    assert_eq!(
+        decision_maker.opponent_choice_prompts,
+        1,
+        "controller should choose among multiple opponents for Tribute"
+    );
+    assert_eq!(
+        decision_maker.tribute_prompt_players,
+        vec![charlie],
+        "only the controller-chosen opponent should receive the Tribute counter prompt"
+    );
+    assert!(!decision_maker.tribute_prompt_players.contains(&bob));
+    let ornitharch = game
+        .object(result.new_id)
+        .expect("Ornitharch should exist on the battlefield");
+    assert!(
+        ornitharch.optional_costs_paid.was_paid_label("Tribute"),
+        "accepted chosen-opponent Tribute choice should be recorded"
+    );
+    assert_eq!(
+        ornitharch
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied(),
+        Some(2),
+        "chosen opponent accepting Tribute 2 should make Ornitharch enter with counters"
+    );
+}
+
+#[test]
 fn ornitharch_unpaid_tribute_creates_two_flying_birds() {
     let def = parse_oracle_card_definition("Ornitharch");
     let alice = PlayerId::from_index(0);
@@ -40700,21 +40746,85 @@ fn ornitharch_bird_tokens(game: &crate::game_state::GameState, controller: Playe
 
 struct OrnitharchTributeDecisionMaker {
     expected_player: PlayerId,
+    chosen_opponent: Option<PlayerId>,
     accept: bool,
+    opponent_choice_prompts: usize,
     tribute_prompts: usize,
+    tribute_prompt_players: Vec<PlayerId>,
 }
 
 impl OrnitharchTributeDecisionMaker {
     fn new(expected_player: PlayerId, accept: bool) -> Self {
         Self {
             expected_player,
+            chosen_opponent: None,
             accept,
+            opponent_choice_prompts: 0,
             tribute_prompts: 0,
+            tribute_prompt_players: Vec::new(),
+        }
+    }
+
+    fn new_with_chosen_opponent(chosen_opponent: PlayerId, accept: bool) -> Self {
+        Self {
+            expected_player: chosen_opponent,
+            chosen_opponent: Some(chosen_opponent),
+            accept,
+            opponent_choice_prompts: 0,
+            tribute_prompts: 0,
+            tribute_prompt_players: Vec::new(),
         }
     }
 }
 
 impl crate::decision::DecisionMaker for OrnitharchTributeDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        let Some(chosen_opponent) = self.chosen_opponent else {
+            return ctx
+                .options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect();
+        };
+        assert!(
+            ctx.description.to_ascii_lowercase().contains("tribute"),
+            "expected only the Tribute opponent-choice prompt, got {:?}",
+            ctx.description
+        );
+        assert_eq!(
+            ctx.player,
+            PlayerId::from_index(0),
+            "the entering creature's controller should choose the Tribute opponent"
+        );
+        assert!(
+            ctx.options.iter().any(|option| option.description == "Bob")
+                && ctx.options.iter().any(|option| option.description == "Charlie"),
+            "Tribute opponent choice should offer all opponents, got {:?}",
+            ctx.options
+                .iter()
+                .map(|option| option.description.as_str())
+                .collect::<Vec<_>>()
+        );
+        self.opponent_choice_prompts += 1;
+        let chosen_name = match chosen_opponent.index() {
+            1 => "Bob",
+            2 => "Charlie",
+            _ => panic!("unexpected chosen opponent {chosen_opponent:?}"),
+        };
+        vec![ctx
+            .options
+            .iter()
+            .find(|option| option.description == chosen_name)
+            .expect("chosen opponent should be offered")
+            .index]
+    }
+
     fn decide_boolean(
         &mut self,
         _game: &crate::game_state::GameState,
@@ -40730,6 +40840,7 @@ impl crate::decision::DecisionMaker for OrnitharchTributeDecisionMaker {
             ctx.description
         );
         self.tribute_prompts += 1;
+        self.tribute_prompt_players.push(ctx.player);
         self.accept
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40515,6 +40515,226 @@ fn parse_oracle_scrapshooter_gift_etb_regression() {
 }
 
 #[test]
+fn parse_oracle_ornitharch_tribute_regression() {
+    let def = parse_oracle_card_definition("Ornitharch");
+
+    assert_eq!(
+        def.optional_costs.len(),
+        0,
+        "Tribute is an as-enters opponent choice, not a cast optional cost"
+    );
+
+    let raw = format!("{def:#?}");
+    assert!(
+        !raw.contains("KeywordFallbackText") && !raw.contains("unsupported"),
+        "Ornitharch should parse strictly without fallback markers, got {raw}"
+    );
+    assert!(
+        raw.contains("Tribute")
+            && raw.contains("Tribute(2)")
+            && raw.contains("EnterWithCountersIfCondition")
+            && raw.contains("PlusOnePlusOne")
+            && raw.contains("Fixed(2)")
+            && raw.contains("ThisSpellPaidLabel")
+            && raw.contains("Tribute"),
+        "expected Tribute 2 to structurally preserve keyword identity and add two +1/+1 counters when paid, got {raw}"
+    );
+    assert!(
+        raw.contains("Not(")
+            && raw.contains("ThisSpellPaidLabel(")
+            && raw.contains("CreateTokenEffect")
+            && raw.contains("Bird"),
+        "expected Ornitharch's unpaid-tribute ETB trigger to create Bird tokens, got {raw}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Tribute 2"),
+        "expected Ornitharch compiled text to include Tribute 2, got {rendered}"
+    );
+    assert!(
+        rendered.contains("When this creature enters, if tribute wasn't paid")
+            && rendered.contains("create two 1/1 white Bird creature tokens with flying"),
+        "expected Ornitharch compiled text to preserve the unpaid tribute trigger, got {rendered}"
+    );
+}
+
+#[test]
+fn ornitharch_paid_tribute_enters_with_counters_and_skips_birds() {
+    let def = parse_oracle_card_definition("Ornitharch");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut decision_maker = OrnitharchTributeDecisionMaker::new(bob, true);
+
+    let result = game
+        .move_object_with_etb_processing_with_dm(source, Zone::Battlefield, &mut decision_maker)
+        .expect("Ornitharch should enter the battlefield");
+    assert_eq!(
+        decision_maker.tribute_prompts,
+        1,
+        "paid-tribute branch should ask the chosen opponent once"
+    );
+    let ornitharch = game
+        .object(result.new_id)
+        .expect("Ornitharch should exist on the battlefield");
+    assert!(
+        ornitharch.optional_costs_paid.was_paid_label("Tribute"),
+        "accepted opponent Tribute choice should be recorded on the entering object"
+    );
+    assert_eq!(
+        ornitharch
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied(),
+        Some(2),
+        "paid Tribute 2 should make Ornitharch enter with two +1/+1 counters"
+    );
+
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            result.new_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let triggers = crate::triggers::check_triggers(&game, &event);
+    assert!(
+        triggers.iter().all(|entry| entry.source != result.new_id),
+        "paid tribute should fail Ornitharch's unpaid-tribute intervening-if trigger"
+    );
+    assert_eq!(
+        ornitharch_bird_tokens(&game, alice),
+        0,
+        "paid tribute should not create Bird tokens"
+    );
+}
+
+#[test]
+fn ornitharch_unpaid_tribute_creates_two_flying_birds() {
+    let def = parse_oracle_card_definition("Ornitharch");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut decision_maker = OrnitharchTributeDecisionMaker::new(bob, false);
+
+    let result = game
+        .move_object_with_etb_processing_with_dm(source, Zone::Battlefield, &mut decision_maker)
+        .expect("Ornitharch should enter the battlefield");
+    assert_eq!(
+        decision_maker.tribute_prompts,
+        1,
+        "unpaid-tribute branch should ask the chosen opponent once"
+    );
+    let ornitharch = game
+        .object(result.new_id)
+        .expect("Ornitharch should exist on the battlefield");
+    assert!(
+        !ornitharch.optional_costs_paid.was_paid_label("Tribute"),
+        "declined opponent Tribute choice should not mark Tribute paid"
+    );
+    assert_eq!(
+        ornitharch
+            .counters
+            .get(&crate::object::CounterType::PlusOnePlusOne)
+            .copied(),
+        None,
+        "unpaid tribute should not add +1/+1 counters"
+    );
+
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            result.new_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &event) {
+        if trigger.source == result.new_id {
+            trigger_queue.add(trigger);
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "unpaid tribute should queue exactly one Ornitharch ETB trigger"
+    );
+
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Ornitharch trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Ornitharch unpaid-tribute trigger should resolve");
+
+    assert_eq!(
+        ornitharch_bird_tokens(&game, alice),
+        2,
+        "unpaid tribute should create two Bird tokens"
+    );
+}
+
+fn ornitharch_bird_tokens(game: &crate::game_state::GameState, controller: PlayerId) -> usize {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|id| {
+            let Some(object) = game.object(*id) else {
+                return false;
+            };
+            matches!(object.kind, crate::object::ObjectKind::Token)
+                && object.name == "Bird"
+                && object.subtypes.contains(&Subtype::Bird)
+                && game.controller_of(object) == controller
+                && game.object_has_static_ability_id(*id, StaticAbilityId::Flying)
+        })
+        .count()
+}
+
+struct OrnitharchTributeDecisionMaker {
+    expected_player: PlayerId,
+    accept: bool,
+    tribute_prompts: usize,
+}
+
+impl OrnitharchTributeDecisionMaker {
+    fn new(expected_player: PlayerId, accept: bool) -> Self {
+        Self {
+            expected_player,
+            accept,
+            tribute_prompts: 0,
+        }
+    }
+}
+
+impl crate::decision::DecisionMaker for OrnitharchTributeDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        assert_eq!(
+            ctx.player, self.expected_player,
+            "Tribute should be offered to an opponent, not the controller"
+        );
+        assert!(
+            ctx.description.contains("+1/+1 counters"),
+            "Tribute prompt should describe the counter choice, got {:?}",
+            ctx.description
+        );
+        self.tribute_prompts += 1;
+        self.accept
+    }
+}
+
+#[test]
 fn parse_oracle_longstalk_brawl_gift_spell_line_keeps_main_effects() {
     let def = parse_oracle_card_definition("Longstalk Brawl");
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -441,6 +441,23 @@ fn is_hidden_gift_etb_ability(ability: &Ability) -> bool {
     rendered.starts_with("if the gift was promised") || is_standard_gift_render_payload(&rendered)
 }
 
+fn is_hidden_tribute_enter_with_counters_ability(ability: &Ability) -> bool {
+    let AbilityKind::Static(static_ability) = &ability.kind else {
+        return false;
+    };
+    let rendered = static_ability.display().to_ascii_lowercase();
+    rendered.starts_with("enters the battlefield with ")
+        && rendered.contains("+1/+1 counter")
+        && rendered.ends_with(" if tribute was paid")
+}
+
+fn is_visible_tribute_keyword_ability(ability: &Ability) -> bool {
+    let AbilityKind::Static(static_ability) = &ability.kind else {
+        return false;
+    };
+    static_ability.id() == crate::static_abilities::StaticAbilityId::Tribute
+}
+
 fn describe_single_self_replacement_segment(
     segment: &crate::resolution::ResolutionSegment,
 ) -> Option<String> {
@@ -2434,6 +2451,7 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
         .optional_costs
         .iter()
         .any(|cost| cost.label.trim().to_ascii_lowercase().starts_with("gift "));
+    let has_visible_tribute_line = def.abilities.iter().any(is_visible_tribute_keyword_ability);
     if let Some(filter) = &def.aura_attach_filter {
         out.push(format!("Enchant {}", describe_enchant_filter(filter)));
     }
@@ -2480,6 +2498,10 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                 continue;
             }
             if has_visible_gift_line && is_hidden_gift_etb_ability(ability) {
+                ability_idx += 1;
+                continue;
+            }
+            if has_visible_tribute_line && is_hidden_tribute_enter_with_counters_ability(ability) {
                 ability_idx += 1;
                 continue;
             }

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11557,6 +11557,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             {
                 return "the gift was promised".to_string();
             }
+            if label.eq_ignore_ascii_case("tribute") {
+                return "tribute was paid".to_string();
+            }
             if label.eq_ignore_ascii_case("bargain") {
                 return "this spell was bargained".to_string();
             }
@@ -12440,6 +12443,10 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 "no permanents left the battlefield this turn".to_string()
             } else if let Condition::CardsInHandOrMore(1) = inner.as_ref() {
                 "you have no cards in hand".to_string()
+            } else if let Condition::ThisSpellPaidLabel(label) = inner.as_ref()
+                && label.eq_ignore_ascii_case("tribute")
+            {
+                "tribute wasn't paid".to_string()
             } else if let Condition::PlayerControls { player, filter } = inner.as_ref() {
                 let subject = describe_player_filter(player);
                 let mut described_filter = filter.clone();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -36491,6 +36491,9 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
     if text == "toxic" || text.starts_with("toxic ") {
         return Some(raw_text.to_string());
     }
+    if text.starts_with("tribute ") {
+        return Some(raw_text.to_string());
+    }
     let first_cycling_idx = words
         .iter()
         .position(|word| trim_cycling_punctuation(word).ends_with("cycling"));

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -1,6 +1,6 @@
 use super::TraitApplyResult;
 use crate::events::{Event, EventKind};
-use crate::filter::ObjectFilterExt as _;
+use crate::filter::{ObjectFilterExt as _, PlayerFilterExt as _};
 use crate::game_state::{GameState, Target};
 use crate::ids::PlayerId;
 use crate::object::CounterType;
@@ -265,6 +265,7 @@ pub(super) fn apply_trait_replacement(
                     effect_id: effect.id,
                     object_id: effect.source,
                     filter: Some(filter.clone()),
+                    mark_label: None,
                     destinations: None,
                 }
             }
@@ -300,8 +301,35 @@ pub(super) fn apply_trait_replacement(
                     effect_id: effect.id,
                     object_id: effect.source,
                     filter: None,
+                    mark_label: None,
                     destinations: None,
                 }
+            }
+        }
+
+        ReplacementAction::InteractiveMarkLabel {
+            chooser,
+            label,
+            prompt,
+        } => {
+            let chooser = choose_replacement_player(game, effect.controller, chooser);
+            let source_name = game.object(effect.source).map(|o| o.name.clone());
+            let mut bool_ctx = crate::decisions::context::BooleanContext::new(
+                chooser,
+                Some(effect.source),
+                prompt.clone(),
+            );
+            if let Some(name) = source_name {
+                bool_ctx = bool_ctx.with_source_name(name);
+            }
+            TraitApplyResult::NeedsInteraction {
+                decision_ctx: crate::decisions::context::DecisionContext::Boolean(bool_ctx),
+                redirect_zone: Zone::Battlefield,
+                effect_id: effect.id,
+                object_id: effect.source,
+                filter: None,
+                mark_label: Some(label.clone()),
+                destinations: None,
             }
         }
 
@@ -347,10 +375,30 @@ pub(super) fn apply_trait_replacement(
                 effect_id: effect.id,
                 object_id: effect.source,
                 filter: None,
+                mark_label: None,
                 destinations: Some(destinations.clone()),
             }
         }
     }
+}
+
+fn choose_replacement_player(
+    game: &GameState,
+    controller: PlayerId,
+    chooser: &crate::target::PlayerFilter,
+) -> PlayerId {
+    let mut ctx = crate::target::FilterContext::new(controller);
+    ctx.opponents = game
+        .players
+        .iter()
+        .map(|player| player.id)
+        .filter(|player| *player != controller)
+        .collect();
+    game.players
+        .iter()
+        .map(|player| player.id)
+        .find(|player| chooser.matches_player(*player, &ctx))
+        .unwrap_or(controller)
 }
 
 fn apply_trait_enter_under_control(event: &Event, controller: PlayerId) -> Option<Event> {

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -266,6 +266,8 @@ pub(super) fn apply_trait_replacement(
                     object_id: effect.source,
                     filter: Some(filter.clone()),
                     mark_label: None,
+                    mark_label_prompt: None,
+                    mark_label_chooser_options: None,
                     destinations: None,
                 }
             }
@@ -302,6 +304,8 @@ pub(super) fn apply_trait_replacement(
                     object_id: effect.source,
                     filter: None,
                     mark_label: None,
+                    mark_label_prompt: None,
+                    mark_label_chooser_options: None,
                     destinations: None,
                 }
             }
@@ -309,11 +313,53 @@ pub(super) fn apply_trait_replacement(
 
         ReplacementAction::InteractiveMarkLabel {
             chooser,
+            chooser_prompt,
             label,
             prompt,
         } => {
-            let chooser = choose_replacement_player(game, effect.controller, chooser);
             let source_name = game.object(effect.source).map(|o| o.name.clone());
+            let choosers = choose_replacement_players(game, effect.controller, chooser);
+            if let Some(chooser_prompt) = chooser_prompt
+                && choosers.len() > 1
+            {
+                let options = choosers
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, player_id)| {
+                        let name = game
+                            .player(*player_id)
+                            .map(|player| player.name.clone())
+                            .unwrap_or_else(|| format!("Player {}", player_id.index()));
+                        crate::decisions::context::SelectableOption::new(idx, name)
+                    })
+                    .collect();
+                let mut select_ctx = crate::decisions::context::SelectOptionsContext::new(
+                    effect.controller,
+                    Some(effect.source),
+                    chooser_prompt.clone(),
+                    options,
+                    1,
+                    1,
+                );
+                if let Some(name) = source_name {
+                    select_ctx.ui_hints.context_text = Some(name);
+                }
+                return TraitApplyResult::NeedsInteraction {
+                    decision_ctx: crate::decisions::context::DecisionContext::SelectOptions(
+                        select_ctx,
+                    ),
+                    redirect_zone: Zone::Battlefield,
+                    effect_id: effect.id,
+                    object_id: effect.source,
+                    filter: None,
+                    mark_label: Some(label.clone()),
+                    mark_label_prompt: Some(prompt.clone()),
+                    mark_label_chooser_options: Some(choosers),
+                    destinations: None,
+                };
+            }
+
+            let chooser = choosers.first().copied().unwrap_or(effect.controller);
             let mut bool_ctx = crate::decisions::context::BooleanContext::new(
                 chooser,
                 Some(effect.source),
@@ -329,6 +375,8 @@ pub(super) fn apply_trait_replacement(
                 object_id: effect.source,
                 filter: None,
                 mark_label: Some(label.clone()),
+                mark_label_prompt: None,
+                mark_label_chooser_options: None,
                 destinations: None,
             }
         }
@@ -376,17 +424,19 @@ pub(super) fn apply_trait_replacement(
                 object_id: effect.source,
                 filter: None,
                 mark_label: None,
+                mark_label_prompt: None,
+                mark_label_chooser_options: None,
                 destinations: Some(destinations.clone()),
             }
         }
     }
 }
 
-fn choose_replacement_player(
+fn choose_replacement_players(
     game: &GameState,
     controller: PlayerId,
     chooser: &crate::target::PlayerFilter,
-) -> PlayerId {
+) -> Vec<PlayerId> {
     let mut ctx = crate::target::FilterContext::new(controller);
     ctx.opponents = game
         .players
@@ -397,8 +447,8 @@ fn choose_replacement_player(
     game.players
         .iter()
         .map(|player| player.id)
-        .find(|player| chooser.matches_player(*player, &ctx))
-        .unwrap_or(controller)
+        .filter(|player| chooser.matches_player(*player, &ctx))
+        .collect()
 }
 
 fn apply_trait_enter_under_control(event: &Event, controller: PlayerId) -> Option<Event> {

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -384,6 +384,7 @@ fn process_event_direct(
                 effect_id,
                 object_id,
                 filter,
+                mark_label,
                 destinations,
             } => TraitEventResult::NeedsInteraction {
                 decision_ctx,
@@ -398,6 +399,7 @@ fn process_event_direct(
                     }
                     _ => None,
                 },
+                mark_label,
                 destinations,
             },
         };
@@ -455,6 +457,7 @@ fn process_event_direct(
             effect_id,
             object_id,
             filter,
+            mark_label,
             destinations,
         } => TraitEventResult::NeedsInteraction {
             decision_ctx,
@@ -464,6 +467,7 @@ fn process_event_direct(
             event: Box::new(event),
             filter,
             life_cost,
+            mark_label,
             destinations,
         },
     }
@@ -578,6 +582,7 @@ fn continue_interactive_replacement(
     filter: Option<&crate::target::ObjectFilter>,
     redirect_zone: Zone,
     life_cost: Option<u32>,
+    mark_label: Option<&str>,
     destinations: Option<&[Zone]>,
     provenance: crate::provenance::ProvNodeId,
     decision_maker: &mut dyn DecisionMaker,
@@ -599,6 +604,15 @@ fn continue_interactive_replacement(
     // Handle pay-life-or-enter-tapped (shock land pattern)
     if let Some(cost) = life_cost {
         return handle_pay_life_or_enter_tapped(game, response, controller, cost);
+    }
+
+    if let Some(label) = mark_label {
+        if matches!(response, InteractiveReplacementResponse::Accept)
+            && let Some(object) = game.object_mut(object_id)
+        {
+            object.optional_costs_paid.mark_label_paid(label);
+        }
+        return InteractiveReplacementResult::enters_battlefield();
     }
 
     if let Some(destinations) = destinations {
@@ -1121,6 +1135,8 @@ enum TraitApplyResult {
         object_id: crate::ids::ObjectId,
         /// The filter for discarding (for InteractiveDiscardOrRedirect).
         filter: Option<crate::target::ObjectFilter>,
+        /// Label to mark on the entering object if the interaction is accepted.
+        mark_label: Option<String>,
         /// Destination options for InteractiveChooseDestination.
         destinations: Option<Vec<Zone>>,
     },
@@ -1249,6 +1265,8 @@ pub enum TraitEventResult {
         filter: Option<crate::target::ObjectFilter>,
         /// The life cost (for InteractivePayLifeOrEnterTapped).
         life_cost: Option<u32>,
+        /// Label to mark on the entering object if the interaction is accepted.
+        mark_label: Option<String>,
         /// Destination options for InteractiveChooseDestination.
         destinations: Option<Vec<Zone>>,
     },
@@ -1981,6 +1999,7 @@ fn process_with_dm_and_additional_effects_and_applied(
                         effect_id,
                         object_id,
                         filter,
+                        mark_label,
                         destinations,
                     } => {
                         return TraitEventResult::NeedsInteraction {
@@ -1996,6 +2015,7 @@ fn process_with_dm_and_additional_effects_and_applied(
                                 } => Some(*life_cost),
                                 _ => None,
                             },
+                            mark_label,
                             destinations,
                         };
                     }
@@ -3017,6 +3037,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                         effect_id,
                         object_id,
                         filter,
+                        mark_label,
                         destinations,
                     } => {
                         let life_cost = match &chosen_effect.replacement {
@@ -3058,6 +3079,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                             filter.as_ref(),
                             redirect_zone,
                             life_cost,
+                            mark_label.as_deref(),
                             destinations.as_deref(),
                             current_event.provenance(),
                             dm,
@@ -3085,6 +3107,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                 event,
                 filter,
                 life_cost,
+                mark_label,
                 destinations,
             } => {
                 let controller = game
@@ -3116,6 +3139,7 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                     filter.as_ref(),
                     redirect_zone,
                     life_cost,
+                    mark_label.as_deref(),
                     destinations.as_deref(),
                     event.provenance(),
                     dm,
@@ -3428,6 +3452,7 @@ pub fn process_event_with_chosen_replacement_trait(
             effect_id,
             object_id,
             filter,
+            mark_label,
             destinations,
         } => TraitEventResult::NeedsInteraction {
             decision_ctx,
@@ -3442,6 +3467,7 @@ pub fn process_event_with_chosen_replacement_trait(
                 }
                 _ => None,
             },
+            mark_label,
             destinations,
         },
     }

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -385,6 +385,8 @@ fn process_event_direct(
                 object_id,
                 filter,
                 mark_label,
+                mark_label_prompt,
+                mark_label_chooser_options,
                 destinations,
             } => TraitEventResult::NeedsInteraction {
                 decision_ctx,
@@ -400,6 +402,8 @@ fn process_event_direct(
                     _ => None,
                 },
                 mark_label,
+                mark_label_prompt,
+                mark_label_chooser_options,
                 destinations,
             },
         };
@@ -458,6 +462,8 @@ fn process_event_direct(
             object_id,
             filter,
             mark_label,
+            mark_label_prompt,
+            mark_label_chooser_options,
             destinations,
         } => TraitEventResult::NeedsInteraction {
             decision_ctx,
@@ -468,6 +474,8 @@ fn process_event_direct(
             filter,
             life_cost,
             mark_label,
+            mark_label_prompt,
+            mark_label_chooser_options,
             destinations,
         },
     }
@@ -583,6 +591,8 @@ fn continue_interactive_replacement(
     redirect_zone: Zone,
     life_cost: Option<u32>,
     mark_label: Option<&str>,
+    mark_label_prompt: Option<&str>,
+    mark_label_chooser_options: Option<&[PlayerId]>,
     destinations: Option<&[Zone]>,
     provenance: crate::provenance::ProvNodeId,
     decision_maker: &mut dyn DecisionMaker,
@@ -607,9 +617,34 @@ fn continue_interactive_replacement(
     }
 
     if let Some(label) = mark_label {
-        if matches!(response, InteractiveReplacementResponse::Accept)
-            && let Some(object) = game.object_mut(object_id)
+        let accepted = if let (Some(prompt), Some(chooser_options)) =
+            (mark_label_prompt, mark_label_chooser_options)
         {
+            let chosen_player = match response {
+                InteractiveReplacementResponse::Options(selected) => selected
+                    .first()
+                    .and_then(|idx| chooser_options.get(*idx))
+                    .copied(),
+                _ => None,
+            };
+            if let Some(chosen_player) = chosen_player {
+                let source_name = game.object(object_id).map(|object| object.name.clone());
+                let mut bool_ctx = crate::decisions::context::BooleanContext::new(
+                    chosen_player,
+                    Some(object_id),
+                    prompt.to_string(),
+                );
+                if let Some(source_name) = source_name {
+                    bool_ctx = bool_ctx.with_source_name(source_name);
+                }
+                decision_maker.decide_boolean(game, &bool_ctx)
+            } else {
+                false
+            }
+        } else {
+            matches!(response, InteractiveReplacementResponse::Accept)
+        };
+        if accepted && let Some(object) = game.object_mut(object_id) {
             object.optional_costs_paid.mark_label_paid(label);
         }
         return InteractiveReplacementResult::enters_battlefield();
@@ -1137,6 +1172,10 @@ enum TraitApplyResult {
         filter: Option<crate::target::ObjectFilter>,
         /// Label to mark on the entering object if the interaction is accepted.
         mark_label: Option<String>,
+        /// Prompt for the player chosen by an earlier mark-label chooser step.
+        mark_label_prompt: Option<String>,
+        /// Players selectable by an earlier mark-label chooser step.
+        mark_label_chooser_options: Option<Vec<PlayerId>>,
         /// Destination options for InteractiveChooseDestination.
         destinations: Option<Vec<Zone>>,
     },
@@ -1267,6 +1306,10 @@ pub enum TraitEventResult {
         life_cost: Option<u32>,
         /// Label to mark on the entering object if the interaction is accepted.
         mark_label: Option<String>,
+        /// Prompt for the player chosen by an earlier mark-label chooser step.
+        mark_label_prompt: Option<String>,
+        /// Players selectable by an earlier mark-label chooser step.
+        mark_label_chooser_options: Option<Vec<PlayerId>>,
         /// Destination options for InteractiveChooseDestination.
         destinations: Option<Vec<Zone>>,
     },
@@ -2000,6 +2043,8 @@ fn process_with_dm_and_additional_effects_and_applied(
                         object_id,
                         filter,
                         mark_label,
+                        mark_label_prompt,
+                        mark_label_chooser_options,
                         destinations,
                     } => {
                         return TraitEventResult::NeedsInteraction {
@@ -2016,6 +2061,8 @@ fn process_with_dm_and_additional_effects_and_applied(
                                 _ => None,
                             },
                             mark_label,
+                            mark_label_prompt,
+                            mark_label_chooser_options,
                             destinations,
                         };
                     }
@@ -3038,6 +3085,8 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                         object_id,
                         filter,
                         mark_label,
+                        mark_label_prompt,
+                        mark_label_chooser_options,
                         destinations,
                     } => {
                         let life_cost = match &chosen_effect.replacement {
@@ -3080,6 +3129,8 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                             redirect_zone,
                             life_cost,
                             mark_label.as_deref(),
+                            mark_label_prompt.as_deref(),
+                            mark_label_chooser_options.as_deref(),
                             destinations.as_deref(),
                             current_event.provenance(),
                             dm,
@@ -3108,6 +3159,8 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                 filter,
                 life_cost,
                 mark_label,
+                mark_label_prompt,
+                mark_label_chooser_options,
                 destinations,
             } => {
                 let controller = game
@@ -3140,6 +3193,8 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                     redirect_zone,
                     life_cost,
                     mark_label.as_deref(),
+                    mark_label_prompt.as_deref(),
+                    mark_label_chooser_options.as_deref(),
                     destinations.as_deref(),
                     event.provenance(),
                     dm,
@@ -3453,6 +3508,8 @@ pub fn process_event_with_chosen_replacement_trait(
             object_id,
             filter,
             mark_label,
+            mark_label_prompt,
+            mark_label_chooser_options,
             destinations,
         } => TraitEventResult::NeedsInteraction {
             decision_ctx,
@@ -3468,6 +3525,8 @@ pub fn process_event_with_chosen_replacement_trait(
                 _ => None,
             },
             mark_label,
+            mark_label_prompt,
+            mark_label_chooser_options,
             destinations,
         },
     }

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -228,6 +228,9 @@ pub enum ReplacementAction {
     InteractiveMarkLabel {
         /// Player asked to make the yes/no choice.
         chooser: crate::target::PlayerFilter,
+        /// Optional prompt for the effect controller to choose which matching
+        /// player will make the yes/no choice.
+        chooser_prompt: Option<String>,
         /// Label recorded on the entering object if the choice is accepted.
         label: String,
         /// Prompt text shown to the chooser.

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -220,6 +220,20 @@ pub enum ReplacementAction {
         life_cost: u32,
     },
 
+    /// Interactive: mark a keyword choice as made without changing zones.
+    ///
+    /// Used by abilities like tribute, where another player may choose to make
+    /// the entering object carry a named result used by a separate replacement
+    /// effect and later branch conditions.
+    InteractiveMarkLabel {
+        /// Player asked to make the yes/no choice.
+        chooser: crate::target::PlayerFilter,
+        /// Label recorded on the entering object if the choice is accepted.
+        label: String,
+        /// Prompt text shown to the chooser.
+        prompt: String,
+    },
+
     /// Interactive: Choose alternate destination for a zone-changing event.
     ///
     /// Used by Library of Leng: "If an effect causes you to discard a card,

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -14,6 +14,13 @@ impl std::fmt::Display for StaticAbilityModelConversionError {
 impl std::error::Error for StaticAbilityModelConversionError {}
 
 impl StaticAbility {
+    fn parse_tribute_label(label: &str) -> Option<u32> {
+        label
+            .trim()
+            .strip_prefix("Tribute ")
+            .and_then(|amount| amount.trim().parse::<u32>().ok())
+    }
+
     fn parse_draw_replacement_exile_top_and_play_count(label: &str) -> Option<u32> {
         let prefix = "draw replacement exile top ";
         let suffix = " and play";
@@ -83,6 +90,14 @@ impl StaticAbility {
             Some(StaticAbilityId::Cascade) => Self::cascade(),
             Some(StaticAbilityId::ReadAhead) => Self::read_ahead(),
             Some(StaticAbilityId::Unleash) => Self::unleash(),
+            Some(StaticAbilityId::Tribute) => {
+                let amount = Self::parse_tribute_label(&label).ok_or_else(|| {
+                    StaticAbilityModelConversionError {
+                        detail: format!("could not parse tribute label '{label}'"),
+                    }
+                })?;
+                Self::tribute(amount)
+            }
             Some(StaticAbilityId::Unblockable) => Self::unblockable(),
             Some(StaticAbilityId::CantBlock) => Self::cant_block(),
             Some(StaticAbilityId::CantAttack) => Self::cant_attack(),

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1101,6 +1101,53 @@ impl ReplacementMatcher for ThisWouldEnterWithBloodthirstMatcher {
     }
 }
 
+/// Tribute N.
+///
+/// As this creature enters, an opponent may put N +1/+1 counters on it. The
+/// choice is recorded with the `Tribute` label so later abilities can test
+/// whether tribute was paid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Tribute {
+    pub amount: u32,
+}
+
+impl Tribute {
+    pub const fn new(amount: u32) -> Self {
+        Self { amount }
+    }
+}
+
+impl StaticAbilityKind for Tribute {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::Tribute
+    }
+
+    fn display(&self) -> String {
+        format!("Tribute {}", self.amount)
+    }
+
+    fn is_keyword(&self) -> bool {
+        true
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            ThisWouldEnterBattlefieldMatcher,
+            ReplacementAction::InteractiveMarkLabel {
+                chooser: PlayerFilter::Opponent,
+                label: "Tribute".to_string(),
+                prompt: format!("Put {} +1/+1 counters on this creature?", self.amount),
+            },
+        ))
+    }
+}
+
 /// Enters the battlefield with counters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EntersWithCounters {

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1141,6 +1141,7 @@ impl StaticAbilityKind for Tribute {
             ThisWouldEnterBattlefieldMatcher,
             ReplacementAction::InteractiveMarkLabel {
                 chooser: PlayerFilter::Opponent,
+                chooser_prompt: Some("Choose an opponent for tribute".to_string()),
                 label: "Tribute".to_string(),
                 prompt: format!("Put {} +1/+1 counters on this creature?", self.amount),
             },

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2121,6 +2121,10 @@ impl StaticAbility {
         ))
     }
 
+    pub fn tribute(amount: u32) -> Self {
+        Self::new(Tribute::new(amount))
+    }
+
     pub fn permanents_enter_tapped() -> Self {
         Self::new(AllPermanentsEnterTapped)
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1415,6 +1415,7 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::Bloodthirst(amount) => {
                 StaticAbility::bloodthirst(*amount)
             }
+            ironsmith_core::StaticAbilityPayload::Tribute(amount) => StaticAbility::tribute(*amount),
             ironsmith_core::StaticAbilityPayload::PreventDamageToSelfRemoveCounter {
                 counter_type,
                 amount,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ornitharch
Initial parse error:
```
card ability compiled to unsupported static ability fallback KeywordFallbackText: Tribute 2; oracle-only fallback also failed: card ability compiled to unsupported static ability fallback KeywordFallbackText: Tribute 2
```

Current worker: i-0cc57611fc6bd903f
Branch: codex/aws-card-fix-ornitharch
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T121724Z-controller-dev-loop-wave0001
