### PR TITLE
Fix Ironsmith parse failure: Polygoyf

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -5968,6 +5968,12 @@ fn parse_characteristic_defining_stat_value(tokens: &[OwnedLexToken]) -> Option<
     equal_prefixed.push(OwnedLexToken::word("to".to_string(), TextSpan::synthetic()));
     equal_prefixed.extend(trimmed.iter().cloned());
 
+    if CARD_TYPES_AMONG_MARKER_PATTERN.matches_words(&trimmed_words)
+        && let Some(value) = parse_characteristic_defining_pt_value(&trimmed)
+    {
+        return Some(value);
+    }
+
     parse_equal_to_aggregate_filter_value(&equal_prefixed)
         .or_else(|| parse_add_mana_equal_amount_value(&equal_prefixed))
         .or_else(|| parse_equal_to_number_of_filter_plus_or_minus_fixed_value(&equal_prefixed))

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -54664,6 +54664,122 @@ fn nighthawk_scavenger_characteristic_runtime_scaling_regression() {
     );
 }
 
+#[test]
+fn polygoyf_strict_parser_and_compiled_text_preserves_all_graveyards_card_types() {
+    assert_oracle_card_parses_strict("Polygoyf");
+
+    let def = parse_oracle_card_definition("Polygoyf");
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    let static_ability = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability)
+                if static_ability.id() == StaticAbilityId::CharacteristicDefiningPT =>
+            {
+                Some(static_ability)
+            }
+            _ => None,
+        })
+        .expect("Polygoyf should have a characteristic-defining P/T ability");
+    let game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let effects = static_ability.generate_effects(
+        crate::ids::ObjectId::from_raw(1),
+        crate::ids::PlayerId::from_index(0),
+        &game,
+    );
+    let crate::continuous::Modification::SetPowerToughness {
+        power,
+        toughness,
+        sublayer: _,
+    } = &effects[0].modification
+    else {
+        panic!("expected Polygoyf to use a SetPowerToughness CDA");
+    };
+
+    assert!(
+        matches!(
+            power,
+            crate::effect::Value::CardTypesInGraveyard(PlayerFilter::Any)
+        ),
+        "Polygoyf should structurally count card types across all graveyards, got {power:?}"
+    );
+    assert!(
+        matches!(
+            toughness,
+            crate::effect::Value::Add(left, right)
+                if matches!(&**left, crate::effect::Value::CardTypesInGraveyard(PlayerFilter::Any))
+                    && matches!(&**right, crate::effect::Value::Fixed(1))
+        ) || matches!(
+            toughness,
+            crate::effect::Value::Add(left, right)
+                if matches!(&**right, crate::effect::Value::CardTypesInGraveyard(PlayerFilter::Any))
+                    && matches!(&**left, crate::effect::Value::Fixed(1))
+        ),
+        "Polygoyf toughness should be card types across all graveyards plus 1, got {toughness:?}"
+    );
+    assert!(
+        rendered.contains("trample") && rendered.contains("myriad"),
+        "Polygoyf compiled text should preserve keyword identity, got {rendered}"
+    );
+    assert!(
+        rendered.contains("number of card types among cards in all graveyards"),
+        "Polygoyf compiled text should preserve the all-graveyards card-types-among clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("toughness is equal to that number plus 1"),
+        "Polygoyf compiled text should render the shared toughness value as that number plus 1, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("number of cards in all graveyards"),
+        "Polygoyf must not collapse card types among graveyards into a plain card count, got {rendered}"
+    );
+}
+
+#[test]
+fn polygoyf_runtime_counts_distinct_card_types_in_all_graveyards() {
+    let def = parse_oracle_card_definition("Polygoyf");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let polygoyf = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert_eq!(
+        (game.current_power(polygoyf), game.current_toughness(polygoyf)),
+        (Some(0), Some(1)),
+        "with empty graveyards, Polygoyf should be 0/1"
+    );
+
+    let artifact_creature = CardDefinitionBuilder::new(CardId::new(), "Artifact Creature Probe")
+        .card_types(vec![CardType::Artifact, CardType::Creature])
+        .build();
+    let enchantment = CardDefinitionBuilder::new(CardId::new(), "Enchantment Probe")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let duplicate_artifact = CardDefinitionBuilder::new(CardId::new(), "Duplicate Artifact Probe")
+        .card_types(vec![CardType::Artifact])
+        .build();
+
+    game.create_object_from_definition(&artifact_creature, alice, Zone::Graveyard);
+    game.create_object_from_definition(&enchantment, bob, Zone::Graveyard);
+    game.create_object_from_definition(&duplicate_artifact, bob, Zone::Graveyard);
+    game.refresh_continuous_state();
+
+    assert_eq!(
+        (game.current_power(polygoyf), game.current_toughness(polygoyf)),
+        (Some(3), Some(4)),
+        "Polygoyf should count distinct card types across both players' graveyards and add 1 toughness"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_gwen_stacy_ghost_spider_compiled_text_regression() {

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4174,6 +4174,24 @@ fn resolve_value_with_context(
             });
             seen.len() as i32
         }
+        Value::CardTypesInGraveyard(player_filter) => {
+            let filter_ctx = continuous_filter_context(ctx.game, controller, source);
+            let mut seen = HashSet::new();
+            for player in ctx.game.players.iter().filter(|player| player.is_in_game()) {
+                if !player_filter.matches_player(player.id, &filter_ctx) {
+                    continue;
+                }
+                for &card_id in &player.graveyard {
+                    let Some(obj) = ctx.game.object(card_id) else {
+                        continue;
+                    };
+                    for card_type in &obj.card_types {
+                        seen.insert(*card_type);
+                    }
+                }
+            }
+            seen.len() as i32
+        }
         Value::ColorsAmong(filter) => {
             let filter_ctx = continuous_filter_context(ctx.game, controller, source);
 
@@ -4447,7 +4465,6 @@ fn resolve_value_with_context(
         | Value::ThisAbilityResolvedThisTurnCount
         | Value::SourceRegeneratedThisTurnCount
         | Value::DamageDealtThisTurnByTaggedSpellCast(_)
-        | Value::CardTypesInGraveyard(_)
         | Value::EffectValue(_)
         | Value::EffectValueOffset(_, _)
         | Value::EffectMetric { .. }

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1462,21 +1462,19 @@ pub fn resolve_value(
         }
 
         Value::CardTypesInGraveyard(player_spec) => {
-            use crate::types::CardType;
-
-            let player_id = resolve_player_filter(game, player_spec, ctx)?;
-            let player = game
-                .player(player_id)
-                .ok_or(ExecutionError::PlayerNotFound(player_id))?;
-
-            let mut types: Vec<CardType> = Vec::new();
-            for &card_id in &player.graveyard {
-                let Some(obj) = game.object(card_id) else {
-                    continue;
-                };
-                for card_type in &obj.card_types {
-                    if !types.contains(card_type) {
-                        types.push(*card_type);
+            let player_ids =
+                resolve_player_filter_to_list(game, player_spec, &ctx.filter_context(game), ctx)?;
+            let mut types = HashSet::new();
+            for player_id in player_ids {
+                let player = game
+                    .player(player_id)
+                    .ok_or(ExecutionError::PlayerNotFound(player_id))?;
+                for &card_id in &player.graveyard {
+                    let Some(obj) = game.object(card_id) else {
+                        continue;
+                    };
+                    for card_type in &obj.card_types {
+                        types.insert(*card_type);
                     }
                 }
             }

--- a/crates/ironsmith-runtime/src/static_abilities/characteristics.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/characteristics.rs
@@ -44,6 +44,12 @@ impl StaticAbilityKind for CharacteristicDefiningPT {
                 "This creature's power and toughness are each equal to {}",
                 describe_value(&self.power)
             )
+        } else if let Some(offset) = toughness_is_power_plus_fixed(&self.power, &self.toughness) {
+            format!(
+                "This creature's power is equal to {} and its toughness is equal to that number plus {}",
+                describe_value(&self.power),
+                offset
+            )
         } else if matches!(self.toughness, Value::SourceToughness) {
             format!(
                 "This creature's power is equal to {}",
@@ -77,6 +83,20 @@ impl StaticAbilityKind for CharacteristicDefiningPT {
             )
             .with_source_type(EffectSourceType::CharacteristicDefining),
         ]
+    }
+}
+
+fn toughness_is_power_plus_fixed(power: &Value, toughness: &Value) -> Option<i32> {
+    match toughness {
+        Value::Add(left, right) if **left == *power => match right.as_ref() {
+            Value::Fixed(offset) if *offset > 0 => Some(*offset),
+            _ => None,
+        },
+        Value::Add(left, right) if **right == *power => match left.as_ref() {
+            Value::Fixed(offset) if *offset > 0 => Some(*offset),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/crates/ironsmith-tools/src/tooling.rs
+++ b/crates/ironsmith-tools/src/tooling.rs
@@ -3167,15 +3167,18 @@ CardDefinition {
     }
 
     #[test]
-    fn authoritative_snapshot_rejects_dropped_card_types_among_marker() {
+    fn authoritative_snapshot_accepts_preserved_card_types_among_marker() {
         let snapshot = compile_authoritative_snapshot_from_payload(&tarmogoyf_payload());
 
-        assert_eq!(snapshot.parse_status, ParseStatus::ParseFailed);
-        assert_eq!(
-            snapshot.parse_error.as_deref(),
-            Some("compiled text dropped required semantic marker: card-types-among")
+        assert_eq!(snapshot.parse_status, ParseStatus::StrictCompiled);
+        assert_eq!(snapshot.parse_error, None);
+        let compiled = snapshot
+            .compiled_text
+            .expect("Tarmogoyf-style card-types-among text should compile");
+        assert!(
+            compiled.contains("number of card types among cards in all graveyards"),
+            "compiled text should preserve card-types-among marker, got: {compiled}"
         );
-        assert!(snapshot.compiled_text.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Polygoyf
Initial parse error:
```
compiled text dropped required semantic marker: card-types-among
```

Current worker: i-05fc6f519a0986013
Branch: codex/aws-card-fix-polygoyf
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260602T154013Z-controller-dev-loop-wave0024
