### PR TITLE
Fix Ironsmith parse failure: Sages of the Anima

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2724,6 +2724,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_effect_discard_to_library_replacement_line),
         single_static_ability_ast_rule!(parse_draw_replace_exile_top_face_down_line),
         single_static_ability_ast_rule!(parse_draw_replacement_exile_top_and_play_line),
+        single_static_ability_ast_rule!(
+            parse_draw_replacement_reveal_top_matching_to_hand_rest_bottom_line
+        ),
         single_static_ability_ast_rule!(parse_conditional_draw_replacement_line),
         single_static_ability_ast_rule!(parse_draw_replacement_double_line),
         single_static_ability_ast_rule!(parse_draw_replacement_skip_empty_library_line),
@@ -3226,6 +3229,12 @@ pub(crate) fn parse_damage_doubling_mana_value_marker_line(
 pub(crate) fn parse_static_ability_ast_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<Vec<StaticAbilityAst>>, CardTextError> {
+    if let Some(ability) =
+        parse_draw_replacement_reveal_top_matching_to_hand_rest_bottom_line(tokens)?
+    {
+        return Ok(Some(vec![StaticAbilityAst::from(ability)]));
+    }
+
     let sentences = split_lexed_sentences(tokens);
     if sentences.len() > 1 {
         let mut combined = Vec::new();
@@ -10122,6 +10131,85 @@ pub(crate) fn parse_draw_replacement_exile_top_and_play_line(
     Ok(Some(StaticAbility::draw_replacement_exile_top_and_play(
         count,
     )))
+}
+
+pub(crate) fn parse_draw_replacement_reveal_top_matching_to_hand_rest_bottom_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let normalized_words = parser_token_word_refs(tokens)
+        .into_iter()
+        .map(|word| word.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let words = normalized_words
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let prefix = [
+        "if", "you", "would", "draw", "a", "card", "instead", "reveal", "the", "top",
+    ];
+    if !words.starts_with(&prefix) {
+        return Ok(None);
+    }
+
+    let Some((count, used_count_words)) =
+        ironsmith_core::parse_cardinal_words(&words[prefix.len()..])
+    else {
+        return Ok(None);
+    };
+    if count == 0 {
+        return Ok(None);
+    }
+
+    let mut idx = prefix.len() + used_count_words;
+    if !words
+        .get(idx)
+        .is_some_and(|word| CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+        || words.get(idx + 1..idx + 6) != Some(&["of", "your", "library", "put", "all"][..])
+    {
+        return Ok(None);
+    }
+    idx += 6;
+
+    let Some(card_type) = words.get(idx).and_then(|word| parse_card_type(word)) else {
+        return Ok(None);
+    };
+    idx += 1;
+
+    if words.get(idx..idx + 17)
+        != Some(&[
+            "cards", "revealed", "this", "way", "into", "your", "hand", "and", "the",
+            "rest", "on", "the", "bottom", "of", "your", "library", "in",
+        ][..])
+    {
+        return Ok(None);
+    }
+    idx += 17;
+
+    let (order, used) = if words.get(idx..idx + 2) == Some(&["any", "order"][..]) {
+        (ironsmith_core::LibraryBottomOrder::ChooserChooses, 2)
+    } else if words.get(idx..idx + 3) == Some(&["a", "random", "order"][..]) {
+        (ironsmith_core::LibraryBottomOrder::Random, 3)
+    } else if words.get(idx..idx + 2) == Some(&["random", "order"][..]) {
+        (ironsmith_core::LibraryBottomOrder::Random, 2)
+    } else {
+        return Ok(None);
+    };
+    idx += used;
+    if idx != words.len() {
+        return Ok(None);
+    }
+
+    let mut filter = ObjectFilter::default();
+    filter.card_types.push(card_type);
+
+    Ok(Some(
+        StaticAbility::draw_replacement_reveal_top_matching_to_hand_rest_bottom(
+            count as u32,
+            filter,
+            order,
+            render_token_slice(tokens),
+        ),
+    ))
 }
 
 pub(crate) fn parse_draw_replacement_double_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1510,6 +1510,7 @@ pub(super) fn run_statement_probe_line_family(
             &ctx.line.tokens,
         ))
         && !is_can_block_additional_creatures_static_line(&ctx.line.tokens)
+        && !is_draw_replacement_reveal_top_static_line(&ctx.line.tokens)
         && let Some(statement_line) = parse_statement_line_cst(ctx.line)?
     {
         return Ok(Some(LineDispatchResult::single(
@@ -1518,6 +1519,13 @@ pub(super) fn run_statement_probe_line_family(
         )));
     }
     Ok(None)
+}
+
+fn is_draw_replacement_reveal_top_static_line(tokens: &[OwnedLexToken]) -> bool {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    words.starts_with(&[
+        "if", "you", "would", "draw", "a", "card", "instead", "reveal", "the", "top",
+    ])
 }
 
 fn is_can_block_additional_creatures_static_line(tokens: &[OwnedLexToken]) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -678,6 +678,7 @@ pub(crate) fn classify_static_line_family_lexed(
                 "once", "each", "turn", "you", "may", "cast", "spells", "from", "the", "top",
                 "of", "your", "library",
             ],
+            &["if", "you", "would", "draw", "a", "card"],
         ],
     ) {
         return Some(StaticLineFamily::Generic);

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8349,6 +8349,42 @@ fn rewrite_grammar_living_conundrum_empty_library_draw_skip_matches_static_shape
 }
 
 #[test]
+fn parse_sages_of_the_anima_draw_replacement_static_line() {
+    let tokens = lex_line(
+        "If you would draw a card, instead reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.",
+        0,
+    )
+    .expect("Sages of the Anima draw replacement line should lex");
+
+    let direct =
+        super::keyword_static::parse_draw_replacement_reveal_top_matching_to_hand_rest_bottom_line(
+            &tokens,
+        )
+        .expect("direct Sages draw replacement parser should not error");
+    assert!(
+        matches!(
+            direct,
+            Some(ref ability)
+                if ability.id()
+                    == crate::static_abilities::StaticAbilityId::DrawReplacementRevealTopMatchingToHandRestBottom
+        ),
+        "expected direct draw replacement static ability, got {direct:?}"
+    );
+
+    let parsed = super::keyword_static::parse_static_ability_ast_line_lexed(&tokens)
+        .expect("Sages of the Anima draw replacement line should parse");
+    assert!(
+        matches!(
+            parsed.as_deref(),
+            Some([
+                crate::cards::builders::StaticAbilityAst::Static(ability)
+            ]) if ability.id() == crate::static_abilities::StaticAbilityId::DrawReplacementRevealTopMatchingToHandRestBottom
+        ),
+        "expected draw replacement static ability, got {parsed:?}"
+    );
+}
+
+#[test]
 fn rewrite_grammar_replacement_static_probes_match_keyword_static_shapes() {
     let library_tokens = lex_line(
         "If an effect causes you to discard a card, you may discard it to the top of your library instead of into your graveyard.",

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -229,6 +229,7 @@ pub enum StaticAbilityId {
     OpponentEffectDiscardThisToBattlefieldReplacement,
     DrawReplacementExileTopFaceDown,
     DrawReplacementExileTopAndPlay,
+    DrawReplacementRevealTopMatchingToHandRestBottom,
     DrawReplacementDouble,
     DrawReplacementSkipEmptyLibrary,
     ConditionalDrawReplacement,
@@ -492,6 +493,7 @@ impl StaticAbilityId {
             | OpponentEffectDiscardThisToBattlefieldReplacement
             | DrawReplacementExileTopFaceDown
             | DrawReplacementExileTopAndPlay
+            | DrawReplacementRevealTopMatchingToHandRestBottom
             | DrawReplacementDouble
             | DrawReplacementSkipEmptyLibrary
             | ConditionalDrawReplacement

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -485,6 +485,12 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         replacement_effects: Vec<E>,
         display: String,
     },
+    DrawReplacementRevealTopMatchingToHandRestBottom {
+        count: u32,
+        filter: ObjectFilter,
+        order: crate::LibraryBottomOrder,
+        display: String,
+    },
     CharacteristicDefiningPt {
         power: Value,
         toughness: Value,
@@ -1426,6 +1432,17 @@ where
                     .into_iter()
                     .map(map_effect)
                     .collect::<Result<Vec<_>, _>>()?,
+                display,
+            },
+            StaticAbilityPayload::DrawReplacementRevealTopMatchingToHandRestBottom {
+                count,
+                filter,
+                order,
+                display,
+            } => StaticAbilityPayload::DrawReplacementRevealTopMatchingToHandRestBottom {
+                count,
+                filter,
+                order,
                 display,
             },
             StaticAbilityPayload::CharacteristicDefiningPt { power, toughness } => {
@@ -3624,6 +3641,25 @@ impl<
             id: Some(StaticAbilityId::DrawReplacementExileTopAndPlay),
             label: format!("draw replacement exile top {count} and play"),
             payload: StaticAbilityPayload::None,
+        }
+    }
+
+    pub fn draw_replacement_reveal_top_matching_to_hand_rest_bottom(
+        count: u32,
+        filter: ObjectFilter,
+        order: crate::LibraryBottomOrder,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::DrawReplacementRevealTopMatchingToHandRestBottom),
+            label: display.clone(),
+            payload: StaticAbilityPayload::DrawReplacementRevealTopMatchingToHandRestBottom {
+                count,
+                filter,
+                order,
+                display,
+            },
         }
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -49267,6 +49267,92 @@ fn living_conundrum_nonempty_library_does_not_skip_or_gain_bonus() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_sages_of_the_anima_strict_regression() {
+    assert_oracle_card_parses_strict("Sages of the Anima");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sages_of_the_anima_compiled_text_keeps_draw_replacement_clause() {
+    let def = parse_oracle_card_definition("Sages of the Anima");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    let static_ids = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        static_ids.contains(&StaticAbilityId::DrawReplacementRevealTopMatchingToHandRestBottom),
+        "expected Sages of the Anima draw-replacement static ability, got {static_ids:?}"
+    );
+    assert!(
+        rendered.contains("If you would draw a card, instead reveal the top three cards of your library"),
+        "Sages of the Anima compiled text should keep the draw replacement and instead marker, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order"
+        ),
+        "Sages of the Anima compiled text should keep the creature/rest split, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sages_of_the_anima_draw_replacement_moves_creatures_and_bottoms_rest() {
+    let def = parse_oracle_card_definition("Sages of the Anima");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    for (name, card_types) in [
+        ("Library Creature One", vec![CardType::Creature]),
+        ("Library Instant", vec![CardType::Instant]),
+        ("Library Creature Two", vec![CardType::Creature]),
+    ] {
+        let card = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(card_types)
+            .build();
+        game.create_object_from_definition(&card, alice, Zone::Library);
+    }
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source_id, alice);
+    crate::effects::DrawCardsEffect::you(1)
+        .execute(&mut game, &mut ctx)
+        .expect("Sages of the Anima draw replacement should resolve");
+
+    let player = game.player(alice).expect("alice should exist");
+    let hand_names = player
+        .hand
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        hand_names.len(),
+        2,
+        "only revealed creature cards should move to hand, got {hand_names:?}"
+    );
+    assert!(hand_names.contains(&"Library Creature One"), "{hand_names:?}");
+    assert!(hand_names.contains(&"Library Creature Two"), "{hand_names:?}");
+
+    let library_names = player
+        .library
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        library_names,
+        vec!["Library Instant"],
+        "noncreature revealed cards should stay in the library on bottom"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_wave_of_rats_strict_regression() {
     assert_oracle_card_parses_strict("Wave of Rats");
 }

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -237,6 +237,12 @@ impl StaticAbility {
                     Self::parse_draw_replacement_exile_top_and_play_count(&label).unwrap_or(2),
                 )
             }
+            Some(StaticAbilityId::DrawReplacementRevealTopMatchingToHandRestBottom) => {
+                return Err(StaticAbilityModelConversionError {
+                    detail: "draw replacement reveal-top matcher needs its structured payload"
+                        .to_string(),
+                });
+            }
             Some(StaticAbilityId::DrawReplacementDouble) => Self::draw_replacement_double(),
             Some(StaticAbilityId::DrawReplacementSkipEmptyLibrary) => {
                 Self::draw_replacement_skip_empty_library()

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -48,10 +48,12 @@ use crate::replacement::{
     EventModification, RedirectTarget, RedirectWhich, ReplacementAction, ReplacementEffect,
     ZoneReplacementSpec,
 };
-use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
+use crate::target::{
+    ChooseSpec, ObjectFilter, PlayerFilter, TaggedObjectConstraint, TaggedOpbjectRelation,
+};
 use crate::types::{CardType, Subtype};
 use crate::zone::Zone;
-use ironsmith_core::{DamagedBySource, ValueSurfaceHint};
+use ironsmith_core::{DamagedBySource, TagKey, ValueSurfaceHint};
 
 fn card_type_word(card_type: crate::types::CardType) -> &'static str {
     card_type.name()
@@ -4610,6 +4612,89 @@ impl StaticAbilityKind for DrawReplacementExileTopAndPlay {
                     true,
                     false,
                 )),
+            ]),
+        ))
+    }
+}
+
+/// "If you would draw a card, instead reveal the top N cards of your library. Put all matching
+/// cards revealed this way into your hand and the rest on the bottom of your library."
+#[derive(Debug, Clone, PartialEq)]
+pub struct DrawReplacementRevealTopMatchingToHandRestBottom {
+    pub count: u32,
+    pub filter: ObjectFilter,
+    pub order: crate::effects::consult_helpers::LibraryBottomOrder,
+    pub display: String,
+}
+
+impl DrawReplacementRevealTopMatchingToHandRestBottom {
+    pub fn new(
+        count: u32,
+        filter: ObjectFilter,
+        order: crate::effects::consult_helpers::LibraryBottomOrder,
+        display: impl Into<String>,
+    ) -> Self {
+        Self {
+            count,
+            filter,
+            order,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for DrawReplacementRevealTopMatchingToHandRestBottom {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::DrawReplacementRevealTopMatchingToHandRestBottom
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        const REVEALED_TAG: &str = "draw_replacement_revealed";
+        const MATCHED_TAG: &str = "draw_replacement_matched";
+
+        let mut matching_filter = self.filter.clone();
+        matching_filter.zone = None;
+        matching_filter.tagged_constraints.push(TaggedObjectConstraint {
+            tag: TagKey::from(REVEALED_TAG),
+            relation: TaggedOpbjectRelation::IsTaggedObject,
+        });
+
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            WouldDrawCardMatcher::you(),
+            ReplacementAction::Instead(vec![
+                Effect::reveal_top_cards(
+                    PlayerFilter::You,
+                    Value::Fixed(self.count as i32),
+                    TagKey::from(REVEALED_TAG),
+                ),
+                Effect::new(
+                    crate::effects::TagMatchingObjectsEffect::new(matching_filter, MATCHED_TAG)
+                        .in_zones(vec![Zone::Library]),
+                ),
+                Effect::for_each_tagged(
+                    MATCHED_TAG,
+                    vec![Effect::move_to_zone(
+                        ChooseSpec::Iterated,
+                        Zone::Hand,
+                        false,
+                    )],
+                ),
+                Effect::put_tagged_remainder_on_library_bottom(
+                    TagKey::from(REVEALED_TAG),
+                    Some(TagKey::from(MATCHED_TAG)),
+                    self.order,
+                    PlayerFilter::You,
+                ),
             ]),
         ))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -3021,6 +3021,17 @@ impl StaticAbility {
         Self::new(DrawReplacementExileTopAndPlay::new(count))
     }
 
+    pub fn draw_replacement_reveal_top_matching_to_hand_rest_bottom(
+        count: u32,
+        filter: crate::target::ObjectFilter,
+        order: crate::effects::consult_helpers::LibraryBottomOrder,
+        display: impl Into<String>,
+    ) -> Self {
+        Self::new(DrawReplacementRevealTopMatchingToHandRestBottom::new(
+            count, filter, order, display,
+        ))
+    }
+
     pub fn keyword_action_replacement(
         action: crate::events::KeywordActionKind,
         source_filter: crate::target::ObjectFilter,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1397,6 +1397,17 @@ impl StaticAbilityModelInterpreter {
                 replacement_effects.clone(),
                 display.clone(),
             ),
+            ironsmith_core::StaticAbilityPayload::DrawReplacementRevealTopMatchingToHandRestBottom {
+                count,
+                filter,
+                order,
+                display,
+            } => StaticAbility::draw_replacement_reveal_top_matching_to_hand_rest_bottom(
+                *count,
+                filter.clone(),
+                *order,
+                display.clone(),
+            ),
             ironsmith_core::StaticAbilityPayload::CharacteristicDefiningPt {
                 power,
                 toughness,

--- a/crates/ironsmith-tools/tests/status_db_binaries.rs
+++ b/crates/ironsmith-tools/tests/status_db_binaries.rs
@@ -1538,6 +1538,47 @@ fn compile_oracle_text_strictly_compiles_yawgmoths_will_with_instead_replacement
 }
 
 #[test]
+fn compile_oracle_text_strictly_compiles_sages_of_the_anima_draw_replacement() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("ironsmith-tools crate should be inside workspace")
+        .parent()
+        .expect("workspace root should be two levels up");
+    let cards_path = workspace_root.join("cards.json");
+    assert!(
+        cards_path.exists(),
+        "expected workspace cards.json at {cards_path:?}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compile_oracle_text"))
+        .arg("--name")
+        .arg("Sages of the Anima")
+        .arg("--cards")
+        .arg(&cards_path)
+        .arg("--compare-text")
+        .output()
+        .expect("run compile_oracle_text --name Sages of the Anima --compare-text");
+
+    assert!(
+        output.status.success(),
+        "Sages of the Anima should compile strictly, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout =
+        String::from_utf8(output.stdout).expect("compile_oracle_text stdout should be utf8");
+    assert!(stdout.contains("Name: Sages of the Anima"), "{stdout}");
+    assert!(
+        stdout.contains("Similarity: 1.0000"),
+        "expected exact compiled-text comparison for Sages of the Anima, got {stdout}"
+    );
+    assert!(
+        stdout.contains("If you would draw a card, instead reveal the top three cards of your library"),
+        "expected draw replacement clause with 'instead' in compiled comparison output, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_oracle_text_sharpened_pitchfork_keeps_conditional_bonus_separate() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sages of the Anima
Initial parse error:
```
compiled text dropped required semantic marker: instead
```

Current worker: i-0a6cf853390a71224
Branch: codex/aws-card-fix-sages-of-the-anima
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0014
