### PR TITLE
Fix Ironsmith parse failure: Soulblast

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -710,6 +710,7 @@ pub(crate) fn compile_effects(
             initial_iterated_player: ctx.iterated_player,
             force_auto_tag_object_targets: ctx.force_auto_tag_object_targets
                 || ctx.auto_tag_object_targets,
+            force_export_last_memory_effect_id: false,
         },
         ctx.id_gen_context(),
     )?;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -114,6 +114,7 @@ use super::lowering_support::{
     rewrite_lower_prepared_additional_cost_choice_modes_with_exports,
     rewrite_lower_prepared_statement_effects, rewrite_lower_static_abilities_ast,
     rewrite_lower_static_ability_ast, rewrite_parsed_triggered_ability,
+    rewrite_prepare_additional_cost_effects_for_lowering,
     rewrite_prepare_effects_for_lowering,
     rewrite_prepare_effects_with_trigger_context_for_lowering,
     rewrite_prepare_triggered_effects_for_lowering, rewrite_static_ability_for_keyword_action,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/normalization_support.rs
@@ -379,8 +379,10 @@ fn normalize_rewrite_line_chunk(
         }
         LineAst::AdditionalCost { effects } => {
             let effects = rewrite_normalize_additional_cost_sacrifice_tags(effects);
-            let prepared =
-                rewrite_prepare_effects_for_lowering(&effects, ReferenceImports::default())?;
+            let prepared = rewrite_prepare_additional_cost_effects_for_lowering(
+                &effects,
+                ReferenceImports::default(),
+            )?;
             state.latest_additional_cost_exports = prepared.exports.clone();
             NormalizedLineChunk::AdditionalCost {
                 effects_ast: effects,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -370,6 +370,27 @@ pub(crate) fn rewrite_prepare_effects_for_lowering(
     )
 }
 
+pub(crate) fn rewrite_prepare_additional_cost_effects_for_lowering(
+    effects: &[EffectAst],
+    imports: impl Into<ReferenceImports>,
+) -> Result<PreparedEffectsForLowering, CardTextError> {
+    let imports = imports.into();
+    let normalized = normalize_effects_ast(effects);
+    rewrite_prepare_effects_from_normalized(
+        normalized.clone(),
+        &normalized,
+        imports,
+        EffectReferenceResolutionConfig {
+            force_auto_tag_object_targets: true,
+            force_export_last_memory_effect_id: true,
+            ..Default::default()
+        },
+        None,
+        None,
+        false,
+    )
+}
+
 pub(crate) fn rewrite_prepare_effects_with_trigger_context_for_lowering(
     trigger: Option<&TriggerSpec>,
     effects: &[EffectAst],

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -49,6 +49,7 @@ pub(crate) struct EffectReferenceResolutionConfig {
     pub(crate) initial_last_effect_id: Option<EffectId>,
     pub(crate) initial_iterated_player: bool,
     pub(crate) force_auto_tag_object_targets: bool,
+    pub(crate) force_export_last_memory_effect_id: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1262,8 +1263,7 @@ fn annotate_effect_sequence_with_env_internal(
                 || effects_reference_its_controller(remaining)
                 || effects_reference_tag(remaining, "damaged_0")
         };
-        let assigned_effect_id =
-            maybe_assign_effect_result_id(effects, idx, id_gen, in_env.allow_life_event_value);
+        let assigned_effect_id = maybe_assign_effect_result_id(effects, idx, id_gen, config);
 
         let mut out_env = advance_reference_env_for_effect(
             &effect,
@@ -1342,7 +1342,7 @@ fn maybe_assign_effect_result_id(
     effects: &[EffectAst],
     idx: usize,
     id_gen: &mut IdGenContext,
-    _allow_life_event_value: bool,
+    config: EffectReferenceResolutionConfig,
 ) -> Option<EffectId> {
     let next_is_result_gate = idx + 1 < effects.len()
         && matches!(
@@ -1385,6 +1385,9 @@ fn maybe_assign_effect_result_id(
         && effects[idx + 1..]
             .iter()
             .any(effect_is_searched_library_gate);
+    let force_export_last_memory_effect_id = config.force_export_last_memory_effect_id
+        && idx + 1 == effects.len()
+        && effect_can_supply_prior_effect_memory(&effects[idx]);
 
     if !(next_is_if_result_with_opponent_doesnt
         || next_is_if_result_with_player_doesnt
@@ -1394,7 +1397,8 @@ fn maybe_assign_effect_result_id(
         || next_needs_event_derived_amount
         || later_needs_event_derived_amount
         || next_needs_prior_effect_value
-        || later_needs_library_search_result)
+        || later_needs_library_search_result
+        || force_export_last_memory_effect_id)
     {
         return None;
     }
@@ -1795,8 +1799,15 @@ fn resolve_effect_sequence_references_with_state(
             &[]
         };
         let _ = effects_reference_it_tag(remaining) || effects_reference_its_controller(remaining);
-        let assigned_effect_id =
-            maybe_assign_effect_result_id(effects, idx, id_gen, state.allow_life_event_value);
+        let assigned_effect_id = maybe_assign_effect_result_id(
+            effects,
+            idx,
+            id_gen,
+            EffectReferenceResolutionConfig {
+                allow_life_event_value: state.allow_life_event_value,
+                ..Default::default()
+            },
+        );
         state.last_effect_id = if matches!(
             effect,
             EffectAst::ResolvedIfResult { .. }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34012,6 +34012,33 @@ fn parse_additional_cost_sacrificed_power_reference_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn soulblast_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Soulblast");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        lower.contains("as an additional cost to cast this spell, sacrifice all creatures you control"),
+        "expected Soulblast all-creatures additional cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Soulblast deals damage to any target equal to the total power of the sacrificed creatures"
+        ),
+        "expected Soulblast damage to use sacrificed-creatures total power, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def);
+    assert!(
+        debug.contains("WithIdEffect")
+            && debug.contains("SacrificePlayerEffect")
+            && debug.contains("EffectMetric")
+            && debug.contains("TotalPower"),
+        "expected Soulblast cost sacrifice to feed total-power damage metric, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn corpse_lunge_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Corpse Lunge");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/cards/definitions/dawn_charm.rs
+++ b/crates/ironsmith-runtime/src/cards/definitions/dawn_charm.rs
@@ -107,6 +107,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
         id
     }

--- a/crates/ironsmith-runtime/src/cards/definitions/library_of_leng.rs
+++ b/crates/ironsmith-runtime/src/cards/definitions/library_of_leng.rs
@@ -301,6 +301,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that discards a land
@@ -395,6 +396,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that DECLINES to discard
@@ -530,6 +532,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that chooses to use Library of Leng

--- a/crates/ironsmith-runtime/src/cards/definitions/mox_diamond.rs
+++ b/crates/ironsmith-runtime/src/cards/definitions/mox_diamond.rs
@@ -314,6 +314,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that discards a land
@@ -392,6 +393,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that declines to discard
@@ -469,6 +471,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that would discard a land (but there are none)
@@ -539,6 +542,7 @@ mod tests {
             saddle_contributors: vec![],
             tagged_objects: std::collections::HashMap::new(),
             chosen_modes: None,
+            effect_outcomes: std::collections::HashMap::new(),
         });
 
         // Resolve with a decision maker that discards a land

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -2807,6 +2807,14 @@ fn rewrite_additional_sacrifice_reference_surface(def: &CardDefinition, text: &s
         .replace(
             "that creature's mana value",
             "the sacrificed creature's mana value",
+        )
+        .replace(
+            "the total power of those creatures",
+            "the total power of the sacrificed creatures",
+        )
+        .replace(
+            "the total toughness of those creatures",
+            "the total toughness of the sacrificed creatures",
         );
 
     if !normalized.contains("sacrificed creature's") {
@@ -2824,6 +2832,10 @@ fn has_additional_creature_sacrifice_cost(def: &CardDefinition) -> bool {
         let Some(effect) = cost.effect_ref() else {
             return false;
         };
+        let effect = effect
+            .downcast_ref::<crate::effects::WithIdEffect>()
+            .map(|with_id| with_id.effect.as_ref())
+            .unwrap_or(effect);
         if effect
             .downcast_ref::<crate::effects::ChooseObjectsEffect>()
             .is_some_and(|choose| {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17737,6 +17737,9 @@ fn normalize_sacrifice_cost_control_phrase(text: &str) -> String {
         let Some(object) = rest.strip_suffix(" you control") else {
             continue;
         };
+        if object.starts_with("all ") {
+            continue;
+        }
         let object = object
             .strip_prefix("other ")
             .map(|rest| format!("another {rest}"))

--- a/crates/ironsmith-runtime/src/costs/cost_effect.rs
+++ b/crates/ironsmith-runtime/src/costs/cost_effect.rs
@@ -282,6 +282,7 @@ impl CostPayer for CostEffect {
             .with_tagged_objects(existing_tags)
             .with_cost_choice_targets(chosen_targets)
             .with_provenance(ctx.provenance);
+        exec_ctx.effect_outcomes = ctx.effect_outcomes.clone();
         if let Some(x) = ctx.x_value {
             exec_ctx = exec_ctx.with_x(x);
         }
@@ -332,6 +333,7 @@ impl CostPayer for CostEffect {
 
         // Copy any new tags back to CostContext for subsequent costs
         ctx.tagged_objects = exec_ctx.tagged_objects;
+        ctx.effect_outcomes = exec_ctx.effect_outcomes;
         ctx.pre_chosen_cards.clear();
 
         Ok(CostPaymentResult::Paid)

--- a/crates/ironsmith-runtime/src/costs/payer_trait.rs
+++ b/crates/ironsmith-runtime/src/costs/payer_trait.rs
@@ -73,6 +73,8 @@ pub struct CostContext<'dm> {
     /// when both are cost effects. The first effect tags the chosen creature,
     /// and the second effect can reference it via the tag.
     pub tagged_objects: HashMap<TagKey, Vec<ObjectSnapshot>>,
+    /// Outcomes of cost effects labeled with `WithIdEffect`.
+    pub effect_outcomes: HashMap<crate::effect::EffectId, crate::effect::EffectOutcome>,
     /// Provenance parent node for events emitted while paying this cost.
     pub provenance: ProvNodeId,
 }
@@ -88,6 +90,10 @@ impl std::fmt::Debug for CostContext<'_> {
             .field(
                 "tagged_objects",
                 &self.tagged_objects.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "effect_outcomes",
+                &self.effect_outcomes.keys().collect::<Vec<_>>(),
             )
             .field("provenance", &self.provenance)
             .finish()
@@ -109,6 +115,7 @@ impl<'dm> CostContext<'dm> {
             decision_maker,
             pre_chosen_cards: Vec::new(),
             tagged_objects: HashMap::new(),
+            effect_outcomes: HashMap::new(),
             provenance: ProvNodeId::default(),
         }
     }
@@ -198,6 +205,7 @@ impl CostCheckContext {
             decision_maker: dm,
             pre_chosen_cards: self.pre_chosen_cards.clone(),
             tagged_objects: HashMap::new(),
+            effect_outcomes: HashMap::new(),
             provenance: ProvNodeId::default(),
         }
     }

--- a/crates/ironsmith-runtime/src/effects/cards/search_overrides.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/search_overrides.rs
@@ -599,6 +599,7 @@ fn cast_from_library_while_searching(
         saddle_contributors: vec![],
         chosen_modes: None,
         tagged_objects: std::collections::HashMap::new(),
+        effect_outcomes: std::collections::HashMap::new(),
     };
     game.push_to_stack(stack_entry);
 

--- a/crates/ironsmith-runtime/src/effects/player/cast_source.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_source.rs
@@ -109,6 +109,7 @@ impl EffectExecutor for CastSourceEffect {
             saddle_contributors: vec![],
             chosen_modes: None,
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         };
 
         game.push_to_stack(stack_entry);

--- a/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/cast_tagged.rs
@@ -605,6 +605,7 @@ impl EffectExecutor for CastTaggedEffect {
             saddle_contributors: vec![],
             chosen_modes: None,
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         };
 
         game.push_to_stack(stack_entry);

--- a/crates/ironsmith-runtime/src/effects/player/discover.rs
+++ b/crates/ironsmith-runtime/src/effects/player/discover.rs
@@ -144,6 +144,7 @@ impl EffectExecutor for DiscoverEffect {
                         saddle_contributors: vec![],
                         chosen_modes: None,
                         tagged_objects: std::collections::HashMap::new(),
+                        effect_outcomes: std::collections::HashMap::new(),
                     };
                     game.push_to_stack(stack_entry);
                     selected_object = Some(new_id);

--- a/crates/ironsmith-runtime/src/effects/player/exile_until_match_cast.rs
+++ b/crates/ironsmith-runtime/src/effects/player/exile_until_match_cast.rs
@@ -140,6 +140,7 @@ impl EffectExecutor for ExileUntilMatchCastEffect {
                         saddle_contributors: vec![],
                         chosen_modes: None,
                         tagged_objects: std::collections::HashMap::new(),
+                        effect_outcomes: std::collections::HashMap::new(),
                     };
                     game.push_to_stack(stack_entry);
                     casted_card = Some((candidate_id, new_id, from_zone));

--- a/crates/ironsmith-runtime/src/effects/player/may_cast_miracle.rs
+++ b/crates/ironsmith-runtime/src/effects/player/may_cast_miracle.rs
@@ -176,6 +176,7 @@ impl EffectExecutor for MayCastForMiracleCostEffect {
                 saddle_contributors: vec![],
                 chosen_modes: None,
                 tagged_objects: std::collections::HashMap::new(),
+                effect_outcomes: std::collections::HashMap::new(),
             };
 
             game.push_to_stack(stack_entry);

--- a/crates/ironsmith-runtime/src/effects/player/runtime_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/player/runtime_helpers.rs
@@ -421,6 +421,7 @@ pub(super) fn cast_effect_driven_spell_with_payment(
         saddle_contributors: vec![],
         chosen_modes: None,
         tagged_objects: std::collections::HashMap::new(),
+        effect_outcomes: std::collections::HashMap::new(),
     };
     game.push_to_stack(stack_entry);
 

--- a/crates/ironsmith-runtime/src/effects/stack/copy_spell.rs
+++ b/crates/ironsmith-runtime/src/effects/stack/copy_spell.rs
@@ -57,6 +57,7 @@ pub(crate) fn resolving_source_stack_entry(ctx: &ExecutionContext) -> StackEntry
     entry.event_value_amount = ctx.event_value_amount;
     entry.chosen_modes = ctx.chosen_modes.clone();
     entry.tagged_objects = ctx.tagged_objects.clone();
+    entry.effect_outcomes = ctx.effect_outcomes.clone();
     entry
 }
 
@@ -130,6 +131,7 @@ pub(crate) fn create_stack_copy_from_object(
     copy_entry.crew_contributors = original_entry.crew_contributors.clone();
     copy_entry.saddle_contributors = original_entry.saddle_contributors.clone();
     copy_entry.tagged_objects = original_entry.tagged_objects.clone();
+    copy_entry.effect_outcomes = original_entry.effect_outcomes.clone();
 
     if let Some(chosen_player) = copy_entry.chosen_player {
         game.set_chosen_player(copy_id, chosen_player);

--- a/crates/ironsmith-runtime/src/effects/zones/sacrifice.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/sacrifice.rs
@@ -131,6 +131,9 @@ fn dynamic_count_tracks_tagged_selection(
     count_filter: &ObjectFilter,
     sacrifice_filter: &ObjectFilter,
 ) -> bool {
+    if count_filter == sacrifice_filter {
+        return true;
+    }
     tagged_selection_tag(count_filter)
         .zip(tagged_selection_tag(sacrifice_filter))
         .is_some_and(|(count_tag, sacrifice_tag)| count_tag == sacrifice_tag)

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1378,6 +1378,7 @@ pub(super) fn finalize_pending_spell_cast(
         mana_spent_to_cast,
         pending.keyword_payment_contributions,
         pending.tagged_objects,
+        pending.effect_outcomes,
         &mut pending.payment_trace,
         true,
         pending.stack_id,
@@ -1487,6 +1488,7 @@ pub(super) fn auto_pay_spell_tap_cost_steps(
         let mut cost_ctx = CostContext::new(pending.spell_id, pending.caster, &mut *decision_maker)
             .with_provenance(pending.provenance);
         cost_ctx.tagged_objects = pending.tagged_objects.clone();
+        cost_ctx.effect_outcomes = pending.effect_outcomes.clone();
         cost_ctx.x_value = pending.x_value;
 
         match cost.pay(game, &mut cost_ctx).map_err(|err| {
@@ -1498,6 +1500,7 @@ pub(super) fn auto_pay_spell_tap_cost_steps(
             crate::costs::CostPaymentResult::Paid => {
                 record_immediate_cost_payment(&mut pending.payment_trace, &cost, pending.spell_id);
                 pending.tagged_objects = cost_ctx.tagged_objects;
+                pending.effect_outcomes = cost_ctx.effect_outcomes;
                 drain_pending_trigger_events(game, trigger_queue);
             }
             crate::costs::CostPaymentResult::NeedsChoice(description) => {
@@ -1533,6 +1536,7 @@ pub(super) fn continue_spell_cost_payment(
                 CostContext::new(pending.spell_id, pending.caster, &mut *decision_maker)
                     .with_provenance(pending.provenance);
             cost_ctx.tagged_objects = pending.tagged_objects.clone();
+            cost_ctx.effect_outcomes = pending.effect_outcomes.clone();
             cost_ctx.x_value = pending.x_value;
 
             let payment = cost.pay(game, &mut cost_ctx).map_err(|err| {
@@ -1554,6 +1558,7 @@ pub(super) fn continue_spell_cost_payment(
                         pending.spell_id,
                     );
                     pending.tagged_objects = cost_ctx.tagged_objects;
+                    pending.effect_outcomes = cost_ctx.effect_outcomes;
                     pending.remaining_cost_steps.remove(0);
                     drain_pending_trigger_events(game, trigger_queue);
                     continue_spell_next_cost_or_finalize(

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3548,6 +3548,8 @@ pub(super) fn finalize_spell_cast(
     mut mana_spent_to_cast: ManaPool,
     keyword_payment_contributions: Vec<KeywordPaymentContribution>,
     stack_entry_tagged_objects: std::collections::HashMap<crate::tag::TagKey, Vec<ObjectSnapshot>>,
+    stack_entry_effect_outcomes:
+        std::collections::HashMap<crate::effect::EffectId, crate::effect::EffectOutcome>,
     payment_trace: &mut Vec<CostStep>,
     mana_already_paid: bool,
     stack_id: ObjectId,
@@ -3849,6 +3851,7 @@ pub(super) fn finalize_spell_cast(
         .with_chosen_player(game.chosen_player(new_id))
         .with_chosen_modes(chosen_modes)
         .with_tagged_objects(stack_entry_tagged_objects)
+        .with_effect_outcomes(stack_entry_effect_outcomes)
         .with_keyword_payment_contributions(keyword_payment_contributions);
     if let Some(spell_obj) = game.object(new_id).cloned() {
         entry = entry.with_source_info(spell_obj.stable_id, spell_obj.name.clone());

--- a/crates/ironsmith-runtime/src/game_loop/priority_state.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_state.rs
@@ -136,6 +136,9 @@ pub struct PendingCast {
     pub remaining_cost_steps: Vec<ActivationCostStep>,
     /// Tagged object snapshots captured while paying spell costs.
     pub tagged_objects: std::collections::HashMap<crate::tag::TagKey, Vec<ObjectSnapshot>>,
+    /// Outcomes of spell cost effects labeled with `WithIdEffect`.
+    pub effect_outcomes:
+        std::collections::HashMap<crate::effect::EffectId, crate::effect::EffectOutcome>,
     /// Next `sacrifice_cost_{N}` tag index to assign for choose-and-sacrifice costs.
     pub next_sacrifice_cost_tag_index: usize,
     /// Pre-chosen modes for modal spells (per MTG rule 601.2b).
@@ -191,6 +194,7 @@ impl PendingCast {
             current_pip_payment_options: Vec::new(),
             remaining_cost_steps: Vec::new(),
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
             next_sacrifice_cost_tag_index: 0,
             chosen_modes,
             hybrid_choices: Vec::new(),

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -567,6 +567,7 @@ pub(super) fn resolve_stack_entry_full(
     if let Some(x) = entry.x_value {
         ctx = ctx.with_x(x);
     }
+    ctx.effect_outcomes = entry.effect_outcomes.clone();
     if let Some(defending) = entry.defending_player {
         ctx = ctx.with_defending_player(defending);
     }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -25247,6 +25247,144 @@ fn test_corpse_cobble_sums_the_power_of_sacrificed_creatures() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn soulblast_definition_for_runtime_tests() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(130_369), "Soulblast")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "As an additional cost to cast this spell, sacrifice all creatures you control.\nSoulblast deals damage to any target equal to the total power of the sacrificed creatures.",
+        )
+        .expect("Soulblast should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn cast_soulblast_targeting_player(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    spell_id: ObjectId,
+    target_player: PlayerId,
+) {
+    use crate::decision::{GameProgress, LegalAction};
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut progress = apply_priority_response(
+        game,
+        trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+    )
+    .expect("Soulblast cast should start");
+
+    for _ in 0..4 {
+        progress = match progress {
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Targets(_),
+            ) => apply_priority_response(
+                game,
+                trigger_queue,
+                &mut state,
+                &PriorityResponse::Targets(vec![Target::Player(target_player)]),
+            )
+            .expect("Soulblast should accept target player"),
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            ) => break,
+            other => panic!("unexpected Soulblast cast flow state: {other:?}"),
+        };
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn soulblast_sacrifices_controlled_creatures_and_deals_their_total_power() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let soulblast = soulblast_definition_for_runtime_tests();
+    let spell_id = game.create_object_from_definition(&soulblast, alice, Zone::Hand);
+    let small = CardBuilder::new(CardId::new(), "Soulblast Fodder One")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let large = CardBuilder::new(CardId::new(), "Soulblast Fodder Two")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let opposing = CardBuilder::new(CardId::new(), "Bob's Untouched Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(9, 9))
+        .build();
+
+    let small_id = game.create_object_from_card(&small, alice, Zone::Battlefield);
+    let large_id = game.create_object_from_card(&large, alice, Zone::Battlefield);
+    let opposing_id = game.create_object_from_card(&opposing, bob, Zone::Battlefield);
+
+    cast_soulblast_targeting_player(&mut game, &mut trigger_queue, spell_id, bob);
+
+    assert!(
+        !game.battlefield.contains(&small_id) && !game.battlefield.contains(&large_id),
+        "Soulblast should sacrifice all creatures controlled by its caster as a cost"
+    );
+    assert!(
+        game.battlefield.contains(&opposing_id),
+        "Soulblast should not sacrifice creatures controlled by another player"
+    );
+
+    resolve_stack_entry(&mut game).expect("Soulblast should resolve");
+    assert_eq!(
+        game.player(bob).expect("Bob exists").life,
+        15,
+        "Soulblast should deal damage equal to the total power of the sacrificed creatures"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn soulblast_with_no_controlled_creatures_deals_zero_damage() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let soulblast = soulblast_definition_for_runtime_tests();
+    let spell_id = game.create_object_from_definition(&soulblast, alice, Zone::Hand);
+    let opposing = CardBuilder::new(CardId::new(), "Bob's Only Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .build();
+    let opposing_id = game.create_object_from_card(&opposing, bob, Zone::Battlefield);
+
+    cast_soulblast_targeting_player(&mut game, &mut trigger_queue, spell_id, bob);
+    assert!(
+        game.battlefield.contains(&opposing_id),
+        "Soulblast should not sacrifice an opponent's creature when you control none"
+    );
+
+    resolve_stack_entry(&mut game).expect("Soulblast with zero sacrificed creatures should resolve");
+    assert_eq!(
+        game.player(bob).expect("Bob exists").life,
+        20,
+        "Soulblast should deal zero damage when no creatures were sacrificed"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_spoils_of_blood_creates_token_using_creatures_died_this_turn_count() {
     use crate::decision::LegalAction;

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -1753,6 +1753,9 @@ pub struct StackEntry {
     /// This supports resolution-time references like `sacrifice_cost_0`.
     pub tagged_objects:
         std::collections::HashMap<crate::tag::TagKey, Vec<crate::snapshot::ObjectSnapshot>>,
+    /// Outcomes preserved from cost effects labeled with `WithIdEffect`.
+    pub effect_outcomes:
+        std::collections::HashMap<crate::effect::EffectId, crate::effect::EffectOutcome>,
 }
 
 /// A mana ability granted to a player until end of turn.
@@ -1797,6 +1800,7 @@ impl StackEntry {
             crew_contributors: Vec::new(),
             saddle_contributors: Vec::new(),
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         }
     }
 
@@ -1835,6 +1839,7 @@ impl StackEntry {
             crew_contributors: Vec::new(),
             saddle_contributors: Vec::new(),
             tagged_objects: std::collections::HashMap::new(),
+            effect_outcomes: std::collections::HashMap::new(),
         }
     }
 
@@ -1970,6 +1975,14 @@ impl StackEntry {
         tagged: std::collections::HashMap<crate::tag::TagKey, Vec<crate::snapshot::ObjectSnapshot>>,
     ) -> Self {
         self.tagged_objects = tagged;
+        self
+    }
+
+    pub fn with_effect_outcomes(
+        mut self,
+        outcomes: std::collections::HashMap<crate::effect::EffectId, crate::effect::EffectOutcome>,
+    ) -> Self {
+        self.effect_outcomes = outcomes;
         self
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Soulblast
Initial parse error:
```
pending effect metric requires a prior memory-producing effect; oracle-only fallback also failed: pending effect metric requires a prior memory-producing effect
```

Current worker: i-0f6256cb8f3dd9b80
Branch: codex/aws-card-fix-soulblast
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0021
