### PR TITLE
Fix Ironsmith parse failure: Polliwallop

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -4055,9 +4055,10 @@ pub(crate) fn parse_affinity_cost_reduction_line(
 
     Ok(Some(StaticAbility::new(
         crate::static_abilities::ThisSpellCostReduction::new(
-            Value::Count(filter),
+            Value::Count(filter.clone()),
             crate::static_abilities::ThisSpellCostCondition::Always,
-        ),
+        )
+        .with_affinity_filter(filter),
     )))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2685,6 +2685,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         ),
         single_static_ability_ast_rule!(parse_damage_doubling_mana_value_marker_line),
         single_static_ability_ast_rule!(parse_conditional_source_spell_keyword_line),
+        single_static_ability_ast_rule!(parse_affinity_cost_reduction_line),
         single_static_ability_ast_rule!(parse_pregame_begin_on_battlefield_line),
         single_static_ability_ast_rule!(parse_pregame_mulligan_redraw_line),
         multi_static_ability_ast_rule!(parse_combined_pregame_choose_color_line),
@@ -4027,6 +4028,37 @@ pub(crate) fn parse_static_text_marker_line(tokens: &[OwnedLexToken]) -> Option<
     }
 
     None
+}
+
+pub(crate) fn parse_affinity_cost_reduction_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let core_tokens = if let Some(paren_idx) = find_token_kind(tokens, TokenKind::LParen) {
+        trim_commas(&tokens[..paren_idx])
+    } else {
+        trim_commas(tokens)
+    };
+    let words = parser_token_word_refs(&core_tokens);
+    if !word_slice_starts_with(&words, &["affinity", "for"]) || words.len() < 3 {
+        return Ok(None);
+    }
+
+    if word_slice_eq(&words, &["affinity", "for", "artifacts"]) {
+        return Ok(None);
+    }
+
+    let filter_tokens = trim_commas(&core_tokens[2..]);
+    let mut filter = parse_object_filter_lexed(&filter_tokens, false)?;
+    if filter.controller.is_none() {
+        filter.controller = Some(PlayerFilter::You);
+    }
+
+    Ok(Some(StaticAbility::new(
+        crate::static_abilities::ThisSpellCostReduction::new(
+            Value::Count(filter),
+            crate::static_abilities::ThisSpellCostCondition::Always,
+        ),
+    )))
 }
 
 pub(crate) fn parse_filter_dont_untap_during_controllers_untap_steps_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/values.rs
@@ -824,7 +824,9 @@ pub(crate) fn parse_add_mana_equal_amount_value_lexed(tokens: &[OwnedLexToken]) 
     };
 
     let parse_amount_segment = |segment: &[&str]| -> Option<Value> {
-        parse_power_or_toughness_segment(segment)
+        parse_value_expr_words(segment)
+            .and_then(|(value, used)| (used == segment.len()).then_some(value))
+            .or_else(|| parse_power_or_toughness_segment(segment))
             .or_else(|| {
                 if segment.len() == 1 {
                     parse_number_word_i32(segment[0]).map(Value::Fixed)

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2708,6 +2708,11 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         return Some((Value::XTimes(2), 2));
     }
 
+    if words.first().is_some_and(|word| *word == "twice") {
+        let (value, used) = parse_value_expr_term_words(&words[1..])?;
+        return Some((Value::Scaled(Box::new(value), 2), used + 1));
+    }
+
     if X_WORD_PATTERN.matches_word(words[0]) {
         return Some((Value::X, 1));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -19,6 +19,32 @@ fn describe_value_for_mode(value: &Value) -> String {
     }
 }
 
+fn bind_source_value_to_damage_source(value: &Value, source: &ChooseSpec) -> Value {
+    match value {
+        Value::SourcePower => Value::PowerOf(Box::new(source.clone())),
+        Value::SourceToughness => Value::ToughnessOf(Box::new(source.clone())),
+        Value::PowerOf(spec) if matches!(spec.base(), ChooseSpec::Source) => {
+            Value::PowerOf(Box::new(source.clone()))
+        }
+        Value::ToughnessOf(spec) if matches!(spec.base(), ChooseSpec::Source) => {
+            Value::ToughnessOf(Box::new(source.clone()))
+        }
+        Value::Add(left, right) => Value::Add(
+            Box::new(bind_source_value_to_damage_source(left, source)),
+            Box::new(bind_source_value_to_damage_source(right, source)),
+        ),
+        Value::Scaled(inner, multiplier) => Value::Scaled(
+            Box::new(bind_source_value_to_damage_source(inner, source)),
+            *multiplier,
+        ),
+        Value::SurfaceHinted { value, hints } => Value::SurfaceHinted {
+            value: Box::new(bind_source_value_to_damage_source(value, source)),
+            hints: hints.clone(),
+        },
+        _ => value.clone(),
+    }
+}
+
 fn prevention_target_from_non_choice_target(
     target: &TargetAst,
     ctx: &EffectLoweringContext,
@@ -4505,9 +4531,14 @@ fn compile_subject_verb_effect(
             }
             Ok((effects, choices))
         }
-        SubjectVerbActionAst::DealDamageEqualToPower { source, target } => {
+        SubjectVerbActionAst::DealDamageEqualToPower {
+            source,
+            amount,
+            target,
+        } => {
             let (source_spec, mut choices) =
                 resolve_target_spec_with_choices(source, &current_reference_env(ctx))?;
+            let amount = resolve_value_it_tag(amount, &current_reference_env(ctx))?;
             let mut damage_target_spec = if source == target {
                 source_spec.clone()
             } else {
@@ -4526,6 +4557,7 @@ fn compile_subject_verb_effect(
             } else {
                 source_spec.clone()
             };
+            let mut damage_amount = bind_source_value_to_damage_source(&amount, &source_spec);
 
             if source_spec.is_target() {
                 let source_tag = ctx.next_tag("damage_source");
@@ -4534,6 +4566,7 @@ fn compile_subject_verb_effect(
                         .tag(source_tag.clone()),
                 );
                 damage_source_spec = ChooseSpec::Tagged(source_tag.as_str().into());
+                damage_amount = bind_source_value_to_damage_source(&amount, &damage_source_spec);
                 if source == target {
                     damage_target_spec = ChooseSpec::Tagged(source_tag.as_str().into());
                 }
@@ -4547,7 +4580,7 @@ fn compile_subject_verb_effect(
                     Effect::new(crate::effects::ExecuteWithSourceEffect::new(
                         per_target_source_spec.clone(),
                         Effect::deal_damage(
-                            Value::PowerOf(Box::new(per_target_source_spec.clone())),
+                            bind_source_value_to_damage_source(&amount, &per_target_source_spec),
                             ChooseSpec::Iterated,
                         ),
                     ));
@@ -4561,10 +4594,7 @@ fn compile_subject_verb_effect(
                 let damage_effect = tag_object_target_effect(
                     Effect::new(crate::effects::ExecuteWithSourceEffect::new(
                         damage_source_spec.clone(),
-                        Effect::deal_damage(
-                            Value::PowerOf(Box::new(damage_source_spec.clone())),
-                            damage_target_spec.clone(),
-                        ),
+                        Effect::deal_damage(damage_amount.clone(), damage_target_spec.clone()),
                     )),
                     &damage_target_spec,
                     ctx,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/tag_support.rs
@@ -334,9 +334,18 @@ pub(crate) fn effect_references_tag(effect: &EffectAst, tag: &str) -> bool {
             .as_ref()
             .is_some_and(|filter| filter_references_tag(filter, tag)),
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
-            action: SubjectVerbActionAst::DealDamageEqualToPower { source, target },
+            action:
+                SubjectVerbActionAst::DealDamageEqualToPower {
+                    source,
+                    amount,
+                    target,
+                },
             ..
-        }) => target_references_tag(source, tag) || target_references_tag(target, tag),
+        }) => {
+            target_references_tag(source, tag)
+                || value_references_tag(amount, tag)
+                || target_references_tag(target, tag)
+        }
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
             action: SubjectVerbActionAst::CreateTokenCopy { object, .. },
             ..
@@ -1072,8 +1081,14 @@ pub(crate) fn effect_references_it_tag(effect: &EffectAst) -> bool {
             SubjectVerbActionAst::CopySpellForEachTarget { object_filter, .. } => object_filter
                 .as_ref()
                 .is_some_and(|filter| filter_references_tag(filter, IT_TAG)),
-            SubjectVerbActionAst::DealDamageEqualToPower { source, target } => {
-                target_references_tag(source, IT_TAG) || target_references_tag(target, IT_TAG)
+            SubjectVerbActionAst::DealDamageEqualToPower {
+                source,
+                amount,
+                target,
+            } => {
+                target_references_tag(source, IT_TAG)
+                    || value_references_tag(amount, IT_TAG)
+                    || target_references_tag(target, IT_TAG)
             }
             SubjectVerbActionAst::CastTagged { tag, .. } => tag.as_str() == IT_TAG,
             SubjectVerbActionAst::GrantPlayTaggedUntilEndOfTurn { tag, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1481,6 +1481,7 @@ pub(crate) enum SubjectVerbActionAst {
     },
     DealDamageEqualToPower {
         source: TargetAst,
+        amount: Value,
         target: TargetAst,
     },
     DealDistributedDamage {
@@ -2969,9 +2970,14 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("amount", amount)
                 .field("filter", filter)
                 .finish(),
-            Self::DealDamageEqualToPower { source, target } => f
+            Self::DealDamageEqualToPower {
+                source,
+                amount,
+                target,
+            } => f
                 .debug_struct("DealDamageEqualToPower")
                 .field("source", source)
+                .field("amount", amount)
                 .field("target", target)
                 .finish(),
             Self::DealDistributedDamage { amount, target } => f
@@ -5251,10 +5257,26 @@ impl EffectAst {
     }
 
     pub(crate) fn subject_verb_damage_equal_to_power(source: TargetAst, target: TargetAst) -> Self {
+        Self::subject_verb_damage_with_source(
+            source.clone(),
+            Value::PowerOf(Box::new(crate::target::ChooseSpec::Source)),
+            target,
+        )
+    }
+
+    pub(crate) fn subject_verb_damage_with_source(
+        source: TargetAst,
+        amount: Value,
+        target: TargetAst,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::DealDamageEqualToPower { source, target },
+            SubjectVerbActionAst::DealDamageEqualToPower {
+                source,
+                amount,
+                target,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -608,6 +608,10 @@ pub(crate) fn resolve_value_it_tag(
             Box::new(resolve_value_it_tag(left, refs)?),
             Box::new(resolve_value_it_tag(right, refs)?),
         )),
+        Value::Scaled(value, multiplier) => Ok(Value::Scaled(
+            Box::new(resolve_value_it_tag(value, refs)?),
+            *multiplier,
+        )),
         Value::SurfaceHinted { value, hints } => Ok(Value::SurfaceHinted {
             value: Box::new(resolve_value_it_tag(value, refs)?),
             hints: hints.clone(),

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1327,6 +1327,7 @@ pub(crate) fn preserves_existing_it_for_power_self_damage_followup(
             SubjectVerbActionAst::DealDamageEqualToPower {
                 source: TargetAst::Tagged(source_tag, _),
                 target: TargetAst::Tagged(target_tag, _),
+                ..
             },
         ..
     })) = next_effect
@@ -2626,8 +2627,13 @@ fn bind_unresolved_it_in_effect_fields(effect: &mut EffectAst, seed_tag: &TagKey
             SubjectVerbActionAst::MoveToLibraryTopOrBottomChoice { target } => {
                 bind_unresolved_it_in_target(target, seed_tag)
             }
-            SubjectVerbActionAst::DealDamageEqualToPower { source, target } => {
+            SubjectVerbActionAst::DealDamageEqualToPower {
+                source,
+                amount,
+                target,
+            } => {
                 bind_unresolved_it_in_target(source, seed_tag)
+                    + bind_unresolved_it_in_value(amount, seed_tag)
                     + bind_unresolved_it_in_target(target, seed_tag)
             }
             SubjectVerbActionAst::Fight {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_primitives.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_primitives.rs
@@ -13,7 +13,9 @@ use super::super::permission_helpers::{
     parse_unsupported_play_cast_permission_clause, parse_until_end_of_turn_may_play_tagged_clause,
     parse_until_your_next_turn_may_play_tagged_clause,
 };
-use super::super::util::{is_article, parse_subject, parse_target_phrase, span_from_tokens};
+use super::super::util::{
+    is_article, parse_subject, parse_target_phrase, parse_value_expr_words, span_from_tokens,
+};
 use super::parse_restriction_duration;
 use super::sentence_helpers::*;
 #[allow(unused_imports)]
@@ -22,7 +24,7 @@ use crate::cards::builders::{
     LineAst, OwnedLexToken, PlayerAst, PredicateAst, ReferenceImports, RetargetModeAst, SubjectAst,
     TagKey, TargetAst, TextSpan, TriggerSpec,
 };
-use crate::effect::ChoiceCount;
+use crate::effect::{ChoiceCount, Value};
 use crate::mana::ManaSymbol;
 use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use crate::target::{ObjectFilter, PlayerFilter};
@@ -1000,6 +1002,15 @@ pub(crate) fn parse_power_reference_word_count(words: &[&str]) -> Option<usize> 
     None
 }
 
+fn value_references_power(value: &Value) -> bool {
+    match value {
+        Value::SourcePower | Value::PowerOf(_) => true,
+        Value::Add(left, right) => value_references_power(left) || value_references_power(right),
+        Value::Scaled(value, _) | Value::SurfaceHinted { value, .. } => value_references_power(value),
+        _ => false,
+    }
+}
+
 pub(crate) fn is_damage_source_target(target: &TargetAst) -> bool {
     matches!(
         target,
@@ -1035,7 +1046,16 @@ pub(crate) fn parse_deal_damage_equal_to_power_clause(
 
     let power_ref_clause = after_equal_clause.trimmed();
     let power_ref_words = power_ref_clause.word_refs();
-    let Some(power_ref_len) = parse_power_reference_word_count(&power_ref_words) else {
+    let (amount, power_ref_len) = if let Some((amount, used)) = parse_value_expr_words(&power_ref_words)
+        && value_references_power(&amount)
+    {
+        (amount, used)
+    } else if let Some(power_ref_len) = parse_power_reference_word_count(&power_ref_words) {
+        (
+            Value::PowerOf(Box::new(crate::target::ChooseSpec::Source)),
+            power_ref_len,
+        )
+    } else {
         return Ok(None);
     };
 
@@ -1081,16 +1101,18 @@ pub(crate) fn parse_deal_damage_equal_to_power_clause(
         let normalized_target_words = normalized_target_clause.word_refs();
         if EACH_PLAYER_TARGET_PATTERN.matches_words(&normalized_target_words) {
             return Ok(Some(EffectAst::ForEachPlayer {
-                effects: vec![EffectAst::subject_verb_damage_equal_to_power(
+                effects: vec![EffectAst::subject_verb_damage_with_source(
                     source.clone(),
+                    amount.clone(),
                     TargetAst::Player(PlayerFilter::IteratedPlayer, None),
                 )],
             }));
         }
         if EACH_OPPONENT_TARGET_PATTERN.matches_words(&normalized_target_words) {
             return Ok(Some(EffectAst::ForEachOpponent {
-                effects: vec![EffectAst::subject_verb_damage_equal_to_power(
+                effects: vec![EffectAst::subject_verb_damage_with_source(
                     source.clone(),
+                    amount.clone(),
                     TargetAst::Player(PlayerFilter::IteratedPlayer, None),
                 )],
             }));
@@ -1108,16 +1130,18 @@ pub(crate) fn parse_deal_damage_equal_to_power_clause(
         let target_words = target_clause.word_refs();
         if EACH_PLAYER_TARGET_PATTERN.matches_words(&target_words) {
             return Ok(Some(EffectAst::ForEachPlayer {
-                effects: vec![EffectAst::subject_verb_damage_equal_to_power(
+                effects: vec![EffectAst::subject_verb_damage_with_source(
                     source.clone(),
+                    amount.clone(),
                     TargetAst::Player(PlayerFilter::IteratedPlayer, None),
                 )],
             }));
         }
         if EACH_OPPONENT_TARGET_PATTERN.matches_words(&target_words) {
             return Ok(Some(EffectAst::ForEachOpponent {
-                effects: vec![EffectAst::subject_verb_damage_equal_to_power(
+                effects: vec![EffectAst::subject_verb_damage_with_source(
                     source.clone(),
+                    amount.clone(),
                     TargetAst::Player(PlayerFilter::IteratedPlayer, None),
                 )],
             }));
@@ -1143,8 +1167,8 @@ pub(crate) fn parse_deal_damage_equal_to_power_clause(
         return Ok(None);
     };
 
-    Ok(Some(EffectAst::subject_verb_damage_equal_to_power(
-        source, target,
+    Ok(Some(EffectAst::subject_verb_damage_with_source(
+        source, amount, target,
     )))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -308,16 +308,22 @@ fn repair_that_object_power_damage_subject(
             {
                 subject_verb.action = SubjectVerbActionAst::DealDamageEqualToPower {
                     source: source_target.clone(),
+                    amount: Value::PowerOf(Box::new(ChooseSpec::Source)),
                     target: target.clone(),
                 };
             }
-            SubjectVerbActionAst::DealDamageEqualToPower { source, target }
+            SubjectVerbActionAst::DealDamageEqualToPower {
+                source,
+                amount,
+                target,
+            }
                 if (matches!(source, TargetAst::Source(_))
                     || matches!(source, TargetAst::Tagged(tag, _) if tag.as_str() == IT_TAG))
                     && matches!(target, TargetAst::Source(_)) =>
             {
                 subject_verb.action = SubjectVerbActionAst::DealDamageEqualToPower {
                     source: source_target.clone(),
+                    amount: amount.clone(),
                     target: target.clone(),
                 };
             }
@@ -339,7 +345,7 @@ fn repair_target_controlled_source_damage_to_that_player(
         let EffectAst::SubjectVerb(subject_verb) = effect else {
             continue;
         };
-        let SubjectVerbActionAst::DealDamageEqualToPower { source, target } =
+        let SubjectVerbActionAst::DealDamageEqualToPower { source, target, .. } =
             &mut subject_verb.action
         else {
             continue;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -907,6 +907,7 @@ fn parse_effect_sentence_with_where_x_lexed(
             | SubjectVerbActionAst::DealDamageEqualToPower {
                 source: creature1,
                 target: creature2,
+                ..
             }
             | SubjectVerbActionAst::BecomeCopy {
                 target: creature1,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -134,6 +134,7 @@ pub enum StaticAbilityId {
     CostIncreaseManaCost,
     CostIncreasePerAdditionalTarget,
     CostIncreaseManaCostPerAdditionalTarget,
+    Affinity,
     AffinityForArtifacts,
     Delve,
     Convoke,
@@ -397,6 +398,7 @@ impl StaticAbilityId {
             | CostIncreaseManaCost
             | CostIncreasePerAdditionalTarget
             | CostIncreaseManaCostPerAdditionalTarget
+            | Affinity
             | AffinityForArtifacts
             | Delve
             | Convoke

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -4359,11 +4359,21 @@ impl CostIncreaseManaCost {
 pub struct ThisSpellCostReduction<Cond> {
     pub amount: Value,
     pub condition: Cond,
+    pub affinity_filter: Option<ObjectFilter>,
 }
 
 impl<Cond> ThisSpellCostReduction<Cond> {
     pub fn new(amount: Value, condition: Cond) -> Self {
-        Self { amount, condition }
+        Self {
+            amount,
+            condition,
+            affinity_filter: None,
+        }
+    }
+
+    pub fn with_affinity_filter(mut self, filter: ObjectFilter) -> Self {
+        self.affinity_filter = Some(filter);
+        self
     }
 }
 

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -1679,8 +1679,13 @@ impl<
             };
         }
         if let Some(payload) = label_any.downcast_ref::<ThisSpellCostReduction<Cond>>() {
+            let id = if payload.affinity_filter.is_some() {
+                StaticAbilityId::Affinity
+            } else {
+                StaticAbilityId::ThisSpellCostReduction
+            };
             return Self {
-                id: Some(StaticAbilityId::ThisSpellCostReduction),
+                id: Some(id),
                 label: "this spell cost reduction".to_string(),
                 payload: StaticAbilityPayload::ThisSpellCostReduction(payload.clone()),
             };

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -47005,6 +47005,199 @@ fn target_assignments_for_requirements(
         .collect()
 }
 
+fn polliwallop_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(669_103), "Polliwallop")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Affinity for Frogs (This spell costs {1} less to cast for each Frog you control.)\n\
+             Target creature you control deals damage equal to twice its power to target creature you don't control.",
+        )
+        .expect("Polliwallop should parse strictly")
+}
+
+#[test]
+fn polliwallop_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Polliwallop");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let debug = format!("{:#?}", def.spell_effect);
+
+    assert!(
+        rendered.contains("Affinity for Frogs"),
+        "expected Polliwallop affinity keyword text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("damage equal to twice its power"),
+        "expected Polliwallop scaled power damage text, got {rendered}"
+    );
+    assert!(
+        debug.contains("TargetOnlyEffect")
+            && debug.contains("ExecuteWithSourceEffect")
+            && debug.contains("Scaled")
+            && debug.contains("PowerOf"),
+        "expected Polliwallop to tag the source creature and deal twice its power, got {debug}"
+    );
+}
+
+#[test]
+fn polliwallop_affinity_for_frogs_reduces_only_for_your_frogs() {
+    let def = polliwallop_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let spell = game.object(spell_id).expect("Polliwallop should be in hand");
+    let base_cost = spell
+        .mana_cost
+        .as_ref()
+        .expect("Polliwallop has a mana cost")
+        .clone();
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(&game, alice, spell, &base_cost).mana_value(),
+        4,
+        "Polliwallop should not be reduced with no Frogs you control"
+    );
+
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(669_104), "Alice Frog One")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Frog])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(669_105), "Alice Frog Two")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Frog])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(669_106), "Bob Frog")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Frog])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(669_107), "Alice Rabbit")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Rabbit])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let spell = game.object(spell_id).expect("Polliwallop should still be in hand");
+    let reduced = crate::decision::calculate_effective_mana_cost(&game, alice, spell, &base_cost);
+    assert_eq!(
+        reduced.mana_value(),
+        2,
+        "Polliwallop should cost {{1}}{{G}} with exactly two Frogs you control"
+    );
+}
+
+#[test]
+fn polliwallop_targets_and_deals_twice_source_creature_power() {
+    let def = polliwallop_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    let alice_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(669_108), "Alice Biter")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(3, 3))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let bob_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(669_109), "Bob Target")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(10, 10))
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Polliwallop should have spell effects");
+    let requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        program,
+        alice,
+        Some(spell_id),
+        None,
+    );
+    assert_eq!(requirements.len(), 2, "Polliwallop should require two targets");
+    assert!(
+        requirements[0]
+            .legal_targets
+            .contains(&crate::game_state::Target::Object(alice_creature)),
+        "first Polliwallop target should include a creature you control"
+    );
+    assert!(
+        !requirements[0]
+            .legal_targets
+            .contains(&crate::game_state::Target::Object(bob_creature)),
+        "first Polliwallop target must not include creatures you don't control"
+    );
+    assert!(
+        requirements[1]
+            .legal_targets
+            .contains(&crate::game_state::Target::Object(bob_creature)),
+        "second Polliwallop target should include a creature you don't control"
+    );
+    assert!(
+        !requirements[1]
+            .legal_targets
+            .contains(&crate::game_state::Target::Object(alice_creature)),
+        "second Polliwallop target must not include creatures you control"
+    );
+
+    let selected_targets = vec![
+        crate::game_state::Target::Object(alice_creature),
+        crate::game_state::Target::Object(bob_creature),
+    ];
+    let assignments = target_assignments_for_requirements(&requirements, &selected_targets);
+    let mut ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_targets(vec![
+            crate::effects::ResolvedTarget::Object(alice_creature),
+            crate::effects::ResolvedTarget::Object(bob_creature),
+        ])
+        .with_target_assignments(assignments);
+    for effect in program.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Polliwallop spell effect should resolve");
+    }
+
+    assert_eq!(
+        game.damage_on(bob_creature),
+        6,
+        "Polliwallop should deal twice the 3-power source creature's power"
+    );
+    assert_eq!(
+        game.damage_on(alice_creature),
+        0,
+        "Polliwallop is one-sided damage, not fight"
+    );
+}
+
 #[test]
 fn season_of_the_burrow_strict_parser_and_weighted_modal_text_regression() {
     let def = parse_oracle_card_definition("Season of the Burrow");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -47024,6 +47024,18 @@ fn polliwallop_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Polliwallop");
     let rendered = compiled_text_lines(&def).join("\n");
     let debug = format!("{:#?}", def.spell_effect);
+    let affinity = def.abilities.iter().find_map(|ability| match &ability.kind {
+        AbilityKind::Static(static_ability) if static_ability.has_affinity() => {
+            Some(static_ability)
+        }
+        _ => None,
+    });
+
+    assert!(
+        affinity.is_some_and(|static_ability| static_ability.id() == StaticAbilityId::Affinity),
+        "expected Polliwallop to preserve affinity keyword identity, got {:#?}",
+        def.abilities
+    );
 
     assert!(
         rendered.contains("Affinity for Frogs"),

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -2466,6 +2466,11 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
         .abilities
         .iter()
         .any(ability_has_begin_on_battlefield_pregame);
+    let render_spell_cost_modifiers_before_spell = spell_like_card
+        && def
+            .abilities
+            .iter()
+            .any(ability_is_this_spell_cost_modifier);
     let push_abilities = |output: &mut Vec<String>| {
         let has_suspend = def
             .alternative_casts
@@ -2474,6 +2479,12 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
         let mut ability_idx = 0usize;
         while ability_idx < def.abilities.len() {
             let ability = &def.abilities[ability_idx];
+            if render_spell_cost_modifiers_before_spell
+                && ability_is_this_spell_cost_modifier(ability)
+            {
+                ability_idx += 1;
+                continue;
+            }
             if has_suspend && is_suspend_helper_ability(ability) {
                 ability_idx += 1;
                 continue;
@@ -2650,6 +2661,23 @@ fn compiled_lines_inner(def: &CardDefinition) -> Vec<String> {
     if !spell_like_card {
         push_abilities(&mut out);
     }
+    if render_spell_cost_modifiers_before_spell {
+        for (idx, ability) in def.abilities.iter().enumerate() {
+            if !ability_is_this_spell_cost_modifier(ability) {
+                continue;
+            }
+            let ability_subject = if ability_prefers_card_name_subject(ability) {
+                def.card.name.as_str()
+            } else {
+                subject
+            };
+            let mut ability_lines = describe_ability(idx + 1, ability, ability_subject, rewrite_it_deals);
+            for line in &mut ability_lines {
+                *line = substitute_legendary_source_reference(line, &def.card, subject);
+            }
+            out.extend(ability_lines);
+        }
+    }
     if let Some(spell_effects) = &def.spell_effect
         && !spell_effects.is_empty()
         && !(def.aura_attach_filter.is_some() && has_attach_only_spell_effect)
@@ -2807,6 +2835,14 @@ fn has_additional_creature_sacrifice_cost(def: &CardDefinition) -> bool {
             .downcast_ref::<crate::effects::zones::SacrificePlayerEffect>()
             .is_some_and(|sacrifice| sacrifice.filter.card_types.contains(&CardType::Creature))
     })
+}
+
+fn ability_is_this_spell_cost_modifier(ability: &Ability) -> bool {
+    let AbilityKind::Static(static_ability) = &ability.kind else {
+        return false;
+    };
+    static_ability.this_spell_cost_reduction().is_some()
+        || static_ability.this_spell_cost_reduction_mana_cost().is_some()
 }
 
 fn is_choose_background_spell_effect(spell_effects: &crate::ResolutionProgram) -> bool {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -16423,6 +16423,7 @@ fn describe_damage_amount_clause(amount: &Value) -> (String, Option<String>) {
         return (amount_text, Some(where_x));
     }
     if value_prefers_equal_to(amount)
+        || power_damage_prefers_equal_to(amount)
         || (!value_prefers_where_x(amount) && count_damage_prefers_equal_to(amount))
     {
         return (format!("damage equal to {}", describe_value(amount)), None);
@@ -16438,6 +16439,19 @@ fn count_damage_prefers_equal_to(amount: &Value) -> bool {
         Value::Count(_) | Value::CountScaled(_, _) => true,
         Value::CountersOnSource(_) | Value::CountersOn(_, _) => true,
         Value::Scaled(inner, _) => count_damage_prefers_equal_to(inner),
+        _ => false,
+    }
+}
+
+fn power_damage_prefers_equal_to(amount: &Value) -> bool {
+    match amount.unhinted() {
+        Value::SourcePower | Value::SourceToughness | Value::PowerOf(_) | Value::ToughnessOf(_) => {
+            true
+        }
+        Value::Scaled(inner, _) => power_damage_prefers_equal_to(inner),
+        Value::Add(left, right) => {
+            power_damage_prefers_equal_to(left) || power_damage_prefers_equal_to(right)
+        }
         _ => false,
     }
 }

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -1872,6 +1872,9 @@ impl ThisSpellCostReduction {
 
 impl StaticAbilityKind for ThisSpellCostReduction {
     fn id(&self) -> StaticAbilityId {
+        if self.affinity_filter.is_some() {
+            return StaticAbilityId::Affinity;
+        }
         StaticAbilityId::ThisSpellCostReduction
     }
 
@@ -1903,6 +1906,10 @@ impl StaticAbilityKind for ThisSpellCostReduction {
 
     fn modifies_costs(&self) -> bool {
         true
+    }
+
+    fn has_affinity(&self) -> bool {
+        self.affinity_filter.is_some()
     }
 
     fn this_spell_cost_reduction(&self) -> Option<&ThisSpellCostReduction> {

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -90,6 +90,24 @@ fn pluralize_cost_noun_phrase(phrase: &str) -> String {
     }
 }
 
+fn describe_affinity_filter(filter: &ObjectFilter) -> String {
+    if filter.card_types.is_empty() && filter.subtypes.len() == 1 {
+        return pluralize_cost_noun_phrase(&filter.subtypes[0].to_string());
+    }
+    if filter.card_types.len() == 1 && filter.subtypes.is_empty() {
+        return pluralize_cost_noun_phrase(filter.card_types[0].name());
+    }
+
+    let mut bare = filter.clone();
+    bare.controller = None;
+    pluralize_cost_noun_phrase(
+        strip_indefinite_article(&bare.description())
+            .trim()
+            .trim_end_matches(" on the battlefield")
+            .trim(),
+    )
+}
+
 fn describe_greatest_count_cost_filter(filter: &ObjectFilter) -> String {
     let Some(controller) = &filter.controller else {
         return pluralize_cost_noun_phrase(strip_indefinite_article(&filter.description()));
@@ -1834,6 +1852,7 @@ pub fn this_spell_cost_condition_is_active_for_cast_with_optional_costs_paid(
 pub struct ThisSpellCostReduction {
     pub reduction: Value,
     pub condition: ThisSpellCostCondition,
+    pub affinity_filter: Option<ObjectFilter>,
 }
 
 impl ThisSpellCostReduction {
@@ -1841,7 +1860,13 @@ impl ThisSpellCostReduction {
         Self {
             reduction,
             condition,
+            affinity_filter: None,
         }
+    }
+
+    pub fn with_affinity_filter(mut self, filter: ObjectFilter) -> Self {
+        self.affinity_filter = Some(filter);
+        self
     }
 }
 
@@ -1851,6 +1876,9 @@ impl StaticAbilityKind for ThisSpellCostReduction {
     }
 
     fn display(&self) -> String {
+        if let Some(filter) = &self.affinity_filter {
+            return format!("Affinity for {}", describe_affinity_filter(filter));
+        }
         let (amount_text, tail) = describe_cost_modifier_amount(&self.reduction);
         let mut line = format!("This spell costs {amount_text} less to cast");
         if let Some(tail) = tail {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -714,6 +714,13 @@ impl StaticAbilityModelInterpreter {
                     reduction.amount.clone(),
                     reduction.condition.clone(),
                 ))
+                .map(|runtime| {
+                    if let Some(filter) = &reduction.affinity_filter {
+                        runtime.with_affinity_filter(filter.clone())
+                    } else {
+                        runtime
+                    }
+                })
             }
             ironsmith_core::StaticAbilityPayload::Conditional { ability, .. } => {
                 Self::cached_this_spell_cost_reduction(ability)

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -2169,7 +2169,7 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
     }
 
     fn has_affinity(&self) -> bool {
-        self.id() == StaticAbilityId::AffinityForArtifacts
+        matches!(self.id(), StaticAbilityId::Affinity | StaticAbilityId::AffinityForArtifacts)
     }
 
     fn has_delve(&self) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Polliwallop
Initial parse error:
```
parser does not yet support line family: 'Affinity for Frogs (This spell costs {1} less to cast for each Frog you control.)'; oracle-only fallback also failed: parser does not yet support line family: 'Affinity for Frogs'
```

Current worker: i-0d83326c022f5f0a5
Branch: codex/aws-card-fix-polliwallop
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0017
