### PR TITLE
Fix Ironsmith parse failure: Fiery Emancipation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -314,8 +314,13 @@ const WOULD_DEAL_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["would", "deal", "damage", "to"]);
 const WOULD_DEAL_DAMAGE_TO_YOU_PHRASE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["would", "deal", "damage", "to", "you"]);
-const IT_DEALS_DOUBLE_THAT_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> =
-    clause_shape!(exact & ["it", "deals", "double", "that", "damage", "to"]);
+const IT_DEALS_MULTIPLE_THAT_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["it", "deals", "double", "that", "damage", "to"],
+            &["it", "deals", "triple", "that", "damage", "to"],
+        ]
+);
 const THAT_SOURCE_DEALS_DAMAGE_EQUAL_TO_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["that", "source", "deals", "damage", "equal", "to"]);
 const DAMAGE_REDIRECT_TO_SOURCE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -4861,11 +4866,16 @@ pub(crate) fn parse_double_damage_amount_replacement_line(
     }
 
     let Some(tail_idx) = find_window_by(&words[would_idx + 4..], 6, |window| {
-        IT_DEALS_DOUBLE_THAT_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
+        IT_DEALS_MULTIPLE_THAT_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
     }) else {
         return Ok(None);
     };
     let replacement_start = would_idx + 4 + tail_idx;
+    let factor = match words.get(replacement_start + 2).copied() {
+        Some("double") => 2,
+        Some("triple") => 3,
+        _ => return Ok(None),
+    };
     let damaged_words = &words[would_idx + 4..replacement_start];
     let replacement_target_words = &words[replacement_start + 6..];
     if damaged_words.is_empty()
@@ -4910,10 +4920,11 @@ pub(crate) fn parse_double_damage_amount_replacement_line(
         display.push('.');
     }
 
-    Ok(Some(StaticAbility::double_damage_amount_replacement(
+    Ok(Some(StaticAbility::multiply_damage_amount_replacement(
         source_filter,
         target_player_filter,
         target_object_filter,
+        factor,
         display,
     )))
 }

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -455,6 +455,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         source_filter: ObjectFilter,
         target_player_filter: Option<PlayerFilter>,
         target_object_filter: Option<ObjectFilter>,
+        factor: u32,
         display: String,
     },
     DoubleCountersReplacement {
@@ -1362,11 +1363,13 @@ where
                 source_filter,
                 target_player_filter,
                 target_object_filter,
+                factor,
                 display,
             } => StaticAbilityPayload::DoubleDamageAmountReplacement {
                 source_filter,
                 target_player_filter,
                 target_object_filter,
+                factor,
                 display,
             },
             StaticAbilityPayload::DoubleCountersReplacement {
@@ -3775,6 +3778,22 @@ impl<
         target_object_filter: Option<ObjectFilter>,
         display: impl Into<String>,
     ) -> Self {
+        Self::multiply_damage_amount_replacement(
+            source_filter,
+            target_player_filter,
+            target_object_filter,
+            2,
+            display,
+        )
+    }
+
+    pub fn multiply_damage_amount_replacement(
+        source_filter: ObjectFilter,
+        target_player_filter: Option<PlayerFilter>,
+        target_object_filter: Option<ObjectFilter>,
+        factor: u32,
+        display: impl Into<String>,
+    ) -> Self {
         let display = display.into();
         Self {
             id: Some(StaticAbilityId::ModifyDamageAmountReplacement),
@@ -3783,6 +3802,7 @@ impl<
                 source_filter,
                 target_player_filter,
                 target_object_filter,
+                factor,
                 display,
             },
         }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -19782,6 +19782,114 @@ fn parse_oracle_healing_grace_strict_and_keeps_source_choice_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn fiery_emancipation_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Fiery Emancipation");
+    let def = parse_oracle_card_definition("Fiery Emancipation");
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "If a source you control would deal damage to a permanent or player, it deals triple that damage to that permanent or player instead"
+        ),
+        "expected Fiery Emancipation triple-damage replacement wording, got {rendered}"
+    );
+    assert!(
+        debug.contains("DoubleDamageAmountReplacement")
+            && debug.contains("factor: 3")
+            && debug.contains("source_filter")
+            && debug.contains("target_player_filter")
+            && debug.contains("target_object_filter"),
+        "expected Fiery Emancipation to compile to a factor-3 damage replacement, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn fiery_emancipation_triples_only_damage_from_sources_you_control() {
+    let fiery = parse_oracle_card_definition("Fiery Emancipation");
+    let alice_source = CardDefinitionBuilder::new(CardId::from_raw(91_300), "Alice Damage Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let bob_source = CardDefinitionBuilder::new(CardId::from_raw(91_301), "Bob Damage Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target = CardDefinitionBuilder::new(CardId::from_raw(91_302), "Bob Target Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let fiery_id = game.create_object_from_definition(&fiery, alice, Zone::Battlefield);
+    let alice_source_id = game.create_object_from_definition(&alice_source, alice, Zone::Battlefield);
+    let bob_source_id = game.create_object_from_definition(&bob_source, bob, Zone::Battlefield);
+    let target_id = game.create_object_from_definition(&target, bob, Zone::Battlefield);
+
+    game.update_replacement_effects();
+    assert!(
+        game.effect_store
+            .replacement_effects
+            .effects()
+            .iter()
+            .any(|replacement| {
+                replacement.source == fiery_id
+                    && matches!(
+                        replacement.replacement,
+                        crate::replacement::ReplacementAction::Modify(
+                            crate::replacement::EventModification::Multiply(3)
+                        )
+                    )
+            }),
+        "Fiery Emancipation should register a factor-3 damage replacement"
+    );
+
+    let (player_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        alice_source_id,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        player_damage, 6,
+        "damage from an Alice-controlled source to a player should be tripled"
+    );
+
+    let (permanent_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        alice_source_id,
+        crate::events::DamageTarget::Object(target_id),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        permanent_damage, 9,
+        "damage from an Alice-controlled source to a permanent should be tripled"
+    );
+
+    let (opponent_source_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        bob_source_id,
+        crate::events::DamageTarget::Player(alice),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        opponent_source_damage, 4,
+        "damage from a source Alice does not control should not be tripled"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn sphere_of_truth_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Sphere of Truth");
     let def = parse_oracle_card_definition("Sphere of Truth");

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3529,6 +3529,7 @@ pub struct DoubleDamageAmountReplacement {
     pub source_filter: ObjectFilter,
     pub target_player_filter: Option<PlayerFilter>,
     pub target_object_filter: Option<ObjectFilter>,
+    pub factor: u32,
     pub display: String,
 }
 
@@ -3537,12 +3538,14 @@ impl DoubleDamageAmountReplacement {
         source_filter: ObjectFilter,
         target_player_filter: Option<PlayerFilter>,
         target_object_filter: Option<ObjectFilter>,
+        factor: u32,
         display: impl Into<String>,
     ) -> Self {
         Self {
             source_filter,
             target_player_filter,
             target_object_filter,
+            factor,
             display: display.into(),
         }
     }
@@ -3573,7 +3576,7 @@ impl StaticAbilityKind for DoubleDamageAmountReplacement {
                 noncombat_only: false,
                 amount_less_than: None,
             },
-            ReplacementAction::Double,
+            ReplacementAction::Modify(EventModification::Multiply(self.factor)),
         ))
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2911,10 +2911,27 @@ impl StaticAbility {
         target_object_filter: Option<crate::target::ObjectFilter>,
         display: String,
     ) -> Self {
+        Self::multiply_damage_amount_replacement(
+            source_filter,
+            target_player_filter,
+            target_object_filter,
+            2,
+            display,
+        )
+    }
+
+    pub fn multiply_damage_amount_replacement(
+        source_filter: crate::target::ObjectFilter,
+        target_player_filter: Option<crate::target::PlayerFilter>,
+        target_object_filter: Option<crate::target::ObjectFilter>,
+        factor: u32,
+        display: String,
+    ) -> Self {
         Self::new(DoubleDamageAmountReplacement::new(
             source_filter,
             target_player_filter,
             target_object_filter,
+            factor,
             display,
         ))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1338,11 +1338,13 @@ impl StaticAbilityModelInterpreter {
                 source_filter,
                 target_player_filter,
                 target_object_filter,
+                factor,
                 display,
-            } => StaticAbility::double_damage_amount_replacement(
+            } => StaticAbility::multiply_damage_amount_replacement(
                 source_filter.clone(),
                 target_player_filter.clone(),
                 target_object_filter.clone(),
+                *factor,
                 display.clone(),
             ),
             ironsmith_core::StaticAbilityPayload::DoubleCountersReplacement {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Fiery Emancipation
Initial parse error:
```
missing damage amount (clause: 'triple that damage to that permanent or player instead'); oracle-only fallback also failed: missing damage amount (clause: 'triple that damage to that permanent or player instead')
```

Current worker: i-079db62527c17157f
Branch: codex/aws-card-fix-fiery-emancipation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0001
