### PR TITLE
Fix Ironsmith parse failure: Soul Nova

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4845,6 +4845,62 @@ fn compile_subject_verb_effect(
             prelude.push(effect);
             Ok((prelude, choices))
         }
+        SubjectVerbActionAst::ExileAllAttachedTo {
+            filter,
+            target,
+            face_down,
+        } => {
+            let (target_spec, choices) =
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let mut prelude = Vec::new();
+            let mut choices = choices;
+            let mut resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
+            let target_tag = if let ChooseSpec::Tagged(tag) = &target_spec {
+                tag.as_str().to_string()
+            } else {
+                if !choose_spec_targets_object(&target_spec) || !target_spec.is_target() {
+                    return Err(CardTextError::ParseError(
+                        "exile-attached target must be a target object or tagged object"
+                            .to_string(),
+                    ));
+                }
+                let tag = ctx.next_tag("attachment_target");
+                prelude.push(
+                    Effect::new(crate::effects::TargetOnlyEffect::new(target_spec.clone()))
+                        .tag(tag.clone()),
+                );
+                tag
+            };
+            ctx.last_object_tag = Some(target_tag.clone());
+
+            resolved_filter
+                .tagged_constraints
+                .push(TaggedObjectConstraint {
+                    tag: TagKey::from(target_tag.as_str()),
+                    relation: TaggedOpbjectRelation::AttachedToTaggedObject,
+                });
+
+            let (mut filter_prelude, filter_choices) =
+                target_context_prelude_for_filter(&resolved_filter);
+            for choice in filter_choices {
+                push_choice(&mut choices, choice);
+            }
+            prelude.append(&mut filter_prelude);
+            prelude.push(Effect::new(
+                crate::effects::ExileEffect::all(resolved_filter).with_face_down(*face_down),
+            ));
+
+            let tagged_target = ChooseSpec::Tagged(TagKey::from(target_tag.as_str()));
+            let target_exile = if *face_down {
+                Effect::new(
+                    crate::effects::ExileEffect::with_spec(tagged_target).with_face_down(true),
+                )
+            } else {
+                Effect::move_to_zone(tagged_target, Zone::Exile, true)
+            };
+            prelude.push(target_exile);
+            Ok((prelude, choices))
+        }
         SubjectVerbActionAst::Exile { target, face_down } => {
             if let Some(compiled) = lower_hand_exile_target(target, *face_down, ctx)? {
                 return Ok(compiled);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -117,6 +117,7 @@ fn with_direct_effect_targets(effect: &EffectAst, mut visit: impl FnMut(&TargetA
                 permanent1: target, ..
             }
             | SubjectVerbActionAst::DestroyAllAttachedTo { target, .. }
+            | SubjectVerbActionAst::ExileAllAttachedTo { target, .. }
             | SubjectVerbActionAst::ExileWhenSourceLeaves { target }
             | SubjectVerbActionAst::SacrificeSourceWhenLeaves { target }
             | SubjectVerbActionAst::MayMoveToZone { target, .. }
@@ -264,6 +265,7 @@ fn effect_tagged_filter(effect: &EffectAst) -> Option<&ObjectFilter> {
             | SubjectVerbActionAst::Sacrifice { filter, .. }
             | SubjectVerbActionAst::ExchangeControl { filter, .. }
             | SubjectVerbActionAst::DestroyAllAttachedTo { filter, .. }
+            | SubjectVerbActionAst::ExileAllAttachedTo { filter, .. }
             | SubjectVerbActionAst::ChooseSpellCastHistory { filter, .. }
             | SubjectVerbActionAst::PreventDamageEach { filter, .. }
             | SubjectVerbActionAst::ReturnAllToBattlefield { filter, .. }
@@ -792,6 +794,7 @@ fn subject_verb_action_value(action: &SubjectVerbActionAst) -> Option<&Value> {
         | SubjectVerbActionAst::ExchangeControl { .. }
         | SubjectVerbActionAst::ExchangeControlHeterogeneous { .. }
         | SubjectVerbActionAst::DestroyAllAttachedTo { .. }
+        | SubjectVerbActionAst::ExileAllAttachedTo { .. }
         | SubjectVerbActionAst::Attach { .. }
         | SubjectVerbActionAst::ExileWhenSourceLeaves { .. }
         | SubjectVerbActionAst::SacrificeSourceWhenLeaves { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1538,6 +1538,11 @@ pub(crate) enum SubjectVerbActionAst {
         filter: ObjectFilter,
         target: TargetAst,
     },
+    ExileAllAttachedTo {
+        filter: ObjectFilter,
+        target: TargetAst,
+        face_down: bool,
+    },
     Exile {
         target: TargetAst,
         face_down: bool,
@@ -3016,6 +3021,16 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .debug_struct("DestroyAllAttachedTo")
                 .field("filter", filter)
                 .field("target", target)
+                .finish(),
+            Self::ExileAllAttachedTo {
+                filter,
+                target,
+                face_down,
+            } => f
+                .debug_struct("ExileAllAttachedTo")
+                .field("filter", filter)
+                .field("target", target)
+                .field("face_down", face_down)
                 .finish(),
             Self::Exile { target, face_down } => f
                 .debug_struct("Exile")
@@ -5028,6 +5043,22 @@ impl EffectAst {
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
             SubjectVerbActionAst::DestroyAllAttachedTo { filter, target },
+        )
+    }
+
+    pub(crate) fn subject_verb_exile_all_attached_to(
+        filter: ObjectFilter,
+        target: TargetAst,
+        face_down: bool,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::ExileAllAttachedTo {
+                filter,
+                target,
+                face_down,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -448,6 +448,7 @@ fn replace_modal_header_x_in_effect_ast(
             | SubjectVerbActionAst::ExchangeControl { .. }
             | SubjectVerbActionAst::ExchangeControlHeterogeneous { .. }
             | SubjectVerbActionAst::DestroyAllAttachedTo { .. }
+            | SubjectVerbActionAst::ExileAllAttachedTo { .. }
             | SubjectVerbActionAst::Attach { .. }
             | SubjectVerbActionAst::ExileWhenSourceLeaves { .. }
             | SubjectVerbActionAst::SacrificeSourceWhenLeaves { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -743,6 +743,12 @@ fn advance_reference_frame_for_effect(
                     }
                     track_player_from_object_filter(filter, frame);
                 }
+                SubjectVerbActionAst::ExileAllAttachedTo { filter, .. } => {
+                    if frame.auto_tag_object_targets {
+                        frame.last_object_tag = Some(next_reference_tag(id_gen, "affected"));
+                    }
+                    track_player_from_object_filter(filter, frame);
+                }
                 SubjectVerbActionAst::ExchangeValues { left, right, .. } => {
                     match left {
                         crate::cards::builders::ExchangeValueAst::LifeTotal(player) => {
@@ -2124,6 +2130,7 @@ fn resolve_effect_result_values_in_fields(
             | SubjectVerbActionAst::ExchangeControl { .. }
             | SubjectVerbActionAst::ExchangeControlHeterogeneous { .. }
             | SubjectVerbActionAst::DestroyAllAttachedTo { .. }
+            | SubjectVerbActionAst::ExileAllAttachedTo { .. }
             | SubjectVerbActionAst::Attach { .. }
             | SubjectVerbActionAst::ExileWhenSourceLeaves { .. }
             | SubjectVerbActionAst::SacrificeSourceWhenLeaves { .. }
@@ -2739,7 +2746,8 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             SubjectVerbActionAst::RegisterDamagedBySourceZoneReplacement { filter, .. } => {
                 bind_unresolved_it_in_filter(filter, seed_tag)
             }
-            SubjectVerbActionAst::DestroyAllAttachedTo { filter, target } => {
+            SubjectVerbActionAst::DestroyAllAttachedTo { filter, target }
+            | SubjectVerbActionAst::ExileAllAttachedTo { filter, target, .. } => {
                 bind_unresolved_it_in_filter(filter, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -2612,6 +2612,7 @@ pub(crate) fn replace_unbound_x_in_effect_anywhere(
             | SubjectVerbActionAst::ExchangeControl { .. }
             | SubjectVerbActionAst::ExchangeControlHeterogeneous { .. }
             | SubjectVerbActionAst::DestroyAllAttachedTo { .. }
+            | SubjectVerbActionAst::ExileAllAttachedTo { .. }
             | SubjectVerbActionAst::Attach { .. }
             | SubjectVerbActionAst::ExileWhenSourceLeaves { .. }
             | SubjectVerbActionAst::SacrificeSourceWhenLeaves { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -188,14 +188,8 @@ pub(crate) fn parse_exile(
             clause_words.join(" ")
         )));
     }
-    let has_attached_bundle = grammar::contains_word(tokens, "and")
-        && grammar::contains_word(tokens, "all")
-        && grammar::contains_word(tokens, "attached");
-    if has_attached_bundle {
-        return Err(CardTextError::ParseError(format!(
-            "unsupported attached-object exile bundle (clause: '{}')",
-            clause_words.join(" ")
-        )));
+    if let Some(effect) = parse_attached_object_exile_bundle(tokens, face_down)? {
+        return Ok(effect);
     }
     let has_same_name_token_bundle = grammar::contains_word(tokens, "and")
         && grammar::contains_word(tokens, "tokens")
@@ -258,6 +252,60 @@ pub(crate) fn parse_exile(
     } else {
         EffectAst::subject_verb_exile(target, face_down)
     })
+}
+
+fn parse_attached_object_exile_bundle(
+    tokens: &[OwnedLexToken],
+    face_down: bool,
+) -> Result<Option<EffectAst>, CardTextError> {
+    let Some((target_tokens, attached_tokens)) =
+        crate::runtime_backend::grammar::primitives::split_lexed_once_on_separator(tokens, || {
+            use winnow::Parser as _;
+            crate::runtime_backend::grammar::primitives::kw("and").void()
+        })
+    else {
+        return Ok(None);
+    };
+    let Some(attached_tokens) =
+        crate::runtime_backend::grammar::primitives::strip_lexed_prefix_phrase(
+            attached_tokens,
+            &["all"],
+        )
+    else {
+        return Ok(None);
+    };
+    let Some(attached_idx) = attached_tokens
+        .iter()
+        .position(|token| token.as_word().is_some_and(|word| word == "attached"))
+    else {
+        return Ok(None);
+    };
+    if !attached_tokens
+        .get(attached_idx + 1)
+        .is_some_and(|token| token.as_word().is_some_and(|word| word == "to"))
+    {
+        return Ok(None);
+    }
+    let attachment_filter_tokens = &attached_tokens[..attached_idx];
+    let attachment_target_tokens = &attached_tokens[attached_idx + 2..];
+    if target_tokens.is_empty()
+        || attachment_filter_tokens.is_empty()
+        || attachment_target_tokens.is_empty()
+    {
+        return Ok(None);
+    }
+    let attachment_target_words = crate::runtime_backend::token_word_refs(attachment_target_tokens);
+    if attachment_target_words.as_slice() != ["it"] {
+        return Ok(None);
+    }
+
+    let target = parse_target_phrase(target_tokens)?;
+    let attachment_filter = parse_object_filter_lexed(attachment_filter_tokens, false)?;
+    Ok(Some(EffectAst::subject_verb_exile_all_attached_to(
+        attachment_filter,
+        target,
+        face_down,
+    )))
 }
 
 pub(crate) fn parse_same_name_exile_hand_and_graveyard_clause(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6003,6 +6003,27 @@ fn test_strip_bare_normalizes_destroy_attached_auras_and_equipment() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn test_soul_nova_parses_and_renders_attached_equipment_exile_bundle() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(48_101), "Soul Nova")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text("Exile target attacking creature and all Equipment attached to it.")
+        .expect("Soul Nova text should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "Exile target attacking creature and all Equipment attached to it.",
+        "Soul Nova should render the attached Equipment exile bundle as one structural clause"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_deadlock_trap_its_activated_abilities_cant_be_activated_this_turn() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Deadlock Trap Test")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3508,6 +3508,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return Some(compact);
     }
 
+    if let Some(compact) = describe_exile_target_and_attached_objects(effects) {
+        return Some(compact);
+    }
+
     if effects.len() == 3 {
         let refs = effects.iter().collect::<Vec<_>>();
         if let Some(compact) = describe_discard_hand_add_mana_draw_sequence(&refs) {
@@ -3539,6 +3543,60 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_choose_name_target_mills_conditional_draw(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_exile_target_and_attached_objects(effects: &[Effect]) -> Option<String> {
+    let [target_effect, attached_exile_effect, target_exile_effect] = effects else {
+        return None;
+    };
+    let tagged_target = target_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let target_only = tagged_target
+        .effect
+        .downcast_ref::<crate::effects::TargetOnlyEffect>()?;
+    let target_exile = target_exile_effect.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if target_exile.zone != Zone::Exile
+        || !matches!(&target_exile.target, ChooseSpec::Tagged(tag) if tag == &tagged_target.tag)
+    {
+        return None;
+    }
+
+    let attached_exile = attached_exile_effect
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .map(|tagged| tagged.effect.as_ref())
+        .unwrap_or(attached_exile_effect)
+        .downcast_ref::<crate::effects::ExileEffect>()?;
+    if attached_exile.face_down {
+        return None;
+    }
+    let ChooseSpec::All(attached_filter) = &attached_exile.spec else {
+        return None;
+    };
+    let matching_constraints = attached_filter
+        .tagged_constraints
+        .iter()
+        .filter(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::AttachedToTaggedObject
+                && constraint.tag == tagged_target.tag
+        })
+        .count();
+    if matching_constraints != 1 {
+        return None;
+    }
+
+    let mut described_filter = attached_filter.clone();
+    described_filter.tagged_constraints.retain(|constraint| {
+        !(constraint.relation == crate::filter::TaggedOpbjectRelation::AttachedToTaggedObject
+            && constraint.tag == tagged_target.tag)
+    });
+    if described_filter == ObjectFilter::default() {
+        return None;
+    }
+
+    let target_text = describe_choose_spec(&target_only.target);
+    let attached_text = described_filter.description();
+    Some(format!(
+        "Exile {target_text} and all {attached_text} attached to it"
+    ))
 }
 
 fn describe_sacrificed_object_conditional_sequence(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -36931,6 +36931,211 @@ fn test_strip_bare_destroys_attached_auras_and_equipment_only() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn soul_nova_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(48_101), "Soul Nova")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text("Exile target attacking creature and all Equipment attached to it.")
+        .expect("Soul Nova should parse strictly for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_soul_nova_exiles_attacking_creature_and_attached_equipment_only() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 5);
+
+    let soul_nova = soul_nova_definition();
+    let soul_nova_id = game.create_object_from_definition(&soul_nova, alice, Zone::Hand);
+    let attacker_id = create_creature(&mut game, "Soul Nova Attacker", bob, 3, 3);
+    let other_creature_id = create_creature(&mut game, "Soul Nova Bystander", bob, 2, 2);
+    game.remove_summoning_sickness(attacker_id);
+
+    let mut combat = CombatState::default();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker_id,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("Soul Nova target creature should be able to attack");
+
+    let equipment_def = CardBuilder::new(CardId::new(), "Soul Nova Equipment")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .build();
+    let equipment_id = game.create_object_from_card(&equipment_def, bob, Zone::Battlefield);
+    assert!(
+        crate::effects::permanents::attach_battlefield_object_to_target(
+            &mut game,
+            equipment_id,
+            crate::object::AttachmentTarget::Object(attacker_id),
+        ),
+        "equipment should attach to the attacking creature"
+    );
+
+    let second_equipment_def = CardBuilder::new(CardId::new(), "Soul Nova Other Equipment")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .build();
+    let other_equipment_id =
+        game.create_object_from_card(&second_equipment_def, bob, Zone::Battlefield);
+    assert!(
+        crate::effects::permanents::attach_battlefield_object_to_target(
+            &mut game,
+            other_equipment_id,
+            crate::object::AttachmentTarget::Object(other_creature_id),
+        ),
+        "other equipment should attach to the non-target creature"
+    );
+
+    let aura_def = CardDefinitionBuilder::new(CardId::new(), "Soul Nova Aura")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .parse_text("Enchant creature")
+        .expect("aura should parse");
+    let aura_id = game.create_object_from_definition(&aura_def, bob, Zone::Battlefield);
+    assert!(
+        crate::effects::permanents::attach_battlefield_object_to_target(
+            &mut game,
+            aura_id,
+            crate::object::AttachmentTarget::Object(attacker_id),
+        ),
+        "aura should attach to the attacking creature"
+    );
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let cast_response = PriorityResponse::PriorityAction(LegalAction::CastSpell {
+        spell_id: soul_nova_id,
+        from_zone: Zone::Hand,
+        casting_method: CastingMethod::Normal,
+    });
+    let progress = apply_priority_response(&mut game, &mut trigger_queue, &mut state, &cast_response)
+        .expect("Soul Nova cast should start successfully");
+    assert!(
+        matches!(
+            progress,
+            GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(_))
+        ),
+        "Soul Nova should ask for one attacking creature target"
+    );
+
+    apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::Targets(vec![Target::Object(attacker_id)]),
+    )
+    .expect("choosing the attacking creature should complete Soul Nova");
+    assert_eq!(game.stack.len(), 1, "Soul Nova should be on the stack");
+    resolve_stack_entry(&mut game).expect("Soul Nova should resolve");
+
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Soul Nova Attacker"),
+        1,
+        "Soul Nova should exile the target attacking creature"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Soul Nova Equipment"),
+        1,
+        "Soul Nova should exile Equipment attached to the target creature"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Battlefield, "Soul Nova Other Equipment"),
+        1,
+        "Soul Nova should not exile Equipment attached to a different creature"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Soul Nova Aura"),
+        0,
+        "Soul Nova should not exile non-Equipment attachments"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_soul_nova_targets_only_attacking_creatures() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::White, 5);
+
+    let soul_nova = soul_nova_definition();
+    let soul_nova_id = game.create_object_from_definition(&soul_nova, alice, Zone::Hand);
+    let attacker_id = create_creature(&mut game, "Soul Nova Legal Attacker", bob, 3, 3);
+    let nonattacker_id = create_creature(&mut game, "Soul Nova Illegal Bystander", bob, 2, 2);
+    game.remove_summoning_sickness(attacker_id);
+
+    let mut combat = CombatState::default();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: attacker_id,
+            target: AttackTarget::Player(alice),
+        }],
+    )
+    .expect("attacker should be legal");
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let progress = apply_priority_response(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id: soul_nova_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("Soul Nova cast should ask for targets");
+
+    let targets_ctx = match progress {
+        GameProgress::NeedsDecisionCtx(crate::decisions::context::DecisionContext::Targets(ctx)) => {
+            ctx
+        }
+        other => panic!("expected Soul Nova target prompt, got {other:?}"),
+    };
+    let legal_targets = &targets_ctx.requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(attacker_id)),
+        "Soul Nova should be able to target the attacking creature"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(nonattacker_id)),
+        "Soul Nova should not be able to target a nonattacking creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_asinine_antics_flash_extra_cost_is_available_at_instant_timing_only_as_alternative() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Soul Nova
Initial parse error:
```
unsupported attached-object exile bundle (clause: 'target attacking creature and all equipment attached to it'); oracle-only fallback also failed: unsupported attached-object exile bundle (clause: 'target attacking creature and all equipment attached to it')
```

Current worker: i-02567c55073c6919a
Branch: codex/aws-card-fix-soul-nova
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0009
