### PR TITLE
Fix Ironsmith parse failure: Touch of the Eternal

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -13,6 +13,61 @@ const ANY_NUMBER_NAMED_DECK_CONSTRUCTION_PREFIX_PATTERN: ClauseShape<'static> = 
 );
 const ANY_NUMBER_NAMED_DECK_CONSTRUCTION_PREFIX_LEN: usize = 9;
 
+fn strip_terminal_period_tokens(tokens: &[OwnedLexToken]) -> &[OwnedLexToken] {
+    if tokens.last().is_some_and(|token| token.kind == TokenKind::Period) {
+        &tokens[..tokens.len().saturating_sub(1)]
+    } else {
+        tokens
+    }
+}
+
+fn rewrite_count_that_number_life_total_trigger_tokens(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<OwnedLexToken>> {
+    let (trigger_tokens, effect_tokens) = grammar::split_lexed_once_on_comma(tokens)?;
+    let sentences = structure::split_lexed_sentences(effect_tokens)
+        .into_iter()
+        .filter(|sentence| !sentence.is_empty())
+        .collect::<Vec<_>>();
+    if sentences.len() != 2 {
+        return None;
+    }
+
+    let count_sentence = strip_terminal_period_tokens(sentences[0]);
+    if !token_slice_first_is(count_sentence, "count") {
+        return None;
+    }
+    let count_value_tokens = count_sentence.get(1..)?;
+    let count_value_words = token_word_refs(count_value_tokens);
+    if !matches!(
+        count_value_words.as_slice(),
+        ["the", "number", "of", ..] | ["number", "of", ..]
+    ) {
+        return None;
+    }
+
+    let life_sentence = strip_terminal_period_tokens(sentences[1]);
+    let becomes_idx = find_token_word(life_sentence, "becomes")?;
+    let subject_tokens = &life_sentence[..becomes_idx];
+    let amount_tokens = &life_sentence[becomes_idx + 1..];
+    let amount_words = token_word_refs(amount_tokens);
+    if !matches!(amount_words.as_slice(), ["that", "number"]) {
+        return None;
+    }
+    let subject_words = token_word_refs(subject_tokens);
+    if !matches!(subject_words.as_slice(), [.., "life", "total"]) {
+        return None;
+    }
+
+    let rewritten = format!(
+        "{}, {} becomes {}.",
+        render_token_slice(trigger_tokens).trim(),
+        render_token_slice(subject_tokens).trim(),
+        render_token_slice(count_value_tokens).trim()
+    );
+    lex_line(rewritten.as_str(), 0).ok()
+}
+
 pub(super) fn parse_triggered_line_cst(
     line: &PreprocessedLine,
 ) -> Result<TriggeredLineCst, CardTextError> {
@@ -44,6 +99,17 @@ pub(super) fn parse_triggered_line_cst(
     let normalized = render_token_slice(tokens_without_cap).trim().to_string();
     if let Some(err) = diagnose_known_unsupported_rewrite_line(tokens_without_cap) {
         return Err(err);
+    }
+
+    if let Some(rewritten_tokens) =
+        rewrite_count_that_number_life_total_trigger_tokens(tokens_without_cap)
+    {
+        let rewritten_line = rewrite_line_tokens(line, &rewritten_tokens);
+        if let Ok(mut parsed) = parse_triggered_line_cst(&rewritten_line) {
+            parsed.full_text = normalized.clone();
+            parsed.full_parse_tokens = tokens_without_cap.to_vec();
+            return Ok(parsed);
+        }
     }
 
     if let Some(nested_trigger_tokens) =

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -21352,6 +21352,40 @@ fn parse_add_any_color_for_each_removed_counter_with_unsupported_tail_fails_stri
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_touch_of_the_eternal_counted_permanents_life_total_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(278_197), "Touch of the Eternal")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "At the beginning of your upkeep, count the number of permanents you control. Your life total becomes that number.",
+        )
+        .expect("Touch of the Eternal should parse strictly");
+
+    let debug = format!("{def:#?}");
+    let compact_debug = debug.split_whitespace().collect::<String>();
+    assert!(debug.contains("SetLifeTotalEffect"), "{debug}");
+    assert!(
+        compact_debug.contains("Count(") && compact_debug.contains("controller:Some(You"),
+        "expected Touch of the Eternal to count permanents you control, got {debug}"
+    );
+
+    let joined = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        joined.contains("at the beginning of your upkeep")
+            && joined.contains("count the number of permanents you control")
+            && joined.contains("your life total becomes that number"),
+        "expected counted-permanents life-total wording, got {joined}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_starting_life_total_amount_in_trigger() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Endstone Variant")
         .card_types(vec![CardType::Artifact])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -34886,9 +34886,17 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_possessive_player_filter(&set_life.player)
             );
         }
+        if let Value::Count(filter) = &set_life.amount
+            && matches!(set_life.player, PlayerFilter::You)
+        {
+            return format!(
+                "Count the number of {}. Your life total becomes that number",
+                describe_count_filter_value_subject(filter)
+            );
+        }
         return format!(
-            "{}'s life total becomes {}",
-            describe_player_filter(&set_life.player),
+            "{} life total becomes {}",
+            describe_possessive_player_filter(&set_life.player),
             describe_value(&set_life.amount)
         );
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -9268,6 +9268,81 @@ fn wild_dogs_upkeep_trigger_hands_control_to_the_life_leader() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn touch_of_the_eternal_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(278_197), "Touch of the Eternal")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "At the beginning of your upkeep, count the number of permanents you control. Your life total becomes that number.",
+        )
+        .expect("Touch of the Eternal should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_touch_counted_permanent(
+    game: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+    card_type: CardType,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![card_type])
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn touch_of_the_eternal_upkeep_sets_life_to_current_permanents_you_control() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let touch = touch_of_the_eternal_definition();
+    let _touch_id = game.create_object_from_definition(&touch, alice, Zone::Battlefield);
+    create_touch_counted_permanent(&mut game, "Alice Relic", alice, CardType::Artifact);
+    create_touch_counted_permanent(&mut game, "Bob Relic", bob, CardType::Artifact);
+    game.player_mut(alice).expect("alice exists").life = 20;
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Touch of the Eternal should not trigger at the beginning of an opponent's upkeep"
+    );
+
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Touch of the Eternal should trigger at the beginning of your upkeep"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Touch of the Eternal upkeep trigger should go on the stack");
+
+    create_touch_counted_permanent(&mut game, "Alice Soldier", alice, CardType::Creature);
+    resolve_stack_entry(&mut game).expect("Touch of the Eternal trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        3,
+        "Touch of the Eternal should set life to the current number of permanents Alice controls and ignore Bob's permanent"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn crystalline_resonance_copies_target_permanent_when_you_cycle() {
     use crate::PriorityResponse;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Touch of the Eternal
Initial parse error:
```
could not find verb in effect clause (clause: 'count the number of permanents you control'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'count the number of permanents you control'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-0844ff9c1d9b1105c
Branch: codex/aws-card-fix-touch-of-the-eternal
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0012
