### PR TITLE
Fix Ironsmith parse failure: Kadena's Silencer

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4928,7 +4928,18 @@ fn compile_subject_verb_effect(
             Ok((vec![effect], choices))
         }
         SubjectVerbActionAst::Counter { target } => {
-            compile_tagged_effect_for_target(target, ctx, "countered", Effect::counter)
+            let (spec, choices) =
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let spec = if choices.is_empty() {
+                match spec {
+                    ChooseSpec::Object(filter) => ChooseSpec::All(filter),
+                    other => other,
+                }
+            } else {
+                spec
+            };
+            let effect = tag_object_target_effect(Effect::counter(spec.clone()), &spec, ctx, "countered");
+            Ok((vec![effect], choices))
         }
         SubjectVerbActionAst::CounterUnlessPays { target, cost } => {
             let cost = cost.clone();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1302,8 +1302,32 @@ fn parse_counter_ability_target_phrase(
 ) -> Result<Option<TargetAst>, CardTextError> {
     let clause_tokens = LexedClause::new(tokens).trim();
     let clause = LexedClause::new(&clause_tokens);
-    let is_you_control_tail =
-        |idx: usize| {
+    let is_opponents_control_tail = |idx: usize| {
+        (clause_tokens
+            .get(idx)
+            .is_some_and(|token| token.as_word() == Some("your"))
+            && clause_tokens
+                .get(idx + 1)
+                .is_some_and(|token| token.as_word() == Some("opponents"))
+            && clause_tokens.get(idx + 2).is_some_and(|token| {
+                CLAUSE_CONTROL_OR_CONTROLS_WORD_PATTERN.matches_token(token)
+            }))
+            || (clause_tokens.get(idx).is_some_and(|token| {
+                matches!(token.as_word(), Some("opponents" | "opponent"))
+            }) && clause_tokens.get(idx + 1).is_some_and(|token| {
+                CLAUSE_CONTROL_OR_CONTROLS_WORD_PATTERN.matches_token(token)
+            }))
+            || (clause_tokens
+                .get(idx)
+                .is_some_and(|token| token.as_word() == Some("an"))
+                && clause_tokens
+                    .get(idx + 1)
+                    .is_some_and(|token| token.as_word() == Some("opponent"))
+                && clause_tokens.get(idx + 2).is_some_and(|token| {
+                    CLAUSE_CONTROL_OR_CONTROLS_WORD_PATTERN.matches_token(token)
+                }))
+    };
+    let is_controller_tail = |idx: usize| {
             clause_tokens
                 .get(idx)
                 .is_some_and(|token| CLAUSE_YOU_WORD_PATTERN.matches_token(token))
@@ -1322,8 +1346,9 @@ fn parse_counter_ability_target_phrase(
                     && clause_tokens.get(idx + 3).is_some_and(|token| {
                         CLAUSE_CONTROL_OR_CONTROLS_WORD_PATTERN.matches_token(token)
                     })))
+                || is_opponents_control_tail(idx)
         };
-    if !clause.contains_word("ability") || clause.contains_no_words(&["activated", "triggered"]) {
+    if clause.contains_no_words(&["ability", "abilities"]) {
         return Ok(None);
     }
 
@@ -1334,13 +1359,18 @@ fn parse_counter_ability_target_phrase(
         idx += used;
     }
 
-    if !clause_tokens
+    let explicit_target = clause_tokens
         .get(idx)
-        .is_some_and(|token| CLAUSE_TARGET_WORD_PATTERN.matches_token(token))
-    {
+        .is_some_and(|token| CLAUSE_TARGET_WORD_PATTERN.matches_token(token));
+    if explicit_target {
+        idx += 1;
+    } else if clause_tokens.get(idx).is_some_and(|token| {
+        matches!(token.as_word(), Some("all" | "each"))
+    }) {
+        idx += 1;
+    } else {
         return Ok(None);
     }
-    idx += 1;
 
     #[derive(Clone, Copy)]
     enum CounterTargetTerm {
@@ -1351,7 +1381,7 @@ fn parse_counter_ability_target_phrase(
     let mut list_end = clause_tokens.len();
     let mut scan = idx;
     while scan < clause_tokens.len() {
-        if CLAUSE_FROM_WORD_PATTERN.matches_token(&clause_tokens[scan]) || is_you_control_tail(scan)
+        if CLAUSE_FROM_WORD_PATTERN.matches_token(&clause_tokens[scan]) || is_controller_tail(scan)
         {
             list_end = scan;
             break;
@@ -1427,7 +1457,12 @@ fn parse_counter_ability_target_phrase(
             }),
             grammar::phrase(&["colorless", "spell"])
                 .map(|_| vec![(ObjectFilter::spell().colorless(), CounterTargetTerm::Spell)]),
-            grammar::kw("spell").map(|_| vec![(ObjectFilter::spell(), CounterTargetTerm::Spell)]),
+            alt((
+                alt((grammar::kw("ability"), grammar::kw("abilities")))
+                    .map(|_| vec![(ObjectFilter::ability(), CounterTargetTerm::Ability)]),
+                grammar::kw("spell")
+                    .map(|_| vec![(ObjectFilter::spell(), CounterTargetTerm::Spell)]),
+            )),
         ))
         .parse_next(input)
     }
@@ -1511,6 +1546,18 @@ fn parse_counter_ability_target_phrase(
             idx += 4;
             continue;
         }
+        if is_opponents_control_tail(idx) {
+            controller_filter = Some(crate::target::PlayerFilter::Opponent);
+            idx += if clause_tokens
+                .get(idx)
+                .is_some_and(|token| matches!(token.as_word(), Some("your" | "an")))
+            {
+                3
+            } else {
+                2
+            };
+            continue;
+        }
         if CLAUSE_FROM_WORD_PATTERN.matches_word(word) {
             idx += 1;
             if clause_tokens
@@ -1578,7 +1625,11 @@ fn parse_counter_ability_target_phrase(
     };
 
     let target = wrap_target_count(
-        TargetAst::Object(target_filter, span_from_tokens(&clause_tokens), None),
+        TargetAst::Object(
+            target_filter,
+            explicit_target.then(|| span_from_tokens(&clause_tokens)).flatten(),
+            None,
+        ),
         target_count,
     );
     Ok(Some(target))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -13,6 +13,19 @@ const COUNTER_YOU_DONT_CONTROL_PREFIX_PATTERN: ClauseShape<'static> = clause_sha
             &["you", "do", "not", "control"],
         ]
 );
+const COUNTER_OPPONENTS_CONTROL_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["your", "opponents", "control"],
+            &["your", "opponents", "controls"],
+            &["opponents", "control"],
+            &["opponents", "controls"],
+            &["an", "opponent", "controls"],
+            &["opponent", "controls"],
+        ]
+);
+const COUNTER_ALL_OR_EACH_WORD_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["all"], &["each"]]);
 const COUNTER_ACTIVATED_OR_TRIGGERED_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["activated", "or", "triggered", "ability"]);
 const COUNTER_TRIGGERED_OR_ACTIVATED_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
@@ -21,8 +34,10 @@ const COUNTER_ACTIVATED_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["activated", "ability"]);
 const COUNTER_TRIGGERED_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["triggered", "ability"]);
+const COUNTER_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix_any & [&["ability"], &["abilities"]]);
 const COUNTER_ABILITY_MARKER_PATTERN: ClauseShape<'static> =
-    clause_shape!(contains_words & ["ability"]);
+    clause_shape!(contains_any_words & [&["ability"], &["abilities"]]);
 const COUNTER_ACTIVATED_OR_TRIGGERED_MARKER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_words & [&["activated"], &["triggered"]]);
 const COUNTER_SPELL_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["spell"]);
@@ -171,14 +186,17 @@ fn parse_counter_ability_target_phrase(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<TargetAst>, CardTextError> {
     let clause_tokens = trim_commas(tokens);
-    let is_you_control_tail = |idx: usize| {
+    let is_controller_tail = |idx: usize| {
         counter_shape_matches_at(&clause_tokens, idx, &COUNTER_YOU_CONTROL_PREFIX_PATTERN)
             || counter_shape_matches_at(&clause_tokens, idx, &COUNTER_YOU_DONT_CONTROL_PREFIX_PATTERN)
+            || counter_shape_matches_at(
+                &clause_tokens,
+                idx,
+                &COUNTER_OPPONENTS_CONTROL_PREFIX_PATTERN,
+            )
     };
     let clause_words = crate::runtime_backend::token_word_refs(&clause_tokens);
-    if !COUNTER_ABILITY_MARKER_PATTERN.matches_words(&clause_words)
-        || !COUNTER_ACTIVATED_OR_TRIGGERED_MARKER_PATTERN.matches_words(&clause_words)
-    {
+    if !COUNTER_ABILITY_MARKER_PATTERN.matches_words(&clause_words) {
         return Ok(None);
     }
 
@@ -189,13 +207,19 @@ fn parse_counter_ability_target_phrase(
         idx += used;
     }
 
-    if !clause_tokens
+    let explicit_target = clause_tokens
         .get(idx)
-        .is_some_and(|token| COUNTER_TARGET_WORD_PATTERN.matches_token(token))
+        .is_some_and(|token| COUNTER_TARGET_WORD_PATTERN.matches_token(token));
+    if explicit_target {
+        idx += 1;
+    } else if clause_tokens
+        .get(idx)
+        .is_some_and(|token| COUNTER_ALL_OR_EACH_WORD_PATTERN.matches_token(token))
     {
+        idx += 1;
+    } else {
         return Ok(None);
     }
-    idx += 1;
 
     #[derive(Clone, Copy)]
     enum CounterTargetTerm {
@@ -214,7 +238,7 @@ fn parse_counter_ability_target_phrase(
             list_end = scan;
             break;
         }
-        if is_you_control_tail(scan) {
+        if is_controller_tail(scan) {
             list_end = scan;
             break;
         }
@@ -279,6 +303,12 @@ fn parse_counter_ability_target_phrase(
             triggered.stack_kind = Some(crate::filter::StackObjectKind::TriggeredAbility);
             term_filters.push((triggered, CounterTargetTerm::Ability));
             idx += 2;
+            continue;
+        }
+
+        if counter_shape_matches_at(&clause_tokens, idx, &COUNTER_ABILITY_PREFIX_PATTERN) {
+            term_filters.push((ObjectFilter::ability(), CounterTargetTerm::Ability));
+            idx += 1;
             continue;
         }
 
@@ -364,6 +394,24 @@ fn parse_counter_ability_target_phrase(
             };
             continue;
         }
+        if counter_shape_matches_at(&clause_tokens, idx, &COUNTER_OPPONENTS_CONTROL_PREFIX_PATTERN)
+        {
+            controller_filter = Some(PlayerFilter::Opponent);
+            idx += if clause_tokens
+                .get(idx)
+                .is_some_and(|token| token.as_word() == Some("your"))
+            {
+                3
+            } else if clause_tokens
+                .get(idx)
+                .is_some_and(|token| token.as_word() == Some("an"))
+            {
+                3
+            } else {
+                2
+            };
+            continue;
+        }
         if COUNTER_FROM_WORD_PATTERN.matches_word(word) {
             idx += 1;
             if clause_tokens
@@ -431,7 +479,11 @@ fn parse_counter_ability_target_phrase(
     };
 
     let target = wrap_target_count(
-        TargetAst::Object(target_filter, span_from_tokens(&clause_tokens), None),
+        TargetAst::Object(
+            target_filter,
+            explicit_target.then(|| span_from_tokens(&clause_tokens)).flatten(),
+            None,
+        ),
         target_count,
     );
     Ok(Some(target))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/counter_stat_verbs.rs
@@ -37,9 +37,9 @@ const COUNTER_TRIGGERED_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
 const COUNTER_ABILITY_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["ability"], &["abilities"]]);
 const COUNTER_ABILITY_MARKER_PATTERN: ClauseShape<'static> =
-    clause_shape!(contains_any_words & [&["ability"], &["abilities"]]);
+    clause_shape!(contains_any_words & [&["ability", "abilities"]]);
 const COUNTER_ACTIVATED_OR_TRIGGERED_MARKER_PATTERN: ClauseShape<'static> =
-    clause_shape!(contains_any_words & [&["activated"], &["triggered"]]);
+    clause_shape!(contains_any_words & [&["activated", "triggered"]]);
 const COUNTER_SPELL_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["spell"]);
 const COUNTER_INSTANT_SPELL_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["instant", "spell"]);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17200,13 +17200,7 @@ fn test_parse_trigger_when_this_creature_is_turned_face_up() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_kadenas_silencer_strict_parse_counter_all_opponent_abilities() {
-    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Kadena's Silencer")
-        .card_types(vec![CardType::Creature])
-        .power_toughness(PowerToughness::fixed(2, 1))
-        .parse_text(
-            "When this creature is turned face up, counter all abilities your opponents control.\nMegamorph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
-        )
-        .expect("Kadena's Silencer should strictly parse");
+    let def = parse_oracle_card_definition("Kadena's Silencer");
 
     let triggered = def
         .abilities

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17199,6 +17199,54 @@ fn test_parse_trigger_when_this_creature_is_turned_face_up() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_kadenas_silencer_strict_parse_counter_all_opponent_abilities() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Kadena's Silencer")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text(
+            "When this creature is turned face up, counter all abilities your opponents control.\nMegamorph {1}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)",
+        )
+        .expect("Kadena's Silencer should strictly parse");
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Kadena's Silencer should have a turned-face-up trigger");
+    let effects_debug = format!("{:#?}", triggered.effects);
+    assert!(
+        effects_debug.contains("CounterEffect")
+            && effects_debug.contains("Stack")
+            && effects_debug.contains("Ability")
+            && effects_debug.contains("Opponent"),
+        "expected counter-all-opponent-abilities effect, got {effects_debug}"
+    );
+
+    let compiled = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        compiled.contains("counter")
+            && compiled.contains("all")
+            && compiled.contains("abilities")
+            && compiled.contains("opponent"),
+        "expected compiled text for countering all opponent abilities, got {compiled}"
+    );
+    assert!(
+        compiled.contains("megamorph {1}{u}"),
+        "expected megamorph text to remain present, got {compiled}"
+    );
+    assert!(
+        !compiled.contains("unsupported parser line fallback"),
+        "Kadena's Silencer should not rely on unsupported fallback: {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_trigger_when_face_down_permanent_is_turned_face_up() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Sumala Trigger Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17229,10 +17229,7 @@ fn test_kadenas_silencer_strict_parse_counter_all_opponent_abilities() {
         .join(" ")
         .to_ascii_lowercase();
     assert!(
-        compiled.contains("counter")
-            && compiled.contains("all")
-            && compiled.contains("abilities")
-            && compiled.contains("opponent"),
+        compiled.contains("counter all abilities your opponents control"),
         "expected compiled text for countering all opponent abilities, got {compiled}"
     );
     assert!(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2822,6 +2822,24 @@ fn describe_stack_object_copy_target(target: &ChooseSpec) -> String {
     }
 }
 
+fn describe_counter_all_stack_abilities(target: &ChooseSpec) -> Option<&'static str> {
+    let ChooseSpec::All(filter) = target else {
+        return None;
+    };
+    if filter.zone != Some(Zone::Stack)
+        || filter.controller != Some(PlayerFilter::Opponent)
+        || filter.stack_kind != Some(StackObjectKind::Ability)
+    {
+        return None;
+    }
+
+    let mut base = filter.clone();
+    base.zone = None;
+    base.controller = None;
+    base.stack_kind = None;
+    (base == ObjectFilter::default()).then_some("all abilities your opponents control")
+}
+
 fn copy_target_player_candidate_text(filter: &PlayerFilter, plural: bool) -> String {
     match (filter, plural) {
         (PlayerFilter::Any, false) => "player".to_string(),
@@ -31100,6 +31118,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             })
         {
             return "Counter target triggered ability or colorless spell".to_string();
+        }
+        if let Some(target_text) = describe_counter_all_stack_abilities(&counter_spell.target) {
+            return format!("Counter {target_text}");
         }
         return format!("Counter {}", describe_choose_spec(&counter_spell.target));
     }

--- a/crates/ironsmith-runtime/src/effects/stack/counter.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/counter.rs
@@ -3,13 +3,100 @@
 use crate::ability::AbilityKind;
 use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
-use crate::effects::helpers::resolve_single_object_for_effect;
+use crate::effects::helpers::resolve_objects_for_effect;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::processing::{EventOutcome, process_zone_change_with_additional_effects};
 use crate::game_state::GameState;
+use crate::ids::ObjectId;
 use crate::target::ChooseSpec;
 use crate::zone::Zone;
 pub use ironsmith_core::CounterEffect;
+
+fn counter_one_stack_object(
+    game: &mut GameState,
+    ctx: &mut ExecutionContext,
+    target_id: ObjectId,
+) -> EffectOutcome {
+    if !game.can_be_countered(target_id) {
+        return EffectOutcome::protected();
+    }
+
+    // Check if the spell can't be countered
+    if let Some(obj) = game.object(target_id) {
+        let abilities = game
+            .current_abilities(target_id)
+            .unwrap_or_else(|| obj.abilities.clone());
+        let cant_be_countered = abilities.iter().any(|ability| {
+            if let AbilityKind::Static(s) = &ability.kind {
+                let display = s.display().to_ascii_lowercase();
+                s.cant_be_countered()
+                    || s.id() == crate::static_abilities::StaticAbilityId::CantBeCountered
+                    || display.contains("can't be countered")
+                    || display.contains("cant be countered")
+            } else {
+                false
+            }
+        });
+        if cant_be_countered {
+            // Spell can't be countered - effect does nothing
+            return EffectOutcome::protected();
+        }
+    }
+
+    // Find the stack entry for this object
+    if game.stack.iter().any(|e| e.object_id == target_id) {
+        let additional_effects = ctx.additional_replacement_effects_snapshot();
+        let outcome = process_zone_change_with_additional_effects(
+            game,
+            target_id,
+            Zone::Stack,
+            Zone::Graveyard,
+            ctx.cause.clone(),
+            &mut ctx.decision_maker,
+            &additional_effects,
+        );
+
+        match outcome {
+            EventOutcome::Prevented => return EffectOutcome::prevented(),
+            EventOutcome::Proceed(final_zone) => {
+                if let Some(idx) = game.stack.iter().position(|e| e.object_id == target_id) {
+                    let entry = game.stack.remove(idx);
+                    // Countered abilities simply disappear; countered spells leave the stack
+                    // through zone-change processing so replacement effects can rewrite
+                    // destinations like Force of Negation's exile clause.
+                    if !entry.is_ability {
+                        let move_result = game.move_object_with_etb_processing_with_dm_and_cause(
+                            entry.object_id,
+                            final_zone,
+                            ctx.cause.clone(),
+                            &mut ctx.decision_maker,
+                        );
+                        if final_zone == Zone::Exile
+                            && let Some(result) = move_result
+                        {
+                            game.add_exiled_with_source_link(ctx.source, result.new_id);
+                        }
+                    }
+                }
+            }
+            EventOutcome::Replaced => {
+                if let Some(idx) = game.stack.iter().position(|e| e.object_id == target_id) {
+                    game.stack.remove(idx);
+                }
+            }
+            EventOutcome::NotApplicable => return EffectOutcome::target_invalid(),
+        }
+
+        if !game.stack.iter().any(|e| e.object_id == target_id) {
+            EffectOutcome::resolved()
+        } else {
+            EffectOutcome::target_invalid()
+        }
+    } else {
+        // Target is no longer on the stack
+        EffectOutcome::target_invalid()
+    }
+}
 
 /// Effect that counters a target spell on the stack.
 ///
@@ -35,88 +122,16 @@ impl EffectExecutor for CounterEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        let target_id = resolve_single_object_for_effect(game, ctx, &self.target)?;
-
-        if !game.can_be_countered(target_id) {
-            return Ok(EffectOutcome::protected());
+        let target_ids = resolve_objects_for_effect(game, ctx, &self.target)?;
+        if target_ids.is_empty() {
+            return Ok(EffectOutcome::target_invalid());
         }
 
-        // Check if the spell can't be countered
-        if let Some(obj) = game.object(target_id) {
-            let abilities = game
-                .current_abilities(target_id)
-                .unwrap_or_else(|| obj.abilities.clone());
-            let cant_be_countered = abilities.iter().any(|ability| {
-                if let AbilityKind::Static(s) = &ability.kind {
-                    let display = s.display().to_ascii_lowercase();
-                    s.cant_be_countered()
-                        || s.id() == crate::static_abilities::StaticAbilityId::CantBeCountered
-                        || display.contains("can't be countered")
-                        || display.contains("cant be countered")
-                } else {
-                    false
-                }
-            });
-            if cant_be_countered {
-                // Spell can't be countered - effect does nothing
-                return Ok(EffectOutcome::protected());
-            }
-        }
-
-        // Find the stack entry for this object
-        if game.stack.iter().any(|e| e.object_id == target_id) {
-            let additional_effects = ctx.additional_replacement_effects_snapshot();
-            let outcome = process_zone_change_with_additional_effects(
-                game,
-                target_id,
-                Zone::Stack,
-                Zone::Graveyard,
-                ctx.cause.clone(),
-                &mut ctx.decision_maker,
-                &additional_effects,
-            );
-
-            match outcome {
-                EventOutcome::Prevented => return Ok(EffectOutcome::prevented()),
-                EventOutcome::Proceed(final_zone) => {
-                    if let Some(idx) = game.stack.iter().position(|e| e.object_id == target_id) {
-                        let entry = game.stack.remove(idx);
-                        // Countered abilities simply disappear; countered spells leave the stack
-                        // through zone-change processing so replacement effects can rewrite
-                        // destinations like Force of Negation's exile clause.
-                        if !entry.is_ability {
-                            let move_result = game
-                                .move_object_with_etb_processing_with_dm_and_cause(
-                                    entry.object_id,
-                                    final_zone,
-                                    ctx.cause.clone(),
-                                    &mut ctx.decision_maker,
-                                );
-                            if final_zone == Zone::Exile
-                                && let Some(result) = move_result
-                            {
-                                game.add_exiled_with_source_link(ctx.source, result.new_id);
-                            }
-                        }
-                    }
-                }
-                EventOutcome::Replaced => {
-                    if let Some(idx) = game.stack.iter().position(|e| e.object_id == target_id) {
-                        game.stack.remove(idx);
-                    }
-                }
-                EventOutcome::NotApplicable => return Ok(EffectOutcome::target_invalid()),
-            }
-
-            if !game.stack.iter().any(|e| e.object_id == target_id) {
-                Ok(EffectOutcome::resolved())
-            } else {
-                Ok(EffectOutcome::target_invalid())
-            }
-        } else {
-            // Target is no longer on the stack
-            Ok(EffectOutcome::target_invalid())
-        }
+        Ok(EffectOutcome::aggregate(
+            target_ids
+                .into_iter()
+                .map(|target_id| counter_one_stack_object(game, ctx, target_id)),
+        ))
     }
 
     fn get_target_spec(&self) -> Option<&ChooseSpec> {
@@ -350,6 +365,99 @@ mod tests {
                 .expect("ability source permanent should still exist")
                 .zone,
             Zone::Battlefield
+        );
+    }
+
+    #[test]
+    fn kadenas_silencer_counter_all_opponent_abilities_leaves_your_stack_objects() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let opponent_first_ability_source = game.create_object_from_card(
+            &CardBuilder::new(CardId::new(), "Opponent Ability Source A")
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            bob,
+            Zone::Battlefield,
+        );
+        let opponent_second_ability_source = game.create_object_from_card(
+            &CardBuilder::new(CardId::new(), "Opponent Ability Source B")
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            bob,
+            Zone::Battlefield,
+        );
+        let your_ability_source = game.create_object_from_card(
+            &CardBuilder::new(CardId::new(), "Your Ability Source")
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            alice,
+            Zone::Battlefield,
+        );
+        let opponent_spell = create_instant(&mut game, bob, Zone::Stack, "Opponent Spell");
+
+        game.stack.push(StackEntry::ability(
+            opponent_first_ability_source,
+            bob,
+            vec![Effect::draw(1)],
+        ));
+        game.stack.push(StackEntry::ability(
+            opponent_second_ability_source,
+            bob,
+            vec![Effect::draw(1)],
+        ));
+        game.stack.push(StackEntry::ability(
+            your_ability_source,
+            alice,
+            vec![Effect::draw(1)],
+        ));
+        game.stack.push(StackEntry::new(opponent_spell, bob));
+
+        let silencer = game.create_object_from_card(
+            &CardBuilder::new(CardId::new(), "Kadena's Silencer")
+                .card_types(vec![CardType::Creature])
+                .build(),
+            alice,
+            Zone::Battlefield,
+        );
+        let mut dm = SelectFirstDecisionMaker;
+        let mut ctx = ExecutionContext::new(silencer, alice, &mut dm);
+        let outcome = execute_effect(
+            &mut game,
+            &Effect::new(CounterEffect::new(ChooseSpec::All(
+                ObjectFilter::ability().controlled_by(PlayerFilter::Opponent),
+            ))),
+            &mut ctx,
+        )
+        .expect("Kadena's Silencer counter-all-abilities effect should resolve");
+
+        assert_eq!(outcome.status, OutcomeStatus::Succeeded);
+        assert!(
+            !game
+                .stack
+                .iter()
+                .any(|entry| entry.object_id == opponent_first_ability_source),
+            "first opponent ability should be countered"
+        );
+        assert!(
+            !game
+                .stack
+                .iter()
+                .any(|entry| entry.object_id == opponent_second_ability_source),
+            "second opponent ability should be countered"
+        );
+        assert!(
+            game.stack
+                .iter()
+                .any(|entry| entry.object_id == your_ability_source && entry.is_ability),
+            "your ability should not be countered"
+        );
+        assert!(
+            game.stack
+                .iter()
+                .any(|entry| entry.object_id == opponent_spell && !entry.is_ability),
+            "opponent spell should not be countered by an ability-only filter"
         );
     }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12178,6 +12178,142 @@ fn test_turn_face_up_action_puts_turned_face_up_trigger_on_stack() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn kadenas_silencer_turn_face_up_trigger_counters_only_opponent_abilities() {
+    use crate::decision::{LegalAction, SelectFirstDecisionMaker};
+    use crate::special_actions::TurnFaceUpMethod;
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let kadena = CardDefinitionBuilder::new(CardId::new(), "Kadena's Silencer")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Snake, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(2, 1))
+        .parse_text(
+            "When this creature is turned face up, counter all abilities your opponents control.\nMegamorph {1}{U}",
+        )
+        .expect("Kadena's Silencer should parse for runtime test");
+    let kadena_id = game.create_object_from_definition(&kadena, alice, Zone::Battlefield);
+    game.set_face_down(kadena_id);
+
+    let opponent_first_ability_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Opponent Ability Source A")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let opponent_second_ability_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Opponent Ability Source B")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let your_ability_source = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Your Ability Source")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let opponent_spell = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Opponent Spell")
+            .card_types(vec![CardType::Instant])
+            .build(),
+        bob,
+        Zone::Stack,
+    );
+
+    game.push_to_stack(StackEntry::ability(
+        opponent_first_ability_source,
+        bob,
+        vec![Effect::draw(1)],
+    ));
+    game.push_to_stack(StackEntry::ability(
+        opponent_second_ability_source,
+        bob,
+        vec![Effect::draw(1)],
+    ));
+    game.push_to_stack(StackEntry::ability(
+        your_ability_source,
+        alice,
+        vec![Effect::draw(1)],
+    ));
+    game.push_to_stack(StackEntry::new(opponent_spell, bob));
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 1);
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    let response = PriorityResponse::PriorityAction(LegalAction::TurnFaceUp {
+        creature_id: kadena_id,
+        method: TurnFaceUpMethod::MegamorphAbility,
+    });
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &response,
+        &mut dm,
+    )
+    .expect("turning Kadena's Silencer face up should succeed");
+
+    let top = game
+        .stack
+        .last()
+        .expect("Kadena's Silencer trigger should be on the stack");
+    assert_eq!(top.object_id, kadena_id);
+    assert!(top.is_ability);
+    resolve_stack_entry(&mut game).expect("Kadena's Silencer trigger should resolve");
+
+    assert!(
+        !game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == opponent_first_ability_source),
+        "first opponent ability should be countered"
+    );
+    assert!(
+        !game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == opponent_second_ability_source),
+        "second opponent ability should be countered"
+    );
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| entry.object_id == your_ability_source && entry.is_ability),
+        "your ability should not be countered"
+    );
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| entry.object_id == opponent_spell && !entry.is_ability),
+        "opponent spell should not be countered"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn roshan_hidden_magister_applies_assassin_subtype_across_zones_for_you_only() {
     use crate::cards::builders::CardDefinitionBuilder;
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kadena's Silencer
Initial parse error:
```
unsupported target phrase lacking object selector (clause: 'all abilities your opponents control'); oracle-only fallback also failed: unsupported target phrase lacking object selector (clause: 'all abilities your opponents control')
```

Current worker: i-030ccbc40e976edbe
Branch: codex/aws-card-fix-kadena-s-silencer
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0001
