### PR TITLE
Fix Ironsmith parse failure: Gilded Light

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -486,6 +486,13 @@ fn player_gain_effects_for_abilities(
                     None,
                 ));
             }
+            GrantedAbilityAst::KeywordAction(KeywordAction::Shroud) => {
+                effects.push(EffectAst::subject_verb_cant(
+                    crate::effect::Restriction::be_targeted_player(player_filter.clone()),
+                    duration.clone(),
+                    None,
+                ));
+            }
             GrantedAbilityAst::KeywordAction(KeywordAction::ProtectionFromEverything) => {
                 effects.push(EffectAst::subject_verb_cant(
                     crate::effect::Restriction::be_targeted_player(player_filter.clone()),
@@ -2480,6 +2487,22 @@ mod tests {
                 && string_contains(&debug, "GrantAbilitiesAll")
                 && string_contains(&debug, "Hexproof"),
             "expected player hexproof restriction plus permanent hexproof grant, got {debug}"
+        );
+    }
+
+    #[test]
+    fn you_gain_shroud_lowers_to_unscoped_player_target_restriction() {
+        let tokens = tokenize_line("You gain shroud until end of turn.", 0);
+        let effects = parse_gain_ability_sentence(&tokens)
+            .expect("player shroud grant should parse")
+            .expect("player shroud grant should produce effects");
+
+        let debug = format!("{effects:?}");
+        assert!(
+            string_contains(&debug, "Cant")
+                && string_contains(&debug, "BeTargetedPlayer")
+                && !string_contains(&debug, "BeTargetedPlayerFrom"),
+            "expected shroud to prevent all targeting of the player, got {debug}"
         );
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -260,13 +260,6 @@ fn display_text_for_tokens(tokens: &[OwnedLexToken]) -> String {
     text
 }
 
-fn grants_protection_from_everything(ability: &GrantedAbilityAst) -> bool {
-    matches!(
-        ability,
-        GrantedAbilityAst::KeywordAction(KeywordAction::ProtectionFromEverything)
-    )
-}
-
 fn append_shared_subject_pump_to_target(
     effects: &mut Vec<EffectAst>,
     target: &TargetAst,
@@ -1765,23 +1758,20 @@ pub(crate) fn parse_gain_ability_sentence(
     }
 
     if !losing && YOU_SUBJECT_PATTERN.matches_words(&real_subject_words) {
-        let has_protection_from_everything =
-            abilities.iter().any(grants_protection_from_everything);
-        if has_protection_from_everything {
-            let player_target =
-                TargetAst::Player(PlayerFilter::You, span_from_tokens(&real_subject_tokens));
-            effects.push(EffectAst::subject_verb_cant(
-                crate::effect::Restriction::be_targeted_player(PlayerFilter::You),
-                duration.clone(),
-                None,
-            ));
-            effects.push(EffectAst::subject_verb_prevent_all_damage_to_target(
-                player_target,
-                duration.clone(),
-            ));
-            effects = append_gain_ability_trailing_effects(effects, &trailing_tail_tokens)?;
-            return Ok(Some(effects));
-        }
+        let Some(mut player_effects) = player_gain_effects_for_abilities(
+            &abilities,
+            &duration,
+            &real_subject_tokens,
+            PlayerFilter::You,
+        ) else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported player gain-ability clause (clause: '{}')",
+                word_list.join(" ")
+            )));
+        };
+        effects.append(&mut player_effects);
+        effects = append_gain_ability_trailing_effects(effects, &trailing_tail_tokens)?;
+        return Ok(Some(effects));
     }
 
     if !losing && YOU_AND_PERMANENTS_YOU_CONTROL_PATTERN.matches_words(&real_subject_words) {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7008,6 +7008,42 @@ fn everybody_lives_compiled_text_includes_player_hexproof_and_life_lock_clauses(
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn gilded_light_parses_strictly_with_player_shroud_and_cycling() {
+    CardDefinitionBuilder::new(CardId::from_raw(46_396), "Gilded Light")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "You gain shroud until end of turn. (You can't be the target of spells or abilities.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
+        )
+        .expect("Gilded Light should parse strictly");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gilded_light_compiled_text_includes_player_shroud_and_cycling() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(46_396), "Gilded Light")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "You gain shroud until end of turn. (You can't be the target of spells or abilities.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
+        )
+        .expect("Gilded Light should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("You can't be targeted this turn") && rendered.contains("Cycling {2}"),
+        "expected Gilded Light compiled text to keep player shroud and cycling, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_characteristic_pt_constant_plus_count() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Aysen Crusader")
         .parse_text(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7035,10 +7035,13 @@ fn gilded_light_compiled_text_includes_player_shroud_and_cycling() {
         )
         .expect("Gilded Light should parse strictly");
 
-    let rendered = unprocessed_compiled_lines(&def).join(" ");
-    assert!(
-        rendered.contains("You can't be targeted this turn") && rendered.contains("Cycling {2}"),
-        "expected Gilded Light compiled text to keep player shroud and cycling, got {rendered}"
+    assert_eq!(
+        unprocessed_compiled_lines(&def),
+        vec![
+            "You gain shroud until end of turn.".to_string(),
+            "Cycling {2}".to_string(),
+        ],
+        "expected Gilded Light compiled text to preserve player shroud and cycling"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3499,6 +3499,11 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return describe_structural_multisentence_effect_list(rest);
     }
 
+    let refs = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_player_protection_from_everything_pair(&refs) {
+        return Some(compact);
+    }
+
     if let Some(compact) = describe_untap_attacking_then_additional_combat(effects) {
         return Some(compact);
     }
@@ -3528,7 +3533,6 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     if effects.len() == 3 {
-        let refs = effects.iter().collect::<Vec<_>>();
         if let Some(compact) = describe_discard_hand_add_mana_draw_sequence(&refs) {
             return Some(compact);
         }
@@ -4968,6 +4972,53 @@ fn may_cast_copy_targets_tag(effect: &Effect, tag: &str) -> bool {
     cast_effect
         .downcast_ref::<crate::effects::CastTaggedEffect>()
         .is_some_and(|cast| cast.as_copy && cast.tag.as_str() == tag)
+}
+
+fn describe_player_gain_keyword(player: &PlayerFilter, keyword: &str, duration: &Until) -> String {
+    let subject = describe_player_set_filter(player);
+    let verb = match player {
+        PlayerFilter::You
+        | PlayerFilter::Any
+        | PlayerFilter::Opponent
+        | PlayerFilter::NotYou
+        | PlayerFilter::Teammate => "gain",
+        _ => "gains",
+    };
+    let duration_text = if *duration == Until::EndOfTurn {
+        "until end of turn".to_string()
+    } else {
+        describe_until(duration)
+    };
+    format!("{subject} {verb} {keyword} {duration_text}")
+}
+
+fn describe_player_protection_from_everything_pair(effects: &[&Effect]) -> Option<String> {
+    let [cant_effect, prevent_effect] = effects else {
+        return None;
+    };
+    let cant = cant_effect.downcast_ref::<crate::effects::CantEffect>()?;
+    let prevent = prevent_effect.downcast_ref::<crate::effects::PreventAllDamageToTargetEffect>()?;
+    let crate::effect::Restriction::BeTargetedPlayer(player) = &cant.restriction else {
+        return None;
+    };
+    let same_player = match prevent.target.base() {
+        ChooseSpec::Player(prevent_player) => prevent_player == player,
+        ChooseSpec::SourceController => player == &PlayerFilter::You,
+        _ => false,
+    };
+    if !same_player
+        || prevent.duration != cant.duration
+        || prevent.damage_filter != crate::prevention::DamageFilter::all()
+        || !prevent.follow_up_effects.is_empty()
+    {
+        return None;
+    }
+
+    Some(describe_player_gain_keyword(
+        player,
+        "protection from everything",
+        &cant.duration,
+    ))
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
@@ -6558,6 +6609,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
 
     if let Some(compact) = describe_source_counter_and_create(&filtered) {
+        return compact;
+    }
+    if let Some(compact) = describe_player_protection_from_everything_pair(&filtered) {
         return compact;
     }
 
@@ -15729,6 +15783,9 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
     }
 
     let effect_refs = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_player_protection_from_everything_pair(&effect_refs) {
+        return Some(compact);
+    }
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&effect_refs) {
         return Some(compact);
     }
@@ -34378,6 +34435,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 _ => capitalize_first(&description),
             };
             return format!("{subject} must be blocked this turn if able");
+        }
+        if let crate::effect::Restriction::BeTargetedPlayer(player) = &cant.restriction {
+            return describe_player_gain_keyword(player, "shroud", &cant.duration);
         }
         if cant.duration == Until::EndOfTurn {
             let restriction_text = describe_restriction(&cant.restriction);

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -47525,6 +47525,67 @@ fn sleep_with_the_fishes_creates_unblockable_fish_token() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn gilded_light_shroud_blocks_all_player_targeting_until_end_of_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let gilded_light = CardDefinitionBuilder::new(CardId::from_raw(46_396), "Gilded Light")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "You gain shroud until end of turn. (You can't be the target of spells or abilities.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
+        )
+        .expect("Gilded Light should parse");
+    let spell_id = game.create_object_from_definition(&gilded_light, alice, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(spell_id, alice).with_source_info(
+            game.object(spell_id)
+                .expect("Gilded Light spell should exist")
+                .stable_id,
+            "Gilded Light".to_string(),
+        ),
+    );
+
+    let alice_source = create_creature(&mut game, "Friendly Source", alice, 2, 2);
+    let bob_source = create_creature(&mut game, "Opposing Source", bob, 2, 2);
+    assert!(game.can_target_player_from_source(alice, alice_source));
+    assert!(game.can_target_player_from_source(alice, bob_source));
+
+    resolve_stack_entry(&mut game).expect("Gilded Light should resolve");
+
+    assert!(
+        !game.can_target_player(alice),
+        "Gilded Light should make its controller untargetable"
+    );
+    assert!(
+        !game.can_target_player_from_source(alice, alice_source),
+        "shroud should stop the controller's own sources from targeting them"
+    );
+    assert!(
+        !game.can_target_player_from_source(alice, bob_source),
+        "shroud should stop opposing sources from targeting the controller"
+    );
+    assert!(
+        game.can_target_player_from_source(bob, bob_source),
+        "Gilded Light should not grant shroud to other players"
+    );
+
+    execute_cleanup_step(&mut game);
+    game.refresh_continuous_state();
+
+    assert!(
+        game.can_target_player_from_source(alice, alice_source)
+            && game.can_target_player_from_source(alice, bob_source),
+        "Gilded Light's shroud should expire at end of turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn absolute_virtue_blocks_opponent_controlled_sources_from_targeting_you() {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::ids::CardId;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gilded Light
Initial parse error:
```
unsupported subject in gain-ability clause (clause: 'you gain shroud until end of turn'); oracle-only fallback also failed: unsupported subject in gain-ability clause (clause: 'you gain shroud until end of turn')
```

Current worker: i-0aee8ff71260302ff
Branch: codex/aws-card-fix-gilded-light
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0017
