### PR TITLE
Fix Ironsmith parse failure: Nymris, Oona's Trickster

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -501,6 +501,9 @@ const PUT_ONE_LOOKED_CARD_INTO_HAND_PATTERN: ClauseShape<'static> = clause_shape
     prefix_any
         & [
             &["put", "one", "of", "them", "into", "your", "hand"],
+            &[
+                "put", "one", "of", "those", "cards", "into", "your", "hand",
+            ],
             &["put", "one", "into", "your", "hand"],
         ]
 );

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -207,6 +207,53 @@ fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn nymris_oonas_trickster_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Nymris, Oona's Trickster");
+
+    let def = parse_oracle_card_definition("Nymris, Oona's Trickster");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Flash, flying"),
+        "Nymris should preserve its keywords, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever you cast your first spell during each opponent's turn, look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard."
+        ),
+        "Nymris should render its first-spell loot trigger, got {rendered}"
+    );
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Nymris should have a triggered ability");
+    assert_eq!(
+        triggered.trigger.display(),
+        "Whenever you cast your first spell during each opponent's turn"
+    );
+    let effects_debug = format!("{:#?}", triggered.effects.flattened_default_effects());
+    assert!(
+        ability_debug.contains("SpellCastTrigger")
+            && ability_debug.contains("during_turn: Some(")
+            && ability_debug.contains("Opponent"),
+        "expected Nymris to lower to a spell-cast trigger during opponents' turns, got {ability_debug}"
+    );
+    assert!(
+        effects_debug.contains("LookAtTopCardsEffect")
+            && effects_debug.contains("ChooseObjectsEffect")
+            && effects_debug.contains("MoveToZoneEffect")
+            && effects_debug.contains("Hand,")
+            && effects_debug.contains("Graveyard,"),
+        "expected Nymris to look at two cards, choose one for hand, and move the other to graveyard, got {effects_debug}"
+    );
+}
+
+#[test]
 fn archon_of_coronation_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Archon of Coronation");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -25532,7 +25532,7 @@ pub(super) fn describe_look_at_top_then_put_into_hand_rest_graveyard(
     {
         if n == 1 && look_at_top.count == Value::Fixed(2) {
             return Some(format!(
-                "{opener} the top {count_text} {noun} of {owner} library. Put one of them into {hand} hand and the other into {owner} graveyard"
+                "{opener} the top {count_text} {noun} of {owner} library. Put one of those cards into {hand} hand and the other into {owner} graveyard"
             ));
         }
         let chosen = match n {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -270,6 +270,24 @@ fn minds_dilation_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn nymris_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(658_546), "Nymris, Oona's Trickster")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 6))
+        .parse_text(
+            "Flash\n\
+             Flying\n\
+             Whenever you cast your first spell during each opponent's turn, look at the top two cards of your library. Put one of those cards into your hand and the other into your graveyard.",
+        )
+        .expect("Nymris, Oona's Trickster should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn necrotic_ooze_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(645_500), "Necrotic Ooze")
         .card_types(vec![CardType::Creature])
@@ -5808,6 +5826,178 @@ fn queue_minds_dilation_spell_cast(
     );
     queue_triggers_from_event(game, trigger_queue, event, false);
     spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn queue_nymris_spell_cast(
+    game: &mut GameState,
+    caster: PlayerId,
+    trigger_queue: &mut TriggerQueue,
+) -> ObjectId {
+    let spell_id = game.create_object_from_card(
+        &CardBuilder::new(CardId::new(), "Nymris Trigger Probe Spell")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+            .card_types(vec![CardType::Instant])
+            .build(),
+        caster,
+        Zone::Stack,
+    );
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, caster, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(game, trigger_queue, event, false);
+    spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_nymris_library_card(
+    game: &mut GameState,
+    owner: PlayerId,
+    name: &str,
+) -> crate::ids::StableId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Instant])
+        .build();
+    let id = game.create_object_from_card(&card, owner, Zone::Library);
+    game.object(id).expect("Nymris library card exists").stable_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nymris_first_spell_on_opponents_turn_moves_one_top_card_to_hand_and_one_to_graveyard() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let nymris = nymris_definition();
+    game.create_object_from_definition(&nymris, alice, Zone::Battlefield);
+    let bottom_stable = create_nymris_library_card(&mut game, alice, "Nymris Bottom Card");
+    let top_one_stable = create_nymris_library_card(&mut game, alice, "Nymris Top Card One");
+    let top_two_stable = create_nymris_library_card(&mut game, alice, "Nymris Top Card Two");
+
+    let mut trigger_queue = TriggerQueue::new();
+    queue_nymris_spell_cast(&mut game, alice, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Nymris should trigger for your first spell during an opponent's turn"
+    );
+    assert_eq!(
+        trigger_queue.entries[0].ability.trigger.display(),
+        "Whenever you cast your first spell during each opponent's turn"
+    );
+
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Nymris trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Nymris trigger should resolve");
+
+    let top_one_id = game
+        .find_object_by_stable_id(top_one_stable)
+        .expect("first looked-at card should still exist");
+    let top_two_id = game
+        .find_object_by_stable_id(top_two_stable)
+        .expect("second looked-at card should still exist");
+    let hand = &game.player(alice).expect("alice exists").hand;
+    let graveyard = &game.player(alice).expect("alice exists").graveyard;
+    assert_eq!(
+        usize::from(hand.contains(&top_one_id)) + usize::from(hand.contains(&top_two_id)),
+        1,
+        "exactly one of the two looked-at cards should move to Alice's hand"
+    );
+    assert_eq!(
+        usize::from(graveyard.contains(&top_one_id)) + usize::from(graveyard.contains(&top_two_id)),
+        1,
+        "the other looked-at card should move to Alice's graveyard"
+    );
+
+    let bottom_id = game
+        .find_object_by_stable_id(bottom_stable)
+        .expect("bottom card should still exist");
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .library
+            .contains(&bottom_id),
+        "Nymris should only move the top two library cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nymris_ignores_your_spell_during_your_own_turn() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let nymris = nymris_definition();
+    game.create_object_from_definition(&nymris, alice, Zone::Battlefield);
+
+    let mut trigger_queue = TriggerQueue::new();
+    queue_nymris_spell_cast(&mut game, alice, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        0,
+        "Nymris should not trigger for your spell during your own turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nymris_ignores_opponents_spell_during_that_opponents_turn() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let nymris = nymris_definition();
+    game.create_object_from_definition(&nymris, alice, Zone::Battlefield);
+
+    let mut trigger_queue = TriggerQueue::new();
+    queue_nymris_spell_cast(&mut game, bob, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        0,
+        "Nymris should not trigger for an opponent casting a spell"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nymris_ignores_your_second_spell_during_same_opponents_turn() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let nymris = nymris_definition();
+    game.create_object_from_definition(&nymris, alice, Zone::Battlefield);
+
+    let mut first_queue = TriggerQueue::new();
+    queue_nymris_spell_cast(&mut game, alice, &mut first_queue);
+    assert_eq!(first_queue.entries.len(), 1);
+
+    let mut second_queue = TriggerQueue::new();
+    queue_nymris_spell_cast(&mut game, alice, &mut second_queue);
+    assert_eq!(
+        second_queue.entries.len(),
+        0,
+        "Nymris should trigger only for your first spell during each opponent's turn"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/spell_cast.rs
@@ -165,16 +165,45 @@ impl TriggerMatcher for SpellCastTrigger {
             .map(describe_spell_filter)
             .unwrap_or_else(|| "a spell".to_string());
         let mut suffix = String::new();
-        let suppress_turn_suffix = false;
+        let mut suppress_turn_suffix = false;
         if let Some(exact_spells) = self.exact_spells_this_turn {
             let ordinal =
                 ironsmith_core::ordinal_word(exact_spells).unwrap_or_else(|| "nth".to_string());
+            let exact_spell_turn_suffix = match self.during_turn {
+                Some(PlayerFilter::You) => Some("during each of your turns"),
+                Some(PlayerFilter::Opponent) => Some("during each opponent's turn"),
+                _ => None,
+            };
             if spell_text == "a spell" || spell_text == "spell" {
                 spell_text = match &self.caster {
-                    PlayerFilter::You => format!("your {ordinal} spell each turn"),
-                    PlayerFilter::Any => format!("their {ordinal} spell each turn"),
-                    PlayerFilter::Active => format!("their {ordinal} spell each turn"),
-                    PlayerFilter::Opponent => format!("their {ordinal} spell each turn"),
+                    PlayerFilter::You => match exact_spell_turn_suffix {
+                        Some(turn_suffix) => {
+                            suppress_turn_suffix = true;
+                            format!("your {ordinal} spell {turn_suffix}")
+                        }
+                        None => format!("your {ordinal} spell each turn"),
+                    },
+                    PlayerFilter::Any => match exact_spell_turn_suffix {
+                        Some(turn_suffix) => {
+                            suppress_turn_suffix = true;
+                            format!("their {ordinal} spell {turn_suffix}")
+                        }
+                        None => format!("their {ordinal} spell each turn"),
+                    },
+                    PlayerFilter::Active => match exact_spell_turn_suffix {
+                        Some(turn_suffix) => {
+                            suppress_turn_suffix = true;
+                            format!("their {ordinal} spell {turn_suffix}")
+                        }
+                        None => format!("their {ordinal} spell each turn"),
+                    },
+                    PlayerFilter::Opponent => match exact_spell_turn_suffix {
+                        Some(turn_suffix) => {
+                            suppress_turn_suffix = true;
+                            format!("their {ordinal} spell {turn_suffix}")
+                        }
+                        None => format!("their {ordinal} spell each turn"),
+                    },
                     PlayerFilter::Specific(_) => {
                         format!("that player's {ordinal} spell each turn")
                     }
@@ -183,12 +212,30 @@ impl TriggerMatcher for SpellCastTrigger {
             } else {
                 let base_spell_text = strip_leading_spell_article(&spell_text);
                 spell_text = match &self.caster {
-                    PlayerFilter::You => format!("your {ordinal} {base_spell_text} each turn"),
+                    PlayerFilter::You => match exact_spell_turn_suffix {
+                        Some(turn_suffix) => {
+                            suppress_turn_suffix = true;
+                            format!("your {ordinal} {base_spell_text} {turn_suffix}")
+                        }
+                        None => format!("your {ordinal} {base_spell_text} each turn"),
+                    },
                     PlayerFilter::Any | PlayerFilter::Active => {
-                        format!("their {ordinal} {base_spell_text} each turn")
+                        match exact_spell_turn_suffix {
+                            Some(turn_suffix) => {
+                                suppress_turn_suffix = true;
+                                format!("their {ordinal} {base_spell_text} {turn_suffix}")
+                            }
+                            None => format!("their {ordinal} {base_spell_text} each turn"),
+                        }
                     }
                     PlayerFilter::Opponent => {
-                        format!("their {ordinal} {base_spell_text} each turn")
+                        match exact_spell_turn_suffix {
+                            Some(turn_suffix) => {
+                                suppress_turn_suffix = true;
+                                format!("their {ordinal} {base_spell_text} {turn_suffix}")
+                            }
+                            None => format!("their {ordinal} {base_spell_text} each turn"),
+                        }
                     }
                     PlayerFilter::Specific(_) => {
                         format!("that player's {ordinal} {base_spell_text} each turn")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nymris, Oona's Trickster
Initial parse error:
```
unsupported target phrase (clause: 'cards'); oracle-only fallback also failed: unsupported target phrase (clause: 'cards')
```

Current worker: i-04a4c11bb7423d7ab
Branch: codex/aws-card-fix-nymris-oona-s-trickster
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0004
