### PR TITLE
Fix Ironsmith parse failure: Frightful Delusion

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -4991,13 +4991,22 @@ fn compile_subject_verb_effect(
             Ok((vec![effect], choices))
         }
         SubjectVerbActionAst::Counter { target } => {
-            compile_tagged_effect_for_target(target, ctx, "countered", Effect::counter)
+            let compiled =
+                compile_tagged_effect_for_target(target, ctx, "countered", Effect::counter)?;
+            if let Some(tag) = ctx.last_object_tag.clone() {
+                ctx.last_player_filter = Some(PlayerFilter::ControllerOf(ObjectRef::tagged(tag)));
+            }
+            Ok(compiled)
         }
         SubjectVerbActionAst::CounterUnlessPays { target, cost } => {
             let cost = cost.clone();
-            compile_tagged_effect_for_target(target, ctx, "countered", |spec| {
+            let compiled = compile_tagged_effect_for_target(target, ctx, "countered", |spec| {
                 Effect::counter_unless_pays_total_cost(spec, cost.clone())
-            })
+            })?;
+            if let Some(tag) = ctx.last_object_tag.clone() {
+                ctx.last_player_filter = Some(PlayerFilter::ControllerOf(ObjectRef::tagged(tag)));
+            }
+            Ok(compiled)
         }
         SubjectVerbActionAst::PutCounters {
             counter_type,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -557,6 +557,11 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::Counter { target }
                 | SubjectVerbActionAst::CounterUnlessPays { target, .. } => {
                     maybe_tag_target(target, frame, id_gen, "countered")?;
+                    if let Some(tag) = frame.last_object_tag.as_deref() {
+                        frame.last_player_filter = Some(PlayerFilter::ControllerOf(
+                            ObjectRef::tagged(tag.to_string()),
+                        ));
+                    }
                 }
                 SubjectVerbActionAst::PutCounters { target, .. }
                 | SubjectVerbActionAst::PutCounterChoice { target, .. } => {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -16351,6 +16351,32 @@ fn test_counter_unless_pays_rendering() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn frightful_delusion_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Frightful Delusion");
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.spell_effect.is_some(),
+        "Frightful Delusion should parse as a strict spell"
+    );
+    assert!(
+        spell_debug.contains("UnlessPaysEffect")
+            && spell_debug.contains("CounterEffect")
+            && spell_debug.contains("DiscardEffect")
+            && spell_debug.contains("ControllerOf(")
+            && !spell_debug.contains("IteratedPlayer"),
+        "expected counter-unless-pay followed by target controller discard, got {spell_debug}"
+    );
+    assert!(
+        rendered.contains("Counter target spell unless its controller pays {1}")
+            && rendered.contains("That player discards a card"),
+        "expected Frightful Delusion counter-unless and discard text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_counter_unless_pays_and_life_rendering() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Mundungu Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3540,6 +3540,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         }
     }
 
+    if let Some(compact) = describe_counter_unless_then_controller_discards(effects) {
+        return Some(compact);
+    }
+
     if let Some(compact) = describe_counter_unless_then_kick_count_draw(effects) {
         return Some(compact);
     }
@@ -3951,6 +3955,35 @@ fn describe_counter_unless_then_kick_count_draw(effects: &[Effect]) -> Option<St
             .to_string()
     };
     Some(format!("{counter_text}. {draw_text}"))
+}
+
+fn describe_counter_unless_then_controller_discards(effects: &[Effect]) -> Option<String> {
+    let [unless_effect, discard_effect] = effects else {
+        return None;
+    };
+    let countered_tag = structural_effect_tag(unless_effect)?.clone();
+    let unless_pays = unwrap_structural_effect_tag(unless_effect)
+        .downcast_ref::<crate::effects::UnlessPaysEffect>()?;
+    let [counter_effect] = unless_pays.effects.as_slice() else {
+        return None;
+    };
+    counter_effect.downcast_ref::<crate::effects::CounterEffect>()?;
+
+    let discard = discard_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+    if discard.count != Value::Fixed(1)
+        || discard.random
+        || discard.any_number
+        || discard.card_filter.is_some()
+        || discard.player
+            != PlayerFilter::ControllerOf(crate::filter::ObjectRef::Tagged(countered_tag))
+    {
+        return None;
+    }
+
+    let counter_text = describe_effect(unless_effect)
+        .trim_end_matches('.')
+        .to_string();
+    Some(format!("{counter_text}. That player discards a card."))
 }
 
 fn describe_return_to_hand_then_owner_discards(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -40758,6 +40758,20 @@ fn spell_contortion_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn frightful_delusion_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(76_303), "Frightful Delusion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Counter target spell unless its controller pays {1}. That player discards a card.",
+        )
+        .expect("Frightful Delusion should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn stack_spell_probe_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(76_302), "Stack Spell Probe")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
@@ -40783,6 +40797,66 @@ fn put_spell_contortion_on_stack(
             .with_optional_costs_paid(paid),
     );
     source
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_frightful_delusion_on_stack(
+    game: &mut GameState,
+    controller: PlayerId,
+    target_spell: ObjectId,
+) -> ObjectId {
+    let def = frightful_delusion_definition();
+    let source = game.create_object_from_definition(&def, controller, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(source, controller).with_targets(vec![Target::Object(target_spell)]),
+    );
+    source
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseSpecificDiscardDecisionMaker {
+    card_to_discard: ObjectId,
+    accept_boolean: bool,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseSpecificDiscardDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept_boolean
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx
+            .candidates
+            .iter()
+            .any(|candidate| candidate.id == self.card_to_discard && candidate.legal)
+        {
+            vec![self.card_to_discard]
+        } else {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_hand_card(game: &mut GameState, owner: PlayerId, name: &str, raw_id: u32) -> ObjectId {
+    let card = CardBuilder::new(CardId::from_raw(raw_id), name)
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&card, owner, Zone::Hand)
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
@@ -40937,6 +41011,112 @@ fn test_strength_of_the_tajuru_puts_x_counters_on_each_kicked_target() {
     assert_eq!(
         untargeted_counters, 0,
         "Strength of the Tajuru should affect only its chosen targets"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn frightful_delusion_unpaid_counter_discards_target_spell_controller_card() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let bob_discard = create_hand_card(&mut game, bob, "Bob Discards", 76_304);
+    let alice_keeps = create_hand_card(&mut game, alice, "Alice Keeps", 76_305);
+    let frightful_delusion = put_frightful_delusion_on_stack(&mut game, alice, target_spell);
+    let mut dm = ChooseSpecificDiscardDecisionMaker {
+        card_to_discard: bob_discard,
+        accept_boolean: false,
+    };
+
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Frightful Delusion should resolve");
+
+    let countered_target = game
+        .current_object_id_after_zone_change(target_spell)
+        .expect("target spell should still be tracked after zone change");
+    assert_eq!(
+        game.object(countered_target)
+            .expect("target spell exists")
+            .zone,
+        Zone::Graveyard,
+        "the target spell should be countered when its controller cannot pay {{1}}"
+    );
+    assert!(
+        game.player(bob).is_some_and(|player| player
+            .graveyard
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|obj| obj.name == "Bob Discards"))),
+        "the target spell's controller should discard a card"
+    );
+    assert!(
+        game.object(alice_keeps)
+            .is_some_and(|obj| obj.zone == Zone::Hand),
+        "Frightful Delusion should not make its controller discard"
+    );
+    assert!(
+        !game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == frightful_delusion),
+        "Frightful Delusion should leave the stack after resolving"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn frightful_delusion_paid_target_survives_but_controller_still_discards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.player_mut(bob)
+        .expect("bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 1);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let bob_discard = create_hand_card(&mut game, bob, "Bob Pays And Discards", 76_306);
+    let frightful_delusion = put_frightful_delusion_on_stack(&mut game, alice, target_spell);
+    let mut dm = ChooseSpecificDiscardDecisionMaker {
+        card_to_discard: bob_discard,
+        accept_boolean: true,
+    };
+
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Frightful Delusion should resolve");
+
+    assert_eq!(
+        game.object(target_spell).expect("target spell exists").zone,
+        Zone::Stack,
+        "the target spell should remain on the stack when its controller pays {{1}}"
+    );
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| entry.object_id == target_spell),
+        "the paid-for target spell should still have a stack entry"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").mana_pool.total(),
+        0,
+        "the target spell's controller should spend {{1}} to prevent the counter effect"
+    );
+    assert!(
+        game.player(bob).is_some_and(|player| player
+            .graveyard
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|obj| obj.name == "Bob Pays And Discards"))),
+        "the target spell's controller should discard even after paying for Frightful Delusion"
+    );
+    assert!(
+        !game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == frightful_delusion),
+        "Frightful Delusion should leave the stack after resolving"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Frightful Delusion
Initial parse error:
```
spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Fixed(1), player: IteratedPlayer, random: false, any_number: false, card_filter: None, tag: Some(TagKey("discarded_1")) }); oracle-only fallback also failed: spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Fixed(1), player: IteratedPlayer, random: false, any_number: false, card_filter: None, tag: Some(TagKey("discarded_1")) })
```

Current worker: i-0b985a8468098c8b5
Branch: codex/aws-card-fix-frightful-delusion
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0018
