### PR TITLE
Fix Ironsmith parse failure: God-Eternal Rhonas

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -9,7 +9,7 @@ use crate::filter::ObjectFilter;
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::runtime_backend::token_primitives::is_static_keyword_marker_text;
 use crate::static_abilities::StaticAbility;
-use crate::target::{ChooseSpec, PlayerFilter};
+use crate::target::{ChooseSpec, PlayerFilter, TaggedOpbjectRelation};
 use crate::zone::Zone;
 
 use super::compile_support::{
@@ -51,6 +51,86 @@ fn target_can_establish_local_object_reference(target: &TargetAst) -> bool {
         | TargetAst::PlayerOrPlaneswalker(_, _)
         | TargetAst::AttackedPlayerOrPlaneswalker(_)
         | TargetAst::Spell(_) => false,
+    }
+}
+
+fn object_filter_is_it_reference(filter: &ObjectFilter) -> bool {
+    filter.tagged_constraints.iter().any(|constraint| {
+        constraint.tag.as_str() == IT_TAG
+            && constraint.relation == TaggedOpbjectRelation::IsTaggedObject
+    })
+}
+
+fn replace_it_target_with_filter(target: &mut TargetAst, filter: &ObjectFilter) -> bool {
+    match target {
+        TargetAst::Tagged(tag, span) if tag.as_str() == IT_TAG => {
+            *target = TargetAst::Object(filter.clone(), *span, None);
+            true
+        }
+        TargetAst::Object(target_filter, _, _) if object_filter_is_it_reference(target_filter) => {
+            *target_filter = filter.clone();
+            true
+        }
+        TargetAst::WithCount(inner, _) | TargetAst::WithCountValue(inner, _, _) => {
+            replace_it_target_with_filter(inner, filter)
+        }
+        _ => false,
+    }
+}
+
+fn replace_it_object_followup_filter(effect: &mut EffectAst, filter: &ObjectFilter) -> bool {
+    match effect {
+        EffectAst::SubjectVerb(subject_verb) => match &mut subject_verb.action {
+            SubjectVerbActionAst::GrantAbilitiesAll {
+                filter: target_filter,
+                ..
+            }
+            | SubjectVerbActionAst::RemoveAbilitiesAll {
+                filter: target_filter,
+                ..
+            }
+            | SubjectVerbActionAst::PumpAll {
+                filter: target_filter,
+                ..
+            } if object_filter_is_it_reference(target_filter) => {
+                *target_filter = filter.clone();
+                true
+            }
+            SubjectVerbActionAst::GrantAbilitiesToTarget { target, .. }
+            | SubjectVerbActionAst::GrantToTarget { target, .. }
+            | SubjectVerbActionAst::RemoveAbilitiesFromTarget { target, .. }
+            | SubjectVerbActionAst::Pump { target, .. } => {
+                replace_it_target_with_filter(target, filter)
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn carry_all_object_sweep_filter_to_it_followups(effects: &mut [EffectAst]) {
+    let mut idx = 0usize;
+    while idx + 1 < effects.len() {
+        let filter = match &effects[idx] {
+            EffectAst::SubjectVerb(subject_verb) => match &subject_verb.action {
+                SubjectVerbActionAst::PumpAll { filter, .. }
+                | SubjectVerbActionAst::ScalePowerToughnessAll { filter, .. } => filter.clone(),
+                _ => {
+                    idx += 1;
+                    continue;
+                }
+            },
+            _ => {
+                idx += 1;
+                continue;
+            }
+        };
+
+        if replace_it_object_followup_filter(&mut effects[idx + 1], &filter) {
+            idx += 2;
+        } else {
+            idx += 1;
+        }
     }
 }
 
@@ -297,6 +377,7 @@ pub(crate) fn rewrite_prepare_effects_with_trigger_context_for_lowering(
 ) -> Result<PreparedEffectsForLowering, CardTextError> {
     let imports = imports.into();
     let mut normalized = normalize_effects_ast(effects);
+    carry_all_object_sweep_filter_to_it_followups(&mut normalized);
     let has_local_target_prelude = has_local_target_prelude_before_it_reference(&normalized);
     let has_phase_step_it_prelude =
         has_local_target_prelude || has_prior_effect_before_it_reference(&normalized);
@@ -399,7 +480,8 @@ pub(crate) fn rewrite_prepare_triggered_effects_for_lowering(
     let mut trigger = trigger;
     ensure_concrete_trigger_spec(&trigger)?;
 
-    let normalized = normalize_effects_ast(effects);
+    let mut normalized = normalize_effects_ast(effects);
+    carry_all_object_sweep_filter_to_it_followups(&mut normalized);
     let has_local_target_prelude = has_local_target_prelude_before_it_reference(&normalized);
     let has_phase_step_it_prelude =
         has_local_target_prelude || has_prior_effect_before_it_reference(&normalized);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -23700,6 +23700,264 @@ fn parse_full_god_eternal_kefnet_oracle() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn god_eternal_rhonas_definition() -> CardDefinition {
+    let oracle = oracle_text_by_name()
+        .get("God-Eternal Rhonas")
+        .expect("God-Eternal Rhonas oracle text")
+        .clone();
+    CardDefinitionBuilder::new(CardId::new(), "God-Eternal Rhonas")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::God])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .parse_text(oracle)
+        .expect("God-Eternal Rhonas should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn vanilla_creature_definition(name: &str, power: i32, toughness: i32) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(power, toughness))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn god_eternal_rhonas_trigger_for_event(
+    game: &crate::game_state::GameState,
+    event: &crate::triggers::TriggerEvent,
+    source: ObjectId,
+) -> crate::triggers::TriggeredAbilityEntry {
+    let triggers = crate::triggers::check_triggers(game, event);
+    let matching = triggers
+        .into_iter()
+        .filter(|entry| entry.source == source)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one God-Eternal Rhonas trigger for event"
+    );
+    matching.into_iter().next().expect("checked one trigger")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_full_god_eternal_rhonas_oracle_and_compiled_text() {
+    assert_oracle_card_parses_strict("God-Eternal Rhonas");
+    let def = god_eternal_rhonas_definition();
+    let abilities_debug = format!("{:#?}", def.abilities);
+    assert!(
+        abilities_debug.contains("ForEachObject")
+            && abilities_debug.contains("PowerOf")
+            && abilities_debug.contains("Vigilance")
+            && abilities_debug.contains("OrTrigger")
+            && abilities_debug.contains("MoveToLibraryNthFromTopEffect"),
+        "expected Rhonas ETB and dies/exile trigger structures, got {abilities_debug}"
+    );
+
+    let rendered = compiled_text_lines(&def).join(" ");
+    assert!(
+        rendered.contains("double the power of each other creature you control until end of turn"),
+        "expected double-power clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Those creatures gain vigilance until end of turn"),
+        "expected same-creature vigilance clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("dies or") && rendered.contains("put into exile from the battlefield"),
+        "expected dies-or-exile marker in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("third from the top"),
+        "expected third-from-top library placement, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn god_eternal_rhonas_etb_doubles_other_creatures_and_grants_vigilance() {
+    let rhonas = god_eternal_rhonas_definition();
+    let ally = vanilla_creature_definition("Allied Bear", 2, 2);
+    let second_ally = vanilla_creature_definition("Allied Soldier", 1, 3);
+    let enemy = vanilla_creature_definition("Enemy Bear", 4, 4);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let rhonas_id = game.create_object_from_definition(&rhonas, alice, Zone::Battlefield);
+    let ally_id = game.create_object_from_definition(&ally, alice, Zone::Battlefield);
+    let second_ally_id = game.create_object_from_definition(&second_ally, alice, Zone::Battlefield);
+    let enemy_id = game.create_object_from_definition(&enemy, bob, Zone::Battlefield);
+
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(rhonas_id).expect("Rhonas exists"),
+        &game,
+    );
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            rhonas_id,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let entry = god_eternal_rhonas_trigger_for_event(&game, &event, rhonas_id);
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(rhonas_id, alice, &mut dm)
+        .with_triggering_event(entry.triggering_event.clone());
+    for effect in &entry.ability.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Rhonas ETB trigger should resolve");
+    }
+
+    assert_eq!(game.calculated_power(ally_id), Some(4));
+    assert_eq!(game.calculated_toughness(ally_id), Some(2));
+    assert!(game.object_has_static_ability_id(ally_id, StaticAbilityId::Vigilance));
+    assert_eq!(game.calculated_power(second_ally_id), Some(2));
+    assert_eq!(game.calculated_toughness(second_ally_id), Some(3));
+    assert!(game.object_has_static_ability_id(
+        second_ally_id,
+        StaticAbilityId::Vigilance
+    ));
+    assert_eq!(game.calculated_power(rhonas_id), Some(5));
+    assert!(
+        !game.object_has_static_ability_id(rhonas_id, StaticAbilityId::Vigilance),
+        "Rhonas should not grant vigilance to itself"
+    );
+    assert_eq!(game.calculated_power(enemy_id), Some(4));
+    assert!(
+        !game.object_has_static_ability_id(enemy_id, StaticAbilityId::Vigilance),
+        "Rhonas should not affect opponents' creatures"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn god_eternal_rhonas_death_or_exile_trigger_may_put_third_from_top() {
+    struct AcceptMay;
+    impl crate::decision::DecisionMaker for AcceptMay {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+    }
+
+    for destination in [Zone::Graveyard, Zone::Exile] {
+        let rhonas = god_eternal_rhonas_definition();
+        let filler = vanilla_creature_definition("Library Filler", 1, 1);
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        for _ in 0..4 {
+            game.create_object_from_definition(&filler, alice, Zone::Library);
+        }
+        let rhonas_id = game.create_object_from_definition(&rhonas, alice, Zone::Battlefield);
+        let snapshot = crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+            game.object(rhonas_id).expect("Rhonas exists before moving"),
+            &game,
+        );
+        let moved_id = game
+            .move_object_by_effect(rhonas_id, destination)
+            .expect("Rhonas should move zones");
+        let event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::zones::ZoneChangeEvent::with_results(
+                rhonas_id,
+                vec![moved_id],
+                Zone::Battlefield,
+                destination,
+                crate::events::cause::EventCause::effect(),
+                Some(snapshot),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        let entry = god_eternal_rhonas_trigger_for_event(&game, &event, rhonas_id);
+        let mut dm = AcceptMay;
+        let mut ctx = crate::effects::ExecutionContext::new(rhonas_id, alice, &mut dm)
+            .with_triggering_event(entry.triggering_event.clone());
+        for effect in &entry.ability.effects {
+            crate::effects::execute_effect(&mut game, effect, &mut ctx)
+                .expect("Rhonas dies/exile trigger should resolve");
+        }
+
+        let third_from_top = game
+            .player(alice)
+            .expect("Alice exists")
+            .library
+            .iter()
+            .rev()
+            .nth(2)
+            .copied()
+            .expect("library should have a third card");
+        assert!(
+            game.object(third_from_top)
+                .is_some_and(|object| object.name == "God-Eternal Rhonas"),
+            "Rhonas should be third from the top after moving from {destination:?}"
+        );
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn god_eternal_rhonas_optional_library_trigger_can_be_declined() {
+    let rhonas = god_eternal_rhonas_definition();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let rhonas_id = game.create_object_from_definition(&rhonas, alice, Zone::Battlefield);
+    let snapshot = crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+        game.object(rhonas_id).expect("Rhonas exists before exile"),
+        &game,
+    );
+    let exile_id = game
+        .move_object_by_effect(rhonas_id, Zone::Exile)
+        .expect("Rhonas should move to exile");
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_results(
+            rhonas_id,
+            vec![exile_id],
+            Zone::Battlefield,
+            Zone::Exile,
+            crate::events::cause::EventCause::effect(),
+            Some(snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let entry = god_eternal_rhonas_trigger_for_event(&game, &event, rhonas_id);
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(rhonas_id, alice, &mut dm)
+        .with_triggering_event(entry.triggering_event.clone());
+    for effect in &entry.ability.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("declined Rhonas trigger should resolve");
+    }
+
+    assert!(
+        game.object(exile_id)
+            .is_some_and(|object| object.zone == Zone::Exile),
+        "declining the may ability should leave Rhonas in exile"
+    );
+    assert!(
+        !game
+            .player(alice)
+            .expect("Alice exists")
+            .library
+            .iter()
+            .any(|id| game
+                .object(*id)
+                .is_some_and(|object| object.name == "God-Eternal Rhonas")),
+        "declining the may ability should not put Rhonas into the library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_long_term_plans_searches_then_puts_card_third_from_top() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Long-Term Plans")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3492,6 +3492,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return Some(compact);
     }
 
+    if let Some(compact) = describe_double_power_then_grant_same_filter(effects) {
+        return Some(compact);
+    }
+
     if let Some(compact) = describe_council_dilemma_named_vote_sequence(effects) {
         return Some(compact);
     }
@@ -3543,6 +3547,87 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_choose_name_target_mills_conditional_draw(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn keyword_label_from_static_ability_id(
+    ability: crate::static_abilities::StaticAbilityId,
+) -> Option<&'static str> {
+    Some(match ability {
+        crate::static_abilities::StaticAbilityId::Flying => "flying",
+        crate::static_abilities::StaticAbilityId::FirstStrike => "first strike",
+        crate::static_abilities::StaticAbilityId::DoubleStrike => "double strike",
+        crate::static_abilities::StaticAbilityId::Deathtouch => "deathtouch",
+        crate::static_abilities::StaticAbilityId::Haste => "haste",
+        crate::static_abilities::StaticAbilityId::Hexproof => "hexproof",
+        crate::static_abilities::StaticAbilityId::Indestructible => "indestructible",
+        crate::static_abilities::StaticAbilityId::Lifelink => "lifelink",
+        crate::static_abilities::StaticAbilityId::Menace => "menace",
+        crate::static_abilities::StaticAbilityId::Reach => "reach",
+        crate::static_abilities::StaticAbilityId::Trample => "trample",
+        crate::static_abilities::StaticAbilityId::Vigilance => "vigilance",
+        _ => return None,
+    })
+}
+
+fn describe_double_power_then_grant_same_filter(effects: &[Effect]) -> Option<String> {
+    let [for_each_effect, grant_effect] = effects else {
+        return None;
+    };
+    let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachObject>()?;
+    let [pump_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let pump = pump_effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if pump.until != Until::EndOfTurn
+        || pump.condition.is_some()
+        || pump.modification.is_some()
+        || !pump.additional_modifications.is_empty()
+        || !matches!(pump.target_spec.as_ref(), Some(ChooseSpec::Iterated))
+    {
+        return None;
+    }
+    let [crate::effects::continuous::RuntimeModification::ModifyPowerToughness {
+        power,
+        toughness,
+    }] = pump.runtime_modifications.as_slice()
+    else {
+        return None;
+    };
+    if !matches!(power, Value::PowerOf(spec) if matches!(spec.as_ref(), ChooseSpec::Iterated))
+        || !matches!(toughness, Value::Fixed(0))
+    {
+        return None;
+    }
+
+    let grant = grant_effect.downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if grant.until != Until::EndOfTurn
+        || grant.condition.is_some()
+        || !grant.runtime_modifications.is_empty()
+        || !grant.additional_modifications.is_empty()
+    {
+        return None;
+    }
+    let Some(crate::continuous::Modification::AddAbility(ability)) = &grant.modification else {
+        return None;
+    };
+    let Some(ChooseSpec::Object(filter)) = grant.target_spec.as_ref() else {
+        return None;
+    };
+    if filter != &for_each.filter {
+        return None;
+    }
+
+    let ability_text = keyword_label_from_static_ability_id(ability.id())?;
+    let description = for_each.filter.description();
+    let filter_text = strip_indefinite_article(&description);
+    let pronoun = if for_each.filter.card_types.contains(&CardType::Creature) {
+        "Those creatures"
+    } else {
+        "Those objects"
+    };
+    Some(format!(
+        "Double the power of each {filter_text} until end of turn. {pronoun} gain {ability_text} until end of turn"
+    ))
 }
 
 fn describe_exile_target_and_attached_objects(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/zone_changes/zone_change_trigger.rs
@@ -391,6 +391,9 @@ impl ZoneChangeTrigger {
                     ZonePattern::Specific(Zone::Battlefield),
                     ZonePattern::Specific(Zone::Graveyard),
                 ) => format!("When {card_subject} is put into a graveyard from the battlefield"),
+                (ZonePattern::Specific(Zone::Battlefield), ZonePattern::Specific(Zone::Exile)) => {
+                    format!("When {battlefield_subject} is put into exile from the battlefield")
+                }
                 (_, ZonePattern::Specific(Zone::Battlefield)) => {
                     format!("When {battlefield_subject} enters the battlefield")
                 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: God-Eternal Rhonas
Initial parse error:
```
compiled text dropped required semantic marker: put-into-exile-from-battlefield
```

Current worker: i-011eadc448a1ae450
Branch: codex/aws-card-fix-god-eternal-rhonas
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0012
