### PR TITLE
Fix Ironsmith parse failure: Trusted Advisor

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2069,6 +2069,8 @@ const MAX_HAND_SIZE_IS_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["maximum", "hand", "size", "is"]);
 const MAX_HAND_SIZE_REDUCED_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["maximum", "hand", "size", "is", "reduced"]);
+const MAX_HAND_SIZE_INCREASED_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix & ["maximum", "hand", "size", "is", "increased"]);
 const MAX_HAND_SIZE_SEVEN_MINUS_CARD_TYPES_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -10014,6 +10016,43 @@ pub(crate) fn parse_reduced_maximum_hand_size_line(
         }
 
         return Ok(Some(StaticAbility::reduce_maximum_hand_size(
+            player, amount,
+        )));
+    }
+
+    if line_words
+        .get(idx..)
+        .is_some_and(|tail| MAX_HAND_SIZE_INCREASED_PATTERN.matches_words(tail))
+    {
+        idx += 5;
+        if !line_words
+            .get(idx)
+            .is_some_and(|word| BY_WORD_PATTERN.matches_word(word))
+        {
+            return Ok(None);
+        }
+        idx += 1;
+
+        let Some(amount_word) = line_words.get(idx) else {
+            return Err(CardTextError::ParseError(format!(
+                "missing maximum-hand-size increase amount (clause: '{}')",
+                line_words.join(" ")
+            )));
+        };
+        let Some(amount) = parse_named_number(amount_word) else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported maximum-hand-size increase amount '{}' (clause: '{}')",
+                amount_word,
+                line_words.join(" ")
+            )));
+        };
+        idx += 1;
+
+        if idx != line_words.len() {
+            return Ok(None);
+        }
+
+        return Ok(Some(StaticAbility::increase_maximum_hand_size(
             player, amount,
         )));
     }

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -215,6 +215,7 @@ pub enum StaticAbilityId {
     NoMaximumHandSize,
     SetMaximumHandSize,
     ReduceMaximumHandSize,
+    IncreaseMaximumHandSize,
     MaximumHandSizeSevenMinusYourGraveyardCardTypes,
     RevealFirstCardYouDrawEachTurn,
     LookAtTopCardOfLibrary,
@@ -478,6 +479,7 @@ impl StaticAbilityId {
             | NoMaximumHandSize
             | SetMaximumHandSize
             | ReduceMaximumHandSize
+            | IncreaseMaximumHandSize
             | MaximumHandSizeSevenMinusYourGraveyardCardTypes
             | RevealFirstCardYouDrawEachTurn
             | LookAtTopCardOfLibrary

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -296,6 +296,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         player: PlayerFilter,
         by: u32,
     },
+    IncreaseMaximumHandSize {
+        player: PlayerFilter,
+        by: u32,
+    },
     MaximumHandSizeSevenMinusYourGraveyardCardTypes {
         player: PlayerFilter,
         min_card_types: u32,
@@ -1033,6 +1037,9 @@ where
             }
             StaticAbilityPayload::ReduceMaximumHandSize { player, by } => {
                 StaticAbilityPayload::ReduceMaximumHandSize { player, by }
+            }
+            StaticAbilityPayload::IncreaseMaximumHandSize { player, by } => {
+                StaticAbilityPayload::IncreaseMaximumHandSize { player, by }
             }
             StaticAbilityPayload::MaximumHandSizeSevenMinusYourGraveyardCardTypes {
                 player,
@@ -2661,6 +2668,13 @@ impl<
             id: Some(StaticAbilityId::ReduceMaximumHandSize),
             label: "reduce maximum hand size".into(),
             payload: StaticAbilityPayload::ReduceMaximumHandSize { player, by },
+        }
+    }
+    pub fn increase_maximum_hand_size(player: PlayerFilter, by: u32) -> Self {
+        Self {
+            id: Some(StaticAbilityId::IncreaseMaximumHandSize),
+            label: "increase maximum hand size".into(),
+            payload: StaticAbilityPayload::IncreaseMaximumHandSize { player, by },
         }
     }
     pub fn set_maximum_hand_size(player: PlayerFilter, amount: u32) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40594,6 +40594,35 @@ fn parse_each_opponents_maximum_hand_size_reduced_static_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn trusted_advisor_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Trusted Advisor");
+
+    let has_increase_max_hand_size = def.abilities.iter().any(|ability| {
+        matches!(
+            &ability.kind,
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::IncreaseMaximumHandSize
+        )
+    });
+    assert!(
+        has_increase_max_hand_size,
+        "Trusted Advisor should compile its maximum hand size increase as a static ability"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def);
+    assert_eq!(
+        rendered,
+        vec![
+            "Your maximum hand size is increased by two.".to_string(),
+            "At the beginning of your upkeep, return a blue creature you control to its owner's hand."
+                .to_string(),
+        ],
+        "Trusted Advisor should render its full oracle text"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn twenty_toed_toad_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Twenty-Toed Toad");
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1519,6 +1519,20 @@ fn twenty_toed_toad_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn trusted_advisor_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_951), "Trusted Advisor")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Advisor])
+        .power_toughness(PowerToughness::fixed(1, 2))
+        .parse_text(
+            "Your maximum hand size is increased by two.\n\
+             At the beginning of your upkeep, return a blue creature you control to its owner's hand.",
+        )
+        .expect("Trusted Advisor should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn ox_drover_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(73_950), "Ox Drover")
         .mana_cost(ManaCost::from_pips(vec![
@@ -2294,6 +2308,140 @@ fn twenty_toed_toad_static_ability_sets_maximum_hand_size_to_twenty() {
 
     assert_eq!(game.player(alice).unwrap().max_hand_size, 20);
     assert_eq!(game.player(bob).unwrap().max_hand_size, 7);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trusted_advisor_static_ability_increases_only_controller_maximum_hand_size() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let advisor = trusted_advisor_definition();
+    game.create_object_from_definition(&advisor, alice, Zone::Battlefield);
+
+    game.update_cant_effects();
+
+    assert_eq!(game.player(alice).unwrap().max_hand_size, 9);
+    assert_eq!(game.player(bob).unwrap().max_hand_size, 7);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trusted_advisor_in_hand_does_not_increase_maximum_hand_size() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let advisor = trusted_advisor_definition();
+    game.create_object_from_definition(&advisor, alice, Zone::Hand);
+
+    game.update_cant_effects();
+
+    assert_eq!(game.player(alice).unwrap().max_hand_size, 7);
+    assert_eq!(game.player(bob).unwrap().max_hand_size, 7);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn trusted_advisor_upkeep_returns_blue_creature_you_control_to_owners_hand() {
+    struct ChooseTrustedAdvisorCreatureDecisionMaker {
+        chosen: ObjectId,
+        seen_legal_objects: Vec<ObjectId>,
+    }
+
+    impl DecisionMaker for ChooseTrustedAdvisorCreatureDecisionMaker {
+        fn decide_targets(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<Target> {
+            panic!("Trusted Advisor should choose, not target, got {ctx:?}");
+        }
+
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            self.seen_legal_objects = ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .collect();
+            assert!(
+                self.seen_legal_objects.contains(&self.chosen),
+                "chosen blue creature you control should be legal, got {:?}",
+                ctx.candidates
+            );
+            vec![self.chosen]
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let advisor = trusted_advisor_definition();
+    game.create_object_from_definition(&advisor, alice, Zone::Battlefield);
+    let borrowed_blue = create_colored_creature(
+        &mut game,
+        "Borrowed Drake",
+        bob,
+        Some(crate::color::ColorSet::BLUE),
+    );
+    game.set_current_controller(borrowed_blue, alice);
+    let borrowed_stable_id = game
+        .object(borrowed_blue)
+        .expect("borrowed creature should exist")
+        .stable_id;
+    let controlled_green = create_colored_creature(
+        &mut game,
+        "Alice Bear",
+        alice,
+        Some(crate::color::ColorSet::GREEN),
+    );
+    let opponents_blue = create_colored_creature(
+        &mut game,
+        "Bob Drake",
+        bob,
+        Some(crate::color::ColorSet::BLUE),
+    );
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Trusted Advisor should trigger at the beginning of its controller's upkeep"
+    );
+
+    let mut dm = ChooseTrustedAdvisorCreatureDecisionMaker {
+        chosen: borrowed_blue,
+        seen_legal_objects: Vec::new(),
+    };
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Trusted Advisor upkeep trigger should go on the stack without targets");
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Trusted Advisor upkeep trigger should resolve");
+
+    assert!(dm.seen_legal_objects.contains(&borrowed_blue));
+    assert!(!dm.seen_legal_objects.contains(&controlled_green));
+    assert!(!dm.seen_legal_objects.contains(&opponents_blue));
+    let returned_borrowed = game
+        .find_object_by_stable_id(borrowed_stable_id)
+        .expect("returned creature should still be tracked by stable id");
+    assert!(
+        game.player(bob)
+            .is_some_and(|player| player.hand.contains(&returned_borrowed)),
+        "the chosen creature should return to its owner's hand"
+    );
+    assert!(!game.battlefield.contains(&borrowed_blue));
+    assert!(game.battlefield.contains(&controlled_green));
+    assert!(game.battlefield.contains(&opponents_blue));
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -4059,6 +4059,67 @@ impl StaticAbilityKind for ReduceMaximumHandSize {
     }
 }
 
+/// "Your/Each opponent's maximum hand size is increased by N."
+#[derive(Debug, Clone, PartialEq)]
+pub struct IncreaseMaximumHandSize {
+    pub player: PlayerFilter,
+    pub amount: u32,
+}
+
+impl IncreaseMaximumHandSize {
+    pub fn new(player: PlayerFilter, amount: u32) -> Self {
+        Self { player, amount }
+    }
+}
+
+impl StaticAbilityKind for IncreaseMaximumHandSize {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::IncreaseMaximumHandSize
+    }
+
+    fn display(&self) -> String {
+        let amount = number_word_u32(self.amount).unwrap_or_else(|| self.amount.to_string());
+        match self.player {
+            PlayerFilter::You => format!("Your maximum hand size is increased by {amount}."),
+            PlayerFilter::Opponent => {
+                format!("Each opponent's maximum hand size is increased by {amount}.")
+            }
+            PlayerFilter::Any => {
+                format!("Each player's maximum hand size is increased by {amount}.")
+            }
+            _ => format!("Maximum hand size is increased by {amount}."),
+        }
+    }
+
+    fn apply_restrictions(&self, game: &mut GameState, _source: ObjectId, controller: PlayerId) {
+        use crate::game_loop::player_matches_filter_with_combat;
+
+        let combat = game.combat.as_ref();
+        let affected: Vec<PlayerId> = game
+            .players
+            .iter()
+            .filter(|player| {
+                player.is_in_game()
+                    && player_matches_filter_with_combat(
+                        player.id,
+                        &self.player,
+                        game,
+                        controller,
+                        combat,
+                    )
+            })
+            .map(|player| player.id)
+            .collect();
+
+        let increase = self.amount as i32;
+        for player_id in affected {
+            if let Some(player) = game.player_mut(player_id) {
+                player.max_hand_size = player.max_hand_size.saturating_add(increase);
+            }
+        }
+    }
+}
+
 fn player_ids_for_filter(
     game: &GameState,
     player_filter: PlayerFilter,
@@ -5626,6 +5687,30 @@ mod tests {
             7
         );
         assert_eq!(game.player(bob).expect("bob should exist").max_hand_size, 3);
+    }
+
+    #[test]
+    fn test_increase_maximum_hand_size_for_you() {
+        let ability = IncreaseMaximumHandSize::new(PlayerFilter::You, 2);
+        assert_eq!(ability.id(), StaticAbilityId::IncreaseMaximumHandSize);
+        assert_eq!(
+            ability.display(),
+            "Your maximum hand size is increased by two."
+        );
+
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = ObjectId::from_raw(44);
+        ability.apply_restrictions(&mut game, source, alice);
+
+        assert_eq!(
+            game.player(alice)
+                .expect("alice should exist")
+                .max_hand_size,
+            9
+        );
+        assert_eq!(game.player(bob).expect("bob should exist").max_hand_size, 7);
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2671,6 +2671,10 @@ impl StaticAbility {
         Self::new(ReduceMaximumHandSize::new(player, amount))
     }
 
+    pub fn increase_maximum_hand_size(player: crate::target::PlayerFilter, amount: u32) -> Self {
+        Self::new(IncreaseMaximumHandSize::new(player, amount))
+    }
+
     pub fn max_hand_size_seven_minus_your_graveyard_card_types(
         player: crate::target::PlayerFilter,
         minimum_types: u32,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1061,6 +1061,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ReduceMaximumHandSize { player, by } => {
                 StaticAbility::reduce_maximum_hand_size(player.clone(), *by)
             }
+            ironsmith_core::StaticAbilityPayload::IncreaseMaximumHandSize { player, by } => {
+                StaticAbility::increase_maximum_hand_size(player.clone(), *by)
+            }
             ironsmith_core::StaticAbilityPayload::MaximumHandSizeSevenMinusYourGraveyardCardTypes {
                 player,
                 min_card_types,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Trusted Advisor
Initial parse error:
```
unsupported maximum-hand-size value 'increased' (clause: 'your maximum hand size is increased by two'); oracle-only fallback also failed: unsupported maximum-hand-size value 'increased' (clause: 'your maximum hand size is increased by two')
```

Current worker: i-0b6dcd493e4d7ef89
Branch: codex/aws-card-fix-trusted-advisor
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0010
