### PR TITLE
Fix Ironsmith parse failure: Sarulf, Realm Eater

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5079,7 +5079,13 @@ fn compile_subject_verb_effect(
             target,
             counter_type,
             up_to,
+            all_of_them,
         } => {
+            if *all_of_them {
+                return Err(CardTextError::ParseError(
+                    "unable to resolve 'all of them' counter reference".to_string(),
+                ));
+            }
             let resolved_amount = resolve_value_it_tag(amount, &current_reference_env(ctx))?;
             let id = ctx.next_effect_id();
             ctx.last_effect_id = Some(id);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::runtime_backend::condition_antecedent::{
     ConditionAntecedentBinding, bind_condition_antecedent_in_effects,
-    predicate_object_filter_antecedent,
+    bind_condition_counter_antecedent_in_effects, predicate_object_filter_antecedent,
+    predicate_source_counter_antecedent,
 };
 
 fn compile_delayed_trigger_spec(
@@ -614,6 +615,9 @@ pub(super) fn try_compile_stack_and_condition_effect(
                     &antecedent,
                     ConditionAntecedentBinding::IncludeRandomWithCountObjects,
                 );
+            }
+            if let Some(counter_type) = predicate_source_counter_antecedent(predicate) {
+                bind_condition_counter_antecedent_in_effects(&mut effective_if_true, counter_type);
             }
             let saved_last_tag = ctx.last_object_tag.clone();
             let saved_source_object_antecedent = ctx.source_object_antecedent;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/condition_antecedent.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/condition_antecedent.rs
@@ -1,5 +1,7 @@
 use crate::cards::builders::{EffectAst, IT_TAG, PredicateAst, SubjectVerbActionAst, TargetAst};
+use crate::effect::Value;
 use crate::filter::{ObjectFilter, TaggedOpbjectRelation};
+use crate::object::CounterType;
 
 use super::effect_ast_traversal::for_each_nested_effects_mut;
 
@@ -38,6 +40,21 @@ pub(crate) fn predicate_object_filter_antecedent(predicate: &PredicateAst) -> Op
                 .or_else(|| predicate_object_filter_antecedent(right))
         }
         PredicateAst::Not(inner) => predicate_object_filter_antecedent(inner),
+        _ => None,
+    }
+}
+
+pub(crate) fn predicate_source_counter_antecedent(predicate: &PredicateAst) -> Option<CounterType> {
+    match predicate {
+        PredicateAst::SourceHasCounterAtLeast { counter_type, .. } => Some(*counter_type),
+        PredicateAst::And(left, right) => match (
+            predicate_source_counter_antecedent(left),
+            predicate_source_counter_antecedent(right),
+        ) {
+            (Some(left), Some(right)) if left == right => Some(left),
+            (Some(counter_type), None) | (None, Some(counter_type)) => Some(counter_type),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -157,6 +174,38 @@ pub(crate) fn bind_condition_antecedent_in_effects(
 ) {
     for effect in effects {
         bind_condition_antecedent_in_effect(effect, antecedent, mode);
+    }
+}
+
+fn bind_condition_counter_antecedent_in_effect(effect: &mut EffectAst, counter_type: CounterType) {
+    if let EffectAst::SubjectVerb(subject_verb) = effect
+        && let SubjectVerbActionAst::RemoveUpToAnyCounters {
+            amount,
+            target,
+            counter_type: remove_counter_type,
+            all_of_them,
+            ..
+        } = &mut subject_verb.action
+        && *all_of_them
+        && remove_counter_type.is_none()
+        && matches!(target, TargetAst::Source(_))
+    {
+        *amount = Value::CountersOnSource(counter_type);
+        *remove_counter_type = Some(counter_type);
+        *all_of_them = false;
+    }
+
+    for_each_nested_effects_mut(effect, true, |nested| {
+        bind_condition_counter_antecedent_in_effects(nested, counter_type);
+    });
+}
+
+pub(crate) fn bind_condition_counter_antecedent_in_effects(
+    effects: &mut [EffectAst],
+    counter_type: CounterType,
+) {
+    for effect in effects {
+        bind_condition_counter_antecedent_in_effect(effect, counter_type);
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
@@ -2,7 +2,8 @@ use super::*;
 use crate::runtime_backend::ast::TriggerIntroSurfaceAst;
 use crate::runtime_backend::condition_antecedent::{
     ConditionAntecedentBinding, bind_condition_antecedent_in_effects,
-    predicate_contains_source_match, predicate_object_filter_antecedent,
+    bind_condition_counter_antecedent_in_effects, predicate_contains_source_match,
+    predicate_object_filter_antecedent, predicate_source_counter_antecedent,
     retarget_it_animations_to_source,
 };
 use crate::runtime_backend::front_end::lexer::{TokenKind, lex_line};
@@ -648,6 +649,9 @@ pub(super) fn apply_explicit_intervening_if_to_triggered_chunk(
                     ConditionAntecedentBinding::TaggedItOnly,
                 );
             }
+            if let Some(counter_type) = predicate_source_counter_antecedent(&predicate) {
+                bind_condition_counter_antecedent_in_effects(&mut effects, counter_type);
+            }
             if predicate_contains_source_match(&predicate) {
                 retarget_it_animations_to_source(&mut effects);
             }
@@ -682,6 +686,9 @@ pub(super) fn apply_explicit_intervening_if_to_triggered_chunk(
                         &antecedent,
                         ConditionAntecedentBinding::TaggedItOnly,
                     );
+                }
+                if let Some(counter_type) = predicate_source_counter_antecedent(&predicate) {
+                    bind_condition_counter_antecedent_in_effects(&mut effects_ast, counter_type);
                 }
                 if predicate_contains_source_match(&predicate) {
                     retarget_it_animations_to_source(&mut effects_ast);

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -22,7 +22,8 @@ use super::compile_support::{
 };
 use super::condition_antecedent::{
     ConditionAntecedentBinding, bind_condition_antecedent_in_effects,
-    predicate_contains_source_match, predicate_object_filter_antecedent,
+    bind_condition_counter_antecedent_in_effects, predicate_contains_source_match,
+    predicate_object_filter_antecedent, predicate_source_counter_antecedent,
     retarget_it_animations_to_source,
 };
 use super::effect_ast_normalization::normalize_effects_ast;
@@ -532,6 +533,12 @@ pub(crate) fn rewrite_prepare_triggered_effects_for_lowering(
             &antecedent,
             ConditionAntecedentBinding::TaggedItOnly,
         );
+    }
+    if let Some(counter_type) = intervening_if
+        .as_ref()
+        .and_then(predicate_source_counter_antecedent)
+    {
+        bind_condition_counter_antecedent_in_effects(&mut body_effects, counter_type);
     }
     if phase_step_trigger_has_no_object_reference(&trigger) && !has_phase_step_it_prelude {
         retarget_phase_step_it_targets_to_source(&mut body_effects);

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -8,7 +8,7 @@ use crate::model::RedirectNextTimeDamageDestinationAst;
 use crate::object::{AuraAttachmentFilter, CounterType};
 use crate::static_abilities::StaticAbility;
 use crate::tag::TagKey;
-use crate::target::{ObjectFilter, PlayerFilter};
+use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype, SubtypeFamily, Supertype};
 use crate::zone::Zone;
 
@@ -1595,6 +1595,7 @@ pub(crate) enum SubjectVerbActionAst {
         target: TargetAst,
         counter_type: Option<CounterType>,
         up_to: bool,
+        all_of_them: bool,
     },
     MoveAllCounters {
         from: TargetAst,
@@ -3112,12 +3113,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 target,
                 counter_type,
                 up_to,
+                all_of_them,
             } => f
                 .debug_struct("RemoveUpToAnyCounters")
                 .field("amount", amount)
                 .field("target", target)
                 .field("counter_type", counter_type)
                 .field("up_to", up_to)
+                .field("all_of_them", all_of_them)
                 .finish(),
             Self::MoveAllCounters { from, to } => f
                 .debug_struct("MoveAllCounters")
@@ -6262,6 +6265,21 @@ impl EffectAst {
                 target,
                 counter_type,
                 up_to,
+                all_of_them: false,
+            },
+        )
+    }
+
+    pub(crate) fn subject_verb_remove_all_of_them_counters_from_source() -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::RemoveUpToAnyCounters {
+                amount: Value::CountersOn(Box::new(ChooseSpec::Source), None),
+                target: TargetAst::Source(None),
+                counter_type: None,
+                up_to: false,
+                all_of_them: true,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/remove_destroy.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/remove_destroy.rs
@@ -66,6 +66,11 @@ const DEALT_DAMAGE_THIS_TURN_FILTER_TAILS: &[&[&str]] = &[
 ];
 
 pub(crate) fn parse_remove(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTextError> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if matches!(words.as_slice(), ["all", "of", "them"]) {
+        return Ok(EffectAst::subject_verb_remove_all_of_them_counters_from_source());
+    }
+
     if let Some(from_idx) = find_index(tokens, |token| FROM_WORD_PATTERN.matches_token(token)) {
         let tail_words = crate::runtime_backend::token_word_refs(&tokens[from_idx + 1..]);
         if COMBAT_WORD_PATTERN.matches_words(&tail_words) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -37512,6 +37512,33 @@ fn remove_all_named_counters_from_target_renders_generically() {
 }
 
 #[test]
+fn sarulf_realm_eater_strict_parser_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Sarulf, Realm Eater");
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let upkeep_text = "At the beginning of your upkeep, if this creature has one or more +1/+1 counters on it, you may remove all +1/+1 counters from it. If you do, exile each other nonland permanent with mana value less than or equal to the number of counters removed this way.";
+
+    assert!(
+        rendered.contains("Whenever a permanent an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on Sarulf."),
+        "expected Sarulf death trigger text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(upkeep_text),
+        "expected Sarulf upkeep all-of-them counter removal and removed-this-way exile text, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("BeginningOfUpkeepTrigger")
+            && ability_debug.contains("SourceHasCounterAtLeast")
+            && ability_debug.contains("RemoveCountersEffect")
+            && ability_debug.contains("PlusOnePlusOne")
+            && ability_debug.contains("IfEffect")
+            && ability_debug.contains("ExileEffect")
+            && ability_debug.contains("EffectValue"),
+        "expected Sarulf to structurally remove +1/+1 counters and exile by the removed count, got {ability_debug}"
+    );
+}
+
+#[test]
 fn blitz_leech_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Blitz Leech");
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1075,6 +1075,7 @@ pub(super) fn substitute_legendary_source_reference(
     let uses_named_source_surface = lower.starts_with("this creature gets ")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
+        || lower.contains("if this creature has one or more ")
         || lower.contains(" counters on this artifact")
         || lower.starts_with("whenever this creature attacks")
         || lower.starts_with("whenever this creature deals combat damage to a player")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -268,6 +268,7 @@ pub(super) fn lowercase_may_clause(text: &str) -> String {
             | "Play"
             | "Put"
             | "Regenerate"
+            | "Remove"
             | "Reveal"
             | "Return"
             | "Sacrifice"
@@ -11736,7 +11737,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::SourceHasCounterAtLeast { counter_type, count } => {
             if *count == 1 {
                 format!(
-                    "this source has a {} counter on it",
+                    "this source has one or more {} counters on it",
                     counter_type.description()
                 )
             } else {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27669,6 +27669,9 @@ fn describe_with_id_if_clause(
     if let Some(compact) = describe_declined_may_mill_then_damage(with_id, if_effect) {
         return Some(compact);
     }
+    if let Some(compact) = describe_removed_counters_then_exile_by_mana_value(with_id, if_effect) {
+        return Some(compact);
+    }
 
     let then_text = describe_effect_list(&if_effect.then);
     let else_text = describe_effect_list(&if_effect.else_);
@@ -27854,6 +27857,56 @@ fn describe_with_id_if_clause(
             lowercase_first(&else_text)
         ))
     }
+}
+
+fn describe_removed_counters_then_exile_by_mana_value(
+    with_id: &crate::effects::WithIdEffect,
+    if_effect: &crate::effects::IfEffect,
+) -> Option<String> {
+    if if_effect.condition != with_id.id
+        || if_effect.predicate != EffectPredicate::Happened
+        || !if_effect.else_.is_empty()
+        || if_effect.then.len() != 1
+    {
+        return None;
+    }
+
+    let may = with_id.effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let removed_counters = may.effects.iter().any(|effect| {
+        effect
+            .downcast_ref::<crate::effects::WithIdEffect>()
+            .is_some_and(|nested| {
+                nested.id == with_id.id
+                    && nested
+                        .effect
+                        .downcast_ref::<crate::effects::RemoveCountersEffect>()
+                        .is_some()
+            })
+            || effect
+                .downcast_ref::<crate::effects::RemoveCountersEffect>()
+                .is_some()
+    });
+    if !removed_counters {
+        return None;
+    }
+
+    let exile = if_effect.then[0].downcast_ref::<crate::effects::ExileEffect>()?;
+    let ChooseSpec::All(filter) = &exile.spec else {
+        return None;
+    };
+    if !is_nonland_permanent_filter(filter) || !filter.other {
+        return None;
+    }
+    let Some(crate::filter::Comparison::LessThanOrEqualExpr(value)) = filter.mana_value.as_ref()
+    else {
+        return None;
+    };
+    if !matches!(value.as_ref(), Value::EffectValue(id) if *id == with_id.id) {
+        return None;
+    }
+
+    let text = "If you do, exile each other nonland permanent with mana value less than or equal to the number of counters removed this way";
+    Some(text.to_string())
 }
 
 fn describe_declined_may_mill_then_damage(

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1246,6 +1246,246 @@ fn rampaging_aetherhood_declining_payment_gets_energy_without_counters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn sarulf_realm_eater_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(792_240), "Sarulf, Realm Eater")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Green],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Wolf])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "Whenever a permanent an opponent controls is put into a graveyard from the battlefield, put a +1/+1 counter on Sarulf.\n\
+             At the beginning of your upkeep, if Sarulf has one or more +1/+1 counters on it, you may remove all of them. If you do, exile each other nonland permanent with mana value less than or equal to the number of counters removed this way.",
+        )
+        .expect("Sarulf, Realm Eater should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn sarulf_test_permanent_definition(
+    card_id: u32,
+    name: &str,
+    card_types: Vec<CardType>,
+    mana_value: u8,
+) -> crate::cards::CardDefinition {
+    let mut builder = CardDefinitionBuilder::new(CardId::from_raw(card_id), name)
+        .card_types(card_types.clone());
+    if mana_value > 0 {
+        builder = builder.mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(
+            mana_value,
+        )]]));
+    }
+    if card_types.contains(&CardType::Creature) {
+        builder = builder.power_toughness(PowerToughness::fixed(2, 2));
+    }
+    builder.build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct SarulfUpkeepDecisionMaker {
+    remove_counters: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for SarulfUpkeepDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.remove_counters
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn queue_sarulf_upkeep_trigger(game: &mut GameState, trigger_queue: &mut TriggerQueue) {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    generate_and_queue_step_triggers(game, trigger_queue);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sarulf_realm_eater_death_trigger_adds_plus_one_counter_for_opponent_permanent() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sarulf = sarulf_realm_eater_definition();
+    let sarulf_id = game.create_object_from_definition(&sarulf, alice, Zone::Battlefield);
+    let opponent_permanent = sarulf_test_permanent_definition(
+        792_241,
+        "Opponent Relic",
+        vec![CardType::Artifact],
+        2,
+    );
+    let own_permanent =
+        sarulf_test_permanent_definition(792_242, "Own Relic", vec![CardType::Artifact], 2);
+    let opponent_id =
+        game.create_object_from_definition(&opponent_permanent, bob, Zone::Battlefield);
+    let own_id = game.create_object_from_definition(&own_permanent, alice, Zone::Battlefield);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.move_object_by_effect(own_id, Zone::Graveyard)
+        .expect("own permanent should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Sarulf should not trigger for its controller's permanent"
+    );
+
+    game.move_object_by_effect(opponent_id, Zone::Graveyard)
+        .expect("opponent permanent should move to graveyard");
+    drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Sarulf should trigger for an opponent-controlled permanent"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Sarulf death trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Sarulf death trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(sarulf_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Sarulf death trigger should add a +1/+1 counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sarulf_realm_eater_upkeep_without_plus_one_counters_does_not_trigger() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let sarulf = sarulf_realm_eater_definition();
+    game.create_object_from_definition(&sarulf, alice, Zone::Battlefield);
+    let mut trigger_queue = TriggerQueue::new();
+
+    queue_sarulf_upkeep_trigger(&mut game, &mut trigger_queue);
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Sarulf upkeep ability has an intervening-if condition and should not trigger without +1/+1 counters"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sarulf_realm_eater_upkeep_removes_all_plus_one_counters_and_exiles_by_removed_count() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sarulf = sarulf_realm_eater_definition();
+    let sarulf_id = game.create_object_from_definition(&sarulf, alice, Zone::Battlefield);
+    game.add_counters(sarulf_id, crate::object::CounterType::PlusOnePlusOne, 3);
+    game.add_counters(sarulf_id, crate::object::CounterType::Charge, 1);
+
+    let low =
+        sarulf_test_permanent_definition(792_243, "Low Permanent", vec![CardType::Artifact], 3);
+    let high = sarulf_test_permanent_definition(
+        792_244,
+        "High Permanent",
+        vec![CardType::Artifact],
+        4,
+    );
+    let land = sarulf_test_permanent_definition(792_245, "Low Land", vec![CardType::Land], 0);
+    game.create_object_from_definition(&low, bob, Zone::Battlefield);
+    let high_id = game.create_object_from_definition(&high, bob, Zone::Battlefield);
+    let land_id = game.create_object_from_definition(&land, bob, Zone::Battlefield);
+    let mut trigger_queue = TriggerQueue::new();
+
+    queue_sarulf_upkeep_trigger(&mut game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Sarulf upkeep ability should trigger while it has +1/+1 counters"
+    );
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Sarulf upkeep trigger should go on the stack");
+    let mut dm = SarulfUpkeepDecisionMaker {
+        remove_counters: true,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Sarulf upkeep trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(sarulf_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "accepting the upkeep choice should remove all +1/+1 counters"
+    );
+    assert_eq!(
+        game.counter_count(sarulf_id, crate::object::CounterType::Charge),
+        1,
+        "all of them should refer to the +1/+1 counters from the intervening condition, not unrelated counters"
+    );
+    assert_eq!(
+        game.object(sarulf_id).expect("Sarulf exists").zone,
+        Zone::Battlefield,
+        "Sarulf should not exile itself because the effect exiles each other permanent"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Low Permanent"),
+        1,
+        "permanents with mana value equal to the removed counter count should be exiled"
+    );
+    assert_eq!(
+        game.object(high_id).expect("high permanent exists").zone,
+        Zone::Battlefield,
+        "permanents with mana value greater than the removed counter count should remain"
+    );
+    assert_eq!(
+        game.object(land_id).expect("land exists").zone,
+        Zone::Battlefield,
+        "lands should remain even when their mana value is low enough"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn sarulf_realm_eater_declining_upkeep_removal_skips_exile_branch() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let sarulf = sarulf_realm_eater_definition();
+    let sarulf_id = game.create_object_from_definition(&sarulf, alice, Zone::Battlefield);
+    game.add_counters(sarulf_id, crate::object::CounterType::PlusOnePlusOne, 2);
+    let low = sarulf_test_permanent_definition(
+        792_246,
+        "Decline Low Permanent",
+        vec![CardType::Artifact],
+        1,
+    );
+    let low_id = game.create_object_from_definition(&low, bob, Zone::Battlefield);
+    let mut trigger_queue = TriggerQueue::new();
+
+    queue_sarulf_upkeep_trigger(&mut game, &mut trigger_queue);
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Sarulf upkeep trigger should go on the stack");
+    let mut dm = SarulfUpkeepDecisionMaker {
+        remove_counters: false,
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("declined Sarulf upkeep trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(sarulf_id, crate::object::CounterType::PlusOnePlusOne),
+        2,
+        "declining the optional removal should leave Sarulf's +1/+1 counters"
+    );
+    assert_eq!(
+        game.object(low_id).expect("low permanent exists").zone,
+        Zone::Battlefield,
+        "if no counters are removed, the if-you-do exile branch should not happen"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn assaultron_dominator_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(74_260), "Assaultron Dominator")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Sarulf, Realm Eater
Initial parse error:
```
missing counter removal amount (clause: 'all of them'); oracle-only fallback also failed: missing counter removal amount (clause: 'all of them')
```

Current worker: i-046cd28fbe8d1e550
Branch: codex/aws-card-fix-sarulf-realm-eater
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0016
