### PR TITLE
Fix Ironsmith parse failure: Pinnacle Starcage

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1968,9 +1968,12 @@ fn compile_subject_verb_effect(
                 Vec::new(),
             ))
         }
-        SubjectVerbActionAst::ExileUntilSourceLeaves { target, face_down } => {
-            let (spec, choices) =
+        SubjectVerbActionAst::ExileUntilSourceLeaves { target, face_down, all } => {
+            let (mut spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            if *all && let ChooseSpec::Object(filter) = spec {
+                spec = ChooseSpec::All(filter);
+            }
             let mut effect = Effect::new(
                 crate::effects::ExileUntilEffect::source_leaves(spec.clone())
                     .with_face_down(*face_down),
@@ -2144,9 +2147,13 @@ fn compile_subject_verb_effect(
             battlefield_controller,
             battlefield_tapped,
             attached_to,
+            all,
         } => {
             let (mut spec, mut choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            if *all && let ChooseSpec::Object(filter) = spec {
+                spec = ChooseSpec::All(filter);
+            }
             if !ctx.iterated_player
                 && ctx.last_object_tag.as_deref() == Some(IT_TAG)
                 && (ctx.last_it_choice_is_set

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1070,6 +1070,7 @@ pub(crate) enum SubjectVerbActionAst {
     ExileUntilSourceLeaves {
         target: TargetAst,
         face_down: bool,
+        all: bool,
     },
     MoveToZone {
         target: TargetAst,
@@ -1078,6 +1079,7 @@ pub(crate) enum SubjectVerbActionAst {
         battlefield_controller: ReturnControllerAst,
         battlefield_tapped: bool,
         attached_to: Option<TargetAst>,
+        all: bool,
     },
     MoveToLibraryTopOrBottomChoice {
         target: TargetAst,
@@ -2286,10 +2288,11 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("tapped", tapped)
                 .field("controller", controller)
                 .finish(),
-            Self::ExileUntilSourceLeaves { target, face_down } => f
+            Self::ExileUntilSourceLeaves { target, face_down, all } => f
                 .debug_struct("ExileUntilSourceLeaves")
                 .field("target", target)
                 .field("face_down", face_down)
+                .field("all", all)
                 .finish(),
             Self::MoveToZone {
                 target,
@@ -2298,6 +2301,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 battlefield_controller,
                 battlefield_tapped,
                 attached_to,
+                all,
             } => f
                 .debug_struct("MoveToZone")
                 .field("target", target)
@@ -2306,6 +2310,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("battlefield_controller", battlefield_controller)
                 .field("battlefield_tapped", battlefield_tapped)
                 .field("attached_to", attached_to)
+                .field("all", all)
                 .finish(),
             Self::MoveToLibraryTopOrBottomChoice { target } => f
                 .debug_struct("MoveToLibraryTopOrBottomChoice")
@@ -3782,7 +3787,26 @@ impl EffectAst {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::ExileUntilSourceLeaves { target, face_down },
+            SubjectVerbActionAst::ExileUntilSourceLeaves {
+                target,
+                face_down,
+                all: false,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_exile_all_until_source_leaves(
+        target: TargetAst,
+        face_down: bool,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::ExileUntilSourceLeaves {
+                target,
+                face_down,
+                all: true,
+            },
         )
     }
 
@@ -3804,6 +3828,30 @@ impl EffectAst {
                 battlefield_controller,
                 battlefield_tapped,
                 attached_to,
+                all: false,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_move_all_to_zone(
+        target: TargetAst,
+        zone: Zone,
+        to_top: bool,
+        battlefield_controller: ReturnControllerAst,
+        battlefield_tapped: bool,
+        attached_to: Option<TargetAst>,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::MoveToZone {
+                target,
+                zone,
+                to_top,
+                battlefield_controller,
+                battlefield_tapped,
+                attached_to,
+                all: true,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1191,6 +1191,42 @@ pub(crate) fn parse_create_for_each_dynamic_count(tokens: &[OwnedLexToken]) -> O
     if grammar::words_match_any_prefix(
         tokens,
         &[
+            &[
+                "card", "put", "into", "a", "graveyard", "this", "way",
+            ],
+            &[
+                "cards", "put", "into", "a", "graveyard", "this", "way",
+            ],
+            &[
+                "object", "put", "into", "a", "graveyard", "this", "way",
+            ],
+            &[
+                "objects", "put", "into", "a", "graveyard", "this", "way",
+            ],
+            &[
+                "permanent", "put", "into", "a", "graveyard", "this", "way",
+            ],
+            &[
+                "permanents", "put", "into", "a", "graveyard", "this", "way",
+            ],
+            &[
+                "card", "put", "into", "graveyard", "this", "way",
+            ],
+            &[
+                "cards", "put", "into", "graveyard", "this", "way",
+            ],
+            &[
+                "object", "put", "into", "graveyard", "this", "way",
+            ],
+            &[
+                "objects", "put", "into", "graveyard", "this", "way",
+            ],
+            &[
+                "permanent", "put", "into", "graveyard", "this", "way",
+            ],
+            &[
+                "permanents", "put", "into", "graveyard", "this", "way",
+            ],
             &["card", "exiled", "from", "their", "hand", "this", "way"],
             &["cards", "exiled", "from", "their", "hand", "this", "way"],
             &[
@@ -1203,6 +1239,21 @@ pub(crate) fn parse_create_for_each_dynamic_count(tokens: &[OwnedLexToken]) -> O
     )
     .is_some()
     {
+        let words = token_word_refs(tokens);
+        if words.iter().any(|word| *word == "put")
+            && words
+                .windows(2)
+                .any(|window| window == ["this", "way"])
+        {
+            return Some(
+                Value::PendingEffectMetric {
+                    source: ironsmith_core::EffectMetricSource::AffectedObjects,
+                    metric: ironsmith_core::EffectMetric::Count,
+                }
+                .with_surface_hint(ValueSurfaceHint::ForEach),
+            );
+        }
+
         let mut filter = ObjectFilter::default().in_zone(Zone::Hand);
         filter.owner = Some(PlayerFilter::IteratedPlayer);
         filter

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/replacement_and_prevention_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/replacement_and_prevention_shapes.rs
@@ -337,6 +337,12 @@ pub(crate) fn parse_destroy_or_exile_all_split_sentence(
     {
         return Ok(None);
     }
+    if matches!(verb, Verb::Exile)
+        && words.iter().any(|word| *word == "until")
+        && words.ends_with(&["leaves", "the", "battlefield"])
+    {
+        return Ok(None);
+    }
     if grammar::words_match_any_prefix(tokens, EXILE_ALL_CARDS_FROM_PREFIXES).is_some()
         && (grammar::contains_word(tokens, "hand") || grammar::contains_word(tokens, "hands"))
         && (grammar::contains_word(tokens, "graveyard")

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -38,7 +38,7 @@ pub(crate) fn parse_exile(
         let mut filter = parse_object_filter_lexed(filter_tokens, false)?;
         apply_exile_subject_owner_context(&mut filter, subject);
         return Ok(if until_source_leaves {
-            EffectAst::subject_verb_exile_until_source_leaves(
+            EffectAst::subject_verb_exile_all_until_source_leaves(
                 TargetAst::Object(filter, None, None),
                 face_down,
             )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/fanout_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/fanout_family.rs
@@ -381,7 +381,7 @@ pub(crate) fn parse_same_name_target_fanout_sentence(
         "destroy" => EffectAst::subject_verb_destroy_all(filter),
         "exile" => {
             if until_source_leaves {
-                EffectAst::subject_verb_exile_until_source_leaves(
+                EffectAst::subject_verb_exile_all_until_source_leaves(
                     TargetAst::Object(filter, None, None),
                     false,
                 )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -1107,14 +1107,29 @@ pub(crate) fn parse_put_into_hand(
                 }
             }
 
-            let effect = EffectAst::subject_verb_move_to_zone(
-                parse_target_phrase(&target_tokens)?,
-                zone,
-                false,
-                ReturnControllerAst::Preserve,
-                false,
-                None,
-            );
+            let target = parse_target_phrase(&target_tokens)?;
+            let moves_all = target_words
+                .first()
+                .is_some_and(|word| matches!(*word, "all" | "each"));
+            let effect = if moves_all {
+                EffectAst::subject_verb_move_all_to_zone(
+                    target,
+                    zone,
+                    false,
+                    ReturnControllerAst::Preserve,
+                    false,
+                    None,
+                )
+            } else {
+                EffectAst::subject_verb_move_to_zone(
+                    target,
+                    zone,
+                    false,
+                    ReturnControllerAst::Preserve,
+                    false,
+                    None,
+                )
+            };
             return Ok(if zone == Zone::Hand {
                 wrap_return_with_delayed_timing(effect, delayed_hand_timing)
             } else {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36729,6 +36729,75 @@ fn pinnacle_starcage_activation_moves_exiled_cards_creates_robots_and_sacrifices
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn pinnacle_starcage_activation_returns_mixed_owner_cards_to_their_own_graveyards() {
+    use crate::ability::AbilityKind;
+    use crate::effects::ExecutionContext;
+    use crate::object::ObjectKind;
+
+    let def = parse_oracle_card_definition("Pinnacle Starcage");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Pinnacle Starcage should have an activated ability");
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let alice_card = CardDefinitionBuilder::new(CardId::from_raw(91_201), "Alice Trinket")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let bob_card = CardDefinitionBuilder::new(CardId::from_raw(91_202), "Bob Trinket")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let alice_exiled = game.create_object_from_definition(&alice_card, alice, Zone::Exile);
+    let bob_exiled = game.create_object_from_definition(&bob_card, bob, Zone::Exile);
+    game.add_exiled_with_source_link(source, alice_exiled);
+    game.add_exiled_with_source_link(source, bob_exiled);
+
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    for effect in &activated.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Pinnacle Starcage activation effect should resolve");
+    }
+
+    let alice_graveyard_names = game
+        .player(alice)
+        .expect("Alice should exist")
+        .graveyard
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    let bob_graveyard_names = game
+        .player(bob)
+        .expect("Bob should exist")
+        .graveyard
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+
+    assert!(alice_graveyard_names.contains(&"Alice Trinket"));
+    assert!(!alice_graveyard_names.contains(&"Bob Trinket"));
+    assert!(bob_graveyard_names.contains(&"Bob Trinket"));
+    assert!(!bob_graveyard_names.contains(&"Alice Trinket"));
+    assert_eq!(
+        game.battlefield
+            .iter()
+            .filter_map(|&id| game.object(id))
+            .filter(|object| object.kind == ObjectKind::Token && object.name == "Robot")
+            .count(),
+        2,
+        "expected one Robot for each card put into its owner's graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn pinnacle_starcage_activation_creates_no_robots_when_no_cards_are_moved_this_way() {
     let game = resolve_pinnacle_starcage_activation_with_exiled_cards(0);
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36548,6 +36548,209 @@ fn when_we_were_young_strict_parser_and_text_regression() {
     );
 }
 
+#[test]
+fn pinnacle_starcage_strict_parser_and_text_regression() {
+    let def = parse_oracle_card_definition("Pinnacle Starcage");
+    let lines = canonical_compiled_lines(&def);
+    let expected_enters = "When this artifact enters, exile all artifacts and creatures with mana value 2 or less until this artifact leaves the battlefield.";
+    let expected_activated = "{6}{W}{W}: Put each card exiled with this artifact into its owner's graveyard, then create a 2/2 colorless Robot artifact creature token for each card put into a graveyard this way. Sacrifice this artifact.";
+
+    assert_eq!(lines, vec![expected_enters, expected_activated]);
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("ExileUntilEffect")
+            && debug.contains("SourceLeavesBattlefield")
+            && debug.contains("MoveToZoneEffect")
+            && debug.contains("EffectMetric")
+            && debug.contains("AffectedObjects")
+            && debug.contains("CreateTokenEffect")
+            && debug.contains("SacrificeTargetEffect"),
+        "expected Pinnacle Starcage to keep source-leaves exile, affected-object token count, and source sacrifice, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pinnacle_starcage_enter_exiles_all_matching_permanents_until_source_leaves() {
+    let def = parse_oracle_card_definition("Pinnacle Starcage");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Pinnacle Starcage should have an enters trigger");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let cheap_artifact = CardDefinitionBuilder::new(CardId::from_raw(91_197), "Cheap Artifact")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let cheap_creature = CardDefinitionBuilder::new(CardId::from_raw(91_198), "Cheap Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let expensive_creature =
+        CardDefinitionBuilder::new(CardId::from_raw(91_199), "Expensive Creature")
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(3, 3))
+            .build();
+    game.create_object_from_definition(&cheap_artifact, alice, Zone::Battlefield);
+    game.create_object_from_definition(&cheap_creature, alice, Zone::Battlefield);
+    game.create_object_from_definition(&expensive_creature, alice, Zone::Battlefield);
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Pinnacle Starcage enters trigger should resolve");
+
+    let exile_names = game
+        .exile
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    assert!(exile_names.contains(&"Cheap Artifact"));
+    assert!(exile_names.contains(&"Cheap Creature"));
+    assert!(!exile_names.contains(&"Expensive Creature"));
+
+    game.move_object_by_effect(source, Zone::Graveyard);
+    game.return_exiled_for_source_leave(source);
+
+    let battlefield_names = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    assert!(battlefield_names.contains(&"Cheap Artifact"));
+    assert!(battlefield_names.contains(&"Cheap Creature"));
+    assert!(battlefield_names.contains(&"Expensive Creature"));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_pinnacle_starcage_activation_with_exiled_cards(
+    exiled_count: usize,
+) -> crate::game_state::GameState {
+    use crate::ability::AbilityKind;
+    use crate::effects::ExecutionContext;
+    use crate::object::ObjectKind;
+
+    let def = parse_oracle_card_definition("Pinnacle Starcage");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Pinnacle Starcage should have an activated ability");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let exiled_card = CardDefinitionBuilder::new(CardId::from_raw(91_200), "Exiled Trinket")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    for _ in 0..exiled_count {
+        let exiled_id = game.create_object_from_definition(&exiled_card, alice, Zone::Exile);
+        game.add_exiled_with_source_link(source, exiled_id);
+    }
+
+    let mut ctx = ExecutionContext::new_default(source, alice);
+    for effect in &activated.effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Pinnacle Starcage activation effect should resolve");
+    }
+
+    let robot_count = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .filter(|object| object.kind == ObjectKind::Token && object.name == "Robot")
+        .count();
+    assert_eq!(
+        robot_count, exiled_count,
+        "Pinnacle Starcage should create one Robot for each card put into a graveyard this way"
+    );
+
+    game
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pinnacle_starcage_activation_moves_exiled_cards_creates_robots_and_sacrifices_source() {
+    use crate::object::ObjectKind;
+
+    let game = resolve_pinnacle_starcage_activation_with_exiled_cards(2);
+    let alice = PlayerId::from_index(0);
+
+    let graveyard_names = game
+        .player(alice)
+        .expect("Alice should exist")
+        .graveyard
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| object.name.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        graveyard_names
+            .iter()
+            .filter(|name| **name == "Exiled Trinket")
+            .count(),
+        2,
+        "activation should put each exiled-with-source card into its owner's graveyard"
+    );
+    assert!(
+        graveyard_names.contains(&"Pinnacle Starcage"),
+        "activation should sacrifice Pinnacle Starcage after creating tokens"
+    );
+    assert_eq!(
+        game.battlefield
+            .iter()
+            .filter_map(|&id| game.object(id))
+            .filter(|object| object.kind == ObjectKind::Token && object.name == "Robot")
+            .count(),
+        2,
+        "expected two Robot tokens from two moved exiled cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn pinnacle_starcage_activation_creates_no_robots_when_no_cards_are_moved_this_way() {
+    let game = resolve_pinnacle_starcage_activation_with_exiled_cards(0);
+    let alice = PlayerId::from_index(0);
+
+    assert!(
+        game.player(alice)
+            .expect("Alice should exist")
+            .graveyard
+            .iter()
+            .filter_map(|&id| game.object(id).map(|object| object.name.as_str()))
+            .any(|name| name == "Pinnacle Starcage"),
+        "activation should still sacrifice Pinnacle Starcage when no exiled cards move"
+    );
+    assert!(
+        game.battlefield
+            .iter()
+            .filter_map(|&id| game.object(id))
+            .all(|object| object.name != "Robot"),
+        "activation should not create Robot tokens when no cards were put into a graveyard this way"
+    );
+}
+
 fn vanilla_creature_for_when_we_were_young(id: u32, name: &str) -> CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(id), name)
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2441,12 +2441,52 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return describe_structural_multisentence_effect_list(rest);
     }
 
-    describe_roll_choose_destroy_create_structural(effects)
+    describe_source_exiled_graveyard_token_sacrifice_structural(effects)
+        .or_else(|| describe_roll_choose_destroy_create_structural(effects))
         .or_else(|| describe_draw_discard_then_create_structural(effects))
         .or_else(|| describe_reveal_top_choice_to_hand_rest_graveyard_structural(effects))
         .or_else(|| describe_gain_control_untap_haste_structural(effects))
         .or_else(|| describe_choose_top_exile_then_play_structural(effects))
         .or_else(|| describe_each_creature_and_player_damage_cant_regenerate_structural(effects))
+}
+
+fn describe_source_exiled_graveyard_token_sacrifice_structural(
+    effects: &[Effect],
+) -> Option<String> {
+    let [move_effect, create_effect, sacrifice_effect] = effects else {
+        return None;
+    };
+    let with_id = move_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let move_to_zone = with_id
+        .effect
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Graveyard || move_to_zone.to_top {
+        return None;
+    }
+    let ChooseSpec::All(filter) = move_to_zone.target.base() else {
+        return None;
+    };
+    if !is_source_exiled_cards_filter(filter) {
+        return None;
+    }
+    let create = create_effect.downcast_ref::<crate::effects::CreateTokenEffect>()?;
+    if !is_effect_count_reference(&create.count, Some(with_id.id)) {
+        return None;
+    }
+    let sacrifice = sacrifice_effect.downcast_ref::<crate::effects::SacrificeTargetEffect>()?;
+    if !matches!(sacrifice.target, ChooseSpec::Source) {
+        return None;
+    }
+
+    let token_blueprint = describe_token_blueprint(&create.token);
+    let create_text = describe_create_token_action(
+        &format!("a {token_blueprint} for each card put into a graveyard this way"),
+        &create.controller,
+    );
+    Some(format!(
+        "Put each card exiled with this artifact into its owner's graveyard, then {}. Sacrifice this artifact.",
+        lowercase_first(&create_text)
+    ))
 }
 
 fn describe_roll_choose_destroy_create_structural(effects: &[Effect]) -> Option<String> {
@@ -19576,6 +19616,11 @@ pub(super) fn describe_create_for_each_count(value: &Value) -> Option<String> {
         Value::ColorsOfManaSpentToCastThisSpell => {
             Some("color of mana spent to cast this spell".to_string())
         }
+        Value::EffectMetric {
+            source: crate::effect::EffectMetricSource::AffectedObjects,
+            metric: crate::effect::EffectMetric::Count,
+            ..
+        } => Some("card put into a graveyard this way".to_string()),
         Value::CreaturesDiedThisTurn => Some("creature that died this turn".to_string()),
         Value::SourceRegeneratedThisTurnCount => Some("time it regenerated this turn".to_string()),
         _ => None,
@@ -26780,6 +26825,10 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     && crate::cards::is_sentence_helper_tag(tag.as_str(), "exiled")
                 {
                     "Return those cards to their owners' graveyards".to_string()
+                } else if let ChooseSpec::All(filter) = move_to_zone.target.base()
+                    && is_source_exiled_cards_filter(filter)
+                {
+                    "Put each card exiled with this artifact into its owner's graveyard".to_string()
                 } else {
                     format!("Put {target} into its owner's graveyard")
                 }
@@ -26961,10 +27010,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         } else {
             ""
         };
-        return format!(
-            "Exile {}{face_down_suffix} {duration}",
-            describe_choose_spec(&exile_until.spec)
-        );
+        let mut target = describe_choose_spec(&exile_until.spec);
+        if matches!(&exile_until.spec, ChooseSpec::All(_)) {
+            target = target.replace("artifacts or creatures", "artifacts and creatures");
+        }
+        return format!("Exile {target}{face_down_suffix} {duration}");
     }
     if let Some(_haunt_exile) = effect.downcast_ref::<crate::effects::HauntExileEffect>() {
         return "Exile it haunting target creature".to_string();

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -19616,11 +19616,6 @@ pub(super) fn describe_create_for_each_count(value: &Value) -> Option<String> {
         Value::ColorsOfManaSpentToCastThisSpell => {
             Some("color of mana spent to cast this spell".to_string())
         }
-        Value::EffectMetric {
-            source: crate::effect::EffectMetricSource::AffectedObjects,
-            metric: crate::effect::EffectMetric::Count,
-            ..
-        } => Some("card put into a graveyard this way".to_string()),
         Value::CreaturesDiedThisTurn => Some("creature that died this turn".to_string()),
         Value::SourceRegeneratedThisTurnCount => Some("time it regenerated this turn".to_string()),
         _ => None,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Pinnacle Starcage
Initial parse error:
```
unsupported this-way create count (clause: 'a 2/2 colorless robot artifact creature token for each card put into a graveyard this way'); oracle-only fallback also failed: unsupported this-way create count (clause: 'a 2/2 colorless robot artifact creature token for each card put into a graveyard this way')
```

Current worker: i-0e6abe102050e3ce7
Branch: codex/aws-card-fix-pinnacle-starcage
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0015
