### PR TITLE
Fix Ironsmith parse failure: Gaea's Balance

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -4,8 +4,8 @@ use winnow::prelude::*;
 
 use crate::cards::builders::{
     CardTextError, ChoiceCount, EffectAst, IT_TAG, LibraryBottomOrderAst, LibraryConsultModeAst,
-    LibraryConsultStopRuleAst, PlayerAst, PredicateAst, ReturnControllerAst, SubjectAst,
-    SubjectVerbActionAst, SubjectVerbRoleAst, TagKey, TargetAst, TextSpan,
+    LibraryConsultStopRuleAst, PlayerAst, PredicateAst, ReturnControllerAst, SearchLibrarySlotAst,
+    SubjectAst, SubjectVerbActionAst, SubjectVerbRoleAst, TagKey, TargetAst, TextSpan,
 };
 use crate::effect::SearchSelectionMode;
 use crate::runtime_backend::sentences::effect_sentences::clause_pattern_helpers::{
@@ -13,6 +13,7 @@ use crate::runtime_backend::sentences::effect_sentences::clause_pattern_helpers:
 };
 use crate::target::PlayerFilter;
 use crate::target::{ObjectFilter, TaggedObjectConstraint, TaggedOpbjectRelation};
+use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
 use ironsmith_core::Value;
 
@@ -1239,11 +1240,21 @@ pub(crate) fn parse_search_library_sentence_with_grammar_entrypoint_lexed(
     };
     let (filter_tokens, distinct_names) =
         strip_search_library_different_names_clause_lexed(&filter_tokens);
-    let same_name_split = parse_search_library_same_name_reference_lexed(
-        &filter_tokens,
-        filter_tokens.clone(),
-        &words_all,
-    )?;
+    let mut basic_land_type_slots =
+        parse_search_library_basic_land_type_slots_lexed(&filter_tokens);
+    let same_name_split = if basic_land_type_slots.is_none() {
+        parse_search_library_same_name_reference_lexed(
+            &filter_tokens,
+            filter_tokens.clone(),
+            &words_all,
+        )?
+    } else {
+        SearchLibrarySameNameSplit {
+            filter_tokens: filter_tokens.clone(),
+            same_name_reference: None,
+            same_name_relation: TaggedOpbjectRelation::SameNameAsTagged,
+        }
+    };
     let filter_tokens = same_name_split.filter_tokens;
     let same_name_reference = same_name_split.same_name_reference;
     let same_name_relation = same_name_split.same_name_relation;
@@ -1253,12 +1264,16 @@ pub(crate) fn parse_search_library_sentence_with_grammar_entrypoint_lexed(
             | Some(SearchLibrarySameNameReference::Choose { .. })
     );
 
-    let named_filters = if count_used == 0 {
+    let named_filters = if basic_land_type_slots.is_none() && count_used == 0 {
         split_search_named_item_filters_lexed(&filter_tokens, &words_all)?
     } else {
         None
     };
-    let mut filter = parse_search_library_object_filter_lexed(&filter_tokens, &words_all)?;
+    let mut filter = if basic_land_type_slots.is_none() {
+        parse_search_library_object_filter_lexed(&filter_tokens, &words_all)?
+    } else {
+        ObjectFilter::default()
+    };
     filter.distinct_names = distinct_names;
     if let Some(same_name_tag) = same_name_reference
         .as_ref()
@@ -1311,7 +1326,28 @@ pub(crate) fn parse_search_library_sentence_with_grammar_entrypoint_lexed(
     let split_battlefield_and_hand = effect_routing.split_battlefield_and_hand;
     let library_position_from_top = effect_routing.library_position_from_top.clone();
     let mut handled_direct_may_in_iterated_search = false;
-    let mut effects = if let Some(iterated_filter) = iterated_subject_filter.clone()
+    let mut effects = if let Some(mut slots) = basic_land_type_slots.take() {
+        if !has_explicit_destination || !search_zones_are_library_only {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported each-basic-land-type search-library clause (clause: '{}')",
+                words_all.join(" ")
+            )));
+        }
+        for slot in &mut slots {
+            if slot.filter.owner.is_none()
+                && let Some(owner) = forced_library_owner.clone()
+            {
+                slot.filter.owner = Some(owner);
+            }
+        }
+        vec![EffectAst::subject_verb_search_library_slots(
+            player,
+            slots,
+            destination,
+            reveal,
+            TagKey::from("search_library_slots_progress"),
+        )]
+    } else if let Some(iterated_filter) = iterated_subject_filter.clone()
         && has_explicit_destination
         && named_filters.is_none()
         && !split_battlefield_and_hand

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/search_library.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/search_library.rs
@@ -622,6 +622,35 @@ pub(crate) fn is_default_search_library_card_selector(tokens: &[OwnedLexToken]) 
     CARD_OR_CARDS_PATTERN.matches_words(&words)
 }
 
+pub(crate) fn parse_search_library_basic_land_type_slots_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<SearchLibrarySlotAst>> {
+    let parser_words = parser_token_word_refs(tokens);
+    let words = crate::runtime_backend::util::non_article_word_refs(&parser_words);
+    if words.as_slice() != ["land", "card", "of", "each", "basic", "land", "type"] {
+        return None;
+    }
+
+    Some(
+        [
+            Subtype::Plains,
+            Subtype::Island,
+            Subtype::Swamp,
+            Subtype::Mountain,
+            Subtype::Forest,
+        ]
+        .into_iter()
+        .map(|subtype| SearchLibrarySlotAst {
+            filter: ObjectFilter::default()
+                .in_zone(Zone::Library)
+                .with_type(CardType::Land)
+                .with_subtype(subtype),
+            optional: true,
+        })
+        .collect(),
+    )
+}
+
 pub(crate) fn find_search_library_marker_lexed(
     tokens: &[OwnedLexToken],
     parser: for<'a> fn(&mut LexStream<'a>) -> Result<(), ErrMode<ContextError>>,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -3831,6 +3831,7 @@ fn compile_subject_verb_effect(
         )),
         SubjectVerbActionAst::SearchLibrarySlotsToHand {
             slots,
+            destination,
             reveal,
             progress_tag,
         } => {
@@ -3852,12 +3853,14 @@ fn compile_subject_verb_effect(
             ctx.last_object_tag = Some(resolved_tag.as_str().to_string());
             ctx.last_player_filter = Some(player_filter.clone());
             Ok((
-                vec![Effect::search_library_slots_to_hand(
+                vec![Effect::new(crate::effects::SearchLibrarySlotsEffect::new(
                     resolved_slots,
+                    *destination,
+                    player_filter.clone(),
                     player_filter,
                     *reveal,
                     resolved_tag,
-                )],
+                ))],
                 subject.into_choices(),
             ))
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1423,6 +1423,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     SearchLibrarySlotsToHand {
         slots: Vec<SearchLibrarySlotAst>,
+        destination: Zone,
         reveal: bool,
         progress_tag: TagKey,
     },
@@ -2865,11 +2866,13 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .finish(),
             Self::SearchLibrarySlotsToHand {
                 slots,
+                destination,
                 reveal,
                 progress_tag,
             } => f
                 .debug_struct("SearchLibrarySlotsToHand")
                 .field("slots", slots)
+                .field("destination", destination)
                 .field("reveal", reveal)
                 .field("progress_tag", progress_tag)
                 .finish(),
@@ -4830,11 +4833,22 @@ impl EffectAst {
         reveal: bool,
         progress_tag: TagKey,
     ) -> Self {
+        Self::subject_verb_search_library_slots(player, slots, Zone::Hand, reveal, progress_tag)
+    }
+
+    pub(crate) fn subject_verb_search_library_slots(
+        player: PlayerAst,
+        slots: Vec<SearchLibrarySlotAst>,
+        destination: Zone,
+        reveal: bool,
+        progress_tag: TagKey,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             player,
             SubjectVerbActionAst::SearchLibrarySlotsToHand {
                 slots,
+                destination,
                 reveal,
                 progress_tag,
             },

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,49 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn gaeas_balance_strict_parser_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Gaea's Balance");
+
+    let def = parse_oracle_card_definition("Gaea's Balance");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    let cost_debug = format!("{:#?}", def.additional_cost);
+
+    assert_eq!(def.name(), "Gaea's Balance");
+    assert_eq!(
+        rendered,
+        "As an additional cost to cast this spell, sacrifice five lands.\nSearch your library for a land card of each basic land type, put them onto the battlefield, then shuffle.",
+        "Gaea's Balance compiled text should preserve the full additional-cost and each-basic-land-type search clauses"
+    );
+    assert!(
+        rendered_lower.contains("as an additional cost to cast this spell, sacrifice five lands"),
+        "Gaea's Balance should render the additional sacrifice cost, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("a land card of each basic land type"),
+        "Gaea's Balance should preserve each-basic-land-type search text, got {rendered}"
+    );
+    assert!(
+        spell_debug.contains("SearchLibrarySlotsEffect")
+            && spell_debug.contains("destination: Battlefield")
+            && ["Plains", "Island", "Swamp", "Mountain", "Forest"]
+                .iter()
+                .all(|subtype| spell_debug.contains(subtype)),
+        "Gaea's Balance should lower to battlefield search slots for every basic land type, got {spell_debug}"
+    );
+    assert!(
+        cost_debug.contains("ChooseObjectsEffect")
+            && cost_debug.contains("SacrificePlayerEffect")
+            && cost_debug.contains("min: 5")
+            && cost_debug.contains("max: Some(")
+            && cost_debug.contains("Fixed(")
+            && cost_debug.contains("Land"),
+        "Gaea's Balance should require sacrificing exactly five lands as an additional cost, got {cost_debug}"
+    );
+}
+
+#[test]
 fn clockspinning_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Clockspinning");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -20438,6 +20438,38 @@ fn title_case_named_card_selection(selection: &str) -> String {
     format!("{head} named {}", title_case_card_name_fragment(name))
 }
 
+fn describe_basic_land_type_search_slots(
+    search_slots: &crate::effects::SearchLibrarySlotsEffect,
+) -> Option<&'static str> {
+    if search_slots.slots.len() != 5 {
+        return None;
+    }
+
+    let basic_land_types = [
+        Subtype::Plains,
+        Subtype::Island,
+        Subtype::Swamp,
+        Subtype::Mountain,
+        Subtype::Forest,
+    ];
+    for subtype in basic_land_types {
+        let expected = ObjectFilter::default()
+            .in_zone(Zone::Library)
+            .with_type(CardType::Land)
+            .with_subtype(subtype);
+        let has_slot = search_slots.slots.iter().any(|slot| {
+            let mut filter = slot.filter.clone();
+            filter.owner = None;
+            filter == expected
+        });
+        if !has_slot {
+            return None;
+        }
+    }
+
+    Some("a land card of each basic land type")
+}
+
 pub(super) fn describe_cost_list(costs: &[crate::costs::Cost]) -> String {
     describe_cost_component_parts(costs).join(", ")
 }
@@ -32627,6 +32659,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_possessive_player_filter(&search_slots.player)
             )
         };
+        if let Some(selection) = describe_basic_land_type_search_slots(search_slots) {
+            if search_slots.reveal {
+                return format!(
+                    "Search {search_origin} for {selection}, reveal those cards, put them {destination}, then shuffle"
+                );
+            }
+            return format!(
+                "Search {search_origin} for {selection}, put them {destination}, then shuffle"
+            );
+        }
         let selections: Vec<String> = search_slots
             .slots
             .iter()

--- a/crates/ironsmith-runtime/src/effects/cards/search_library_slots.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/search_library_slots.rs
@@ -228,14 +228,65 @@ mod tests {
         crate::tests::test_helpers::setup_two_player_game()
     }
 
-    fn push_basic_land(game: &mut GameState, controller: PlayerId, name: &str, subtype: Subtype) {
+    fn push_basic_land_in_zone(
+        game: &mut GameState,
+        controller: PlayerId,
+        name: &str,
+        subtype: Subtype,
+        zone: Zone,
+    ) {
         let card = CardBuilder::new(CardId::new(), name)
             .card_types(vec![CardType::Land])
             .supertypes(vec![Supertype::Basic])
             .subtypes(vec![subtype])
             .mana_cost(ManaCost::new())
             .build();
+        game.create_object_from_card(&card, controller, zone);
+    }
+
+    fn push_land_with_subtypes(
+        game: &mut GameState,
+        controller: PlayerId,
+        name: &str,
+        subtypes: Vec<Subtype>,
+    ) {
+        let card = CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Land])
+            .subtypes(subtypes)
+            .mana_cost(ManaCost::new())
+            .build();
         game.create_object_from_card(&card, controller, Zone::Library);
+    }
+
+    fn push_basic_land(game: &mut GameState, controller: PlayerId, name: &str, subtype: Subtype) {
+        push_basic_land_in_zone(game, controller, name, subtype, Zone::Library);
+    }
+
+    fn gaeas_balance_search_effect() -> SearchLibrarySlotsEffect {
+        SearchLibrarySlotsEffect::new(
+            [
+                Subtype::Plains,
+                Subtype::Island,
+                Subtype::Swamp,
+                Subtype::Mountain,
+                Subtype::Forest,
+            ]
+            .into_iter()
+            .map(|subtype| {
+                SearchLibrarySlot::optional(
+                    ObjectFilter::default()
+                        .in_zone(Zone::Library)
+                        .with_type(CardType::Land)
+                        .with_subtype(subtype),
+                )
+            })
+            .collect(),
+            Zone::Battlefield,
+            PlayerFilter::You,
+            PlayerFilter::You,
+            false,
+            "gaeas_balance_progress",
+        )
     }
 
     struct PendingOnSecondChoiceDm {
@@ -366,5 +417,113 @@ mod tests {
         assert_eq!(second.output_objects().len(), 2);
         assert!(ctx.get_tagged_all("progress").is_none());
         assert_eq!(game.player(alice).expect("alice exists").hand.len(), 2);
+    }
+
+    #[test]
+    fn gaeas_balance_slots_put_each_basic_land_type_onto_battlefield() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        for (name, subtype) in [
+            ("Plains", Subtype::Plains),
+            ("Island", Subtype::Island),
+            ("Swamp", Subtype::Swamp),
+            ("Mountain", Subtype::Mountain),
+            ("Forest", Subtype::Forest),
+        ] {
+            push_basic_land(&mut game, alice, name, subtype);
+        }
+
+        let source = ObjectId::from_raw(2001);
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let outcome = gaeas_balance_search_effect()
+            .execute(&mut game, &mut ctx)
+            .expect("Gaea's Balance search should resolve");
+
+        assert_eq!(outcome.output_objects().len(), 5);
+        let battlefield_names: Vec<_> = game
+            .battlefield
+            .iter()
+            .filter_map(|id| game.object(*id).map(|obj| obj.name.clone()))
+            .collect();
+        for name in ["Plains", "Island", "Swamp", "Mountain", "Forest"] {
+            assert!(
+                battlefield_names.iter().any(|candidate| candidate == name),
+                "Gaea's Balance should put {name} onto the battlefield, got {battlefield_names:?}"
+            );
+        }
+        assert!(ctx.get_tagged_all("gaeas_balance_progress").is_none());
+    }
+
+    #[test]
+    fn gaeas_balance_slots_do_not_find_missing_type_from_graveyard() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        for (name, subtype) in [
+            ("Plains", Subtype::Plains),
+            ("Island", Subtype::Island),
+            ("Mountain", Subtype::Mountain),
+            ("Forest", Subtype::Forest),
+        ] {
+            push_basic_land(&mut game, alice, name, subtype);
+        }
+        push_basic_land_in_zone(
+            &mut game,
+            alice,
+            "Graveyard Swamp",
+            Subtype::Swamp,
+            Zone::Graveyard,
+        );
+
+        let source = ObjectId::from_raw(2002);
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let outcome = gaeas_balance_search_effect()
+            .execute(&mut game, &mut ctx)
+            .expect("Gaea's Balance partial search should resolve");
+
+        assert_eq!(outcome.output_objects().len(), 4);
+        assert!(
+            !game.battlefield.iter().any(|id| game
+                .object(*id)
+                .is_some_and(|obj| obj.name == "Graveyard Swamp")),
+            "Gaea's Balance must not find a missing basic land type from the graveyard"
+        );
+        let graveyard_names: Vec<_> = game
+            .player(alice)
+            .expect("alice exists")
+            .graveyard
+            .iter()
+            .filter_map(|id| game.object(*id).map(|obj| obj.name.clone()))
+            .collect();
+        assert!(
+            graveyard_names.iter().any(|name| name == "Graveyard Swamp"),
+            "Gaea's Balance should leave the graveyard Swamp in the graveyard, got {graveyard_names:?}"
+        );
+    }
+
+    #[test]
+    fn gaeas_balance_slots_use_multitype_land_for_only_one_slot() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        push_land_with_subtypes(
+            &mut game,
+            alice,
+            "Savannah",
+            vec![Subtype::Plains, Subtype::Forest],
+        );
+
+        let source = ObjectId::from_raw(2003);
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let outcome = gaeas_balance_search_effect()
+            .execute(&mut game, &mut ctx)
+            .expect("Gaea's Balance dual-land search should resolve");
+
+        assert_eq!(
+            outcome.output_objects().len(),
+            1,
+            "one land card with two basic land types must not satisfy two slots"
+        );
+        assert!(game.battlefield.iter().any(|id| game
+            .object(*id)
+            .is_some_and(|obj| obj.name == "Savannah")));
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gaea's Balance
Initial parse error:
```
compiled text dropped required semantic marker: each-basic-land-type
```

Current worker: i-005c46e7373d6a116
Branch: codex/aws-card-fix-gaea-s-balance
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0011
