### PR TITLE
Fix Ironsmith parse failure: Reprocess

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -1824,6 +1824,8 @@ const COUNTERS_REMOVED_THIS_WAY_PATTERN: ClauseShape<'static> = clause_shape!(
 );
 const DESTROYED_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["destroyed"]);
+const SACRIFICED_THIS_WAY_PATTERN: ClauseShape<'static> =
+    clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["sacrificed"]);
 const DISCARDED_THIS_WAY_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["this", "way"]]; contains_words & ["discarded"]);
 const REVEALED_THIS_WAY_PATTERN: ClauseShape<'static> =
@@ -7887,6 +7889,12 @@ pub(crate) fn parse_dynamic_cost_modifier_value(
         return Ok(Some(Value::X));
     }
     if DESTROYED_THIS_WAY_PATTERN.matches_words(&filter_words) {
+        return Ok(Some(Value::PendingEffectMetric {
+            source: EffectMetricSource::AffectedObjects,
+            metric: EffectMetric::Count,
+        }));
+    }
+    if SACRIFICED_THIS_WAY_PATTERN.matches_words(&filter_words) {
         return Ok(Some(Value::PendingEffectMetric {
             source: EffectMetricSource::AffectedObjects,
             metric: EffectMetric::Count,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/token_copy_control_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/token_copy_control_family.rs
@@ -68,6 +68,13 @@ fn token_copy_clause_first_is_word(clause: SubjectVerbPrimitiveClause<'_>, expec
     clause.first_is_word(expected)
 }
 
+fn sacrifice_choice_filter(mut filter: ObjectFilter) -> ObjectFilter {
+    if filter.controller.is_none() {
+        filter.controller = Some(PlayerFilter::You);
+    }
+    filter
+}
+
 pub(crate) const DESTROY_ALL_ATTACHED_TO_TARGET_PATTERN_ATOMS: &[LexPatternAtom<'static>] = &[
     LexPattern::word("destroy"),
     LexPattern::any_word(ALL_OR_EACH_WORDS),
@@ -614,7 +621,7 @@ pub(crate) fn parse_sacrifice_any_number_sentence_matched(
         )));
     }
 
-    let filter = parse_object_filter(filter_clause.tokens(), false)?;
+    let filter = sacrifice_choice_filter(parse_object_filter(filter_clause.tokens(), false)?);
     let tag = TagKey::from(IT_TAG);
 
     let mut effects = vec![
@@ -693,7 +700,7 @@ pub(crate) fn parse_sacrifice_one_or_more_sentence_matched(
             clause.text()
         )));
     }
-    let filter = parse_object_filter(filter_clause.tokens(), false)?;
+    let filter = sacrifice_choice_filter(parse_object_filter(filter_clause.tokens(), false)?);
     let tag = TagKey::from(IT_TAG);
     Ok(Some(vec![
         EffectAst::ChooseObjects {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -180,6 +180,63 @@ fn clockspinning_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn reprocess_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Reprocess");
+
+    let def = parse_oracle_card_definition("Reprocess");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert_eq!(def.name(), "Reprocess");
+    assert_eq!(def.card.card_types, vec![CardType::Sorcery]);
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Reprocess should have spell effects")
+        .flattened_default_effects();
+    let [choose_effect, sacrifice_effect, draw_effect] = effects else {
+        panic!("Reprocess should lower to choose, sacrifice, and draw effects, got {effects:#?}");
+    };
+    let choose = choose_effect
+        .downcast_ref::<crate::effects::ChooseObjectsEffect>()
+        .expect("Reprocess should choose permanents to sacrifice");
+    let sacrifice_with_id = sacrifice_effect
+        .downcast_ref::<crate::effects::WithIdEffect>()
+        .expect("Reprocess sacrifice should be effect-metric addressable");
+    let sacrifice = sacrifice_with_id
+        .effect
+        .downcast_ref::<crate::effects::zones::SacrificePlayerEffect>()
+        .expect("Reprocess should sacrifice the chosen permanents");
+    let draw = draw_effect
+        .downcast_ref::<crate::effects::DrawCardsEffect>()
+        .expect("Reprocess should draw from the sacrificed count");
+
+    assert_eq!(choose.filter.controller, Some(PlayerFilter::You));
+    assert_eq!(
+        choose.filter.card_types,
+        vec![CardType::Artifact, CardType::Creature, CardType::Land]
+    );
+    assert_eq!(sacrifice.player, PlayerFilter::You);
+    assert!(
+        matches!(
+            draw.count,
+            Value::EffectMetric {
+                effect_id,
+                source: crate::effect::EffectMetricSource::AffectedObjects,
+                metric: crate::effect::EffectMetric::Count,
+            } if effect_id == sacrifice_with_id.id
+        ),
+        "Reprocess draw count should reference the sacrificed-object metric, got {:?}",
+        draw.count
+    );
+    assert!(
+        rendered.contains(
+            "Sacrifice any number of artifacts, creatures, and/or lands. Draw a card for each permanent sacrificed this way."
+        ),
+        "Reprocess should render its sacrificed-this-way draw clause, got {rendered}"
+    );
+}
+
+#[test]
 fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Boss's Chauffeur");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1845,6 +1845,80 @@ fn sacrifice_view_unwrapped(effect: &Effect) -> Option<SacrificeView<'_>> {
     }
 }
 
+fn filter_is_exactly_tagged(filter: &ObjectFilter, tag: &crate::TagKey) -> bool {
+    filter.tagged_constraints.len() == 1
+        && filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag == *tag
+        })
+        && filter.zone.is_none()
+        && filter.controller.is_none()
+        && filter.card_types.is_empty()
+        && filter.all_card_types.is_empty()
+        && filter.excluded_card_types.is_empty()
+        && filter.subtypes.is_empty()
+        && filter.excluded_subtypes.is_empty()
+}
+
+fn describe_choose_sacrifice_then_draw_for_sacrificed(effects: &[&Effect]) -> Option<String> {
+    let [choose_effect, sacrifice_effect, draw_effect] = effects else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    let with_id = sacrifice_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let sacrifice = sacrifice_view(&with_id.effect)?;
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+
+    if choose.is_search
+        || choose.reveal
+        || choose.chooser != PlayerFilter::You
+        || choose.count.min != 0
+        || choose.count.max.is_some()
+        || choose.count.dynamic_x
+        || choose.count.up_to_x
+        || choose.count.random
+        || choose_primary_zone(choose) != Some(Zone::Battlefield)
+        || sacrifice.player != &PlayerFilter::You
+        || draw.player != PlayerFilter::You
+        || !filter_is_exactly_tagged(sacrifice.filter, &choose.tag)
+    {
+        return None;
+    }
+
+    let Value::Count(count_filter) = sacrifice.count else {
+        return None;
+    };
+    if !filter_is_exactly_tagged(count_filter, &choose.tag) {
+        return None;
+    }
+    if !matches!(
+        &draw.count,
+        Value::EffectMetric {
+            effect_id,
+            source: crate::effect::EffectMetricSource::AffectedObjects,
+            metric:
+                crate::effect::EffectMetric::Count | crate::effect::EffectMetric::AffectedCount,
+        } if *effect_id == with_id.id
+    ) {
+        return None;
+    }
+
+    let mut selection = describe_choose_selection(choose);
+    if let Some(rest) = selection.strip_prefix("any number ") {
+        selection = format!("any number of {rest}");
+    }
+    if let Some(rest) = selection.strip_suffix(" you control") {
+        selection = rest.to_string();
+    }
+    if choose.filter.card_types.len() > 1 {
+        selection = selection.replace(", or ", ", and/or ");
+    }
+
+    Some(format!(
+        "Sacrifice {selection}. Draw a card for each permanent sacrificed this way"
+    ))
+}
+
 fn tagged_target_only_effect(
     effect: &Effect,
 ) -> Option<(&crate::TagKey, &crate::effects::TargetOnlyEffect)> {
@@ -3549,6 +3623,9 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     if effects.len() == 3 {
+        if let Some(compact) = describe_choose_sacrifice_then_draw_for_sacrificed(&refs) {
+            return Some(compact);
+        }
         if let Some(compact) = describe_discard_hand_add_mana_draw_sequence(&refs) {
             return Some(compact);
         }
@@ -15468,6 +15545,14 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         {
             parts.push(compact);
             idx += 2;
+            continue;
+        }
+        if idx + 2 < filtered.len()
+            && let Some(compact) =
+                describe_choose_sacrifice_then_draw_for_sacrificed(&filtered[idx..idx + 3])
+        {
+            parts.push(compact);
+            idx += 3;
             continue;
         }
         if idx + 2 < filtered.len()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -39,6 +39,178 @@ fn setup_three_player_game() -> GameState {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn reprocess_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(646_813), "Reprocess")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Sacrifice any number of artifacts, creatures, and/or lands. Draw a card for each \
+             permanent sacrificed this way.",
+        )
+        .expect("Reprocess should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_reprocess_permanent(
+    game: &mut GameState,
+    name: &str,
+    card_types: Vec<CardType>,
+    controller: PlayerId,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_reprocess_library_cards(game: &mut GameState, owner: PlayerId, count: usize) {
+    for idx in 0..count {
+        let card = CardBuilder::new(CardId::new(), &format!("Reprocess Draw Card {}", idx + 1))
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        game.create_object_from_card(&card, owner, Zone::Library);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ReprocessDecisionMaker {
+    selected: Vec<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ReprocessDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal && self.selected.contains(&candidate.id))
+            .map(|candidate| candidate.id)
+            .take(ctx.max.unwrap_or(self.selected.len()))
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_reprocess_with_selection(
+    game: &mut GameState,
+    controller: PlayerId,
+    selected: Vec<ObjectId>,
+) {
+    let reprocess = reprocess_definition();
+    let source = game.create_object_from_definition(&reprocess, controller, Zone::Stack);
+    let mut dm = ReprocessDecisionMaker { selected };
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller)
+        .with_decision_maker(&mut dm);
+
+    for effect in reprocess
+        .spell_effect
+        .as_ref()
+        .expect("Reprocess should have spell effects")
+        .flattened_default_effects()
+    {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Reprocess effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn reprocess_sacrifices_selected_controlled_permanents_and_draws_that_many() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_reprocess_library_cards(&mut game, alice, 3);
+
+    let artifact = create_reprocess_permanent(
+        &mut game,
+        "Reprocess Artifact",
+        vec![CardType::Artifact],
+        alice,
+    );
+    let land = create_reprocess_permanent(&mut game, "Reprocess Land", vec![CardType::Land], alice);
+    let creature = create_reprocess_permanent(
+        &mut game,
+        "Reprocess Creature",
+        vec![CardType::Creature],
+        alice,
+    );
+    let bob_artifact = create_reprocess_permanent(
+        &mut game,
+        "Bob's Artifact",
+        vec![CardType::Artifact],
+        bob,
+    );
+
+    resolve_reprocess_with_selection(&mut game, alice, vec![artifact, land, bob_artifact]);
+
+    let graveyard_names = game
+        .objects_in_zone(Zone::Graveyard)
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect::<Vec<_>>();
+
+    assert!(
+        graveyard_names.iter().any(|name| name == "Reprocess Artifact"),
+        "selected artifact should be sacrificed into a graveyard, got {graveyard_names:?}"
+    );
+    assert!(
+        graveyard_names.iter().any(|name| name == "Reprocess Land"),
+        "selected land should be sacrificed into a graveyard, got {graveyard_names:?}"
+    );
+    assert_eq!(
+        game.object(creature).expect("unselected creature").zone,
+        Zone::Battlefield,
+        "unselected controlled permanents should remain on the battlefield"
+    );
+    assert_eq!(
+        game.object(bob_artifact).expect("opponent artifact").zone,
+        Zone::Battlefield,
+        "Reprocess should not choose or sacrifice permanents controlled by another player"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice").hand.len(),
+        2,
+        "Reprocess should draw one card for each permanent sacrificed this way"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn reprocess_can_choose_zero_and_draws_no_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    add_reprocess_library_cards(&mut game, alice, 2);
+
+    let artifact = create_reprocess_permanent(
+        &mut game,
+        "Reprocess Artifact",
+        vec![CardType::Artifact],
+        alice,
+    );
+
+    resolve_reprocess_with_selection(&mut game, alice, Vec::new());
+
+    assert_eq!(
+        game.object(artifact).expect("artifact").zone,
+        Zone::Battlefield,
+        "choosing zero permanents should leave available permanents untouched"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice").hand.len(),
+        0,
+        "choosing zero permanents should not draw cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn tide_of_war_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(78_606), "Tide of War")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Reprocess
Initial parse error:
```
unsupported this-way dynamic value (clause: 'for each permanent sacrificed this way'); oracle-only fallback also failed: unsupported this-way dynamic value (clause: 'for each permanent sacrificed this way')
```

Current worker: i-0a33ca2f4b1bbc5b6
Branch: codex/aws-card-fix-reprocess
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0022
