### PR TITLE
Fix Ironsmith parse failure: Blitz Leech

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/remove_destroy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/remove_destroy.rs
@@ -81,7 +81,7 @@ pub(crate) fn parse_remove(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
         && let Some(counter_idx) = find_index(tokens, |token: &OwnedLexToken| {
             COUNTER_OR_COUNTERS_WORD_PATTERN.matches_token(token)
         })
-        && counter_idx > 1
+        && counter_idx > 0
     {
         let counter_descriptor = trim_commas(&tokens[1..counter_idx]);
         let counter_type = parse_counter_type_from_descriptor_tokens(&counter_descriptor);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36946,6 +36946,33 @@ fn remove_all_named_counters_from_target_renders_generically() {
     );
 }
 
+#[test]
+fn blitz_leech_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Blitz Leech");
+
+    let def = parse_oracle_card_definition("Blitz Leech");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(def.name(), "Blitz Leech");
+    assert!(
+        rendered.contains("Flash"),
+        "Blitz Leech should keep flash in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "When this creature enters, target creature an opponent controls gets -2/-2 until end of turn. Remove all counters from that creature"
+        ),
+        "Blitz Leech should render the target-relative all-counters clause, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("ModifyPowerToughness")
+            && ability_debug.contains("RemoveUpToAnyCountersEffect")
+            && ability_debug.contains("CountersOn"),
+        "Blitz Leech should structurally model the -2/-2 and all-counters effects, got {ability_debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn fear_of_immobility_keeps_tap_target_and_conditional_stun_counter() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5097,6 +5097,66 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         ))
     }
 
+    fn tagged_reference_noun_from_target(spec: &ChooseSpec) -> Option<&'static str> {
+        let ChooseSpec::Target(inner) = spec else {
+            return None;
+        };
+        let ChooseSpec::Object(filter) = inner.as_ref() else {
+            return None;
+        };
+        if filter.card_types.contains(&CardType::Creature) {
+            Some("that creature")
+        } else if filter.card_types.contains(&CardType::Artifact) {
+            Some("that artifact")
+        } else if filter.card_types.contains(&CardType::Enchantment) {
+            Some("that enchantment")
+        } else if filter.card_types.contains(&CardType::Planeswalker) {
+            Some("that planeswalker")
+        } else if filter.card_types.contains(&CardType::Battle) {
+            Some("that battle")
+        } else if filter.card_types.contains(&CardType::Land) {
+            Some("that land")
+        } else {
+            Some("that permanent")
+        }
+    }
+
+    fn describe_tagged_effect_then_remove_all_counters(effects: &[&Effect]) -> Option<String> {
+        let effects = if let Some(first) = effects.first()
+            && first
+                .downcast_ref::<crate::effects::TagTriggeringObjectEffect>()
+                .is_some()
+        {
+            &effects[1..]
+        } else {
+            effects
+        };
+        let [target_effect, remove_effect] = effects else {
+            return None;
+        };
+        let target_tag = effect_tag(target_effect)?;
+        let apply = tagged_apply_continuous(target_effect)?;
+        let target_reference = tagged_reference_noun_from_target(apply.target_spec.as_ref()?)?;
+        let remove = unwrap_wrapped_effect(remove_effect)
+            .downcast_ref::<crate::effects::RemoveUpToAnyCountersEffect>()?;
+        let removes_all_counters_from_tagged_target = match &remove.max_count {
+            Value::CountersOn(spec, None) => {
+                matches!(spec.as_ref(), ChooseSpec::Tagged(tag) if tag == target_tag)
+            }
+            _ => false,
+        };
+        if !matches!(&remove.target, ChooseSpec::Tagged(tag) if tag == target_tag)
+            || !removes_all_counters_from_tagged_target
+        {
+            return None;
+        }
+
+        Some(format!(
+            "{}. Remove all counters from {target_reference}",
+            describe_effect(target_effect).trim_end_matches('.')
+        ))
+    }
+
     fn conditional_tagged_subtype(
         conditional: &crate::effects::ConditionalEffect,
     ) -> Option<(&crate::TagKey, Subtype)> {
@@ -5176,6 +5236,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     if let Some(compact) = describe_choose_then_mount_vehicle_become(&raw_effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_tagged_effect_then_remove_all_counters(&raw_effects) {
         return compact;
     }
     if let Some(compact) = describe_tagged_pump_then_conditional_keyword(&raw_effects) {
@@ -31590,6 +31653,21 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             describe_value(&remove_up_to_counters.max_count),
             describe_counter_type(remove_up_to_counters.counter_type),
             describe_choose_spec(&remove_up_to_counters.target)
+        );
+    }
+    if let Some(remove_up_to_any_counters) =
+        effect.downcast_ref::<crate::effects::RemoveUpToAnyCountersEffect>()
+    {
+        let target = describe_choose_spec(&remove_up_to_any_counters.target);
+        if let Value::CountersOn(counter_source, None) = &remove_up_to_any_counters.max_count
+            && counter_source.unhinted() == remove_up_to_any_counters.target.unhinted()
+        {
+            return format!("Remove all counters from {target}");
+        }
+        return format!(
+            "Remove up to {} counters from {}",
+            describe_value(&remove_up_to_any_counters.max_count),
+            target
         );
     }
     if let Some(move_counters) = effect.downcast_ref::<crate::effects::MoveAllCountersEffect>() {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -2154,6 +2154,122 @@ fn scuttling_sentinel_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn blitz_leech_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(479_594), "Blitz Leech")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(5, 2))
+        .parse_text(
+            "Flash\nWhen this creature enters, target creature an opponent controls gets -2/-2 until end of turn. Remove all counters from that creature.",
+        )
+        .expect("Blitz Leech should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseBlitzLeechTarget {
+    chosen: ObjectId,
+    seen_legal_targets: Vec<Target>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseBlitzLeechTarget {
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<Target> {
+        self.seen_legal_targets = ctx
+            .requirements
+            .first()
+            .map(|requirement| requirement.legal_targets.clone())
+            .unwrap_or_default();
+        assert!(
+            self.seen_legal_targets.contains(&Target::Object(self.chosen)),
+            "chosen opponent creature should be a legal Blitz Leech target"
+        );
+        vec![Target::Object(self.chosen)]
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn blitz_leech_enter_trigger_removes_all_counters_from_opponent_creature_only() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let opponent_creature = create_creature(&mut game, "Bob's Countered Creature", bob, 4, 4);
+    let own_creature = create_creature(&mut game, "Alice's Countered Creature", alice, 4, 4);
+    game.add_counters(
+        opponent_creature,
+        crate::object::CounterType::PlusOnePlusOne,
+        2,
+    )
+    .expect("opponent creature should receive +1/+1 counters");
+    game.add_counters(opponent_creature, crate::object::CounterType::Charge, 3)
+        .expect("opponent creature should receive charge counters");
+    game.add_counters(own_creature, crate::object::CounterType::PlusOnePlusOne, 1)
+        .expect("own creature should receive a +1/+1 counter");
+
+    let blitz = blitz_leech_definition();
+    let blitz_id = game.create_object_from_definition(&blitz, alice, Zone::Hand);
+    game.move_object_by_effect(blitz_id, Zone::Battlefield)
+        .expect("Blitz Leech should enter the battlefield");
+
+    let mut trigger_queue = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Blitz Leech should queue exactly one enters trigger"
+    );
+
+    let mut dm = ChooseBlitzLeechTarget {
+        chosen: opponent_creature,
+        seen_legal_targets: Vec::new(),
+    };
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Blitz Leech trigger should go on the stack with its target");
+    assert!(
+        !dm.seen_legal_targets.contains(&Target::Object(own_creature)),
+        "Blitz Leech should not be able to target a creature its controller controls"
+    );
+
+    resolve_stack_entry(&mut game).expect("Blitz Leech trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(opponent_creature, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Blitz Leech should remove all +1/+1 counters from the targeted creature"
+    );
+    assert_eq!(
+        game.counter_count(opponent_creature, crate::object::CounterType::Charge),
+        0,
+        "Blitz Leech should remove all non-P/T counters from the targeted creature too"
+    );
+    assert_eq!(
+        game.counter_count(own_creature, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Blitz Leech should not remove counters from untargeted friendly creatures"
+    );
+    assert_eq!(game.calculated_power(opponent_creature), Some(2));
+    assert_eq!(game.calculated_toughness(opponent_creature), Some(2));
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        game.counter_count(opponent_creature, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "removed counters should stay removed after the turn ends"
+    );
+    assert_eq!(game.calculated_power(opponent_creature), Some(4));
+    assert_eq!(game.calculated_toughness(opponent_creature), Some(4));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn scuttling_sentinel_enter_trigger_buffs_only_another_creature_you_control_until_eot() {
     struct ChooseSpecificCreatureDecisionMaker {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Blitz Leech
Initial parse error:
```
missing counter removal amount (clause: 'all counters from that creature'); oracle-only fallback also failed: missing counter removal amount (clause: 'all counters from that creature')
```

Current worker: i-00186443ae2cfd011
Branch: codex/aws-card-fix-blitz-leech
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0013
