### PR TITLE
Fix Ironsmith parse failure: Mistmeadow Skulk

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -30,6 +30,7 @@ use super::util::{
     parse_card_type, parse_color, parse_filter_counter_constraint_words,
     parse_flashback_keyword_line, parse_subtype_flexible, strip_leading_word_refs_any, trim_commas,
 };
+use super::value_helpers::parse_filter_comparison_tokens;
 
 const PROTECTION_FROM_COLORED_SPELLS_PATTERN: ClauseShape<'static> = clause_shape!(
     exact
@@ -250,6 +251,20 @@ fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<KeywordAction>
             let filter_tokens = trim_commas(&tokens[filter_start..]);
             let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
             return Some(KeywordAction::ProtectionFromEachManaValueAmong(filter));
+        }
+        if value == "mana" && words.get(idx + 2).copied() == Some("value") {
+            let comparison_tail = words.get(idx + 3..)?;
+            let (comparison, consumed) = parse_filter_comparison_tokens(
+                "mana value",
+                comparison_tail,
+                words,
+            )
+            .ok()??;
+            if consumed == comparison_tail.len() {
+                let mut filter = ObjectFilter::default();
+                filter.mana_value = Some(comparison);
+                return Some(KeywordAction::ProtectionFromFilter(filter));
+            }
         }
         if PERMANENT_OR_PERMANENTS_WORD_PATTERN.matches_word(value)
             && words
@@ -605,6 +620,20 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
                 let filter_tokens = trim_commas(&tokens[filter_start..]);
                 let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
                 return Some(KeywordAction::ProtectionFromEachManaValueAmong(filter));
+            }
+            if value == "mana" && words.get(idx + 2).copied() == Some("value") {
+                let comparison_tail = words.get(idx + 3..)?;
+                let (comparison, consumed) = parse_filter_comparison_tokens(
+                    "mana value",
+                    comparison_tail,
+                    &words,
+                )
+                .ok()??;
+                if consumed == comparison_tail.len() {
+                    let mut filter = ObjectFilter::default();
+                    filter.mana_value = Some(comparison);
+                    return Some(KeywordAction::ProtectionFromFilter(filter));
+                }
             }
             if PERMANENT_OR_PERMANENTS_WORD_PATTERN.matches_word(value)
                 && words

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
@@ -105,6 +105,20 @@ pub(crate) fn parse_protection_chain(tokens: &[OwnedLexToken]) -> Option<Vec<Key
             let filter = parse_object_filter_lexed(&filter_tokens, false).ok()?;
             return Some(KeywordAction::ProtectionFromEachManaValueAmong(filter));
         }
+        if value == "mana" && words.get(idx + 2).copied() == Some("value") {
+            let comparison_tail = words.get(idx + 3..)?;
+            let (comparison, consumed) = parse_filter_comparison_tokens(
+                "mana value",
+                comparison_tail,
+                words,
+            )
+            .ok()??;
+            if consumed == comparison_tail.len() {
+                let mut filter = ObjectFilter::default();
+                filter.mana_value = Some(comparison);
+                return Some(KeywordAction::ProtectionFromFilter(filter));
+            }
+        }
         if KEYWORD_PERMANENT_OR_PERMANENTS_WORD_PATTERN.matches_word(value)
             && KEYWORD_WITH_WORD_PATTERN.matches_word_at(words, idx + 2)
         {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -114,7 +114,7 @@ use super::util::{
     word_refs_at_is_article, words,
 };
 use super::util::{source_choose_spec_for_surface, source_reference_surface_for_words};
-use super::value_helpers::parse_commander_cast_count_player;
+use super::value_helpers::{parse_commander_cast_count_player, parse_filter_comparison_tokens};
 #[allow(unused_imports)]
 use crate::ability::{Ability, AbilityKind, TriggeredAbility};
 #[allow(unused_imports)]

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -7778,6 +7778,24 @@ fn rewrite_lexed_keyword_line_parses_protection_from_permanents_with_named_count
 }
 
 #[test]
+fn rewrite_lexed_keyword_line_parses_protection_from_mana_value_comparison() {
+    let protection_tokens = lex_line("Protection from mana value 3 or greater", 0)
+        .expect("rewrite lexer should classify mana-value protection");
+
+    let parsed = super::clause_support::parse_ability_line_lexed(&protection_tokens)
+        .expect("mana-value protection should parse");
+    assert_eq!(parsed.len(), 1, "{parsed:?}");
+
+    let crate::cards::builders::KeywordAction::ProtectionFromFilter(filter) = &parsed[0] else {
+        panic!("expected protection-from-filter action, got {parsed:?}");
+    };
+    assert_eq!(
+        filter.mana_value,
+        Some(crate::filter::Comparison::GreaterThanOrEqual(3))
+    );
+}
+
+#[test]
 fn rewrite_lexed_keyword_line_routes_separator_lists_through_grammar_primitives() {
     let keyword_tokens = lex_line("Flying, vigilance; trample and haste", 0)
         .expect("rewrite lexer should classify mixed keyword separator line");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45076,6 +45076,63 @@ fn assert_oracle_card_parses_strict(name: &str) {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mistmeadow_skulk_strict_parser_text_structure_and_runtime_regression() {
+    let def = parse_oracle_card_definition("Mistmeadow Skulk");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Lifelink, protection from mana value 3 or greater"),
+        "expected Mistmeadow Skulk to render its lifelink and mana-value protection clause, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("Lifelink")
+            && ability_debug.contains("Protection")
+            && ability_debug.contains("GreaterThanOrEqual(3)"),
+        "expected Mistmeadow Skulk to lower into lifelink plus mana-value protection, got {ability_debug}"
+    );
+
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let skulk_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    assert!(
+        game.current_has_static_ability_id(skulk_id, StaticAbilityId::Lifelink),
+        "Mistmeadow Skulk should have lifelink on the battlefield"
+    );
+    assert!(
+        game.current_has_static_ability_id(skulk_id, StaticAbilityId::Protection),
+        "Mistmeadow Skulk should have protection on the battlefield"
+    );
+
+    let high_mana_value_spell = CardDefinitionBuilder::new(CardId::new(), "Mana Value Three Bolt")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let high_source_id =
+        game.create_object_from_definition(&high_mana_value_spell, bob, Zone::Stack);
+    assert!(
+        crate::targeting::computation::has_protection_from_source(
+            &game,
+            skulk_id,
+            high_source_id,
+        ),
+        "Mistmeadow Skulk should be protected from a source with mana value 3"
+    );
+
+    let low_mana_value_spell = CardDefinitionBuilder::new(CardId::new(), "Mana Value Two Bolt")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let low_source_id = game.create_object_from_definition(&low_mana_value_spell, bob, Zone::Stack);
+    assert!(
+        !crate::targeting::computation::has_protection_from_source(&game, skulk_id, low_source_id),
+        "Mistmeadow Skulk should not be protected from a source with mana value 2"
+    );
+}
+
 #[test]
 fn departed_deckhand_strict_parser_text_and_structure_regression() {
     let def = parse_oracle_card_definition("Departed Deckhand");
@@ -50679,6 +50736,7 @@ strict_parse_card_expected_fail_test!(
 );
 strict_parse_card_expected_fail_test!(strict_parse_lake_of_the_dead, "Lake of the Dead");
 strict_parse_card_test!(strict_parse_maskwood_nexus, "Maskwood Nexus");
+strict_parse_card_test!(strict_parse_mistmeadow_skulk, "Mistmeadow Skulk");
 strict_parse_card_test!(strict_parse_mox_amber, "Mox Amber");
 strict_parse_card_test!(strict_parse_nesting_grounds, "Nesting Grounds");
 strict_parse_card_test!(strict_parse_nine_lives_familiar, "Nine-Lives Familiar");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45114,12 +45114,21 @@ fn mistmeadow_skulk_strict_parser_text_structure_and_runtime_regression() {
     let high_source_id =
         game.create_object_from_definition(&high_mana_value_spell, bob, Zone::Stack);
     assert!(
-        crate::targeting::computation::has_protection_from_source(
+        crate::targeting::has_protection_from_source(
             &game,
             skulk_id,
             high_source_id,
         ),
         "Mistmeadow Skulk should be protected from a source with mana value 3"
+    );
+    assert!(
+        matches!(
+            crate::targeting::can_target_object(&game, skulk_id, high_source_id, bob),
+            crate::targeting::TargetingResult::Invalid(
+                crate::targeting::TargetingInvalidReason::HasProtection
+            )
+        ),
+        "Mistmeadow Skulk should be an illegal target for a source with mana value 3"
     );
 
     let low_mana_value_spell = CardDefinitionBuilder::new(CardId::new(), "Mana Value Two Bolt")
@@ -45128,8 +45137,12 @@ fn mistmeadow_skulk_strict_parser_text_structure_and_runtime_regression() {
         .build();
     let low_source_id = game.create_object_from_definition(&low_mana_value_spell, bob, Zone::Stack);
     assert!(
-        !crate::targeting::computation::has_protection_from_source(&game, skulk_id, low_source_id),
+        !crate::targeting::has_protection_from_source(&game, skulk_id, low_source_id),
         "Mistmeadow Skulk should not be protected from a source with mana value 2"
+    );
+    assert!(
+        crate::targeting::can_target_object(&game, skulk_id, low_source_id, bob).is_legal(),
+        "Mistmeadow Skulk should remain targetable by a source with mana value 2"
     );
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -148,6 +148,17 @@ fn pluralize_leading_subject(description: &str) -> Option<String> {
 }
 
 fn describe_protection_permanent_filter(filter: &ObjectFilter) -> String {
+    if filter.mana_value.is_some() {
+        let mut without_mana_value = filter.clone();
+        without_mana_value.mana_value = None;
+        if without_mana_value == ObjectFilter::default() {
+            let description = filter.description();
+            if let Some(stripped) = description.strip_prefix("permanent with ") {
+                return stripped.to_string();
+            }
+        }
+    }
+
     if filter.card_types.is_empty()
         && filter.all_card_types.is_empty()
         && filter.subtypes.len() == 1


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mistmeadow Skulk
Initial parse error:
```
parser does not yet support line family: 'Lifelink, protection from mana value 3 or greater'; oracle-only fallback also failed: parser does not yet support line family: 'Lifelink, protection from mana value 3 or greater'
```

Current worker: i-09d1e833ff3ada9a4
Branch: codex/aws-card-fix-mistmeadow-skulk
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0004
