### PR TITLE
Fix Ironsmith parse failure: Gorex, the Tombshell

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -391,6 +391,15 @@ pub(crate) fn parse_you_choose_objects_clause(
     {
         choose_words = choose_words[1..].to_vec();
     }
+    let mut idx = 0usize;
+    while idx + 1 < choose_words.len() {
+        if choose_words[idx] == "at" && choose_words[idx + 1] == "random" {
+            count = count.at_random();
+            choose_words.drain(idx..idx + 2);
+            continue;
+        }
+        idx += 1;
+    }
 
     if choose_words.is_empty() {
         return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -1853,6 +1853,8 @@ const DESTROYED_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["destroyed"]);
 const DISCARDED_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["discarded"]);
+const EXILED_THIS_WAY_PATTERN: ClauseShape<'static> =
+    clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["exiled"]);
 const REVEALED_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["revealed"]);
 const THIS_WAY_PATTERN: ClauseShape<'static> = clause_shape!(contains_phrases & [&["this", "way"]]);
@@ -7789,6 +7791,11 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
             source: EffectMetricSource::Outcome,
             metric: EffectMetric::Count,
         }));
+    }
+    if EXILED_THIS_WAY_PATTERN.matches_words(&filter_words) {
+        return Ok(Some(Value::Count(
+            ObjectFilter::tagged(crate::tag::SOURCE_EXILED_TAG).in_zone(Zone::Exile),
+        )));
     }
     if REVEALED_THIS_WAY_PATTERN.matches_words(&filter_words)
         && let Some((value, used_words)) = parse_for_each_count_value_words(&words_all)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -3961,6 +3961,7 @@ fn tagged_it_owner_or_controller_player_filter(word: &str) -> PlayerFilter {
 
 fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, CardTextError> {
     let mut tokens = tokens;
+    let stripped_random_tokens;
     while token_slice_first_is(tokens, "then") {
         tokens = &tokens[1..];
     }
@@ -3995,6 +3996,22 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
         && let Some(random_idx) = token_word_view.token_index_for_word_index(token_words.len() - 2)
     {
         tokens = &tokens[..random_idx];
+        random_choice = true;
+    } else if let Some(random_word_idx) = token_words
+        .windows(2)
+        .position(|window| window == ["at", "random"])
+        && let Some(random_start) = token_word_view.token_index_for_word_index(random_word_idx)
+    {
+        let random_end = token_word_view
+            .token_index_for_word_index(random_word_idx + 2)
+            .unwrap_or(tokens.len());
+        stripped_random_tokens = tokens
+            .iter()
+            .take(random_start)
+            .chain(tokens.iter().skip(random_end))
+            .cloned()
+            .collect::<Vec<_>>();
+        tokens = &stripped_random_tokens;
         random_choice = true;
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,147 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn gorex_the_tombshell_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Gorex, the Tombshell");
+
+    let def = parse_oracle_card_definition("Gorex, the Tombshell");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        ability_debug.contains(crate::tag::SOURCE_EXILED_TAG)
+            && ability_debug.contains("random: true")
+            && ability_debug.contains("CountScaled")
+            && ability_debug.contains("MoveToZoneEffect"),
+        "Gorex should structurally count cards exiled this way and choose one at random to move to hand, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("This spell costs {2} less to cast for each card exiled this way."),
+        "Gorex should render the source-exiled cost reduction, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever this creature attacks or dies, you choose a card at random exiled with this creature and put that card into its owner's hand."
+        ),
+        "Gorex should render the random source-exiled return trigger, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gorex_the_tombshell_cost_reduction_counts_cards_exiled_with_gorex() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let def = parse_oracle_card_definition("Gorex, the Tombshell");
+    let gorex_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let base_cost = ManaCost::from_pips(vec![
+        vec![ManaSymbol::Generic(6)],
+        vec![ManaSymbol::Black],
+        vec![ManaSymbol::Black],
+    ]);
+
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(
+            &game,
+            alice,
+            game.object(gorex_id).expect("Gorex should exist"),
+            &base_cost,
+        )
+        .to_oracle(),
+        "{6}{B}{B}",
+        "without source-exiled links, Gorex should receive no reduction"
+    );
+
+    let linked_card = CardDefinitionBuilder::new(CardId::new(), "Actually Exiled Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let linked_id = game.create_object_from_definition(&linked_card, alice, Zone::Exile);
+    game.add_exiled_with_source_link(gorex_id, linked_id);
+
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(
+            &game,
+            alice,
+            game.object(gorex_id).expect("Gorex should exist"),
+            &base_cost,
+        )
+        .to_oracle(),
+        "{4}{B}{B}",
+        "one card exiled with Gorex should reduce its cost by {{2}}"
+    );
+
+    for _ in 0..2 {
+        let extra_id = game.create_object_from_definition(&linked_card, alice, Zone::Exile);
+        game.add_exiled_with_source_link(gorex_id, extra_id);
+    }
+
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(
+            &game,
+            alice,
+            game.object(gorex_id).expect("Gorex should exist"),
+            &base_cost,
+        )
+        .to_oracle(),
+        "{B}{B}",
+        "three cards exiled with Gorex should reduce its cost by {{6}}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gorex_the_tombshell_trigger_returns_only_card_exiled_with_gorex() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    game.set_random_seed(1);
+    let alice = PlayerId::from_index(0);
+    let def = parse_oracle_card_definition("Gorex, the Tombshell");
+    let gorex_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let linked_card = CardDefinitionBuilder::new(CardId::new(), "Linked Exiled Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let unrelated_card = CardDefinitionBuilder::new(CardId::new(), "Unrelated Exiled Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let linked_id = game.create_object_from_definition(&linked_card, alice, Zone::Exile);
+    let unrelated_id = game.create_object_from_definition(&unrelated_card, alice, Zone::Exile);
+    game.add_exiled_with_source_link(gorex_id, linked_id);
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered.clone()),
+            _ => None,
+        })
+        .expect("Gorex should have an attacks-or-dies trigger");
+    let mut ctx = crate::effects::ExecutionContext::new_default(gorex_id, alice);
+    for effect in triggered.effects.flattened_default_effects() {
+        if effect
+            .downcast_ref::<crate::effects::TagTriggeringObjectEffect>()
+            .is_some()
+        {
+            continue;
+        }
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Gorex source-exiled choice and move should resolve");
+    }
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        1,
+        "Gorex should put the linked exiled card into its owner's hand"
+    );
+    assert_eq!(
+        game.object(unrelated_id).expect("unrelated card exists").zone,
+        Zone::Exile,
+        "Gorex should ignore exiled cards not linked to it"
+    );
+}
+
+#[test]
 fn clockspinning_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Clockspinning");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -14341,6 +14341,17 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         if idx + 1 < filtered.len()
             && let Some(choose) =
                 filtered[idx].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some(move_to_zone) = unwrap_tag_wrappers(filtered[idx + 1])
+                .downcast_ref::<crate::effects::MoveToZoneEffect>()
+            && let Some(compact) = describe_choose_then_move_to_hand(choose, move_to_zone)
+        {
+            parts.push(compact);
+            idx += 2;
+            continue;
+        }
+        if idx + 1 < filtered.len()
+            && let Some(choose) =
+                filtered[idx].downcast_ref::<crate::effects::ChooseObjectsEffect>()
             && let Some(move_to_zone) =
                 filtered[idx + 1].downcast_ref::<crate::effects::MoveToZoneEffect>()
             && let Some(compact) = describe_choose_then_move_to_battlefield(choose, move_to_zone)
@@ -16858,7 +16869,8 @@ fn describe_trigger_surface_with_frequency(
         return "At the beginning of the end step".to_string();
     }
 
-    let mut trigger_surface = triggered.trigger.display();
+    let mut trigger_surface = describe_this_attacks_or_dies_trigger(&triggered.trigger)
+        .unwrap_or_else(|| triggered.trigger.display());
     if matches!(
         trigger_frequency,
         Some(TriggerFrequencySurface::FirstTimeThisTurn)
@@ -16866,6 +16878,28 @@ fn describe_trigger_surface_with_frequency(
         trigger_surface.push_str(" for the first time each turn");
     }
     trigger_surface
+}
+
+fn describe_this_attacks_or_dies_trigger(trigger: &crate::triggers::Trigger) -> Option<String> {
+    let or_trigger = trigger.downcast_ref::<crate::triggers::OrTrigger>()?;
+    if or_trigger.triggers.len() != 2 {
+        return None;
+    }
+    let has_attacks = or_trigger.triggers.iter().any(trigger_is_this_attacks);
+    let has_dies = or_trigger.triggers.iter().any(|trigger| {
+        trigger
+            .downcast_ref::<crate::triggers::zone_changes::ZoneChangeTrigger>()
+            .is_some_and(|zone_change| {
+                zone_change.this_object
+                    && zone_change.from
+                        == crate::triggers::zone_changes::ZonePattern::Specific(Zone::Battlefield)
+                    && zone_change.to
+                        == crate::triggers::zone_changes::ZonePattern::Specific(Zone::Graveyard)
+                    && zone_change.player == crate::triggers::zone_changes::PlayerRelation::Any
+            })
+    });
+
+    (has_attacks && has_dies).then(|| "Whenever this creature attacks or dies".to_string())
 }
 
 fn describe_triggered_resolution_text(
@@ -23353,6 +23387,10 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
         return "the top card".to_string();
     }
 
+    if let Some(selection) = describe_source_exiled_choose_selection(choose) {
+        return selection;
+    }
+
     let filter_text = choose.filter.description();
     let mut card_desc = filter_text
         .split(" in ")
@@ -23419,7 +23457,12 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
     };
 
     if choose.count.is_single() {
-        return format!("{}{}", with_indefinite_article(&card_desc), where_x_suffix);
+        let mut selection = with_indefinite_article(&card_desc);
+        if choose.count.random {
+            selection.push_str(" at random");
+        }
+        selection.push_str(&where_x_suffix);
+        return selection;
     }
     if let Some(runtime_count) = describe_runtime_choice_count(choose) {
         let mut selection = describe_plural_selection(runtime_count, &card_desc);
@@ -23436,6 +23479,38 @@ pub(super) fn describe_choose_selection(choose: &crate::effects::ChooseObjectsEf
     let mut selection = describe_plural_selection(describe_choice_count(&choose.count), &card_desc);
     selection.push_str(&where_x_suffix);
     selection
+}
+
+fn source_exiled_with_phrase(filter: &ObjectFilter) -> String {
+    let description = filter.description();
+    let base = description
+        .split(" in ")
+        .next()
+        .unwrap_or(description.as_str())
+        .trim();
+    if let Some(source) = base
+        .strip_prefix("exiled with ")
+        .and_then(|rest| rest.strip_suffix(" card"))
+    {
+        return format!("exiled with {source}");
+    }
+    "exiled with this source".to_string()
+}
+
+fn describe_source_exiled_choose_selection(
+    choose: &crate::effects::ChooseObjectsEffect,
+) -> Option<String> {
+    if !choose.count.is_single() || !is_source_exiled_cards_filter(&choose.filter) {
+        return None;
+    }
+
+    let mut selection = "a card".to_string();
+    if choose.count.random {
+        selection.push_str(" at random");
+    }
+    selection.push(' ');
+    selection.push_str(&source_exiled_with_phrase(&choose.filter));
+    Some(selection)
 }
 
 fn apply_mana_value_where_x_surface(card_desc: &mut String, filter: &ObjectFilter) -> String {
@@ -23902,6 +23977,32 @@ pub(super) fn describe_choose_then_move_to_battlefield(
     let put_verb = player_verb(&chooser, "put", "puts");
     Some(format!(
         "{chooser} {put_verb} {chosen} {origin} onto the battlefield{tapped}{attacking}{control_suffix}{where_x_clause}"
+    ))
+}
+
+pub(super) fn describe_choose_then_move_to_hand(
+    choose: &crate::effects::ChooseObjectsEffect,
+    move_to_zone: &crate::effects::MoveToZoneEffect,
+) -> Option<String> {
+    if choose.is_search
+        || !is_source_exiled_cards_filter(&choose.filter)
+        || !move_to_hand_uses_chosen_tag(move_to_zone, choose.tag.as_str())
+    {
+        return None;
+    }
+
+    let chooser = describe_player_filter(&choose.chooser);
+    let choose_verb = player_verb(&chooser, "choose", "chooses");
+    let put_verb = player_verb(&chooser, "put", "puts");
+    let chosen = describe_choose_selection(choose);
+    let moved_ref = if choose.count.is_single() {
+        "that card"
+    } else {
+        "those cards"
+    };
+
+    Some(format!(
+        "{chooser} {choose_verb} {chosen} and {put_verb} {moved_ref} into its owner's hand"
     ))
 }
 
@@ -40794,6 +40895,22 @@ pub(super) fn describe_enchant_filter(filter: &crate::object::AuraAttachmentFilt
 }
 
 pub(super) fn describe_additional_costs(costs: &[crate::costs::Cost]) -> String {
+    fn normalize_additional_cost_surface(text: String) -> String {
+        let mut text = if let Some(rest) = text.strip_prefix("may ") {
+            format!("you may {rest}")
+        } else if let Some(rest) = text.strip_prefix("May ") {
+            format!("you may {rest}")
+        } else {
+            text
+        };
+        if text.contains("exile ") {
+            text = text
+                .replace(" cards in your graveyard", " cards from your graveyard")
+                .replace(" card in your graveyard", " card from your graveyard");
+        }
+        text
+    }
+
     fn describe_blight_cost(amount: &str) -> String {
         if amount == "1" || amount == "one" {
             "you may blight 1 by putting a -1/-1 counter on a creature you control".to_string()
@@ -40907,7 +41024,7 @@ pub(super) fn describe_additional_costs(costs: &[crate::costs::Cost]) -> String 
     {
         return describe_blight_cost(amount_text);
     }
-    described
+    normalize_additional_cost_surface(described)
 }
 
 pub(super) fn describe_alternative_costs(costs: &[crate::costs::Cost]) -> String {

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -428,6 +428,32 @@ fn count_as_card_named_for_spell_effect_bonus(
         .count()
 }
 
+fn source_exiled_link_count(
+    game: &GameState,
+    filter: &crate::filter::ObjectFilter,
+    ctx: &ExecutionContext<'_>,
+    filter_ctx: &crate::target::FilterContext,
+) -> Option<i32> {
+    let uses_source_exiled_tag = filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+    });
+    if !uses_source_exiled_tag {
+        return None;
+    }
+    if ctx.get_tagged_all(crate::tag::SOURCE_EXILED_TAG).is_some() {
+        return None;
+    }
+
+    Some(
+        game.get_exiled_with_source_links(ctx.source)
+            .iter()
+            .filter_map(|&id| game.object(id))
+            .filter(|object| filter.matches(object, filter_ctx, game))
+            .count() as i32,
+    )
+}
+
 /// Resolve a Value to a concrete i32.
 pub fn resolve_value(
     game: &GameState,
@@ -471,6 +497,11 @@ pub fn resolve_value(
                     .iter()
                     .filter(|snapshot| filter.matches_snapshot(snapshot, &filter_ctx, game))
                     .count();
+                if count == 0
+                    && let Some(count) = source_exiled_link_count(game, filter, ctx, &filter_ctx)
+                {
+                    return Ok(count);
+                }
                 return Ok(count as i32);
             }
             let candidate_ids = value_candidate_ids_for_filter(game, filter, ctx);
@@ -502,6 +533,11 @@ pub fn resolve_value(
                     .iter()
                     .filter(|snapshot| filter.matches_snapshot(snapshot, &filter_ctx, game))
                     .count() as i32;
+                if count == 0
+                    && let Some(count) = source_exiled_link_count(game, filter, ctx, &filter_ctx)
+                {
+                    return Ok(count * *multiplier);
+                }
                 return Ok(count * *multiplier);
             }
             let candidate_ids = value_candidate_ids_for_filter(game, filter, ctx);

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -220,6 +220,13 @@ fn describe_types_among_scope(filter: &ObjectFilter) -> String {
     description
 }
 
+fn is_source_exiled_count_filter(filter: &ObjectFilter) -> bool {
+    filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+    })
+}
+
 fn describe_spell_cast_count_tail(
     player: &PlayerFilter,
     filter: &ObjectFilter,
@@ -275,11 +282,19 @@ fn describe_cost_modifier_amount(amount: &Value) -> (String, Option<String>) {
         Value::X => ("{X}".to_string(), None),
         Value::Count(filter) => (
             "{1}".to_string(),
-            Some(format!("for each {}", filter.description())),
+            Some(if is_source_exiled_count_filter(filter) {
+                "for each card exiled this way".to_string()
+            } else {
+                format!("for each {}", filter.description())
+            }),
         ),
         Value::CountScaled(filter, multiplier) => (
             format!("{{{multiplier}}}"),
-            Some(format!("for each {}", filter.description())),
+            Some(if is_source_exiled_count_filter(filter) {
+                "for each card exiled this way".to_string()
+            } else {
+                format!("for each {}", filter.description())
+            }),
         ),
         Value::GreatestCount(filter) => (
             "{X}".to_string(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gorex, the Tombshell
Initial parse error:
```
unsupported this-way dynamic value (clause: 'less to cast for each card exiled this way'); oracle-only fallback also failed: unsupported this-way dynamic value (clause: 'less to cast for each card exiled this way')
```

Current worker: i-00ff63890d0af6c3b
Branch: codex/aws-card-fix-gorex-the-tombshell
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0006
