### PR TITLE
Fix Ironsmith parse failure: Clockspinning

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5097,13 +5097,16 @@ fn compile_subject_verb_effect(
             );
             Ok((vec![effect], choices))
         }
-        SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {
+        SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, all_kinds } => {
             let (spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let effect = if *all_kinds {
+                crate::effects::ForEachCounterKindPutOrRemoveEffect::new(spec)
+            } else {
+                crate::effects::ForEachCounterKindPutOrRemoveEffect::one_kind(spec)
+            };
             Ok((
-                vec![Effect::new(
-                    crate::effects::ForEachCounterKindPutOrRemoveEffect::new(spec),
-                )],
+                vec![Effect::new(effect)],
                 choices,
             ))
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -137,7 +137,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
             | SubjectVerbActionAst::MoveToLibraryTopOrBottomChoice { target }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { target, .. }
             | SubjectVerbActionAst::DoubleCountersOnTarget { target, .. }
-            | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target }
+            | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, .. }
             | SubjectVerbActionAst::PutSticker { target, .. }
             | SubjectVerbActionAst::SwitchPowerToughness { target, .. }
             | SubjectVerbActionAst::GrantProtectionChoice { target, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -123,7 +123,7 @@ fn retarget_bare_it_effect_targets_to_source(effect: &mut EffectAst) {
             | SubjectVerbActionAst::PutOrRemoveCounters { target, .. }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { target, .. }
             | SubjectVerbActionAst::DoubleCountersOnTarget { target, .. }
-            | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {
+            | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, .. } => {
                 retarget_it_target_to_source(target);
             }
             SubjectVerbActionAst::MoveToZone {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1601,6 +1601,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     ForEachCounterKindPutOrRemove {
         target: TargetAst,
+        all_kinds: bool,
     },
     ReturnToHand {
         target: TargetAst,
@@ -3113,9 +3114,10 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("from", from)
                 .field("to", to)
                 .finish(),
-            Self::ForEachCounterKindPutOrRemove { target } => f
+            Self::ForEachCounterKindPutOrRemove { target, all_kinds } => f
                 .debug_struct("ForEachCounterKindPutOrRemove")
                 .field("target", target)
+                .field("all_kinds", all_kinds)
                 .finish(),
             Self::ReturnToHand { target, random } => f
                 .debug_struct("ReturnToHand")
@@ -6250,10 +6252,18 @@ impl EffectAst {
     }
 
     pub(crate) fn subject_verb_for_each_counter_kind_put_or_remove(target: TargetAst) -> Self {
+        Self::subject_verb_counter_kind_put_or_remove(target, true)
+    }
+
+    pub(crate) fn subject_verb_one_counter_kind_put_or_remove(target: TargetAst) -> Self {
+        Self::subject_verb_counter_kind_put_or_remove(target, false)
+    }
+
+    fn subject_verb_counter_kind_put_or_remove(target: TargetAst, all_kinds: bool) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target },
+            SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, all_kinds },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -563,7 +563,7 @@ fn advance_reference_frame_for_effect(
                     maybe_tag_target(target, frame, id_gen, "counters")?;
                 }
                 SubjectVerbActionAst::RemoveUpToAnyCounters { target, .. }
-                | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {
+                | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "counters")?;
                 }
                 SubjectVerbActionAst::MoveAllCounters { from, to }
@@ -2690,7 +2690,7 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
                 bind_unresolved_it_in_target(from, seed_tag)
                     + bind_unresolved_it_in_target(to, seed_tag)
             }
-            SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target } => {
+            SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, .. } => {
                 bind_unresolved_it_in_target(target, seed_tag)
             }
             SubjectVerbActionAst::Discard { count, filter, .. } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -25,6 +25,8 @@ use crate::cards::builders::{
     SubjectVerbEffectAst, SubjectVerbRoleAst, TagKey, TargetAst, TextSpan, Verb,
 };
 use crate::effect::{EventValueSpec, Value};
+use crate::filter::AlternativeCastKind;
+use crate::object::CounterType;
 use crate::runtime_backend::effect_sentences;
 use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use crate::target::{ObjectFilter, PlayerFilter, TaggedOpbjectRelation};
@@ -1223,6 +1225,92 @@ fn parse_choose_objects_then_for_each_of_those_bundle(
     Ok(Some(combined))
 }
 
+fn target_with_any_counter(target: TargetAst) -> TargetAst {
+    match target {
+        TargetAst::Object(filter, target_span, it_span) => {
+            TargetAst::Object(filter.with_any_counter(), target_span, it_span)
+        }
+        TargetAst::WithCount(inner, count) => {
+            TargetAst::WithCount(Box::new(target_with_any_counter(*inner)), count)
+        }
+        TargetAst::WithCountValue(inner, count, value) => {
+            TargetAst::WithCountValue(Box::new(target_with_any_counter(*inner)), count, value)
+        }
+        other => other,
+    }
+}
+
+fn choose_counter_target(
+    first: &[OwnedLexToken],
+    first_words: &[&str],
+) -> Result<TargetAst, CardTextError> {
+    if first_words[4..] == ["target", "permanent", "or", "suspended", "card"] {
+        return Ok(TargetAst::Object(
+            ObjectFilter {
+                any_of: vec![
+                    ObjectFilter::permanent().with_any_counter(),
+                    ObjectFilter::default()
+                        .in_zone(Zone::Exile)
+                        .with_alternative_cast(AlternativeCastKind::Suspend)
+                        .with_counter_type(CounterType::Time),
+                ],
+                ..ObjectFilter::default()
+            },
+            span_from_tokens(first),
+            None,
+        ));
+    }
+
+    let target_token_start = token_index_for_word_index(first, 4).ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "missing target after choose-counter prelude (clause: '{}')",
+            first_words.join(" ")
+        ))
+    })?;
+    let target_tokens = trim_commas(&first[target_token_start..]);
+    Ok(target_with_any_counter(parse_target_phrase(&target_tokens)?))
+}
+
+fn parse_choose_counter_on_target_then_put_or_remove_bundle(
+    first: &[OwnedLexToken],
+    second: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let first_words = parser_token_word_refs(first);
+    if first_words.len() < 5 || !first_words.starts_with(&["choose", "a", "counter", "on"]) {
+        return Ok(None);
+    }
+
+    let second_words = parser_token_word_refs(second);
+    if !matches!(
+        second_words.as_slice(),
+        [
+            "remove",
+            "that",
+            "counter",
+            "from",
+            "that",
+            "permanent",
+            "or",
+            "card",
+            "or",
+            "put",
+            "another",
+            "of",
+            "those",
+            "counters",
+            "on",
+            "it"
+        ]
+    ) {
+        return Ok(None);
+    }
+
+    let target = choose_counter_target(first, &first_words)?;
+    Ok(Some(vec![
+        EffectAst::subject_verb_one_counter_kind_put_or_remove(target),
+    ]))
+}
+
 fn split_search_library_slot_filter_items_lexed(
     filter_tokens: &[OwnedLexToken],
 ) -> Option<Vec<Vec<OwnedLexToken>>> {
@@ -2173,6 +2261,12 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
     if sentences.len() == 2
         && let Ok(Some(effects)) =
             parse_choose_objects_then_for_each_of_those_bundle(sentences[0], sentences[1], None)
+    {
+        return Some(effects);
+    }
+    if sentences.len() == 2
+        && let Ok(Some(effects)) =
+            parse_choose_counter_on_target_then_put_or_remove_bundle(sentences[0], sentences[1])
     {
         return Some(effects);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2091,7 +2091,7 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             | SubjectVerbActionAst::MoveToLibraryNthFromTop { target, .. }
             | SubjectVerbActionAst::MoveToLibraryTopOrBottomChoice { target }
             | SubjectVerbActionAst::RemoveUpToAnyCounters { target, .. }
-            | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target }
+            | SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, .. }
             | SubjectVerbActionAst::PutSticker { target, .. }
             | SubjectVerbActionAst::SwitchPowerToughness { target, .. }
             | SubjectVerbActionAst::GrantProtectionChoice { target, .. }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3473,11 +3473,22 @@ impl DealDistributedDamageEffect {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ForEachCounterKindPutOrRemoveEffect {
     pub target: ChooseSpec,
+    pub all_kinds: bool,
 }
 
 impl ForEachCounterKindPutOrRemoveEffect {
     pub fn new(target: ChooseSpec) -> Self {
-        Self { target }
+        Self {
+            target,
+            all_kinds: true,
+        }
+    }
+
+    pub fn one_kind(target: ChooseSpec) -> Self {
+        Self {
+            target,
+            all_kinds: false,
+        }
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,42 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn clockspinning_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Clockspinning");
+
+    let def = parse_oracle_card_definition("Clockspinning");
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert_eq!(def.name(), "Clockspinning");
+    assert_eq!(def.card.card_types, vec![CardType::Instant]);
+    assert!(
+        def.optional_costs.iter().any(|cost| {
+            cost.label == "Buyback"
+                && cost.returns_to_hand
+                && format!("{:?}", cost.cost).contains("Generic(3)")
+        }),
+        "Clockspinning should preserve buyback {{3}}, got {:?}",
+        def.optional_costs
+    );
+    assert!(
+        spell_debug.contains("ForEachCounterKindPutOrRemoveEffect")
+            && spell_debug.contains("all_kinds: false")
+            && spell_debug.contains("alternative_cast: Some")
+            && spell_debug.contains("Suspend")
+            && spell_debug.contains("with_counter: Some")
+            && spell_debug.contains("Time"),
+        "Clockspinning should compile to a one-counter-kind put/remove effect targeting countered permanents or suspended cards, got {spell_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "Choose a counter on target permanent or suspended card. Remove that counter from that permanent or card or put another of those counters on it."
+        ),
+        "Clockspinning should render the chosen-counter put/remove clause, got {rendered}"
+    );
+}
+
+#[test]
 fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Boss's Chauffeur");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -70,6 +70,24 @@ fn describe_pay_any_energy_amount(
     }
 }
 
+fn is_target_permanent_with_counter_or_suspended_card(spec: &ChooseSpec) -> bool {
+    let ChooseSpec::Target(inner) = spec else {
+        return false;
+    };
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        return false;
+    };
+    let permanent = crate::target::ObjectFilter::permanent().with_any_counter();
+    let suspended = crate::target::ObjectFilter::default()
+        .in_zone(crate::zone::Zone::Exile)
+        .with_alternative_cast(crate::filter::AlternativeCastKind::Suspend)
+        .with_counter_type(crate::object::CounterType::Time);
+    filter.any_of.len() == 2
+        && filter.zone.is_none()
+        && filter.any_of.iter().any(|arm| arm == &permanent)
+        && filter.any_of.iter().any(|arm| arm == &suspended)
+}
+
 fn describe_discard_hand_add_mana_draw_sequence(effects: &[&Effect]) -> Option<String> {
     let [discard_effect, mana_effect, draw_effect] = effects else {
         return None;
@@ -35823,9 +35841,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(for_each_counter_kind) =
         effect.downcast_ref::<crate::effects::ForEachCounterKindPutOrRemoveEffect>()
     {
+        let target = describe_choose_spec(&for_each_counter_kind.target);
+        if for_each_counter_kind.all_kinds {
+            return format!(
+                "For each kind of counter on {target}, choose to put or remove one of that kind"
+            );
+        }
+        if is_target_permanent_with_counter_or_suspended_card(&for_each_counter_kind.target) {
+            return "Choose a counter on target permanent or suspended card. Remove that counter from that permanent or card or put another of those counters on it".to_string();
+        }
         return format!(
-            "For each kind of counter on {}, choose to put or remove one of that kind",
-            describe_choose_spec(&for_each_counter_kind.target)
+            "Choose a counter on {target}. Remove that counter from it or put another of those counters on it"
         );
     }
     if let Some(grant) = effect.downcast_ref::<crate::effects::GrantEffect>() {

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1146,8 +1146,13 @@ where
     if let Some(payload) =
         M::downcast_ref::<ironsmith_core::ForEachCounterKindPutOrRemoveEffect>(&effect)
     {
+        let effect = if payload.all_kinds {
+            crate::effects::ForEachCounterKindPutOrRemoveEffect::new(payload.target.clone())
+        } else {
+            crate::effects::ForEachCounterKindPutOrRemoveEffect::one_kind(payload.target.clone())
+        };
         return Ok(Effect::new(
-            crate::effects::ForEachCounterKindPutOrRemoveEffect::new(payload.target.clone()),
+            effect,
         ));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::DoubleCountersEffect>(&effect) {

--- a/crates/ironsmith-runtime/src/effects/counters/for_each_counter_kind_put_or_remove.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/for_each_counter_kind_put_or_remove.rs
@@ -14,15 +14,61 @@ use crate::target::ChooseSpec;
 #[derive(Debug, Clone, PartialEq)]
 pub struct ForEachCounterKindPutOrRemoveEffect {
     pub target: ChooseSpec,
+    pub all_kinds: bool,
 }
 
 impl ForEachCounterKindPutOrRemoveEffect {
     pub fn new(target: ChooseSpec) -> Self {
-        Self { target }
+        Self {
+            target,
+            all_kinds: true,
+        }
+    }
+
+    pub fn one_kind(target: ChooseSpec) -> Self {
+        Self {
+            target,
+            all_kinds: false,
+        }
     }
 
     fn counter_label(counter_type: CounterType) -> String {
         format!("{counter_type:?}").to_ascii_lowercase()
+    }
+
+    fn choose_counter_kind(
+        &self,
+        game: &mut GameState,
+        ctx: &mut ExecutionContext,
+        counter_kinds: &[CounterType],
+    ) -> Option<CounterType> {
+        let options = counter_kinds
+            .iter()
+            .enumerate()
+            .map(|(idx, counter_type)| {
+                SelectableOption::new(
+                    idx,
+                    format!("Choose {} counter", Self::counter_label(*counter_type)),
+                )
+            })
+            .collect::<Vec<_>>();
+        let choice_ctx = SelectOptionsContext::new(
+            ctx.controller,
+            Some(ctx.source),
+            "Choose a counter kind".to_string(),
+            options,
+            1,
+            1,
+        );
+        let choice = ctx
+            .decision_maker
+            .decide_options(game, &choice_ctx)
+            .into_iter()
+            .next();
+        if ctx.decision_maker.awaiting_choice() {
+            return None;
+        }
+        choice.and_then(|idx| counter_kinds.get(idx).copied())
     }
 }
 
@@ -54,7 +100,16 @@ impl EffectExecutor for ForEachCounterKindPutOrRemoveEffect {
             }
             counter_kinds.sort_by_key(|counter_type| format!("{counter_type:?}"));
 
-            for counter_type in counter_kinds {
+            let selected_kinds = if self.all_kinds {
+                counter_kinds
+            } else {
+                let Some(counter_type) = self.choose_counter_kind(game, ctx, &counter_kinds) else {
+                    return Ok(EffectOutcome::count(0));
+                };
+                vec![counter_type]
+            };
+
+            for counter_type in selected_kinds {
                 let label = Self::counter_label(counter_type);
                 let options = vec![
                     SelectableOption::new(0, format!("Put one {label} counter on it")),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -6663,6 +6663,191 @@ fn bought_back_instant_returns_to_owners_hand_after_resolution() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn clockspinning_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(80_600), "Clockspinning")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Buyback {3}
+Choose a counter on target permanent or suspended card. Remove that counter from that permanent or card or put another of those counters on it.",
+        )
+        .expect("Clockspinning should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn suspended_card_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(80_601), "Suspended Probe")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Instant])
+        .parse_text("Suspend 3—{U}")
+        .expect("suspend probe should parse for Clockspinning target tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ClockspinningDecisionMaker {
+    mode_index: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ClockspinningDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if ctx.description == "Choose a counter kind" {
+            vec![0]
+        } else if ctx.description.starts_with("Choose for ") {
+            vec![self.mode_index.min(ctx.options.len().saturating_sub(1))]
+        } else {
+            vec![0]
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn clockspinning_counter_effect(
+    def: &crate::cards::CardDefinition,
+) -> &crate::effect::Effect {
+    def.spell_effect
+        .as_ref()
+        .expect("Clockspinning should have spell effects")
+        .flattened_default_effects()
+        .into_iter()
+        .find(|effect| {
+            effect
+                .downcast_ref::<crate::effects::ForEachCounterKindPutOrRemoveEffect>()
+                .is_some()
+        })
+        .expect("Clockspinning should have a chosen-counter put/remove effect")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn clockspinning_target_permanent(game: &mut GameState, controller: PlayerId) -> ObjectId {
+    let target = CardBuilder::new(CardId::from_raw(80_602), "Clockspinning Target")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&target, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn clockspinning_targets_only_countered_permanents_or_suspended_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = clockspinning_definition();
+    let effects = def.spell_effect.as_ref().expect("Clockspinning spell effects");
+
+    let countered_permanent = clockspinning_target_permanent(&mut game, alice);
+    game.add_counters(countered_permanent, crate::object::CounterType::Charge, 1)
+        .expect("countered permanent should accept a charge counter");
+    let uncountered_permanent = clockspinning_target_permanent(&mut game, alice);
+    let suspended = suspended_card_definition();
+    let suspended_id = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    game.add_counters(suspended_id, crate::object::CounterType::Time, 1)
+        .expect("suspended card should accept a time counter");
+    let uncountered_suspended = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    let no_longer_suspended = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    game.add_counters(no_longer_suspended, crate::object::CounterType::Charge, 1)
+        .expect("exiled suspend card should accept non-time counters");
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(
+        requirements.len(),
+        1,
+        "Clockspinning should have one target requirement"
+    );
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(countered_permanent)),
+        "countered permanents should be legal Clockspinning targets, got {legal_targets:?}"
+    );
+    assert!(
+        legal_targets.contains(&Target::Object(suspended_id)),
+        "suspended cards with counters should be legal Clockspinning targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(uncountered_permanent)),
+        "permanents without counters should not be legal Clockspinning targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(uncountered_suspended)),
+        "suspended cards without counters should not be legal Clockspinning targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(no_longer_suspended)),
+        "exiled cards with suspend but no time counter should not be legal Clockspinning targets, got {legal_targets:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn clockspinning_buyback_put_branch_returns_to_hand_and_adds_counter() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = clockspinning_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target = clockspinning_target_permanent(&mut game, alice);
+    game.add_counters(target, crate::object::CounterType::Charge, 1)
+        .expect("target should accept an initial charge counter");
+
+    let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+    paid.mark_label_paid("Buyback");
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice)
+            .with_targets(vec![Target::Object(target)])
+            .with_optional_costs_paid(paid)
+            .with_source_info(
+                game.object(spell_id)
+                    .expect("Clockspinning spell object")
+                    .stable_id,
+                "Clockspinning".to_string(),
+            ),
+    );
+
+    let mut dm = ClockspinningDecisionMaker { mode_index: 0 };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Clockspinning should resolve its put branch");
+
+    assert_eq!(
+        game.counter_count(target, crate::object::CounterType::Charge),
+        2,
+        "Clockspinning put branch should add one chosen counter kind"
+    );
+    assert!(
+        game.player(alice).expect("alice exists").hand.iter().any(|&id| game
+            .object(id)
+            .is_some_and(|object| object.name == "Clockspinning")),
+        "Clockspinning should return to hand when buyback was paid"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn clockspinning_remove_branch_removes_one_chosen_counter() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = clockspinning_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target = clockspinning_target_permanent(&mut game, alice);
+    game.add_counters(target, crate::object::CounterType::Charge, 2)
+        .expect("target should accept charge counters");
+
+    let mut dm = ClockspinningDecisionMaker { mode_index: 1 };
+    let ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)]);
+    let mut ctx = ctx.with_decision_maker(&mut dm);
+    crate::effects::execute_effect(&mut game, clockspinning_counter_effect(&def), &mut ctx)
+        .expect("Clockspinning remove branch should execute");
+
+    assert_eq!(
+        game.counter_count(target, crate::object::CounterType::Charge),
+        1,
+        "Clockspinning remove branch should remove exactly one chosen counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn feudkillers_verdict_creates_token_when_you_have_more_life_than_an_opponent() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Clockspinning
Initial parse error:
```
missing counter removal amount (clause: 'that counter from that permanent or card or put another of those counters on it'); oracle-only fallback also failed: missing counter removal amount (clause: 'that counter from that permanent or card or put another of those counters on it')
```

Current worker: i-02d9145d7a0fb2fb0
Branch: codex/aws-card-fix-clockspinning
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0001
