### PR TITLE
Fix Ironsmith parse failure: Academic Probation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -522,7 +522,9 @@ fn player_negated_restriction_from_tail(
 ) -> Option<crate::effect::Restriction> {
     use crate::effect::Restriction;
 
-    if PLAYER_GAIN_LIFE_TAIL_PATTERN.matches_words(words) {
+    if let Some(spell_filter) = parse_cast_restriction_tail_filter(words) {
+        Some(Restriction::cast_spells_matching(player, spell_filter))
+    } else if PLAYER_GAIN_LIFE_TAIL_PATTERN.matches_words(words) {
         Some(Restriction::gain_life(player))
     } else if PLAYER_SEARCH_LIBRARIES_TAIL_PATTERN.matches_words(words) {
         Some(Restriction::search_libraries(player))
@@ -1037,6 +1039,15 @@ fn parse_spell_restriction_subject_filter(words: &[&str]) -> Option<ObjectFilter
             continue;
         }
 
+        match &words[idx..] {
+            ["the", "chosen", "name", rest @ ..] | ["chosen", "name", rest @ ..] => {
+                filter.name = Some("{chosen name}".to_string());
+                idx = words.len() - rest.len();
+                continue;
+            }
+            _ => {}
+        }
+
         return None;
     }
 
@@ -1461,6 +1472,13 @@ pub(crate) fn target_ast_player_filter(
 }
 
 pub(crate) fn parse_cast_restriction_tail_filter(words: &[&str]) -> Option<ObjectFilter> {
+    if words.first().is_some_and(|word| CAST_WORD_PATTERN.matches_word(word))
+        && let Some(mut filter) = parse_spell_restriction_subject_filter(&words[1..])
+    {
+        filter.zone = None;
+        filter.stack_kind = None;
+        return Some(filter);
+    }
     if CAST_SPELLS_PATTERN.matches_words(words) {
         return Some(ObjectFilter::default());
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41598,6 +41598,208 @@ fn parse_grand_abolisher_conditioned_or_restrictions_keep_opponent_subject() {
     );
 }
 
+fn academic_probation_modal_effect(def: &CardDefinition) -> &ChooseModeEffect {
+    def.spell_effect
+        .as_ref()
+        .expect("Academic Probation should compile to spell effects")
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        .expect("Academic Probation should compile to one modal choice effect")
+}
+
+#[test]
+fn academic_probation_strict_parser_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Academic Probation");
+
+    let def = parse_oracle_card_definition("Academic Probation");
+    let modal = academic_probation_modal_effect(&def);
+    let modal_debug = format!("{modal:#?}");
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let oracle = oracle_text_by_name()
+        .get("Academic Probation")
+        .expect("Academic Probation oracle text");
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            oracle,
+            &compiled,
+            Some(crate::semantic_compare::EmbeddingConfig {
+                dims: 384,
+                mismatch_threshold: 0.99,
+            }),
+        );
+
+    assert_eq!(modal.min_choose_count, Value::Fixed(1));
+    assert_eq!(modal.choose_count, Value::Fixed(1));
+    assert_eq!(modal.modes.len(), 2);
+    assert!(
+        modal_debug.contains("ChooseCardNameEffect")
+            && modal_debug.contains("CastSpellsMatching")
+            && modal_debug.contains("name: Some")
+            && modal_debug.contains("{chosen name}")
+            && modal_debug.contains("AttackOrBlock")
+            && modal_debug.contains("ActivateAbilitiesOf"),
+        "Academic Probation should structurally lower both modes, got {modal_debug}"
+    );
+    assert!(
+        rendered_lower.contains("opponents can't cast spells with the chosen name")
+            && rendered_lower.contains("until your next turn")
+            && rendered_lower.contains("choose target nonland permanent")
+            && rendered_lower.contains("it can't attack or block")
+            && rendered_lower.contains("activated abilities can't be activated"),
+        "expected Academic Probation compiled text to cover both restriction modes, got {rendered}"
+    );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Academic Probation semantic comparison to clear target, score={similarity}, mismatch={mismatch}, compiled={compiled:?}"
+    );
+}
+
+#[test]
+fn academic_probation_chosen_name_mode_restricts_only_opponents_matching_spell_name() {
+    struct ChooseLightningBolt;
+
+    impl crate::decision::DecisionMaker for ChooseLightningBolt {
+        fn decide_text(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::TextInputContext,
+        ) -> String {
+            "Lightning Bolt".to_string()
+        }
+    }
+
+    let def = parse_oracle_card_definition("Academic Probation");
+    let modal = academic_probation_modal_effect(&def).clone();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = ChooseLightningBolt;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(vec![0]));
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Academic Probation chosen-name mode should resolve");
+
+    let bob_filters = game
+        .effect_store
+        .cant_effects
+        .cast_filters_for_player(bob)
+        .expect("Bob should receive a cast restriction");
+    assert!(
+        bob_filters
+            .iter()
+            .any(|filter| filter.name.as_deref() == Some("Lightning Bolt")),
+        "chosen-name mode should restrict Bob from casting Lightning Bolt, got {bob_filters:#?}"
+    );
+    assert!(
+        bob_filters
+            .iter()
+            .all(|filter| filter.name.as_deref() != Some("Opt")),
+        "chosen-name mode should not restrict Bob from casting a different spell, got {bob_filters:#?}"
+    );
+    assert!(
+        game.effect_store
+            .cant_effects
+            .cast_filters_for_player(alice)
+            .is_none(),
+        "Academic Probation should not restrict its controller from casting the chosen name"
+    );
+
+    let lightning = CardDefinitionBuilder::new(CardId::new(), "Lightning Bolt")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Instant])
+        .build();
+    let opt = CardDefinitionBuilder::new(CardId::new(), "Opt")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Instant])
+        .build();
+    let bob_lightning = game.create_object_from_definition(&lightning, bob, Zone::Hand);
+    let bob_opt = game.create_object_from_definition(&opt, bob, Zone::Hand);
+    let alice_lightning = game.create_object_from_definition(&lightning, alice, Zone::Hand);
+    assert!(
+        !crate::decision::can_cast_spell(
+            &game,
+            bob,
+            game.object(bob_lightning)
+                .expect("Bob's Lightning Bolt should be in hand"),
+            &crate::alternative_cast::CastingMethod::Normal,
+        ),
+        "Bob should not be able to cast the chosen Lightning Bolt"
+    );
+    assert!(
+        crate::decision::can_cast_spell(
+            &game,
+            bob,
+            game.object(bob_opt).expect("Bob's Opt should be in hand"),
+            &crate::alternative_cast::CastingMethod::Normal,
+        ),
+        "Bob should still be able to cast a spell with a different name"
+    );
+    assert!(
+        crate::decision::can_cast_spell(
+            &game,
+            alice,
+            game.object(alice_lightning)
+                .expect("Alice's Lightning Bolt should be in hand"),
+            &crate::alternative_cast::CastingMethod::Normal,
+        ),
+        "Academic Probation should not stop its controller from casting the chosen name"
+    );
+}
+
+#[test]
+fn academic_probation_target_permanent_mode_restricts_only_chosen_permanent() {
+    let def = parse_oracle_card_definition("Academic Probation");
+    let modal = academic_probation_modal_effect(&def).clone();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let target = CardDefinitionBuilder::new(CardId::new(), "Target Grizzly")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let other = CardDefinitionBuilder::new(CardId::new(), "Other Grizzly")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let target_id = game.create_object_from_definition(&target, bob, Zone::Battlefield);
+    let other_id = game.create_object_from_definition(&other, bob, Zone::Battlefield);
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm)
+        .with_chosen_modes(Some(vec![1]))
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target_id)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::target_permanent(),
+            range: 0..1,
+        }]);
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Academic Probation target-permanent mode should resolve");
+
+    assert!(!game.can_attack(target_id), "target should not be able to attack");
+    assert!(!game.can_block(target_id), "target should not be able to block");
+    assert!(
+        !game.can_activate_abilities_of(target_id),
+        "target's activated abilities should not be activatable"
+    );
+    assert!(game.can_attack(other_id), "other creature should still be able to attack");
+    assert!(game.can_block(other_id), "other creature should still be able to block");
+    assert!(
+        game.can_activate_abilities_of(other_id),
+        "other creature's activated abilities should remain unrestricted"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_your_opponents_cant_cast_noncreature_spells_this_turn() {

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -900,7 +900,20 @@ impl RestrictionExt for Restriction {
             Restriction::CastSpellsMatching(filter, spell_filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
-                        tracker.add_cant_cast_filter(player.id, spell_filter.clone());
+                        if spell_filter.name.as_deref() == Some("{chosen name}")
+                            && let Some(source) = source
+                            && let Some(chosen_names) = game.chosen_named_option(source)
+                        {
+                            for chosen_name in chosen_names.lines().map(str::trim) {
+                                if !chosen_name.is_empty() {
+                                    let mut resolved_filter = spell_filter.clone();
+                                    resolved_filter.name = Some(chosen_name.to_string());
+                                    tracker.add_cant_cast_filter(player.id, resolved_filter);
+                                }
+                            }
+                        } else {
+                            tracker.add_cant_cast_filter(player.id, spell_filter.clone());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Academic Probation
Initial parse error:
```
unsupported player negated restriction tail (clause: 'opponents can't cast spells with the chosen name'); oracle-only fallback also failed: unsupported player negated restriction tail (clause: 'opponents can't cast spells with the chosen name')
```

Current worker: i-0c4e9235d7685429a
Branch: codex/aws-card-fix-academic-probation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0012
