### PR TITLE
Fix Ironsmith parse failure: Flamestick Courier

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -304,8 +304,15 @@ const ABILITY_FIRST_STRIKE_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["first", "strike"]]);
 const AND_GET_OR_GETS_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["and", "get"], &["and", "gets"]]]);
-const AND_GAIN_OR_GAINS_PATTERN: ClauseShape<'static> =
-    clause_shape!(contains_any_phrases & [&[&["and", "gain"], &["and", "gains"]]]);
+const AND_GAIN_OR_GAINS_PATTERN: ClauseShape<'static> = clause_shape!(
+    contains_any_phrases
+        & [&[
+            &["and", "gain"],
+            &["and", "gains"],
+            &["and", "have"],
+            &["and", "has"],
+        ]]
+);
 const AND_GAIN_HAVE_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
@@ -594,7 +594,7 @@ pub(crate) fn parse_get_modifier_values_with_tail(
         return Ok((
             out_power,
             out_toughness,
-            Until::ThisLeavesTheBattlefield,
+            Until::SourceUntaps,
             condition,
         ));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -662,6 +662,55 @@ pub(crate) fn parse_simple_ability_duration(
     None
 }
 
+fn parse_source_tapped_ability_duration(
+    words_after_verb: &[&str],
+) -> Option<(usize, usize, Until, crate::ConditionExpr)> {
+    let idx = words_after_verb.windows(4).position(|window| {
+        window == ["for", "as", "long", "as"]
+    })?;
+    let tail = &words_after_verb[idx..];
+    if tail.contains(&"this") && tail.contains(&"remains") && tail.contains(&"tapped") {
+        Some((
+            idx,
+            words_after_verb.len().saturating_sub(idx),
+            Until::ThisLeavesTheBattlefield,
+            crate::ConditionExpr::SourceIsTapped,
+        ))
+    } else {
+        None
+    }
+}
+
+fn parse_ability_duration_with_condition(
+    words_after_verb: &[&str],
+) -> (Option<(usize, usize, Until)>, Option<crate::ConditionExpr>) {
+    if let Some((idx, len, duration, condition)) =
+        parse_source_tapped_ability_duration(words_after_verb)
+    {
+        (Some((idx, len, duration)), Some(condition))
+    } else {
+        (parse_simple_ability_duration(words_after_verb), None)
+    }
+}
+
+fn subject_verb_grant_abilities_to_target_with_optional_condition(
+    target: TargetAst,
+    abilities: Vec<GrantedAbilityAst>,
+    duration: Until,
+    condition: &Option<crate::ConditionExpr>,
+) -> EffectAst {
+    if let Some(condition) = condition {
+        EffectAst::subject_verb_grant_abilities_to_target_with_condition(
+            target,
+            abilities,
+            duration,
+            condition.clone(),
+        )
+    } else {
+        EffectAst::subject_verb_grant_abilities_to_target(target, abilities, duration)
+    }
+}
+
 fn words_start_nested_triggered_ability(words_after_verb: &[&str]) -> bool {
     matches!(
         words_after_verb,
@@ -1267,10 +1316,10 @@ pub(crate) fn parse_gain_ability_sentence(
         }
     }
 
-    let duration_phrase = if words_start_nested_triggered_ability(after_gain) {
-        None
+    let (duration_phrase, duration_condition) = if words_start_nested_triggered_ability(after_gain) {
+        (None, None)
     } else {
-        parse_simple_ability_duration(after_gain)
+        parse_ability_duration_with_condition(after_gain)
     };
     let duration = duration_phrase
         .as_ref()
@@ -1464,6 +1513,11 @@ pub(crate) fn parse_gain_ability_sentence(
                 } else {
                     local_duration
                 };
+                let condition = if has_local_duration {
+                    condition
+                } else {
+                    condition.or_else(|| duration_condition.clone())
+                };
                 Some((
                     power,
                     toughness,
@@ -1628,10 +1682,11 @@ pub(crate) fn parse_gain_ability_sentence(
                 duration,
             ));
         } else {
-            effects.push(EffectAst::subject_verb_grant_abilities_to_target(
+            effects.push(subject_verb_grant_abilities_to_target_with_optional_condition(
                 target.clone(),
                 abilities,
                 duration,
+                &duration_condition,
             ));
         }
         append_shared_subject_pump_to_target(&mut effects, &target, &following_pump_effect);
@@ -1659,10 +1714,11 @@ pub(crate) fn parse_gain_ability_sentence(
                 duration,
             ));
         } else {
-            effects.push(EffectAst::subject_verb_grant_abilities_to_target(
+            effects.push(subject_verb_grant_abilities_to_target_with_optional_condition(
                 target.clone(),
                 abilities,
                 duration,
+                &duration_condition,
             ));
         }
         append_shared_subject_pump_to_target(&mut effects, &target, &following_pump_effect);
@@ -1694,10 +1750,11 @@ pub(crate) fn parse_gain_ability_sentence(
                 duration,
             ));
         } else {
-            effects.push(EffectAst::subject_verb_grant_abilities_to_target(
+            effects.push(subject_verb_grant_abilities_to_target_with_optional_condition(
                 target.clone(),
                 abilities,
                 duration,
+                &duration_condition,
             ));
         }
         append_shared_subject_pump_to_target(&mut effects, &target, &following_pump_effect);
@@ -1735,10 +1792,11 @@ pub(crate) fn parse_gain_ability_sentence(
                 duration,
             ));
         } else {
-            effects.push(EffectAst::subject_verb_grant_abilities_to_target(
+            effects.push(subject_verb_grant_abilities_to_target_with_optional_condition(
                 grant_target,
                 abilities,
                 duration,
+                &duration_condition,
             ));
         }
         let following_pump_target =

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -673,7 +673,7 @@ fn parse_source_tapped_ability_duration(
         Some((
             idx,
             words_after_verb.len().saturating_sub(idx),
-            Until::ThisLeavesTheBattlefield,
+            Until::SourceUntaps,
             crate::ConditionExpr::SourceIsTapped,
         ))
     } else {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/search_library.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/search_library.rs
@@ -275,7 +275,7 @@ pub(crate) fn parse_restriction_duration_lexed(
         let suffix_tokens = &tokens[token_idx..];
         if is_source_remains_tapped_duration_tokens(suffix_tokens) {
             let remainder = trim_lexed_commas(&tokens[..token_idx]).to_vec();
-            return Ok(Some((Until::ThisLeavesTheBattlefield, remainder)));
+            return Ok(Some((Until::SourceUntaps, remainder)));
         }
         if is_source_remains_battlefield_duration_tokens(suffix_tokens) {
             let remainder = trim_lexed_commas(&tokens[..token_idx]).to_vec();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/search_library_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/search_library_support.rs
@@ -157,7 +157,7 @@ pub(crate) fn parse_restriction_duration_lexed(
         if is_source_remains_tapped_duration_tokens(suffix_tokens) {
             let remainder = trim_lexed_commas(&tokens[..token_idx]).to_vec();
             if !remainder.is_empty() {
-                return Ok(Some((Until::ThisLeavesTheBattlefield, remainder)));
+                return Ok(Some((Until::SourceUntaps, remainder)));
             }
         }
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4305,7 +4305,7 @@ fn rewrite_lexed_restriction_duration_handles_for_as_long_as_token_shapes() {
     let parsed = parse_restriction_duration_lexed(&suffix)
         .expect("suffix duration should parse")
         .expect("suffix duration should be present");
-    assert_eq!(parsed.0, crate::effect::Until::ThisLeavesTheBattlefield);
+    assert_eq!(parsed.0, crate::effect::Until::SourceUntaps);
     assert_eq!(
         TokenWordView::new(&parsed.1).to_word_refs(),
         vec!["target", "creature", "cant", "attack"]

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -70,6 +70,7 @@ pub enum Until {
     ControllersNextUntapStep,
     EndOfCombat,
     ThisLeavesTheBattlefield,
+    SourceUntaps,
     YouStopControllingThis,
     TurnsPass(crate::value_model::Value),
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45076,6 +45076,174 @@ fn assert_oracle_card_parses_strict(name: &str) {
     );
 }
 
+fn flamestick_courier_activated_ability(
+    def: &CardDefinition,
+) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Flamestick Courier should have an activated ability")
+}
+
+fn flamestick_courier_target_filter(
+    activated: &crate::ability::ActivatedAbility,
+) -> &crate::target::ObjectFilter {
+    match activated.choices.first() {
+        Some(ChooseSpec::Target(inner)) => match inner.as_ref() {
+            ChooseSpec::Object(filter) => filter,
+            other => panic!("Flamestick Courier should target an object, got {other:?}"),
+        },
+        other => panic!("Flamestick Courier should have one target choice, got {other:?}"),
+    }
+}
+
+#[test]
+fn flamestick_courier_strict_parser_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Flamestick Courier");
+
+    let def = parse_oracle_card_definition("Flamestick Courier");
+    let activated = flamestick_courier_activated_ability(&def);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{activated:#?}");
+
+    assert!(
+        rendered.contains("You may choose not to untap this creature during your untap step"),
+        "expected optional untap static line for Flamestick Courier, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "{2}{R}, {T}: Target Goblin creature gets +2/+2 and has haste for as long as this creature remains tapped"
+        ),
+        "expected source-tapped pump-and-haste line for Flamestick Courier, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("SourceUntaps")
+            && ability_debug.contains("SourceIsTapped")
+            && ability_debug.contains("ModifyPowerToughness")
+            && ability_debug.contains("Haste"),
+        "expected source-remains-tapped +2/+2 and haste effects, got {ability_debug}"
+    );
+
+    let target_filter = flamestick_courier_target_filter(activated);
+    assert_eq!(
+        target_filter.card_types,
+        vec![CardType::Creature],
+        "Flamestick Courier should target a creature"
+    );
+    assert_eq!(
+        target_filter.subtypes,
+        vec![Subtype::Goblin],
+        "Flamestick Courier should target a Goblin creature"
+    );
+}
+
+#[test]
+fn flamestick_courier_activation_pumps_goblin_only_while_source_remains_tapped() {
+    let def = parse_oracle_card_definition("Flamestick Courier");
+    let activated = flamestick_courier_activated_ability(&def);
+    let target_filter = flamestick_courier_target_filter(activated);
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(source);
+
+    let goblin_def = CardDefinitionBuilder::new(CardId::new(), "Goblin Target")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Goblin])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let goblin = game.create_object_from_definition(&goblin_def, alice, Zone::Battlefield);
+    let non_goblin_def = CardDefinitionBuilder::new(CardId::new(), "Elf Bystander")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elf])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let non_goblin = game.create_object_from_definition(&non_goblin_def, alice, Zone::Battlefield);
+
+    let filter_ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .filter_context(&game);
+    assert!(
+        target_filter.matches(
+            game.object(goblin).expect("Goblin target should exist"),
+            &filter_ctx,
+            &game,
+        ),
+        "Flamestick Courier should be able to target a Goblin creature"
+    );
+    assert!(
+        !target_filter.matches(
+            game.object(non_goblin).expect("Elf bystander should exist"),
+            &filter_ctx,
+            &game,
+        ),
+        "Flamestick Courier should not be able to target a non-Goblin creature"
+    );
+
+    assert!(
+        crate::cost::can_pay_cost(&game, source, alice, &activated.mana_cost).is_err(),
+        "Flamestick Courier activation should require mana before the tap cost can be paid"
+    );
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .red = 3;
+    crate::cost::can_pay_cost(&game, source, alice, &activated.mana_cost).expect(
+        "Flamestick Courier activation should be payable with three red mana and an untapped source",
+    );
+    let mut dm = crate::decision::AutoPassDecisionMaker::default();
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        source,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("Flamestick Courier activation cost should be paid");
+    assert!(game.is_tapped(source), "activation cost should tap Flamestick Courier");
+    assert_eq!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .mana_pool
+            .total(),
+        0,
+        "activation cost should spend {{2}}{{R}}"
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(goblin)]);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Flamestick Courier activation should resolve");
+    }
+
+    assert_eq!(game.calculated_power(goblin), Some(3));
+    assert_eq!(game.calculated_toughness(goblin), Some(3));
+    assert!(
+        game.object_has_static_ability_id(goblin, StaticAbilityId::Haste),
+        "target Goblin should have haste while Flamestick Courier remains tapped"
+    );
+
+    game.untap(source);
+    assert_eq!(game.calculated_power(goblin), Some(1));
+    assert_eq!(game.calculated_toughness(goblin), Some(1));
+    assert!(
+        !game.object_has_static_ability_id(goblin, StaticAbilityId::Haste),
+        "target Goblin should lose haste once Flamestick Courier untaps"
+    );
+
+    game.tap(source);
+    assert_eq!(game.calculated_power(goblin), Some(1));
+    assert_eq!(game.calculated_toughness(goblin), Some(1));
+    assert!(
+        !game.object_has_static_ability_id(goblin, StaticAbilityId::Haste),
+        "source-remains-tapped duration should not reactivate after Flamestick Courier taps again"
+    );
+}
+
 #[test]
 fn departed_deckhand_strict_parser_text_and_structure_regression() {
     let def = parse_oracle_card_definition("Departed Deckhand");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8924,6 +8924,13 @@ pub(super) fn describe_apply_continuous_clauses(
     let has = if plural_target { "have" } else { "has" };
     let gains = if plural_target { "gain" } else { "gains" };
     let loses = if plural_target { "lose" } else { "loses" };
+    let add_ability_verb = if effect.condition == Some(Condition::SourceIsTapped)
+        && matches!(effect.until, Until::SourceUntaps)
+    {
+        has
+    } else {
+        gains
+    };
     let self_subject = granted_ability_self_subject_for_apply_continuous(effect);
 
     let mut clauses = Vec::new();
@@ -9082,11 +9089,14 @@ pub(super) fn describe_apply_continuous_clauses(
         crate::continuous::Modification::AddAbility(ability) => {
             if let Some(inline) = ability.granted_inline_ability() {
                 clauses.push(format!(
-                    "{gains} {}",
+                    "{add_ability_verb} {}",
                     describe_inline_ability_with_self_subject(inline, self_subject)
                 ));
             } else {
-                clauses.push(format!("{gains} {}", lowercase_first(&ability.display())));
+                clauses.push(format!(
+                    "{add_ability_verb} {}",
+                    lowercase_first(&ability.display())
+                ));
             }
         }
         crate::continuous::Modification::RemoveAbility(ability) => {
@@ -9217,6 +9227,12 @@ pub(super) fn describe_apply_continuous_clauses(
 pub(super) fn describe_apply_continuous_tail(
     effect: &crate::effects::ApplyContinuousEffect,
 ) -> Option<String> {
+    if effect.condition == Some(Condition::SourceIsTapped)
+        && matches!(effect.until, Until::SourceUntaps)
+    {
+        return Some("for as long as this source remains tapped".to_string());
+    }
+
     let mut tail_parts = Vec::new();
     if let Some(condition) = &effect.condition
         && matches!(effect.until, Until::ThisLeavesTheBattlefield)
@@ -10225,6 +10241,7 @@ pub(super) fn describe_until(until: &Until) -> String {
         Until::ThisLeavesTheBattlefield => {
             "for as long as this source remains on the battlefield".to_string()
         }
+        Until::SourceUntaps => "for as long as this source remains tapped".to_string(),
         Until::YouStopControllingThis => "while you control this source".to_string(),
         Until::TurnsPass(turns) => format!("for {} turn(s)", describe_value(turns)),
     }

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -672,6 +672,13 @@ impl ContinuousEffectManager {
         self.revision += 1;
     }
 
+    /// Remove effects from a specific source with the given duration.
+    pub fn remove_effects_from_source_with_duration(&mut self, source: ObjectId, duration: Until) {
+        self.effects
+            .retain(|e| !(e.source == source && e.duration == duration));
+        self.revision += 1;
+    }
+
     /// Remove all effects with duration UntilEndOfTurn.
     pub fn cleanup_end_of_turn(&mut self) {
         self.effects
@@ -2200,6 +2207,9 @@ fn continuous_effect_duration_is_active(
         Until::ThisLeavesTheBattlefield => game
             .object(effect.source)
             .is_some_and(|obj| obj.zone == Zone::Battlefield),
+        Until::SourceUntaps => game.object(effect.source).is_some_and(|obj| {
+            obj.zone == Zone::Battlefield && game.is_tapped(effect.source)
+        }),
         Until::YouStopControllingThis => game.object(effect.source).is_some_and(|obj| {
             obj.zone == Zone::Battlefield
                 && game

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -744,6 +744,9 @@ impl RestrictionEffectInstance {
             crate::effect::Until::ThisLeavesTheBattlefield => game
                 .object(self.source)
                 .is_some_and(|obj| obj.zone == Zone::Battlefield),
+            crate::effect::Until::SourceUntaps => game.object(self.source).is_some_and(|obj| {
+                obj.zone == Zone::Battlefield && game.is_tapped(self.source)
+            }),
             crate::effect::Until::YouStopControllingThis => {
                 game.object(self.source).is_some_and(|obj| {
                     obj.zone == Zone::Battlefield && game.controller_of(obj) == self.controller
@@ -783,6 +786,9 @@ impl GoadEffectInstance {
             crate::effect::Until::ThisLeavesTheBattlefield => game
                 .object(self.source)
                 .is_some_and(|obj| obj.zone == Zone::Battlefield),
+            crate::effect::Until::SourceUntaps => game.object(self.source).is_some_and(|obj| {
+                obj.zone == Zone::Battlefield && game.is_tapped(self.source)
+            }),
             crate::effect::Until::YouStopControllingThis => {
                 game.object(self.source).is_some_and(|obj| {
                     obj.zone == Zone::Battlefield && game.controller_of(obj) == self.goaded_by
@@ -8248,6 +8254,16 @@ impl GameState {
     pub fn untap(&mut self, id: ObjectId) {
         self.mark_continuous_state_dirty();
         self.tapped_permanents.remove(&id);
+        self.effect_store
+            .continuous_effects
+            .remove_effects_from_source_with_duration(id, crate::effect::Until::SourceUntaps);
+        self.effect_store.restriction_effects.retain(|effect| {
+            !(effect.source == id && effect.duration == crate::effect::Until::SourceUntaps)
+        });
+        self.effect_store.goad_effects.retain(|effect| {
+            !(effect.source == id && effect.duration == crate::effect::Until::SourceUntaps)
+        });
+        self.update_cant_effects();
     }
 
     /// Check if a creature has summoning sickness.


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Flamestick Courier
Initial parse error:
```
unsupported trailing gets clause (clause: '+2/+2 and has haste for as long as this creature remains tapped'); oracle-only fallback also failed: unsupported trailing gets clause (clause: '+2/+2 and has haste for as long as this creature remains tapped')
```

Current worker: i-077a80bc34514dd26
Branch: codex/aws-card-fix-flamestick-courier
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0004
