### PR TITLE
Fix Ironsmith parse failure: Kargan Dragonlord

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -22,8 +22,9 @@ pub use crate::payload::{IfResultPredicate, KeywordAction};
 use crate::resolution::ResolutionProgram;
 pub(crate) use crate::runtime_backend::semantic::{
     GiftTimingAst, LineAst, ParsedAbility, ParsedCardItem, ParsedLevelAbilityAst,
-    ParsedLevelAbilityItemAst, ParsedLineAst, ParsedModalActivatedHeader, ParsedModalAst,
-    ParsedModalGate, ParsedModalHeader, ParsedModalModeAst, ParsedRestrictions,
+    ParsedLevelAbilityItemAst, ParsedLevelActivatedAbilityAst, ParsedLineAst,
+    ParsedModalActivatedHeader, ParsedModalAst, ParsedModalGate, ParsedModalHeader,
+    ParsedModalModeAst, ParsedRestrictions,
 };
 pub(crate) use crate::runtime_backend::util::SubjectAst;
 pub(crate) use crate::runtime_backend::{

--- a/crates/ironsmith-compiler/src/oracle_grammar.rs
+++ b/crates/ironsmith-compiler/src/oracle_grammar.rs
@@ -203,6 +203,7 @@ fn convert_line(line: RewriteLineCst) -> OracleGrammarLine {
                     kind: match item.kind {
                         LevelItemKindCst::KeywordActions => "KeywordActions",
                         LevelItemKindCst::StaticAbilities => "StaticAbilities",
+                        LevelItemKindCst::ActivatedAbility => "ActivatedAbility",
                     }
                     .to_string(),
                     parsed_debug: format!("{:?}", item.parsed),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst.rs
@@ -149,6 +149,7 @@ pub(crate) struct LevelHeaderCst {
 pub(crate) enum LevelItemKindCst {
     KeywordActions,
     StaticAbilities,
+    ActivatedAbility,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/cst_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/cst_lowering.rs
@@ -175,6 +175,7 @@ fn lower_level_header(
                 kind: match item.kind {
                     LevelItemKindCst::KeywordActions => RewriteLevelItemKind::KeywordActions,
                     LevelItemKindCst::StaticAbilities => RewriteLevelItemKind::StaticAbilities,
+                    LevelItemKindCst::ActivatedAbility => RewriteLevelItemKind::ActivatedAbility,
                 },
                 parsed: item.parsed,
             })

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/block_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/block_parsing.rs
@@ -28,7 +28,7 @@ pub(super) fn try_parse_level_header_block(
             probe_idx += 1;
             continue;
         }
-        match parse_level_item_cst(next_line) {
+        match parse_level_item_cst(&preprocessed.builder, next_line) {
             Ok(Some(item)) => {
                 items.push(item);
                 probe_idx += 1;

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -409,9 +409,39 @@ pub(super) fn strict_unsupported_triggered_line_error(
 }
 
 pub(super) fn parse_level_item_cst(
+    builder: &CardDefinitionBuilder,
     line: &PreprocessedLine,
 ) -> Result<Option<LevelItemCst>, CardTextError> {
     let normalized = line.info.normalized.normalized.as_str();
+
+    if let Some((cost_tokens, effect_parse_tokens)) =
+        split_activation_text_tokens_lexed(&line.tokens)
+    {
+        let effect_text = render_token_slice(&effect_parse_tokens).trim().to_string();
+        let normalized_cost_tokens =
+            normalize_activation_cost_tokens_for_builder(builder, line, cost_tokens.clone())?;
+        match parse_activation_cost_tokens_rewrite(&normalized_cost_tokens) {
+            Ok(cost_cst) => {
+                let cost = lower_activation_cost_cst(&cost_cst)?;
+                return Ok(Some(LevelItemCst {
+                    info: line.info.clone(),
+                    text: normalized.to_string(),
+                    kind: LevelItemKindCst::ActivatedAbility,
+                    parsed: ParsedLevelAbilityItemAst::ActivatedAbility(
+                        ParsedLevelActivatedAbilityAst {
+                            info: line.info.clone(),
+                            cost,
+                            cost_parse_tokens: normalized_cost_tokens,
+                            effect_text,
+                            effect_parse_tokens,
+                        },
+                    ),
+                }));
+            }
+            Err(err) if looks_like_activation_cost_prefix(&cost_tokens) => return Err(err),
+            Err(_) => {}
+        }
+    }
 
     if !should_skip_keyword_action_static_probe(&line.tokens)
         && let Some(actions) = parse_ability_line_lexed(&line.tokens)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -2,7 +2,7 @@ use crate::PtValue;
 use crate::ability::ActivationTiming;
 use crate::cards::builders::{
     CardDefinitionBuilder, CardTextError, LineAst, ParseAnnotations, ParsedLevelAbilityItemAst,
-    PredicateAst, TextSpan,
+    ParsedLevelActivatedAbilityAst, PredicateAst, TextSpan,
 };
 use crate::parse_trace;
 use winnow::Parser;
@@ -1974,9 +1974,12 @@ mod tests {
 
     #[test]
     fn level_item_cst_stores_parsed_payload() -> Result<(), CardTextError> {
+        let builder = CardDefinitionBuilder::new(CardId::new(), "Document Parser Test")
+            .card_types(vec![CardType::Creature]);
         let line = single_preprocessed_line("Flying");
 
-        let parsed = parse_level_item_cst(&line)?.expect("expected flying to parse as level item");
+        let parsed =
+            parse_level_item_cst(&builder, &line)?.expect("expected flying to parse as level item");
 
         assert_eq!(parsed.text, "flying");
         match &parsed.parsed {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/damage_and_cost_rewrites.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/damage_and_cost_rewrites.rs
@@ -128,6 +128,7 @@ pub(crate) fn lower_normalized_card_ast(
     } = ast;
 
     let mut level_abilities = Vec::new();
+    let mut level_activated_lines = Vec::new();
     let mut last_restrictable_ability: Option<usize> = None;
     let mut state = RewriteLoweredCardState::default();
 
@@ -153,13 +154,25 @@ pub(crate) fn lower_normalized_card_ast(
                 );
             }
             NormalizedCardItem::LevelAbility(level) => {
-                level_abilities.push(rewrite_lower_level_ability_ast(level)?);
+                let lowered = rewrite_lower_level_ability_ast(level)?;
+                level_abilities.push(lowered.level_ability);
+                level_activated_lines.extend(lowered.activated_lines);
             }
         }
     }
 
     if !level_abilities.is_empty() {
         builder = builder.with_level_abilities(level_abilities);
+    }
+    for line in level_activated_lines {
+        rewrite_lower_line_ast(
+            &mut builder,
+            &mut state,
+            &mut annotations,
+            line,
+            allow_unsupported,
+            &mut last_restrictable_ability,
+        )?;
     }
 
     builder = rewrite_finalize_lowered_card(builder, &mut state);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -33,6 +33,7 @@ pub(crate) use activated_lowering::lower_rewrite_activated_to_chunk;
 use activated_lowering::{LoweredRewriteActivatedLine, align_rewrite_activated_parse_sentences};
 use normalization_support::{
     apply_chosen_option_to_triggered_chunk, apply_explicit_intervening_if_to_triggered_chunk,
+    normalize_rewrite_line_ast_standalone,
 };
 pub(crate) use normalization_support::{
     prepare_parsed_card_ast_for_lowering, rewrite_document_to_normalized_card_ast,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
@@ -328,6 +328,15 @@ fn normalize_rewrite_line_ast(
     })
 }
 
+pub(super) fn normalize_rewrite_line_ast_standalone(
+    info: crate::cards::builders::LineInfo,
+    chunks: Vec<LineAst>,
+    restrictions: ParsedRestrictions,
+) -> Result<NormalizedLineAst, CardTextError> {
+    let mut state = RewriteNormalizationState::default();
+    normalize_rewrite_line_ast(info, chunks, restrictions, &mut state)
+}
+
 fn normalize_rewrite_line_chunk(
     chunk: LineAst,
     state: &mut RewriteNormalizationState,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
@@ -42,12 +42,13 @@ pub(crate) fn rewrite_update_last_restrictable_ability(
 
 pub(crate) fn rewrite_lower_level_ability_ast(
     level: ParsedLevelAbilityAst,
-) -> Result<crate::ability::LevelAbility, CardTextError> {
+) -> Result<RewriteLoweredLevelAbilityAst, CardTextError> {
     let mut lowered = crate::ability::LevelAbility::new(level.min_level, level.max_level);
     if let Some((power, toughness)) = level.pt {
         lowered = lowered.with_pt(power, toughness);
     }
 
+    let mut activated_lines = Vec::new();
     for item in level.items {
         match item {
             ParsedLevelAbilityItemAst::StaticAbilities(abilities) => {
@@ -62,10 +63,83 @@ pub(crate) fn rewrite_lower_level_ability_ast(
                     }
                 }
             }
+            ParsedLevelAbilityItemAst::ActivatedAbility(activated) => {
+                let info = activated.info.clone();
+                let mut activated = lower_rewrite_activated_to_chunk(
+                    info.clone(),
+                    activated.cost,
+                    activated.cost_parse_tokens,
+                    activated.effect_text,
+                    activated.effect_parse_tokens,
+                    ActivationTiming::AnyTime,
+                    false,
+                    None,
+                    None,
+                )?;
+                apply_level_range_activation_condition(
+                    &mut activated.chunk,
+                    level.min_level,
+                    level.max_level,
+                );
+                activated_lines.push(normalize_rewrite_line_ast_standalone(
+                    info,
+                    vec![activated.chunk],
+                    activated.restrictions,
+                )?);
+            }
         }
     }
 
-    Ok(lowered)
+    Ok(RewriteLoweredLevelAbilityAst {
+        level_ability: lowered,
+        activated_lines,
+    })
+}
+
+pub(crate) struct RewriteLoweredLevelAbilityAst {
+    pub(crate) level_ability: crate::ability::LevelAbility,
+    pub(crate) activated_lines: Vec<NormalizedLineAst>,
+}
+
+fn apply_level_range_activation_condition(
+    chunk: &mut LineAst,
+    min_level: u32,
+    max_level: Option<u32>,
+) {
+    let LineAst::Ability(parsed) = chunk else {
+        return;
+    };
+    let AbilityKind::Activated(activated) = parsed.kind_mut() else {
+        return;
+    };
+
+    let min_condition = crate::ConditionExpr::SourceHasCounterAtLeast {
+        counter_type: crate::CounterType::Level,
+        count: min_level,
+    };
+    let level_condition = if let Some(max_level) = max_level {
+        crate::ConditionExpr::And(
+            Box::new(min_condition),
+            Box::new(crate::ConditionExpr::ValueComparison {
+                left: crate::Value::CountersOnSource(crate::CounterType::Level),
+                operator: crate::effect::ValueComparisonOperator::LessThanOrEqual,
+                right: crate::Value::Fixed(max_level as i32),
+            }),
+        )
+    } else {
+        min_condition
+    };
+
+    activated.activation_condition = Some(match activated.activation_condition.take() {
+        Some(existing) => crate::ConditionExpr::And(Box::new(existing), Box::new(level_condition)),
+        None => level_condition,
+    });
+    let max_label = max_level
+        .map(|level| level.to_string())
+        .unwrap_or_else(|| "+".to_string());
+    activated
+        .additional_restrictions
+        .push(format!("__ironsmith_level_range:{min_level}:{max_label}"));
 }
 
 pub(crate) fn uses_spell_only_functional_zones(static_ability: &StaticAbility) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ir.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ir.rs
@@ -110,6 +110,7 @@ pub(crate) struct RewriteLevelHeader {
 pub(crate) enum RewriteLevelItemKind {
     KeywordActions,
     StaticAbilities,
+    ActivatedAbility,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ironsmith-compiler/src/runtime_backend/model/semantic.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/semantic.rs
@@ -5,6 +5,7 @@ use crate::ability::{Ability, AbilityKind, ActivationTiming};
 use crate::alternative_cast::AlternativeCastingMethod;
 use crate::cost::OptionalCost;
 use crate::effect::{EffectPredicate, Value};
+use crate::runtime_backend::lexer::OwnedLexToken;
 use crate::zone::Zone;
 
 use super::super::{KeywordAction, PlayerAst, SharedTypeConstraintAst, TargetAst, TotalCost};
@@ -272,7 +273,17 @@ pub(crate) struct ParsedLevelAbilityAst {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct ParsedLevelActivatedAbilityAst {
+    pub(crate) info: LineInfo,
+    pub(crate) cost: TotalCost,
+    pub(crate) cost_parse_tokens: Vec<OwnedLexToken>,
+    pub(crate) effect_text: String,
+    pub(crate) effect_parse_tokens: Vec<OwnedLexToken>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum ParsedLevelAbilityItemAst {
     StaticAbilities(Vec<StaticAbilityAst>),
     KeywordActions(Vec<KeywordAction>),
+    ActivatedAbility(ParsedLevelActivatedAbilityAst),
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -16783,6 +16783,37 @@ Double strike",
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_kargan_dragonlord_level_tier_activation() {
+    assert_oracle_card_parses_strict("Kargan Dragonlord");
+    let def = parse_oracle_card_definition("Kargan Dragonlord");
+    let debug = format!("{:?}", def.abilities);
+
+    assert!(
+        debug.contains("__ironsmith_level_range:8:+")
+            && debug.contains("SourceHasCounterAtLeast")
+            && debug.contains("ModifyPowerToughness"),
+        "Kargan Dragonlord should lower its level-8 pump as a level-gated activated ability, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn compiled_text_kargan_dragonlord_keeps_pump_in_level_block() {
+    let def = parse_oracle_card_definition("Kargan Dragonlord");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Level up {R}")
+            && rendered.contains(
+                "Level 8+.\n8/8.\nFlying, trample\n{R}: This creature gets +1/+0 until end of turn."
+            )
+            && !rendered.contains("Activated ability"),
+        "Kargan Dragonlord compiled text should render the level-up line and level-8 pump block, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_standalone_may_effect_does_not_emit_with_id_wrapper() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Slayer Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -233,6 +233,83 @@ fn render_color_conditional_keyword_grants(
     format!("{label}{subject} {}", join_english_list(&clauses))
 }
 
+fn ability_level_range_prefix(ability: &Ability) -> Option<String> {
+    let AbilityKind::Activated(activated) = &ability.kind else {
+        return None;
+    };
+    level_range_activation_prefix(activated)
+}
+
+fn ability_has_level_tiers(ability: &Ability) -> bool {
+    matches!(
+        &ability.kind,
+        AbilityKind::Static(static_ability)
+            if static_ability.level_abilities().is_some_and(|levels| !levels.is_empty())
+    )
+}
+
+fn level_tier_header_range(line: &str) -> Option<String> {
+    let (_, text) = line.split_once(": ")?;
+    let range = text.trim().trim_end_matches('.');
+    range.starts_with("Level ").then(|| range.to_string())
+}
+
+fn interleave_level_range_activations(
+    lines: Vec<String>,
+    abilities: &[Ability],
+    subject: &str,
+    rewrite_it_deals: bool,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut active_range: Option<String> = None;
+    for line in lines {
+        if let Some(next_range) = level_tier_header_range(&line) {
+            flush_level_range_activations(
+                &mut out,
+                active_range.as_deref(),
+                abilities,
+                subject,
+                rewrite_it_deals,
+            );
+            active_range = Some(next_range);
+        }
+        out.push(line);
+    }
+    flush_level_range_activations(
+        &mut out,
+        active_range.as_deref(),
+        abilities,
+        subject,
+        rewrite_it_deals,
+    );
+    out
+}
+
+fn flush_level_range_activations(
+    out: &mut Vec<String>,
+    range: Option<&str>,
+    abilities: &[Ability],
+    subject: &str,
+    rewrite_it_deals: bool,
+) {
+    let Some(range) = range else {
+        return;
+    };
+    let range_prefix = format!("{range}. ");
+    for (idx, ability) in abilities.iter().enumerate() {
+        if ability_level_range_prefix(ability).as_deref() != Some(range) {
+            continue;
+        }
+        for line in describe_ability(idx + 1, ability, subject, rewrite_it_deals) {
+            out.push(
+                line.strip_prefix(&range_prefix)
+                    .unwrap_or(line.as_str())
+                    .to_string(),
+            );
+        }
+    }
+}
+
 fn is_mergeable_keyword_surface(keyword: &str) -> bool {
     let keyword = keyword.trim_end_matches('.');
     let lower = keyword.to_ascii_lowercase();
@@ -2486,6 +2563,10 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
                 ability_idx += 1;
                 continue;
             }
+            if ability_level_range_prefix(ability).is_some() {
+                ability_idx += 1;
+                continue;
+            }
             if let Some(keyword) = describe_structural_ascend_ability(ability) {
                 output.push(format!("Keyword ability {}: {keyword}", ability_idx + 1));
                 ability_idx += 1;
@@ -2614,6 +2695,14 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
             };
             let mut ability_lines =
                 describe_ability(ability_idx + 1, ability, ability_subject, rewrite_it_deals);
+            if ability_has_level_tiers(ability) {
+                ability_lines = interleave_level_range_activations(
+                    ability_lines,
+                    &def.abilities,
+                    ability_subject,
+                    rewrite_it_deals,
+                );
+            }
             if ability_has_begin_on_battlefield_pregame(ability) {
                 for line in &mut ability_lines {
                     *line = substitute_pregame_self_reference(line, &def.card.name);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -16423,6 +16423,9 @@ pub(super) fn describe_inline_ability_with_self_subject(
             }
         }
         AbilityKind::Activated(activated) => {
+            if let Some(level_up) = describe_level_up_activation(activated) {
+                return level_up;
+            }
             if let Some(level) = activated
                 .additional_restrictions
                 .iter()
@@ -16522,6 +16525,11 @@ pub(super) fn describe_inline_ability_with_self_subject(
             } else {
                 normalize_ability_self_reference_surface(&line, self_subject)
             };
+            let line = if let Some(prefix) = level_range_activation_prefix(activated) {
+                format!("{prefix}. {line}")
+            } else {
+                line
+            };
             if let Some(label) = activated_presentation_label(activated)
                 && !line.starts_with(label)
             {
@@ -16539,6 +16547,23 @@ fn activated_presentation_label(activated: &crate::ability::ActivatedAbility) ->
         .iter()
         .find_map(|restriction| restriction.strip_prefix("__ironsmith_activation_label:"))
         .or_else(|| inferred_throw_activation_label(activated))
+}
+
+pub(super) fn level_range_activation_prefix(
+    activated: &crate::ability::ActivatedAbility,
+) -> Option<String> {
+    let range = activated
+        .additional_restrictions
+        .iter()
+        .find_map(|restriction| restriction.strip_prefix("__ironsmith_level_range:"))?;
+    let (min, max) = range.split_once(':')?;
+    if max == "+" {
+        Some(format!("Level {min}+"))
+    } else if min == max {
+        Some(format!("Level {min}"))
+    } else {
+        Some(format!("Level {min}-{max}"))
+    }
 }
 
 fn inferred_throw_activation_label(
@@ -37176,6 +37201,9 @@ pub(super) fn collect_activation_restriction_clauses(
         if raw.starts_with("__ironsmith_class_level:") {
             continue;
         }
+        if raw.starts_with("__ironsmith_level_range:") {
+            continue;
+        }
         if raw.starts_with(STATION_THRESHOLD_RESTRICTION_PREFIX) {
             continue;
         }
@@ -39918,6 +39946,28 @@ fn describe_class_level_activation(activated: &crate::ability::ActivatedAbility)
     ))
 }
 
+fn describe_level_up_activation(activated: &crate::ability::ActivatedAbility) -> Option<String> {
+    if !matches!(activated.timing, ActivationTiming::SorcerySpeed)
+        || !activated.choices.is_empty()
+        || !activated.additional_restrictions.is_empty()
+        || !activated.activation_restrictions.is_empty()
+        || activated.activation_condition.is_some()
+    {
+        return None;
+    }
+    let [effect] = activated.effects.flattened_default_effects() else {
+        return None;
+    };
+    let put = effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.counter_type != crate::CounterType::Level || !matches!(put.target, ChooseSpec::Source) {
+        return None;
+    }
+    Some(format!(
+        "Level up {}",
+        describe_cost_list(activated.mana_cost.costs())
+    ))
+}
+
 pub(super) fn describe_ability(
     index: usize,
     ability: &Ability,
@@ -40254,6 +40304,9 @@ pub(super) fn describe_ability(
             vec![line]
         }
         AbilityKind::Activated(activated) => {
+            if let Some(level_up) = describe_level_up_activation(activated) {
+                return vec![level_up];
+            }
             if let Some(level_text) = describe_class_level_activation(activated) {
                 return vec![level_text];
             }
@@ -40330,7 +40383,10 @@ pub(super) fn describe_ability(
             let is_grandeur = is_grandeur_activation_cost(activated);
             let is_exhaust = activated.is_exhaust_ability();
             let has_presentation_label = activated_presentation_label(activated).is_some();
-            let mut line = if is_grandeur || is_exhaust || has_presentation_label {
+            let has_level_range = level_range_activation_prefix(activated).is_some();
+            let omit_debug_prefix =
+                is_grandeur || is_exhaust || has_presentation_label || has_level_range;
+            let mut line = if omit_debug_prefix {
                 String::new()
             } else {
                 format!("Activated ability {index}")
@@ -40407,6 +40463,9 @@ pub(super) fn describe_ability(
             }
             if is_grandeur_activation_cost(activated) {
                 line = format!("Grandeur — {line}");
+            }
+            if let Some(prefix) = level_range_activation_prefix(activated) {
+                line = format!("{prefix}. {line}");
             }
             if is_exhaust {
                 line = format!("Exhaust — {line}");

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -5267,6 +5267,209 @@ fn party_dude_does_not_trigger_when_its_controller_is_attacked() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn kargan_dragonlord_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(18_920), "Kargan Dragonlord")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red], vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Warrior])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "Level up {R}\n\
+             LEVEL 4-7\n\
+             4/4\n\
+             Flying\n\
+             LEVEL 8+\n\
+             8/8\n\
+             Flying, trample\n\
+             {R}: This creature gets +1/+0 until end of turn.",
+        )
+        .expect("Kargan Dragonlord should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn kargan_pump_ability_index(game: &GameState, kargan_id: ObjectId) -> usize {
+    game.object(kargan_id)
+        .expect("Kargan Dragonlord should be on the battlefield")
+        .abilities
+        .iter()
+        .enumerate()
+        .find_map(|(index, ability)| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.additional_restrictions.iter().any(|restriction| {
+                    restriction == "__ironsmith_level_range:8:+"
+                }) =>
+            {
+                Some(index)
+            }
+            _ => None,
+        })
+        .expect("Kargan Dragonlord should have its level-8 pump ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn kargan_level_up_ability_index(game: &GameState, kargan_id: ObjectId) -> usize {
+    game.object(kargan_id)
+        .expect("Kargan Dragonlord should be on the battlefield")
+        .abilities
+        .iter()
+        .enumerate()
+        .find_map(|(index, ability)| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if matches!(activated.timing, crate::ability::ActivationTiming::SorcerySpeed)
+                    && activated
+                        .effects
+                        .flattened_default_effects()
+                        .iter()
+                        .any(|effect| {
+                            effect
+                                .downcast_ref::<crate::effects::PutCountersEffect>()
+                                .is_some_and(|put| put.counter_type == crate::object::CounterType::Level)
+                        }) =>
+            {
+                Some(index)
+            }
+            _ => None,
+        })
+        .expect("Kargan Dragonlord should have its level-up ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn kargan_can_activate(game: &GameState, kargan_id: ObjectId, ability_index: usize) -> bool {
+    crate::decision::compute_legal_actions(game, PlayerId::from_index(0))
+        .iter()
+        .any(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == kargan_id && *idx == ability_index
+            )
+        })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_kargan_ability_and_resolve(
+    game: &mut GameState,
+    kargan_id: ObjectId,
+    ability_index: usize,
+) {
+    let action = crate::decision::compute_legal_actions(game, PlayerId::from_index(0))
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == kargan_id && *idx == ability_index
+            )
+        })
+        .expect("Kargan Dragonlord activation should be legal");
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = AutoPassDecisionMaker;
+    apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(action),
+        &mut dm,
+    )
+    .expect("Kargan Dragonlord activation should start");
+    resolve_stack_entry_with_dm_and_triggers(game, &mut dm, &mut trigger_queue)
+        .expect("Kargan Dragonlord activation should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kargan_dragonlord_level_up_adds_counter_and_uses_sorcery_timing() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let kargan = kargan_dragonlord_definition();
+    let kargan_id = game.create_object_from_definition(&kargan, alice, Zone::Battlefield);
+    let level_up_index = kargan_level_up_ability_index(&game, kargan_id);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 1);
+
+    assert!(
+        kargan_can_activate(&game, kargan_id, level_up_index),
+        "Kargan's level-up ability should be legal in its controller's main phase"
+    );
+    game.turn.phase = Phase::Combat;
+    assert!(
+        !kargan_can_activate(&game, kargan_id, level_up_index),
+        "Kargan's level-up ability should not be legal outside sorcery timing"
+    );
+
+    game.turn.phase = Phase::FirstMain;
+    activate_kargan_ability_and_resolve(&mut game, kargan_id, level_up_index);
+
+    assert_eq!(
+        game.object(kargan_id)
+            .expect("Kargan should exist")
+            .counters
+            .get(&crate::object::CounterType::Level)
+            .copied(),
+        Some(1),
+        "Kargan's level-up activation should put one level counter on itself"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice should exist").mana_pool.red,
+        0,
+        "Kargan's level-up activation should spend its red mana cost"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kargan_dragonlord_level_eight_pump_is_gated_and_expires() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let kargan = kargan_dragonlord_definition();
+    let kargan_id = game.create_object_from_definition(&kargan, alice, Zone::Battlefield);
+    let pump_index = kargan_pump_ability_index(&game, kargan_id);
+    game.add_counters(kargan_id, crate::object::CounterType::Level, 7);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Red, 2);
+
+    assert!(
+        !kargan_can_activate(&game, kargan_id, pump_index),
+        "Kargan's pump should not be legal before it has eight level counters"
+    );
+    game.add_counters(kargan_id, crate::object::CounterType::Level, 1);
+    assert!(
+        kargan_can_activate(&game, kargan_id, pump_index),
+        "Kargan's pump should become legal at eight level counters"
+    );
+
+    activate_kargan_ability_and_resolve(&mut game, kargan_id, pump_index);
+    game.refresh_continuous_state();
+
+    assert_eq!(game.calculated_power(kargan_id), Some(9));
+    assert_eq!(game.calculated_toughness(kargan_id), Some(8));
+    assert!(
+        game.object_has_ability(kargan_id, &StaticAbility::flying())
+            && game.object_has_ability(kargan_id, &StaticAbility::trample()),
+        "Kargan should have its level-eight flying and trample while pumped"
+    );
+
+    execute_cleanup_step(&mut game);
+    assert_eq!(game.calculated_power(kargan_id), Some(8));
+    assert_eq!(game.calculated_toughness(kargan_id), Some(8));
+}
+
 #[test]
 fn guardian_of_the_ages_loses_defender_and_stops_triggering() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kargan Dragonlord
Initial parse error:
```
unsupported level ability line: '{R}: This creature gets +1/+0 until end of turn.'; oracle-only fallback also failed: unsupported level ability line: '{R}: This creature gets +1/+0 until end of turn.'
```

Current worker: i-0e85ab8dfd87d21ef
Branch: codex/aws-card-fix-kargan-dragonlord
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0004
