### PR TITLE
Fix Ironsmith parse failure: Embermaw Hellion

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -281,35 +281,6 @@ const DAMAGE_DOUBLING_TO_TARGET_PATTERN: ClauseShape<'static> = clause_shape!(
             &["would", "deal", "damage", "to", "target"],
         ]]
 );
-const DAMAGE_PLUS_REPLACEMENT_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
-    prefix
-        & [
-            "if",
-            "a",
-            "source",
-            "you",
-            "control",
-            "would",
-            "deal",
-            "damage",
-            "to",
-            "an",
-            "opponent",
-            "or",
-            "a",
-            "permanent",
-            "an",
-            "opponent",
-            "controls",
-            "it",
-            "deals",
-            "that",
-            "much",
-            "damage",
-            "plus",
-        ];
-    suffix & ["instead"]
-);
 const WOULD_DEAL_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["would", "deal", "damage", "to"]);
 const WOULD_DEAL_DAMAGE_TO_YOU_PHRASE_PATTERN: ClauseShape<'static> =
@@ -321,6 +292,8 @@ const IT_DEALS_MULTIPLE_THAT_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> = cl
             &["it", "deals", "triple", "that", "damage", "to"],
         ]
 );
+const IT_DEALS_THAT_MUCH_DAMAGE_PLUS_PHRASE_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["it", "deals", "that", "much", "damage", "plus"]);
 const THAT_SOURCE_DEALS_DAMAGE_EQUAL_TO_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["that", "source", "deals", "damage", "equal", "to"]);
 const DAMAGE_REDIRECT_TO_SOURCE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -4841,30 +4814,106 @@ pub(crate) fn parse_damage_amount_replacement_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     let tokens = trim_edge_punctuation(tokens);
     let words = parser_token_word_refs(&tokens);
-    const DAMAGE_PLUS_REPLACEMENT_PREFIX_LEN: usize = 23;
-    if !DAMAGE_PLUS_REPLACEMENT_PREFIX_PATTERN.matches_words(&words) {
+    if !IF_PREFIX_PATTERN.matches_words(&words) {
         return Ok(None);
     }
-    let Some(delta_word) = words.get(DAMAGE_PLUS_REPLACEMENT_PREFIX_LEN) else {
+
+    let Some(would_idx) = find_window_by(&words, 4, |window| {
+        WOULD_DEAL_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
+    }) else {
+        return Ok(None);
+    };
+    let Some(source_idx) = SOURCE_WORD_PATTERN.find_word(&words[..would_idx]) else {
+        return Ok(None);
+    };
+    if source_idx <= 1 {
+        return Ok(None);
+    }
+
+    let Some(tail_idx) = find_window_by(&words[would_idx + 4..], 6, |window| {
+        IT_DEALS_THAT_MUCH_DAMAGE_PLUS_PHRASE_PATTERN.matches_words(window)
+    }) else {
+        return Ok(None);
+    };
+    let replacement_start = would_idx + 4 + tail_idx;
+    let Some(delta_word) = words.get(replacement_start + 6) else {
         return Ok(None);
     };
     let Some(delta) = parse_number_word_i32(delta_word) else {
         return Ok(None);
     };
-    if words.len() != DAMAGE_PLUS_REPLACEMENT_PREFIX_LEN + 2 {
+
+    let damaged_words = &words[would_idx + 4..replacement_start];
+    let replacement_target_words = &words[replacement_start + 7..];
+    let (target_player_filter, target_object_filter) =
+        parse_damage_amount_replacement_target_filters(damaged_words)?;
+    if target_player_filter.is_none() && target_object_filter.is_none() {
+        return Ok(None);
+    }
+    if !damage_amount_plus_tail_matches_target(
+        replacement_target_words,
+        target_player_filter.as_ref(),
+        target_object_filter.as_ref(),
+    )? {
         return Ok(None);
     }
 
-    let display = format!(
-        "If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus {delta} instead."
+    let source_tokens = trim_lexed_commas(
+        LexedClause::new(&tokens)
+            .between_word_range(1, source_idx)
+            .unwrap_or_else(|| LexedClause::new(&tokens).between(tokens.len(), tokens.len()))
+            .tokens(),
     );
+    let source_words = parser_token_word_refs(source_tokens);
+    let mut source_filter =
+        if source_tokens.is_empty() || ARTICLE_WORD_PATTERN.matches_words(&source_words) {
+            ObjectFilter::default()
+        } else {
+            parse_object_filter_lexed(source_tokens, false)?
+        };
+
+    match &words[source_idx + 1..would_idx] {
+        ["you", "control"] => source_filter = source_filter.you_control(),
+        ["an", "opponent", "controls"] | ["opponent", "controls"] => {
+            source_filter = source_filter.controlled_by(PlayerFilter::Opponent);
+        }
+        [] => {}
+        _ => return Ok(None),
+    }
+
+    let mut display = render_token_slice(&tokens).trim().to_string();
+    if !display.ends_with('.') {
+        display.push('.');
+    }
     Ok(Some(StaticAbility::modify_damage_amount_replacement(
-        ObjectFilter::default().you_control(),
-        Some(PlayerFilter::Opponent),
-        Some(ObjectFilter::permanent().controlled_by(PlayerFilter::Opponent)),
+        source_filter,
+        target_player_filter,
+        target_object_filter,
         delta,
         display,
     )))
+}
+
+fn damage_amount_plus_tail_matches_target(
+    words: &[&str],
+    target_player_filter: Option<&PlayerFilter>,
+    target_object_filter: Option<&ObjectFilter>,
+) -> Result<bool, CardTextError> {
+    if words == ["instead"] {
+        return Ok(true);
+    }
+    if words.len() < 4
+        || !TO_WORD_PATTERN.matches_word(words[0])
+        || !THAT_WORD_PATTERN.matches_word(words[1])
+        || !INSTEAD_WORD_PATTERN.matches_last_word(words)
+    {
+        return Ok(false);
+    }
+
+    let (tail_player_filter, tail_object_filter) =
+        parse_damage_amount_replacement_target_filters(&words[2..words.len() - 1])?;
+    Ok(tail_player_filter.as_ref() == target_player_filter
+        && tail_object_filter.as_ref() == target_object_filter)
 }
 
 pub(crate) fn parse_double_damage_amount_replacement_line(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -20091,6 +20091,168 @@ fn fiery_emancipation_triples_only_damage_from_sources_you_control() {
     );
 }
 
+#[test]
+fn embermaw_hellion_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Embermaw Hellion");
+    let def = parse_oracle_card_definition("Embermaw Hellion");
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Trample")
+            && rendered.contains(
+                "If another red source you control would deal damage to a permanent or player, it deals that much damage plus 1 to that permanent or player instead"
+            ),
+        "expected Embermaw Hellion trample and additive damage replacement wording, got {rendered}"
+    );
+    assert!(
+        debug.contains("ModifyDamageAmountReplacement")
+            && debug.contains("other: true")
+            && debug.contains("colors: Some")
+            && debug.contains("controller: Some(You)")
+            && debug.contains("target_player_filter")
+            && debug.contains("target_object_filter")
+            && debug.contains("delta: 1"),
+        "expected Embermaw Hellion to compile to an other red source +1 damage replacement, got {debug}"
+    );
+}
+
+#[test]
+fn embermaw_hellion_adds_one_to_another_red_source_damage_to_players_and_permanents() {
+    let embermaw = parse_oracle_card_definition("Embermaw Hellion");
+    let red_source = CardDefinitionBuilder::new(CardId::from_raw(91_400), "Alice Red Source")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let red_spell = CardDefinitionBuilder::new(CardId::from_raw(91_404), "Alice Red Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Instant])
+        .build();
+    let target = CardDefinitionBuilder::new(CardId::from_raw(91_401), "Alice Target Permanent")
+        .card_types(vec![CardType::Artifact])
+        .build();
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let embermaw_id = game.create_object_from_definition(&embermaw, alice, Zone::Battlefield);
+    let red_source_id = game.create_object_from_definition(&red_source, alice, Zone::Battlefield);
+    let red_spell_id = game.create_object_from_definition(&red_spell, alice, Zone::Stack);
+    let target_id = game.create_object_from_definition(&target, alice, Zone::Battlefield);
+
+    game.update_replacement_effects();
+    assert!(
+        game.effect_store
+            .replacement_effects
+            .effects()
+            .iter()
+            .any(|replacement| {
+                replacement.source == embermaw_id
+                    && matches!(
+                        replacement.replacement,
+                        crate::replacement::ReplacementAction::Modify(
+                            crate::replacement::EventModification::Add(1)
+                        )
+                    )
+            }),
+        "Embermaw Hellion should register a +1 damage replacement"
+    );
+
+    let player_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        red_source_id,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(player_damage.assignments.len(), 1);
+    assert_eq!(player_damage.assignments[0].amount, 3);
+
+    let permanent_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        red_source_id,
+        crate::events::DamageTarget::Object(target_id),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(permanent_damage.assignments.len(), 1);
+    assert_eq!(permanent_damage.assignments[0].amount, 5);
+
+    let spell_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        red_spell_id,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(spell_damage.assignments.len(), 1);
+    assert_eq!(spell_damage.assignments[0].amount, 3);
+}
+
+#[test]
+fn embermaw_hellion_ignores_self_nonred_and_opposing_sources() {
+    let embermaw = parse_oracle_card_definition("Embermaw Hellion");
+    let colorless_source =
+        CardDefinitionBuilder::new(CardId::from_raw(91_402), "Alice Colorless Source")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+    let bob_red_source = CardDefinitionBuilder::new(CardId::from_raw(91_403), "Bob Red Source")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let embermaw_id = game.create_object_from_definition(&embermaw, alice, Zone::Battlefield);
+    let colorless_source_id =
+        game.create_object_from_definition(&colorless_source, alice, Zone::Battlefield);
+    let bob_red_source_id =
+        game.create_object_from_definition(&bob_red_source, bob, Zone::Battlefield);
+    game.update_replacement_effects();
+
+    let self_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        embermaw_id,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(self_damage.assignments.len(), 1);
+    assert_eq!(self_damage.assignments[0].amount, 2);
+
+    let nonred_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        colorless_source_id,
+        crate::events::DamageTarget::Player(bob),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(nonred_damage.assignments.len(), 1);
+    assert_eq!(nonred_damage.assignments[0].amount, 2);
+
+    let opposing_damage = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        bob_red_source_id,
+        crate::events::DamageTarget::Player(alice),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(opposing_damage.assignments.len(), 1);
+    assert_eq!(opposing_damage.assignments[0].amount, 2);
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn sphere_of_truth_strict_parser_and_compiled_text_regression() {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Embermaw Hellion
Initial parse error:
```
unsupported predicate (predicate: 'another red source you control would deal damage to permanent'); oracle-only fallback also failed: unsupported predicate (predicate: 'another red source you control would deal damage to permanent')
```

Current worker: i-0ff3dcb813c2c0db2
Branch: codex/aws-card-fix-embermaw-hellion
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0019
