### PR TITLE
Fix Ironsmith parse failure: Mob Verdict

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/control_flow_handlers.rs
@@ -916,15 +916,20 @@ pub(crate) fn compile_vote_sequence(
     }
 
     let vote_start = match &first.effect {
-        EffectAst::VoteStart { options, secret } => Some((Some(options.clone()), None, *secret)),
+        EffectAst::VoteStart { options, secret } => Some((Some(options.clone()), None, None, *secret)),
         EffectAst::VoteStartObjects {
             filter,
             count,
             secret,
-        } => Some((None, Some((filter.clone(), *count)), *secret)),
+        } => Some((None, Some((filter.clone(), *count)), None, *secret)),
+        EffectAst::VoteStartPlayers {
+            filter,
+            exclude_voter,
+            secret,
+        } => Some((None, None, Some((filter.clone(), *exclude_voter)), *secret)),
         _ => None,
     };
-    let Some((named_options, object_vote, secret)) = vote_start else {
+    let Some((named_options, object_vote, player_vote, secret)) = vote_start else {
         return Ok(None);
     };
 
@@ -961,6 +966,36 @@ pub(crate) fn compile_vote_sequence(
         } else {
             crate::effects::VoteEffect::vote_objects(resolved, count, extra_mandatory)
         }
+        .with_secret(secret);
+        let effect = Effect::new(vote);
+        let mut compiled = vec![effect];
+        let mut choices = Vec::new();
+        for annotated in effects.iter().take(consumed).skip(1) {
+            apply_local_reference_env(ctx, &annotated.in_env);
+            ctx.auto_tag_object_targets =
+                ctx.force_auto_tag_object_targets || annotated.auto_tag_object_targets;
+            match &annotated.effect {
+                EffectAst::VoteExtra { .. } => {}
+                _ => {
+                    let (followups, followup_choices) = compile_effect(&annotated.effect, ctx)?;
+                    compiled.extend(followups);
+                    for choice in followup_choices {
+                        push_choice(&mut choices, choice);
+                    }
+                }
+            }
+            apply_local_reference_env(ctx, &annotated.out_env);
+        }
+        return Ok(Some((compiled, choices, consumed)));
+    }
+
+    if let Some((filter, exclude_voter)) = player_vote {
+        let vote = crate::effects::VoteEffect::vote_players_with_optional_extra(
+            filter,
+            exclude_voter,
+            extra_mandatory,
+            extra_optional,
+        )
         .with_secret(secret);
         let effect = Effect::new(vote);
         let mut compiled = vec![effect];

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
@@ -493,6 +493,7 @@ pub(super) fn try_compile_search_and_reorder_effect(
         EffectAst::SecretChoiceReveal => (Vec::new(), Vec::new()),
         EffectAst::VoteStart { .. }
         | EffectAst::VoteStartObjects { .. }
+        | EffectAst::VoteStartPlayers { .. }
         | EffectAst::VoteExtra { .. } => {
             return Err(CardTextError::ParseError(
                 "vote clauses must appear together".to_string(),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -3510,6 +3510,11 @@ pub(crate) enum EffectAst {
         count: ChoiceCount,
         secret: bool,
     },
+    VoteStartPlayers {
+        filter: PlayerFilter,
+        exclude_voter: bool,
+        secret: bool,
+    },
     VoteOption {
         option: String,
         effects: Vec<EffectAst>,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
@@ -163,6 +163,7 @@ pub(crate) fn assert_effect_ast_variant_coverage(effect: &EffectAst) {
         EffectAst::SecretChoiceStart { .. } => {}
         EffectAst::SecretChoiceReveal => {}
         EffectAst::VoteStartObjects { .. } => {}
+        EffectAst::VoteStartPlayers { .. } => {}
         EffectAst::VoteOption { .. } => {}
         EffectAst::VoteExtra { .. } => {}
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1217,6 +1217,7 @@ fn advance_reference_frame_for_effect(
         | EffectAst::SecretChoiceStart { .. }
         | EffectAst::SecretChoiceReveal
         | EffectAst::VoteStartObjects { .. }
+        | EffectAst::VoteStartPlayers { .. }
         | EffectAst::VoteOption { .. }
         | EffectAst::VoteExtra { .. } => {}
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -1482,6 +1482,21 @@ fn parse_generic_vote_start(tokens: &[OwnedLexToken]) -> Result<Option<EffectAst
     let option_tokens = crate::runtime_backend::lexer::synthetic_word_tokens(&option_words);
     if let Ok(target) = parse_target_phrase(&option_tokens) {
         match target {
+            TargetAst::Player(filter, _) => {
+                let exclude_voter = option_words
+                    .first()
+                    .is_some_and(|word| matches!(*word, "other" | "another"));
+                let filter = if exclude_voter && matches!(filter, PlayerFilter::NotYou) {
+                    PlayerFilter::Any
+                } else {
+                    filter
+                };
+                return Ok(Some(EffectAst::VoteStartPlayers {
+                    filter,
+                    exclude_voter,
+                    secret,
+                }));
+            }
             TargetAst::Object(filter, _, _) => {
                 return Ok(Some(EffectAst::VoteStartObjects {
                     filter,
@@ -1552,6 +1567,10 @@ fn parse_generic_vote_option_effects(
         return Ok(None);
     };
     if vote_idx <= 2 {
+        if let Some(effect) = parse_generic_player_vote_received_effects(tokens, &words, vote_idx)?
+        {
+            return Ok(Some(effect));
+        }
         return Err(CardTextError::ParseError(
             "missing vote option name".to_string(),
         ));
@@ -1572,6 +1591,52 @@ fn parse_generic_vote_option_effects(
             })?;
     let effects = parse_effect_chain_lexed(effect_tokens)?;
     Ok(Some(EffectAst::VoteOption { option, effects }))
+}
+
+fn parse_generic_player_vote_received_effects(
+    tokens: &[OwnedLexToken],
+    words: &[&str],
+    vote_idx: usize,
+) -> Result<Option<EffectAst>, CardTextError> {
+    let Some(received_idx) = find_index(&words[vote_idx + 1..], |word| {
+        matches!(*word, "received" | "receives")
+    })
+    .map(|idx| idx + vote_idx + 1)
+    else {
+        return Ok(None);
+    };
+    if received_idx <= vote_idx + 1 {
+        return Ok(None);
+    }
+    let player_words = crate::runtime_backend::util::non_article_word_refs(
+        &words[vote_idx + 1..received_idx],
+    );
+    if player_words.is_empty() {
+        return Ok(None);
+    }
+    let player_tokens = crate::runtime_backend::lexer::synthetic_word_tokens(&player_words);
+    let TargetAst::Player(filter, _) = parse_target_phrase(&player_tokens)? else {
+        return Ok(None);
+    };
+    let (_before, effect_tokens) =
+        grammar::split_lexed_once_on_delimiter(tokens, super::super::lexer::TokenKind::Comma)
+            .ok_or_else(|| {
+                CardTextError::ParseError("missing comma in for each vote clause".to_string())
+            })?;
+    let effects = parse_effect_chain_lexed(effect_tokens)?;
+    if filter == PlayerFilter::You {
+        return Ok(Some(EffectAst::RepeatEffects {
+            count: Value::PlayerVoteCount(PlayerFilter::You),
+            effects,
+        }));
+    }
+    Ok(Some(EffectAst::ForEachPlayersFiltered {
+        filter,
+        effects: vec![EffectAst::RepeatEffects {
+            count: Value::PlayerVoteCount(PlayerFilter::IteratedPlayer),
+            effects,
+        }],
+    }))
 }
 
 fn parse_generic_extra_vote(tokens: &[OwnedLexToken]) -> Option<EffectAst> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -872,6 +872,38 @@ pub(crate) fn parse_deal_damage_with_amount(
         });
     }
 
+    if let Some(and_each_idx) = find_window_by(&target_words, 2, |window| {
+        ClauseShape::new()
+            .exact_any(&[&["and", "each"], &["and", "all"]])
+            .matches_words(window)
+    }) && and_each_idx > 0
+    {
+        let player_target_tokens = trim_commas(&target_tokens[..and_each_idx]);
+        let object_filter_tokens = trim_commas(&target_tokens[and_each_idx + 1..]);
+        if !player_target_tokens.is_empty()
+            && !object_filter_tokens.is_empty()
+            && let Ok(TargetAst::Player(player_filter, span)) = parse_target_phrase(&player_target_tokens)
+            && crate::runtime_backend::lexer::contains_token_any_word(
+                &object_filter_tokens,
+                &["creature", "creatures"],
+            )
+        {
+            let mut filter = parse_object_filter(&object_filter_tokens, false)?;
+            if filter.controller.is_none() {
+                filter.controller = Some(player_filter.clone());
+            }
+            return Ok(EffectAst::Sequence {
+                effects: vec![
+                    EffectAst::subject_verb_damage(
+                        amount.clone(),
+                        TargetAst::Player(player_filter, span),
+                    ),
+                    EffectAst::subject_verb_damage_each(amount.clone(), filter),
+                ],
+            });
+        }
+    }
+
     if combat_words_start_with_shape(&target_words, &COMBAT_EACH_OR_ALL_WORD_PATTERN)
         && let Some(and_each_idx) = find_window_by(&target_words, 3, |window| {
             ClauseShape::new()

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3028,6 +3028,10 @@ pub enum VoteChoice<E> {
         filter: ObjectFilter,
         count: ChoiceCount,
     },
+    Players {
+        filter: PlayerFilter,
+        exclude_voter: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3108,6 +3112,31 @@ impl<E> VoteEffect<E> {
     ) -> Self {
         Self {
             choice: VoteChoice::Objects { filter, count },
+            controller_extra_votes,
+            controller_optional_extra_votes,
+            secret: false,
+        }
+    }
+
+    pub fn vote_players(
+        filter: PlayerFilter,
+        exclude_voter: bool,
+        controller_extra_votes: u32,
+    ) -> Self {
+        Self::vote_players_with_optional_extra(filter, exclude_voter, controller_extra_votes, 0)
+    }
+
+    pub fn vote_players_with_optional_extra(
+        filter: PlayerFilter,
+        exclude_voter: bool,
+        controller_extra_votes: u32,
+        controller_optional_extra_votes: u32,
+    ) -> Self {
+        Self {
+            choice: VoteChoice::Players {
+                filter,
+                exclude_voter,
+            },
             controller_extra_votes,
             controller_optional_extra_votes,
             secret: false,

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -168,6 +168,7 @@ pub enum Value {
     CountersOn(Box<ChooseSpec>, Option<CounterType>),
     TaggedCount,
     VoteCount(String),
+    PlayerVoteCount(PlayerFilter),
 }
 
 impl Value {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -53616,6 +53616,7 @@ fn strict_parse_vote_regression_cards() {
         "Tivit, Seller of Secrets",
         "Elrond of the White Council",
         "Travel Through Caradhras",
+        "Mob Verdict",
     ] {
         assert_oracle_card_parses_strict(name);
     }
@@ -53992,6 +53993,170 @@ fn travel_through_caradhras_runtime_mines_votes_return_graveyard_cards_without_s
         vec!["Travel Through Caradhras".to_string()],
         "Travel Through Caradhras should exile itself after resolving"
     );
+}
+
+#[test]
+fn mob_verdict_strict_parser_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Mob Verdict");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "Secret council — Each player secretly votes for another player, then those votes are revealed"
+        ) && rendered.contains(
+            "For each vote an opponent received, Mob Verdict deals 2 damage to that player and each creature that player controls"
+        ) && rendered.contains("For each vote you received, draw a card"),
+        "expected Mob Verdict to render secret player votes and received-vote followups, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("Unsupported effect"),
+        "Mob Verdict should parse strictly without unsupported placeholders, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("VoteEffect")
+            && debug.contains("Players")
+            && debug.contains("exclude_voter: true")
+            && debug.contains("PlayerVoteCount")
+            && debug.contains("ForPlayersEffect")
+            && debug.contains("DealDamageEffect")
+            && debug.contains("DrawCardsEffect"),
+        "expected player-vote counts, opponent damage, controlled-creature damage, and draw structurally, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct MobVerdictDecisionMaker {
+    votes: Vec<usize>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for MobVerdictDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if !self.votes.is_empty() {
+            vec![self.votes.remove(0)]
+        } else {
+            ctx.options
+                .iter()
+                .filter(|option| option.legal)
+                .map(|option| option.index)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn mob_test_creature(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn mob_test_card(id: u32, name: &str) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(id), name)
+        .card_types(vec![CardType::Instant])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn mob_owner_zone_count(
+    game: &crate::game_state::GameState,
+    owner: PlayerId,
+    zone: Zone,
+) -> usize {
+    game.objects_in_zone(zone)
+        .into_iter()
+        .filter(|&id| game.object(id).is_some_and(|object| object.owner == owner))
+        .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_mob_verdict_with_votes(
+    votes: Vec<usize>,
+    alice_library_cards: usize,
+) -> (crate::game_state::GameState, ObjectId, ObjectId, ObjectId) {
+    let def = parse_oracle_card_definition("Mob Verdict");
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Mob Verdict should compile to spell effects");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+
+    let alice_creature = mob_test_creature(91_301, "Alice Mob Creature");
+    let bob_creature = mob_test_creature(91_302, "Bob Mob Creature");
+    let charlie_creature = mob_test_creature(91_303, "Charlie Mob Creature");
+    let filler = mob_test_card(91_304, "Mob Draw Filler");
+    let alice_creature_id = game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+    let bob_creature_id = game.create_object_from_definition(&bob_creature, bob, Zone::Battlefield);
+    let charlie_creature_id =
+        game.create_object_from_definition(&charlie_creature, charlie, Zone::Battlefield);
+    for _ in 0..alice_library_cards {
+        game.create_object_from_definition(&filler, alice, Zone::Library);
+    }
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = MobVerdictDecisionMaker { votes };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        program,
+        None,
+        &[],
+    )
+    .expect("Mob Verdict should resolve");
+    (game, alice_creature_id, bob_creature_id, charlie_creature_id)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mob_verdict_runtime_opponent_votes_damage_players_and_their_creatures_without_you_draw() {
+    let (game, alice_creature, bob_creature, charlie_creature) =
+        resolve_mob_verdict_with_votes(vec![0, 1, 1], 0);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    assert_eq!(game.player(alice).unwrap().life, 20, "Alice received no votes and should not be damaged");
+    assert_eq!(game.player(bob).unwrap().life, 16, "Bob received two votes and should take 4 damage");
+    assert_eq!(game.player(charlie).unwrap().life, 18, "Charlie received one vote and should take 2 damage");
+    assert_eq!(game.damage_on(alice_creature), 0, "Alice's creature should not be damaged by opponent-only vote followup");
+    assert_eq!(game.damage_on(bob_creature), 4, "Bob's creature should be damaged once per vote Bob received");
+    assert_eq!(game.damage_on(charlie_creature), 2, "Charlie's creature should be damaged once per vote Charlie received");
+    assert_eq!(mob_owner_zone_count(&game, alice, Zone::Hand), 0, "Alice should not draw when she received no votes");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mob_verdict_runtime_votes_you_received_draw_cards_without_opponent_damage_to_you() {
+    let (game, alice_creature, bob_creature, charlie_creature) =
+        resolve_mob_verdict_with_votes(vec![1, 0, 0], 3);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+
+    assert_eq!(mob_owner_zone_count(&game, alice, Zone::Hand), 2, "Alice should draw once for each vote she received");
+    assert_eq!(mob_owner_zone_count(&game, alice, Zone::Library), 1, "drawing two cards should leave one filler in Alice's library");
+    assert_eq!(game.player(alice).unwrap().life, 20, "votes Alice received should draw cards, not damage Alice");
+    assert_eq!(game.damage_on(alice_creature), 0, "Alice's creature should not be damaged by votes Alice received");
+    assert_eq!(game.player(bob).unwrap().life, 20, "Bob received no votes and should not be damaged");
+    assert_eq!(game.damage_on(bob_creature), 0, "Bob's creature should not be damaged without Bob receiving votes");
+    assert_eq!(game.player(charlie).unwrap().life, 18, "Charlie received Alice's vote and should take 2 damage");
+    assert_eq!(game.damage_on(charlie_creature), 2, "Charlie's creature should be damaged for Charlie's received vote");
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -54099,7 +54099,8 @@ fn resolve_mob_verdict_with_votes(
     let bob_creature = mob_test_creature(91_302, "Bob Mob Creature");
     let charlie_creature = mob_test_creature(91_303, "Charlie Mob Creature");
     let filler = mob_test_card(91_304, "Mob Draw Filler");
-    let alice_creature_id = game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+    let alice_creature_id =
+        game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
     let bob_creature_id = game.create_object_from_definition(&bob_creature, bob, Zone::Battlefield);
     let charlie_creature_id =
         game.create_object_from_definition(&charlie_creature, charlie, Zone::Battlefield);
@@ -54157,6 +54158,58 @@ fn mob_verdict_runtime_votes_you_received_draw_cards_without_opponent_damage_to_
     assert_eq!(game.damage_on(bob_creature), 0, "Bob's creature should not be damaged without Bob receiving votes");
     assert_eq!(game.player(charlie).unwrap().life, 18, "Charlie received Alice's vote and should take 2 damage");
     assert_eq!(game.damage_on(charlie_creature), 2, "Charlie's creature should be damaged for Charlie's received vote");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn mob_verdict_runtime_another_player_vote_has_no_legal_self_vote() {
+    let def = parse_oracle_card_definition("Mob Verdict");
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Mob Verdict should compile to spell effects");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice_creature = mob_test_creature(91_305, "Solo Mob Creature");
+    let filler = mob_test_card(91_306, "Solo Mob Draw Filler");
+    let alice_creature_id =
+        game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
+    game.create_object_from_definition(&filler, alice, Zone::Library);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = MobVerdictDecisionMaker { votes: vec![0] };
+    let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        program,
+        None,
+        &[],
+    )
+    .expect("Mob Verdict should resolve even when no another-player vote is legal");
+
+    assert_eq!(
+        game.player(alice).unwrap().life,
+        20,
+        "Alice should not damage herself when another-player voting has no legal candidate"
+    );
+    assert_eq!(
+        game.damage_on(alice_creature_id),
+        0,
+        "Alice's creature should not be damaged when Alice cannot vote for herself"
+    );
+    assert_eq!(
+        mob_owner_zone_count(&game, alice, Zone::Hand),
+        0,
+        "Alice should not draw because no player received a vote"
+    );
+    assert_eq!(
+        mob_owner_zone_count(&game, alice, Zone::Library),
+        1,
+        "the draw followup should not consume Alice's library card when no vote was cast"
+    );
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -54081,7 +54081,13 @@ fn mob_owner_zone_count(
 fn resolve_mob_verdict_with_votes(
     votes: Vec<usize>,
     alice_library_cards: usize,
-) -> (crate::game_state::GameState, ObjectId, ObjectId, ObjectId) {
+) -> (
+    crate::game_state::GameState,
+    ObjectId,
+    ObjectId,
+    ObjectId,
+    ObjectId,
+) {
     let def = parse_oracle_card_definition("Mob Verdict");
     let program = def
         .spell_effect
@@ -54098,12 +54104,15 @@ fn resolve_mob_verdict_with_votes(
     let alice_creature = mob_test_creature(91_301, "Alice Mob Creature");
     let bob_creature = mob_test_creature(91_302, "Bob Mob Creature");
     let charlie_creature = mob_test_creature(91_303, "Charlie Mob Creature");
+    let bob_second_creature = mob_test_creature(91_305, "Second Bob Mob Creature");
     let filler = mob_test_card(91_304, "Mob Draw Filler");
     let alice_creature_id =
         game.create_object_from_definition(&alice_creature, alice, Zone::Battlefield);
     let bob_creature_id = game.create_object_from_definition(&bob_creature, bob, Zone::Battlefield);
     let charlie_creature_id =
         game.create_object_from_definition(&charlie_creature, charlie, Zone::Battlefield);
+    let bob_second_creature_id =
+        game.create_object_from_definition(&bob_second_creature, bob, Zone::Battlefield);
     for _ in 0..alice_library_cards {
         game.create_object_from_definition(&filler, alice, Zone::Library);
     }
@@ -54120,13 +54129,19 @@ fn resolve_mob_verdict_with_votes(
         &[],
     )
     .expect("Mob Verdict should resolve");
-    (game, alice_creature_id, bob_creature_id, charlie_creature_id)
+    (
+        game,
+        alice_creature_id,
+        bob_creature_id,
+        charlie_creature_id,
+        bob_second_creature_id,
+    )
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn mob_verdict_runtime_opponent_votes_damage_players_and_their_creatures_without_you_draw() {
-    let (game, alice_creature, bob_creature, charlie_creature) =
+    let (game, alice_creature, bob_creature, charlie_creature, bob_second_creature) =
         resolve_mob_verdict_with_votes(vec![0, 1, 1], 0);
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
@@ -54137,6 +54152,11 @@ fn mob_verdict_runtime_opponent_votes_damage_players_and_their_creatures_without
     assert_eq!(game.player(charlie).unwrap().life, 18, "Charlie received one vote and should take 2 damage");
     assert_eq!(game.damage_on(alice_creature), 0, "Alice's creature should not be damaged by opponent-only vote followup");
     assert_eq!(game.damage_on(bob_creature), 4, "Bob's creature should be damaged once per vote Bob received");
+    assert_eq!(
+        game.damage_on(bob_second_creature),
+        4,
+        "every creature Bob controls should be damaged once per vote Bob received"
+    );
     assert_eq!(game.damage_on(charlie_creature), 2, "Charlie's creature should be damaged once per vote Charlie received");
     assert_eq!(mob_owner_zone_count(&game, alice, Zone::Hand), 0, "Alice should not draw when she received no votes");
 }
@@ -54144,7 +54164,7 @@ fn mob_verdict_runtime_opponent_votes_damage_players_and_their_creatures_without
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn mob_verdict_runtime_votes_you_received_draw_cards_without_opponent_damage_to_you() {
-    let (game, alice_creature, bob_creature, charlie_creature) =
+    let (game, alice_creature, bob_creature, charlie_creature, _bob_second_creature) =
         resolve_mob_verdict_with_votes(vec![1, 0, 0], 3);
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8178,6 +8178,9 @@ pub(crate) fn describe_value(value: &Value) -> String {
             }
         }
         Value::VoteCount(option) => format!("the number of {} votes", option.to_ascii_lowercase()),
+        Value::PlayerVoteCount(filter) => {
+            format!("the number of votes {} received", filter.description())
+        }
         Value::Count(filter) => {
             format!(
                 "the number of {}",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2949,6 +2949,96 @@ fn copy_spell_from_effect(effect: &Effect) -> Option<&crate::effects::CopySpellE
     None
 }
 
+fn describe_for_players_vote_received_repeat(
+    for_players: &crate::effects::ForPlayersEffect,
+) -> Option<String> {
+    let [effect] = for_players.effects.as_slice() else {
+        return None;
+    };
+    let repeat = effect.downcast_ref::<crate::effects::RepeatEffectsEffect>()?;
+    if repeat.count != Value::PlayerVoteCount(PlayerFilter::IteratedPlayer) {
+        return None;
+    }
+
+    let player = match for_players.filter {
+        PlayerFilter::Opponent => "an opponent".to_string(),
+        PlayerFilter::You => "you".to_string(),
+        PlayerFilter::Any => "a player".to_string(),
+        _ => strip_leading_article(&describe_player_filter(&for_players.filter)).to_string(),
+    };
+    let repeated = describe_damage_and_controlled_damage_pair(&repeat.effects)
+        .unwrap_or_else(|| describe_effect_list(&repeat.effects));
+    let repeated = lowercase_first(repeated.trim().trim_end_matches('.'));
+    Some(format!("For each vote {player} received, {repeated}"))
+}
+
+fn describe_damage_and_controlled_damage_pair(effects: &[Effect]) -> Option<String> {
+    fn source_damage(
+        effect: &Effect,
+    ) -> Option<(Option<&ChooseSpec>, &crate::effects::DealDamageEffect)> {
+        if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+            return source_damage(&tagged.effect);
+        }
+        if let Some(with_source) = effect.downcast_ref::<crate::effects::ExecuteWithSourceEffect>()
+            && let Some(damage) = with_source
+                .effect
+                .downcast_ref::<crate::effects::DealDamageEffect>()
+        {
+            return Some((Some(&with_source.source), damage));
+        }
+        effect
+            .downcast_ref::<crate::effects::DealDamageEffect>()
+            .map(|damage| (None, damage))
+    }
+
+    fn source_for_each(
+        effect: &Effect,
+    ) -> Option<(Option<&ChooseSpec>, &crate::effects::ForEachObject)> {
+        if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+            return source_for_each(&tagged.effect);
+        }
+        if let Some(with_source) = effect.downcast_ref::<crate::effects::ExecuteWithSourceEffect>()
+            && let Some(for_each) = with_source
+                .effect
+                .downcast_ref::<crate::effects::ForEachObject>()
+        {
+            return Some((Some(&with_source.source), for_each));
+        }
+        effect
+            .downcast_ref::<crate::effects::ForEachObject>()
+            .map(|for_each| (None, for_each))
+    }
+
+    let [first, second] = effects else {
+        return None;
+    };
+    let (source, player_damage) = source_damage(first)?;
+    if !matches!(
+        player_damage.target,
+        ChooseSpec::Player(PlayerFilter::IteratedPlayer)
+    ) {
+        return None;
+    }
+    let (for_each_source, for_each) = source_for_each(second)?;
+    let [inner] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let (inner_source, object_damage) = source_damage(inner)?;
+    if object_damage.amount != player_damage.amount || !matches!(object_damage.target, ChooseSpec::Iterated)
+    {
+        return None;
+    }
+    let mut objects = describe_each_controlled_by_iterated(&for_each.filter)?;
+    objects = objects.replace(" they control", " that player controls");
+    let amount = describe_damage_amount_clause(&player_damage.amount).0;
+    if let Some(subject) = source.or(for_each_source).or(inner_source).map(describe_choose_spec) {
+        return Some(format!(
+            "{subject} deals {amount} to that player and {objects}"
+        ));
+    }
+    Some(format!("Deal {amount} to that player and {objects}"))
+}
+
 fn tagged_copy_spell_from_effect(
     effect: &Effect,
 ) -> Option<(&crate::TagKey, &crate::effects::CopySpellEffect)> {
@@ -4931,6 +5021,9 @@ fn may_cast_copy_targets_tag(effect: &Effect, tag: &str) -> bool {
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_vote_with_received_vote_followups(effects) {
+        return compact;
+    }
     if let Some(compact) = describe_reveal_top_to_hand_then_lose_mana_value_effects(effects) {
         return compact;
     }
@@ -15667,6 +15760,42 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     cleanup_decompiled_text(&text)
 }
 
+fn describe_vote_with_received_vote_followups(effects: &[Effect]) -> Option<String> {
+    let [first, rest @ ..] = effects else {
+        return None;
+    };
+    first.downcast_ref::<crate::effects::VoteEffect>()?;
+    if rest.is_empty() {
+        return None;
+    }
+    let structurally_received_vote_followups = rest.iter().all(|effect| {
+        if let Some(for_players) = effect.downcast_ref::<crate::effects::ForPlayersEffect>() {
+            return for_players.effects.len() == 1
+                && for_players.effects[0]
+                    .downcast_ref::<crate::effects::RepeatEffectsEffect>()
+                    .is_some_and(|repeat| {
+                        repeat.count == Value::PlayerVoteCount(PlayerFilter::IteratedPlayer)
+                    });
+        }
+        effect
+            .downcast_ref::<crate::effects::RepeatEffectsEffect>()
+            .is_some_and(|repeat| matches!(repeat.count, Value::PlayerVoteCount(_)))
+    });
+    let rendered = effects
+        .iter()
+        .map(describe_effect)
+        .filter(|text| !text.trim().is_empty())
+        .collect::<Vec<_>>();
+    let rendered_received_vote_followups = rendered
+        .iter()
+        .skip(1)
+        .all(|text| text.starts_with("For each vote ") && text.contains(" received,"));
+    if !structurally_received_vote_followups && !rendered_received_vote_followups {
+        return None;
+    }
+    Some(rendered.join(". "))
+}
+
 fn normalize_haunting_echoes_text(text: &str) -> Option<String> {
     let expected = concat!(
         "Exile all nonland cards in target player's graveyard or nonbasic cards in target player's graveyard. ",
@@ -16475,6 +16604,8 @@ pub(super) fn cleanup_decompiled_text(text: &str) -> String {
     }
 
     for (from, to) in [
+        ("votes are revealed, for each vote", "votes are revealed. For each vote"),
+        (", then for each vote", ". For each vote"),
         ("you gets", "you get"),
         ("you puts", "you put"),
         ("a artifact", "an artifact"),
@@ -30456,6 +30587,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(compact) = describe_for_players_target_return_unless_draw(for_players) {
             return compact;
         }
+        if let Some(compact) = describe_for_players_vote_received_repeat(for_players) {
+            return compact;
+        }
         if let Some(compact) =
             describe_each_player_return_all_from_their_graveyard_with_counters(for_players)
         {
@@ -36925,6 +37059,16 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     pluralize_noun_phrase(&strip_leading_article(&filter.description()))
                 ),
             },
+            crate::effects::VoteChoice::Players {
+                filter,
+                exclude_voter,
+            } => {
+                if *exclude_voter && *filter == PlayerFilter::Any {
+                    "another player".to_string()
+                } else {
+                    strip_leading_article(&describe_player_filter(filter)).to_string()
+                }
+            }
         };
         let mut suffix = String::new();
         if vote.controller_extra_votes > 0 {
@@ -36950,6 +37094,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             ));
         }
         if vote.secret {
+            if matches!(vote.choice, crate::effects::VoteChoice::Players { .. }) {
+                return format!(
+                    "Secret council — Each player secretly votes for {}, then those votes are revealed{}",
+                    choices, suffix
+                );
+            }
             return format!(
                 "Each player secretly votes for {}, then those votes are revealed{}",
                 choices, suffix
@@ -36970,6 +37120,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 option.to_ascii_lowercase(),
                 repeated
             );
+        }
+        if let Value::PlayerVoteCount(filter) = &repeat.count {
+            let player = match filter {
+                PlayerFilter::IteratedPlayer => "that player".to_string(),
+                PlayerFilter::You => "you".to_string(),
+                _ => strip_leading_article(&describe_player_filter(filter)).to_string(),
+            };
+            return format!("For each vote {player} received, {repeated}");
         }
         if repeat
             .count

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4091,6 +4091,7 @@ fn resolve_value_with_context(
 
         Value::X => 0, // X is 0 unless specified (resolved at cast time, not layer time)
         Value::VoteCount(_) => 0,
+        Value::PlayerVoteCount(_) => 0,
 
         Value::Count(filter) => {
             let filter_ctx = continuous_filter_context(ctx.game, controller, source);

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1348,6 +1348,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::X
         | Value::XTimes(_)
         | Value::VoteCount(_)
+        | Value::PlayerVoteCount(_)
         | Value::Count(_)
         | Value::CountScaled(_, _)
         | Value::GreatestCount(_)

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -808,6 +808,16 @@ where
                 )
                 .with_secret(payload.secret)
             }
+            ironsmith_core::VoteChoice::Players {
+                filter,
+                exclude_voter,
+            } => crate::effects::VoteEffect::vote_players_with_optional_extra(
+                filter.clone(),
+                *exclude_voter,
+                payload.controller_extra_votes,
+                payload.controller_optional_extra_votes,
+            )
+            .with_secret(payload.secret),
         };
         return Ok(Effect::new(converted));
     }

--- a/crates/ironsmith-runtime/src/effects/composition/vote.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/vote.rs
@@ -7,7 +7,9 @@ use crate::effects::EffectExecutor;
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
 use crate::ids::ObjectId;
+use crate::ids::PlayerId;
 use crate::target::ChooseSpec;
+use crate::target::PlayerFilter;
 
 pub type VoteOption = ironsmith_core::VoteOption<Effect>;
 
@@ -16,6 +18,7 @@ pub type VoteOption = ironsmith_core::VoteOption<Effect>;
 pub struct VoteResult {
     pub option_counts: HashMap<String, usize>,
     pub object_counts: HashMap<ObjectId, usize>,
+    pub player_counts: HashMap<PlayerId, usize>,
     pub total_votes: usize,
 }
 
@@ -25,6 +28,13 @@ impl VoteResult {
             .iter()
             .find_map(|(name, count)| name.eq_ignore_ascii_case(option).then_some(*count))
             .unwrap_or(0)
+    }
+
+    pub fn count_for_player_filter(&self, filter: &PlayerFilter) -> usize {
+        match filter {
+            PlayerFilter::Specific(player) => self.player_counts.get(player).copied().unwrap_or(0),
+            _ => 0,
+        }
     }
 
     pub fn option_gets_more_votes(&self, option: &str) -> bool {

--- a/crates/ironsmith-runtime/src/effects/composition/vote_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/vote_runtime.rs
@@ -8,6 +8,7 @@ use crate::decisions::spec::DisplayOption;
 use crate::decisions::specs::{ChoiceSpec, ChooseObjectsSpec};
 use crate::decisions::{make_boolean_decision, make_decision};
 use crate::effect::EffectOutcome;
+use crate::effects::helpers::resolve_player_filter_to_list;
 use crate::effects::InvestigateEffect;
 use crate::effects::{ExecutionContext, ExecutionError, execute_effect};
 use crate::events::{
@@ -284,6 +285,91 @@ fn collect_object_votes(
     Some((votes, vote_counts))
 }
 
+fn candidate_player_ids_for_vote(
+    effect: &VoteEffect,
+    game: &GameState,
+    ctx: &mut ExecutionContext,
+    voter: PlayerId,
+) -> Result<Vec<PlayerId>, ExecutionError> {
+    let VoteChoice::Players {
+        filter,
+        exclude_voter,
+    } = &effect.choice
+    else {
+        return Ok(Vec::new());
+    };
+
+    let mut candidates = ctx.with_temp_iterated_player(Some(voter), |ctx| {
+        let filter_ctx = ctx.filter_context(game);
+        resolve_player_filter_to_list(game, filter, &filter_ctx, ctx)
+    })?;
+    if *exclude_voter {
+        candidates.retain(|player| *player != voter);
+    }
+    candidates.sort_by_key(|player| player.0);
+    candidates.dedup();
+    Ok(candidates)
+}
+
+fn collect_player_votes(
+    effect: &VoteEffect,
+    game: &mut GameState,
+    ctx: &mut ExecutionContext,
+    players: &[PlayerId],
+) -> Result<Option<(Vec<PlayerVote>, HashMap<PlayerId, usize>)>, ExecutionError> {
+    if !matches!(effect.choice, VoteChoice::Players { .. }) {
+        return Ok(None);
+    }
+
+    let mut votes: Vec<PlayerVote> = Vec::new();
+    let mut vote_counts: HashMap<PlayerId, usize> = HashMap::new();
+
+    for &player_id in players {
+        let num_votes = vote_instances_for_player(effect, game, ctx, player_id);
+        for _ in 0..num_votes {
+            let candidates = candidate_player_ids_for_vote(effect, game, ctx, player_id)?;
+            let options = candidates
+                .iter()
+                .filter_map(|candidate| {
+                    game.player(*candidate)
+                        .map(|player| (player.name.clone(), *candidate))
+                })
+                .collect::<Vec<_>>();
+            let Some(chosen) = (!options.is_empty())
+                .then(|| {
+                    crate::decisions::ask_choose_one(
+                        game,
+                        &mut ctx.decision_maker,
+                        player_id,
+                        ctx.source,
+                        &options,
+                    )
+                })
+                .flatten()
+            else {
+                continue;
+            };
+            if ctx.decision_maker.awaiting_choice() {
+                return Ok(None);
+            }
+
+            let option_name = game
+                .player(chosen)
+                .map(|player| player.name.clone())
+                .unwrap_or_else(|| "player".to_string());
+            *vote_counts.entry(chosen).or_default() += 1;
+            votes.push(PlayerVote {
+                player: player_id,
+                option_index: chosen.0 as usize,
+                option_name,
+                object_vote: None,
+            });
+        }
+    }
+
+    Ok(Some((votes, vote_counts)))
+}
+
 fn build_vote_counts_map(vote_counts: &[usize]) -> HashMap<usize, usize> {
     vote_counts
         .iter()
@@ -332,7 +418,9 @@ fn queue_vote_events(
         VoteChoice::NamedOptions(options) => {
             options.iter().map(|option| option.name.clone()).collect()
         }
-        VoteChoice::Objects { .. } => votes.iter().map(|vote| vote.option_name.clone()).collect(),
+        VoteChoice::Objects { .. } | VoteChoice::Players { .. } => {
+            votes.iter().map(|vote| vote.option_name.clone()).collect()
+        }
     };
     let voting_event = PlayersFinishedVotingEvent::new(
         ctx.source,
@@ -536,6 +624,25 @@ pub(crate) fn run_vote(
             let mut vote_counts_map: HashMap<usize, usize> = HashMap::new();
             for (object_id, count) in object_vote_counts {
                 vote_counts_map.insert(object_id.0 as usize, count);
+            }
+            queue_vote_events(effect, game, ctx, &votes, vote_counts_map);
+            Ok(EffectOutcome::resolved())
+        }
+        VoteChoice::Players { .. } => {
+            let Some((votes, player_vote_counts)) =
+                collect_player_votes(effect, game, ctx, &players)?
+            else {
+                return Ok(EffectOutcome::count(0));
+            };
+
+            let mut result = VoteResult::default();
+            result.total_votes = votes.len();
+            result.player_counts = player_vote_counts.clone();
+            ctx.vote_results.insert(ctx.source, result);
+
+            let mut vote_counts_map: HashMap<usize, usize> = HashMap::new();
+            for (player_id, count) in player_vote_counts {
+                vote_counts_map.insert(player_id.0 as usize, count);
             }
             queue_vote_events(effect, game, ctx, &votes, vote_counts_map);
             Ok(EffectOutcome::resolved())

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1795,6 +1795,18 @@ pub fn resolve_value(
             .get(&ctx.source)
             .map(|result| result.count_for_option(option) as i32)
             .unwrap_or(0)),
+        Value::PlayerVoteCount(filter) => {
+            let resolved_filter = resolve_player_filter(game, filter, ctx)?;
+            Ok(ctx
+                .vote_results
+                .get(&ctx.source)
+                .map(|result| {
+                    result.count_for_player_filter(&crate::target::PlayerFilter::Specific(
+                        resolved_filter,
+                    )) as i32
+                })
+                .unwrap_or(0))
+        }
     }
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mob Verdict
Initial parse error:
```
vote clause requires at least two options; oracle-only fallback also failed: vote clause requires at least two options
```

Current worker: i-0f6e3c7d39fef411a
Branch: codex/aws-card-fix-mob-verdict
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0016
