### PR TITLE
Fix Ironsmith parse failure: Hydra Omnivore

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -636,7 +636,9 @@ impl CardDefinitionBuilder {
     pub fn toxic(self, amount: u32) -> Self {
         self.with_ability(crate::ability::Ability {
             kind: crate::ability::AbilityKind::Triggered(crate::ability::TriggeredAbility {
-                trigger: crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+                trigger: crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                    crate::target::PlayerFilter::Any,
+                ),
                 effects: vec![crate::effect::Effect::poison_counters_player(
                     amount as i32,
                     crate::target::PlayerFilter::DamagedPlayer,
@@ -845,7 +847,9 @@ impl CardDefinitionBuilder {
 
     pub fn ingest(self) -> Self {
         self.with_ability(crate::ability::Ability::triggered(
-            crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+            crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                crate::target::PlayerFilter::Any,
+            ),
             vec![crate::effect::Effect::exile_top_of_library_player(
                 1,
                 crate::target::PlayerFilter::DamagedPlayer,
@@ -1173,7 +1177,9 @@ impl CardDefinitionBuilder {
 
     pub fn renown(self, amount: u32) -> Self {
         self.with_ability(crate::ability::Ability::triggered(
-            crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+            crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                crate::target::PlayerFilter::Any,
+            ),
             vec![crate::effect::Effect::renown_source(amount)],
         ))
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2014,7 +2014,7 @@ pub(crate) fn parse_trigger_clause_lexed(
                                     TriggerSpec::DealsCombatDamageToPlayer { source, player }
                                 }
                             }
-                            None => TriggerSpec::ThisDealsCombatDamageToPlayer,
+                            None => TriggerSpec::ThisDealsCombatDamageToPlayer { player },
                         });
                     }
 
@@ -2033,7 +2033,7 @@ pub(crate) fn parse_trigger_clause_lexed(
                                 }
                             }
                             None if player == PlayerFilter::Any => {
-                                TriggerSpec::ThisDealsCombatDamageToPlayer
+                                TriggerSpec::ThisDealsCombatDamageToPlayer { player }
                             }
                             None => {
                                 return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -2618,7 +2618,7 @@ pub(crate) fn parse_token_tap_add_single_mana_symbol(words: &[&str]) -> Option<M
 pub(crate) fn token_damage_to_player_poison_counter_ability() -> Ability {
     Ability {
         kind: AbilityKind::Triggered(TriggeredAbility {
-            trigger: Trigger::this_deals_combat_damage_to_player(),
+            trigger: Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
             effects: crate::resolution::ResolutionProgram::from_effects(vec![
                 Effect::poison_counters_player(1, PlayerFilter::DamagedPlayer),
             ]),
@@ -2657,7 +2657,7 @@ pub(crate) fn token_combat_damage_gain_control_target_artifact_ability() -> Abil
     ));
     Ability {
         kind: AbilityKind::Triggered(TriggeredAbility {
-            trigger: Trigger::this_deals_combat_damage_to_player(),
+            trigger: Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
             effects: crate::resolution::ResolutionProgram::from_effects(vec![Effect::new(
                 crate::effects::ApplyContinuousEffect::with_spec_runtime(
                     target.clone(),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -417,7 +417,9 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             surface.clone(),
             destination_name.clone(),
         ),
-        TriggerSpec::ThisDealsCombatDamageToPlayer => Trigger::this_deals_combat_damage_to_player(),
+        TriggerSpec::ThisDealsCombatDamageToPlayer { player } => {
+            Trigger::this_deals_combat_damage_to_player(player.clone())
+        }
         TriggerSpec::DealsCombatDamageToPlayer { source, player } => {
             Trigger::deals_combat_damage_to_player(source, player)
         }
@@ -500,7 +502,7 @@ fn trigger_binds_iterated_player(trigger: &TriggerSpec) -> bool {
         | TriggerSpec::ThisDealsDamageToPlayer { .. }
         | TriggerSpec::DealsDamageToPlayer { .. }
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
-        | TriggerSpec::ThisDealsCombatDamageToPlayer
+        | TriggerSpec::ThisDealsCombatDamageToPlayer { .. }
         | TriggerSpec::DealsCombatDamageToPlayer { .. }
         | TriggerSpec::BeginningOfUpkeep(_)
         | TriggerSpec::BeginningOfDrawStep(_)
@@ -574,7 +576,7 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         TriggerSpec::ThisDealsDamageToPlayer { .. }
         | TriggerSpec::DealsDamageToPlayer { .. }
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
-        | TriggerSpec::ThisDealsCombatDamageToPlayer
+        | TriggerSpec::ThisDealsCombatDamageToPlayer { .. }
         | TriggerSpec::DealsCombatDamageToPlayer { .. } => Some(PlayerFilter::DamagedPlayer),
         TriggerSpec::ThisAttacks | TriggerSpec::ThisBecomesBlocked => Some(PlayerFilter::Defending),
         TriggerSpec::Attacks(filter) | TriggerSpec::AttacksOneOrMore(filter)
@@ -655,7 +657,7 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             | TriggerSpec::ThisDealsCombatDamageTo(_)
             | TriggerSpec::DealsCombatDamage(_)
             | TriggerSpec::DealsCombatDamageTo { .. }
-            | TriggerSpec::ThisDealsCombatDamageToPlayer
+            | TriggerSpec::ThisDealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { .. }
             | TriggerSpec::AttacksOneOrMore(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -347,7 +347,9 @@ pub(crate) enum TriggerSpec {
         surface: crate::target::SourceReferenceSurface,
         destination_name: Option<String>,
     },
-    ThisDealsCombatDamageToPlayer,
+    ThisDealsCombatDamageToPlayer {
+        player: PlayerFilter,
+    },
     DealsCombatDamageToPlayer {
         source: ObjectFilter,
         player: PlayerFilter,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -80,7 +80,7 @@ fn trigger_supports_event_amount(trigger: &TriggerSpec) -> bool {
             | TriggerSpec::ThisDealsCombatDamageTo(_)
             | TriggerSpec::DealsCombatDamage(_)
             | TriggerSpec::DealsCombatDamageTo { .. }
-            | TriggerSpec::ThisDealsCombatDamageToPlayer
+            | TriggerSpec::ThisDealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayer { .. }
             | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { .. }
             | TriggerSpec::AttacksOneOrMore(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -32,6 +32,14 @@ const COMBAT_EACH_OPPONENT_TARGET_PATTERN: ClauseShape<'static> = clause_shape!(
             &["each", "other", "players"],
         ]
 );
+const COMBAT_EACH_OTHER_OPPONENT_TARGET_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["each", "other", "opponent"],
+            &["each", "other", "opponents"],
+            &["all", "other", "opponents"],
+        ]
+);
 const COMBAT_EACH_OR_ALL_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["each"], &["all"]]);
 const COMBAT_DAMAGE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["damage"]);
@@ -88,6 +96,16 @@ fn is_divided_damage_clause(words: &[&str]) -> bool {
         return false;
     };
     words[divided_idx + 1..].iter().any(|word| *word == "among")
+}
+
+fn damage_each_other_opponent(amount: Value) -> EffectAst {
+    EffectAst::ForEachPlayersFiltered {
+        filter: PlayerFilter::excluding(PlayerFilter::Opponent, PlayerFilter::DamagedPlayer),
+        effects: vec![EffectAst::subject_verb_damage(
+            amount,
+            TargetAst::Player(PlayerFilter::IteratedPlayer, None),
+        )],
+    }
 }
 
 pub(crate) fn parse_attach_object_phrase(
@@ -392,6 +410,9 @@ pub(crate) fn parse_deal_damage_to_target_equal_to_clause(
             )],
         }));
     }
+    if COMBAT_EACH_OTHER_OPPONENT_TARGET_PATTERN.matches_words(&target_words) {
+        return Ok(Some(damage_each_other_opponent(amount.clone())));
+    }
     if COMBAT_EACH_OPPONENT_TARGET_PATTERN.matches_words(&target_words) {
         return Ok(Some(EffectAst::ForEachOpponent {
             effects: vec![EffectAst::subject_verb_damage(
@@ -519,6 +540,11 @@ pub(crate) fn parse_deal_damage_equal_to_clause(
                 TargetAst::Player(PlayerFilter::IteratedPlayer, None),
             )],
         }));
+    }
+    if COMBAT_EACH_OTHER_OPPONENT_TARGET_PATTERN
+        .matches_words(&crate::runtime_backend::token_word_refs(normalized_target_tokens))
+    {
+        return Ok(Some(damage_each_other_opponent(amount.clone())));
     }
     if grammar::words_match_any_prefix(
         normalized_target_tokens,
@@ -846,6 +872,9 @@ pub(crate) fn parse_deal_damage_with_amount(
                 TargetAst::Player(PlayerFilter::IteratedPlayer, None),
             )],
         });
+    }
+    if COMBAT_EACH_OTHER_OPPONENT_TARGET_PATTERN.matches_words(&target_words) {
+        return Ok(damage_each_other_opponent(amount.clone()));
     }
     if grammar::words_match_any_prefix(target_tokens, EACH_OPPONENT_WHO_PREFIXES).is_some()
         && grammar::words_find_phrase(target_tokens, &["this", "way"]).is_some()

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -122,7 +122,9 @@ pub enum TriggerKind {
     ThisDealsCombatDamageTo {
         filter: ObjectFilter,
     },
-    ThisDealsCombatDamageToPlayer,
+    ThisDealsCombatDamageToPlayer {
+        player: PlayerFilter,
+    },
     DealsDamage {
         filter: ObjectFilter,
     },
@@ -615,10 +617,10 @@ impl Trigger {
             TriggerKind::ThisDealsCombatDamageTo { filter },
         )
     }
-    pub fn this_deals_combat_damage_to_player() -> Self {
+    pub fn this_deals_combat_damage_to_player(player: PlayerFilter) -> Self {
         Self::typed(
             "this_deals_combat_damage_to_player",
-            TriggerKind::ThisDealsCombatDamageToPlayer,
+            TriggerKind::ThisDealsCombatDamageToPlayer { player },
         )
     }
     pub fn deals_damage(filter: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -2438,7 +2438,7 @@ impl CardDefinitionBuilder {
     pub fn toxic(self, amount: u32) -> Self {
         self.with_ability(Ability {
             kind: AbilityKind::Triggered(TriggeredAbility {
-                trigger: Trigger::this_deals_combat_damage_to_player(),
+                trigger: Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
                 effects: vec![Effect::poison_counters_player(
                     amount as i32,
                     PlayerFilter::DamagedPlayer,
@@ -2541,7 +2541,7 @@ impl CardDefinitionBuilder {
     /// put N +1/+1 counters on it and it becomes renowned."
     pub fn renown(self, amount: u32) -> Self {
         self.with_ability(Ability::triggered(
-            Trigger::this_deals_combat_damage_to_player(),
+            Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
             vec![Effect::renown_source(amount)],
         ))
     }
@@ -3652,7 +3652,7 @@ impl CardDefinitionBuilder {
     /// that player exiles the top card of their library."
     pub fn ingest(self) -> Self {
         self.with_ability(Ability::triggered(
-            Trigger::this_deals_combat_damage_to_player(),
+            Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
             vec![Effect::exile_top_of_library_player(
                 1,
                 PlayerFilter::DamagedPlayer,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,138 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn hydra_omnivore_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Hydra Omnivore");
+
+    let def = parse_oracle_card_definition("Hydra Omnivore");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert_eq!(def.name(), "Hydra Omnivore");
+    assert!(
+        ability_debug.contains("ThisDealsCombatDamageToPlayerTrigger")
+            && ability_debug.contains("player: Opponent")
+            && ability_debug.contains("ForPlayersEffect")
+            && ability_debug.contains("Excluding")
+            && ability_debug.contains("Opponent")
+            && ability_debug.contains("DamagedPlayer")
+            && ability_debug.contains("DealDamageEffect")
+            && ability_debug.contains("EventValue")
+            && ability_debug.contains("Amount"),
+        "Hydra Omnivore should compile to damage each opponent except the damaged player, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever this creature deals combat damage to an opponent, it deals that much damage to each other opponent."
+        ),
+        "Hydra Omnivore should render the each-other-opponent damage clause, got {rendered}"
+    );
+}
+
+#[test]
+fn hydra_omnivore_runtime_damages_each_other_opponent_only() {
+    let def = parse_oracle_card_definition("Hydra Omnivore");
+    let mut game = crate::game_state::GameState::new(
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+            "Dana".to_string(),
+        ],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let dana = PlayerId::from_index(3);
+    let hydra = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let noncombat = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            hydra,
+            crate::events::DamageTarget::Player(bob),
+            8,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, hydra, &noncombat),
+        0,
+        "Hydra Omnivore should not trigger from noncombat damage"
+    );
+
+    let hits_controller = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            hydra,
+            crate::events::DamageTarget::Player(alice),
+            8,
+            true,
+            crate::events::cause::EventCause::combat_damage(hydra),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, hydra, &hits_controller),
+        0,
+        "Hydra Omnivore should not trigger from combat damage to its controller"
+    );
+
+    let combat = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            hydra,
+            crate::events::DamageTarget::Player(bob),
+            8,
+            true,
+            crate::events::cause::EventCause::combat_damage(hydra),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, hydra, &combat),
+        1,
+        "Hydra Omnivore should trigger once from its combat damage to an opponent"
+    );
+
+    assert_eq!(game.life_total(alice), 20, "controller is not an opponent");
+    assert_eq!(
+        game.life_total(bob),
+        20,
+        "the damaged opponent should be excluded from each other opponent"
+    );
+    assert_eq!(game.life_total(charlie), 12, "first other opponent should take 8");
+    assert_eq!(game.life_total(dana), 12, "second other opponent should take 8");
+}
+
+#[test]
+fn hydra_omnivore_runtime_has_no_extra_damage_without_other_opponents() {
+    let def = parse_oracle_card_definition("Hydra Omnivore");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let hydra = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let combat = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            hydra,
+            crate::events::DamageTarget::Player(bob),
+            8,
+            true,
+            crate::events::cause::EventCause::combat_damage(hydra),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert_eq!(resolve_triggers_for_source(&mut game, hydra, &combat), 1);
+    assert_eq!(game.life_total(alice), 20, "controller should not be damaged");
+    assert_eq!(
+        game.life_total(bob),
+        20,
+        "with no other opponent, the damaged opponent should not take extra damage"
+    );
+}
+
+#[test]
 fn clockspinning_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Clockspinning");
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -13120,7 +13120,9 @@ mod tests {
     fn toxic_token_blueprint_keeps_toxic_as_keyword() {
         let toxic = Ability {
             kind: AbilityKind::Triggered(crate::ability::TriggeredAbility {
-                trigger: crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+                trigger: crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                    PlayerFilter::Any,
+                ),
                 effects: crate::resolution::ResolutionProgram::from_effects(vec![Effect::new(
                     crate::effects::PoisonCountersEffect::new(1, PlayerFilter::DamagedPlayer),
                 )]),
@@ -13154,7 +13156,9 @@ mod tests {
     fn token_with_non_toxic_poison_trigger_does_not_promote_toxic_surface() {
         let toxic = Ability {
             kind: AbilityKind::Triggered(crate::ability::TriggeredAbility {
-                trigger: crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+                trigger: crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                    PlayerFilter::Any,
+                ),
                 effects: crate::resolution::ResolutionProgram::from_effects(vec![Effect::new(
                     crate::effects::PoisonCountersEffect::new(1, PlayerFilter::DamagedPlayer),
                 )]),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17210,6 +17210,10 @@ fn describe_triggered_resolution_text(
     subject: &str,
     rewrite_it_deals: bool,
 ) -> Option<String> {
+    if triggered_deals_same_damage_to_each_other_opponent(triggered) {
+        return Some("it deals that much damage to each other opponent".to_string());
+    }
+
     if let Some(keyword) = triggered
         .trigger
         .downcast_ref::<crate::triggers::KeywordActionTrigger>()
@@ -17261,6 +17265,49 @@ fn describe_triggered_resolution_text(
     ))
 }
 
+fn triggered_deals_same_damage_to_each_other_opponent(
+    triggered: &crate::ability::TriggeredAbility,
+) -> bool {
+    if !triggered
+        .trigger
+        .downcast_ref::<crate::triggers::ThisDealsCombatDamageToPlayerTrigger>()
+        .is_some_and(|trigger| trigger.player == PlayerFilter::Opponent)
+    {
+        return false;
+    }
+    let [segment] = triggered.effects.segments.as_slice() else {
+        return false;
+    };
+    if !segment.self_replacements.is_empty() {
+        return false;
+    }
+    let [effect] = segment.default_effects.as_slice() else {
+        return false;
+    };
+    let Some(for_players) = effect.downcast_ref::<crate::effects::ForPlayersEffect>() else {
+        return false;
+    };
+    if !matches!(
+        &for_players.filter,
+        PlayerFilter::Excluding { base, excluded }
+            if matches!(base.as_ref(), PlayerFilter::Opponent)
+                && matches!(excluded.as_ref(), PlayerFilter::DamagedPlayer)
+    ) {
+        return false;
+    }
+    let [inner] = for_players.effects.as_slice() else {
+        return false;
+    };
+    let Some(deal_damage) = inner.downcast_ref::<crate::effects::DealDamageEffect>() else {
+        return false;
+    };
+    matches!(
+        deal_damage.amount,
+        Value::EventValue(EventValueSpec::Amount)
+    ) && matches!(deal_damage.target, ChooseSpec::Player(PlayerFilter::IteratedPlayer))
+        && !deal_damage.source_is_combat
+}
+
 fn rewrite_damaged_player_reference_for_damage_trigger(
     triggered: &crate::ability::TriggeredAbility,
     effects: String,
@@ -17303,6 +17350,9 @@ fn describe_triggered_inline_ability(
         intervening_condition
     };
     let mut line = describe_trigger_surface_with_frequency(triggered, trigger_frequency);
+    if triggered_deals_same_damage_to_each_other_opponent(triggered) {
+        line = line.replace("combat damage to a player", "combat damage to an opponent");
+    }
     if matches!(intervening_condition, Some(Condition::YourTurn))
         && line.to_ascii_lowercase().ends_with("becomes tapped")
     {
@@ -17388,6 +17438,9 @@ fn describe_triggered_inline_ability(
     line = normalize_redundant_short_name_etb_surface(line, triggered, self_subject);
     line = normalize_modal_named_source_etb_surface(line, triggered, self_subject);
     line = normalize_spellcast_trigger_mana_value_surface(triggered, line);
+    if triggered_deals_same_damage_to_each_other_opponent(triggered) {
+        line = line.replace("combat damage to a player", "combat damage to an opponent");
+    }
     if triggered.presentation_label.is_none()
         && line.starts_with("Whenever you cast a spell that targets this creature")
     {
@@ -40526,6 +40579,10 @@ pub(super) fn describe_ability(
                 triggered,
                 describe_trigger_surface_with_frequency(triggered, trigger_frequency),
             );
+            if triggered_deals_same_damage_to_each_other_opponent(triggered) {
+                trigger_surface = trigger_surface
+                    .replace("combat damage to a player", "combat damage to an opponent");
+            }
             if triggered.presentation_label.is_none()
                 && trigger_surface
                     .starts_with("Whenever you cast a spell that targets this creature")

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -2630,7 +2630,9 @@ fn apply_modification_to_chars(
         }
         Modification::AddCombatDamageDrawAbility => {
             chars.abilities.push(Ability::triggered(
-                crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+                crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                    crate::target::PlayerFilter::Any,
+                ),
                 vec![crate::effect::Effect::draw(1)],
             ));
         }
@@ -3477,7 +3479,9 @@ fn calculate_with_layers(object: &Object, ctx: &CalculationContext) -> Calculate
                 }
                 Modification::AddCombatDamageDrawAbility => {
                     chars.abilities.push(Ability::triggered(
-                        crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+                        crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                            crate::target::PlayerFilter::Any,
+                        ),
                         vec![crate::effect::Effect::draw(1)],
                     ));
                 }

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1225,7 +1225,9 @@ pub(crate) fn apply_modification_to_chars_for_dependency(
         | Modification::CopyTriggeredAbilities { .. } => {}
         Modification::AddCombatDamageDrawAbility => {
             chars.abilities.push(crate::ability::Ability::triggered(
-                crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+                crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                    crate::target::PlayerFilter::Any,
+                ),
                 vec![crate::effect::Effect::draw(1)],
             ));
         }

--- a/crates/ironsmith-runtime/src/effects/composition/mechanic_actions.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/mechanic_actions.rs
@@ -1011,7 +1011,9 @@ impl EffectExecutor for CipherEffect {
 
         game.imprint_card(chosen_creature, exiled_id);
         let ability = crate::ability::Ability::triggered(
-            crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+            crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                crate::target::PlayerFilter::Any,
+            ),
             vec![crate::effect::Effect::cast_encoded_card_copy(
                 exiled_stable_id,
             )],
@@ -2569,7 +2571,9 @@ mod tests {
         let source = create_creature(&mut game, alice, 22, "Backup Source", 2, 2);
         let target = create_creature(&mut game, alice, 23, "Backup Target", 1, 1);
         let granted = Ability::triggered(
-            crate::triggers::Trigger::this_deals_combat_damage_to_player(),
+            crate::triggers::Trigger::this_deals_combat_damage_to_player(
+                crate::target::PlayerFilter::Any,
+            ),
             vec![],
         );
         let mut ctx = ExecutionContext::new_default(source, alice)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -26200,7 +26200,7 @@ fn test_combat_damage_with_triggers() {
     let attacker_id = create_creature(&mut game, "Ninja", alice, 2, 2);
     if let Some(obj) = game.object_mut(attacker_id) {
         obj.abilities.push(Ability::triggered(
-            Trigger::this_deals_combat_damage_to_player(),
+            Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
             vec![Effect::draw(1)],
         ));
     }

--- a/crates/ironsmith-runtime/src/triggers/combat/this_deals_combat_damage_to_player.rs
+++ b/crates/ironsmith-runtime/src/triggers/combat/this_deals_combat_damage_to_player.rs
@@ -3,11 +3,21 @@
 use crate::events::DamageEvent;
 use crate::events::DamageTarget;
 use crate::events::EventKind;
+use crate::filter::PlayerFilterExt;
+use crate::target::PlayerFilter;
 use crate::triggers::TriggerEvent;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ThisDealsCombatDamageToPlayerTrigger;
+pub struct ThisDealsCombatDamageToPlayerTrigger {
+    pub player: PlayerFilter,
+}
+
+impl ThisDealsCombatDamageToPlayerTrigger {
+    pub fn new(player: PlayerFilter) -> Self {
+        Self { player }
+    }
+}
 
 impl TriggerMatcher for ThisDealsCombatDamageToPlayerTrigger {
     fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
@@ -17,18 +27,33 @@ impl TriggerMatcher for ThisDealsCombatDamageToPlayerTrigger {
         let Some(e) = event.downcast::<DamageEvent>() else {
             return false;
         };
-        // Must be combat damage to a player from the source
-        e.is_combat && matches!(e.target, DamageTarget::Player(_)) && e.source == ctx.source_id
+        let DamageTarget::Player(damaged_player) = e.target else {
+            return false;
+        };
+        // Must be combat damage to a matching player from the source.
+        e.is_combat
+            && e.source == ctx.source_id
+            && self.player.matches_player(damaged_player, &ctx.filter_ctx)
     }
 
     fn display(&self) -> String {
-        "Whenever this creature deals combat damage to a player".to_string()
+        let player = match &self.player {
+            PlayerFilter::Any => "a player".to_string(),
+            PlayerFilter::Opponent => "an opponent".to_string(),
+            _ => self.player.description(),
+        };
+        format!("Whenever this creature deals combat damage to {player}")
     }
 
     fn event_value_amount(&self, event: &TriggerEvent, ctx: &TriggerContext) -> Option<i32> {
         let e = event.downcast::<DamageEvent>()?;
-        (e.is_combat && matches!(e.target, DamageTarget::Player(_)) && e.source == ctx.source_id)
-            .then_some(e.amount as i32)
+        let DamageTarget::Player(damaged_player) = e.target else {
+            return None;
+        };
+        (e.is_combat
+            && e.source == ctx.source_id
+            && self.player.matches_player(damaged_player, &ctx.filter_ctx))
+        .then_some(e.amount as i32)
     }
 }
 
@@ -45,7 +70,7 @@ mod tests {
         let bob = PlayerId::from_index(1);
         let source_id = ObjectId::from_raw(1);
 
-        let trigger = ThisDealsCombatDamageToPlayerTrigger;
+        let trigger = ThisDealsCombatDamageToPlayerTrigger::new(PlayerFilter::Any);
         let ctx = TriggerContext::for_source(source_id, alice, &game);
 
         let event = TriggerEvent::new_with_provenance(
@@ -69,7 +94,7 @@ mod tests {
         let bob = PlayerId::from_index(1);
         let source_id = ObjectId::from_raw(1);
 
-        let trigger = ThisDealsCombatDamageToPlayerTrigger;
+        let trigger = ThisDealsCombatDamageToPlayerTrigger::new(PlayerFilter::Any);
         let ctx = TriggerContext::for_source(source_id, alice, &game);
 
         let event = TriggerEvent::new_with_provenance(
@@ -94,7 +119,7 @@ mod tests {
         let bob = PlayerId::from_index(1);
         let source_id = ObjectId::from_raw(1);
 
-        let trigger = ThisDealsCombatDamageToPlayerTrigger;
+        let trigger = ThisDealsCombatDamageToPlayerTrigger::new(PlayerFilter::Any);
         let ctx = TriggerContext::for_source(source_id, alice, &game);
 
         let event = TriggerEvent::new_with_provenance(
@@ -109,5 +134,49 @@ mod tests {
         );
 
         assert_eq!(trigger.event_value_amount(&event, &ctx), Some(5));
+    }
+
+    #[test]
+    fn test_matches_respects_opponent_filter() {
+        let game = GameState::new(
+            vec![
+                "Alice".to_string(),
+                "Bob".to_string(),
+                "Charlie".to_string(),
+            ],
+            20,
+        );
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source_id = ObjectId::from_raw(1);
+
+        let trigger = ThisDealsCombatDamageToPlayerTrigger::new(PlayerFilter::Opponent);
+        let ctx = TriggerContext::for_source(source_id, alice, &game);
+
+        let hits_controller = TriggerEvent::new_with_provenance(
+            DamageEvent::with_cause(
+                source_id,
+                DamageTarget::Player(alice),
+                5,
+                true,
+                crate::events::cause::EventCause::combat_damage(source_id),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        assert!(!trigger.matches(&hits_controller, &ctx));
+        assert_eq!(trigger.event_value_amount(&hits_controller, &ctx), None);
+
+        let hits_opponent = TriggerEvent::new_with_provenance(
+            DamageEvent::with_cause(
+                source_id,
+                DamageTarget::Player(bob),
+                5,
+                true,
+                crate::events::cause::EventCause::combat_damage(source_id),
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+        assert!(trigger.matches(&hits_opponent, &ctx));
+        assert_eq!(trigger.event_value_amount(&hits_opponent, &ctx), Some(5));
     }
 }

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -584,9 +584,9 @@ impl Trigger {
         Self::either(Self::this_blocks(), Self::this_becomes_blocked())
     }
 
-    /// Create a "when this creature deals combat damage to a player" trigger.
-    pub fn this_deals_combat_damage_to_player() -> Self {
-        Self::new(ThisDealsCombatDamageToPlayerTrigger)
+    /// Create a "when this creature deals combat damage to [player]" trigger.
+    pub fn this_deals_combat_damage_to_player(player: PlayerFilter) -> Self {
+        Self::new(ThisDealsCombatDamageToPlayerTrigger::new(player))
     }
 
     /// Create a "when this creature deals combat damage" trigger.
@@ -1147,7 +1147,7 @@ impl Trigger {
     /// ```ignore
     /// let trigger = Trigger::or(vec![
     ///     Trigger::this_enters_battlefield(),
-    ///     Trigger::this_deals_combat_damage_to_player(),
+    ///     Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
     /// ]);
     /// ```
     pub fn or(triggers: Vec<Self>) -> Self {
@@ -1163,7 +1163,7 @@ impl Trigger {
     /// ```ignore
     /// let trigger = Trigger::either(
     ///     Trigger::this_enters_battlefield(),
-    ///     Trigger::this_deals_combat_damage_to_player(),
+    ///     Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
     /// );
     /// ```
     pub fn either(a: Self, b: Self) -> Self {

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -198,8 +198,8 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::ThisDealsCombatDamageTo { filter } => {
             crate::triggers::Trigger::this_deals_combat_damage_to(filter)
         }
-        TriggerKind::ThisDealsCombatDamageToPlayer => {
-            crate::triggers::Trigger::this_deals_combat_damage_to_player()
+        TriggerKind::ThisDealsCombatDamageToPlayer { player } => {
+            crate::triggers::Trigger::this_deals_combat_damage_to_player(player)
         }
         TriggerKind::DealsDamage { filter } => crate::triggers::Trigger::deals_damage(filter),
         TriggerKind::DealsDamageToPlayer { source, player } => {

--- a/crates/ironsmith-runtime/src/triggers/special/or_trigger.rs
+++ b/crates/ironsmith-runtime/src/triggers/special/or_trigger.rs
@@ -16,7 +16,7 @@ use crate::zone::Zone;
 /// ```ignore
 /// let trigger = Trigger::or(vec![
 ///     Trigger::this_enters_battlefield(),
-///     Trigger::this_deals_combat_damage_to_player(),
+///     Trigger::this_deals_combat_damage_to_player(PlayerFilter::Any),
 /// ]);
 /// ```
 #[derive(Debug, Clone)]
@@ -276,7 +276,9 @@ mod tests {
 
         let trigger = OrTrigger::two(
             Trigger::this_enters_battlefield(),
-            Trigger::new(ThisDealsCombatDamageToPlayerTrigger),
+            Trigger::new(ThisDealsCombatDamageToPlayerTrigger::new(
+                crate::target::PlayerFilter::Any,
+            )),
         );
         let ctx = TriggerContext::for_source(source_id, alice, &game);
 
@@ -297,7 +299,9 @@ mod tests {
 
         let trigger = OrTrigger::two(
             Trigger::this_enters_battlefield(),
-            Trigger::new(ThisDealsCombatDamageToPlayerTrigger),
+            Trigger::new(ThisDealsCombatDamageToPlayerTrigger::new(
+                crate::target::PlayerFilter::Any,
+            )),
         );
         let ctx = TriggerContext::for_source(source_id, alice, &game);
 
@@ -325,7 +329,9 @@ mod tests {
 
         let trigger = OrTrigger::two(
             Trigger::this_enters_battlefield(),
-            Trigger::new(ThisDealsCombatDamageToPlayerTrigger),
+            Trigger::new(ThisDealsCombatDamageToPlayerTrigger::new(
+                crate::target::PlayerFilter::Any,
+            )),
         );
         let ctx = TriggerContext::for_source(source_id, alice, &game);
 
@@ -354,7 +360,9 @@ mod tests {
     fn test_or_trigger_display() {
         let trigger = OrTrigger::two(
             Trigger::this_enters_battlefield(),
-            Trigger::new(ThisDealsCombatDamageToPlayerTrigger),
+            Trigger::new(ThisDealsCombatDamageToPlayerTrigger::new(
+                crate::target::PlayerFilter::Any,
+            )),
         );
 
         let display = trigger.display();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hydra Omnivore
Initial parse error:
```
unsupported target phrase lacking object selector (clause: 'other opponent'); oracle-only fallback also failed: unsupported target phrase lacking object selector (clause: 'other opponent')
```

Current worker: i-04d5f2ed85d7ba171
Branch: codex/aws-card-fix-hydra-omnivore
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0022
