### PR TITLE
Fix Ironsmith parse failure: Krang, Master Mind

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -5,8 +5,13 @@ use winnow::stream::Stream;
 use winnow::token::any;
 
 use crate::cards::TextSpan;
-use crate::cards::builders::{CardTextError, EffectAst, IfResultPredicate, PredicateAst};
+use crate::cards::builders::{
+    CardTextError, EffectAst, IfResultPredicate, PlayerAst, PredicateAst, SubjectVerbActionAst,
+    SubjectVerbRoleAst,
+};
 use crate::effect::{Comparison, Value};
+use crate::target::PlayerFilter;
+use ironsmith_core::ValueSurfaceHint;
 
 use super::super::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use super::super::lexer::{
@@ -1438,8 +1443,7 @@ pub(crate) fn split_if_clause_lexed(
         if !predicate_tokens_without_commas.is_empty() {
             if let Ok(predicate) =
                 parse_predicate_with_grammar_entrypoint_lexed(&predicate_tokens_without_commas)
-                && let Ok(effects) =
-                    parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1472,15 +1476,25 @@ pub(crate) fn split_if_clause_lexed(
             if effect_tokens.is_empty() {
                 continue;
             }
-            if let Ok(predicate) = parse_predicate_with_grammar_entrypoint_lexed(predicate_tokens)
-                && let Ok(effects) =
-                    parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
-                && !effects.is_empty()
-            {
-                return Ok(IfClauseSplitSpec {
-                    predicate: IfClausePredicateSpec::Conditional(predicate),
-                    effects,
-                });
+            if let Ok(predicate) = parse_predicate_with_grammar_entrypoint_lexed(predicate_tokens) {
+                if let Some(effects) = parse_cards_in_hand_difference_draw_effect(
+                    &predicate,
+                    predicate_tokens,
+                    effect_tokens,
+                ) {
+                    return Ok(IfClauseSplitSpec {
+                        predicate: IfClausePredicateSpec::Conditional(predicate),
+                        effects,
+                    });
+                }
+                if let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
+                    && !effects.is_empty()
+                {
+                    return Ok(IfClauseSplitSpec {
+                        predicate: IfClausePredicateSpec::Conditional(predicate),
+                        effects,
+                    });
+                }
             }
             if let Some(predicate) = parse_if_result_predicate(predicate_tokens)
                 && let Ok(effects) =
@@ -1503,6 +1517,16 @@ pub(crate) fn split_if_clause_lexed(
         let predicate_tokens = &tokens[1..first_comma_idx];
         if let Ok(predicate) = parse_predicate_with_grammar_entrypoint_lexed(predicate_tokens) {
             let effect_tokens = &tokens[first_comma_idx + 1..];
+            if let Some(effects) = parse_cards_in_hand_difference_draw_effect(
+                &predicate,
+                predicate_tokens,
+                effect_tokens,
+            ) {
+                return Ok(IfClauseSplitSpec {
+                    predicate: IfClausePredicateSpec::Conditional(predicate),
+                    effects,
+                });
+            }
             let comma_fragment_looks_like_effect = if comma_indices.len() > 1 {
                 let fragment_tokens = &tokens[first_comma_idx + 1..comma_indices[1]];
                 parse_effects_with_leading_instead(fragment_tokens, &mut parse_effects)
@@ -1515,8 +1539,7 @@ pub(crate) fn split_if_clause_lexed(
                 .first()
                 .is_some_and(|token| token.is_word("when") || token.is_word("whenever"));
             if (comma_fragment_looks_like_effect || comma_fragment_looks_like_delayed_trigger)
-                && let Ok(effects) =
-                    parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
+                && let Ok(effects) = parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
                 && !effects.is_empty()
             {
                 return Ok(IfClauseSplitSpec {
@@ -1579,6 +1602,54 @@ pub(crate) fn split_if_clause_lexed(
         predicate: IfClausePredicateSpec::Result(predicate),
         effects,
     })
+}
+
+fn parse_cards_in_hand_difference_draw_effect(
+    predicate: &PredicateAst,
+    predicate_tokens: &[OwnedLexToken],
+    effect_tokens: &[OwnedLexToken],
+) -> Option<Vec<EffectAst>> {
+    let PredicateAst::PlayerCardsInHandOrFewer { player, count } = predicate else {
+        return None;
+    };
+    let predicate_words = TokenWordView::new(predicate_tokens).to_word_refs();
+    if !words_contain_phrase(&predicate_words, &["fewer", "than"])
+        && !words_contain_phrase(&predicate_words, &["less", "than"])
+    {
+        return None;
+    }
+
+    let effect_words = TokenWordView::new(trim_lexed_commas(effect_tokens)).to_word_refs();
+    let subject = match effect_words.as_slice() {
+        ["draw", "cards", "equal", "to", "the", "difference"]
+        | ["draw", "cards", "equal", "to", "difference"] => PlayerAst::Implicit,
+        ["you", "draw", "cards", "equal", "to", "the", "difference"]
+        | ["you", "draw", "cards", "equal", "to", "difference"] => PlayerAst::You,
+        _ => return None,
+    };
+    let hand_player = match player {
+        PlayerAst::You | PlayerAst::Implicit => PlayerFilter::You,
+        _ => return None,
+    };
+    let threshold = (*count as i32) + 1;
+    let difference = Value::Add(
+        Box::new(Value::Fixed(threshold)),
+        Box::new(Value::Scaled(
+            Box::new(Value::CardsInHand(hand_player)),
+            -1,
+        )),
+    )
+    .with_surface_hint(ValueSurfaceHint::Difference);
+
+    Some(vec![EffectAst::subject_verb(
+        SubjectVerbRoleAst::AffectedPlayer,
+        subject,
+        SubjectVerbActionAst::Draw { count: difference },
+    )])
+}
+
+fn words_contain_phrase(words: &[&str], phrase: &[&str]) -> bool {
+    !phrase.is_empty() && words.windows(phrase.len()).any(|window| window == phrase)
 }
 
 pub(crate) fn split_trailing_unless_clause_lexed<'a>(

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -43,6 +43,7 @@ pub enum ValueSurfaceHint {
     EqualTo,
     ForEach,
     CountersRemovedThisWay,
+    Difference,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -47824,6 +47824,284 @@ fn polliwallop_affinity_for_frogs_reduces_only_for_your_frogs() {
     );
 }
 
+fn krang_master_mind_definition() -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(955_852), "Krang, Master Mind")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(6)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 4))
+        .parse_text(
+            "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n\
+             When Krang enters, if you have fewer than four cards in hand, draw cards equal to the difference.\n\
+             Krang gets +1/+0 for each other artifact you control.",
+        )
+        .expect("Krang, Master Mind should parse strictly")
+}
+
+#[test]
+fn krang_master_mind_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Krang, Master Mind");
+    let def = parse_oracle_card_definition("Krang, Master Mind");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Affinity for artifacts"),
+        "Krang should preserve affinity keyword text, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("draw cards equal to the difference"),
+        "Krang should render the conditional difference draw count, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains("gets +1/+0 for each other artifact you control"),
+        "Krang should render its other-artifact power bonus, got {rendered}"
+    );
+    assert!(
+        debug.contains("PlayerCardsInHandOrFewer")
+            && debug.contains("CardsInHand")
+            && debug.contains("Difference"),
+        "Krang should lower the fewer-than-four hand condition and difference draw structurally, got {debug}"
+    );
+}
+
+#[test]
+fn krang_master_mind_etb_draws_up_to_four_cards_in_hand() {
+    let def = krang_master_mind_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let krang_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    for idx in 0..5 {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(955_860 + idx), &format!("Library Card {idx}"))
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            alice,
+            Zone::Library,
+        );
+    }
+
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            krang_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, krang_id, &event),
+        1,
+        "Krang should trigger when its controller has fewer than four cards in hand"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        4,
+        "Krang should draw exactly the difference up to four cards in hand"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").library.len(),
+        1,
+        "Krang should draw four cards from a five-card library"
+    );
+}
+
+#[test]
+fn krang_master_mind_etb_does_not_trigger_with_four_cards_in_hand() {
+    let def = krang_master_mind_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let krang_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    for idx in 0..4 {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(955_870 + idx), &format!("Hand Card {idx}"))
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            alice,
+            Zone::Hand,
+        );
+    }
+    for idx in 0..3 {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(955_880 + idx), &format!("Library Card {idx}"))
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            alice,
+            Zone::Library,
+        );
+    }
+
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            krang_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, krang_id, &event),
+        0,
+        "Krang should use the hand-size condition as an intervening-if trigger gate"
+    );
+    assert_eq!(game.player(alice).expect("alice exists").hand.len(), 4);
+    assert_eq!(game.player(alice).expect("alice exists").library.len(), 3);
+}
+
+#[test]
+fn krang_master_mind_etb_draw_condition_is_rechecked_on_resolution() {
+    let def = krang_master_mind_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let krang_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    for idx in 0..3 {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(955_883 + idx), &format!("Library Card {idx}"))
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            alice,
+            Zone::Library,
+        );
+    }
+
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_cause(
+            krang_id,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::EventCause::from_game_rule(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let triggers = crate::triggers::check_triggers(&game, &event);
+    assert_eq!(
+        triggers.iter().filter(|entry| entry.source == krang_id).count(),
+        1,
+        "Krang should initially trigger while its controller has fewer than four cards in hand"
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in triggers.into_iter().filter(|entry| entry.source == krang_id) {
+        trigger_queue.add(trigger);
+    }
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Krang trigger should go on the stack");
+    for idx in 0..4 {
+        game.create_object_from_definition(
+            &CardDefinitionBuilder::new(CardId::from_raw(955_886 + idx), &format!("Hand Card {idx}"))
+                .card_types(vec![CardType::Artifact])
+                .build(),
+            alice,
+            Zone::Hand,
+        );
+    }
+
+    crate::game_loop::resolve_stack_entry(&mut game).expect("Krang trigger should resolve");
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        4,
+        "Krang should not draw if the intervening-if condition fails on resolution"
+    );
+    assert_eq!(game.player(alice).expect("alice exists").library.len(), 3);
+}
+
+#[test]
+fn krang_master_mind_affinity_reduces_only_for_your_artifacts() {
+    let def = krang_master_mind_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let krang_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let krang = game.object(krang_id).expect("Krang should be in hand");
+    let base_cost = krang.mana_cost.as_ref().expect("Krang has a mana cost").clone();
+
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(&game, alice, krang, &base_cost).mana_value(),
+        8,
+        "Krang should cost eight mana with no artifacts you control"
+    );
+
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(955_890), "Alice Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(955_891), "Bob Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(955_892), "Alice Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let krang = game.object(krang_id).expect("Krang should still be in hand");
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(&game, alice, krang, &base_cost).mana_value(),
+        7,
+        "Krang affinity should count only artifacts controlled by its controller"
+    );
+}
+
+#[test]
+fn krang_master_mind_gets_plus_one_power_for_each_other_artifact_you_control() {
+    let def = krang_master_mind_definition();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let krang_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert_eq!(game.current_power(krang_id), Some(1));
+    assert_eq!(game.current_toughness(krang_id), Some(4));
+
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(955_900), "Bob Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    assert_eq!(
+        game.current_power(krang_id),
+        Some(1),
+        "Krang should not count artifacts controlled by opponents"
+    );
+
+    game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(955_901), "Alice Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    assert_eq!(
+        game.current_power(krang_id),
+        Some(2),
+        "Krang should get +1/+0 for one other artifact you control"
+    );
+    assert_eq!(game.current_toughness(krang_id), Some(4));
+}
+
 #[test]
 fn polliwallop_targets_and_deals_twice_source_creature_power() {
     let def = polliwallop_definition();

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6143,6 +6143,9 @@ pub(super) fn describe_card_count(value: &Value) -> String {
         Value::CardTypesAmong(_) | Value::CardTypesInGraveyard(_) => {
             format!("X cards, where X is {}", describe_value(value))
         }
+        value if value.has_surface_hint(ironsmith_core::ValueSurfaceHint::Difference) => {
+            "cards equal to the difference".to_string()
+        }
         value if value.has_surface_hint(ironsmith_core::ValueSurfaceHint::EqualTo) => {
             format!("cards equal to {}", describe_value(value.unhinted()))
         }
@@ -8119,6 +8122,11 @@ fn describe_effect_metric_value(
 
 pub(crate) fn describe_value(value: &Value) -> String {
     match value {
+        Value::SurfaceHinted { hints, .. }
+            if hints.contains(&ironsmith_core::ValueSurfaceHint::Difference) =>
+        {
+            "the difference".to_string()
+        }
         Value::SurfaceHinted { value, .. } => describe_value(value),
         Value::Fixed(n) => n.to_string(),
         Value::Add(left, right) => {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17388,6 +17388,12 @@ fn describe_triggered_inline_ability(
     line = normalize_redundant_short_name_etb_surface(line, triggered, self_subject);
     line = normalize_modal_named_source_etb_surface(line, triggered, self_subject);
     line = normalize_spellcast_trigger_mana_value_surface(triggered, line);
+    if triggered_has_you_difference_draw(triggered) {
+        line = line.replace(
+            "you draw cards equal to the difference",
+            "draw cards equal to the difference",
+        );
+    }
     if triggered.presentation_label.is_none()
         && line.starts_with("Whenever you cast a spell that targets this creature")
     {
@@ -17405,12 +17411,38 @@ fn describe_trigger_intervening_condition(
     condition: &Condition,
     triggered: &crate::ability::TriggeredAbility,
 ) -> String {
+    if let Condition::PlayerCardsInHandOrFewer { player, count } = condition
+        && *player == PlayerFilter::You
+        && triggered_has_you_difference_draw(triggered)
+    {
+        let threshold = count + 1;
+        if threshold > 0 {
+            let count_text = number_word(threshold).unwrap_or_else(|| threshold.to_string());
+            return format!("you have fewer than {count_text} cards in hand");
+        }
+    }
     if matches!(condition, Condition::SourceIsInZone(Zone::Graveyard))
         && let Some(subject) = source_return_from_graveyard_subject(triggered)
     {
         return format!("{subject} is in your graveyard");
     }
     describe_condition(condition)
+}
+
+fn triggered_has_you_difference_draw(triggered: &crate::ability::TriggeredAbility) -> bool {
+    triggered
+        .effects
+        .segments
+        .iter()
+        .flat_map(|segment| segment.default_effects.iter())
+        .any(|effect| {
+            effect
+                .downcast_ref::<crate::effects::DrawCardsEffect>()
+                .is_some_and(|draw| {
+                    draw.player == PlayerFilter::You
+                        && draw.count.has_surface_hint(ValueSurfaceHint::Difference)
+                })
+        })
 }
 
 fn source_return_from_graveyard_subject(
@@ -17592,6 +17624,9 @@ fn normalize_redundant_short_name_etb_surface(
     else {
         return line;
     };
+    if triggered_has_you_difference_draw(triggered) {
+        return line;
+    }
 
     let Some((start, prefix_len)) = [
         format!("When {surface} enters,"),
@@ -29635,6 +29670,32 @@ pub(super) fn describe_effect(effect: &Effect) -> String {
     with_effect_render_depth(|| describe_effect_impl(effect))
 }
 
+fn describe_cards_in_hand_difference_conditional(
+    conditional: &crate::effects::ConditionalEffect,
+) -> Option<String> {
+    if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+        return None;
+    }
+    let Condition::PlayerCardsInHandOrFewer { player, count } = &conditional.condition else {
+        return None;
+    };
+    if *player != PlayerFilter::You {
+        return None;
+    }
+    let draw = conditional.if_true[0].downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if draw.player != PlayerFilter::You || !draw.count.has_surface_hint(ValueSurfaceHint::Difference) {
+        return None;
+    }
+    let threshold = count + 1;
+    if threshold <= 0 {
+        return None;
+    }
+    let count_text = number_word(threshold).unwrap_or_else(|| threshold.to_string());
+    Some(format!(
+        "If you have fewer than {count_text} cards in hand, draw cards equal to the difference"
+    ))
+}
+
 fn describe_unless_any_player_pays_search_prefix(
     unless_pays: &crate::effects::UnlessPaysEffect,
     payment_text: &str,
@@ -33617,6 +33678,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         };
     }
     if let Some(conditional) = effect.downcast_ref::<crate::effects::ConditionalEffect>() {
+        if let Some(compact) = describe_cards_in_hand_difference_conditional(conditional) {
+            return compact;
+        }
         if let Some(compact) = describe_conditional_damage_instead(conditional) {
             return compact;
         }
@@ -40594,6 +40658,12 @@ pub(super) fn describe_ability(
                     line.push_str(": ");
                     line.push_str(&clauses.join(": "));
                 }
+            }
+            if triggered_has_you_difference_draw(triggered) {
+                line = line.replace(
+                    "you draw cards equal to the difference",
+                    "draw cards equal to the difference",
+                );
             }
             let line_lower = line.to_ascii_lowercase();
             if line_lower.contains("whenever an opponent loses life")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Krang, Master Mind
Initial parse error:
```
missing draw count (clause: 'cards equal to the difference'); oracle-only fallback also failed: missing draw count (clause: 'cards equal to the difference')
```

Current worker: i-0f4d73f8e4cd5e880
Branch: codex/aws-card-fix-krang-master-mind
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0021
