### PR TITLE
Fix Ironsmith parse failure: Cult of Skaro

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -257,6 +257,7 @@ pub(crate) struct ModalHeaderChooseSpec {
     pub(crate) choose_idx: usize,
     pub(crate) min: Value,
     pub(crate) max: Option<Value>,
+    pub(crate) random: bool,
     pub(crate) x_clause_start: Option<usize>,
 }
 
@@ -1902,12 +1903,14 @@ fn parse_modal_header_choose_spec_inner<'a>(
         };
         let x_clause_start = primitives::find_phrase_start(choose_tail, &["x", "is"])
             .map(|idx| choose_idx + 1 + idx);
+        let random = primitives::find_phrase_start(choose_tail, &["at", "random"]).is_some();
 
         input.finish();
         return Ok(Some(ModalHeaderChooseSpec {
             choose_idx,
             min,
             max,
+            random,
             x_clause_start,
         }));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/modal_and_level_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/modal_and_level_lowering.rs
@@ -51,6 +51,7 @@ pub(crate) fn try_merge_modal_into_remove_mode(
             min: choose_mode.min.clone(),
             max: choose_mode.max.clone(),
             allow_repeat: choose_mode.allow_repeat,
+            random: choose_mode.random,
             choose_count: choose_mode.choose_count.clone(),
             min_choose_count: choose_mode.min_choose_count.clone(),
             allow_repeated_modes: choose_mode.allow_repeated_modes,
@@ -64,6 +65,7 @@ pub(crate) fn try_merge_modal_into_remove_mode(
     effects.push(crate::effect::Effect::new(
         crate::effects::ChooseModeEffect {
             modes,
+            random: choose_mode.random,
             choose_count: choose_mode.choose_count.clone(),
             min_choose_count: choose_mode.min_choose_count.clone(),
             allow_repeated_modes: choose_mode.allow_repeated_modes,
@@ -113,6 +115,7 @@ pub(crate) fn rewrite_lower_parsed_modal(
     let crate::cards::builders::ParsedModalHeader {
         min: header_min,
         max: header_max,
+        random: random_mode_choice,
         same_mode_more_than_once,
         mode_must_be_unchosen,
         mode_must_be_unchosen_this_turn,
@@ -197,6 +200,9 @@ pub(crate) fn rewrite_lower_parsed_modal(
         let mut choose_mode = choose_mode.clone();
         if same_mode_more_than_once {
             choose_mode = choose_mode.with_repeated_modes();
+        }
+        if random_mode_choice {
+            choose_mode = choose_mode.with_random_mode_choice();
         }
         if weighted_mode_points {
             choose_mode = choose_mode.with_mode_point_costs(mode_point_costs.clone());

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -67,6 +67,7 @@ pub(crate) fn parse_modal_header(info: &LineInfo) -> Result<Option<ModalHeader>,
     let choose_idx = choose_spec.choose_idx;
     let min = choose_spec.min;
     let max = choose_spec.max;
+    let random = choose_spec.random;
 
     let mut trigger = None;
     let mut activated = None;
@@ -139,6 +140,7 @@ pub(crate) fn parse_modal_header(info: &LineInfo) -> Result<Option<ModalHeader>,
     Ok(Some(ModalHeader {
         min,
         max,
+        random,
         same_mode_more_than_once: modal_flags.same_mode_more_than_once,
         mode_must_be_unchosen: modal_flags.mode_must_be_unchosen,
         mode_must_be_unchosen_this_turn: modal_flags.mode_must_be_unchosen_this_turn,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/semantic.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/semantic.rs
@@ -227,6 +227,7 @@ pub(crate) struct ParsedModalAst {
 pub(crate) struct ParsedModalHeader {
     pub(crate) min: Value,
     pub(crate) max: Option<Value>,
+    pub(crate) random: bool,
     pub(crate) same_mode_more_than_once: bool,
     pub(crate) mode_must_be_unchosen: bool,
     pub(crate) mode_must_be_unchosen_this_turn: bool,

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -839,6 +839,7 @@ pub struct ChooseModeEffect<E> {
     pub min: Value,
     pub max: Value,
     pub allow_repeat: bool,
+    pub random: bool,
     pub choose_count: Value,
     pub min_choose_count: Value,
     pub allow_repeated_modes: bool,
@@ -857,6 +858,7 @@ impl<E> ChooseModeEffect<E> {
             min,
             max,
             allow_repeat,
+            random: false,
             choose_count,
             min_choose_count,
             allow_repeated_modes: allow_repeat,
@@ -886,6 +888,11 @@ impl<E> ChooseModeEffect<E> {
     pub fn with_repeated_modes(mut self) -> Self {
         self.allow_repeat = true;
         self.allow_repeated_modes = true;
+        self
+    }
+
+    pub fn with_random_mode_choice(mut self) -> Self {
+        self.random = true;
         self
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -45123,6 +45123,182 @@ fn assert_oracle_card_parses_strict(name: &str) {
     );
 }
 
+fn cult_of_skaro_modal_effect(def: &CardDefinition) -> &ChooseModeEffect {
+    def.abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Triggered(triggered) = &ability.kind else {
+                return None;
+            };
+            triggered
+                .effects
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        })
+        .expect("Cult of Skaro should lower its attack trigger to a modal choice")
+}
+
+fn cult_of_skaro_test_game() -> (crate::game_state::GameState, PlayerId, PlayerId) {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    for idx in 0..2 {
+        let filler =
+            CardDefinitionBuilder::new(CardId::from_raw(95_500 + idx), "Cult Draw Filler")
+                .card_types(vec![CardType::Creature])
+                .build();
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+    (game, alice, bob)
+}
+
+#[test]
+fn cult_of_skaro_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Cult of Skaro");
+    let def = parse_oracle_card_definition("Cult of Skaro");
+    let modal = cult_of_skaro_modal_effect(&def);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(modal.random, "Cult of Skaro's modal choice should be random");
+    assert_eq!(
+        modal.modes.len(),
+        4,
+        "Cult of Skaro should have four random modes"
+    );
+    assert!(
+        rendered_lower.contains("choose one at random"),
+        "compiled text should preserve the random modal marker, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("put a +1/+1 counter on each artifact creature you control")
+            && rendered_lower.contains("draw two cards")
+            && rendered_lower
+                .contains("create a 3/3 black dalek artifact creature token with menace")
+            && rendered_lower.contains("each opponent loses 4 life"),
+        "compiled text should preserve all Cult of Skaro mode effects, got {rendered}"
+    );
+}
+
+#[test]
+fn cult_of_skaro_random_runtime_selects_one_mode_without_prompting() {
+    let def = parse_oracle_card_definition("Cult of Skaro");
+    let effect = cult_of_skaro_modal_effect(&def);
+    let (mut game, alice, bob) = cult_of_skaro_test_game();
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let hand_before = game.player(alice).expect("Alice").hand.len();
+    let bob_life_before = game.player(bob).expect("Bob").life;
+    let battlefield_before = game.objects_in_zone(Zone::Battlefield).len();
+    let random_count_before = game.irreversible_random_count();
+    let mut decisions = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut decisions);
+
+    let outcome = crate::effects::execute_effect(&mut game, &Effect::new(effect.clone()), &mut ctx)
+        .expect("Cult of Skaro random modal choice should resolve");
+    let chosen = outcome
+        .execution_facts()
+        .iter()
+        .find_map(|fact| match fact {
+            crate::effect::ExecutionFact::ChosenOptions(indices) => Some(indices.as_slice()),
+            _ => None,
+        })
+        .expect("random Cult of Skaro choice should record the selected mode");
+
+    assert_eq!(
+        chosen.len(),
+        1,
+        "Cult of Skaro should choose exactly one random mode"
+    );
+    assert!(
+        !ctx.decision_maker.awaiting_choice(),
+        "random mode choice should not prompt"
+    );
+    assert_eq!(
+        game.irreversible_random_count(),
+        random_count_before + 1,
+        "random mode choice should consume deterministic game RNG"
+    );
+    match chosen[0] {
+        0 => assert_eq!(
+            game.counter_count(source, crate::object::CounterType::PlusOnePlusOne),
+            1,
+            "Thay should put a +1/+1 counter on Cult of Skaro as an artifact creature"
+        ),
+        1 => assert_eq!(
+            game.player(alice).expect("Alice").hand.len(),
+            hand_before + 2,
+            "Caan should draw two cards"
+        ),
+        2 => assert_eq!(
+            game.objects_in_zone(Zone::Battlefield).len(),
+            battlefield_before + 1,
+            "Sec should create one Dalek token"
+        ),
+        3 => assert_eq!(
+            game.player(bob).expect("Bob").life,
+            bob_life_before - 4,
+            "Jast should make each opponent lose 4 life"
+        ),
+        other => panic!("unexpected random Cult of Skaro mode {other}"),
+    }
+}
+
+#[test]
+fn cult_of_skaro_runtime_branches_resolve_each_mode() {
+    let def = parse_oracle_card_definition("Cult of Skaro");
+    let effect = cult_of_skaro_modal_effect(&def);
+
+    for mode_idx in 0..4 {
+        let (mut game, alice, bob) = cult_of_skaro_test_game();
+        let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+        let hand_before = game.player(alice).expect("Alice").hand.len();
+        let battlefield_before = game.objects_in_zone(Zone::Battlefield).len();
+        let mut decisions = crate::decision::SelectFirstDecisionMaker;
+        let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut decisions)
+            .with_chosen_modes(Some(vec![mode_idx]));
+
+        let outcome =
+            crate::effects::execute_effect(&mut game, &Effect::new(effect.clone()), &mut ctx)
+                .unwrap_or_else(|err| {
+                    panic!("Cult of Skaro mode {mode_idx} should resolve: {err:?}")
+                });
+
+        match mode_idx {
+            0 => {
+                assert_eq!(
+                    game.counter_count(source, crate::object::CounterType::PlusOnePlusOne),
+                    1,
+                    "Thay should put a +1/+1 counter on each artifact creature you control"
+                );
+                assert_eq!(game.player(alice).expect("Alice").hand.len(), hand_before);
+            }
+            1 => assert_eq!(
+                game.player(alice).expect("Alice").hand.len(),
+                hand_before + 2,
+                "Caan should draw exactly two cards"
+            ),
+            2 => {
+                assert_eq!(
+                    outcome.objects().map(|objects| objects.len()),
+                    Some(1),
+                    "Sec should report one created token object"
+                );
+                assert_eq!(
+                    game.objects_in_zone(Zone::Battlefield).len(),
+                    battlefield_before + 1,
+                    "Sec should put one created token onto the battlefield"
+                );
+            }
+            3 => assert_eq!(
+                game.player(bob).expect("Bob").life,
+                16,
+                "Jast should make the opposing player lose 4 life"
+            ),
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[test]
 fn departed_deckhand_strict_parser_text_and_structure_regression() {
     let def = parse_oracle_card_definition("Departed Deckhand");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33464,6 +33464,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             Some(&choose_mode.min_choose_count),
             Some(choose_mode.modes.len()),
         );
+        if choose_mode.random {
+            if let Some(prefix) = header.strip_suffix(" —") {
+                header = format!("{prefix} at random —");
+            }
+        }
         let has_weighted_modes = choose_mode
             .mode_point_costs
             .iter()

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -233,6 +233,7 @@ where
         converted.choose_count = payload.choose_count.clone();
         converted.min_choose_count = payload.min_choose_count.clone();
         converted.allow_repeated_modes = payload.allow_repeated_modes;
+        converted.random = payload.random;
         converted.mode_point_costs = payload.mode_point_costs.clone();
         converted.disallow_previously_chosen_modes = payload.disallow_previously_chosen_modes;
         converted.disallow_previously_chosen_modes_this_turn =

--- a/crates/ironsmith-runtime/src/effects/composition/choose_mode_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_mode_runtime.rs
@@ -185,6 +185,31 @@ pub(crate) fn run_choose_mode(
     // Check if modes were pre-chosen during the casting process.
     let chosen_indices: Vec<usize> = if let Some(ref pre_chosen) = ctx.chosen_modes {
         pre_chosen.clone()
+    } else if effect.random {
+        let mut randomized_modes: Vec<usize> = (0..effect.modes.len())
+            .filter(|idx| is_mode_legal(*idx))
+            .collect();
+        let legal_mode_count = randomized_modes.len();
+        if legal_mode_count < min_modes {
+            return Err(ExecutionError::Impossible(
+                "Not enough legal modes available".to_string(),
+            ));
+        }
+        game.shuffle_slice(&mut randomized_modes);
+        let mut selected = Vec::new();
+        let mut point_total = 0usize;
+        for idx in randomized_modes {
+            let point_cost = mode_point_cost(effect, idx);
+            if point_total.saturating_add(point_cost) > max_modes {
+                continue;
+            }
+            selected.push(idx);
+            point_total += point_cost;
+            if point_total >= min_modes {
+                break;
+            }
+        }
+        selected
     } else {
         let mode_options: Vec<ModeOption> = effect
             .modes
@@ -375,6 +400,44 @@ mod tests {
                 .contains(&ExecutionFact::ChosenOptions(vec![1]))
         );
         assert_eq!(game.player(alice).expect("alice").life, 22);
+    }
+
+    #[test]
+    fn random_choose_mode_selects_legal_mode_without_prompting() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let random_count_before = game.irreversible_random_count();
+        let mut decisions = CapturingOptionsDecisionMaker::default();
+        let mut ctx = ExecutionContext::new(source, alice, &mut decisions);
+
+        let effect = ChooseModeEffect::choose_one(vec![
+            EffectMode::new("Gain 1 life", vec![Effect::gain_life(1)]),
+            EffectMode::new("Gain 2 life", vec![Effect::gain_life(2)]),
+        ])
+        .with_random_mode_choice();
+
+        let result = run_choose_mode(&effect, &mut game, &mut ctx).expect("choose mode resolves");
+        let chosen = result
+            .execution_facts()
+            .iter()
+            .find_map(|fact| match fact {
+                ExecutionFact::ChosenOptions(indices) => Some(indices.as_slice()),
+                _ => None,
+            })
+            .expect("random modal choice should record the selected mode");
+
+        assert_eq!(chosen.len(), 1, "random choose-one should select exactly one mode");
+        assert!(!ctx.decision_maker.awaiting_choice(), "random modal choice should not prompt");
+        assert_eq!(
+            game.irreversible_random_count(),
+            random_count_before + 1,
+            "random modal choice should consume deterministic game RNG"
+        );
+        assert!(
+            matches!(game.player(alice).expect("alice").life, 21 | 22),
+            "one of the random gain-life modes should resolve"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Cult of Skaro
Initial parse error:
```
compiled text dropped required semantic marker: at-random
```

Current worker: i-070190792ed8cf53e
Branch: codex/aws-card-fix-cult-of-skaro
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0010
