### PR TITLE
Fix Ironsmith parse failure: Jhoira of the Ghitu

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -1342,7 +1342,8 @@ impl CardDefinitionBuilder {
                     crate::effect::Effect::new(
                         crate::effects::CastSourceEffect::new()
                             .without_paying_mana_cost()
-                            .require_exile(),
+                            .require_exile()
+                            .cast_as_suspend(),
                     ),
                 ])]
                 .into(),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -347,7 +347,8 @@ pub(crate) fn suspend_exile_triggered_abilities() -> Vec<Ability> {
                 effects: ResolutionProgram::from_effects(vec![Effect::may(vec![Effect::new(
                     crate::effects::CastSourceEffect::new()
                         .without_paying_mana_cost()
-                        .require_exile(),
+                        .require_exile()
+                        .cast_as_suspend(),
                 )])]),
                 choices: vec![],
                 intervening_if: Some(crate::ConditionExpr::SourceHasNoCounter(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -320,6 +320,46 @@ pub(crate) fn myriad_triggered_ability() -> Ability {
     )
 }
 
+pub(crate) fn suspend_exile_triggered_abilities() -> Vec<Ability> {
+    vec![
+        Ability {
+            kind: crate::ability::AbilityKind::Triggered(crate::ability::TriggeredAbility {
+                trigger: Trigger::beginning_of_upkeep(PlayerFilter::You),
+                effects: ResolutionProgram::from_effects(vec![Effect::remove_counters(
+                    crate::object::CounterType::Time,
+                    1,
+                    crate::target::ChooseSpec::Source,
+                )]),
+                choices: vec![],
+                intervening_if: Some(crate::ConditionExpr::SourceHasCounterAtLeast {
+                    counter_type: crate::object::CounterType::Time,
+                    count: 1,
+                }),
+                presentation_label: Some("keyword:suspend".to_string()),
+            }),
+            functional_zones: vec![crate::zone::Zone::Exile],
+        },
+        Ability {
+            kind: crate::ability::AbilityKind::Triggered(crate::ability::TriggeredAbility {
+                trigger: Trigger::new(crate::triggers::CounterRemovedFromTrigger::new(
+                    ObjectFilter::source(),
+                )),
+                effects: ResolutionProgram::from_effects(vec![Effect::may(vec![Effect::new(
+                    crate::effects::CastSourceEffect::new()
+                        .without_paying_mana_cost()
+                        .require_exile(),
+                )])]),
+                choices: vec![],
+                intervening_if: Some(crate::ConditionExpr::SourceHasNoCounter(
+                    crate::object::CounterType::Time,
+                )),
+                presentation_label: Some("keyword:suspend".to_string()),
+            }),
+            functional_zones: vec![crate::zone::Zone::Exile],
+        },
+    ]
+}
+
 fn graveyard_return_counter_ability(
     counter_type: crate::object::CounterType,
     trigger_tag: &'static str,
@@ -448,6 +488,9 @@ pub(crate) fn lower_granted_abilities_ast_to_object_abilities(
             }
             GrantedAbilityAst::KeywordAction(KeywordAction::Myriad) => {
                 lowered.push(myriad_triggered_ability());
+            }
+            GrantedAbilityAst::KeywordAction(KeywordAction::Marker("suspend")) => {
+                lowered.extend(suspend_exile_triggered_abilities());
             }
             _ => lowered.push(lower_granted_ability_ast_to_object_ability(ability)?),
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -5351,6 +5351,21 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
 
     if let Some(reference_len) = demonstrative_reference_len {
         let mut descriptor_words = filtered[reference_len..].to_vec();
+        let mut negative = false;
+        if descriptor_words.len() >= 2
+            && matches!(descriptor_words[0], "doesnt" | "doesn't")
+            && HAVE_WORD_PATTERN.matches_word(descriptor_words[1])
+        {
+            descriptor_words.drain(0..2);
+            negative = true;
+        } else if descriptor_words.len() >= 3
+            && descriptor_words[0] == "does"
+            && NOT_WORD_PATTERN.matches_word(descriptor_words[1])
+            && HAVE_WORD_PATTERN.matches_word(descriptor_words[2])
+        {
+            descriptor_words.drain(0..3);
+            negative = true;
+        }
         if descriptor_words.len() >= 2
             && POWER_OR_TOUGHNESS_WORD_PATTERN.matches_word(descriptor_words[0])
         {
@@ -5468,7 +5483,12 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
                         filter,
                     ));
                 }
-                return Ok(PredicateAst::ItMatches(filter));
+                let predicate = PredicateAst::ItMatches(filter);
+                return Ok(if negative {
+                    PredicateAst::Not(Box::new(predicate))
+                } else {
+                    predicate
+                });
             }
         }
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -1061,18 +1061,40 @@ fn parse_exile_segment_tokens(
             idx += 1;
         }
 
-        if !subject
+        if subject
             .get(idx)
             .is_some_and(|word| CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+            && idx + 1 == subject.len()
         {
+            return Ok(ActivationCostSegmentCst::ExileFromHand {
+                count,
+                color_filter,
+            });
+        }
+
+        let Some(subject_tokens) =
+            token_slice_for_word_range(tokens, &words, 1, lowered.len().saturating_sub(3))
+        else {
+            return Err(CardTextError::ParseError(format!(
+                "rewrite exile-from-hand parser found empty selector in '{raw}'"
+            )));
+        };
+        let (choice_count, filter_tokens) = parse_generic_choice_prefix_tokens(subject_tokens)
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "rewrite exile-from-hand parser expected card selector in '{raw}'"
+                ))
+            })?;
+        let filter_text = render_lower_lexed_tokens(filter_tokens);
+        if filter_text.is_empty() {
             return Err(CardTextError::ParseError(format!(
                 "rewrite exile-from-hand parser expected card selector in '{raw}'"
             )));
         }
 
-        return Ok(ActivationCostSegmentCst::ExileFromHand {
-            count,
-            color_filter,
+        return Ok(ActivationCostSegmentCst::ExileChosen {
+            choice_count,
+            filter_text: format!("{filter_text} from your hand"),
         });
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -11,6 +11,7 @@ use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::CounterType;
 use crate::target::PlayerFilter;
 use crate::types::{CardType, Subtype};
+use crate::zone::Zone;
 
 use super::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use super::effect_sentences::parse_subtype_word;
@@ -120,6 +121,7 @@ pub(crate) enum ActivationCostSegmentCst {
     ExileChosen {
         choice_count: ChoiceCount,
         filter_text: String,
+        source_zone: Option<Zone>,
     },
     ExileSelfAndNamedArtifacts {
         names: Vec<String>,
@@ -1095,6 +1097,7 @@ fn parse_exile_segment_tokens(
         return Ok(ActivationCostSegmentCst::ExileChosen {
             choice_count,
             filter_text: format!("{filter_text} from your hand"),
+            source_zone: Some(Zone::Hand),
         });
     }
 
@@ -1116,6 +1119,7 @@ fn parse_exile_segment_tokens(
         return Ok(ActivationCostSegmentCst::ExileChosen {
             choice_count,
             filter_text: format!("{filter_text} from your graveyard"),
+            source_zone: Some(Zone::Graveyard),
         });
     }
 
@@ -1135,6 +1139,7 @@ fn parse_exile_segment_tokens(
     Ok(ActivationCostSegmentCst::ExileChosen {
         choice_count,
         filter_text: render_exile_filter_text(filter_tokens),
+        source_zone: None,
     })
 }
 
@@ -2262,6 +2267,7 @@ pub(crate) fn lower_activation_cost_cst(
             ActivationCostSegmentCst::ExileChosen {
                 choice_count,
                 filter_text,
+                source_zone,
             } => {
                 flush_pending_mana(&mut costs, &mut pending_mana_pips);
                 let mut filter = parse_filter_text(filter_text, false)?;
@@ -2269,6 +2275,11 @@ pub(crate) fn lower_activation_cost_cst(
                     filter.zone = Some(crate::zone::Zone::Stack);
                     filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
                     filter.has_mana_cost = true;
+                } else if let Some(zone) = source_zone {
+                    filter.zone = Some(*zone);
+                    if matches!(zone, Zone::Hand | Zone::Graveyard) && filter.owner.is_none() {
+                        filter.owner = Some(PlayerFilter::You);
+                    }
                 }
                 if filter.zone.is_none() {
                     filter.zone = Some(crate::zone::Zone::Battlefield);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -96,7 +96,7 @@ use super::reference_resolution::{
 use super::static_ability_helpers::{
     decayed_triggered_ability, exalted_triggered_ability, lower_granted_abilities_ast,
     lower_granted_abilities_ast_to_object_abilities, persist_triggered_ability,
-    undying_triggered_ability,
+    suspend_exile_triggered_abilities, undying_triggered_ability,
 };
 use super::util::{
     contains_until_end_of_turn, map_span_to_original, parse_card_type, parse_number_word_i32,
@@ -1798,6 +1798,13 @@ fn lower_granted_ability_grant_modifications(
                 modifications.push(crate::continuous::Modification::AddAbilityGeneric(
                     exalted_triggered_ability(),
                 ));
+            }
+            GrantedAbilityAst::KeywordAction(crate::KeywordAction::Marker("suspend")) => {
+                modifications.extend(
+                    suspend_exile_triggered_abilities()
+                        .into_iter()
+                        .map(crate::continuous::Modification::AddAbilityGeneric),
+                );
             }
             _ => {
                 let mut lowered = lower_granted_abilities_ast(std::slice::from_ref(ability))?;

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -6,6 +6,7 @@ use crate::mana::ManaSymbol;
 use crate::object::CounterType;
 use crate::static_abilities::StaticAbilityId;
 use crate::types::{CardType, Subtype, Supertype};
+use crate::zone::Zone;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -13094,8 +13095,10 @@ fn rewrite_activation_cost_token_entrypoint_parses_tap_return_and_exile_variants
         [super::ActivationCostSegmentCst::ExileChosen {
             choice_count,
             filter_text,
+            source_zone,
         }] if *choice_count == ChoiceCount::at_least(1)
             && filter_text == "cards from your graveyard"
+            && *source_zone == Some(Zone::Graveyard)
     ));
 
     let single_graveyard_tokens = lex_line("Exile a card from a single graveyard", 0)
@@ -13107,9 +13110,28 @@ fn rewrite_activation_cost_token_entrypoint_parses_tap_return_and_exile_variants
         [super::ActivationCostSegmentCst::ExileChosen {
             choice_count,
             filter_text,
+            source_zone,
         }] if *choice_count == ChoiceCount::exactly(1)
             && filter_text == "card from a graveyard"
+            && source_zone.is_none()
     ));
+
+    let exile_hand_tokens = lex_line("Exile a nonland card from your hand", 0)
+        .expect("lexer should classify exile-from-hand activation cost");
+    let lowered = super::parse_activation_cost(&exile_hand_tokens)
+        .expect("activation-cost parser should support exiling a filtered card from hand");
+    let hand_choice = lowered
+        .as_all()
+        .expect("exile-from-hand activation cost should lower to sequential costs")
+        .iter()
+        .find_map(|cost| {
+            cost.effect_ref()
+                .and_then(|effect| effect.downcast_ref::<crate::effects::ChooseObjectsEffect>())
+        })
+        .expect("exile-from-hand activation cost should choose a card to exile");
+    assert_eq!(hand_choice.filter.zone, Some(Zone::Hand));
+    assert_eq!(hand_choice.filter.owner, Some(crate::target::PlayerFilter::You));
+    assert_eq!(hand_choice.filter.excluded_card_types, vec![CardType::Land]);
 
     let exile_spell_tokens = lex_line("Exile an instant or sorcery spell you control", 0)
         .expect("lexer should classify exile-spell activation cost");

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -4897,6 +4897,7 @@ impl WinTheGameEffect {
 pub struct CastSourceEffect {
     pub without_paying_mana_cost: bool,
     pub require_exile: bool,
+    pub cast_as_suspend: bool,
 }
 
 impl CastSourceEffect {
@@ -4904,6 +4905,7 @@ impl CastSourceEffect {
         Self {
             without_paying_mana_cost: false,
             require_exile: false,
+            cast_as_suspend: false,
         }
     }
 
@@ -4914,6 +4916,11 @@ impl CastSourceEffect {
 
     pub fn require_exile(mut self) -> Self {
         self.require_exile = true;
+        self
+    }
+
+    pub fn cast_as_suspend(mut self) -> Self {
+        self.cast_as_suspend = true;
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -4185,7 +4185,8 @@ impl CardDefinitionBuilder {
                         Effect::may_single(Effect::new(
                             crate::effects::CastSourceEffect::new()
                                 .without_paying_mana_cost()
-                                .require_exile(),
+                                .require_exile()
+                                .cast_as_suspend(),
                         )),
                     ]),
                     choices: vec![],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11423,6 +11423,34 @@ fn test_parse_suspend_keyword_line_with_reminder_text_keeps_suspend_clause() {
     );
 }
 
+#[test]
+fn jhoira_of_the_ghitu_strict_parser_text_and_suspend_grant_regression() {
+    assert_oracle_card_parses_strict("Jhoira of the Ghitu");
+
+    let def = parse_oracle_card_definition("Jhoira of the Ghitu");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains(
+            "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend"
+        ),
+        "expected Jhoira's activated ability to render with compact gained suspend text, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("ExileEffect")
+            && debug.contains("nonland")
+            && debug.contains("PutCountersEffect")
+            && debug.contains("keyword:suspend")
+            && debug.contains("AddAbilityGeneric"),
+        "expected Jhoira to lower exile-from-hand, time counters, and real suspend triggers, got {debug}"
+    );
+    assert!(
+        !debug.contains("KeywordFallbackText") && !debug.contains("unsupported"),
+        "Jhoira should not rely on unsupported fallback text, got {debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_the_face_of_boe_suspend_cost_activation() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11439,7 +11439,8 @@ fn jhoira_of_the_ghitu_strict_parser_text_and_suspend_grant_regression() {
     let debug = format!("{def:#?}");
     assert!(
         debug.contains("ExileEffect")
-            && debug.contains("nonland")
+            && debug.contains("excluded_card_types")
+            && debug.contains("Land")
             && debug.contains("PutCountersEffect")
             && debug.contains("keyword:suspend")
             && debug.contains("AddAbilityGeneric"),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3527,6 +3527,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return Some(compact);
     }
 
+    if let Some(compact) = describe_put_counters_then_gain_suspend(effects) {
+        return Some(compact);
+    }
+
     if effects.len() == 3 {
         let refs = effects.iter().collect::<Vec<_>>();
         if let Some(compact) = describe_discard_hand_add_mana_draw_sequence(&refs) {
@@ -23786,6 +23790,108 @@ fn describe_choose_exile_then_put_counter(
     let exile_text = describe_choose_then_exile(choose, exile)?;
     Some(format!(
         "{exile_text} and put {} on it",
+        describe_put_counter_phrase(&put.amount, put.counter_type)
+    ))
+}
+
+fn choose_spec_references_tagged_object(spec: &ChooseSpec, tag: &crate::TagKey) -> bool {
+    match spec.base() {
+        ChooseSpec::Tagged(found) => found == tag,
+        ChooseSpec::Object(filter) | ChooseSpec::All(filter) => {
+            filter.tagged_constraints.iter().any(|constraint| {
+                constraint.tag == *tag
+                    && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            })
+        }
+        _ => false,
+    }
+}
+
+fn filter_checks_for_suspend(filter: &ObjectFilter) -> bool {
+    filter.alternative_cast == Some(crate::filter::AlternativeCastKind::Suspend)
+}
+
+fn condition_is_tagged_object_without_suspend(condition: &Condition, tag: &crate::TagKey) -> bool {
+    let Condition::Not(inner) = condition else {
+        return false;
+    };
+    matches!(
+        inner.as_ref(),
+        Condition::TaggedObjectMatches(found, filter)
+            if found == tag && filter_checks_for_suspend(filter)
+    )
+}
+
+fn ability_is_suspend_exile_trigger(ability: &crate::ability::Ability) -> bool {
+    let crate::ability::AbilityKind::Triggered(triggered) = &ability.kind else {
+        return false;
+    };
+    triggered.presentation_label.as_deref() == Some("keyword:suspend")
+        && ability.functional_zones == [Zone::Exile]
+}
+
+fn modification_adds_suspend_exile_trigger(
+    modification: &crate::continuous::Modification,
+) -> bool {
+    matches!(
+        modification,
+        crate::continuous::Modification::AddAbilityGeneric(ability)
+            if ability_is_suspend_exile_trigger(ability)
+    )
+}
+
+fn apply_grants_suspend_to_tag(
+    apply: &crate::effects::ApplyContinuousEffect,
+    tag: &crate::TagKey,
+) -> bool {
+    if apply.until != Until::Forever
+        || apply.condition.is_some()
+        || !apply.runtime_modifications.is_empty()
+        || !matches!(apply.target_spec.as_ref(), Some(spec) if choose_spec_references_tagged_object(spec, tag))
+    {
+        return false;
+    }
+
+    let modifications = apply
+        .modification
+        .iter()
+        .chain(apply.additional_modifications.iter())
+        .collect::<Vec<_>>();
+    modifications.len() == 2
+        && modifications
+            .iter()
+            .all(|modification| modification_adds_suspend_exile_trigger(modification))
+}
+
+fn describe_put_counters_then_gain_suspend(effects: &[Effect]) -> Option<String> {
+    let [put_effect, conditional_effect] = effects else {
+        return None;
+    };
+    let tagged_put = put_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let put = tagged_put
+        .effect
+        .downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if put.counter_type != CounterType::Time
+        || put.target_count.is_some()
+        || put.distributed
+    {
+        return None;
+    }
+
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty()
+        || conditional.if_true.len() != 1
+        || !condition_is_tagged_object_without_suspend(&conditional.condition, &tagged_put.tag)
+    {
+        return None;
+    }
+    let apply = conditional.if_true[0].downcast_ref::<crate::effects::ApplyContinuousEffect>()?;
+    if !apply_grants_suspend_to_tag(apply, &tagged_put.tag) {
+        return None;
+    }
+
+    Some(format!(
+        "Put {} on the exiled card. If it doesn't have suspend, it gains suspend",
         describe_put_counter_phrase(&put.amount, put.counter_type)
     ))
 }

--- a/crates/ironsmith-runtime/src/effects/player/cast_source.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_source.rs
@@ -36,7 +36,7 @@ impl EffectExecutor for CastSourceEffect {
         let mana_cost = source_obj.mana_cost.clone();
         let stable_id = source_obj.stable_id;
         let source_name = source_obj.name.clone();
-        let suspend_alternative_index = if from_zone == Zone::Exile {
+        let mut suspend_alternative_index = if from_zone == Zone::Exile {
             source_obj
                 .alternative_casts
                 .iter()
@@ -74,6 +74,19 @@ impl EffectExecutor for CastSourceEffect {
 
         if let Some(obj) = game.object_mut(new_id) {
             obj.x_value = x_value;
+            if self.cast_as_suspend && suspend_alternative_index.is_none() {
+                suspend_alternative_index = Some(obj.alternative_casts.len());
+                obj.alternative_casts
+                    .push(crate::alternative_cast::AlternativeCastingMethod::Suspend {
+                        cost: crate::mana::ManaCost::new(),
+                        time: 0,
+                    });
+            }
+        }
+
+        let mut optional_costs_paid = OptionalCostsPaid::default();
+        if self.cast_as_suspend {
+            optional_costs_paid.mark_label_paid("Suspend");
         }
 
         let stack_entry = StackEntry {
@@ -92,7 +105,7 @@ impl EffectExecutor for CastSourceEffect {
                 zone: from_zone,
                 use_alternative: suspend_alternative_index,
             },
-            optional_costs_paid: OptionalCostsPaid::default(),
+            optional_costs_paid,
             defending_player: None,
             chosen_player: None,
             chapter_ability_source: None,

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -63,10 +63,11 @@ fn pay_selected_cost(
         .with_pre_chosen_cards(vec![chosen_id])
         .with_provenance(provenance);
     cost_ctx.tagged_objects = tagged_objects.clone();
+    let chosen_snapshot = game
+        .object(chosen_id)
+        .map(|obj| crate::snapshot::ObjectSnapshot::from_object(obj, game));
     if let Some(tag) = effective_choice_tag.as_ref()
-        && let Some(snapshot) = game
-            .object(chosen_id)
-            .map(|obj| crate::snapshot::ObjectSnapshot::from_object(obj, game))
+        && let Some(snapshot) = chosen_snapshot.clone()
     {
         cost_ctx
             .tagged_objects
@@ -77,6 +78,16 @@ fn pay_selected_cost(
 
     match cost.pay(game, &mut cost_ctx) {
         Ok(crate::costs::CostPaymentResult::Paid) => {
+            if let Some(tag) = effective_choice_tag.as_ref()
+                && let Some(snapshot) = chosen_snapshot.as_ref()
+                && let Some(current_id) = game.find_object_by_stable_id(snapshot.stable_id)
+                && let Some(current) = game.object(current_id)
+            {
+                let current_snapshot = crate::snapshot::ObjectSnapshot::from_object(current, game);
+                let tagged = cost_ctx.tagged_objects.entry(tag.clone()).or_default();
+                tagged.retain(|existing| existing.stable_id != snapshot.stable_id);
+                tagged.push(current_snapshot);
+            }
             *tagged_objects = cost_ctx.tagged_objects;
             Ok(())
         }

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -997,7 +997,8 @@ pub(super) fn resolve_stack_entry_full(
                         Some(crate::alternative_cast::AlternativeCastingMethod::Suspend { .. })
                     ),
                     _ => false,
-                };
+                } || entry.optional_costs_paid.was_paid_label("Suspend")
+                    || obj.optional_costs_paid.was_paid_label("Suspend");
                 if cast_with_dash {
                     let dash_haste = crate::effects::ApplyContinuousEffect::new(
                         crate::continuous::EffectTarget::Specific(result.new_id),

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -30,18 +30,25 @@ fn resolve_modal_count_value_for_source(
 
 /// Check if a ChooseSpec requires player selection.
 /// Check if a target spec requires the player to select a target.
+fn object_filter_is_tagged_reference(filter: &crate::filter::ObjectFilter) -> bool {
+    !filter.tagged_constraints.is_empty()
+        && filter.tagged_constraints.iter().all(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+        })
+}
+
 pub fn requires_target_selection(spec: &ChooseSpec) -> bool {
     match spec {
-        // Target wrapper - check the inner spec
-        ChooseSpec::Target(inner)
-        | ChooseSpec::WithCount(inner, _)
+        // Explicit target wrappers always require cast/activation-time selection.
+        ChooseSpec::Target(_) => true,
+        ChooseSpec::WithCount(inner, _)
         | ChooseSpec::WithCountValue(inner, _, _) => requires_target_selection(inner),
         // These require target selection during casting
         ChooseSpec::AnyTarget
         | ChooseSpec::AnyOtherTarget
         | ChooseSpec::PlayerOrPlaneswalker(_)
-        | ChooseSpec::Player(_)
-        | ChooseSpec::Object(_) => true,
+        | ChooseSpec::Player(_) => true,
+        ChooseSpec::Object(filter) => !object_filter_is_tagged_reference(filter),
         ChooseSpec::AttackedPlayerOrPlaneswalker => false,
         // These don't require selection - they're resolved at execution time
         _ => false,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -8189,6 +8189,7 @@ fn jhoira_exiles_nonland_card_and_granted_suspend_triggers_from_exile() {
 
     let jhoira_def = jhoira_of_the_ghitu_definition();
     let jhoira_id = game.create_object_from_definition(&jhoira_def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(jhoira_id);
     let land_def = CardDefinitionBuilder::new(CardId::from_raw(73_201), "Island Probe")
         .card_types(vec![CardType::Land])
         .build();
@@ -8214,26 +8215,113 @@ fn jhoira_exiles_nonland_card_and_granted_suspend_triggers_from_exile() {
         .power_toughness(PowerToughness::fixed(3, 3))
         .build();
     let spell_id = game.create_object_from_definition(&spell_def, alice, Zone::Hand);
-    let activate_action = crate::decision::compute_legal_actions(&game, alice)
-        .into_iter()
+    let ability_index = game
+        .object(jhoira_id)
+        .expect("Jhoira should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Jhoira should have an activated ability");
+    let AbilityKind::Activated(activated) = &game
+        .object(jhoira_id)
+        .expect("Jhoira should exist")
+        .abilities[ability_index]
+        .kind
+    else {
+        unreachable!("ability index should point at Jhoira's activation")
+    };
+    assert!(
+        crate::decision::can_activate_ability_with_restrictions(
+            &game,
+            jhoira_id,
+            ability_index,
+            activated,
+        ),
+        "Jhoira activation should pass direct activation checks"
+    );
+    let actions = crate::decision::compute_legal_actions(&game, alice);
+    let activate_action = actions
+        .iter()
         .find(|action| matches!(
             action,
             crate::decision::LegalAction::ActivateAbility { source, .. }
                 if *source == jhoira_id
         ))
-        .expect("Jhoira should be activatable with a nonland card in hand");
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!(
+                "Jhoira should be activatable with a nonland card in hand; actions={actions:?}"
+            )
+        });
 
     let mut trigger_queue = TriggerQueue::new();
     let mut state = PriorityLoopState::new(game.players_in_game());
     let mut dm = SelectFirstDecisionMaker;
-    apply_priority_response_with_dm(
+    let mut progress = apply_priority_response_with_dm(
         &mut game,
         &mut trigger_queue,
         &mut state,
         &PriorityResponse::PriorityAction(activate_action),
         &mut dm,
     )
-    .expect("Jhoira activation should be paid and put on the stack");
+    .expect("Jhoira activation should start cost payment");
+    let mut paid_exile_cost = false;
+    for _ in 0..8 {
+        progress = match progress {
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectObjects(_),
+            ) => {
+                paid_exile_cost = true;
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::CardCostChoice(spell_id),
+                    &mut dm,
+                )
+                .expect("choosing Jhoira's nonland exile cost should continue activation")
+            }
+            crate::decision::GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(cost_ctx),
+            ) if cost_ctx
+                .description
+                .to_ascii_lowercase()
+                .contains("choose the next cost") => {
+                let option = cost_ctx
+                    .options
+                    .iter()
+                    .find(|option| {
+                        option.legal
+                            && !paid_exile_cost
+                            && option.description.to_ascii_lowercase().contains("exile")
+                    })
+                    .or_else(|| cost_ctx.options.iter().find(|option| option.legal))
+                    .expect("Jhoira should have a payable remaining cost");
+                apply_priority_response_with_dm(
+                    &mut game,
+                    &mut trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(option.index),
+                    &mut dm,
+                )
+                .expect("choosing next Jhoira cost should continue activation")
+            }
+            other => {
+                progress = other;
+                break;
+            }
+        };
+    }
+    assert!(
+        matches!(
+            progress,
+            crate::decision::GameProgress::Continue
+                | crate::decision::GameProgress::NeedsDecisionCtx(
+                    crate::decisions::context::DecisionContext::Priority(_)
+                )
+        ),
+        "expected Jhoira activation to finish cost payment, got {progress:?}"
+    );
     resolve_stack_entry(&mut game).expect("Jhoira activation should resolve");
 
     assert!(

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -8181,6 +8181,7 @@ fn jhoira_of_the_ghitu_definition() -> crate::cards::CardDefinition {
 fn jhoira_exiles_nonland_card_and_granted_suspend_triggers_from_exile() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
 
     game.turn.phase = Phase::FirstMain;
     game.turn.step = None;
@@ -8367,6 +8368,76 @@ fn jhoira_exiles_nonland_card_and_granted_suspend_triggers_from_exile() {
         game.counter_count(exiled_id, crate::object::CounterType::Time),
         3,
         "the granted suspend upkeep trigger should remove a time counter"
+    );
+
+    for expected_counters in [2, 1, 0] {
+        game.turn.turn_number += 1;
+        game.turn.phase = Phase::Beginning;
+        game.turn.step = Some(crate::game_state::Step::Upkeep);
+        game.turn.active_player = alice;
+        game.turn.priority_player = Some(alice);
+        generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+        assert_eq!(
+            trigger_queue.entries.len(),
+            1,
+            "Jhoira-granted suspend should keep queueing upkeep triggers while time counters remain"
+        );
+        put_triggers_on_stack(&mut game, &mut trigger_queue)
+            .expect("granted suspend upkeep trigger should go on the stack");
+        resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+            .expect("granted suspend upkeep trigger should resolve");
+        assert_eq!(
+            game.counter_count(exiled_id, crate::object::CounterType::Time),
+            expected_counters,
+            "granted suspend upkeep trigger should remove the next time counter"
+        );
+    }
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Jhoira-granted suspend last-counter trigger should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Jhoira-granted suspend cast trigger should resolve");
+    assert_eq!(
+        game.stack.len(),
+        1,
+        "Jhoira-granted suspend should cast the exiled creature when the last time counter is removed"
+    );
+
+    resolve_stack_entry(&mut game).expect("Jhoira-granted suspended creature should resolve");
+
+    let creature_id = *game
+        .battlefield
+        .iter()
+        .find(|&&id| {
+            game.object(id)
+                .is_some_and(|object| object.name == "Suspend Gift Probe")
+        })
+        .expect("Jhoira-granted suspended creature should enter the battlefield");
+
+    let has_haste = game
+        .current_abilities(creature_id)
+        .expect("Jhoira-granted suspended creature should exist")
+        .iter()
+        .any(|ability| {
+            matches!(&ability.kind, AbilityKind::Static(static_ability) if static_ability.has_haste())
+        });
+    assert!(
+        has_haste,
+        "Jhoira-granted suspended creature should gain suspend haste"
+    );
+
+    game.set_current_controller(creature_id, bob);
+
+    let has_haste_after_control_change = game
+        .current_abilities(creature_id)
+        .expect("Jhoira-granted suspended creature should still exist")
+        .iter()
+        .any(|ability| {
+            matches!(&ability.kind, AbilityKind::Static(static_ability) if static_ability.has_haste())
+        });
+    assert!(
+        !has_haste_after_control_change,
+        "Jhoira-granted suspend haste should end once its controller stops controlling it"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -8165,6 +8165,124 @@ fn test_suspend_declined_cast_does_not_keep_triggering_without_time_counters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn jhoira_of_the_ghitu_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(73_200), "Jhoira of the Ghitu")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Wizard])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .parse_text(
+            "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend.",
+        )
+        .expect("Jhoira of the Ghitu should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn jhoira_exiles_nonland_card_and_granted_suspend_triggers_from_exile() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let jhoira_def = jhoira_of_the_ghitu_definition();
+    let jhoira_id = game.create_object_from_definition(&jhoira_def, alice, Zone::Battlefield);
+    let land_def = CardDefinitionBuilder::new(CardId::from_raw(73_201), "Island Probe")
+        .card_types(vec![CardType::Land])
+        .build();
+    let land_id = game.create_object_from_definition(&land_def, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 2);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, .. }
+                    if source == jhoira_id
+            )),
+        "Jhoira should not be activatable when the only card in hand is a land"
+    );
+
+    let spell_def = CardDefinitionBuilder::new(CardId::from_raw(73_202), "Suspend Gift Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let spell_id = game.create_object_from_definition(&spell_def, alice, Zone::Hand);
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateAbility { source, .. }
+                if *source == jhoira_id
+        ))
+        .expect("Jhoira should be activatable with a nonland card in hand");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Jhoira activation should be paid and put on the stack");
+    resolve_stack_entry(&mut game).expect("Jhoira activation should resolve");
+
+    assert!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .hand
+            .contains(&land_id),
+        "Jhoira's exile cost must not choose the land card"
+    );
+    assert!(
+        !game
+            .player(alice)
+            .expect("Alice should exist")
+            .hand
+            .contains(&spell_id),
+        "Jhoira should move the nonland card out of hand"
+    );
+    let exiled_id = *game
+        .exile
+        .iter()
+        .find(|&&id| game.object(id).is_some_and(|object| object.name == "Suspend Gift Probe"))
+        .expect("Jhoira should exile the chosen nonland card");
+    assert_eq!(
+        game.counter_count(exiled_id, crate::object::CounterType::Time),
+        4,
+        "Jhoira should put four time counters on the exiled card"
+    );
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "the suspend ability granted by Jhoira should trigger from exile"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("granted suspend upkeep trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("granted suspend upkeep trigger should resolve");
+    assert_eq!(
+        game.counter_count(exiled_id, crate::object::CounterType::Time),
+        3,
+        "the granted suspend upkeep trigger should remove a time counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn the_face_of_boe_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(73_100), "The Face of Boe")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -1219,12 +1219,12 @@ pub(crate) fn check_triggers_with_view(
 
     // Check objects in all public non-battlefield zones.
     for_each_public_nonbattlefield_trigger_object_id(game, |obj_id| {
-        check_triggers_in_zone(game, obj_id, trigger_event, &mut triggered);
+        check_triggers_in_zone(game, obj_id, trigger_event, view, &mut triggered);
     });
 
     // Hand is hidden, but some mechanics (for example Miracle) legitimately trigger there.
     for_each_hidden_trigger_object_id(game, |obj_id| {
-        check_triggers_in_zone(game, obj_id, trigger_event, &mut triggered);
+        check_triggers_in_zone(game, obj_id, trigger_event, view, &mut triggered);
     });
 
     // Note: Undying/Persist/Miracle triggers are handled through the normal trigger system.
@@ -1870,6 +1870,7 @@ fn check_triggers_in_zone(
     game: &GameState,
     obj_id: ObjectId,
     trigger_event: &TriggerEvent,
+    view: &crate::derived_view::DerivedGameView<'_>,
     triggered: &mut Vec<TriggeredAbilityEntry>,
 ) {
     let Some(obj) = game.object(obj_id) else {
@@ -1878,7 +1879,11 @@ fn check_triggers_in_zone(
 
     let ctx = TriggerContext::for_source(obj_id, game.controller_of(obj), game);
 
-    for ability in &obj.abilities {
+    let calculated_abilities = view
+        .abilities_rc(obj_id)
+        .unwrap_or_else(|| Rc::new(obj.abilities.clone()));
+
+    for ability in calculated_abilities.iter() {
         let AbilityKind::Triggered(trigger_ability) = &ability.kind else {
             continue;
         };


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jhoira of the Ghitu
Initial parse error:
```
unsupported activation cost segment (clause: 'exile a nonland card from your hand'): rewrite exile-from-hand parser expected card selector in 'exile a nonland card from your hand'; oracle-only fallback also failed: unsupported activation cost segment (clause: 'exile a nonland card from your hand'): rewrite exile-from-hand parser expected card selector in 'exile a nonland card from your hand'
```

Current worker: i-0a0153ee2cf4cc326
Branch: codex/aws-card-fix-jhoira-of-the-ghitu
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0015
