### PR TITLE
Fix Ironsmith parse failure: Bumi, King of Three Trials

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -417,7 +417,7 @@ fn compile_subject_verb_effect(
             player,
             count,
             ctx,
-            false,
+            true,
             false,
             true,
             false,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/modal_and_level_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/modal_and_level_lowering.rs
@@ -129,7 +129,7 @@ pub(crate) fn rewrite_lower_parsed_modal(
         choose_both_control_card_types,
         trigger,
         activated,
-        x_replacement: _,
+        x_replacement,
         prefix_effects_ast: _,
         modal_gate,
         line_text,
@@ -195,8 +195,20 @@ pub(crate) fn rewrite_lower_parsed_modal(
 
     let mode_count = compiled_modes.len() as i32;
     let default_max = crate::effect::Value::Fixed(mode_count);
-    let max = header_max.unwrap_or_else(|| default_max.clone());
-    let min = header_min;
+    let max = header_max
+        .map(|max| {
+            if matches!(max, crate::effect::Value::X) {
+                x_replacement.clone().unwrap_or(max)
+            } else {
+                max
+            }
+        })
+        .unwrap_or_else(|| default_max.clone());
+    let min = if matches!(header_min, crate::effect::Value::X) {
+        x_replacement.unwrap_or(header_min)
+    } else {
+        header_min
+    };
     let is_fixed_one =
         |value: &crate::effect::Value| matches!(value, crate::effect::Value::Fixed(1));
     let apply_modal_metadata = |effect: crate::effect::Effect| {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -4,6 +4,7 @@ use crate::cards::builders::{
 };
 use crate::effect::Value;
 use crate::target::PlayerFilter;
+use ironsmith_core::ValueSurfaceHint;
 
 use super::activation_and_restrictions::activated_line_core::infer_activated_functional_zones_lexed;
 use super::clause_support::{parse_effect_sentences_lexed, parse_trigger_clause_lexed};
@@ -182,6 +183,7 @@ fn parse_x_is_value_clause(tokens: &[OwnedLexToken]) -> Option<Value> {
     ));
     where_prefixed.extend_from_slice(tokens);
     parse_value_binding_clause_lexed(&where_prefixed)
+        .map(|value| value.with_surface_hint(ValueSurfaceHint::WhereXIs))
 }
 
 pub(crate) fn replace_modal_header_x_in_effects_ast(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2697,6 +2697,7 @@ fn parse_oracle_bumi_king_of_three_trials_strict_parser_text_and_structure_regre
     let modal = bumi_modal_effect(&def);
     let modal_debug = format!("{modal:#?}");
     let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let canonical = canonical_compiled_lines(&def).join("\n");
 
     assert!(
         rendered.contains(
@@ -2707,6 +2708,12 @@ fn parse_oracle_bumi_king_of_three_trials_strict_parser_text_and_structure_regre
     assert!(
         rendered.contains("Target player scries 3") && rendered.contains("Earthbend 3"),
         "expected Bumi compiled text to keep the targeted scry and earthbend modes, got {rendered}"
+    );
+    assert!(
+        canonical.contains(
+            "When Bumi enters, choose up to X, where X is the number of Lesson cards in your graveyard —\n•"
+        ) && !canonical.contains("—.\n•"),
+        "Bumi canonical compiled text should not add a period after the modal-header dash, got {canonical}"
     );
     assert_eq!(modal.min_choose_count, Value::Fixed(0));
     assert_eq!(modal.modes.len(), 3);

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -2637,6 +2637,201 @@ fn tromp_the_domains_strict_parser_and_compiled_text_regression() {
     );
 }
 
+fn bumi_modal_effect(def: &CardDefinition) -> &ChooseModeEffect {
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Bumi, King of Three Trials should compile an enters trigger");
+    triggered
+        .effects
+        .flattened_default_effects()
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        .expect("Bumi, King of Three Trials should compile one modal choice effect")
+}
+
+fn bumi_game_with_lessons(
+    lesson_count: usize,
+) -> (
+    CardDefinition,
+    crate::game_state::GameState,
+    PlayerId,
+    PlayerId,
+    ObjectId,
+) {
+    let def = parse_oracle_card_definition("Bumi, King of Three Trials");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let lesson = CardDefinitionBuilder::new(CardId::new(), "Bumi Test Lesson")
+        .card_types(vec![CardType::Sorcery])
+        .subtypes(vec![Subtype::Lesson])
+        .build();
+
+    for _ in 0..lesson_count {
+        game.create_object_from_definition(&lesson, alice, Zone::Graveyard);
+    }
+
+    (def, game, alice, bob, source)
+}
+
+fn bumi_earthbend_target_assignment() -> crate::game_state::TargetAssignment {
+    crate::game_state::TargetAssignment {
+        spec: ChooseSpec::target(ChooseSpec::Object(
+            crate::filter::ObjectFilter::land().you_control(),
+        )),
+        range: 0..1,
+    }
+}
+
+#[test]
+fn parse_oracle_bumi_king_of_three_trials_strict_parser_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Bumi, King of Three Trials");
+
+    let def = parse_oracle_card_definition("Bumi, King of Three Trials");
+    let modal = bumi_modal_effect(&def);
+    let modal_debug = format!("{modal:#?}");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains(
+            "When Bumi enters, choose up to X, where X is the number of Lesson cards in your graveyard"
+        ),
+        "expected Bumi compiled text to keep the Lesson-based modal X clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Target player scries 3") && rendered.contains("Earthbend 3"),
+        "expected Bumi compiled text to keep the targeted scry and earthbend modes, got {rendered}"
+    );
+    assert_eq!(modal.min_choose_count, Value::Fixed(0));
+    assert_eq!(modal.modes.len(), 3);
+    assert!(
+        modal_debug.contains("WhereXIs")
+            && modal_debug.contains("Lesson")
+            && modal_debug.contains("TargetOnlyEffect")
+            && modal_debug.contains("ScryEffect")
+            && modal_debug.contains("EarthbendEffect"),
+        "Bumi should structurally model dynamic Lesson mode count, targeted scry, and earthbend, got {modal_debug}"
+    );
+}
+
+#[test]
+fn bumi_zero_lesson_graveyard_cannot_apply_selected_counter_mode() {
+    let (def, mut game, alice, _bob, source) = bumi_game_with_lessons(0);
+    let modal = bumi_modal_effect(&def).clone();
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![0]));
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Bumi with zero Lesson cards should resolve without choosing modes");
+
+    assert_eq!(
+        game.counter_count(source, CounterType::PlusOnePlusOne),
+        0,
+        "zero Lesson cards in graveyard should make Bumi choose up to zero modes"
+    );
+}
+
+#[test]
+fn bumi_counter_mode_uses_lesson_based_modal_bound() {
+    let (def, mut game, alice, _bob, source) = bumi_game_with_lessons(1);
+    let modal = bumi_modal_effect(&def).clone();
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![0]));
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Bumi should allow one mode with one Lesson card in graveyard");
+
+    assert_eq!(
+        game.counter_count(source, CounterType::PlusOnePlusOne),
+        3,
+        "counter mode should put three +1/+1 counters on Bumi"
+    );
+}
+
+#[test]
+fn bumi_target_player_scry_mode_targets_the_chosen_player() {
+    let (def, mut game, alice, bob, source) = bumi_game_with_lessons(1);
+    let modal = bumi_modal_effect(&def).clone();
+    let library_card = CardDefinitionBuilder::new(CardId::new(), "Bumi Scry Card")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    game.create_object_from_definition(&library_card, bob, Zone::Library);
+    game.create_object_from_definition(&library_card, bob, Zone::Library);
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![1]))
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::target_player(),
+            range: 0..1,
+        }]);
+
+    let outcome = modal
+        .execute(&mut game, &mut ctx)
+        .expect("Bumi targeted scry mode should resolve");
+
+    let scry_event = outcome
+        .events_of_type::<crate::events::KeywordActionEvent>()
+        .find(|event| event.action == crate::events::KeywordActionKind::Scry)
+        .expect("targeted scry mode should emit a scry keyword action event");
+    assert_eq!(scry_event.player, bob);
+    assert_eq!(
+        scry_event.amount, 2,
+        "targeted scry should apply to Bob's two-card library"
+    );
+}
+
+#[test]
+fn bumi_earthbend_mode_targets_a_land_you_control() {
+    let (def, mut game, alice, _bob, source) = bumi_game_with_lessons(1);
+    let modal = bumi_modal_effect(&def).clone();
+    let land = CardDefinitionBuilder::new(CardId::new(), "Bumi Test Land")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Forest])
+        .build();
+    let land_id = game.create_object_from_definition(&land, alice, Zone::Battlefield);
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![2]))
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(land_id)])
+        .with_target_assignments(vec![bumi_earthbend_target_assignment()]);
+
+    modal
+        .execute(&mut game, &mut ctx)
+        .expect("Bumi earthbend mode should resolve with a controlled land target");
+
+    assert!(
+        game.current_is_creature(land_id),
+        "earthbend should make the targeted land a creature"
+    );
+    assert_eq!(game.counter_count(land_id, CounterType::PlusOnePlusOne), 3);
+    assert_eq!(game.calculated_power(land_id), Some(3));
+    assert_eq!(game.calculated_toughness(land_id), Some(3));
+}
+
+#[test]
+fn bumi_earthbend_mode_is_illegal_without_a_controlled_land_target() {
+    let (def, mut game, alice, _bob, source) = bumi_game_with_lessons(1);
+    let modal = bumi_modal_effect(&def).clone();
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_chosen_modes(Some(vec![2]));
+
+    let err = modal
+        .execute(&mut game, &mut ctx)
+        .expect_err("Bumi earthbend mode should be illegal with no land you control");
+    assert!(
+        format!("{err:?}").contains("Selected mode is not legal"),
+        "expected earthbend target legality failure, got {err:?}"
+    );
+}
+
 #[test]
 fn kin_tree_nurturer_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Kin-Tree Nurturer");

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -809,10 +809,15 @@ fn finalize_ast_surface_line(line: String) -> String {
         "if it would leave the battlefield, exile it instead",
     );
     line = capitalize_sentence_boundaries(&line);
-    if is_keyword_style_line(&line) {
+    let finalized = if is_keyword_style_line(&line) {
         line
     } else {
         ensure_trailing_period(&line)
+    };
+    if finalized.contains("\n•") {
+        finalized.replace("—.\n•", "—\n•")
+    } else {
+        finalized
     }
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::TaggedOpbjectRelation;
 use crate::filter::StackObjectKind;
+use ironsmith_core::ValueSurfaceHint;
 
 use std::cell::Cell;
 
@@ -7750,6 +7751,22 @@ pub(super) fn describe_mode_choice_header(
     min: Option<&Value>,
     mode_count: Option<usize>,
 ) -> String {
+    if max.has_surface_hint(ValueSurfaceHint::WhereXIs) {
+        let max_basis = describe_value(max);
+        return match min {
+            Some(Value::Fixed(0)) => format!("Choose up to X, where X is {max_basis} —"),
+            Some(Value::Fixed(min_value)) => {
+                let min_text = number_word(*min_value).unwrap_or_else(|| min_value.to_string());
+                format!("Choose between {min_text} and X mode(s), where X is {max_basis} —")
+            }
+            Some(min) => format!(
+                "Choose between {} and X mode(s), where X is {max_basis} —",
+                describe_value(min)
+            ),
+            None => format!("Choose X mode(s), where X is {max_basis} —"),
+        };
+    }
+
     match (min, max) {
         (Some(Value::Fixed(min_value)), Value::Fixed(max_value)) => {
             match (*min_value, *max_value) {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7565,6 +7565,7 @@ pub(super) fn ensure_trailing_period(text: &str) -> String {
     if trimmed.ends_with('.')
         || trimmed.ends_with('!')
         || trimmed.ends_with('?')
+        || trimmed.ends_with('—')
         || trimmed.ends_with('"')
         || trimmed.ends_with(')')
     {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Bumi, King of Three Trials
Initial parse error:
```
target player requires explicit targeting; oracle-only fallback also failed: target player requires explicit targeting
```

Current worker: i-0190c0797855f6183
Branch: codex/aws-card-fix-bumi-king-of-three-trials
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0021
