### PR TITLE
Fix Ironsmith parse failure: Geode Golem

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -1843,6 +1843,34 @@ fn parse_cast_with_tagged_mana_value_limit_clause(
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
+        if from_idx + 4 == without_idx
+            && normalized_words
+                .get(from_idx + 1)
+                .is_some_and(|word| word == "the")
+            && normalized_words
+                .get(from_idx + 2)
+                .is_some_and(|word| word == "command")
+            && normalized_words
+                .get(from_idx + 3)
+                .is_some_and(|word| word == "zone")
+            && WITHOUT_PAYING_ITS_MANA_COST_PATTERN.matches_words(&without_tail)
+        {
+            let Some(filter_end) = token_index_for_word_index(rest_tokens, from_idx) else {
+                return Ok(None);
+            };
+            let filter_words = token_word_refs(trim_lexed_commas(&rest_tokens[..filter_end]));
+            if filter_words == ["your", "commander"] {
+                return Ok(Some(
+                    EffectAst::may_cast_matching_spell_without_paying_mana_cost(
+                        lead.player,
+                        ObjectFilter::default()
+                            .commander()
+                            .owned_by(crate::target::PlayerFilter::You),
+                        Zone::Command,
+                    ),
+                ));
+            }
+        }
         if from_idx + 3 == without_idx
             && normalized_words
                 .get(from_idx + 1)

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4692,6 +4692,47 @@ fn rewrite_lexed_permission_helpers_route_singular_hand_free_casts_to_one_shot_e
 }
 
 #[test]
+fn rewrite_lexed_parse_commander_command_zone_free_cast_clause() {
+    let tokens = lex_line(
+        "You may cast your commander from the command zone without paying its mana cost",
+        0,
+    )
+    .expect("rewrite lexer should classify commander command-zone free-cast clause");
+
+    let effects = parse_effect_sentence_lexed(&tokens)
+        .expect("commander command-zone free-cast clause should parse");
+
+    let (player, filter, zone) = match effects.as_slice() {
+        [crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+            player,
+            filter,
+            zone,
+            ..
+        }] => (player, filter, zone),
+        [crate::cards::builders::EffectAst::MayByPlayer {
+            player: crate::cards::builders::PlayerAst::You,
+            effects,
+        }] => match effects.as_slice() {
+            [crate::cards::builders::EffectAst::MayCastMatchingSpellWithoutPayingManaCost {
+                player,
+                filter,
+                zone,
+                ..
+            }] => (player, filter, zone),
+            _ => panic!("expected nested commander command-zone free-cast effect, got {effects:#?}"),
+        },
+        _ => panic!("expected commander command-zone free-cast effect, got {effects:#?}"),
+    };
+    assert!(matches!(
+        player,
+        crate::cards::builders::PlayerAst::Implicit | crate::cards::builders::PlayerAst::You
+    ));
+    assert_eq!(*zone, crate::zone::Zone::Command);
+    assert!(filter.is_commander, "expected commander filter, got {filter:#?}");
+    assert_eq!(filter.owner, Some(crate::target::PlayerFilter::You));
+}
+
+#[test]
 fn rewrite_lexed_parse_cast_target_graveyard_without_paying_mana_cost() {
     let tokens = lex_line(
         "Cast target instant, sorcery, or artifact card from your graveyard without paying its mana cost",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -58193,6 +58193,44 @@ fn mindleech_mass_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn geode_golem_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Geode Golem");
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Geode Golem should have a combat-damage trigger");
+    assert_eq!(
+        triggered.trigger.display(),
+        "Whenever this creature deals combat damage to a player"
+    );
+
+    let abilities_debug = format!("{:?}", def.abilities);
+    assert!(
+        abilities_debug.contains("MayCastMatchingSpellWithoutPayingManaCostEffect")
+            && abilities_debug.contains("zone: Command")
+            && abilities_debug.contains("is_commander: true"),
+        "expected Geode Golem to lower to command-zone commander free-cast effect, got {abilities_debug}"
+    );
+
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("trample")
+            && rendered_lower.contains("whenever this creature deals combat damage to a player")
+            && rendered_lower.contains(
+                "you may cast your commander from the command zone without paying its mana cost"
+            ),
+        "expected Geode Golem compiled text to preserve the command-zone commander free-cast clause, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn minds_dilation_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Mind's Dilation");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -36135,7 +36135,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             );
         }
 
-        let mut spell_text = if let Some(kind) = may_cast_matching.filter.alternative_cast {
+        let mut spell_text = if may_cast_matching.filter
+            == crate::target::ObjectFilter::default()
+                .commander()
+                .owned_by(crate::target::PlayerFilter::You)
+        {
+            "your commander".to_string()
+        } else if let Some(kind) = may_cast_matching.filter.alternative_cast {
             format!("a spell with {}", alternative_cast_kind_text(kind))
         } else if !may_cast_matching.filter.card_types.is_empty() {
             let card_type_words: Vec<String> = may_cast_matching
@@ -36164,6 +36170,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else if !spell_text.starts_with("a ")
             && !spell_text.starts_with("an ")
             && !spell_text.starts_with("the ")
+            && !spell_text.starts_with("your ")
         {
             spell_text = format!("a {spell_text}");
         }

--- a/crates/ironsmith-runtime/src/effects/player/may_cast_matching_spell.rs
+++ b/crates/ironsmith-runtime/src/effects/player/may_cast_matching_spell.rs
@@ -43,7 +43,8 @@ fn object_ids_in_zone(game: &GameState, player: PlayerId, zone: Zone) -> Vec<Obj
         Zone::Exile => game.exile.clone(),
         Zone::Battlefield => game.battlefield.clone(),
         Zone::Stack => game.stack.iter().map(|entry| entry.object_id).collect(),
-        Zone::Command | Zone::OutsideGame => Vec::new(),
+        Zone::Command => game.command_zone.clone(),
+        Zone::OutsideGame => Vec::new(),
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26586,6 +26586,187 @@ fn mindleech_mass_casts_spell_from_damaged_players_hand_without_paying() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn geode_golem_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(627_850), "Geode Golem")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(5)]]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .subtypes(vec![Subtype::Golem])
+        .power_toughness(PowerToughness::fixed(5, 3))
+        .parse_text(
+            "Trample\nWhenever this creature deals combat damage to a player, you may cast your commander from the command zone without paying its mana cost.",
+        )
+        .expect("Geode Golem should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_geode_golem_damage_trigger(
+    game: &mut GameState,
+    definition: &crate::cards::CardDefinition,
+    source_id: ObjectId,
+    damaged_player: PlayerId,
+    dm: &mut dyn DecisionMaker,
+) {
+    let controller = game
+        .controller_of_id(source_id)
+        .expect("Geode Golem should have a controller");
+    let triggered = definition
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Geode Golem should have a combat damage trigger");
+
+    let damage_event = TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            source_id,
+            crate::events::DamageTarget::Player(damaged_player),
+            5,
+            true,
+            crate::events::cause::EventCause::combat_damage(source_id),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = ExecutionContext::new_default(source_id, controller)
+        .with_decision_maker(dm)
+        .with_triggering_event(damage_event);
+    for effect in &triggered.effects {
+        execute_effect(game, effect, &mut ctx).expect("Geode Golem trigger should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn geode_golem_damage_trigger_casts_your_commander_from_command_zone_without_mana() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let definition = geode_golem_definition();
+    let geode_id = game.create_object_from_definition(&definition, alice, Zone::Battlefield);
+
+    let opponents_commander =
+        CardBuilder::new(CardId::from_raw(627_849), "Bob's Geode Commander")
+            .supertypes(vec![Supertype::Legendary])
+            .card_types(vec![CardType::Creature])
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+            .build();
+    let opponents_commander_id =
+        game.create_object_from_card(&opponents_commander, bob, Zone::Command);
+    game.set_as_commander(opponents_commander_id, bob);
+
+    let noncommander = CardBuilder::new(
+        CardId::from_raw(627_848),
+        "Geode Command-Zone Noncommander",
+    )
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    let noncommander_id =
+        game.create_object_from_card(&noncommander, alice, Zone::Command);
+
+    let commander = CardBuilder::new(CardId::from_raw(627_851), "Geode Test Commander")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    let commander_id = game.create_object_from_card(&commander, alice, Zone::Command);
+    game.set_as_commander(commander_id, alice);
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_geode_golem_damage_trigger(&mut game, &definition, geode_id, bob, &mut dm);
+
+    let stack_entry = game
+        .stack
+        .last()
+        .expect("accepting Geode Golem should cast the commander onto the stack");
+    let stack_object = game
+        .object(stack_entry.object_id)
+        .expect("cast commander should exist on the stack");
+    assert_eq!(stack_object.name, "Geode Test Commander");
+    assert_eq!(stack_entry.controller, alice);
+    assert_eq!(
+        stack_entry.casting_method,
+        crate::alternative_cast::CastingMethod::PlayFrom {
+            source: geode_id,
+            zone: Zone::Command,
+            use_alternative: None,
+        }
+    );
+    assert_eq!(
+        game.commander_cast_count(commander_id),
+        1,
+        "effect-driven command-zone casts should update commander cast count"
+    );
+    assert_eq!(
+        game.object(opponents_commander_id)
+            .expect("opponent commander should remain in the command zone")
+            .zone,
+        Zone::Command,
+        "Geode Golem should not offer an opponent's commander"
+    );
+    assert_eq!(
+        game.object(noncommander_id)
+            .expect("noncommander should remain in the command zone")
+            .zone,
+        Zone::Command,
+        "Geode Golem should not offer noncommander command-zone objects"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn geode_golem_damage_trigger_does_not_cast_when_declined_or_no_commander_exists() {
+    let mut declined_game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let definition = geode_golem_definition();
+    let geode_id =
+        declined_game.create_object_from_definition(&definition, alice, Zone::Battlefield);
+    let commander = CardBuilder::new(CardId::from_raw(627_852), "Declined Geode Commander")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .build();
+    let commander_id = declined_game.create_object_from_card(&commander, alice, Zone::Command);
+    declined_game.set_as_commander(commander_id, alice);
+
+    let mut decline_dm = AutoPassDecisionMaker;
+    resolve_geode_golem_damage_trigger(
+        &mut declined_game,
+        &definition,
+        geode_id,
+        bob,
+        &mut decline_dm,
+    );
+    assert!(declined_game.stack.is_empty());
+    assert_eq!(
+        declined_game
+            .object(commander_id)
+            .expect("declined commander should remain in command zone")
+            .zone,
+        Zone::Command
+    );
+
+    let mut no_commander_game = setup_game();
+    let geode_id =
+        no_commander_game.create_object_from_definition(&definition, alice, Zone::Battlefield);
+    let mut accept_dm = SelectFirstDecisionMaker;
+    resolve_geode_golem_damage_trigger(
+        &mut no_commander_game,
+        &definition,
+        geode_id,
+        bob,
+        &mut accept_dm,
+    );
+    assert!(
+        no_commander_game.stack.is_empty(),
+        "Geode Golem should not cast anything when you have no commander in the command zone"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn mindleech_mass_declining_look_prevents_free_cast_branch() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Geode Golem
Initial parse error:
```
could not find verb in effect clause (clause: 'cast your commander from the command zone without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'cast your commander from the command zone without paying its mana cost'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0e33879833fe0931a
Branch: codex/aws-card-fix-geode-golem
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0001
