### PR TITLE
Fix Ironsmith parse failure: Archon of Valor's Reach

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -88,6 +88,15 @@ const CANT_CAST_CREATURE_SPELLS_TAIL_PATTERN: ClauseShape<'static> = clause_shap
             &["cast", "creature", "spells", "this", "turn"],
         ]
 );
+const CANT_CAST_SPELLS_OF_CHOSEN_TYPE_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["cast", "spells", "of", "the", "chosen", "type"],
+            &[
+                "cast", "spells", "of", "the", "chosen", "type", "this", "turn",
+            ],
+        ]
+);
 const CANT_CAST_SPELLS_WITH_PARITY_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["cast", "spells", "with"]; suffix & ["mana", "values"]);
 const THIS_TURN_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["this", "turn"]);
@@ -1463,6 +1472,9 @@ pub(crate) fn target_ast_player_filter(
 pub(crate) fn parse_cast_restriction_tail_filter(words: &[&str]) -> Option<ObjectFilter> {
     if CAST_SPELLS_PATTERN.matches_words(words) {
         return Some(ObjectFilter::default());
+    }
+    if CANT_CAST_SPELLS_OF_CHOSEN_TYPE_TAIL_PATTERN.matches_words(words) {
+        return Some(ObjectFilter::default().of_chosen_card_type());
     }
     if words.first() != Some(&"cast") || words.last() != Some(&"spells") || words.len() < 3 {
         return None;

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -4465,6 +4465,29 @@ pub(crate) fn parse_choose_named_options_as_enters_line(
         return Ok(None);
     }
 
+    let mut card_type_options = Vec::new();
+    for word in choice_words.iter().skip(1) {
+        if OR_WORD_PATTERN.matches_word(word) || *word == "," {
+            continue;
+        }
+        let Some(card_type) = parse_card_type(word.trim_end_matches('s')) else {
+            card_type_options.clear();
+            break;
+        };
+        if !card_type_options.contains(&card_type) {
+            card_type_options.push(card_type);
+        }
+    }
+    if card_type_options.len() >= 2 {
+        return Ok(Some(StaticAbility::choose_named_option_as_enters(
+            card_type_options
+                .iter()
+                .map(|card_type| card_type.name().to_string())
+                .collect(),
+            format!("As {display_subject} enters, {}.", choice_words.join(" ")),
+        )));
+    }
+
     let mut options = Vec::new();
     let mut current = Vec::new();
     for word in choice_words.iter().skip(1) {

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -382,6 +382,7 @@ pub struct ObjectFilter {
     pub colors: Option<ColorSet>,
     pub chosen_color: bool,
     pub chosen_creature_type: bool,
+    pub chosen_card_type: bool,
     pub excluded_chosen_creature_type: bool,
     pub excluded_colors: ColorSet,
     pub colorless: bool,
@@ -486,6 +487,7 @@ impl ObjectFilter {
             || self.colors.is_some()
             || self.chosen_color
             || self.chosen_creature_type
+            || self.chosen_card_type
             || self.excluded_chosen_creature_type
             || !self.excluded_colors.is_empty()
             || self.colorless
@@ -937,6 +939,11 @@ impl ObjectFilter {
         self
     }
 
+    pub fn of_chosen_card_type(mut self) -> Self {
+        self.chosen_card_type = true;
+        self
+    }
+
     pub fn not_of_chosen_creature_type(mut self) -> Self {
         self.excluded_chosen_creature_type = true;
         self
@@ -1341,6 +1348,9 @@ impl ObjectFilter {
             post_noun_qualifiers.push("of the chosen color".to_string());
         }
         if self.chosen_creature_type {
+            post_noun_qualifiers.push("of the chosen type".to_string());
+        }
+        if self.chosen_card_type {
             post_noun_qualifiers.push("of the chosen type".to_string());
         }
         if self.excluded_chosen_creature_type {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41598,6 +41598,111 @@ fn parse_grand_abolisher_conditioned_or_restrictions_keep_opponent_subject() {
     );
 }
 
+#[test]
+fn archon_of_valors_reach_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Archon of Valor's Reach");
+    let abilities_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert_eq!(def.name(), "Archon of Valor's Reach");
+    assert!(
+        abilities_debug.contains("ChooseNamedOptionAsEnters")
+            && abilities_debug.contains("artifact")
+            && abilities_debug.contains("enchantment")
+            && abilities_debug.contains("instant")
+            && abilities_debug.contains("sorcery")
+            && abilities_debug.contains("planeswalker"),
+        "Archon should parse its enters card-type choice into individual options, got {abilities_debug}"
+    );
+    assert!(
+        abilities_debug.contains("CastSpellsMatching")
+            && abilities_debug.contains("chosen_card_type: true"),
+        "Archon should lower the chosen-type cast ban structurally, got {abilities_debug}"
+    );
+    assert!(
+        rendered.contains("Players can't cast spells of the chosen type"),
+        "Archon compiled text should preserve the chosen-type cast restriction, got {rendered}"
+    );
+}
+
+#[test]
+fn archon_of_valors_reach_blocks_only_spells_of_the_chosen_card_type() {
+    use crate::card::CardBuilder;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let archon = parse_oracle_card_definition("Archon of Valor's Reach");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = bob;
+    game.turn.priority_player = Some(bob);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    game.player_mut(bob)
+        .expect("Bob should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    let archon_in_hand = game.create_object_from_definition(&archon, alice, Zone::Hand);
+    let archon_id = game
+        .move_object_with_etb_processing(archon_in_hand, Zone::Battlefield)
+        .expect("Archon should enter with its card-type choice")
+        .new_id;
+    assert_eq!(
+        game.chosen_card_type(archon_id),
+        Some(CardType::Artifact),
+        "Archon's enters choice should record the selected card type"
+    );
+
+    let instant = CardBuilder::new(CardId::from_raw(91_001), "Bob Instant")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let instant_id = game.create_object_from_card(&instant, bob, Zone::Hand);
+    let sorcery = CardBuilder::new(CardId::from_raw(91_002), "Bob Sorcery")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let sorcery_id = game.create_object_from_card(&sorcery, bob, Zone::Hand);
+
+    let has_cast_action = |actions: &[LegalAction], spell_id| {
+        actions.iter().any(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id: action_spell_id,
+                    from_zone: Zone::Hand,
+                    ..
+                } if *action_spell_id == spell_id
+            )
+        })
+    };
+
+    game.set_chosen_card_type(archon_id, CardType::Instant);
+    game.refresh_continuous_state();
+    let instant_banned_actions = compute_legal_actions(&game, bob);
+    assert!(
+        !has_cast_action(&instant_banned_actions, instant_id),
+        "Archon choosing instant should remove instant spell cast actions, got {instant_banned_actions:?}"
+    );
+    assert!(
+        has_cast_action(&instant_banned_actions, sorcery_id),
+        "Archon choosing instant should still allow nonchosen sorcery spells, got {instant_banned_actions:?}"
+    );
+
+    game.set_chosen_card_type(archon_id, CardType::Sorcery);
+    game.refresh_continuous_state();
+    let sorcery_banned_actions = compute_legal_actions(&game, bob);
+    assert!(
+        has_cast_action(&sorcery_banned_actions, instant_id),
+        "Archon choosing sorcery should still allow nonchosen instant spells, got {sorcery_banned_actions:?}"
+    );
+    assert!(
+        !has_cast_action(&sorcery_banned_actions, sorcery_id),
+        "Archon choosing sorcery should remove sorcery spell cast actions, got {sorcery_banned_actions:?}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_your_opponents_cant_cast_noncreature_spells_this_turn() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -198,6 +198,9 @@ pub(super) fn describe_cast_ban_spell_filter(filter: &ObjectFilter) -> String {
     if filter == &ObjectFilter::default().with_type(CardType::Creature) {
         return "creature spells".to_string();
     }
+    if filter == &ObjectFilter::default().of_chosen_card_type() {
+        return "spells of the chosen type".to_string();
+    }
 
     let singular = describe_cast_limit_spell_filter(filter);
     if singular.ends_with("spells") {

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -722,9 +722,13 @@ pub(crate) fn violates_any_cant_cast_restriction(
         .cant_effects
         .cast_filters_for_player(player)
         .is_some_and(|filters| {
-            filters
-                .iter()
-                .any(|spell_filter| spell_matches_cast_filter(game, spell, spell_filter))
+            filters.iter().any(|restriction| {
+                let mut ctx = crate::target::FilterContext::default();
+                if let Some(source) = restriction.source {
+                    ctx = ctx.with_source(source);
+                }
+                restriction.filter.matches(spell, &ctx, game)
+            })
         })
 }
 

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -900,7 +900,11 @@ impl RestrictionExt for Restriction {
             Restriction::CastSpellsMatching(filter, spell_filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
-                        tracker.add_cant_cast_filter(player.id, spell_filter.clone());
+                        tracker.add_cant_cast_filter_from_source(
+                            player.id,
+                            spell_filter.clone(),
+                            source,
+                        );
                     }
                 }
             }

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -2074,6 +2074,15 @@ impl ObjectFilterExt for ObjectFilter {
                 return false;
             }
         }
+        if self.chosen_card_type {
+            let Some(chosen_type) = ctx.source.and_then(|source| game.chosen_card_type(source))
+            else {
+                return false;
+            };
+            if !object.card_types.contains(&chosen_type) {
+                return false;
+            }
+        }
         if self.excluded_chosen_creature_type {
             let Some(source) = ctx.source else {
                 return false;
@@ -2680,6 +2689,15 @@ impl ObjectFilterExt for ObjectFilter {
                 return false;
             }
         }
+        if self.chosen_card_type {
+            let Some(chosen_type) = ctx.source.and_then(|source| game.chosen_card_type(source))
+            else {
+                return false;
+            };
+            if !snapshot.card_types.contains(&chosen_type) {
+                return false;
+            }
+        }
         if self.excluded_chosen_creature_type {
             let Some(source) = ctx.source else {
                 return false;
@@ -3265,6 +3283,9 @@ impl ObjectFilterExt for ObjectFilter {
             post_noun_qualifiers.push("of the chosen color".to_string());
         }
         if self.chosen_creature_type {
+            post_noun_qualifiers.push("of the chosen type".to_string());
+        }
+        if self.chosen_card_type {
             post_noun_qualifiers.push("of the chosen type".to_string());
         }
         if self.excluded_chosen_creature_type {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -513,6 +513,14 @@ impl TurnCounterTracker {
 // - "Damage can't be prevented" (Leyline of Punishment)
 // - "This permanent can't be destroyed" (Indestructible)
 
+/// A per-player cast prohibition and the source object needed to evaluate
+/// source-dependent spell filters such as "of the chosen type".
+#[derive(Debug, Clone, PartialEq)]
+pub struct CastRestrictionFilter {
+    pub filter: crate::target::ObjectFilter,
+    pub source: Option<ObjectId>,
+}
+
 /// Tracks active "can't" effects in the game.
 ///
 /// Per Rule 614.17, "can't" effects are not replacement effects - they are
@@ -581,7 +589,7 @@ pub struct CantEffectTracker {
     /// Examples:
     /// - default filter => "can't cast spells"
     /// - creature filter => "can't cast creature spells"
-    pub cant_cast_filters: HashMap<PlayerId, Vec<crate::target::ObjectFilter>>,
+    pub cant_cast_filters: HashMap<PlayerId, Vec<CastRestrictionFilter>>,
 
     /// Players who can cast spells only any time they could cast a sorcery.
     pub cast_spells_only_as_sorcery: HashSet<PlayerId>,
@@ -864,8 +872,12 @@ impl CantEffectTracker {
         self.cant_be_regenerated.extend(other.cant_be_regenerated);
         self.cant_be_sacrificed.extend(other.cant_be_sacrificed);
         for (player, filters) in other.cant_cast_filters {
-            for filter in filters {
-                self.add_cant_cast_filter(player, filter);
+            for restriction in filters {
+                self.add_cant_cast_filter_from_source(
+                    player,
+                    restriction.filter,
+                    restriction.source,
+                );
             }
         }
         self.cast_spells_only_as_sorcery
@@ -1112,7 +1124,7 @@ impl CantEffectTracker {
         self.cast_filters_for_player(player).is_none_or(|filters| {
             !filters
                 .iter()
-                .any(|filter| filter == &crate::target::ObjectFilter::default())
+                .any(|restriction| restriction.filter == crate::target::ObjectFilter::default())
         })
     }
 
@@ -1139,9 +1151,9 @@ impl CantEffectTracker {
     /// Check if a player can cast creature spells.
     pub fn can_cast_creature_spells(&self, player: PlayerId) -> bool {
         self.cast_filters_for_player(player).is_none_or(|filters| {
-            !filters.iter().any(|filter| {
-                filter
-                    == &crate::target::ObjectFilter::default()
+            !filters.iter().any(|restriction| {
+                restriction.filter
+                    == crate::target::ObjectFilter::default()
                         .with_type(crate::types::CardType::Creature)
             })
         })
@@ -1153,9 +1165,22 @@ impl CantEffectTracker {
         player: PlayerId,
         spell_filter: crate::target::ObjectFilter,
     ) {
+        self.add_cant_cast_filter_from_source(player, spell_filter, None);
+    }
+
+    pub fn add_cant_cast_filter_from_source(
+        &mut self,
+        player: PlayerId,
+        spell_filter: crate::target::ObjectFilter,
+        source: Option<ObjectId>,
+    ) {
+        let restriction = CastRestrictionFilter {
+            filter: spell_filter,
+            source,
+        };
         let filters = self.cant_cast_filters.entry(player).or_default();
-        if !filters.iter().any(|existing| existing == &spell_filter) {
-            filters.push(spell_filter);
+        if !filters.iter().any(|existing| existing == &restriction) {
+            filters.push(restriction);
         }
     }
 
@@ -1163,7 +1188,7 @@ impl CantEffectTracker {
     pub fn cast_filters_for_player(
         &self,
         player: PlayerId,
-    ) -> Option<&[crate::target::ObjectFilter]> {
+    ) -> Option<&[CastRestrictionFilter]> {
         self.cant_cast_filters.get(&player).map(Vec::as_slice)
     }
 
@@ -4755,7 +4780,29 @@ impl GameState {
                         if let Some(chosen_idx) =
                             chosen.pop().filter(|idx| *idx < spec.options.len())
                         {
-                            self.set_chosen_named_option(new_id, spec.options[chosen_idx].clone());
+                            let option = spec.options[chosen_idx].clone();
+                            match option.as_str() {
+                                "artifact" => self
+                                    .set_chosen_card_type(new_id, crate::types::CardType::Artifact),
+                                "creature" => self
+                                    .set_chosen_card_type(new_id, crate::types::CardType::Creature),
+                                "enchantment" => self.set_chosen_card_type(
+                                    new_id,
+                                    crate::types::CardType::Enchantment,
+                                ),
+                                "instant" => self
+                                    .set_chosen_card_type(new_id, crate::types::CardType::Instant),
+                                "sorcery" => self
+                                    .set_chosen_card_type(new_id, crate::types::CardType::Sorcery),
+                                "planeswalker" => self.set_chosen_card_type(
+                                    new_id,
+                                    crate::types::CardType::Planeswalker,
+                                ),
+                                "land" => self
+                                    .set_chosen_card_type(new_id, crate::types::CardType::Land),
+                                _ => {}
+                            }
+                            self.set_chosen_named_option(new_id, option);
                         }
                     }
                     if static_ability.life_total_note_as_enters().is_some() {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1936,6 +1936,17 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
         .then_some(super::ChooseCreatureTypeAsEntersSpec)
     }
 
+    fn named_option_choice_as_enters(&self) -> Option<super::ChooseNamedOptionAsEntersSpec> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::ChooseNamedOptionAsEnters { options, .. } => {
+                Some(super::ChooseNamedOptionAsEntersSpec {
+                    options: options.clone(),
+                })
+            }
+            _ => None,
+        }
+    }
+
     fn power_toughness_choice_as_enters_or_turns_face_up(
         &self,
     ) -> Option<super::ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Archon of Valor's Reach
Initial parse error:
```
unsupported player negated restriction tail (clause: 'players can't cast spells of the chosen type'); oracle-only fallback also failed: unsupported player negated restriction tail (clause: 'players can't cast spells of the chosen type')
```

Current worker: i-0c7389305e511344c
Branch: codex/aws-card-fix-archon-of-valor-s-reach
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0012
