### PR TITLE
Fix Ironsmith parse failure: Consulate Surveillance

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1846,19 +1846,41 @@ fn compile_subject_verb_effect(
                 Ok((effects, choices))
             }
         }
-        SubjectVerbActionAst::PreventAllDamageToTarget { target, duration } => {
+        SubjectVerbActionAst::PreventAllDamageToTarget {
+            target,
+            duration,
+            source_of_your_choice,
+        } => {
+            if *source_of_your_choice
+                && let TargetAst::Player(crate::target::PlayerFilter::You, _) = target
+            {
+                let effect = crate::effects::PreventAllDamageEffect::new(
+                    ironsmith_core::PreventionTarget::You,
+                    ironsmith_core::DamageFilter::all(),
+                    duration.clone(),
+                )
+                .with_source_of_your_choice();
+                return Ok((vec![Effect::new(effect)], Vec::new()));
+            }
             if let TargetAst::Object(filter, explicit_target_span, _) = target
                 && explicit_target_span.is_none()
             {
                 let resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
-                Ok((
-                    vec![Effect::prevent_all_damage_to(
-                        resolved_filter,
-                        duration.clone(),
-                    )],
-                    Vec::new(),
-                ))
+                let mut effect = crate::effects::PreventAllDamageEffect::matching(
+                    resolved_filter,
+                    duration.clone(),
+                );
+                if *source_of_your_choice {
+                    effect = effect.with_source_of_your_choice();
+                }
+                Ok((vec![Effect::new(effect)], Vec::new()))
             } else {
+                if *source_of_your_choice {
+                    return Err(CardTextError::ParseError(
+                        "prevent-all damage by a source of your choice currently supports non-targeted recipients"
+                            .to_string(),
+                    ));
+                }
                 compile_effect_for_target(target, ctx, |spec| {
                     Effect::prevent_all_damage_to_target(spec, duration.clone())
                 })

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1051,6 +1051,7 @@ pub(crate) enum SubjectVerbActionAst {
     PreventAllDamageToTarget {
         target: TargetAst,
         duration: Until,
+        source_of_your_choice: bool,
     },
     PreventAllDamageToTargetFromSourceFilter {
         target: TargetAst,
@@ -2264,10 +2265,15 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("duration", duration)
                 .field("follow_up_effects", follow_up_effects)
                 .finish(),
-            Self::PreventAllDamageToTarget { target, duration } => f
+            Self::PreventAllDamageToTarget {
+                target,
+                duration,
+                source_of_your_choice,
+            } => f
                 .debug_struct("PreventAllDamageToTarget")
                 .field("target", target)
                 .field("duration", duration)
+                .field("source_of_your_choice", source_of_your_choice)
                 .finish(),
             Self::PreventAllDamageToTargetFromSourceFilter {
                 target,
@@ -3808,10 +3814,22 @@ impl EffectAst {
         target: TargetAst,
         duration: Until,
     ) -> Self {
+        Self::subject_verb_prevent_all_damage_to_target_with_source_choice(target, duration, false)
+    }
+
+    pub(crate) fn subject_verb_prevent_all_damage_to_target_with_source_choice(
+        target: TargetAst,
+        duration: Until,
+        source_of_your_choice: bool,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::PreventAllDamageToTarget { target, duration },
+            SubjectVerbActionAst::PreventAllDamageToTarget {
+                target,
+                duration,
+                source_of_your_choice,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1729,6 +1729,22 @@ pub(crate) fn parse_prevent_all_damage_clause(
         }
 
         let target = parse_target_phrase(target_clause.tokens())?;
+        if CLAUSE_SOURCE_OF_YOUR_CHOICE_MARKER_PATTERN.matches(source_clause) {
+            let target_words = target_clause.word_refs();
+            if !matches!(target_words.as_slice(), ["you"]) {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported prevent-all damage source choice target (clause: '{}')",
+                    clause_text
+                )));
+            }
+            return Ok(Some(
+                EffectAst::subject_verb_prevent_all_damage_to_target_with_source_choice(
+                    target,
+                    Until::EndOfTurn,
+                    true,
+                ),
+            ));
+        }
         let source_filter_target = parse_target_phrase(source_clause.tokens())?;
         let TargetAst::Object(source_filter, _, _) = source_filter_target else {
             return Err(CardTextError::ParseError(format!(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/mod.rs
@@ -497,7 +497,10 @@ pub(crate) fn parse_damage_prevention_counter_sequence(
             ..
         }) => (Some(amount.clone()), target.clone(), duration.clone()),
         EffectAst::SubjectVerb(SubjectVerbEffectAst {
-            action: SubjectVerbActionAst::PreventAllDamageToTarget { target, duration },
+            action:
+                SubjectVerbActionAst::PreventAllDamageToTarget {
+                    target, duration, ..
+                },
             ..
         }) => (None, target.clone(), duration.clone()),
         _ => return Ok(None),

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -5406,6 +5406,8 @@ pub struct PreventAllDamageEffect {
     pub target: PreventionTarget,
     /// What kinds of damage this shield prevents.
     pub damage_filter: DamageFilter,
+    /// Whether the source is chosen as the effect resolves.
+    pub source_of_your_choice: bool,
     pub until: Until,
 }
 
@@ -5415,8 +5417,15 @@ impl PreventAllDamageEffect {
         Self {
             target,
             damage_filter,
+            source_of_your_choice: false,
             until,
         }
+    }
+
+    /// Restrict this prevention shield to a source chosen as the effect resolves.
+    pub fn with_source_of_your_choice(mut self) -> Self {
+        self.source_of_your_choice = true;
+        self
     }
 
     /// Prevent all damage to everything.

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,199 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn consulate_surveillance_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Consulate Surveillance");
+    let def = parse_oracle_card_definition("Consulate Surveillance");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Triggered(_))),
+        "Consulate Surveillance should parse its enters trigger strictly"
+    );
+    assert!(
+        def.abilities
+            .iter()
+            .any(|ability| matches!(ability.kind, AbilityKind::Activated(_))),
+        "Consulate Surveillance should parse its activated prevention ability strictly"
+    );
+    assert!(
+        ability_debug.contains("EnergyCountersEffect")
+            && ability_debug.contains("PreventAllDamageEffect")
+            && ability_debug.contains("source_of_your_choice: true"),
+        "expected energy trigger and chosen-source prevent-all-damage effect, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("When this enchantment enters, you get {E}{E}{E}{E}")
+            && rendered.contains(
+                "Pay {E}{E}: Prevent all damage that would be dealt to you this turn by a source of your choice"
+            ),
+        "expected Consulate Surveillance compiled text to preserve energy and source-choice prevention clauses, got {rendered}"
+    );
+}
+
+#[test]
+fn consulate_surveillance_activation_cost_requires_and_spends_two_energy() {
+    let def = parse_oracle_card_definition("Consulate Surveillance");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Consulate Surveillance should have an activated ability");
+    let costs = activated.mana_cost.costs();
+    assert_eq!(
+        costs.len(),
+        1,
+        "Consulate Surveillance activation should have only its energy payment cost"
+    );
+    assert!(
+        costs[0].display().contains("{E}{E}"),
+        "expected two-energy activation cost, got {}",
+        costs[0].display()
+    );
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .energy_counters = 1;
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let ctx = crate::costs::CostContext::new(source, alice, &mut dm);
+    assert!(
+        costs[0].can_pay(&game, &ctx).is_err(),
+        "Consulate Surveillance activation should not be payable with one energy"
+    );
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .energy_counters = 2;
+    let mut dm = crate::decision::AutoPassDecisionMaker;
+    let mut ctx = crate::costs::CostContext::new(source, alice, &mut dm);
+    costs[0]
+        .pay(&mut game, &mut ctx)
+        .expect("Consulate Surveillance activation should spend two energy");
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        0,
+        "Consulate Surveillance activation should spend exactly two energy"
+    );
+}
+
+#[test]
+fn consulate_surveillance_prevents_damage_from_chosen_source_only() {
+    struct ChooseSourceDecisionMaker {
+        chosen: ObjectId,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseSourceDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            if ctx
+                .candidates
+                .iter()
+                .any(|candidate| candidate.id == self.chosen && candidate.legal)
+            {
+                vec![self.chosen]
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    let def = parse_oracle_card_definition("Consulate Surveillance");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Consulate Surveillance should have an activated ability");
+    let creature_def = CardDefinitionBuilder::new(CardId::new(), "Damage Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let chosen_source = game.create_object_from_definition(&creature_def, bob, Zone::Battlefield);
+    let other_source = game.create_object_from_definition(&creature_def, bob, Zone::Battlefield);
+    let surveillance = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let mut dm = ChooseSourceDecisionMaker {
+        chosen: chosen_source,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(surveillance, alice, &mut dm);
+    for effect in activated.effects.flattened_default_effects() {
+        effect
+            .0
+            .execute(&mut game, &mut ctx)
+            .expect("Consulate Surveillance prevention effect should resolve");
+    }
+
+    let shields = game.effect_store.prevention_effects.shields();
+    assert_eq!(
+        shields.len(),
+        1,
+        "activation should create one prevention shield"
+    );
+    assert_eq!(
+        shields[0].damage_filter.from_specific_source,
+        Some(chosen_source),
+        "prevention shield should be restricted to the chosen source"
+    );
+
+    let (chosen_remaining, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        chosen_source,
+        crate::events::DamageTarget::Player(alice),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        chosen_remaining, 0,
+        "chosen source damage should be prevented"
+    );
+
+    let (chosen_to_bob_remaining, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        chosen_source,
+        crate::events::DamageTarget::Player(bob),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        chosen_to_bob_remaining, 3,
+        "chosen source damage to another player should not be prevented"
+    );
+
+    let (other_remaining, _) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        other_source,
+        crate::events::DamageTarget::Player(alice),
+        2,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        other_remaining, 2,
+        "damage from a different source should not be prevented"
+    );
+}
+
+#[test]
 fn hydra_omnivore_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Hydra Omnivore");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -36766,6 +36766,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         };
     }
     if let Some(prevent_all) = effect.downcast_ref::<crate::effects::PreventAllDamageEffect>() {
+        if prevent_all.source_of_your_choice && matches!(prevent_all.until, Until::EndOfTurn) {
+            let protected = describe_prevention_target(&prevent_all.target);
+            if prevent_all.damage_filter == crate::prevention::DamageFilter::all() {
+                if matches!(prevent_all.target, crate::prevention::PreventionTarget::All) {
+                    return "Prevent all damage that would be dealt this turn by a source of your choice"
+                        .to_string();
+                }
+                return format!(
+                    "Prevent all damage that would be dealt to {protected} this turn by a source of your choice"
+                );
+            }
+        }
         let simple_damage_filter = prevent_all.damage_filter.from_source.is_none()
             && prevent_all.damage_filter.from_colors.is_none()
             && prevent_all.damage_filter.from_card_types.is_none()

--- a/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/combat/prevent_all_damage.rs
@@ -37,13 +37,58 @@ impl EffectExecutor for PreventAllDamageEffect {
             return Ok(EffectOutcome::prevented());
         }
 
+        let mut damage_filter = self.damage_filter.clone();
+        if self.source_of_your_choice {
+            let mut candidates = Vec::new();
+            candidates.extend(game.stack.iter().map(|entry| entry.object_id));
+            candidates.extend(game.battlefield.iter().copied());
+            candidates.sort_by_key(|id| id.0);
+            candidates.dedup();
+
+            if candidates.is_empty() {
+                return Ok(EffectOutcome::resolved());
+            }
+
+            let selectable = candidates
+                .iter()
+                .copied()
+                .map(|id| {
+                    let name = game
+                        .object(id)
+                        .map(|object| object.name.clone())
+                        .unwrap_or_else(|| format!("object {}", id.0));
+                    crate::decisions::context::SelectableObject::new(id, name)
+                })
+                .collect::<Vec<_>>();
+            let select_ctx = crate::decisions::context::SelectObjectsContext::new(
+                ctx.controller,
+                Some(ctx.source),
+                "Choose a source",
+                selectable,
+                1,
+                Some(1),
+            );
+            let chosen_source = ctx
+                .decision_maker
+                .decide_objects(game, &select_ctx)
+                .into_iter()
+                .find(|id| candidates.contains(id));
+            if ctx.decision_maker.awaiting_choice() {
+                return Ok(EffectOutcome::count(0));
+            }
+            let Some(chosen_source) = chosen_source else {
+                return Ok(EffectOutcome::count(0));
+            };
+            damage_filter.from_specific_source = Some(chosen_source);
+        }
+
         register_prevention_shield(
             game,
             ctx,
             self.target.clone(),
             None,
             self.until.clone(),
-            self.damage_filter.clone(),
+            damage_filter,
             Vec::new(),
             Vec::new(),
             Vec::new(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Consulate Surveillance
Initial parse error:
```
unsupported target phrase (clause: 'source of your choice'); oracle-only fallback also failed: unsupported target phrase (clause: 'source of your choice')
```

Current worker: i-04082640fef10b1e2
Branch: codex/aws-card-fix-consulate-surveillance
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
