### PR TITLE
Fix Ironsmith parse failure: Emrakul, the World Anew

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -31,6 +31,15 @@ fn this_enters_battlefield_trigger_spec(
     }
 }
 
+fn this_leaves_battlefield_trigger_spec(
+    surface: Option<crate::target::SourceReferenceSurface>,
+) -> TriggerSpec {
+    match surface {
+        Some(surface) => TriggerSpec::ThisLeavesBattlefieldWithSurface(surface),
+        None => TriggerSpec::ThisLeavesBattlefield,
+    }
+}
+
 pub(crate) fn split_trigger_or_index(tokens: &[OwnedLexToken]) -> Option<usize> {
     tokens.iter().enumerate().find_map(|(idx, token)| {
         if !token.is_word("or") {
@@ -927,6 +936,12 @@ pub(crate) fn parse_trigger_clause_lexed(
             .token_index_for_word_index(leaves_word_idx)
             .unwrap_or(tokens.len());
         let subject_tokens = &tokens[..leaves_token_idx];
+
+        if let Some(surface) =
+            source_reference_surface_for_trigger_subject(strip_leading_trigger_intro(subject_tokens))
+        {
+            return Ok(this_leaves_battlefield_trigger_spec(Some(surface)));
+        }
 
         if let Some(or_idx) =
             find_index(subject_tokens, |token: &OwnedLexToken| token.is_word("or"))

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -190,6 +190,17 @@ fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if value == "spells" || value == "spell" {
+            return Some(KeywordAction::ProtectionFromFilter(ObjectFilter::spell()));
+        }
+        if matches!(value, "permanent" | "permanents")
+            && words.get(idx + 2..idx + 7)
+                == Some(&["that", "were", "cast", "this", "turn"][..])
+        {
+            let mut filter = ObjectFilter::permanent();
+            filter.cast_this_turn = true;
+            return Some(KeywordAction::ProtectionFromFilter(filter));
+        }
         if matches!(value, "permanent" | "permanents")
             && words.get(idx + 2).copied() == Some("with")
         {
@@ -540,6 +551,17 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
 
         let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
             let value = *words.get(idx + 1)?;
+            if value == "spells" || value == "spell" {
+                return Some(KeywordAction::ProtectionFromFilter(ObjectFilter::spell()));
+            }
+            if matches!(value, "permanent" | "permanents")
+                && words.get(idx + 2..idx + 7)
+                    == Some(&["that", "were", "cast", "this", "turn"][..])
+            {
+                let mut filter = ObjectFilter::permanent();
+                filter.cast_this_turn = true;
+                return Some(KeywordAction::ProtectionFromFilter(filter));
+            }
             if matches!(value, "permanent" | "permanents")
                 && words.get(idx + 2).copied() == Some("with")
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
@@ -87,6 +87,17 @@ pub(crate) fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<Key
     let mut actions = Vec::new();
     let parse_from_target = |words: &[&str], idx: usize| -> Option<KeywordAction> {
         let value = *words.get(idx + 1)?;
+        if value == "spells" || value == "spell" {
+            return Some(KeywordAction::ProtectionFromFilter(ObjectFilter::spell()));
+        }
+        if matches!(value, "permanent" | "permanents")
+            && words.get(idx + 2..idx + 7)
+                == Some(&["that", "were", "cast", "this", "turn"][..])
+        {
+            let mut filter = ObjectFilter::permanent();
+            filter.cast_this_turn = true;
+            return Some(KeywordAction::ProtectionFromFilter(filter));
+        }
         if matches!(value, "permanent" | "permanents")
             && words.get(idx + 2).copied() == Some("with")
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -925,6 +925,11 @@ fn normalize_named_source_trigger_for_builder(
     let trimmed = text.trim();
     let lower = trimmed.to_ascii_lowercase();
     if let Some((trigger_head, effect_body)) = str_split_once(lower.as_str(), ",") {
+        if trigger_head.contains(" leaves the battlefield")
+            && normalized_line_mentions_source_alias(builder, trigger_head)
+        {
+            return None;
+        }
         let rewritten_head =
             normalize_named_source_trigger_head_for_builder(builder, trigger_head)?;
         let names = source_name_aliases_for_builder(builder);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1005,7 +1005,10 @@ fn normalized_line_mentions_source_alias(builder: &CardDefinitionBuilder, text: 
     let subject = named_source_subject_for_builder(builder);
     source_name_aliases_for_builder(builder)
         .iter()
-        .any(|alias| replace_named_source_aliases(lower.as_str(), alias, subject) != lower)
+        .any(|alias| {
+            replace_named_source_aliases_for_trigger_normalization(lower.as_str(), alias, subject)
+                != lower
+        })
 }
 
 fn normalize_named_source_trigger_head_for_builder(
@@ -2142,6 +2145,31 @@ mod tests {
     }
 
     #[test]
+    fn named_source_leaves_trigger_keeps_original_head_for_surface_rendering() {
+        crate::runtime_backend::front_end::shared::util::with_source_reference_context(
+            "Emrakul, the World Anew",
+            || {
+                let document = preprocess_document(
+                    CardDefinitionBuilder::new(CardId::from_raw(1), "Emrakul, the World Anew")
+                        .card_types(vec![CardType::Creature]),
+                    "When Emrakul leaves the battlefield, sacrifice all creatures you control.",
+                )
+                .expect("named source leaves line should preprocess");
+                let line = match document.items.first().expect("expected one line") {
+                    PreprocessedItem::Line(line) => line,
+                    other => panic!("expected preprocessed line, got {other:?}"),
+                };
+
+                let parsed = parse_triggered_line_cst(line)
+                    .expect("named source leaves trigger should parse as triggered CST");
+
+                assert_eq!(parsed.trigger_text, "emrakul leaves the battlefield");
+                assert_eq!(render_token_slice(&parsed.trigger_parse_tokens), parsed.trigger_text);
+            },
+        );
+    }
+
+    #[test]
     fn reveal_first_draw_splitter_reuses_token_ranges() {
         let tokens = lex_line(
             "Reveal the first card you draw each turn. Whenever you reveal an instant card this way, draw a card.",
@@ -3230,13 +3258,16 @@ pub(crate) fn parse_document_cst(
                     idx += 1;
                     continue;
                 }
-                if normalized_line_mentions_source_alias(
-                    &preprocessed.builder,
-                    line.info.normalized.normalized.as_str(),
-                ) && let Some(rewritten) = normalize_named_source_sentence_for_builder(
-                    &preprocessed.builder,
-                    line.info.normalized.normalized.as_str(),
-                ) {
+                if !line_starts_with_trigger_intro_tokens(&line.tokens)
+                    && normalized_line_mentions_source_alias(
+                        &preprocessed.builder,
+                        line.info.normalized.normalized.as_str(),
+                    )
+                    && let Some(rewritten) = normalize_named_source_sentence_for_builder(
+                        &preprocessed.builder,
+                        line.info.normalized.normalized.as_str(),
+                    )
+                {
                     let rewritten_line = rewrite_line_normalized(line, rewritten.as_str())?;
                     if let Ok(dispatch) = dispatch_standard_line_cst(
                         preprocessed,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/preprocess.rs
@@ -459,6 +459,8 @@ fn replace_names_with_map(
                         | b"deals"
                         | b"enter"
                         | b"enters"
+                        | b"leave"
+                        | b"leaves"
                         | b"power"
                         | b"toughness"
                 )

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -4055,11 +4055,15 @@ pub(crate) fn parse_madness_line(
         .enumerate()
         .find_map(|(idx, token)| token.is_comma().then_some(idx))
         .unwrap_or(cost_tokens.len());
-    let cost_tokens = &cost_tokens[..cost_end];
+    let cost_tokens = strip_leading_keyword_cost_separator(&cost_tokens[..cost_end]);
     if cost_tokens.is_empty() {
         return Err(CardTextError::ParseError(
             "madness keyword missing mana cost".to_string(),
         ));
+    }
+
+    if let Some(mana_cost) = parse_pay_repeated_mana_symbol_cost(cost_tokens) {
+        return Ok(Some(AlternativeCastingMethod::Madness { cost: mana_cost }));
     }
 
     let total_cost = parse_activation_cost(cost_tokens)?;
@@ -4074,6 +4078,42 @@ pub(crate) fn parse_madness_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<AlternativeCastingMethod>, CardTextError> {
     parse_madness_line(tokens)
+}
+
+fn strip_leading_keyword_cost_separator(tokens: &[OwnedLexToken]) -> &[OwnedLexToken] {
+    if matches!(tokens.first().map(|token| token.kind), Some(TokenKind::Dash | TokenKind::EmDash)) {
+        tokens.get(1..).unwrap_or_default()
+    } else {
+        tokens
+    }
+}
+
+fn parse_pay_repeated_mana_symbol_cost(tokens: &[OwnedLexToken]) -> Option<ManaCost> {
+    let mut end = tokens.len();
+    while end > 0 && tokens[end - 1].kind == TokenKind::Period {
+        end -= 1;
+    }
+    let tokens = &tokens[..end];
+    if tokens.len() != 3 || !tokens[0].is_word("pay") {
+        return None;
+    }
+
+    let count = tokens[1]
+        .parser_text()
+        .parse::<u8>()
+        .ok()
+        .or_else(|| {
+            ironsmith_core::parse_cardinal_word(tokens[1].parser_text())
+                .and_then(|value| value.try_into().ok())
+        })?;
+    let pip = mana_pips_from_token(&tokens[2])?;
+    if pip.len() != 1 {
+        return None;
+    }
+
+    Some(ManaCost::from_pips(
+        (0..count).map(|_| pip.clone()).collect(),
+    ))
 }
 
 pub(crate) fn parse_buyback_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -56,6 +56,12 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             )
         }
         TriggerSpec::ThisLeavesBattlefield => Trigger::this_leaves_battlefield(),
+        TriggerSpec::ThisLeavesBattlefieldWithSurface(surface) => Trigger::new(
+            crate::triggers::ZoneChangeTrigger::new()
+                .from(crate::zone::Zone::Battlefield)
+                .this()
+                .this_surface(surface.clone()),
+        ),
         TriggerSpec::ThisMutates => Trigger::this_mutates(),
         TriggerSpec::ThisBecomesMonstrous => Trigger::this_becomes_monstrous(),
         TriggerSpec::ThisBecomesTapped => Trigger::becomes_tapped(),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -127,6 +127,7 @@ pub(crate) enum TriggerSpec {
         marker: String,
     },
     ThisLeavesBattlefield,
+    ThisLeavesBattlefieldWithSurface(crate::target::SourceReferenceSurface),
     ThisMutates,
     ThisBecomesMonstrous,
     ThisBecomesTapped,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -136,6 +136,60 @@ pub(crate) fn infer_player_filter_from_object_filter(
         .find_map(infer_player_filter_from_object_filter)
 }
 
+fn push_target_player_filter_choices(filter: &PlayerFilter, choices: &mut Vec<ChooseSpec>) {
+    match filter {
+        PlayerFilter::Target(inner) => {
+            let choice = ChooseSpec::target(ChooseSpec::Player((**inner).clone()));
+            if !choices.contains(&choice) {
+                choices.push(choice);
+            }
+        }
+        PlayerFilter::CardsInHandAtLeastMoreThanYou { base, .. }
+        | PlayerFilter::MaxSpeed { base, .. } => {
+            push_target_player_filter_choices(base, choices);
+        }
+        PlayerFilter::Excluding { base, excluded } => {
+            push_target_player_filter_choices(base, choices);
+            push_target_player_filter_choices(excluded, choices);
+        }
+        PlayerFilter::Any
+        | PlayerFilter::You
+        | PlayerFilter::NotYou
+        | PlayerFilter::Opponent
+        | PlayerFilter::Teammate
+        | PlayerFilter::Active
+        | PlayerFilter::Defending
+        | PlayerFilter::Attacking
+        | PlayerFilter::DamagedPlayer
+        | PlayerFilter::EffectController
+        | PlayerFilter::Specific(_)
+        | PlayerFilter::MostLifeTied
+        | PlayerFilter::LowestLifeTied
+        | PlayerFilter::MostCardsInHand
+        | PlayerFilter::CastCardTypeThisTurn(_)
+        | PlayerFilter::ChosenPlayer
+        | PlayerFilter::TaggedPlayer(_)
+        | PlayerFilter::IteratedPlayer
+        | PlayerFilter::TargetPlayerOrControllerOfTarget
+        | PlayerFilter::ControllerOf(_)
+        | PlayerFilter::OwnerOf(_)
+        | PlayerFilter::AliasedOwnerOf(_)
+        | PlayerFilter::AliasedControllerOf(_) => {}
+    }
+}
+
+fn append_object_filter_target_player_choices(filter: &ObjectFilter, choices: &mut Vec<ChooseSpec>) {
+    if let Some(owner) = &filter.owner {
+        push_target_player_filter_choices(owner, choices);
+    }
+    if let Some(controller) = &filter.controller {
+        push_target_player_filter_choices(controller, choices);
+    }
+    for branch in &filter.any_of {
+        append_object_filter_target_player_choices(branch, choices);
+    }
+}
+
 fn resolve_object_ref(reference: &ObjectRef, refs: &ReferenceEnv) -> ObjectRef {
     match reference {
         ObjectRef::Tagged(tag) if tag.as_str() == IT_TAG => refs
@@ -748,11 +802,14 @@ pub(crate) fn resolve_target_spec_with_choices(
         }
     }
     let spec = resolve_choose_spec_it_tag(&spec, refs)?;
-    let choices = if spec.is_target() {
+    let mut choices = if spec.is_target() {
         vec![spec.clone()]
     } else {
         Vec::new()
     };
+    if let TargetAst::Object(filter, _, _) = target {
+        append_object_filter_target_player_choices(filter, &mut choices);
+    }
     Ok((spec, choices))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -9519,6 +9519,29 @@ fn rewrite_lexed_trigger_clause_supports_this_creature_leaves_battlefield() {
 }
 
 #[test]
+fn rewrite_lexed_trigger_clause_preserves_named_source_leaves_surface() {
+    crate::runtime_backend::front_end::shared::util::with_source_reference_context(
+        "Emrakul, the World Anew",
+        || {
+            let tokens = lex_line("emrakul leaves the battlefield", 0)
+                .expect("rewrite lexer should classify named leaves-the-battlefield trigger");
+
+            let parsed = super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
+                &tokens,
+            )
+            .expect("named source leaves-the-battlefield trigger should parse");
+            let debug = format!("{parsed:?}");
+
+            assert!(
+                debug.contains("ThisLeavesBattlefieldWithSurface")
+                    && debug.contains("ShortName(\"Emrakul\")"),
+                "expected named source leaves trigger to preserve surface, got {debug}"
+            );
+        },
+    );
+}
+
+#[test]
 fn rewrite_lexed_triggered_line_supports_leave_battlefield_sacrifice_land() {
     let tokens = lex_line("When this leaves the battlefield, sacrifice a land.", 0)
         .expect("rewrite lexer should classify leave-battlefield sacrifice line");
@@ -9531,6 +9554,72 @@ fn rewrite_lexed_triggered_line_supports_leave_battlefield_sacrifice_land() {
             Ok(crate::cards::builders::LineAst::Triggered { .. })
         ),
         "{parsed:?}"
+    );
+}
+
+#[test]
+fn rewrite_lexed_triggered_line_preserves_named_source_leaves_surface() {
+    crate::runtime_backend::front_end::shared::util::with_source_reference_context(
+        "Emrakul, the World Anew",
+        || {
+            let tokens = lex_line(
+                "When emrakul leaves the battlefield, sacrifice all creatures you control.",
+                0,
+            )
+            .expect("rewrite lexer should classify named leave-battlefield sacrifice line");
+
+            let parsed = super::clause_support::parse_triggered_line_lexed(&tokens)
+                .expect("named source leaves trigger line should parse");
+            let debug = format!("{parsed:#?}");
+
+            assert!(
+                debug.contains("ThisLeavesBattlefieldWithSurface")
+                    && debug.contains("ShortName")
+                    && debug.contains("\"Emrakul\""),
+                "expected named source leaves trigger line to preserve surface, got {debug}"
+            );
+        },
+    );
+}
+
+#[test]
+fn compile_named_source_leaves_trigger_preserves_surface() {
+    let (semantic, _) = crate::runtime_backend::front_end::shared::util::with_source_reference_context(
+        "Emrakul, the World Anew",
+        || {
+            parse_text_to_semantic_document(
+                CardDefinitionBuilder::new(CardId::from_raw(1), "Emrakul, the World Anew")
+                    .card_types(vec![CardType::Creature]),
+                "When Emrakul leaves the battlefield, sacrifice all creatures you control."
+                    .to_string(),
+                false,
+            )
+        },
+    )
+    .expect("named source leaves trigger should parse semantically");
+    let semantic_debug = format!("{semantic:#?}");
+    assert!(
+        semantic_debug.contains("trigger_text: \"emrakul leaves the battlefield\""),
+        "expected semantic document to keep named source trigger text, got {semantic_debug}"
+    );
+
+    let compiled = crate::runtime_backend::front_end::shared::util::with_source_reference_context(
+        "Emrakul, the World Anew",
+        || {
+            super::compile_card_text(
+                CardDefinitionBuilder::new(CardId::from_raw(1), "Emrakul, the World Anew")
+                    .card_types(vec![CardType::Creature]),
+                "When Emrakul leaves the battlefield, sacrifice all creatures you control.",
+                false,
+            )
+        },
+    )
+    .expect("named source leaves trigger should compile");
+    let debug = format!("{:#?}", compiled.definition.abilities);
+
+    assert!(
+        debug.contains("this_surface") && debug.contains("\"Emrakul\""),
+        "expected compiled trigger model to preserve named source surface, got {debug}"
     );
 }
 

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -346,6 +346,7 @@ pub struct ObjectFilter {
     pub zone: Option<Zone>,
     pub controller: Option<PlayerFilter>,
     pub cast_by: Option<PlayerFilter>,
+    pub cast_this_turn: bool,
     pub first_spell_cast_each_turn: bool,
     pub owner: Option<PlayerFilter>,
     pub single_graveyard: bool,
@@ -1212,6 +1213,9 @@ impl ObjectFilter {
 
         if let Some(cast_by) = &self.cast_by {
             post_noun_qualifiers.push(format!("cast by {}", describe_player_filter(cast_by)));
+        }
+        if self.cast_this_turn {
+            post_noun_qualifiers.push("cast this turn".to_string());
         }
         if self.first_spell_cast_each_turn {
             post_noun_qualifiers.push("first spell cast each turn".to_string());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13143,6 +13143,34 @@ fn parse_protection_from_spells_that_are_one_or_more_colors() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_emrakul_the_world_anew_strict_oracle_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(124_001), "Emrakul, the World Anew")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(12)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi])
+        .power_toughness(PowerToughness::fixed(12, 12))
+        .parse_text(
+            "When you cast this spell, gain control of all creatures target player controls.\n\
+             Flying, protection from spells and from permanents that were cast this turn\n\
+             When Emrakul leaves the battlefield, sacrifice all creatures you control.\n\
+             Madness—Pay six {C}.",
+        )
+        .expect("Emrakul, the World Anew should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert_eq!(
+        rendered,
+        "When you cast this spell, gain control of all creatures target player controls.\n\
+         Flying, protection from spells and from permanents that were cast this turn\n\
+         When Emrakul leaves the battlefield, sacrifice all creatures you control.\n\
+         Madness—Pay six {C}.",
+        "Emrakul's strict parser output should preserve every oracle clause"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_exile_face_down_manifest_tail_fails_instead_of_partial_exile() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Ghastly Conscription Variant")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13167,6 +13167,28 @@ fn parse_emrakul_the_world_anew_strict_oracle_text() {
          Madness—Pay six {C}.",
         "Emrakul's strict parser output should preserve every oracle clause"
     );
+
+    let cast_trigger = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered
+                .choices
+                .contains(&ChooseSpec::target_player())
+                .then_some(triggered),
+            _ => None,
+        })
+        .expect("Emrakul cast trigger should require a target player choice");
+    assert_eq!(
+        cast_trigger.choices,
+        vec![ChooseSpec::target_player()],
+        "Emrakul's gain-control trigger should target only the player whose creatures are affected"
+    );
+    let effects_debug = format!("{:?}", cast_trigger.effects);
+    assert!(
+        effects_debug.contains("controller: Some(") && effects_debug.contains("Target"),
+        "Emrakul's gain-control effect should filter creatures by the target player's controller, got {effects_debug}"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1818,7 +1818,7 @@ pub(super) fn describe_alternative_cast_line(
             }
             line
         }
-        AlternativeCastingMethod::Madness { cost } => format!("Madness {}", cost.to_oracle()),
+        AlternativeCastingMethod::Madness { cost } => render_madness_cost(cost),
         AlternativeCastingMethod::Miracle { cost } => format!("Miracle {}", cost.to_oracle()),
         AlternativeCastingMethod::FlashWithAdditionalCost {
             additional_cost, ..
@@ -1918,6 +1918,19 @@ pub(super) fn describe_alternative_cast_line(
             }
         }
     }
+}
+
+fn render_madness_cost(cost: &crate::mana::ManaCost) -> String {
+    let pips = cost.pips();
+    if !pips.is_empty()
+        && pips
+            .iter()
+            .all(|pip| matches!(pip.as_slice(), [crate::mana::ManaSymbol::Colorless]))
+    {
+        let amount = small_number_word(pips.len() as u32).unwrap_or_else(|| pips.len().to_string());
+        return format!("Madness—Pay {amount} {{C}}");
+    }
+    format!("Madness {}", cost.to_oracle())
 }
 
 fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8847,6 +8847,9 @@ pub(super) fn describe_apply_continuous_effect(
             [crate::effects::continuous::RuntimeModification::ChangeControllerToEffectController]
         )
     {
+        if let Some(text) = describe_gain_control_target_player_creatures(effect) {
+            return Some(text);
+        }
         let mut text = format!("Gain control of {target}");
         if !matches!(effect.until, Until::Forever) {
             text.push(' ');
@@ -9235,6 +9238,28 @@ pub(super) fn describe_tag_attached_then_tap_or_untap(
         return Some(format!("Untap {attached_object}"));
     }
     None
+}
+
+fn describe_gain_control_target_player_creatures(
+    effect: &crate::effects::ApplyContinuousEffect,
+) -> Option<String> {
+    if !matches!(effect.until, Until::Forever) {
+        return None;
+    }
+    let crate::continuous::EffectTarget::Filter(filter) = &effect.target else {
+        return None;
+    };
+    if filter.zone != Some(Zone::Battlefield)
+        || filter.card_types != [CardType::Creature]
+        || filter.controller.is_none()
+    {
+        return None;
+    }
+    let Some(PlayerFilter::Target(player)) = &filter.controller else {
+        return None;
+    };
+    let player = describe_player_filter(&PlayerFilter::Target(player.clone()));
+    Some(format!("Gain control of all creatures {player} controls"))
 }
 
 fn object_filter_references_tag(filter: &ObjectFilter, tag: &str) -> bool {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17685,7 +17685,11 @@ fn describe_sacrifice_effect(sacrifice: SacrificeView<'_>) -> String {
         } else if let Some(rest) = noun.strip_prefix("an ") {
             noun = rest.to_string();
         }
-        return format!("{player} {verb} all {}", pluralize_noun_phrase(&noun));
+        let subject = pluralize_noun_phrase(&noun);
+        if matches!(sacrifice.player, PlayerFilter::You) {
+            return format!("Sacrifice all {subject}");
+        }
+        return format!("{player} {verb} all {subject}");
     }
     if matches!(sacrifice.count, Value::Fixed(value) if *value == 1) {
         let description = sacrifice.filter.description();

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1858,6 +1858,16 @@ impl ObjectFilterExt for ObjectFilter {
             }
         }
 
+        if self.cast_this_turn
+            && game
+                .turn_store
+                .turn_history
+                .spell_cast_order(object.id)
+                .is_none()
+        {
+            return false;
+        }
+
         if self.first_spell_cast_each_turn
             && game.turn_store.turn_history.spell_cast_order(object.id) != Some(1)
         {
@@ -2471,6 +2481,17 @@ impl ObjectFilterExt for ObjectFilter {
             if !caster_filter.matches_player(cast_player, ctx) {
                 return false;
             }
+        }
+
+        if self.cast_this_turn
+            && snapshot.cast_order_this_turn.is_none()
+            && game
+                .turn_store
+                .turn_history
+                .spell_cast_order(snapshot.object_id)
+                .is_none()
+        {
+            return false;
         }
 
         if self.first_spell_cast_each_turn

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -62,6 +62,61 @@ fn player_filter_references_target_player(filter: &crate::target::PlayerFilter) 
     }
 }
 
+fn object_filter_references_target_player(filter: &crate::target::ObjectFilter) -> bool {
+    [
+        filter.controller.as_ref(),
+        filter.cast_by.as_ref(),
+        filter.owner.as_ref(),
+        filter.targets_player.as_ref(),
+        filter.targets_only_player.as_ref(),
+        filter.attacking_player_or_planeswalker_controlled_by.as_ref(),
+        filter.attached_to_player.as_ref(),
+        filter.entered_battlefield_controller.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    .any(player_filter_references_target_player)
+        || filter
+            .targets_object
+            .as_deref()
+            .is_some_and(object_filter_references_target_player)
+        || filter
+            .targets_only_object
+            .as_deref()
+            .is_some_and(object_filter_references_target_player)
+        || filter
+            .any_of
+            .iter()
+            .any(object_filter_references_target_player)
+}
+
+fn choose_spec_references_target_player(spec: &crate::target::ChooseSpec) -> bool {
+    use crate::target::ChooseSpec;
+
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::Target(spec)
+        | ChooseSpec::WithCount(spec, _)
+        | ChooseSpec::WithCountValue(spec, _, _) => choose_spec_references_target_player(spec),
+        ChooseSpec::Player(filter)
+        | ChooseSpec::EachPlayer(filter)
+        | ChooseSpec::PlayerOrPlaneswalker(filter) => player_filter_references_target_player(filter),
+        ChooseSpec::Object(filter) | ChooseSpec::All(filter) => {
+            object_filter_references_target_player(filter)
+        }
+        ChooseSpec::SpecificObject(_)
+        | ChooseSpec::SpecificPlayer(_)
+        | ChooseSpec::AnyTarget
+        | ChooseSpec::AnyOtherTarget
+        | ChooseSpec::AttackedPlayerOrPlaneswalker
+        | ChooseSpec::Source
+        | ChooseSpec::SourceController
+        | ChooseSpec::SourceOwner
+        | ChooseSpec::Tagged(_)
+        | ChooseSpec::Iterated => false,
+    }
+}
+
 fn runtime_modification_references_target_player(
     modification: &crate::effects::continuous::RuntimeModification,
 ) -> bool {
@@ -74,10 +129,14 @@ fn runtime_modification_references_target_player(
 
 fn effect_references_prior_target_player(effect: &Effect) -> bool {
     if let Some(apply) = effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()
-        && apply
+        && (apply
             .runtime_modifications
             .iter()
             .any(runtime_modification_references_target_player)
+            || apply
+                .target_spec
+                .as_ref()
+                .is_some_and(choose_spec_references_target_player))
     {
         return true;
     }
@@ -432,13 +491,21 @@ pub(crate) fn execute_resolution_program(
             if is_modal_effect {
                 active_scope = None;
             } else if !effect_target_assignments.is_empty()
+                || effect_references_prior_target_player(effect)
                 || effect_references_prior_object_targets(effect)
             {
                 let scope_assignments = if effect_references_prior_target_player(effect) {
+                    let previous_assignment_end = if assignment_start == 0
+                        && effect_target_assignments.is_empty()
+                    {
+                        valid_target_assignments.len()
+                    } else {
+                        assignment_start
+                    };
                     let mut assignments = previous_player_target_assignments(
                         &ctx.targets,
                         valid_target_assignments,
-                        assignment_start,
+                        previous_assignment_end,
                     );
                     assignments.extend(effect_target_assignments.clone());
                     assignments
@@ -1981,6 +2048,64 @@ mod tests {
         .expect("modal program should resolve");
 
         assert_eq!(game.damage_on(damaged), 2);
+    }
+
+    #[test]
+    fn stack_resolution_preserves_explicit_player_target_for_filtered_continuous_effect() {
+        let mut game = GameState::new(
+            vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let charlie = PlayerId::from_index(2);
+
+        let source_card = CardBuilder::new(CardId::from_raw(91_005), "Control Test")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build();
+        let source = game.create_object_from_card(&source_card, alice, Zone::Battlefield);
+        let bob_creature = create_creature(&mut game, "Bob Creature", bob, 2, 2);
+        let bob_second_creature = create_creature(&mut game, "Bob Creature Two", bob, 2, 2);
+        let charlie_creature = create_creature(&mut game, "Charlie Creature", charlie, 2, 2);
+
+        let mut filter = crate::filter::ObjectFilter::creature();
+        filter.controller = Some(crate::target::PlayerFilter::target_player());
+        let spec = crate::target::ChooseSpec::Object(filter);
+        let program = crate::resolution::ResolutionProgram::from_effects(vec![
+            Effect::new(crate::effects::TargetOnlyEffect::new(
+                crate::target::ChooseSpec::target_player(),
+            )),
+            Effect::new(crate::effects::ApplyContinuousEffect::with_spec_runtime(
+                spec,
+                crate::effects::continuous::RuntimeModification::ChangeControllerToEffectController,
+                crate::effect::Until::Forever,
+            )),
+        ]);
+        let target_spec = crate::target::ChooseSpec::target_player();
+        let mut dm = crate::decision::SelectFirstDecisionMaker;
+        let mut ctx = ExecutionContext::new(source, alice, &mut dm)
+            .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+            .with_target_assignments(vec![crate::game_state::TargetAssignment {
+                spec: target_spec,
+                range: 0..1,
+            }]);
+        let assignments = ctx.target_assignments.clone();
+
+        execute_resolution_program(
+            &mut game,
+            &mut ctx,
+            alice,
+            source,
+            &program,
+            None,
+            &assignments,
+        )
+        .expect("continuous effect should resolve");
+
+        assert_eq!(game.current_controller(bob_creature), Some(alice));
+        assert_eq!(game.current_controller(bob_second_creature), Some(alice));
+        assert_eq!(game.current_controller(charlie_creature), Some(charlie));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12091,6 +12091,197 @@ fn test_resolution_target_validation_uses_source_lki_for_protection() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn emrakul_the_world_anew_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(124_010), "Emrakul, the World Anew")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(12)]]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi])
+        .power_toughness(PowerToughness::fixed(12, 12))
+        .parse_text(
+            "When you cast this spell, gain control of all creatures target player controls.\n\
+             Flying, protection from spells and from permanents that were cast this turn\n\
+             When Emrakul leaves the battlefield, sacrifice all creatures you control.\n\
+             Madness—Pay six {C}.",
+        )
+        .expect("Emrakul, the World Anew should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn stage_spell_cast_for_test(game: &mut GameState, object_id: ObjectId, caster: PlayerId) {
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(object_id, caster, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.stage_turn_history_event(&event);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_cast_trigger_gains_control_of_target_players_creatures() {
+    #[derive(Debug)]
+    struct ChoosePlayerDecisionMaker {
+        player: PlayerId,
+    }
+
+    impl DecisionMaker for ChoosePlayerDecisionMaker {
+        fn decide_targets(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<Target> {
+            ctx.requirements
+                .iter()
+                .map(|requirement| {
+                    let target = Target::Player(self.player);
+                    assert!(
+                        requirement.legal_targets.contains(&target),
+                        "chosen Emrakul target player should be legal"
+                    );
+                    target
+                })
+                .collect()
+        }
+    }
+
+    let mut game = setup_three_player_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    let bob_first = create_creature(&mut game, "Bob Creature One", bob, 2, 2);
+    let bob_second = create_creature(&mut game, "Bob Creature Two", bob, 3, 3);
+    let charlie_creature = create_creature(&mut game, "Charlie Creature", charlie, 4, 4);
+    let alice_creature = create_creature(&mut game, "Alice Creature", alice, 1, 1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, alice, Zone::Stack);
+    let (emrakul_stable_id, emrakul_name) = game
+        .object(emrakul_id)
+        .map(|object| (object.stable_id, object.name.clone()))
+        .expect("Emrakul spell should exist on the stack");
+    game.push_to_stack(
+        StackEntry::new(emrakul_id, alice).with_source_info(emrakul_stable_id, emrakul_name),
+    );
+
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(emrakul_id, alice, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+    put_triggers_on_stack_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut ChoosePlayerDecisionMaker { player: bob },
+    )
+    .expect("Emrakul's cast trigger should go on the stack");
+
+    resolve_stack_entry(&mut game).expect("Emrakul's cast trigger should resolve");
+    game.refresh_continuous_state();
+
+    assert_eq!(game.current_controller(bob_first), Some(alice));
+    assert_eq!(game.current_controller(bob_second), Some(alice));
+    assert_eq!(game.current_controller(charlie_creature), Some(charlie));
+    assert_eq!(game.current_controller(alice_creature), Some(alice));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_leaves_trigger_sacrifices_only_your_creatures() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, alice, Zone::Battlefield);
+    let alice_first = create_creature(&mut game, "Alice Creature One", alice, 2, 2);
+    let alice_second = create_creature(&mut game, "Alice Creature Two", alice, 3, 3);
+    let bob_creature = create_creature(&mut game, "Bob Creature", bob, 4, 4);
+
+    game.move_object_by_effect(emrakul_id, Zone::Graveyard)
+        .expect("Emrakul should move to the graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Emrakul's leaves trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Emrakul's leaves trigger should resolve");
+
+    assert!(!game.battlefield.contains(&alice_first));
+    assert!(!game.battlefield.contains(&alice_second));
+    assert!(game.battlefield.contains(&bob_creature));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_protection_rejects_spell_targets() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, bob, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    let spell = CardDefinitionBuilder::new(CardId::from_raw(124_011), "Targeting Spell")
+        .card_types(vec![CardType::Instant])
+        .parse_text("Destroy target creature.")
+        .expect("targeted spell should parse");
+    let spell_id = game.create_object_from_definition(&spell, alice, Zone::Stack);
+    assert!(
+        crate::targeting::has_protection_from_source(&game, emrakul_id, spell_id),
+        "Emrakul should have protection from spell sources"
+    );
+    let entry = StackEntry::new(spell_id, alice).with_targets(vec![Target::Object(emrakul_id)]);
+
+    let (valid_targets, _, all_targets_invalid) = validate_stack_entry_targets(&game, &entry);
+    assert!(valid_targets.is_empty(), "Emrakul should have protection from spells");
+    assert!(all_targets_invalid, "a spell with only Emrakul as target should fizzle");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn emrakul_the_world_anew_protection_only_rejects_permanents_cast_this_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let emrakul = emrakul_the_world_anew_definition();
+    let emrakul_id = game.create_object_from_definition(&emrakul, bob, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    let cast_source = create_creature(&mut game, "Fresh Ability Source", alice, 2, 2);
+    stage_spell_cast_for_test(&mut game, cast_source, alice);
+    let cast_entry = StackEntry::ability(
+        cast_source,
+        alice,
+        vec![Effect::deal_damage(1, ChooseSpec::AnyTarget)],
+    )
+    .with_targets(vec![Target::Object(emrakul_id)]);
+    let (cast_valid_targets, _, cast_all_invalid) = validate_stack_entry_targets(&game, &cast_entry);
+    assert!(
+        cast_valid_targets.is_empty(),
+        "Emrakul should have protection from permanents that were cast this turn"
+    );
+    assert!(cast_all_invalid);
+
+    let old_source = create_creature(&mut game, "Old Ability Source", alice, 2, 2);
+    let old_entry = StackEntry::ability(
+        old_source,
+        alice,
+        vec![Effect::deal_damage(1, ChooseSpec::AnyTarget)],
+    )
+    .with_targets(vec![Target::Object(emrakul_id)]);
+    let (old_valid_targets, _, old_all_invalid) = validate_stack_entry_targets(&game, &old_entry);
+    assert_eq!(
+        old_valid_targets,
+        vec![crate::effects::ResolvedTarget::Object(emrakul_id)],
+        "Emrakul should not have protection from permanents that were not cast this turn"
+    );
+    assert!(!old_all_invalid);
+}
+
 #[test]
 fn test_resolution_player_target_validation_uses_source_lki_for_source_filter() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -14,7 +14,7 @@ use crate::card::{Card, LinkedFaceLayout};
 use crate::cards::CardRegistry;
 use crate::continuous::{
     CalculatedCharacteristics, ContinuousEffect, ContinuousEffectId, ContinuousEffectManager,
-    EffectTarget, Modification,
+    EffectSourceType, EffectTarget, Modification,
 };
 use crate::cost::OptionalCostsPaid;
 use crate::decision::KeywordPaymentContribution;
@@ -5470,6 +5470,11 @@ impl GameState {
             .filter(|effect| matches!(effect.modification, Modification::ChangeController(_)))
         {
             if skipped_effect == Some(effect.id) {
+                continue;
+            }
+            if let EffectSourceType::Resolution { locked_targets } = &effect.source_type
+                && !locked_targets.contains(&id)
+            {
                 continue;
             }
             let can_apply = match &effect.applies_to {

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -116,6 +116,14 @@ impl StaticAbilityKind for Protection {
 }
 
 fn describe_protection_permanent_filter(filter: &ObjectFilter) -> String {
+    if *filter == ObjectFilter::spell() {
+        return "spells".to_string();
+    }
+    let mut cast_this_turn_permanent_filter = ObjectFilter::permanent();
+    cast_this_turn_permanent_filter.cast_this_turn = true;
+    if *filter == cast_this_turn_permanent_filter {
+        return "permanents that were cast this turn".to_string();
+    }
     if filter.card_types.is_empty()
         && filter.all_card_types.is_empty()
         && filter.subtypes.len() == 1

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -321,8 +321,11 @@ pub(crate) fn source_matches_protection_with_view(
         ProtectionFrom::CardType(card_type) => view.object_has_card_type(source.id, *card_type),
         // Protection from permanents matching a filter
         ProtectionFrom::Permanents(filter) => {
-            // Use active player for context since we don't have a specific controller
-            let filter_ctx = game.filter_context_for(game.turn.active_player, None);
+            let controller = game.controller_of(source);
+            let mut filter_ctx = game.filter_context_for(controller, Some(source.id));
+            if source.zone == Zone::Stack {
+                filter_ctx.caster = Some(controller);
+            }
             filter.matches(source, &filter_ctx, game)
         }
         // Protection from everything
@@ -347,7 +350,10 @@ fn source_snapshot_matches_protection(
         ProtectionFrom::ChosenColor => false,
         ProtectionFrom::CardType(card_type) => source.card_types.contains(card_type),
         ProtectionFrom::Permanents(filter) => {
-            let filter_ctx = game.filter_context_for(game.turn.active_player, None);
+            let mut filter_ctx = game.filter_context_for(source.controller, Some(source.object_id));
+            if source.zone == Zone::Stack {
+                filter_ctx.caster = Some(source.controller);
+            }
             filter.matches_snapshot(source, &filter_ctx, game)
         }
         ProtectionFrom::Everything => true,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Emrakul, the World Anew
Initial parse error:
```
parser does not yet support line family: 'Flying, protection from spells and from permanents that were cast this turn'; oracle-only fallback also failed: parser does not yet support line family: 'Flying, protection from spells and from permanents that were cast this turn'
```

Current worker: i-0d5c5c29c979d7cd0
Branch: codex/aws-card-fix-emrakul-the-world-anew
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0001
