### PR TITLE
Fix Ironsmith parse failure: Cemetery Illuminator

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -2,7 +2,7 @@ use crate::effect::{Until, Value, ValueComparisonOperator};
 use crate::host::{CardTextError, EffectAst, IT_TAG, PlayerAst, PredicateAst, TagKey, TargetAst};
 use crate::runtime_backend::GrantedAbilityAst;
 use crate::static_abilities::StaticAbility;
-use crate::target::ObjectFilter;
+use crate::target::{ObjectFilter, TaggedObjectConstraint, TaggedOpbjectRelation};
 use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
 use winnow::combinator::alt;
@@ -19,8 +19,8 @@ use super::grammar::primitives as grammar;
 use super::grammar::values::parse_value_comparison_tokens;
 use super::lexer::{
     LexStream, OwnedLexToken, TokenKind, token_slice_first_is_any, token_slice_strip_word_prefix,
-    token_word_refs, trim_lexed_commas, word_slice_ends_with, word_slice_eq,
-    word_slice_starts_with,
+    parser_token_word_refs, token_word_refs, trim_lexed_commas, word_slice_ends_with,
+    word_slice_eq, word_slice_starts_with,
 };
 use super::object_filters::merge_spell_filters;
 use super::token_primitives::{
@@ -1088,6 +1088,56 @@ fn parse_once_each_turn_graveyard_cast_permission(
     }))
 }
 
+fn parse_once_each_turn_top_library_cast_shares_source_exiled_type_permission(
+    clause_refs: &[&str],
+) -> Option<PermissionClauseSpec> {
+    const PREFIX: &[&str] = &["once", "each", "turn", "you", "may", "cast"];
+    const TOP_LIBRARY_TAIL: &[&str] = &["from", "the", "top", "of", "your", "library"];
+    const CONDITION_PREFIX: &[&str] = &["if", "it", "shares", "a", "card", "type", "with"];
+    const SOURCE_EXILED_PREFIX: &[&str] = &["a", "card", "exiled", "with", "this"];
+
+    if !word_slice_starts_with(clause_refs, PREFIX) {
+        return None;
+    }
+    let rest = &clause_refs[PREFIX.len()..];
+    let subject_len = match rest {
+        ["a", "spell", ..] => 2,
+        ["spells", ..] => 1,
+        _ => return None,
+    };
+    let after_subject = &rest[subject_len..];
+    if !word_slice_starts_with(after_subject, TOP_LIBRARY_TAIL) {
+        return None;
+    }
+    let after_zone = &after_subject[TOP_LIBRARY_TAIL.len()..];
+    if !word_slice_starts_with(after_zone, CONDITION_PREFIX) {
+        return None;
+    }
+    let source_exiled = &after_zone[CONDITION_PREFIX.len()..];
+    if source_exiled.len() != SOURCE_EXILED_PREFIX.len() + 1
+        || !word_slice_starts_with(source_exiled, SOURCE_EXILED_PREFIX)
+    {
+        return None;
+    }
+
+    let mut filter = ObjectFilter::nonland();
+    filter.tagged_constraints.push(TaggedObjectConstraint {
+        tag: TagKey::from(crate::tag::SOURCE_EXILED_TAG),
+        relation: TaggedOpbjectRelation::SharesCardType,
+    });
+
+    Some(PermissionClauseSpec::GrantBySpec {
+        player: PlayerAst::You,
+        spec: crate::grant::GrantSpec::new(
+            crate::grant::Grantable::play_from(),
+            filter,
+            Zone::Library,
+        )
+        .with_usage_limit(crate::grant::GrantUsageLimit::OnceEachTurn),
+        lifetime: PermissionLifetime::Static,
+    })
+}
+
 pub(crate) fn parse_permission_clause_spec_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<PermissionClauseSpec>, CardTextError> {
@@ -1100,12 +1150,17 @@ pub(crate) fn parse_permission_clause_spec_lexed(
         tokens = trim_lexed_commas(tokens);
     }
 
-    let clause_refs = token_word_refs(tokens);
+    let clause_refs = parser_token_word_refs(tokens);
     if clause_refs.is_empty() {
         return Ok(None);
     }
 
     if let Some(spec) = parse_once_each_turn_graveyard_cast_permission(tokens, &clause_refs)? {
+        return Ok(Some(spec));
+    }
+    if let Some(spec) =
+        parse_once_each_turn_top_library_cast_shares_source_exiled_type_permission(&clause_refs)
+    {
         return Ok(Some(spec));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -670,6 +670,14 @@ pub(crate) fn classify_static_line_family_lexed(
         &[
             &["you", "may", "cast", "this", "card", "from", "your", "graveyard"],
             &["you", "may", "cast", "this", "spell", "from", "your", "graveyard"],
+            &[
+                "once", "each", "turn", "you", "may", "cast", "a", "spell", "from", "the",
+                "top", "of", "your", "library",
+            ],
+            &[
+                "once", "each", "turn", "you", "may", "cast", "spells", "from", "the", "top",
+                "of", "your", "library",
+            ],
         ],
     ) {
         return Some(StaticLineFamily::Generic);

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -4452,6 +4452,30 @@ fn rewrite_lexed_permission_helpers_cover_flash_and_free_cast_grants() {
 }
 
 #[test]
+fn rewrite_lexed_permission_helpers_parse_once_each_turn_top_library_source_exiled_type_grant() {
+    let tokens = lex_line(
+        "Once each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with this creature.",
+        0,
+    )
+    .expect("rewrite lexer should classify once-per-turn top-library cast permission");
+
+    assert!(matches!(
+        super::permission_helpers::parse_permission_clause_spec_lexed(&tokens),
+        Ok(Some(super::PermissionClauseSpec::GrantBySpec {
+            player: crate::cards::builders::PlayerAst::You,
+            spec,
+            lifetime: super::PermissionLifetime::Static,
+        })) if spec.zone == crate::zone::Zone::Library
+            && matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+            && spec.usage_limit == Some(crate::grant::GrantUsageLimit::OnceEachTurn)
+            && spec.filter.tagged_constraints.iter().any(|constraint|
+                constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG
+                    && constraint.relation == crate::target::TaggedOpbjectRelation::SharesCardType
+            )
+    ));
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_preserve_until_next_turn_flash_grants() {
     let tokens = lex_line(
         "Until your next turn, you may cast sorcery spells as though they had flash",

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -1421,6 +1421,13 @@ impl ObjectFilter {
                         .push("that shares a creature type with that object".to_string());
                 }
                 TaggedOpbjectRelation::SharesCardType => {
+                    if constraint.tag.as_str() == crate::SOURCE_EXILED_TAG {
+                        post_noun_qualifiers.push(
+                            "that shares a card type with a card exiled with this permanent"
+                                .to_string(),
+                        );
+                        continue;
+                    }
                     let permanent_type_context = self.zone == Some(Zone::Battlefield)
                         || (!self.card_types.is_empty()
                             && self.card_types.iter().all(|card_type| {

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -72,6 +72,7 @@ impl<C> DerivedAlternativeCast<C> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GrantUsageLimit {
+    OnceEachTurn,
     OnceDuringEachOfYourTurns,
 }
 
@@ -329,6 +330,8 @@ pub struct GrantSpec<SA, E, C, Cond> {
     pub zone: Zone,
     /// Which player may use the grant when rendered or applied statically.
     pub beneficiary: PlayerFilter,
+    /// How often this permission may be used from the same source.
+    pub usage_limit: Option<GrantUsageLimit>,
     /// Static abilities granted to a spell as it is cast using this permission.
     pub cast_this_way_grants: Vec<SA>,
 }
@@ -341,6 +344,7 @@ impl<SA, E, C, Cond> GrantSpec<SA, E, C, Cond> {
             filter,
             zone,
             beneficiary: PlayerFilter::You,
+            usage_limit: None,
             cast_this_way_grants: Vec::new(),
         }
     }
@@ -348,6 +352,11 @@ impl<SA, E, C, Cond> GrantSpec<SA, E, C, Cond> {
     /// Return a copy of this grant specification with an explicit beneficiary.
     pub fn with_beneficiary(mut self, beneficiary: PlayerFilter) -> Self {
         self.beneficiary = beneficiary;
+        self
+    }
+
+    pub fn with_usage_limit(mut self, usage_limit: GrantUsageLimit) -> Self {
+        self.usage_limit = Some(usage_limit);
         self
     }
 
@@ -391,6 +400,7 @@ where
             filter,
             zone: Zone::Hand,
             beneficiary: PlayerFilter::You,
+            usage_limit: None,
             cast_this_way_grants: Vec::new(),
         }
     }
@@ -448,6 +458,7 @@ where
             filter: ObjectFilter::nonland(),
             zone: Zone::Graveyard,
             beneficiary: PlayerFilter::You,
+            usage_limit: None,
             cast_this_way_grants: Vec::new(),
         }
     }
@@ -583,12 +594,16 @@ where
                 return format!("{} {type_text} spell", article_for(type_text.as_str()));
             }
             let description = filter.description();
-            if description.contains("permanent") {
+            if description.contains("card exiled with this permanent")
+                && description.contains(" card")
+            {
+                description.replacen(" card", " spell", 1)
+            } else if description.contains("permanent") {
                 description.replace("permanent", "spell")
             } else if description.contains("spell") {
                 description
             } else if description.contains(" card") {
-                description.replace(" card", " spell")
+                description.replacen(" card", " spell", 1)
             } else {
                 format!("{description} spells")
             }
@@ -754,7 +769,18 @@ where
         let mut filter = self.filter.clone();
         filter.zone.get_or_insert(self.zone);
         let filter_desc = filter.description();
-        let may_prefix = beneficiary_may_prefix(&self.beneficiary);
+        let mut may_prefix = beneficiary_may_prefix(&self.beneficiary);
+        if matches!(self.usage_limit, Some(GrantUsageLimit::OnceEachTurn))
+            && let Some(rest) = may_prefix.strip_prefix("You may")
+        {
+            may_prefix = format!("Once each turn, you may{rest}");
+        } else if matches!(
+            self.usage_limit,
+            Some(GrantUsageLimit::OnceDuringEachOfYourTurns)
+        ) && let Some(rest) = may_prefix.strip_prefix("You may")
+        {
+            may_prefix = format!("Once during each of your turns, you may{rest}");
+        }
         let cast_this_way_suffix = || {
             if self.cast_this_way_grants.is_empty() {
                 return String::new();
@@ -816,6 +842,20 @@ where
             && self.filter.card_types.as_slice() == [CardType::Land]
         {
             return format!("{may_prefix} play lands from the top of your library");
+        }
+        if matches!(self.grantable, Grantable::PlayFrom)
+            && self.zone == Zone::Library
+            && matches!(self.usage_limit, Some(GrantUsageLimit::OnceEachTurn))
+            && self.filter.excluded_card_types.as_slice() == [CardType::Land]
+            && self.filter.tagged_constraints.iter().any(|constraint| {
+                constraint.tag.as_str() == crate::SOURCE_EXILED_TAG
+                    && constraint.relation
+                        == crate::filter_model::TaggedOpbjectRelation::SharesCardType
+            })
+        {
+            return format!(
+                "{may_prefix} cast a spell from the top of your library if it shares a card type with a card exiled with this permanent"
+            );
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Library

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -792,6 +792,7 @@ where
                 filter: spec.filter,
                 zone: spec.zone,
                 beneficiary: spec.beneficiary,
+                usage_limit: spec.usage_limit,
                 cast_this_way_grants: spec
                     .cast_this_way_grants
                     .into_iter()

--- a/crates/ironsmith-registry/src/compiler_runtime.rs
+++ b/crates/ironsmith-registry/src/compiler_runtime.rs
@@ -204,6 +204,7 @@ impl ironsmith::effect_model_interpreter::EffectModelInterpreterHooks<CompilerEf
             filter: spec.filter,
             zone: spec.zone,
             beneficiary: spec.beneficiary,
+            usage_limit: spec.usage_limit,
             cast_this_way_grants: spec
                 .cast_this_way_grants
                 .into_iter()

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57453,6 +57453,44 @@ fn parse_traveling_chocobo_top_library_lines_compile() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_cemetery_illuminator_top_library_source_exiled_type_permission() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Cemetery Illuminator")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(2, 3))
+        .parse_text(
+            "Flying\nWhenever this creature enters or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with this creature.",
+        )
+        .expect("Cemetery Illuminator should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("once each turn")
+            && rendered_lower.contains("cast")
+            && rendered_lower.contains("from the top of your library")
+            && rendered_lower.contains("shares a card type with a card exiled with this creature"),
+        "expected source-exiled top-library cast permission in compiled text, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("LookAtTopCardOfLibrary")
+            && debug.contains("PlayFrom")
+            && debug.contains("OnceEachTurn")
+            && debug.contains(crate::tag::SOURCE_EXILED_TAG)
+            && debug.contains("SharesCardType"),
+        "expected Cemetery Illuminator to lower into a limited top-library PlayFrom grant keyed to source-exiled card types, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_guardian_naga_banishing_coils_creature_face_strict() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Guardian Naga // Banishing Coils")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -8,6 +8,10 @@ fn grant_usage_limit_allows(
     limit: Option<crate::grant::GrantUsageLimit>,
 ) -> bool {
     match limit {
+        Some(crate::grant::GrantUsageLimit::OnceEachTurn) => !game
+            .turn_store
+            .grant_cast_uses_this_turn
+            .contains(&(player, source_id)),
         Some(crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns) => {
             game.turn.active_player == player
                 && !game
@@ -30,6 +34,9 @@ fn append_granted_play_from_actions_for_card(
 ) {
     let play_from_grants = view.granted_play_from_for_card(card_id, source_zone, player);
     for grant in play_from_grants {
+        if !grant_usage_limit_allows(game, player, grant.source_id, grant.usage_limit) {
+            continue;
+        }
         // PlayFrom (e.g., Yawgmoth's Will): can cast from zone as if from hand.
         let from_zone = grant.zone;
         let granted_alternatives =
@@ -116,6 +123,9 @@ fn append_granted_play_from_actions_for_card(
         return;
     }
     for grant in adventure_play_from_grants {
+        if !grant_usage_limit_allows(game, player, grant.source_id, grant.usage_limit) {
+            continue;
+        }
         actions.push(LegalAction::CastSpell {
             spell_id: card_id,
             from_zone: grant.zone,

--- a/crates/ironsmith-runtime/src/derived_view.rs
+++ b/crates/ironsmith-runtime/src/derived_view.rs
@@ -785,6 +785,7 @@ impl<'a> DerivedGameView<'a> {
                 Grantable::PlayFrom => Some(GrantedPlayFrom {
                     source_id: grant.source.source_id(),
                     zone: grant.zone,
+                    usage_limit: grant.usage_limit,
                 }),
                 Grantable::Ability(_)
                 | Grantable::AlternativeCast(_)
@@ -851,6 +852,7 @@ impl<'a> DerivedGameView<'a> {
                 Grantable::PlayFrom => Some(GrantedPlayFrom {
                     source_id: grant.source.source_id(),
                     zone: grant.zone,
+                    usage_limit: grant.usage_limit,
                 }),
                 Grantable::Ability(_)
                 | Grantable::AlternativeCast(_)
@@ -1284,7 +1286,7 @@ fn grant_applies_to_card(
     grant
         .filter
         .as_ref()
-        .is_some_and(|filter| filter.matches(card, ctx, game))
+        .is_some_and(|filter| filter.matches(card, &grant_filter_context(ctx, grant, game), game))
 }
 
 fn grant_applies_to_card_non_recursive(
@@ -1304,7 +1306,31 @@ fn grant_applies_to_card_non_recursive(
     grant
         .filter
         .as_ref()
-        .is_some_and(|filter| filter.matches_non_recursive(card, ctx, game))
+        .is_some_and(|filter| {
+            filter.matches_non_recursive(card, &grant_filter_context(ctx, grant, game), game)
+        })
+}
+
+fn grant_filter_context(
+    ctx: &crate::filter::FilterContext,
+    grant: &Grant,
+    game: &GameState,
+) -> crate::filter::FilterContext {
+    let mut ctx = ctx.clone();
+    let source_id = grant.source.source_id();
+    let source_exiled = game
+        .get_exiled_with_source_links(source_id)
+        .iter()
+        .filter_map(|id| {
+            game.object(*id)
+                .map(|object| crate::snapshot::ObjectSnapshot::from_object(object, game))
+        })
+        .collect::<Vec<_>>();
+    if !source_exiled.is_empty() {
+        ctx.tagged_objects
+            .insert(crate::tag::SOURCE_EXILED_TAG.into(), source_exiled);
+    }
+    ctx
 }
 
 fn materialize_derived_alternative_cast(

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3345,6 +3345,13 @@ impl ObjectFilterExt for ObjectFilter {
                         .push("that shares a creature type with that object".to_string());
                 }
                 TaggedOpbjectRelation::SharesCardType => {
+                    if constraint.tag.as_str() == crate::tag::SOURCE_EXILED_TAG {
+                        post_noun_qualifiers.push(
+                            "that shares a card type with a card exiled with this permanent"
+                                .to_string(),
+                        );
+                        continue;
+                    }
                     let permanent_type_context = self.zone == Some(Zone::Battlefield)
                         || (!self.card_types.is_empty()
                             && self.card_types.iter().all(|card_type| {

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3797,27 +3797,37 @@ pub(super) fn finalize_spell_cast(
         }
     }
 
-    if let CastingMethod::PlayFrom {
-        source,
-        use_alternative: Some(_),
-        ..
-    } = &casting_method
-    {
+    if let CastingMethod::PlayFrom { source, .. } = &casting_method {
         let source_has_selected_once_grant = game.object(*source).is_some_and(|source_obj| {
             source_obj.abilities.iter().any(|ability| {
                 let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
                     return false;
                 };
                 static_ability.grant_spec().is_some_and(|spec| {
+                    if matches!(
+                        spec.usage_limit,
+                        Some(
+                            crate::grant::GrantUsageLimit::OnceEachTurn
+                                | crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns
+                        )
+                    ) && matches!(spec.grantable, crate::grant::Grantable::PlayFrom)
+                    {
+                        return true;
+                    }
+
                     let Some(label) = selected_alternative_label.as_deref() else {
                         return false;
                     };
                     matches!(
                         spec.grantable,
                         crate::grant::Grantable::DerivedAlternativeCast(ref derived)
-                            if derived.usage_limit()
-                                == Some(crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns)
-                                && derived.display_name().eq_ignore_ascii_case(label)
+                            if matches!(
+                                derived.usage_limit(),
+                                Some(
+                                    crate::grant::GrantUsageLimit::OnceEachTurn
+                                        | crate::grant::GrantUsageLimit::OnceDuringEachOfYourTurns
+                                )
+                            ) && derived.display_name().eq_ignore_ascii_case(label)
                     )
                 })
             })

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -38702,6 +38702,249 @@ fn thundermane_dragon_does_not_cast_top_creature_below_power_four() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn cemetery_illuminator_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Cemetery Illuminator")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(2, 3))
+        .parse_text(
+            "Flying\nWhenever this creature enters or attacks, exile a card from a graveyard.\nYou may look at the top card of your library any time.\nOnce each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with this creature.",
+        )
+        .expect("Cemetery Illuminator should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_cemetery_illuminator_in_cast_window(
+    game: &mut GameState,
+    active_player: PlayerId,
+    priority_player: PlayerId,
+) {
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = active_player;
+    game.turn.priority_player = Some(priority_player);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn cemetery_illuminator_play_from_action(
+    game: &GameState,
+    player: PlayerId,
+    spell_id: ObjectId,
+    source_id: ObjectId,
+) -> Option<CastingMethod> {
+    crate::decision::compute_legal_actions(game, player)
+        .into_iter()
+        .find_map(|action| match action {
+            LegalAction::CastSpell {
+                spell_id: action_spell_id,
+                from_zone: Zone::Library,
+                casting_method:
+                    method @ CastingMethod::PlayFrom {
+                        source,
+                        zone: Zone::Library,
+                        ..
+                    },
+            } if action_spell_id == spell_id && source == source_id => Some(method),
+            _ => None,
+        })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_zero_cost_card(
+    game: &mut GameState,
+    player: PlayerId,
+    name: &str,
+    card_types: Vec<CardType>,
+    zone: Zone,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::new())
+        .card_types(card_types)
+        .build();
+    game.create_object_from_card(&card, player, zone)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cemetery_illuminator_casts_top_spell_sharing_type_with_source_exiled_card() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    put_cemetery_illuminator_in_cast_window(&mut game, alice, alice);
+
+    let source = cemetery_illuminator_definition();
+    let source_id = game.create_object_from_definition(&source, alice, Zone::Battlefield);
+    let exiled_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Exiled Instant",
+        vec![CardType::Instant],
+        Zone::Exile,
+    );
+    game.exiled_with_source
+        .entry(source_id)
+        .or_default()
+        .push(exiled_instant);
+    let top_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Top Instant",
+        vec![CardType::Instant],
+        Zone::Library,
+    );
+
+    assert!(
+        cemetery_illuminator_play_from_action(&game, alice, top_instant, source_id).is_some(),
+        "Cemetery Illuminator should allow casting a top-library spell sharing a card type with a card exiled with it"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cemetery_illuminator_does_not_cast_top_spell_without_source_exiled_card() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    put_cemetery_illuminator_in_cast_window(&mut game, alice, alice);
+
+    let source = cemetery_illuminator_definition();
+    let source_id = game.create_object_from_definition(&source, alice, Zone::Battlefield);
+    let top_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Top Instant",
+        vec![CardType::Instant],
+        Zone::Library,
+    );
+
+    assert!(
+        cemetery_illuminator_play_from_action(&game, alice, top_instant, source_id).is_none(),
+        "Cemetery Illuminator should not allow top-library casting before a card is exiled with it"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cemetery_illuminator_does_not_cast_top_spell_with_nonmatching_source_exiled_type() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    put_cemetery_illuminator_in_cast_window(&mut game, alice, alice);
+
+    let source = cemetery_illuminator_definition();
+    let source_id = game.create_object_from_definition(&source, alice, Zone::Battlefield);
+    let exiled_creature = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Exiled Creature",
+        vec![CardType::Creature],
+        Zone::Exile,
+    );
+    game.exiled_with_source
+        .entry(source_id)
+        .or_default()
+        .push(exiled_creature);
+    let top_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Top Instant",
+        vec![CardType::Instant],
+        Zone::Library,
+    );
+
+    assert!(
+        cemetery_illuminator_play_from_action(&game, alice, top_instant, source_id).is_none(),
+        "Cemetery Illuminator should require the top spell to share a card type with a source-exiled card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cemetery_illuminator_can_cast_matching_top_instant_on_opponents_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    put_cemetery_illuminator_in_cast_window(&mut game, bob, alice);
+
+    let source = cemetery_illuminator_definition();
+    let source_id = game.create_object_from_definition(&source, alice, Zone::Battlefield);
+    let exiled_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Exiled Instant",
+        vec![CardType::Instant],
+        Zone::Exile,
+    );
+    game.exiled_with_source
+        .entry(source_id)
+        .or_default()
+        .push(exiled_instant);
+    let top_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Top Instant",
+        vec![CardType::Instant],
+        Zone::Library,
+    );
+
+    assert!(
+        cemetery_illuminator_play_from_action(&game, alice, top_instant, source_id).is_some(),
+        "'Once each turn' should allow a matching top instant on an opponent's turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn cemetery_illuminator_top_library_cast_is_limited_to_once_each_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    put_cemetery_illuminator_in_cast_window(&mut game, alice, alice);
+
+    let source = cemetery_illuminator_definition();
+    let source_id = game.create_object_from_definition(&source, alice, Zone::Battlefield);
+    let exiled_instant = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Exiled Instant",
+        vec![CardType::Instant],
+        Zone::Exile,
+    );
+    game.exiled_with_source
+        .entry(source_id)
+        .or_default()
+        .push(exiled_instant);
+    let first_top = create_zero_cost_card(
+        &mut game,
+        alice,
+        "First Top Instant",
+        vec![CardType::Instant],
+        Zone::Library,
+    );
+
+    assert!(
+        cemetery_illuminator_play_from_action(&game, alice, first_top, source_id).is_some(),
+        "first matching top spell should be castable"
+    );
+    game.turn_store
+        .grant_cast_uses_this_turn
+        .insert((alice, source_id));
+
+    let second_top = create_zero_cost_card(
+        &mut game,
+        alice,
+        "Second Top Instant",
+        vec![CardType::Instant],
+        Zone::Library,
+    );
+    assert!(
+        cemetery_illuminator_play_from_action(&game, alice, second_top, source_id).is_none(),
+        "Cemetery Illuminator should not allow a second top-library cast from the same source in one turn"
+    );
+}
+
 #[test]
 fn test_library_play_from_grant_offers_adventure_half_when_linked_face_matches() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/grant_registry.rs
+++ b/crates/ironsmith-runtime/src/grant_registry.rs
@@ -238,6 +238,7 @@ pub struct GrantedAlternativeCast {
 pub struct GrantedPlayFrom {
     pub source_id: ObjectId,
     pub zone: Zone,
+    pub usage_limit: Option<GrantUsageLimit>,
 }
 
 /// A unified grant that can represent either an ability or alternative casting method.
@@ -257,6 +258,8 @@ pub struct Grant {
     pub player: PlayerId,
     /// What is being granted (ability or alternative casting method).
     pub grantable: Grantable,
+    /// How often this grant may be used from the same source.
+    pub usage_limit: Option<GrantUsageLimit>,
     /// How this grant was created.
     pub source: GrantSource,
 }
@@ -295,6 +298,7 @@ impl GrantRegistry {
             zone,
             player,
             grantable,
+            usage_limit: None,
             source,
         });
     }
@@ -316,6 +320,7 @@ impl GrantRegistry {
             zone,
             player,
             grantable,
+            usage_limit: None,
             source,
         });
     }
@@ -337,6 +342,7 @@ impl GrantRegistry {
             zone,
             player,
             grantable,
+            usage_limit: None,
             source,
         });
     }
@@ -494,7 +500,7 @@ impl GrantRegistry {
             } else if let Some(ref filter) = grant.filter {
                 // Filter-based grant - check if card matches filter
                 if let Some(card) = card {
-                    filter.matches(card, &ctx, game)
+                    filter.matches(card, &grant_filter_context(&ctx, grant, game), game)
                 } else {
                     false
                 }
@@ -521,7 +527,7 @@ impl GrantRegistry {
             let matches = if let Some(target_id) = grant.target_id {
                 target_id == card_id
             } else if let Some(ref filter) = grant.filter {
-                filter.matches(card, &ctx, game)
+                filter.matches(card, &grant_filter_context(&ctx, &grant, game), game)
             } else {
                 false
             };
@@ -592,6 +598,7 @@ impl GrantRegistry {
                 Grantable::PlayFrom => Some(GrantedPlayFrom {
                     source_id: grant.source.source_id(),
                     zone: grant.zone,
+                    usage_limit: grant.usage_limit,
                 }),
                 _ => None,
             })
@@ -690,6 +697,7 @@ impl GrantRegistry {
                         zone: spec.zone,
                         player: player.id,
                         grantable: spec.grantable.clone(),
+                        usage_limit: spec.usage_limit,
                         source: GrantSource::StaticAbility { source_id },
                     });
                 }
@@ -755,6 +763,28 @@ fn normalize_grant_filter(mut filter: ObjectFilter) -> ObjectFilter {
     dedupe_vec(&mut filter.supertypes);
     dedupe_vec(&mut filter.excluded_supertypes);
     filter
+}
+
+fn grant_filter_context(
+    ctx: &crate::filter::FilterContext,
+    grant: &Grant,
+    game: &crate::game_state::GameState,
+) -> crate::filter::FilterContext {
+    let mut ctx = ctx.clone();
+    let source_id = grant.source.source_id();
+    let source_exiled = game
+        .get_exiled_with_source_links(source_id)
+        .iter()
+        .filter_map(|id| {
+            game.object(*id)
+                .map(|object| crate::snapshot::ObjectSnapshot::from_object(object, game))
+        })
+        .collect::<Vec<_>>();
+    if !source_exiled.is_empty() {
+        ctx.tagged_objects
+            .insert(crate::tag::SOURCE_EXILED_TAG.into(), source_exiled);
+    }
+    ctx
 }
 
 fn dedupe_vec<T: Eq + std::hash::Hash + Copy>(values: &mut Vec<T>) {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -406,6 +406,7 @@ impl StaticAbilityModelInterpreter {
             filter: spec.filter.clone(),
             zone: spec.zone,
             beneficiary: spec.beneficiary.clone(),
+            usage_limit: spec.usage_limit,
             cast_this_way_grants: spec
                 .cast_this_way_grants
                 .iter()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cemetery Illuminator
Initial parse error:
```
parser does not yet support line family: 'Once each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with this creature.'; oracle-only fallback also failed: parser does not yet support line family: 'Once each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with this creature.'
```

Current worker: i-01d92628a5d623138
Branch: codex/aws-card-fix-cemetery-illuminator
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0009
