### PR TITLE
Fix Ironsmith parse failure: Satya, Aetherflux Genius

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -681,6 +681,9 @@ fn parse_dynamic_payment_clause_as_total_cost(
     if tokens.is_empty() {
         return Ok(None);
     }
+    if let Some(energy_cost) = parse_dynamic_energy_payment_clause_as_total_cost(&tokens)? {
+        return Ok(Some(energy_cost));
+    }
     let token_words = words(&tokens);
     if MANA_PREFIX_PATTERN.matches_words(&token_words)
         && let Some(value) = parse_equal_to_aggregate_filter_value(&tokens)
@@ -787,6 +790,64 @@ fn parse_dynamic_payment_clause_as_total_cost(
             ironsmith_core::DynamicManaDisplayHint::Default,
         )),
     )))
+}
+
+fn parse_dynamic_energy_payment_clause_as_total_cost(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<TotalCost>, CardTextError> {
+    let mut idx = 0usize;
+    if tokens
+        .get(idx)
+        .and_then(OwnedLexToken::as_word)
+        .is_some_and(is_article)
+    {
+        idx += 1;
+    }
+    if !tokens
+        .get(idx)
+        .is_some_and(|token| token.as_word() == Some("amount"))
+    {
+        return Ok(None);
+    }
+    idx += 1;
+    if !tokens
+        .get(idx)
+        .is_some_and(|token| token.as_word() == Some("of"))
+    {
+        return Ok(None);
+    }
+    idx += 1;
+    if !tokens
+        .get(idx)
+        .is_some_and(|token| token.slice.as_str().eq_ignore_ascii_case("{E}"))
+    {
+        return Ok(None);
+    }
+    idx += 1;
+
+    let trailing = trim_edge_punctuation(&trim_commas(&tokens[idx..]));
+    if trailing.len() < 3
+        || trailing[0].as_word() != Some("equal")
+        || trailing[1].as_word() != Some("to")
+    {
+        return Ok(None);
+    }
+    let value_tokens = trim_edge_punctuation(&trim_commas(&trailing[2..]));
+    let Some((value, used)) = parse_value(&value_tokens) else {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported dynamic energy payment amount (clause: '{}')",
+            words(tokens).join(" ")
+        )));
+    };
+    if !trim_edge_punctuation(&trim_commas(&value_tokens[used..])).is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported trailing dynamic energy payment text (clause: '{}')",
+            words(tokens).join(" ")
+        )));
+    }
+
+    let cost = crate::costs::Cost::energy(value);
+    Ok(Some(TotalCost::from_cost(cost)))
 }
 
 pub(crate) fn marker_keyword_id(keyword: &str) -> Option<&'static str> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -181,6 +181,8 @@ const YOU_GAIN_LIFE_TRIGGER_PATTERN: ClauseShape<'static> =
 const YOU_DRAW_CARD_TRIGGER_SUBJECT_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["you"]);
 const BEGINNING_END_STEP_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "end", "step"]);
+const NEXT_END_STEP_TRIGGER_PATTERN: ClauseShape<'static> =
+    clause_shape!(contains_words & ["next", "end", "step"]);
 const BEGINNING_UPKEEP_TRIGGER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["beginning", "upkeep"]);
 const BEGINNING_DRAW_STEP_TRIGGER_PATTERN: ClauseShape<'static> =
@@ -4064,7 +4066,8 @@ pub(crate) fn parse_trigger_clause_lexed(
                 during_turn: PlayerFilter::You,
             })
         }
-        _ if BEGINNING_END_STEP_TRIGGER_PATTERN.matches_words(&words) => Ok(
+        _ if BEGINNING_END_STEP_TRIGGER_PATTERN.matches_words(&words)
+            && !NEXT_END_STEP_TRIGGER_PATTERN.matches_words(&words) => Ok(
             TriggerSpec::BeginningOfEndStep(parse_possessive_clause_player_filter(&words)),
         ),
         _ if BEGINNING_UPKEEP_TRIGGER_PATTERN.matches_words(&words) => Ok(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -281,6 +281,11 @@ fn is_sticker_sheet_ticket_marker_line(ctx: &LineDispatchContext<'_>) -> bool {
 pub(super) fn run_triggered_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
+    if line_starts_with_words(ctx.line, &["at", "the", "beginning", "of"])
+        && contains_token_word_sequence(&ctx.line.tokens, &["next", "end", "step"])
+    {
+        return Ok(None);
+    }
     try_parse_triggered_line_dispatch(ctx.preprocessed, ctx.idx, ctx.line, ctx.allow_unsupported)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -289,6 +289,14 @@ fn line_starts_with_trigger_intro_tokens(tokens: &[OwnedLexToken]) -> bool {
     if super::parser_support::looks_like_reflexive_followup_intro_lexed(tokens) {
         return false;
     }
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.starts_with(&["at", "the", "beginning", "of"])
+        && words
+            .windows(3)
+            .any(|window| window == ["next", "end", "step"])
+    {
+        return false;
+    }
     parse_trigger_intro_tokens(tokens).is_some()
 }
 
@@ -3201,6 +3209,15 @@ fn try_parse_triggered_line_dispatch(
     allow_unsupported: bool,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     if !line_starts_with_trigger_intro_tokens(&line.tokens) {
+        return Ok(None);
+    }
+
+    let words = crate::runtime_backend::token_word_refs(&line.tokens);
+    if words.starts_with(&["at", "the", "beginning", "of"])
+        && words
+            .windows(3)
+            .any(|window| window == ["next", "end", "step"])
+    {
         return Ok(None);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -48,7 +48,8 @@ use super::for_each_helpers::{
 };
 use super::search_library::parse_restriction_duration;
 use super::subject_verb_primitives::{
-    SubjectVerbPrimitiveClause, find_unquoted_token_word, try_build_unless,
+    SubjectVerbPrimitiveClause, find_unquoted_token_word, parse_sentence_delayed_next_step_unless_pays,
+    try_build_unless,
 };
 use super::verb_dispatch::parse_effect_with_verb;
 use super::verb_handlers::parse_control_duration;
@@ -1088,6 +1089,14 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
                 ],
             });
         }
+    }
+
+    if let Some(effects) = parse_sentence_delayed_next_step_unless_pays(SubjectVerbPrimitiveClause::new(tokens))?
+    {
+        return Ok(match effects.as_slice() {
+            [effect] => effect.clone(),
+            _ => EffectAst::Sequence { effects },
+        });
     }
 
     if let Some(effect) = run_clause_primitives(tokens)? {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1034,8 +1034,22 @@ pub(crate) fn parse_create(
                 || grammar::words_find_phrase(&tail_tokens, &["gain", "haste"]).is_some()
                 || grammar::words_find_phrase(&tail_tokens, &["gains", "haste"]).is_some()
                 || grammar::contains_word(&tail_tokens, "haste");
-            let mut enters_tapped = false;
-            let mut enters_attacking = false;
+            let token_modifier_words = tail_words
+                .iter()
+                .position(|word| *word == "token" || *word == "tokens")
+                .map(|idx| &tail_words[..idx])
+                .unwrap_or(&[]);
+            let copy_modifier_words = tail_words
+                .iter()
+                .position(|word| CREATE_COPY_OR_COPIES_WORD_PATTERN.matches_word(word))
+                .map(|idx| &tail_words[..idx])
+                .unwrap_or(&[]);
+            let mut enters_tapped = tapped
+                || CREATE_TAPPED_MARKER_PATTERN.matches_words(token_modifier_words)
+                || CREATE_TAPPED_MARKER_PATTERN.matches_words(copy_modifier_words);
+            let mut enters_attacking = attacking
+                || CREATE_ATTACKING_MARKER_PATTERN.matches_words(token_modifier_words)
+                || CREATE_ATTACKING_MARKER_PATTERN.matches_words(copy_modifier_words);
             let mut attack_target_player_or_planeswalker_controlled_by = None;
             if player == PlayerAst::Implicit {
                 player = PlayerAst::You;
@@ -1069,6 +1083,15 @@ pub(crate) fn parse_create(
                 enters_attacking = tail_attacking || inline_attacking;
                 attack_target_player_or_planeswalker_controlled_by = inline_attack_target_player;
                 if !source_tokens.is_empty() {
+                    if let Some(token_word_idx) = clause_words
+                        .iter()
+                        .position(|word| *word == "token" || *word == "tokens")
+                    {
+                        let token_prefix = &clause_words[..token_word_idx];
+                        enters_tapped |= CREATE_TAPPED_MARKER_PATTERN.matches_words(token_prefix);
+                        enters_attacking |=
+                            CREATE_ATTACKING_MARKER_PATTERN.matches_words(token_prefix);
+                    }
                     let source = parse_target_phrase(&source_tokens)?;
                     let references_iterated_object = target_references_it(&source);
                     let create = EffectAst::subject_verb(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -1,5 +1,9 @@
 type DispatchInnerNormalizedWords<'a> = TokenWordView<'a>;
 
+use crate::runtime_backend::effect_sentences::{
+    SubjectVerbPrimitiveClause, parse_sentence_delayed_next_step_unless_pays,
+};
+
 macro_rules! sentence_unsupported_adapters_lexed {
     ($(($adapter:ident, $predicate:ident)),* $(,)?) => {
         $(
@@ -709,6 +713,16 @@ fn parse_effect_sentence_lexed_inner(
     }
 
     let sentence_words = crate::runtime_backend::token_word_refs(tokens);
+    if sentence_words.starts_with(&["at", "the", "beginning", "of"])
+        && sentence_words
+            .windows(3)
+            .any(|window| window == ["next", "end", "step"])
+        && let Some(effects) = parse_sentence_delayed_next_step_unless_pays(
+            SubjectVerbPrimitiveClause::new(tokens),
+        )?
+    {
+        return Ok(effects);
+    }
     if let Some(effects) = parse_it_is_aura_enchantment_sentence(sentence_words.as_slice()) {
         return Ok(effects);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -6,7 +6,7 @@ use crate::runtime_backend::sentences::effect_sentences::lex_chain_helpers::{
     find_verb_lexed, has_effect_head_without_verb_lexed,
 };
 use crate::runtime_backend::sentences::effect_sentences::subject_verb_primitives::{
-    SubjectVerbPrimitiveClause, try_build_unless,
+    SubjectVerbPrimitiveClause, rewrite_unless_cost_source_values_to_it_tag, try_build_unless,
 };
 
 const DISCARD_SAME_MANA_VALUE_FILTER_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -50,7 +50,8 @@ const CHOICE_SUFFIX_THREE_WORD_PATTERNS: &[&[&str]] = &[
 const CHOICE_SUFFIX_FIVE_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(suffix & ["of", "his", "or", "her", "choice"]);
 const TAGGED_IT_OR_CARD_PATTERN: ClauseShape<'static> =
-    clause_shape!(exact_any & [&["it"], &["that", "card"]]);
+    clause_shape!(exact_any & [&["it"], &["that", "card"], &["that", "token"]]);
+const TAGGED_TOKEN_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["that", "token"]);
 const ATTACHED_OBJECT_EXCLUSION_PATTERN: ClauseShape<'static> = clause_shape!(
     contains_any_phrases
         & [&[
@@ -225,6 +226,8 @@ pub(crate) fn parse_sacrifice(
                 )));
             };
             let sacrifice_tokens = trim_commas(&tokens[..unless_token_idx]);
+            let sacrifice_refs_it = TAGGED_IT_OR_CARD_PATTERN
+                .matches_words(&crate::runtime_backend::token_word_refs(&sacrifice_tokens));
             let base = parse_sacrifice(&sacrifice_tokens, subject.clone(), target.clone())?;
             if let Some(predicate) =
                 parse_unless_mana_spent_to_cast_predicate(&tokens[unless_token_idx + 1..])
@@ -244,11 +247,14 @@ pub(crate) fn parse_sacrifice(
                     if_false: vec![base],
                 });
             }
-            if let Some(unless_effect) = try_build_unless(
+            if let Some(mut unless_effect) = try_build_unless(
                 vec![base],
                 SubjectVerbPrimitiveClause::new(tokens),
                 unless_token_idx,
             )? {
+                if sacrifice_refs_it {
+                    rewrite_unless_cost_source_values_to_it_tag(&mut unless_effect);
+                }
                 return Ok(unless_effect);
             }
             return Err(CardTextError::ParseError(format!(
@@ -382,7 +388,12 @@ pub(crate) fn parse_sacrifice(
     }
     let filter_words = crate::runtime_backend::token_word_refs(filter_tokens);
     let mut filter = if TAGGED_IT_OR_CARD_PATTERN.matches_words(&filter_words) {
-        ObjectFilter::tagged(TagKey::from(IT_TAG))
+        let mut tagged_filter = ObjectFilter::tagged(TagKey::from(IT_TAG));
+        tagged_filter.zone = Some(Zone::Battlefield);
+        if TAGGED_TOKEN_PATTERN.matches_words(&filter_words) {
+            tagged_filter.token = true;
+        }
+        tagged_filter
     } else {
         parse_object_filter_lexed(filter_tokens, other)?
     };

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/delayed_step_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/delayed_step_family.rs
@@ -198,6 +198,19 @@ const DELAYED_REPEAT_THIS_PROCESS_PATTERN: ClauseShape<'static> =
 const DELAYED_LIFE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["life"]);
 const DELAYED_CARD_OR_CARDS_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["card"], &["cards"]]);
+const NEXT_END_STEP_PREFIXES: &[&[&str]] = &[
+    &[
+        "at",
+        "the",
+        "beginning",
+        "of",
+        "the",
+        "next",
+        "end",
+        "step",
+    ],
+    &["at", "the", "beginning", "of", "next", "end", "step"],
+];
 
 fn delayed_find_phrase_start(words: &[&str], shape: ClauseShape<'static>) -> Option<usize> {
     (0..words.len()).find(|idx| shape.matches_words(&words[*idx..]))
@@ -254,6 +267,66 @@ fn bind_unless_player_context(effect: &mut EffectAst, player: PlayerAst) {
     }
 }
 
+fn rewrite_value_source_to_it_tag(value: &mut Value) {
+    match value {
+        Value::SurfaceHinted { value, .. } => rewrite_value_source_to_it_tag(value),
+        Value::Add(left, right) | Value::Min(left, right) => {
+            rewrite_value_source_to_it_tag(left);
+            rewrite_value_source_to_it_tag(right);
+        }
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner) => rewrite_value_source_to_it_tag(inner),
+        Value::PowerOf(spec) | Value::ToughnessOf(spec) | Value::ManaValueOf(spec)
+            if matches!(spec.as_ref(), crate::target::ChooseSpec::Source) =>
+        {
+            *spec = Box::new(crate::target::ChooseSpec::Tagged(TagKey::from(IT_TAG)));
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_cost_source_values_to_it_tag(cost: &mut crate::cost::TotalCost) {
+    match cost.kind() {
+        ironsmith_core::TotalCostKind::All(_) => {
+            let mut components = cost.costs().to_vec();
+            for component in &mut components {
+                match component {
+                    crate::costs::Cost::DynamicMana(dynamic) => {
+                        if let Some(value) = dynamic.x_value.as_mut() {
+                            rewrite_value_source_to_it_tag(value);
+                        }
+                        if let Some(value) = dynamic.additional_generic.as_mut() {
+                            rewrite_value_source_to_it_tag(value);
+                        }
+                        if let Some(value) = dynamic.multiplier.as_mut() {
+                            rewrite_value_source_to_it_tag(value);
+                        }
+                    }
+                    crate::costs::Cost::Energy(value)
+                    | crate::costs::Cost::Mill(value)
+                    | crate::costs::Cost::Life(value) => rewrite_value_source_to_it_tag(value),
+                    _ => {}
+                }
+            }
+            *cost = crate::cost::TotalCost::from_costs(components);
+        }
+        ironsmith_core::TotalCostKind::OneOf(branches) => {
+            let mut branches = branches.to_vec();
+            for branch in &mut branches {
+                rewrite_cost_source_values_to_it_tag(branch);
+            }
+            *cost = crate::cost::TotalCost::one_of(branches);
+        }
+    }
+}
+
+pub(crate) fn rewrite_unless_cost_source_values_to_it_tag(effect: &mut EffectAst) {
+    if let EffectAst::UnlessPays { cost, .. } = effect {
+        rewrite_cost_source_values_to_it_tag(cost);
+    }
+}
+
 pub(crate) fn parse_sentence_delayed_next_step_unless_pays(
     clause: SubjectVerbPrimitiveClause<'_>,
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
@@ -263,6 +336,50 @@ pub(crate) fn parse_sentence_delayed_next_step_unless_pays(
     }
 
     let (leading_segments, final_segment) = segments.split_at(segments.len() - 1);
+    if let Some((_, after_timing)) = final_segment[0].strip_any_prefix_clause(NEXT_END_STEP_PREFIXES)
+    {
+        let timing_clause = after_timing.trimmed();
+        if timing_clause.is_empty() {
+            return Ok(None);
+        }
+        let Some(unless_idx) = timing_clause.find_token_word("unless") else {
+            return Ok(None);
+        };
+        let delayed_effect_clause = timing_clause.before(unless_idx).trimmed();
+        if delayed_effect_clause.is_empty() {
+            return Ok(None);
+        }
+        let delayed_effects = parse_effect_chain(delayed_effect_clause.tokens())?;
+        if delayed_effects.is_empty() {
+            return Ok(None);
+        }
+        let delayed_words = delayed_effect_clause.word_refs();
+        let delayed_refs_it = matches!(
+            delayed_words.as_slice(),
+            ["sacrifice", "it"] | ["sacrifice", "that", "card"] | ["sacrifice", "that", "token"]
+        );
+        let Some(mut unless_effect) = try_build_unless(delayed_effects, timing_clause, unless_idx)?
+        else {
+            return Ok(None);
+        };
+        if delayed_refs_it {
+            rewrite_unless_cost_source_values_to_it_tag(&mut unless_effect);
+        }
+
+        let mut effects = Vec::new();
+        for segment in leading_segments {
+            let parsed = parse_effect_chain(segment.tokens())?;
+            if parsed.is_empty() {
+                return Ok(None);
+            }
+            effects.extend(parsed);
+        }
+        effects.push(EffectAst::DelayedUntilNextEndStep {
+            player: PlayerFilter::Any,
+            effects: vec![unless_effect],
+        });
+        return Ok(Some(effects));
+    }
     let Some((timing_start_word, _timing_end_word, step, player)) =
         delayed_next_step_marker(final_segment[0])
     else {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,38 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn satya_aetherflux_genius_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Satya, Aetherflux Genius");
+
+    let def = parse_oracle_card_definition("Satya, Aetherflux Genius");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        ability_debug.contains("CreateTokenCopyEffect")
+            && ability_debug.contains("enters_tapped: true")
+            && ability_debug.contains("enters_attacking: true")
+            && ability_debug.contains("EnergyCountersEffect")
+            && ability_debug.contains("ScheduleDelayedTriggerEffect")
+            && ability_debug.contains("UnlessPaysEffect")
+            && ability_debug.contains("PayEnergyEffect")
+            && ability_debug.contains("ManaValueOf"),
+        "Satya should structurally keep tapped-attacking copy, energy, delayed sacrifice, and dynamic energy payment, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "create a tapped and attacking token that's a copy of up to one other target nontoken creature you control"
+        ),
+        "expected Satya copy token text to keep tapped and attacking, got {rendered}"
+    );
+    assert!(
+        rendered.contains("At the beginning of the next end step, you sacrifice that token")
+            && rendered.contains("unless you pay an amount of {E} equal to its mana value"),
+        "expected Satya delayed sacrifice energy payment text, got {rendered}"
+    );
+}
+
+#[test]
 fn clockspinning_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Clockspinning");
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -415,7 +415,7 @@ pub(super) fn repeated_energy_symbols(count: usize) -> String {
 pub(super) fn describe_energy_payment_amount(value: &Value) -> String {
     match value {
         Value::Fixed(amount) if *amount > 0 => repeated_energy_symbols(*amount as usize),
-        _ => format!("{} energy counter(s)", describe_value(value)),
+        _ => format!("an amount of {{E}} equal to {}", describe_value(value)),
     }
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -21688,6 +21688,12 @@ pub(super) fn describe_choose_then_sacrifice(
         constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
             && matches!(constraint.tag.as_str(), "triggering" | "damaged")
     });
+    let refers_to_created_token = choose.filter.token
+        && choose.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && (constraint.tag.as_str().starts_with("created_")
+                    || crate::cards::is_sentence_helper_tag(constraint.tag.as_str(), "created"))
+        });
     let chosen = choose.filter.description();
     if choose_is_any_number && sacrifice_any_number {
         let chosen = pluralize_noun_phrase(strip_leading_article(&chosen));
@@ -21706,6 +21712,9 @@ pub(super) fn describe_choose_then_sacrifice(
     if sacrifice_count == 1 {
         if refers_to_triggering_object {
             return Some(format!("{player} {verb} it"));
+        }
+        if refers_to_created_token {
+            return Some(format!("{player} {verb} that token"));
         }
         if let Some(rest) = chosen.strip_prefix(&format!("{player}'s ")) {
             let chosen_kind = with_indefinite_article(rest);
@@ -21744,6 +21753,9 @@ fn describe_sacrifice_effect(sacrifice: SacrificeView<'_>) -> String {
     }
     if matches!(sacrifice.count, Value::Fixed(value) if *value == 1) {
         let description = sacrifice.filter.description();
+        if sacrifice.filter.token && filter_is_tagged_it(sacrifice.filter) {
+            return format!("{player} {verb} that token");
+        }
         if matches!(
             sacrifice.player,
             PlayerFilter::Any | PlayerFilter::Opponent | PlayerFilter::IteratedPlayer
@@ -33718,11 +33730,19 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             }
             _ => describe_choose_spec(&create_copy.target),
         };
+        let inline_tapped = create_copy.enters_tapped;
+        let inline_attacking = create_copy.enters_attacking && create_copy.attack_target_mode.is_none();
+        let token_state = match (inline_tapped, inline_attacking) {
+            (true, true) => "tapped and attacking ",
+            (true, false) => "tapped ",
+            (false, true) => "attacking ",
+            (false, false) => "",
+        };
         let mut text = match create_copy.count {
-            Value::Fixed(1) => format!("Create a token that's a copy of {target}"),
-            Value::Fixed(n) => format!("Create {n} tokens that are copies of {target}"),
+            Value::Fixed(1) => format!("Create a {token_state}token that's a copy of {target}"),
+            Value::Fixed(n) => format!("Create {n} {token_state}tokens that are copies of {target}"),
             _ => format!(
-                "Create {} tokens that are copies of {target}",
+                "Create {} {token_state}tokens that are copies of {target}",
                 describe_value(&create_copy.count)
             ),
         };
@@ -33732,13 +33752,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_possessive_player_filter(&create_copy.controller)
             ));
         }
-        if create_copy.enters_tapped {
+        if create_copy.enters_tapped && !inline_tapped {
             text.push_str(", tapped");
         }
         if create_copy.has_haste {
             text.push_str(", with haste");
         }
-        if create_copy.enters_attacking {
+        if create_copy.enters_attacking && !inline_attacking {
             if let Some(crate::effects::CopyAttackTargetMode::PlayerOrPlaneswalkerControlledBy(
                 player_filter,
             )) = &create_copy.attack_target_mode

--- a/crates/ironsmith-runtime/src/costs/cost_effect.rs
+++ b/crates/ironsmith-runtime/src/costs/cost_effect.rs
@@ -247,6 +247,24 @@ fn simple_exile_from_graveyard_filter(
 
 impl CostPayer for CostEffect {
     fn can_pay(&self, game: &GameState, ctx: &CostContext) -> Result<(), CostPaymentError> {
+        if let Some(pay_energy) = self.effect.downcast_ref::<crate::effects::PayEnergyEffect>() {
+            let exec_ctx = crate::effects::ExecutionContext::new_default(ctx.source, ctx.payer)
+                .with_tagged_objects(ctx.tagged_objects.clone());
+            let payer = crate::effects::helpers::resolve_player_from_spec(
+                game,
+                &pay_energy.player,
+                &exec_ctx,
+            )
+            .map_err(|_| CostPaymentError::Other("unable to resolve player for energy cost".to_string()))?;
+            let needed = crate::effects::helpers::resolve_value(game, &pay_energy.amount, &exec_ctx)
+                .map_err(|_| CostPaymentError::Other("unable to resolve energy amount".to_string()))?
+                .max(0) as u32;
+            return game
+                .player(payer)
+                .filter(|player| player.energy_counters >= needed)
+                .map(|_| ())
+                .ok_or_else(|| CostPaymentError::Other("not enough energy counters".to_string()));
+        }
         self.effect
             .0
             .can_execute_as_cost_with_reason(game, ctx.source, ctx.payer, ctx.reason)

--- a/crates/ironsmith-runtime/src/costs/mod.rs
+++ b/crates/ironsmith-runtime/src/costs/mod.rs
@@ -232,7 +232,13 @@ impl Cost {
                     Self::remove_any_counters_from_source(counter_type, display_x)
                 }
             }
-            ironsmith_core::Cost::Energy(amount) => Self::energy(fixed_u32(amount, "energy cost")?),
+            ironsmith_core::Cost::Energy(amount) => Self::try_effect(crate::effect::Effect::new(
+                crate::effects::PayEnergyEffect::new(
+                    amount,
+                    crate::target::ChooseSpec::Player(crate::target::PlayerFilter::You),
+                ),
+            ))
+            .map_err(|detail| format!("energy cost is not cost-executable: {detail}"))?,
             ironsmith_core::Cost::Mill(count) => Self::mill(fixed_u32(count, "mill cost")?),
             ironsmith_core::Cost::Life(amount) => Self::life(fixed_u32(amount, "life cost")?),
             ironsmith_core::Cost::ExileSelf => Self::exile_self(),

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -3273,7 +3273,7 @@ impl ObjectFilterExt for ObjectFilter {
         for constraint in &self.tagged_constraints {
             match constraint.relation {
                 TaggedOpbjectRelation::IsTaggedObject => match constraint.tag.as_str() {
-                    "it" => parts.push("that".to_string()),
+                    "it" | "__it__" => parts.push("that".to_string()),
                     "enchanted" => parts.push("enchanted".to_string()),
                     "equipped" => parts.push("equipped".to_string()),
                     "convoked_this_spell" => {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1244,6 +1244,195 @@ fn rampaging_aetherhood_declining_payment_gets_energy_without_counters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn satya_aetherflux_genius_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_210), "Satya, Aetherflux Genius")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Artificer])
+        .power_toughness(PowerToughness::fixed(3, 5))
+        .parse_text(
+            "Menace, haste\n\
+             Whenever this creature attacks, create a tapped and attacking token that's a copy of up to one other target nontoken creature you control. You get {E}{E} (two energy counters). At the beginning of the next end step, sacrifice that token unless you pay an amount of {E} equal to its mana value.",
+        )
+        .expect("Satya should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn satya_copy_target_definition(mana_value: u8) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Satya Copy Target")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(
+            mana_value,
+        )]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_satya_attack_trigger(
+    game: &mut GameState,
+    satya_id: ObjectId,
+    controller: PlayerId,
+    defender: PlayerId,
+    copy_target: ObjectId,
+) -> ObjectId {
+    let satya = satya_aetherflux_genius_definition();
+    let effects = satya
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if format!("{:?}", triggered.effects).contains("CreateTokenCopyEffect") =>
+            {
+                Some(triggered.effects.clone())
+            }
+            _ => None,
+        })
+        .expect("Satya should have an attack trigger with a copy-token effect");
+
+    game.combat = Some(CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: satya_id,
+            target: AttackTarget::Player(defender),
+        }],
+        ..CombatState::default()
+    });
+
+    let attack_event = TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::new(
+            satya_id,
+            crate::triggers::AttackEventTarget::Player(defender),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(satya_id, controller)
+        .with_triggering_event(attack_event)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(copy_target)]);
+    for effect in &effects {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Satya attack trigger effect should resolve");
+    }
+
+    let token_id = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id).is_some_and(|object| {
+                object.kind == ObjectKind::Token && object.name == "Satya Copy Target"
+            })
+        })
+        .expect("Satya should create a copy token");
+    assert!(
+        game.is_tapped(token_id),
+        "Satya's copy token should enter tapped"
+    );
+    assert!(
+        game.combat.as_ref().is_some_and(|combat| combat
+            .attackers
+            .iter()
+            .any(|attacker| attacker.creature == token_id
+                && attacker.target == AttackTarget::Player(defender))),
+        "Satya's copy token should enter attacking the same defending player"
+    );
+    assert_eq!(
+        game.player(controller)
+            .expect("controller should exist")
+            .energy_counters,
+        2,
+        "Satya's attack trigger should grant two energy before the delayed payment"
+    );
+    assert_eq!(
+        game.effect_store.delayed_triggers.len(),
+        1,
+        "Satya should schedule exactly one delayed end-step sacrifice trigger"
+    );
+    token_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_satya_delayed_trigger(game: &mut GameState, dm: &mut impl DecisionMaker) {
+    let mut trigger_queue = TriggerQueue::new();
+    let end_step_event = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(game.turn.active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_delayed_triggers(game, &end_step_event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Satya should have one delayed trigger to put on the stack"
+    );
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Satya delayed trigger should go on the stack");
+    resolve_stack_entry_with(game, dm).expect("Satya delayed trigger should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn satya_delayed_sacrifice_pays_energy_and_keeps_token() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+
+    let satya = satya_aetherflux_genius_definition();
+    let satya_id = game.create_object_from_definition(&satya, alice, Zone::Battlefield);
+    let target = satya_copy_target_definition(2);
+    let target_id = game.create_object_from_definition(&target, alice, Zone::Battlefield);
+
+    let token_id = execute_satya_attack_trigger(&mut game, satya_id, alice, bob, target_id);
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_satya_delayed_trigger(&mut game, &mut dm);
+
+    assert!(
+        game.battlefield.contains(&token_id),
+        "paying energy equal to the token's mana value should keep the token"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        0,
+        "paying the delayed cost should spend Satya's two energy"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn satya_delayed_sacrifice_without_enough_energy_sacrifices_token() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+
+    let satya = satya_aetherflux_genius_definition();
+    let satya_id = game.create_object_from_definition(&satya, alice, Zone::Battlefield);
+    let target = satya_copy_target_definition(3);
+    let target_id = game.create_object_from_definition(&target, alice, Zone::Battlefield);
+
+    let token_id = execute_satya_attack_trigger(&mut game, satya_id, alice, bob, target_id);
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_satya_delayed_trigger(&mut game, &mut dm);
+
+    assert!(
+        !game.battlefield.contains(&token_id),
+        "without enough energy to pay the token's mana value, Satya should sacrifice it"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        2,
+        "failing to pay the delayed cost should leave Satya's two energy unspent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn assaultron_dominator_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(74_260), "Assaultron Dominator")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -1748,9 +1748,6 @@ pub(crate) fn can_pay_total_cost_with_reason_in_context(
     reason: crate::costs::PaymentReason,
     execution_ctx: &mut ExecutionContext<'_>,
 ) -> Result<(), CostPaymentError> {
-    use crate::costs::{CostCheckContext, can_pay_with_check_context};
-
-    let check_ctx = CostCheckContext::new(source, payer).with_reason(reason);
     match cost.kind() {
         ironsmith_core::TotalCostKind::All(costs) => {
             for component in costs {
@@ -1764,7 +1761,16 @@ pub(crate) fn can_pay_total_cost_with_reason_in_context(
                 )?;
                 game.validate_cost_for_payment_reason(payer, source, &adjusted_component, reason)
                     .map_err(|err| err)?;
-                can_pay_with_check_context(&*adjusted_component.0, game, &check_ctx)?;
+                let mut cost_ctx = crate::costs::CostContext::new(
+                    source,
+                    payer,
+                    execution_ctx.decision_maker,
+                )
+                .with_reason(reason)
+                .with_provenance(execution_ctx.provenance);
+                cost_ctx.x_value = execution_ctx.x_value;
+                cost_ctx.tagged_objects = execution_ctx.tagged_objects.clone();
+                adjusted_component.0.can_pay(game, &cost_ctx)?;
             }
             Ok(())
         }
@@ -2340,7 +2346,11 @@ fn pay_component_in_context(
     let mut cost_ctx = CostContext::new(source, payer, execution_ctx.decision_maker)
         .with_reason(reason)
         .with_provenance(provenance);
-    pay_component_without_execution_context(game, component, &mut cost_ctx)
+    cost_ctx.x_value = execution_ctx.x_value;
+    cost_ctx.tagged_objects = execution_ctx.tagged_objects.clone();
+    let result = pay_component_without_execution_context(game, component, &mut cost_ctx);
+    execution_ctx.tagged_objects = cost_ctx.tagged_objects;
+    result
 }
 
 fn resolve_and_adjust_component_in_context(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Satya, Aetherflux Genius
Initial parse error:
```
unsupported sacrifice-unless clause (clause: 'that token unless you pay an amount of equal to its mana value'); oracle-only fallback also failed: unsupported sacrifice-unless clause (clause: 'that token unless you pay an amount of equal to its mana value')
```

Current worker: i-09fc21448632e7044
Branch: codex/aws-card-fix-satya-aetherflux-genius
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0009
