### PR TITLE
Fix Ironsmith parse failure: Component Pouch

### DIFF
--- a/crates/ironsmith-compiler/src/effect.rs
+++ b/crates/ironsmith-compiler/src/effect.rs
@@ -1413,8 +1413,26 @@ impl Effect {
         ))
     }
 
+    pub fn add_mana_of_different_colors_restricted(
+        amount: impl Into<Value>,
+        colors: Vec<crate::color::Color>,
+    ) -> Self {
+        Self::new(crate::effects::AddManaOfAnyColorEffect::restricted_distinct(
+            amount,
+            crate::target::PlayerFilter::You,
+            colors,
+        ))
+    }
+
     pub fn add_mana_of_any_color(amount: impl Into<Value>) -> Self {
         Self::new(crate::effects::AddManaOfAnyColorEffect::new(
+            amount,
+            crate::target::PlayerFilter::You,
+        ))
+    }
+
+    pub fn add_mana_of_different_colors(amount: impl Into<Value>) -> Self {
+        Self::new(crate::effects::AddManaOfAnyColorEffect::distinct(
             amount,
             crate::target::PlayerFilter::You,
         ))
@@ -1430,11 +1448,30 @@ impl Effect {
         ))
     }
 
+    pub fn add_mana_of_different_colors_restricted_player(
+        amount: impl Into<Value>,
+        player: crate::target::PlayerFilter,
+        colors: Vec<crate::color::Color>,
+    ) -> Self {
+        Self::new(crate::effects::AddManaOfAnyColorEffect::restricted_distinct(
+            amount, player, colors,
+        ))
+    }
+
     pub fn add_mana_of_any_color_player(
         amount: impl Into<Value>,
         player: crate::target::PlayerFilter,
     ) -> Self {
         Self::new(crate::effects::AddManaOfAnyColorEffect::new(amount, player))
+    }
+
+    pub fn add_mana_of_different_colors_player(
+        amount: impl Into<Value>,
+        player: crate::target::PlayerFilter,
+    ) -> Self {
+        Self::new(crate::effects::AddManaOfAnyColorEffect::distinct(
+            amount, player,
+        ))
     }
 
     pub fn add_mana_of_any_one_color(amount: impl Into<Value>) -> Self {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_helpers.rs
@@ -55,6 +55,8 @@ const ADD_MANA_ANY_ONE_COLOR_OR_TYPE_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["any", "one", "color"], &["any", "one", "type"]]]);
 const ADD_MANA_ANY_COLOR_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["any", "color"], &["one", "color"]]]);
+const ADD_MANA_DIFFERENT_COLORS_PATTERN: ClauseShape<'static> =
+    clause_shape!(contains_phrases & [&["different", "colors"]]);
 const ADD_MANA_ANY_TYPE_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["any", "type"], &["one", "type"]]]);
 const CARD_OR_CARDS_WORD_PATTERN: ClauseShape<'static> =
@@ -216,6 +218,15 @@ pub(crate) fn parse_add_mana(
             .unwrap_or(Value::Fixed(1));
         return Ok(EffectAst::subject_verb_add_mana_commander_identity(
             player, amount,
+        ));
+    }
+
+    if ADD_MANA_DIFFERENT_COLORS_PATTERN.matches_words(&clause_words) {
+        let amount = parse_value(tokens)
+            .map(|(value, _)| value)
+            .unwrap_or(Value::Fixed(1));
+        return Ok(EffectAst::subject_verb_add_mana_any_color_with_distinct(
+            player, amount, None, true,
         ));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1238,17 +1238,23 @@ pub(super) fn run_activation_line_family(
         )?;
         match parse_activation_cost_tokens_rewrite(&normalized_cost_tokens) {
             Ok(cost) => {
+                let activated = ActivatedLineCst {
+                    info: ctx.line.info.clone(),
+                    cost,
+                    cost_parse_tokens: normalized_cost_tokens,
+                    effect_text,
+                    effect_parse_tokens,
+                    presentation_label,
+                    chosen_option_label: None,
+                };
+                let (activated, next_idx) = extend_activated_line_with_result_followups(
+                    &ctx.preprocessed.items,
+                    ctx.idx,
+                    activated,
+                );
                 return Ok(Some(LineDispatchResult::single(
-                    RewriteLineCst::Activated(ActivatedLineCst {
-                        info: ctx.line.info.clone(),
-                        cost,
-                        cost_parse_tokens: normalized_cost_tokens,
-                        effect_text,
-                        effect_parse_tokens,
-                        presentation_label,
-                        chosen_option_label: None,
-                    }),
-                    ctx.idx + 1,
+                    RewriteLineCst::Activated(activated),
+                    next_idx,
                 )));
             }
             Err(err) if looks_like_activation_cost_prefix(&cost_tokens) => {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -159,9 +159,9 @@ use line_dispatch::{LineDispatchResult, dispatch_standard_line_cst};
 #[cfg(test)]
 use statement_cst_support::looks_like_statement_line;
 use statement_cst_support::{
-    extend_triggered_line_with_result_followups, looks_like_statement_line_lexed,
-    normalize_statement_parse_groups_lexed, parse_colon_nonactivation_statement_fallback,
-    parse_statement_line_cst,
+    extend_activated_line_with_result_followups, extend_triggered_line_with_result_followups,
+    looks_like_statement_line_lexed, normalize_statement_parse_groups_lexed,
+    parse_colon_nonactivation_statement_fallback, parse_statement_line_cst,
 };
 use unsupported::diagnose_known_unsupported_rewrite_line;
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -210,6 +210,31 @@ pub(super) fn extend_triggered_line_with_result_followups(
     (triggered, next_idx)
 }
 
+pub(super) fn extend_activated_line_with_result_followups(
+    items: &[PreprocessedItem],
+    idx: usize,
+    mut activated: ActivatedLineCst,
+) -> (ActivatedLineCst, usize) {
+    let mut next_idx = idx + 1;
+
+    while let Some(PreprocessedItem::Line(line)) = items.get(next_idx) {
+        if !is_trigger_result_followup_line(line) {
+            break;
+        }
+
+        let followup_text = render_token_slice(&line.tokens).trim().to_string();
+        if !activated.effect_text.is_empty() {
+            activated.effect_text.push('\n');
+        }
+        activated.effect_text.push_str(followup_text.as_str());
+        append_joined_line_tokens(&mut activated.effect_parse_tokens, &line.tokens);
+
+        next_idx += 1;
+    }
+
+    (activated, next_idx)
+}
+
 fn looks_like_statement_line_tokens(tokens: &[OwnedLexToken]) -> bool {
     if matches!(
         structure::classify_static_line_family_lexed(tokens),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -928,6 +928,7 @@ fn compile_subject_verb_effect(
         SubjectVerbActionAst::AddManaAnyColor {
             amount,
             available_colors,
+            distinct_colors,
         } => {
             let (amount, player_filter, choices) =
                 resolve_player_scoped_value(amount, player, ctx, true, true, true)?;
@@ -936,18 +937,34 @@ fn compile_subject_verb_effect(
                 choices,
                 || {
                     if let Some(colors) = available_colors.clone() {
-                        Effect::add_mana_of_any_color_restricted(amount.clone(), colors)
+                        if *distinct_colors {
+                            Effect::add_mana_of_different_colors_restricted(amount.clone(), colors)
+                        } else {
+                            Effect::add_mana_of_any_color_restricted(amount.clone(), colors)
+                        }
+                    } else if *distinct_colors {
+                        Effect::add_mana_of_different_colors(amount.clone())
                     } else {
                         Effect::add_mana_of_any_color(amount.clone())
                     }
                 },
                 |filter| {
                     if let Some(colors) = available_colors.clone() {
-                        Effect::add_mana_of_any_color_restricted_player(
-                            amount.clone(),
-                            filter,
-                            colors,
-                        )
+                        if *distinct_colors {
+                            Effect::add_mana_of_different_colors_restricted_player(
+                                amount.clone(),
+                                filter,
+                                colors,
+                            )
+                        } else {
+                            Effect::add_mana_of_any_color_restricted_player(
+                                amount.clone(),
+                                filter,
+                                colors,
+                            )
+                        }
+                    } else if *distinct_colors {
+                        Effect::add_mana_of_different_colors_player(amount.clone(), filter)
                     } else {
                         Effect::add_mana_of_any_color_player(amount.clone(), filter)
                     }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -846,6 +846,7 @@ pub(crate) enum SubjectVerbActionAst {
     AddManaAnyColor {
         amount: Value,
         available_colors: Option<Vec<crate::color::Color>>,
+        distinct_colors: bool,
     },
     AddManaAnyOneColor {
         amount: Value,
@@ -1941,10 +1942,12 @@ impl std::fmt::Debug for SubjectVerbActionAst {
             Self::AddManaAnyColor {
                 amount,
                 available_colors,
+                distinct_colors,
             } => f
                 .debug_struct("AddManaAnyColor")
                 .field("amount", amount)
                 .field("available_colors", available_colors)
+                .field("distinct_colors", distinct_colors)
                 .finish(),
             Self::AddManaAnyOneColor { amount } => {
                 f.debug_tuple("AddManaAnyOneColor").field(amount).finish()
@@ -5585,12 +5588,27 @@ impl EffectAst {
         amount: Value,
         available_colors: Option<Vec<crate::color::Color>>,
     ) -> Self {
+        Self::subject_verb_add_mana_any_color_with_distinct(
+            player,
+            amount,
+            available_colors,
+            false,
+        )
+    }
+
+    pub(crate) fn subject_verb_add_mana_any_color_with_distinct(
+        player: PlayerAst,
+        amount: Value,
+        available_colors: Option<Vec<crate::color::Color>>,
+        distinct_colors: bool,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::AffectedPlayer,
             player,
             SubjectVerbActionAst::AddManaAnyColor {
                 amount,
                 available_colors,
+                distinct_colors,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/mana_actions.rs
@@ -19,6 +19,8 @@ const ANY_ONE_COLOR_OR_TYPE_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["any", "one", "color"], &["any", "one", "type"]]]);
 const ANY_COLOR_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["any", "color"], &["one", "color"]]]);
+const DIFFERENT_COLORS_PATTERN: ClauseShape<'static> =
+    clause_shape!(contains_phrases & [&["different", "colors"]]);
 const ANY_TYPE_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_phrases & [&[&["any", "type"], &["one", "type"]]]);
 const COLOR_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["color"]);
@@ -137,6 +139,15 @@ pub(crate) fn parse_add_mana(
             .unwrap_or(Value::Fixed(1));
         return Ok(EffectAst::subject_verb_add_mana_commander_identity(
             player, amount,
+        ));
+    }
+
+    if DIFFERENT_COLORS_PATTERN.matches_words(&clause_words) {
+        let amount = parse_value(tokens)
+            .map(|(value, _)| value)
+            .unwrap_or(Value::Fixed(1));
+        return Ok(EffectAst::subject_verb_add_mana_any_color_with_distinct(
+            player, amount, None, true,
         ));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -3926,6 +3926,7 @@ fn rewrite_activation_helpers_parse_add_mana_accepts_player_choice_tail_without_
                 action: crate::cards::builders::SubjectVerbActionAst::AddManaAnyColor {
                     amount: crate::effect::Value::Fixed(1),
                     available_colors: None,
+                    distinct_colors: false,
                 },
             }
         )

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -4101,6 +4101,7 @@ pub struct AddManaOfAnyColorEffect {
     pub amount: Value,
     pub player: PlayerFilter,
     pub available_colors: Option<Vec<Color>>,
+    pub distinct_colors: bool,
 }
 
 impl AddManaOfAnyColorEffect {
@@ -4109,6 +4110,16 @@ impl AddManaOfAnyColorEffect {
             amount: amount.into(),
             player,
             available_colors: None,
+            distinct_colors: false,
+        }
+    }
+
+    pub fn distinct(amount: impl Into<Value>, player: PlayerFilter) -> Self {
+        Self {
+            amount: amount.into(),
+            player,
+            available_colors: None,
+            distinct_colors: true,
         }
     }
 
@@ -4121,6 +4132,20 @@ impl AddManaOfAnyColorEffect {
             amount: amount.into(),
             player,
             available_colors: Some(available_colors),
+            distinct_colors: false,
+        }
+    }
+
+    pub fn restricted_distinct(
+        amount: impl Into<Value>,
+        player: PlayerFilter,
+        available_colors: Vec<Color>,
+    ) -> Self {
+        Self {
+            amount: amount.into(),
+            player,
+            available_colors: Some(available_colors),
+            distinct_colors: true,
         }
     }
 
@@ -4128,8 +4153,19 @@ impl AddManaOfAnyColorEffect {
         Self::new(amount, PlayerFilter::You)
     }
 
+    pub fn you_distinct(amount: impl Into<Value>) -> Self {
+        Self::distinct(amount, PlayerFilter::You)
+    }
+
     pub fn you_restricted(amount: impl Into<Value>, available_colors: Vec<Color>) -> Self {
         Self::restricted(amount, PlayerFilter::You, available_colors)
+    }
+
+    pub fn you_restricted_distinct(
+        amount: impl Into<Value>,
+        available_colors: Vec<Color>,
+    ) -> Self {
+        Self::restricted_distinct(amount, PlayerFilter::You, available_colors)
     }
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7669,6 +7669,39 @@ fn test_parse_aberrant_mind_sorcerer_rolls_and_branch_ranges() {
     );
 }
 
+#[test]
+fn component_pouch_strict_parser_compiled_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Component Pouch");
+    let rendered = unprocessed_compiled_lines(&def);
+    assert_eq!(
+        rendered.join("\n"),
+        "{T}, Remove a component counter from this artifact: Add two mana of different colors.\n{T}: Roll a d20.\n1—9 | Put a component counter on this artifact.\n10—20 | Put two component counters on this artifact.",
+        "Component Pouch should compile back to its strict oracle text"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    let compact_debug = debug.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        compact_debug.contains("RemoveCountersEffect")
+            && compact_debug.contains("Named( \"component\"")
+            && compact_debug.contains("distinct_colors: true"),
+        "expected Component Pouch mana ability to remove a component counter and add distinct-color mana, got {debug}"
+    );
+    assert!(
+        compact_debug.contains("RollDieEffect")
+            && compact_debug.contains("sides: 20")
+            && compact_debug.contains("BetweenInclusive( 1, 9")
+            && compact_debug.contains("BetweenInclusive( 10, 20"),
+        "expected Component Pouch d20 branches for 1-9 and 10-20, got {debug}"
+    );
+    assert!(
+        compact_debug.contains("PutCountersEffect")
+            && compact_debug.contains("Named( \"component\"")
+            && compact_debug.contains("Fixed( 2"),
+        "expected Component Pouch d20 high branch to put two component counters, got {debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_arden_angel_rolls_four_sided_die_and_returns_itself_from_graveyard() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5037,6 +5037,50 @@ fn describe_player_protection_from_everything_pair(effects: &[&Effect]) -> Optio
     ))
 }
 
+fn numeric_roll_branch_label(predicate: &EffectPredicate) -> Option<String> {
+    let EffectPredicate::Value(cmp) = predicate else {
+        return None;
+    };
+    match cmp {
+        Comparison::Equal(value) => Some(value.to_string()),
+        Comparison::BetweenInclusive(min, max) => Some(format!("{min}—{max}")),
+        _ => None,
+    }
+}
+
+fn unwrap_if_effect(effect: &Effect) -> Option<&crate::effects::IfEffect> {
+    if let Some(if_effect) = effect.downcast_ref::<crate::effects::IfEffect>() {
+        return Some(if_effect);
+    }
+    effect
+        .downcast_ref::<crate::effects::WithIdEffect>()?
+        .effect
+        .downcast_ref::<crate::effects::IfEffect>()
+}
+
+fn describe_roll_die_with_numeric_result_table(effects: &[Effect]) -> Option<String> {
+    if effects.len() < 2 {
+        return None;
+    }
+    let roll_with_id = effects[0].downcast_ref::<crate::effects::WithIdEffect>()?;
+    roll_with_id
+        .effect
+        .downcast_ref::<crate::effects::RollDieEffect>()?;
+
+    let mut lines = vec![describe_effect(&effects[0])];
+    for effect in &effects[1..] {
+        let if_effect = unwrap_if_effect(effect)?;
+        if if_effect.condition != roll_with_id.id || !if_effect.else_.is_empty() {
+            return None;
+        }
+        let label = numeric_roll_branch_label(&if_effect.predicate)?;
+        let branch = describe_effect_list(&if_effect.then);
+        lines.push(format!("{label} | {branch}"));
+    }
+
+    Some(lines.join("\n"))
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let [first, second] = effects
         && let Some(tagged) = first.downcast_ref::<crate::effects::TaggedEffect>()
@@ -5049,6 +5093,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_roll_die_with_numeric_result_table(effects) {
         return compact;
     }
 
@@ -35257,6 +35304,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(add_any) = effect.downcast_ref::<crate::effects::AddManaOfAnyColorEffect>() {
+        if add_any.distinct_colors {
+            return format!(
+                "Add {} mana of different colors{}",
+                describe_mana_amount_for_add_effect(&add_any.amount),
+                describe_add_mana_destination_suffix(&add_any.player)
+            );
+        }
         if let Some(colors) = &add_any.available_colors {
             let has_all_colors = crate::color::Color::ALL
                 .iter()

--- a/crates/ironsmith-runtime/src/decision/io.rs
+++ b/crates/ironsmith-runtime/src/decision/io.rs
@@ -1031,12 +1031,24 @@ impl DecisionMaker for SelectFirstDecisionMaker {
         _game: &GameState,
         ctx: &crate::decisions::context::ColorsContext,
     ) -> Vec<crate::color::Color> {
-        let default_color = ctx
+        let available = ctx
             .available_colors
-            .as_ref()
-            .and_then(|colors| colors.first().copied())
-            .unwrap_or(crate::color::Color::Green);
-        vec![default_color; ctx.count as usize]
+            .as_deref()
+            .unwrap_or(&crate::color::Color::ALL);
+        let default_color = available.first().copied().unwrap_or(crate::color::Color::Green);
+        if ctx.distinct_colors && !ctx.same_color {
+            let mut colors = available
+                .iter()
+                .copied()
+                .take(ctx.count as usize)
+                .collect::<Vec<_>>();
+            while colors.len() < ctx.count as usize {
+                colors.push(default_color);
+            }
+            colors
+        } else {
+            vec![default_color; ctx.count as usize]
+        }
     }
 
     fn decide_counters(
@@ -1979,11 +1991,13 @@ impl DecisionMaker for CliDecisionMaker {
             ctx.count,
             if ctx.same_color {
                 " (must be same)"
+            } else if ctx.distinct_colors {
+                " (must be different)"
             } else {
                 ""
             }
         );
-        prompt_choose_colors(ctx.count, ctx.same_color)
+        prompt_choose_colors(ctx.count, ctx.same_color, ctx.distinct_colors)
     }
 
     fn decide_counters(
@@ -3111,7 +3125,11 @@ fn prompt_distribute(
 }
 
 /// Prompt for choosing colors, returning Vec<Color> directly.
-fn prompt_choose_colors(count: u32, same_color: bool) -> Vec<crate::color::Color> {
+fn prompt_choose_colors(
+    count: u32,
+    same_color: bool,
+    distinct_colors: bool,
+) -> Vec<crate::color::Color> {
     use crate::color::Color;
 
     println!("Choose {} color(s):", count);
@@ -3144,6 +3162,10 @@ fn prompt_choose_colors(count: u32, same_color: bool) -> Vec<crate::color::Color
                 // Check same_color constraint
                 if same_color && !result.is_empty() && result[0] != c {
                     println!("All colors must be the same.");
+                    continue;
+                }
+                if distinct_colors && result.contains(&c) {
+                    println!("Colors must be different.");
                     continue;
                 }
                 result.push(c);

--- a/crates/ironsmith-runtime/src/decisions/context.rs
+++ b/crates/ironsmith-runtime/src/decisions/context.rs
@@ -1005,6 +1005,8 @@ pub struct ColorsContext {
     pub count: u32,
     /// If true, all selections must be the same color.
     pub same_color: bool,
+    /// If true, selections must be different colors when possible.
+    pub distinct_colors: bool,
     /// Available colors (None = all five colors).
     pub available_colors: Option<Vec<Color>>,
 }
@@ -1016,17 +1018,21 @@ impl ColorsContext {
         source: Option<ObjectId>,
         count: u32,
         same_color: bool,
+        distinct_colors: bool,
     ) -> Self {
         Self {
             player,
             source,
             description: if same_color {
                 format!("Choose a color for {} mana", count)
+            } else if distinct_colors {
+                format!("Choose {} different mana color(s)", count)
             } else {
                 format!("Choose {} mana color(s)", count)
             },
             count,
             same_color,
+            distinct_colors,
             available_colors: None,
         }
     }
@@ -1037,6 +1043,7 @@ impl ColorsContext {
         source: Option<ObjectId>,
         count: u32,
         same_color: bool,
+        distinct_colors: bool,
         available_colors: Vec<Color>,
     ) -> Self {
         Self {
@@ -1044,11 +1051,14 @@ impl ColorsContext {
             source,
             description: if same_color {
                 format!("Choose a color for {} mana", count)
+            } else if distinct_colors {
+                format!("Choose {} different mana color(s)", count)
             } else {
                 format!("Choose {} mana color(s)", count)
             },
             count,
             same_color,
+            distinct_colors,
             available_colors: Some(available_colors),
         }
     }

--- a/crates/ironsmith-runtime/src/decisions/spec.rs
+++ b/crates/ironsmith-runtime/src/decisions/spec.rs
@@ -78,6 +78,8 @@ pub enum DecisionPrimitive {
         count: u32,
         /// If true, all selections must be the same color
         same_color: bool,
+        /// If true, selections must be different colors when possible
+        distinct_colors: bool,
     },
 
     /// Select counters to remove (counter type + count pairs).

--- a/crates/ironsmith-runtime/src/decisions/specs/special.rs
+++ b/crates/ironsmith-runtime/src/decisions/specs/special.rs
@@ -377,6 +377,8 @@ pub struct ManaColorsSpec {
     pub count: u32,
     /// If true, all mana must be the same color.
     pub same_color: bool,
+    /// If true, selected mana colors must be different when possible.
+    pub distinct_colors: bool,
     /// Available colors (None = all five colors).
     pub available_colors: Option<Vec<Color>>,
 }
@@ -388,6 +390,18 @@ impl ManaColorsSpec {
             source,
             count,
             same_color,
+            distinct_colors: false,
+            available_colors: None,
+        }
+    }
+
+    /// Create a new ManaColorsSpec for different colors.
+    pub fn different_colors(source: ObjectId, count: u32) -> Self {
+        Self {
+            source,
+            count,
+            same_color: false,
+            distinct_colors: true,
             available_colors: None,
         }
     }
@@ -403,6 +417,22 @@ impl ManaColorsSpec {
             source,
             count,
             same_color,
+            distinct_colors: false,
+            available_colors: Some(available_colors),
+        }
+    }
+
+    /// Create a new ManaColorsSpec with restricted different colors.
+    pub fn restricted_different_colors(
+        source: ObjectId,
+        count: u32,
+        available_colors: Vec<Color>,
+    ) -> Self {
+        Self {
+            source,
+            count,
+            same_color: false,
+            distinct_colors: true,
             available_colors: Some(available_colors),
         }
     }
@@ -414,6 +444,8 @@ impl DecisionSpec for ManaColorsSpec {
     fn description(&self) -> String {
         if self.same_color {
             format!("Choose a color for {} mana", self.count)
+        } else if self.distinct_colors {
+            format!("Choose {} different mana color(s)", self.count)
         } else {
             format!("Choose {} mana color(s)", self.count)
         }
@@ -423,17 +455,27 @@ impl DecisionSpec for ManaColorsSpec {
         DecisionPrimitive::SelectColors {
             count: self.count,
             same_color: self.same_color,
+            distinct_colors: self.distinct_colors,
         }
     }
 
     fn default_response(&self, _strategy: FallbackStrategy) -> Vec<Color> {
         // Default: green (arbitrary but consistent)
-        let default_color = self
-            .available_colors
-            .as_ref()
-            .and_then(|colors| colors.first().copied())
-            .unwrap_or(Color::Green);
-        vec![default_color; self.count as usize]
+        let available = self.available_colors.as_deref().unwrap_or(&Color::ALL);
+        let default_color = available.first().copied().unwrap_or(Color::Green);
+        if self.distinct_colors && !self.same_color {
+            let mut colors = available
+                .iter()
+                .copied()
+                .take(self.count as usize)
+                .collect::<Vec<_>>();
+            while colors.len() < self.count as usize {
+                colors.push(default_color);
+            }
+            colors
+        } else {
+            vec![default_color; self.count as usize]
+        }
     }
 
     fn build_context(
@@ -448,10 +490,17 @@ impl DecisionSpec for ManaColorsSpec {
                 Some(self.source),
                 self.count,
                 self.same_color,
+                self.distinct_colors,
                 colors.clone(),
             )
         } else {
-            ColorsContext::any_color(player, Some(self.source), self.count, self.same_color)
+            ColorsContext::any_color(
+                player,
+                Some(self.source),
+                self.count,
+                self.same_color,
+                self.distinct_colors,
+            )
         };
 
         DecisionContext::Colors(ctx)

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -2536,10 +2536,25 @@ impl Effect {
         Self::new(AddManaOfAnyColorEffect::you(amount))
     }
 
+    /// Create an "add mana of different colors" effect.
+    pub fn add_mana_of_different_colors(amount: impl Into<Value>) -> Self {
+        use crate::effects::AddManaOfAnyColorEffect;
+        Self::new(AddManaOfAnyColorEffect::you_distinct(amount))
+    }
+
     /// Create an "add mana of any color" effect for a specific player.
     pub fn add_mana_of_any_color_player(amount: impl Into<Value>, player: PlayerFilter) -> Self {
         use crate::effects::AddManaOfAnyColorEffect;
         Self::new(AddManaOfAnyColorEffect::new(amount, player))
+    }
+
+    /// Create an "add mana of different colors" effect for a specific player.
+    pub fn add_mana_of_different_colors_player(
+        amount: impl Into<Value>,
+        player: PlayerFilter,
+    ) -> Self {
+        use crate::effects::AddManaOfAnyColorEffect;
+        Self::new(AddManaOfAnyColorEffect::distinct(amount, player))
     }
 
     /// Create an "add mana of restricted colors" effect (can choose different colors).
@@ -2551,6 +2566,17 @@ impl Effect {
         Self::new(AddManaOfAnyColorEffect::you_restricted(amount, colors))
     }
 
+    /// Create an "add mana of restricted different colors" effect.
+    pub fn add_mana_of_different_colors_restricted(
+        amount: impl Into<Value>,
+        colors: Vec<crate::color::Color>,
+    ) -> Self {
+        use crate::effects::AddManaOfAnyColorEffect;
+        Self::new(AddManaOfAnyColorEffect::you_restricted_distinct(
+            amount, colors,
+        ))
+    }
+
     /// Create an "add mana of restricted colors" effect for a specific player.
     pub fn add_mana_of_any_color_restricted_player(
         amount: impl Into<Value>,
@@ -2559,6 +2585,18 @@ impl Effect {
     ) -> Self {
         use crate::effects::AddManaOfAnyColorEffect;
         Self::new(AddManaOfAnyColorEffect::restricted(amount, player, colors))
+    }
+
+    /// Create an "add mana of restricted different colors" effect for a specific player.
+    pub fn add_mana_of_different_colors_restricted_player(
+        amount: impl Into<Value>,
+        player: PlayerFilter,
+        colors: Vec<crate::color::Color>,
+    ) -> Self {
+        use crate::effects::AddManaOfAnyColorEffect;
+        Self::new(AddManaOfAnyColorEffect::restricted_distinct(
+            amount, player, colors,
+        ))
     }
 
     /// Create an "add mana of any one color" effect (all must be same color).

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_from_commander_color_identity.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_from_commander_color_identity.rs
@@ -91,6 +91,7 @@ impl EffectExecutor for AddManaFromCommanderColorIdentityEffect {
             player_id,
             1,
             true,
+            false,
             Some(&available_colors),
             available_colors[0],
         )

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_color.rs
@@ -56,6 +56,7 @@ impl EffectExecutor for AddManaOfAnyColorEffect {
             player_id,
             amount,
             false,
+            self.distinct_colors,
             self.available_colors.as_deref(),
             Color::Green,
         );
@@ -191,5 +192,20 @@ mod tests {
         assert_eq!(result.value, crate::effect::OutcomeValue::Count(2));
         assert_eq!(game.player(alice).unwrap().mana_pool.red, 2);
         assert_eq!(game.player(alice).unwrap().mana_pool.green, 0);
+    }
+
+    #[test]
+    fn test_add_mana_of_any_color_distinct_defaults_to_different_choices() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let mut ctx = ExecutionContext::new_default(source, alice);
+
+        let effect = AddManaOfAnyColorEffect::you_distinct(2);
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        assert_eq!(result.value, crate::effect::OutcomeValue::Count(2));
+        assert_eq!(game.player(alice).unwrap().mana_pool.white, 1);
+        assert_eq!(game.player(alice).unwrap().mana_pool.blue, 1);
     }
 }

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_one_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_any_one_color.rs
@@ -47,7 +47,7 @@ impl EffectExecutor for AddManaOfAnyOneColorEffect {
             return Ok(EffectOutcome::count(0));
         }
 
-        let color = choose_mana_colors(game, ctx, player_id, 1, true, None, Color::Green)
+        let color = choose_mana_colors(game, ctx, player_id, 1, true, false, None, Color::Green)
             .into_iter()
             .next()
             .unwrap_or(Color::Green);

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_chosen_color.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_chosen_color.rs
@@ -36,7 +36,7 @@ impl EffectExecutor for AddManaOfChosenColorEffect {
                 fixed
             } else {
                 let options = [fixed, chosen];
-                choose_mana_colors(game, ctx, player_id, 1, true, Some(&options), fixed)
+                choose_mana_colors(game, ctx, player_id, 1, true, false, Some(&options), fixed)
                     .into_iter()
                     .next()
                     .unwrap_or(fixed)

--- a/crates/ironsmith-runtime/src/effects/mana/add_mana_of_imprinted_colors.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/add_mana_of_imprinted_colors.rs
@@ -66,7 +66,7 @@ impl EffectExecutor for AddManaOfImprintedColorsEffect {
         }
 
         let chosen_color =
-            choose_mana_colors(game, ctx, controller, 1, true, Some(&colors), colors[0])
+            choose_mana_colors(game, ctx, controller, 1, true, false, Some(&colors), colors[0])
                 .into_iter()
                 .next()
                 .unwrap_or(colors[0]);

--- a/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/mana/choice_helpers.rs
@@ -55,6 +55,7 @@ pub(crate) fn choose_mana_colors(
     player_id: PlayerId,
     count: u32,
     same_color: bool,
+    distinct_colors: bool,
     available_colors: Option<&[Color]>,
     default_color: Color,
 ) -> Vec<Color> {
@@ -84,7 +85,13 @@ pub(crate) fn choose_mana_colors(
         if colors.is_empty() {
             return vec![fallback; count as usize];
         }
-        ManaColorsSpec::restricted(ctx.source, count, same_color, colors.to_vec())
+        if distinct_colors && !same_color {
+            ManaColorsSpec::restricted_different_colors(ctx.source, count, colors.to_vec())
+        } else {
+            ManaColorsSpec::restricted(ctx.source, count, same_color, colors.to_vec())
+        }
+    } else if distinct_colors && !same_color {
+        ManaColorsSpec::different_colors(ctx.source, count)
     } else {
         ManaColorsSpec::any_color(ctx.source, count, same_color)
     };
@@ -104,8 +111,30 @@ pub(crate) fn choose_mana_colors(
         chosen.retain(|color| available.contains(color));
     }
 
-    while chosen.len() < count as usize {
-        chosen.push(fallback);
+    if distinct_colors && !same_color {
+        let available = effective_available.as_deref().unwrap_or(&Color::ALL);
+        let mut distinct = Vec::with_capacity(count as usize);
+        for color in chosen {
+            if !distinct.contains(&color) {
+                distinct.push(color);
+            }
+        }
+        while distinct.len() < count as usize {
+            if let Some(color) = available
+                .iter()
+                .copied()
+                .find(|color| !distinct.contains(color))
+            {
+                distinct.push(color);
+            } else {
+                distinct.push(fallback);
+            }
+        }
+        chosen = distinct;
+    } else {
+        while chosen.len() < count as usize {
+            chosen.push(fallback);
+        }
     }
     chosen.truncate(count as usize);
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -38,6 +38,159 @@ fn setup_three_player_game() -> GameState {
     )
 }
 
+fn component_pouch_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(900_071), "Component Pouch")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "{T}, Remove a component counter from this artifact: Add two mana of different colors.\n\
+             {T}: Roll a d20.\n\
+             1—9 | Put a component counter on this artifact.\n\
+             10—20 | Put two component counters on this artifact.",
+        )
+        .expect("Component Pouch should parse for runtime tests")
+}
+
+fn component_pouch_mana_ability_index(def: &crate::cards::CardDefinition) -> usize {
+    def.abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::AddManaOfAnyColorEffect>()
+                        .is_some_and(|add| add.distinct_colors)
+                }),
+            _ => false,
+        })
+        .expect("Component Pouch should have its component-counter mana ability")
+}
+
+fn component_pouch_d20_ability_index(def: &crate::cards::CardDefinition) -> usize {
+    def.abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::WithIdEffect>()
+                        .and_then(|with_id| {
+                            with_id
+                                .effect
+                                .downcast_ref::<crate::effects::RollDieEffect>()
+                        })
+                        .is_some_and(|roll| roll.sides == 20)
+                }),
+            _ => false,
+        })
+        .expect("Component Pouch should have its d20 counter ability")
+}
+
+#[test]
+fn component_pouch_mana_activation_requires_counter_pays_cost_and_adds_distinct_mana_runtime() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let def = component_pouch_definition();
+    let pouch_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let ability_index = component_pouch_mana_ability_index(&def);
+
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateManaAbility { source, ability_index: idx }
+                    if *source == pouch_id && *idx == ability_index
+            )),
+        "Component Pouch mana ability should be illegal without a component counter"
+    );
+
+    game.add_counters(pouch_id, crate::object::CounterType::Named("component"), 1)
+        .expect("component counter should be addable to Component Pouch");
+    let activate_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| matches!(
+            action,
+            crate::decision::LegalAction::ActivateManaAbility { source, ability_index: idx }
+                if *source == pouch_id && *idx == ability_index
+        ))
+        .expect("Component Pouch mana ability should be legal with a component counter");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        &mut dm,
+    )
+    .expect("Component Pouch mana ability should pay costs and resolve");
+
+    assert_eq!(
+        game.counter_count(pouch_id, crate::object::CounterType::Named("component")),
+        0,
+        "activation cost should remove the component counter"
+    );
+    assert!(
+        game.is_tapped(pouch_id),
+        "activation cost should tap Component Pouch"
+    );
+    let pool = &game.player(alice).expect("Alice should exist").mana_pool;
+    let colored_counts = [pool.white, pool.blue, pool.black, pool.red, pool.green];
+    assert_eq!(pool.total(), 2, "mana ability should add exactly two mana");
+    assert_eq!(
+        colored_counts.iter().filter(|&&count| count > 0).count(),
+        2,
+        "mana ability should add two different colors, got {colored_counts:?}"
+    );
+}
+
+#[test]
+fn component_pouch_d20_branches_put_one_or_two_component_counters_runtime() {
+    fn resolve_forced_roll(roll: u32) -> u32 {
+        let def = component_pouch_definition();
+        let ability_index = component_pouch_d20_ability_index(&def);
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let pouch_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+        game.force_next_die_roll(roll);
+
+        let AbilityKind::Activated(activated) = &def.abilities[ability_index].kind else {
+            panic!("Component Pouch d20 ability should be activated")
+        };
+        let mut ctx = crate::effects::ExecutionContext::new_default(pouch_id, alice);
+        for effect in activated.effects.flattened_default_effects() {
+            crate::effects::execute_effect(&mut game, effect, &mut ctx)
+                .expect("Component Pouch d20 effect should resolve");
+        }
+        game.counter_count(pouch_id, crate::object::CounterType::Named("component"))
+    }
+
+    assert_eq!(
+        resolve_forced_roll(7),
+        1,
+        "1-9 branch should put one component counter"
+    );
+    assert_eq!(
+        resolve_forced_roll(15),
+        2,
+        "10-20 branch should put two component counters and not also take the low branch"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 fn tide_of_war_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(78_606), "Tide of War")


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Component Pouch
Initial parse error:
```
missing mana symbols (clause: 'two mana of different colors'); oracle-only fallback also failed: missing mana symbols (clause: 'two mana of different colors')
```

Current worker: i-0224519b7d9880535
Branch: codex/aws-card-fix-component-pouch
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0022
