### PR TITLE
Fix Ironsmith parse failure: Esper Origins // Summon: Esper Maduin

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1516,6 +1516,9 @@ fn predicate_words_start_with_reference(words: &[&str]) -> bool {
 }
 
 fn parse_single_card_type_card_descriptor(words: &[&str]) -> Option<ObjectFilter> {
+    if matches!(words, ["permanent", "card"] | ["permanent", "cards"]) {
+        return Some(ObjectFilter::permanent_card());
+    }
     if words.len() == 2
         && CARD_OR_CARDS_WORD_PATTERN.matches_word(words[1])
         && let Some(card_type) = parse_card_type(words[0])

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -37,6 +37,8 @@ pub(crate) const RETURN_WITH_COUNTERS_ON_IT_PATTERN_ATOMS: &[LexPatternAtom<'sta
     ),
 ];
 const PUT_ONTO_BATTLEFIELD_WORDS: &[&str] = &["put", "puts"];
+const OPTIONAL_PUT_ONTO_BATTLEFIELD_PATTERN_ATOMS: &[LexPatternAtom<'static>] =
+    &[LexPattern::any_word(PUT_ONTO_BATTLEFIELD_WORDS)];
 const PUT_WORD: &str = "put";
 const AND_WORD: &str = "and";
 const ON_WORD: &str = "on";
@@ -53,7 +55,7 @@ const PUT_OR_REMOVE_COUNTER_KIND_TAIL_PHRASE: &[&str] = &[
 pub(crate) const PUT_ONTO_BATTLEFIELD_WITH_COUNTERS_ON_IT_PATTERN_ATOMS: &[LexPatternAtom<
     'static,
 >] = &[
-    LexPattern::any_word(PUT_ONTO_BATTLEFIELD_WORDS),
+    LexPattern::optional(OPTIONAL_PUT_ONTO_BATTLEFIELD_PATTERN_ATOMS),
     LexPattern::role_capture(
         "object",
         LexCaptureRole::Object,
@@ -198,15 +200,20 @@ const OWNER_CONTROL_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
             &["under", "its", "owner", "control"],
+            &["under", "its", "owners", "control"],
             &["under", "their", "owner", "control"],
+            &["under", "their", "owners", "control"],
             &["under", "his", "owner", "control"],
+            &["under", "his", "owners", "control"],
             &["under", "her", "owner", "control"],
+            &["under", "her", "owners", "control"],
             &["under", "that", "player", "control"],
         ]
 );
 const IT_OR_THEM_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["it"], &["them"]]);
 const IT_OR_THEM_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["it"], &["them"]]);
+const TRANSFORMED_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["transformed"]);
 const ENTERS_AS_CREATURE_PREDICATE_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -226,6 +233,23 @@ fn subject_verb_put_counters_target(effect: &EffectAst) -> Option<TargetAst> {
         },
         _ => None,
     }
+}
+
+fn strip_transformed_destination_tail<'a>(words: &[&'a str]) -> (Vec<&'a str>, bool) {
+    let mut transformed = false;
+    let stripped = words
+        .iter()
+        .copied()
+        .filter(|word| {
+            if TRANSFORMED_WORD_PATTERN.matches_word(word) {
+                transformed = true;
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+    (stripped, transformed)
 }
 
 fn counter_type_from_choice_segment(
@@ -775,6 +799,7 @@ pub(crate) fn parse_return_with_counters_on_it_sentence_matched(
         .copied()
         .filter(|word| !TAPPED_WORD_PATTERN.matches_word(word))
         .collect::<Vec<_>>();
+    let (destination_tail, transformed) = strip_transformed_destination_tail(&destination_tail);
     let battlefield_controller = if destination_tail.is_empty()
         || PRESERVE_CONTROL_TAIL_PATTERN.matches_words(&destination_tail)
     {
@@ -833,7 +858,7 @@ pub(crate) fn parse_return_with_counters_on_it_sentence_matched(
     let mut effects = vec![EffectAst::subject_verb_return_to_battlefield(
         parse_target_phrase(target_clause.tokens())?,
         tapped,
-        false,
+        transformed,
         false,
         battlefield_controller,
         None,
@@ -915,16 +940,17 @@ pub(crate) fn parse_put_onto_battlefield_with_counters_on_it_sentence_matched(
         return Ok(None);
     }
 
-    let destination_tail = &base_destination_words[1..];
+    let (destination_tail, transformed) =
+        strip_transformed_destination_tail(&base_destination_words[1..]);
     let supported_control_tail = destination_tail.is_empty()
-        || YOUR_CONTROL_TAIL_PATTERN.matches_words(destination_tail)
-        || OWNER_CONTROL_TAIL_PATTERN.matches_words(destination_tail);
+        || YOUR_CONTROL_TAIL_PATTERN.matches_words(&destination_tail)
+        || OWNER_CONTROL_TAIL_PATTERN.matches_words(&destination_tail);
     if !supported_control_tail {
         return Ok(None);
     }
-    let battlefield_controller = if YOUR_CONTROL_TAIL_PATTERN.matches_words(destination_tail) {
+    let battlefield_controller = if YOUR_CONTROL_TAIL_PATTERN.matches_words(&destination_tail) {
         ReturnControllerAst::You
-    } else if OWNER_CONTROL_TAIL_PATTERN.matches_words(destination_tail) {
+    } else if OWNER_CONTROL_TAIL_PATTERN.matches_words(&destination_tail) {
         ReturnControllerAst::Owner
     } else {
         ReturnControllerAst::Preserve
@@ -966,6 +992,9 @@ pub(crate) fn parse_put_onto_battlefield_with_counters_on_it_sentence_matched(
         None,
     )];
     let tagged_target = TargetAst::Tagged(TagKey::from(IT_TAG), clause.span());
+    if transformed {
+        effects.push(EffectAst::subject_verb_transform(tagged_target.clone()));
+    }
     for descriptor in descriptors {
         let (count, counter_type) = parse_counter_descriptor(descriptor.tokens())?;
         effects.push(EffectAst::subject_verb_put_counters(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/zone_counter_helpers.rs
@@ -281,12 +281,16 @@ pub(crate) fn parse_counter_descriptor(
 ) -> Result<(u32, CounterType), CardTextError> {
     let descriptor = trim_commas(tokens);
     let descriptor_text = render_clause_words(&descriptor);
-    let (count, used) = parse_number(&descriptor).ok_or_else(|| {
-        CardTextError::ParseError(format!(
+    let (count, used) = if let Some((count, used)) = parse_number(&descriptor) {
+        (count, used)
+    } else if token_slice_at_is(&descriptor, 0, "a") || token_slice_at_is(&descriptor, 0, "an") {
+        (1, 1)
+    } else {
+        return Err(CardTextError::ParseError(format!(
             "missing counter amount (clause: '{}')",
             descriptor_text
-        ))
-    })?;
+        )));
+    };
     let rest = &descriptor[used..];
     if !rest
         .iter()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -60508,6 +60508,220 @@ fn card_fixer_parse_color_conditional_keyword_grants_merge_to_oracle_surface() {
 }
 
 #[test]
+fn esper_origins_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Esper Origins // Summon: Esper Maduin");
+
+    let front = parse_oracle_card_definition("Esper Origins // Summon: Esper Maduin");
+    let rendered = crate::compiled_text::compiled_text_lines(&front).join("\n");
+    let debug = format!("{:#?}", front.spell_effect);
+    assert!(
+        rendered.contains(
+            "exile it, then put it onto the battlefield transformed under its owner's control with a finality counter on it"
+        ),
+        "Esper Origins should render the transformed finality-counter return clause, got {rendered}"
+    );
+    assert!(
+        debug.contains("ThisSpellWasCastFromZone")
+            && debug.contains("Graveyard")
+            && debug.contains("TransformEffect")
+            && debug.contains("Finality"),
+        "Esper Origins should structurally lower graveyard-cast transform and finality counter effects, got {debug}"
+    );
+
+    let back = summon_esper_maduin_test_definition();
+    let back_rendered = crate::compiled_text::compiled_text_lines(&back).join("\n");
+    assert!(
+        back_rendered.contains(
+            "I — Reveal the top card of your library. If it's a permanent card, put it into your hand."
+        ) && back_rendered.contains(
+            "III — Other creatures you control get +2/+2 and gain trample until end of turn."
+        ),
+        "Summon: Esper Maduin should render oracle-style Saga chapters, got {back_rendered}"
+    );
+}
+
+#[test]
+fn esper_origins_graveyard_cast_condition_moves_source_with_finality_counter() {
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::tests::test_helpers::setup_two_player_game;
+
+    let (def, back_def) = esper_origins_linked_test_definitions();
+    let conditional = def
+        .spell_effect
+        .as_ref()
+        .expect("Esper Origins spell effect")
+        .flattened_default_effects()
+        .into_iter()
+        .find(|effect| effect.downcast_ref::<crate::effects::ConditionalEffect>().is_some())
+        .expect("Esper Origins graveyard-cast conditional");
+
+    let mut normal_game = setup_two_player_game();
+    normal_game.register_linked_face_definition(&back_def);
+    let alice = PlayerId::from_index(0);
+    let normal_source = normal_game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut normal_ctx = ExecutionContext::new_default(normal_source, alice);
+    execute_effect(&mut normal_game, conditional, &mut normal_ctx)
+        .expect("normal-cast conditional should resolve");
+    assert_eq!(
+        normal_game.object(normal_source).expect("source exists").zone,
+        Zone::Stack,
+        "Esper Origins should not move itself when it was not cast from a graveyard"
+    );
+    assert!(
+        normal_game.objects_in_zone(Zone::Battlefield).is_empty(),
+        "normal-cast condition should not put Esper Origins onto the battlefield"
+    );
+
+    let mut flashback_game = setup_two_player_game();
+    flashback_game.register_linked_face_definition(&back_def);
+    let flashback_source = flashback_game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut flashback_ctx = ExecutionContext::new_default(flashback_source, alice)
+        .with_casting_method(crate::alternative_cast::CastingMethod::GrantedFlashback);
+    execute_effect(&mut flashback_game, conditional, &mut flashback_ctx)
+        .expect("graveyard-cast conditional should resolve");
+    let battlefield = flashback_game.objects_in_zone(Zone::Battlefield);
+    assert_eq!(
+        battlefield.len(),
+        1,
+        "graveyard-cast Esper Origins should put itself onto the battlefield, got {battlefield:?}"
+    );
+    let returned = flashback_game
+        .object(battlefield[0])
+        .expect("graveyard-cast Esper Origins should remain on the battlefield");
+    assert_eq!(returned.name, "Summon: Esper Maduin");
+    assert!(returned.card_types.contains(&CardType::Enchantment));
+    assert!(returned.card_types.contains(&CardType::Creature));
+    assert_eq!(
+        flashback_game.controller_of(returned),
+        alice,
+        "graveyard-cast Esper Origins should return transformed under its owner's control"
+    );
+    assert_eq!(
+        flashback_game.counter_count(battlefield[0], crate::object::CounterType::Finality),
+        1,
+        "graveyard-cast Esper Origins should return with one finality counter"
+    );
+}
+
+fn esper_origins_linked_test_definitions() -> (CardDefinition, CardDefinition) {
+    let front_id = CardId::from_raw(605_190_001);
+    let back_id = CardId::from_raw(605_190_002);
+    let front_text = oracle_text_by_name()
+        .get("Esper Origins")
+        .expect("Esper Origins front-face oracle text")
+        .clone();
+    let front = CardDefinitionBuilder::new(front_id, "Esper Origins")
+        .card_types(vec![CardType::Sorcery])
+        .other_face(back_id)
+        .other_face_name("Summon: Esper Maduin")
+        .linked_face_layout(crate::card::LinkedFaceLayout::TransformLike)
+        .parse_text(front_text)
+        .expect("Esper Origins front face should parse");
+    let mut back = summon_esper_maduin_test_definition();
+    back.card.id = back_id;
+    back.card.other_face = Some(front_id);
+    back.card.other_face_name = Some("Esper Origins".to_string());
+    back.card.linked_face_layout = crate::card::LinkedFaceLayout::TransformLike;
+    (front, back)
+}
+
+#[test]
+fn summon_esper_maduin_saga_chapters_resolve_their_branches() {
+    use crate::effects::{ExecutionContext, execute_effect};
+    use crate::tests::test_helpers::setup_two_player_game;
+
+    fn execute_chapter(
+        game: &mut crate::game_state::GameState,
+        ability: &crate::ability::TriggeredAbility,
+        source: ObjectId,
+        controller: PlayerId,
+    ) {
+        let mut ctx = ExecutionContext::new_default(source, controller);
+        for effect in ability.effects.flattened_default_effects() {
+            if effect
+                .downcast_ref::<crate::effects::TagTriggeringObjectEffect>()
+                .is_some()
+            {
+                continue;
+            }
+            execute_effect(game, effect, &mut ctx).expect("Saga chapter effect should resolve");
+        }
+    }
+
+    let saga = summon_esper_maduin_test_definition();
+    let chapters = saga
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(chapters.len(), 3, "expected three Saga chapter abilities");
+
+    let alice = PlayerId::from_index(0);
+    let permanent = CardDefinitionBuilder::new(CardId::new(), "Library Permanent")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let mut permanent_game = setup_two_player_game();
+    let permanent_source =
+        permanent_game.create_object_from_definition(&saga, alice, Zone::Battlefield);
+    permanent_game.create_object_from_definition(&permanent, alice, Zone::Library);
+    execute_chapter(&mut permanent_game, chapters[0], permanent_source, alice);
+    assert_eq!(
+        permanent_game.objects_in_zone(Zone::Hand).len(),
+        1,
+        "chapter I should put a revealed permanent card into your hand"
+    );
+
+    let instant = CardDefinitionBuilder::new(CardId::new(), "Library Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let mut instant_game = setup_two_player_game();
+    let instant_source =
+        instant_game.create_object_from_definition(&saga, alice, Zone::Battlefield);
+    instant_game.create_object_from_definition(&instant, alice, Zone::Library);
+    execute_chapter(&mut instant_game, chapters[0], instant_source, alice);
+    assert!(
+        instant_game.objects_in_zone(Zone::Hand).is_empty(),
+        "chapter I should not put a revealed nonpermanent card into your hand"
+    );
+
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Other Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let mut pump_game = setup_two_player_game();
+    let pump_source = pump_game.create_object_from_definition(&saga, alice, Zone::Battlefield);
+    let other_creature =
+        pump_game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    execute_chapter(&mut pump_game, chapters[2], pump_source, alice);
+    assert_eq!(pump_game.calculated_power(other_creature), Some(3));
+    assert_eq!(pump_game.calculated_toughness(other_creature), Some(3));
+    assert!(
+        pump_game.current_has_static_ability_id(other_creature, StaticAbilityId::Trample),
+        "chapter III should grant trample to other creatures you control"
+    );
+    assert!(
+        !pump_game.current_has_static_ability_id(pump_source, StaticAbilityId::Trample),
+        "chapter III should not grant trample to Summon: Esper Maduin itself"
+    );
+}
+
+fn summon_esper_maduin_test_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Summon: Esper Maduin")
+        .card_types(vec![CardType::Enchantment, CardType::Creature])
+        .subtypes(vec![Subtype::Saga, Subtype::Elemental])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "I — Reveal the top card of your library. If it's a permanent card, put it into your hand.\n\
+             II — Add {G}{G}.\n\
+             III — Other creatures you control get +2/+2 and gain trample until end of turn.",
+        )
+        .expect("Summon: Esper Maduin back face should parse")
+}
+
+#[test]
 fn parse_additional_combat_phase_followed_by_main_phase() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Extra Combat Variant")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6010,7 +6010,35 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             "Choose target creature you control and target creature an opponent controls. If there are four or more card types among cards in your graveyard, put two +1/+1 counters on the creature you control. The creature you control deals damage equal to its power to the creature an opponent controls.",
         )
         ;
+    normalized = normalize_saga_chapter_prefixes(normalized);
     normalized
+}
+
+fn normalize_saga_chapter_prefixes(text: String) -> String {
+    text.lines()
+        .map(|line| {
+            for prefix in ["I", "II", "III", "IV", "V"] {
+                let Some(rest) = line.strip_prefix(&format!("{prefix}, ")) else {
+                    continue;
+                };
+                let rest = if let Some(tail) =
+                    rest.strip_prefix("each other creature you control gets ")
+                {
+                    format!(
+                        "Other creatures you control get {}",
+                        tail.replace(" and gains ", " and gain ")
+                    )
+                } else {
+                    rest.strip_prefix("each other ")
+                        .map(|tail| format!("Other {tail}"))
+                        .unwrap_or_else(|| capitalize_first(rest))
+                };
+                return format!("{prefix} — {rest}");
+            }
+            line.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub(super) fn normalize_reveal_match_filter(filter: &str) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -13731,6 +13731,18 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 2;
             continue;
         }
+        if idx + 3 < filtered.len()
+            && let Some(compact) = describe_exile_then_return_transformed_with_counter(
+                filtered[idx],
+                filtered[idx + 1],
+                filtered[idx + 2],
+                filtered[idx + 3],
+            )
+        {
+            parts.push(compact);
+            idx += 4;
+            continue;
+        }
         if idx + 2 < filtered.len()
             && let Some(compact) = describe_exile_return_then_transform(
                 filtered[idx],
@@ -15683,6 +15695,70 @@ pub(super) fn describe_exile_then_return(
     ))
 }
 
+fn describe_exile_then_return_transformed_with_counter(
+    exile_effect: &Effect,
+    return_effect: &Effect,
+    transform_effect: &Effect,
+    put_counter_effect: &Effect,
+) -> Option<String> {
+    let exile_move = unwrap_basic_tag_wrappers(exile_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    let move_back = unwrap_basic_tag_wrappers(return_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    let transform = unwrap_basic_tag_wrappers(transform_effect)
+        .downcast_ref::<crate::effects::TransformEffect>()?;
+    let put_counter = unwrap_basic_tag_wrappers(put_counter_effect)
+        .downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if move_back.zone != Zone::Battlefield
+        || exile_move.zone != Zone::Exile
+        || put_counter.distributed
+        || put_counter.target_count.is_some()
+    {
+        return None;
+    }
+    let crate::target::ChooseSpec::Tagged(return_tag) = &move_back.target else {
+        return None;
+    };
+    if !return_tag.as_str().starts_with("exiled_") && return_tag.as_str() != "__source_exiled__" {
+        return None;
+    }
+    if !matches!(&transform.target, ChooseSpec::Tagged(tag) if tag == return_tag)
+        || !matches!(&put_counter.target, ChooseSpec::Tagged(tag) if tag == return_tag)
+    {
+        return None;
+    }
+
+    let target = if matches!(exile_move.target, ChooseSpec::Source) {
+        "it".to_string()
+    } else {
+        describe_choose_spec(&exile_move.target)
+    };
+    let return_object = if choose_spec_allows_multiple(&exile_move.target) {
+        "them"
+    } else {
+        "it"
+    };
+    let owner_control_suffix = if choose_spec_allows_multiple(&exile_move.target) {
+        " under their owners' control"
+    } else {
+        " under its owner's control"
+    };
+    let tapped_suffix = if move_back.enters_tapped {
+        " tapped"
+    } else {
+        ""
+    };
+    let controller_suffix = match move_back.battlefield_controller {
+        crate::effects::BattlefieldController::Preserve => "",
+        crate::effects::BattlefieldController::Owner => owner_control_suffix,
+        crate::effects::BattlefieldController::You => " under your control",
+    };
+    let counter_text = describe_put_counter_phrase(&put_counter.amount, put_counter.counter_type);
+    Some(format!(
+        "Exile {target}, then put {return_object} onto the battlefield{tapped_suffix} transformed{controller_suffix} with {counter_text} on it"
+    ))
+}
+
 pub(super) fn describe_exile_return_then_transform(
     exile_effect: &Effect,
     return_effect: &Effect,
@@ -15852,6 +15928,7 @@ pub(super) fn describe_reveal_top_then_if_put_into_hand(
             | "enchantment"
             | "planeswalker"
             | "battle"
+            | "permanent"
             | "instant"
             | "sorcery"
     ) {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Esper Origins // Summon: Esper Maduin
Initial parse error:
```
missing counter amount (clause: 'it onto the battlefield transformed under its owners control with a finality counter on it'); oracle-only fallback also failed: missing counter amount (clause: 'it onto the battlefield transformed under its owners control with a finality counter on it')
```

Current worker: i-057d1d9f3aaff5e67
Branch: codex/aws-card-fix-esper-origins-summon-esper-maduin
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0001
