### PR TITLE
Fix Ironsmith parse failure: Divine Deflection

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1693,8 +1693,37 @@ fn compile_subject_verb_effect(
             target,
             duration,
             source_of_your_choice,
+            protect_you_and_permanents_you_control,
+            follow_up_effects,
         } => {
             let amount = resolve_value_it_tag(amount, &current_reference_env(ctx))?;
+            let (follow_up_effects, follow_up_choices) = if follow_up_effects.is_empty() {
+                (Vec::new(), Vec::new())
+            } else {
+                let mut follow_up_ctx = EffectLoweringContext::from_parts(
+                    ctx.id_gen_context(),
+                    ctx.lowering_frame(),
+                );
+                follow_up_ctx.allow_life_event_value = true;
+                let compiled = compile_effects(follow_up_effects, &mut follow_up_ctx)?;
+                ctx.apply_id_gen_context(follow_up_ctx.id_gen_context());
+                compiled
+            };
+            if *protect_you_and_permanents_you_control {
+                let mut prevent = crate::effects::PreventDamageEffect::new(
+                    amount,
+                    ChooseSpec::SourceController,
+                    duration.clone(),
+                )
+                .protecting_you_and_permanents_you_control();
+                if *source_of_your_choice {
+                    prevent = prevent.with_source_of_your_choice();
+                }
+                if !follow_up_effects.is_empty() {
+                    prevent = prevent.with_follow_up_effects(follow_up_effects);
+                }
+                return Ok((vec![Effect::new(prevent)], follow_up_choices));
+            }
             if let TargetAst::Object(filter, explicit_target_span, _) = target
                 && explicit_target_span.is_none()
             {
@@ -1707,19 +1736,41 @@ fn compile_subject_verb_effect(
                         duration.clone(),
                     )],
                 );
-                Ok((vec![effect], Vec::new()))
+                Ok((vec![effect], follow_up_choices))
             } else {
-                compile_effect_for_target(target, ctx, |spec| {
+                let (effects, mut choices) = compile_effect_for_target(target, ctx, |spec| {
                     if *source_of_your_choice {
-                        Effect::prevent_damage_with_source_choice(
+                        let mut prevent = crate::effects::PreventDamageEffect::new(
                             amount.clone(),
                             spec,
                             duration.clone(),
                         )
+                        .with_source_of_your_choice();
+                        if !follow_up_effects.is_empty() {
+                            prevent = prevent.with_follow_up_effects(follow_up_effects.clone());
+                        }
+                        Effect::new(prevent)
+                    } else if !follow_up_effects.is_empty() {
+                        Effect::new(
+                            crate::effects::PreventDamageEffect::new(
+                                amount.clone(),
+                                spec,
+                                duration.clone(),
+                            )
+                            .with_follow_up_effects(follow_up_effects.clone()),
+                        )
                     } else {
-                        Effect::prevent_damage(amount.clone(), spec, duration.clone())
+                        Effect::prevent_damage(
+                            amount.clone(),
+                            spec,
+                            duration.clone(),
+                        )
                     }
-                })
+                })?;
+                if !follow_up_effects.is_empty() {
+                    choices.extend(follow_up_choices);
+                }
+                Ok((effects, choices))
             }
         }
         SubjectVerbActionAst::PreventAllDamageToTarget { target, duration } => {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1030,6 +1030,8 @@ pub(crate) enum SubjectVerbActionAst {
         target: TargetAst,
         duration: Until,
         source_of_your_choice: bool,
+        protect_you_and_permanents_you_control: bool,
+        follow_up_effects: Vec<EffectAst>,
     },
     PreventAllDamageToTarget {
         target: TargetAst,
@@ -2218,12 +2220,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 amount,
                 target,
                 duration,
+                follow_up_effects,
                 ..
             } => f
                 .debug_struct("PreventDamage")
                 .field("amount", amount)
                 .field("target", target)
                 .field("duration", duration)
+                .field("follow_up_effects", follow_up_effects)
                 .finish(),
             Self::PreventAllDamageToTarget { target, duration } => f
                 .debug_struct("PreventAllDamageToTarget")
@@ -3711,6 +3715,24 @@ impl EffectAst {
         duration: Until,
         source_of_your_choice: bool,
     ) -> Self {
+        Self::subject_verb_prevent_damage_with_options(
+            amount,
+            target,
+            duration,
+            source_of_your_choice,
+            false,
+            Vec::new(),
+        )
+    }
+
+    pub(crate) fn subject_verb_prevent_damage_with_options(
+        amount: Value,
+        target: TargetAst,
+        duration: Until,
+        source_of_your_choice: bool,
+        protect_you_and_permanents_you_control: bool,
+        follow_up_effects: Vec<EffectAst>,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
@@ -3719,6 +3741,8 @@ impl EffectAst {
                 target,
                 duration,
                 source_of_your_choice,
+                protect_you_and_permanents_you_control,
+                follow_up_effects,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -782,14 +782,30 @@ pub(crate) fn parse_prevent_next_damage_clause(
             clause_text
         )));
     }
-    let target = parse_target_phrase(target_clause.tokens())?;
+    let target_words = target_clause.word_refs();
+    let protects_you_and_permanents_you_control = matches!(
+        target_words.as_slice(),
+        ["you", "and/or", "permanents", "you", "control"]
+            | ["you", "and/or", "permanent", "you", "control"]
+            | ["you", "and", "or", "permanents", "you", "control"]
+            | ["you", "and", "or", "permanent", "you", "control"]
+            | ["you", "and", "permanents", "you", "control"]
+            | ["you", "and", "permanent", "you", "control"]
+    );
+    let target = if protects_you_and_permanents_you_control {
+        TargetAst::Player(PlayerFilter::You, span_from_tokens(target_clause.tokens()))
+    } else {
+        parse_target_phrase(target_clause.tokens())?
+    };
 
     Ok(Some(
-        EffectAst::subject_verb_prevent_damage_with_source_choice(
+        EffectAst::subject_verb_prevent_damage_with_options(
             amount,
             target,
             Until::EndOfTurn,
             source_of_your_choice,
+            protects_you_and_permanents_you_control,
+            Vec::new(),
         ),
     ))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
@@ -531,6 +531,75 @@ pub(crate) fn parse_damage_prevention_counter_sequence(
     ]))
 }
 
+pub(crate) fn parse_damage_prevention_reflect_to_any_target_sequence(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let Ok(first_effects) =
+        effect_sentences::parse_effect_sentence_lexed(sentences[sentence_idx].lowered())
+    else {
+        return Ok(None);
+    };
+    let Some(first_effect) = first_effects.first() else {
+        return Ok(None);
+    };
+    if first_effects.len() != 1 {
+        return Ok(None);
+    }
+
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action:
+            SubjectVerbActionAst::PreventDamage {
+                amount,
+                target,
+                duration,
+                source_of_your_choice,
+                protect_you_and_permanents_you_control,
+                ..
+            },
+        ..
+    }) = first_effect
+    else {
+        return Ok(None);
+    };
+
+    let second_clause = LexedClause::new(sentences[sentence_idx + 1].lowered()).trimmed();
+    let second_words = second_clause.word_refs();
+    let prefix = ["if", "damage", "is", "prevented", "this", "way"];
+    if !second_words.starts_with(&prefix) {
+        return Ok(None);
+    }
+    let Some(deals_idx) = second_words
+        .iter()
+        .position(|word| matches!(*word, "deal" | "deals"))
+    else {
+        return Ok(None);
+    };
+    if deals_idx <= prefix.len() {
+        return Ok(None);
+    }
+    if second_words.get(deals_idx + 1..)
+        != Some(&["that", "much", "damage", "to", "any", "target"][..])
+    {
+        return Ok(None);
+    }
+
+    let follow_up = EffectAst::subject_verb_damage(
+        Value::EventValue(EventValueSpec::Amount),
+        TargetAst::AnyTarget(None),
+    );
+    Ok(Some(vec![
+        EffectAst::subject_verb_prevent_damage_with_options(
+            amount.clone(),
+            target.clone(),
+            duration.clone(),
+            *source_of_your_choice,
+            *protect_you_and_permanents_you_control,
+            vec![follow_up],
+        ),
+    ]))
+}
+
 pub(crate) fn parse_next_damage_prevention_gain_life_sequence(
     sentences: &[SentenceInput],
     sentence_idx: usize,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -496,6 +496,14 @@ const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
         parser: generic_subject_verb_sequences::pairs::parse_gain_life_then_self_animate_source,
     },
     SequenceRuleDef {
+        name: "damage-prevention-then-damage-any-target",
+        feature_tag: Some("damage-prevention-followup"),
+        priority: 241,
+        consumed_sentences: 2,
+        predicate: first_word_prevent,
+        parser: generic_subject_verb_sequences::parse_damage_prevention_reflect_to_any_target_sequence,
+    },
+    SequenceRuleDef {
         name: "damage-prevention-then-put-counters",
         feature_tag: Some("damage-prevention-followup"),
         priority: 240,

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3586,6 +3586,7 @@ pub struct PreventDamageEffect<E> {
     pub until: Until,
     pub follow_up_effects: Vec<E>,
     pub source_of_your_choice: bool,
+    pub protect_you_and_permanents_you_control: bool,
 }
 
 impl<E> PreventDamageEffect<E> {
@@ -3596,6 +3597,7 @@ impl<E> PreventDamageEffect<E> {
             until,
             follow_up_effects: Vec::new(),
             source_of_your_choice: false,
+            protect_you_and_permanents_you_control: false,
         }
     }
 
@@ -3606,6 +3608,11 @@ impl<E> PreventDamageEffect<E> {
 
     pub fn with_source_of_your_choice(mut self) -> Self {
         self.source_of_your_choice = true;
+        self
+    }
+
+    pub fn protecting_you_and_permanents_you_control(mut self) -> Self {
+        self.protect_you_and_permanents_you_control = true;
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20746,6 +20746,194 @@ fn cho_arrim_alchemist_runtime_prevents_chosen_source_to_you_and_gains_that_life
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn divine_deflection_strict_parser_compiled_text_and_shape_regression() {
+    assert_oracle_card_parses_strict("Divine Deflection");
+    let def = parse_oracle_card_definition("Divine Deflection");
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.spell_effect);
+
+    assert!(
+        rendered.contains(
+            "Prevent the next X damage that would be dealt to you and/or permanents you control this turn"
+        ) && rendered.contains(
+            "If damage is prevented this way, this spell deals that much damage to any target"
+        ),
+        "expected Divine Deflection prevention and conditional damage text, got {rendered}"
+    );
+    assert!(
+        debug.contains("PreventDamageEffect")
+            && debug.contains("protect_you_and_permanents_you_control: true")
+            && debug.contains("DealDamageEffect")
+            && debug.contains("EventValue")
+            && debug.contains("Amount")
+            && debug.contains("target: AnyTarget"),
+        "expected Divine Deflection to compile to a shared prevention shield with prevented-damage follow-up, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn divine_deflection_runtime_prevents_shared_pool_and_damages_chosen_target() {
+    let def = parse_oracle_card_definition("Divine Deflection");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Divine Deflection should produce spell effects")
+        .clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_105), "Damage Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let alice_permanent = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_106), "Alice Permanent")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_x(5)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::AnyTarget,
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &spell,
+        None,
+        &[],
+    )
+    .expect("Divine Deflection should resolve");
+
+    let (alice_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(alice_damage, 0, "damage to Alice should be prevented");
+    assert_eq!(
+        game.life_total(bob),
+        17,
+        "prevented damage should be dealt to the chosen any-target player"
+    );
+
+    let (permanent_damage, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Object(alice_permanent),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        permanent_damage, 2,
+        "the shared prevention pool should have only 2 damage remaining"
+    );
+    assert_eq!(
+        game.life_total(bob),
+        15,
+        "the follow-up should deal only the amount actually prevented"
+    );
+
+    let (bob_damage, bob_prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(bob),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(bob_damage, 3, "damage to Bob should not be protected");
+    assert!(!bob_prevented, "unprotected damage should not trigger prevention");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn divine_deflection_runtime_does_not_damage_target_when_damage_cannot_be_prevented() {
+    let def = parse_oracle_card_definition("Divine Deflection");
+    let spell = def
+        .spell_effect
+        .as_ref()
+        .expect("Divine Deflection should produce spell effects")
+        .clone();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let damage_source = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_107), "Unpreventable Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let no_prevention = CardDefinitionBuilder::new(CardId::from_raw(91_108), "No Prevention")
+        .card_types(vec![CardType::Enchantment])
+        .with_ability(crate::ability::Ability::static_ability(
+            crate::static_abilities::StaticAbility::damage_cant_be_prevented(),
+        ))
+        .build();
+    game.create_object_from_definition(&no_prevention, bob, Zone::Battlefield);
+
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_source, alice, &mut dm)
+        .with_x(5)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::AnyTarget,
+            range: 0..1,
+        }]);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        spell_source,
+        &spell,
+        None,
+        &[],
+    )
+    .expect("Divine Deflection should resolve");
+
+    let (damage, prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        damage_source,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(damage, 3, "unpreventable damage should not be reduced");
+    assert!(!prevented, "unpreventable damage should not count as prevented");
+    assert_eq!(
+        game.life_total(bob),
+        20,
+        "the conditional follow-up should not happen when no damage was prevented"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_target_opponent_chooses_creature_then_other_cant_block() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Eunuchs Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20756,7 +20756,7 @@ fn divine_deflection_strict_parser_compiled_text_and_shape_regression() {
         rendered.contains(
             "Prevent the next X damage that would be dealt to you and/or permanents you control this turn"
         ) && rendered.contains(
-            "If damage is prevented this way, this spell deals that much damage to any target"
+            "If damage is prevented this way, Divine Deflection deals that much damage to any target"
         ),
         "expected Divine Deflection prevention and conditional damage text, got {rendered}"
     );

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -974,6 +974,8 @@ fn rewrite_spell_resolution_damage_source(def: &CardDefinition, rendered: &str) 
         return rendered.to_string();
     }
     let rendered = rewrite_damage_phrases_for_permanent_abilities(rendered, &def.card.name, false)
+        .replace("This spell deals ", &format!("{} deals ", def.card.name))
+        .replace("this spell deals ", &format!("{} deals ", def.card.name))
         .replace("Exile this source", &format!("Exile {}", def.card.name));
     let rendered = rewrite_standalone_spell_self_exile(&rendered, &def.card.name);
     rewrite_inline_spell_self_exile(&rendered, &def.card.name)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -866,6 +866,22 @@ fn prevention_gain_life_follow_up(
     Some(gain)
 }
 
+fn prevention_damage_any_target_follow_up(
+    follow_up_effects: &[Effect],
+) -> Option<&crate::effects::DealDamageEffect> {
+    let [effect] = follow_up_effects else {
+        return None;
+    };
+    let damage = unwrap_basic_tag_wrappers(effect).downcast_ref::<crate::effects::DealDamageEffect>()?;
+    if !matches!(damage.amount.unhinted(), Value::EventValue(EventValueSpec::Amount)) {
+        return None;
+    }
+    if !matches!(damage.target, ChooseSpec::AnyTarget) {
+        return None;
+    }
+    Some(damage)
+}
+
 fn describe_assigns_no_combat_damage(source: &ChooseSpec, until: &Until) -> Option<String> {
     if !matches!(until, Until::EndOfTurn) {
         return None;
@@ -35256,22 +35272,42 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             ""
         };
         if let Some(put) = prevention_put_counters_follow_up(&prevent_damage.follow_up_effects) {
+            let protected = if prevent_damage.protect_you_and_permanents_you_control {
+                "you and/or permanents you control".to_string()
+            } else {
+                describe_choose_spec(&prevent_damage.target)
+            };
             return format!(
                 "Prevent the next {} {} that would be dealt to {} {}{}. For each 1 damage prevented this way, put a {} counter on {}",
                 describe_value(&prevent_damage.amount),
                 damage_text,
-                describe_choose_spec(&prevent_damage.target),
+                protected,
                 timing,
                 source_text,
                 describe_counter_type(put.counter_type),
                 describe_prevention_follow_up_target(&prevent_damage.target)
             );
         }
+        let protected = if prevent_damage.protect_you_and_permanents_you_control {
+            "you and/or permanents you control".to_string()
+        } else {
+            describe_choose_spec(&prevent_damage.target)
+        };
+        if prevention_damage_any_target_follow_up(&prevent_damage.follow_up_effects).is_some() {
+            return format!(
+                "Prevent the next {} {} that would be dealt to {} {}{}. If damage is prevented this way, this spell deals that much damage to any target",
+                describe_value(&prevent_damage.amount),
+                damage_text,
+                protected,
+                timing,
+                source_text
+            );
+        }
         return format!(
             "Prevent the next {} {} that would be dealt to {} {}{}",
             describe_value(&prevent_damage.amount),
             damage_text,
-            describe_choose_spec(&prevent_damage.target),
+            protected,
             timing,
             source_text
         );

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -615,6 +615,8 @@ where
             hooks,
         )?);
         prevent.source_of_your_choice = payload.source_of_your_choice;
+        prevent.protect_you_and_permanents_you_control =
+            payload.protect_you_and_permanents_you_control;
         return Ok(Effect::new(prevent));
     }
     if let Some(converted) = clone_direct_effect::<M, crate::effects::LoseTheGameEffect>(&effect) {

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_combat_damage_from.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_combat_damage_from.rs
@@ -49,6 +49,7 @@ impl EffectExecutor for PreventAllCombatDamageFromEffect {
             self.until.clone(),
             filter,
             Vec::new(),
+            Vec::new(),
         );
         Ok(EffectOutcome::resolved())
     }

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_combat_damage_from.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_combat_damage_from.rs
@@ -50,6 +50,7 @@ impl EffectExecutor for PreventAllCombatDamageFromEffect {
             filter,
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         );
         Ok(EffectOutcome::resolved())
     }

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage.rs
@@ -45,6 +45,7 @@ impl EffectExecutor for PreventAllDamageEffect {
             self.until.clone(),
             self.damage_filter.clone(),
             Vec::new(),
+            Vec::new(),
         );
 
         Ok(EffectOutcome::resolved())

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage.rs
@@ -46,6 +46,7 @@ impl EffectExecutor for PreventAllDamageEffect {
             self.damage_filter.clone(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         );
 
         Ok(EffectOutcome::resolved())

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage_to_target.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage_to_target.rs
@@ -70,6 +70,7 @@ impl EffectExecutor for PreventAllDamageToTargetEffect {
             self.duration.clone(),
             self.damage_filter.clone(),
             self.follow_up_effects.clone(),
+            ctx.targets.clone(),
         );
 
         Ok(EffectOutcome::resolved())

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage_to_target.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage_to_target.rs
@@ -71,6 +71,7 @@ impl EffectExecutor for PreventAllDamageToTargetEffect {
             self.damage_filter.clone(),
             self.follow_up_effects.clone(),
             ctx.targets.clone(),
+            ctx.target_assignments.clone(),
         );
 
         Ok(EffectOutcome::resolved())

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
@@ -43,6 +43,8 @@ pub struct PreventDamageEffect {
     pub follow_up_effects: Vec<Effect>,
     /// Whether the source is chosen as the effect resolves.
     pub source_of_your_choice: bool,
+    /// Protect the controller and permanents they control with one shared shield.
+    pub protect_you_and_permanents_you_control: bool,
 }
 
 impl PreventDamageEffect {
@@ -55,6 +57,7 @@ impl PreventDamageEffect {
             damage_filter: DamageFilter::all(),
             follow_up_effects: Vec::new(),
             source_of_your_choice: false,
+            protect_you_and_permanents_you_control: false,
         }
     }
 
@@ -77,6 +80,12 @@ impl PreventDamageEffect {
     /// Execute these effects using the amount this shield prevented.
     pub fn with_follow_up_effects(mut self, effects: Vec<Effect>) -> Self {
         self.follow_up_effects = effects;
+        self
+    }
+
+    /// Protect the controller and permanents they control with one prevention pool.
+    pub fn protecting_you_and_permanents_you_control(mut self) -> Self {
+        self.protect_you_and_permanents_you_control = true;
         self
     }
 }
@@ -140,7 +149,11 @@ impl EffectExecutor for PreventDamageEffect {
             damage_filter.from_specific_source = Some(chosen_source);
         }
 
-        let protected = resolve_prevention_target_from_spec(game, &self.target, ctx)?;
+        let protected = if self.protect_you_and_permanents_you_control {
+            crate::prevention::PreventionTarget::YouAndPermanentsYouControl
+        } else {
+            resolve_prevention_target_from_spec(game, &self.target, ctx)?
+        };
         register_prevention_shield(
             game,
             ctx,
@@ -149,6 +162,7 @@ impl EffectExecutor for PreventDamageEffect {
             self.duration.clone(),
             damage_filter,
             self.follow_up_effects.clone(),
+            ctx.targets.clone(),
         );
 
         Ok(EffectOutcome::resolved())

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_damage.rs
@@ -163,6 +163,7 @@ impl EffectExecutor for PreventDamageEffect {
             damage_filter,
             self.follow_up_effects.clone(),
             ctx.targets.clone(),
+            ctx.target_assignments.clone(),
         );
 
         Ok(EffectOutcome::resolved())
@@ -290,5 +291,57 @@ mod tests {
         let effect = PreventDamageEffect::to_you(3, Until::EndOfTurn);
         let cloned = effect.clone_box();
         assert!(format!("{:?}", cloned).contains("PreventDamageEffect"));
+    }
+
+    #[test]
+    fn follow_up_effects_preserve_target_assignment_ranges() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let spell_source = game.new_object_id();
+        let damage_source = create_creature(&mut game, "Damage Source", bob);
+        let protected = create_creature(&mut game, "Protected", alice);
+        let protected_spec = ChooseSpec::target(ChooseSpec::Object(
+            crate::target::ObjectFilter::creature(),
+        ));
+        let follow_up_spec = ChooseSpec::AnyTarget;
+
+        let follow_up = Effect::deal_damage(
+            Value::EventValue(crate::effect::EventValueSpec::Amount),
+            follow_up_spec.clone(),
+        );
+        let effect = PreventDamageEffect::new(3, protected_spec.clone(), Until::EndOfTurn)
+            .with_follow_up_effects(vec![follow_up]);
+        let mut ctx = ExecutionContext::new_default(spell_source, alice)
+            .with_targets(vec![
+                ResolvedTarget::Object(protected),
+                ResolvedTarget::Player(bob),
+            ])
+            .with_target_assignments(vec![
+                crate::game_state::TargetAssignment {
+                    spec: protected_spec,
+                    range: 0..1,
+                },
+                crate::game_state::TargetAssignment {
+                    spec: follow_up_spec,
+                    range: 1..2,
+                },
+            ]);
+
+        effect
+            .execute(&mut game, &mut ctx)
+            .expect("prevention shield should register");
+        let (remaining, _replaced) = crate::events::processing::process_damage_with_event(
+            &mut game,
+            damage_source,
+            crate::events::DamageTarget::Object(protected),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+
+        assert_eq!(remaining, 0);
+        assert_eq!(game.life_total(bob), 18);
+        assert_eq!(game.damage_on(protected), 0);
     }
 }

--- a/crates/ironsmith-runtime/src/effects/combat/prevention_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevention_helpers.rs
@@ -44,10 +44,12 @@ pub fn register_prevention_shield(
     duration: Until,
     damage_filter: DamageFilter,
     follow_up_effects: Vec<Effect>,
+    follow_up_targets: Vec<ResolvedTarget>,
 ) -> PreventionShieldId {
     let shield = PreventionShield::new(ctx.source, ctx.controller, protected, amount, duration)
         .with_filter(damage_filter)
-        .with_follow_up_effects(follow_up_effects);
+        .with_follow_up_effects(follow_up_effects)
+        .with_follow_up_targets(follow_up_targets);
     game.effect_store.prevention_effects.add_shield(shield)
 }
 
@@ -103,6 +105,7 @@ mod tests {
             Some(3),
             Until::EndOfTurn,
             DamageFilter::all(),
+            Vec::new(),
             Vec::new(),
         );
 

--- a/crates/ironsmith-runtime/src/effects/combat/prevention_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevention_helpers.rs
@@ -1,7 +1,7 @@
 use crate::effect::{Effect, Until};
 use crate::effects::helpers::{resolve_objects_from_spec, resolve_players_from_spec};
 use crate::effects::{ExecutionContext, ExecutionError, ResolvedTarget};
-use crate::game_state::GameState;
+use crate::game_state::{GameState, TargetAssignment};
 use crate::prevention::{DamageFilter, PreventionShield, PreventionShieldId, PreventionTarget};
 use crate::target::ChooseSpec;
 
@@ -45,11 +45,13 @@ pub fn register_prevention_shield(
     damage_filter: DamageFilter,
     follow_up_effects: Vec<Effect>,
     follow_up_targets: Vec<ResolvedTarget>,
+    follow_up_target_assignments: Vec<TargetAssignment>,
 ) -> PreventionShieldId {
     let shield = PreventionShield::new(ctx.source, ctx.controller, protected, amount, duration)
         .with_filter(damage_filter)
         .with_follow_up_effects(follow_up_effects)
-        .with_follow_up_targets(follow_up_targets);
+        .with_follow_up_targets(follow_up_targets)
+        .with_follow_up_target_assignments(follow_up_target_assignments);
     game.effect_store.prevention_effects.add_shield(shield)
 }
 
@@ -105,6 +107,7 @@ mod tests {
             Some(3),
             Until::EndOfTurn,
             DamageFilter::all(),
+            Vec::new(),
             Vec::new(),
             Vec::new(),
         );

--- a/crates/ironsmith-runtime/src/effects/damage/deal_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/deal_damage.rs
@@ -312,6 +312,66 @@ impl EffectExecutor for DealDamageEffect {
             ));
         }
 
+        if matches!(
+            self.target.base(),
+            ChooseSpec::AnyTarget
+                | ChooseSpec::AnyOtherTarget
+                | ChooseSpec::PlayerOrPlaneswalker(_)
+        ) {
+            let mut found_assignment = false;
+            for assignment in &ctx.target_assignments {
+                if assignment.spec == self.target || assignment.spec.base() == self.target.base() {
+                    found_assignment = true;
+                    let Some(assigned_targets) = ctx.targets.get(assignment.range.clone()) else {
+                        continue;
+                    };
+                    for target in assigned_targets {
+                        match target {
+                            ResolvedTarget::Player(player_id) => {
+                                if !game
+                                    .player(*player_id)
+                                    .is_some_and(|player| player.is_in_game())
+                                {
+                                    continue;
+                                }
+                                return Ok(apply_processed_damage_outcome(
+                                    game,
+                                    ctx.source,
+                                    ctx.source_snapshot.as_ref(),
+                                    DamageTarget::Player(*player_id),
+                                    amount,
+                                    self.source_is_combat,
+                                    ctx.provenance,
+                                    ctx.cause.clone(),
+                                ));
+                            }
+                            ResolvedTarget::Object(object_id) => {
+                                if !game.object(*object_id).is_some_and(|obj| {
+                                    obj.has_card_type(CardType::Creature)
+                                        || obj.has_card_type(CardType::Planeswalker)
+                                }) {
+                                    continue;
+                                }
+                                return Ok(apply_processed_damage_outcome(
+                                    game,
+                                    ctx.source,
+                                    ctx.source_snapshot.as_ref(),
+                                    DamageTarget::Object(*object_id),
+                                    amount,
+                                    self.source_is_combat,
+                                    ctx.provenance,
+                                    ctx.cause.clone(),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            if found_assignment {
+                return Ok(EffectOutcome::target_invalid());
+            }
+        }
+
         let controller_of_tagged = match &self.target {
             ChooseSpec::Player(
                 PlayerFilter::ControllerOf(ObjectRef::Tagged(tag))

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2584,6 +2584,7 @@ fn apply_prevention_for_damage_assignment(
                 }
             } else {
                 exec_ctx.targets = follow_up.targets;
+                exec_ctx.target_assignments = follow_up.target_assignments;
             }
             for effect in follow_up.effects {
                 if let Ok(outcome) = crate::effects::execute_effect(game, &effect, &mut exec_ctx) {

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2546,17 +2546,17 @@ fn apply_prevention_for_damage_assignment(
     };
 
     if can_prevent && !result.follow_ups.is_empty() {
-        let prevented_event = crate::events::RawEvent::new(
-            DamageEvent::with_cause(
-                source,
-                target,
-                amount - result.remaining,
-                is_combat,
-                cause.clone(),
-            ),
-            provenance,
-        );
         for follow_up in result.follow_ups {
+            let prevented_event = crate::events::RawEvent::new(
+                DamageEvent::with_cause(
+                    source,
+                    target,
+                    follow_up.prevented,
+                    is_combat,
+                    cause.clone(),
+                ),
+                provenance,
+            );
             let mut dm = crate::decision::AutoPassDecisionMaker;
             let mut exec_ctx = crate::effects::ExecutionContext::new(
                 follow_up.source,
@@ -2569,17 +2569,21 @@ fn apply_prevention_for_damage_assignment(
                 follow_up.controller,
             ))
             .with_provenance(provenance);
-            match target {
-                DamageTarget::Player(player_id) => {
-                    exec_ctx
-                        .targets
-                        .push(crate::effects::ResolvedTarget::Player(player_id));
+            if follow_up.targets.is_empty() {
+                match target {
+                    DamageTarget::Player(player_id) => {
+                        exec_ctx
+                            .targets
+                            .push(crate::effects::ResolvedTarget::Player(player_id));
+                    }
+                    DamageTarget::Object(object_id) => {
+                        exec_ctx
+                            .targets
+                            .push(crate::effects::ResolvedTarget::Object(object_id));
+                    }
                 }
-                DamageTarget::Object(object_id) => {
-                    exec_ctx
-                        .targets
-                        .push(crate::effects::ResolvedTarget::Object(object_id));
-                }
+            } else {
+                exec_ctx.targets = follow_up.targets;
             }
             for effect in follow_up.effects {
                 if let Ok(outcome) = crate::effects::execute_effect(game, &effect, &mut exec_ctx) {

--- a/crates/ironsmith-runtime/src/prevention.rs
+++ b/crates/ironsmith-runtime/src/prevention.rs
@@ -12,6 +12,7 @@
 
 use crate::color::Color;
 use crate::effect::{Effect, Until};
+use crate::effects::ResolvedTarget;
 use crate::ids::{ObjectId, PlayerId};
 use crate::types::CardType;
 pub use ironsmith_core::{DamageFilter, PreventionTarget};
@@ -58,6 +59,9 @@ pub struct PreventionShield {
     /// Effects to execute using the prevented amount when this shield prevents damage.
     pub follow_up_effects: Vec<Effect>,
 
+    /// Targets chosen when the prevention shield was created, for delayed follow-ups.
+    pub follow_up_targets: Vec<ResolvedTarget>,
+
     /// Turn this shield was created (for end-of-turn cleanup)
     pub created_turn: u32,
 }
@@ -80,6 +84,7 @@ impl PreventionShield {
             duration,
             damage_filter: DamageFilter::default(),
             follow_up_effects: Vec::new(),
+            follow_up_targets: Vec::new(),
             created_turn: 0, // Set when added to manager
         }
     }
@@ -93,6 +98,12 @@ impl PreventionShield {
     /// Execute these effects with the amount of damage this shield prevented.
     pub fn with_follow_up_effects(mut self, effects: Vec<Effect>) -> Self {
         self.follow_up_effects = effects;
+        self
+    }
+
+    /// Store targets chosen for delayed follow-up effects.
+    pub fn with_follow_up_targets(mut self, targets: Vec<ResolvedTarget>) -> Self {
+        self.follow_up_targets = targets;
         self
     }
 
@@ -168,6 +179,7 @@ pub struct PreventionFollowUp {
     pub controller: PlayerId,
     pub prevented: u32,
     pub effects: Vec<Effect>,
+    pub targets: Vec<ResolvedTarget>,
 }
 
 /// Result of applying prevention to a single damage assignment.
@@ -362,6 +374,7 @@ impl PreventionEffectManager {
                         controller: shield.controller,
                         prevented,
                         effects: shield.follow_up_effects.clone(),
+                        targets: shield.follow_up_targets.clone(),
                     });
                 }
             }
@@ -458,6 +471,7 @@ impl PreventionEffectManager {
                         controller: shield.controller,
                         prevented,
                         effects: shield.follow_up_effects.clone(),
+                        targets: shield.follow_up_targets.clone(),
                     });
                 }
             }

--- a/crates/ironsmith-runtime/src/prevention.rs
+++ b/crates/ironsmith-runtime/src/prevention.rs
@@ -13,6 +13,7 @@
 use crate::color::Color;
 use crate::effect::{Effect, Until};
 use crate::effects::ResolvedTarget;
+use crate::game_state::TargetAssignment;
 use crate::ids::{ObjectId, PlayerId};
 use crate::types::CardType;
 pub use ironsmith_core::{DamageFilter, PreventionTarget};
@@ -62,6 +63,9 @@ pub struct PreventionShield {
     /// Targets chosen when the prevention shield was created, for delayed follow-ups.
     pub follow_up_targets: Vec<ResolvedTarget>,
 
+    /// Target assignment ranges for delayed follow-ups.
+    pub follow_up_target_assignments: Vec<TargetAssignment>,
+
     /// Turn this shield was created (for end-of-turn cleanup)
     pub created_turn: u32,
 }
@@ -85,6 +89,7 @@ impl PreventionShield {
             damage_filter: DamageFilter::default(),
             follow_up_effects: Vec::new(),
             follow_up_targets: Vec::new(),
+            follow_up_target_assignments: Vec::new(),
             created_turn: 0, // Set when added to manager
         }
     }
@@ -104,6 +109,15 @@ impl PreventionShield {
     /// Store targets chosen for delayed follow-up effects.
     pub fn with_follow_up_targets(mut self, targets: Vec<ResolvedTarget>) -> Self {
         self.follow_up_targets = targets;
+        self
+    }
+
+    /// Store target assignment ranges for delayed follow-up effects.
+    pub fn with_follow_up_target_assignments(
+        mut self,
+        target_assignments: Vec<TargetAssignment>,
+    ) -> Self {
+        self.follow_up_target_assignments = target_assignments;
         self
     }
 
@@ -180,6 +194,7 @@ pub struct PreventionFollowUp {
     pub prevented: u32,
     pub effects: Vec<Effect>,
     pub targets: Vec<ResolvedTarget>,
+    pub target_assignments: Vec<TargetAssignment>,
 }
 
 /// Result of applying prevention to a single damage assignment.
@@ -375,6 +390,7 @@ impl PreventionEffectManager {
                         prevented,
                         effects: shield.follow_up_effects.clone(),
                         targets: shield.follow_up_targets.clone(),
+                        target_assignments: shield.follow_up_target_assignments.clone(),
                     });
                 }
             }
@@ -472,6 +488,7 @@ impl PreventionEffectManager {
                         prevented,
                         effects: shield.follow_up_effects.clone(),
                         targets: shield.follow_up_targets.clone(),
+                        target_assignments: shield.follow_up_target_assignments.clone(),
                     });
                 }
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Divine Deflection
Initial parse error:
```
parser does not yet support line family: 'Prevent the next X damage that would be dealt to you and/or permanents you control this turn. If damage is prevented this way, Divine Deflection deals that much damage to any target.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent the next X damage that would be dealt to you and/or permanents you control this turn. If damage is prevented this way, Divine Deflection deals that much damage to any target.'
```

Current worker: i-01d0cdfcccec568cc
Branch: codex/aws-card-fix-divine-deflection
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0016
