### PR TITLE
Fix Ironsmith parse failure: Arvinox, the Mind Flail

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -6889,7 +6889,37 @@ pub(crate) fn parse_isnt_creature_line(
     } else {
         None
     };
-    let clause_tokens = clause_tokens_buf.as_deref().unwrap_or(tokens);
+    let mut clause_tokens_storage: Vec<OwnedLexToken> = Vec::new();
+    let mut clause_tokens = clause_tokens_buf.as_deref().unwrap_or(tokens);
+
+    let clause_words = crate::runtime_backend::token_word_refs(clause_tokens);
+    if let Some(unless_word_idx) = clause_words.iter().position(|word| *word == "unless") {
+        let unless_token_idx = token_index_for_word_index(clause_tokens, unless_word_idx)
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unable to map unless condition in isn't-a-creature clause (clause: '{}')",
+                    all_words.join(" ")
+                ))
+            })?;
+        let condition_tokens = trim_commas(&clause_tokens[unless_token_idx + 1..]);
+        if condition_tokens.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing condition after trailing 'unless' clause (clause: '{}')",
+                all_words.join(" ")
+            )));
+        }
+        let unless_condition = crate::ConditionExpr::Not(Box::new(parse_static_condition_clause(
+            &condition_tokens,
+        )?));
+        condition = Some(match condition {
+            Some(existing) => {
+                crate::ConditionExpr::And(Box::new(existing), Box::new(unless_condition))
+            }
+            None => unless_condition,
+        });
+        clause_tokens_storage.extend(trim_commas(&clause_tokens[..unless_token_idx]));
+        clause_tokens = &clause_tokens_storage;
+    }
 
     let clause_words = crate::runtime_backend::token_word_refs(clause_tokens);
     if clause_words.len() < 3 {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -53,6 +53,7 @@ pub(crate) enum PermissionClauseSpec {
         as_copy: bool,
         without_paying_mana_cost: bool,
         lifetime: PermissionLifetime,
+        filter: Option<ObjectFilter>,
     },
     GrantBySpec {
         player: PlayerAst,
@@ -255,6 +256,9 @@ const PERMISSION_LIFETIME_PREFIXES: &[&[&str]] = &[
     &["for", "as", "long", "as", "it", "remains", "exiled"],
     &[
         "for", "as", "long", "as", "that", "card", "remains", "exiled",
+    ],
+    &[
+        "for", "as", "long", "as", "those", "cards", "remain", "exiled",
     ],
     &[
         "for", "as", "long", "as", "you", "control", "this", "creature",
@@ -700,6 +704,9 @@ fn permission_lifetime_from_prefix_words(words: &[&str]) -> Option<PermissionLif
             "card",
             "remains",
             "exiled",
+        ]
+        | [
+            "for", "as", "long", "as", "those", "cards", "remain", "exiled",
         ] => Some(PermissionLifetime::ForAsLongAsExiled),
         [
             "for",
@@ -733,6 +740,72 @@ fn parse_permission_lifetime_prefix_tokens<'a>(
         lifetime,
         rest_tokens: rest_clause.tokens(),
     })
+}
+
+fn strip_for_as_long_as_look_at_tagged_prefix_tokens(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<OwnedLexToken>> {
+    let parsed = parse_permission_lifetime_prefix_tokens(tokens)?;
+    if parsed.lifetime != PermissionLifetime::ForAsLongAsExiled {
+        return None;
+    }
+    let prefix_len = tokens.len().checked_sub(parsed.rest_tokens.len())?;
+    let rest_tokens = trim_lexed_commas(parsed.rest_tokens);
+    let rest_words = token_word_refs(rest_tokens);
+    let look_word_count = if rest_words.starts_with(&["you", "may", "look", "at", "them"]) {
+        5
+    } else if rest_words.starts_with(&["you", "may", "look", "at", "those", "cards"]) {
+        6
+    } else {
+        return None;
+    };
+    let after_look_idx = token_index_for_word_index(rest_tokens, look_word_count)?;
+    let after_look = trim_lexed_commas(strip_leading_token_words_any(
+        trim_lexed_commas(&rest_tokens[after_look_idx..]),
+        &["and"],
+    ));
+    if after_look.is_empty() {
+        return None;
+    }
+
+    let mut permission_tokens = tokens[..prefix_len].to_vec();
+    permission_tokens.extend_from_slice(after_look);
+    Some(permission_tokens)
+}
+
+fn parse_permanent_spells_from_among_tagged_tokens<'a>(
+    tokens: &'a [OwnedLexToken],
+) -> Option<(TaggedPermissionTarget, &'a [OwnedLexToken], ObjectFilter)> {
+    for phrase in [
+        &["permanent", "spells", "from", "among", "them"][..],
+        &[
+            "permanent",
+            "spells",
+            "from",
+            "among",
+            "those",
+            "cards",
+        ][..],
+    ] {
+        let words = token_word_refs(tokens);
+        if !words.starts_with(phrase) {
+            continue;
+        }
+        let rest_idx = if words.len() == phrase.len() {
+            tokens.len()
+        } else {
+            token_index_for_word_index(tokens, phrase.len())?
+        };
+        return Some((
+            TaggedPermissionTarget {
+                tag: TagKey::from(IT_TAG),
+                as_copy: false,
+            },
+            &tokens[rest_idx..],
+            permanent_spell_filter(),
+        ));
+    }
+    None
 }
 
 fn parse_once_each_turn_graveyard_cast_rest_tokens<'a>(
@@ -1886,8 +1959,13 @@ pub(crate) fn parse_permission_clause_spec_lexed(
         return Ok(None);
     }
 
-    if let Some((target_ref, tagged_tail_tokens)) =
-        parse_tagged_cast_or_play_target_tokens(rest_tokens)
+    if let Some((target_ref, tagged_tail_tokens, filter)) =
+        parse_permanent_spells_from_among_tagged_tokens(rest_tokens)
+            .map(|(target_ref, tail, filter)| (target_ref, tail, Some(filter)))
+            .or_else(|| {
+                parse_tagged_cast_or_play_target_tokens(rest_tokens)
+                    .map(|(target_ref, tail)| (target_ref, tail, None))
+            })
     {
         let target_len = rest_tokens.len() - tagged_tail_tokens.len();
         let target_tokens = &rest_tokens[..target_len];
@@ -1973,6 +2051,7 @@ pub(crate) fn parse_permission_clause_spec_lexed(
             as_copy: target_ref.as_copy,
             without_paying_mana_cost,
             lifetime,
+            filter,
         }));
     }
 
@@ -2188,6 +2267,7 @@ pub(crate) fn parse_until_end_of_turn_may_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::UntilEndOfTurn,
+            ..
         }) if player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 tag,
@@ -2212,6 +2292,7 @@ pub(crate) fn parse_until_your_next_turn_may_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::UntilYourNextTurn,
+            ..
         }) if matches!(player, PlayerAst::You | PlayerAst::Implicit) => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
                 tag,
@@ -2546,6 +2627,19 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
         return Ok(Some(effect));
     }
 
+    if let Some(permission_tokens) = strip_for_as_long_as_look_at_tagged_prefix_tokens(&trimmed)
+        && let Some(permission) = parse_cast_or_play_tagged_clause(&permission_tokens)?
+    {
+        let mut look_filter = ObjectFilter::tagged(TagKey::from(IT_TAG));
+        look_filter.zone = Some(Zone::Exile);
+        return Ok(Some(EffectAst::Sequence {
+            effects: vec![
+                EffectAst::subject_verb_look_at_objects(PlayerAst::You, look_filter),
+                permission,
+            ],
+        }));
+    }
+
     let mut allow_any_color_for_cast = false;
     if let Some(stripped) = strip_allow_any_color_for_cast_suffix_tokens(&trimmed) {
         allow_any_color_for_cast = true;
@@ -2620,6 +2714,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::Immediate,
+            ..
         }) => {
             let cast = EffectAst::subject_verb_cast_tagged(
                 tag,
@@ -2645,6 +2740,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::ThisTurn | PermissionLifetime::UntilEndOfTurn,
+            ..
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_until_end_of_turn(
                 tag,
@@ -2661,6 +2757,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::UntilYourNextTurn,
+            ..
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_until_your_next_turn(
                 tag,
@@ -2709,6 +2806,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost,
             lifetime: PermissionLifetime::ForAsLongAsExiled,
+            filter,
         }) if matches!(
             player,
             PlayerAst::Implicit | PlayerAst::You | PlayerAst::ItsOwner
@@ -2721,6 +2819,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
                     allow_land,
                     without_paying_mana_cost,
                     allow_any_color_for_cast,
+                    filter,
                 ),
             ))
         }
@@ -2731,6 +2830,7 @@ pub(crate) fn parse_cast_or_play_tagged_clause(
             as_copy: false,
             without_paying_mana_cost: false,
             lifetime: PermissionLifetime::ForAsLongAsYouControlSource,
+            ..
         }) if player == PlayerAst::Implicit || player == PlayerAst::You => Ok(Some(
             EffectAst::subject_verb_grant_play_tagged_for_as_long_as_you_control_source(
                 tag,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2365,6 +2365,7 @@ fn compile_subject_verb_effect(
             allow_land,
             without_paying_mana_cost,
             allow_any_color_for_cast,
+            filter,
         } => {
             let player_filter =
                 resolve_non_target_player_filter(*player, &current_reference_env(ctx))?;
@@ -2384,13 +2385,17 @@ fn compile_subject_verb_effect(
             } else {
                 tag.clone()
             };
-            let mut effects = vec![Effect::new(crate::effects::GrantPlayTaggedEffect::new(
+            let mut grant_play = crate::effects::GrantPlayTaggedEffect::new(
                 resolved_tag.clone(),
                 player_filter.clone(),
                 crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled,
                 *allow_land,
                 *allow_any_color_for_cast,
-            ))];
+            );
+            if let Some(filter) = filter.clone() {
+                grant_play = grant_play.with_filter(filter);
+            }
+            let mut effects = vec![Effect::new(grant_play)];
             if *without_paying_mana_cost {
                 effects.push(Effect::new(
                     crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect::new(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
@@ -247,6 +247,36 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
             ctx.last_player_filter = Some(followup_player);
             (effects, choices)
         }
+        EffectAst::ChooseObjectsBottomOfLibrary {
+            filter,
+            count,
+            count_value,
+            player,
+            tag,
+        } => {
+            let subject = LoweredSubject::resolve_chooser(*player, ctx, true, true, false)?;
+            let chooser = subject.clone_player_filter();
+            let mut resolved_filter = subject.resolve_object_refs_and_bind_player_refs_in_filter(filter, ctx)?;
+            resolved_filter.zone = Some(Zone::Library);
+            let mut choose_effect = crate::effects::ChooseObjectsEffect::new(
+                resolved_filter,
+                *count,
+                chooser.clone(),
+                tag.clone(),
+            )
+            .with_count_value_opt(count_value.clone())
+            .in_zone(Zone::Library)
+            .bottom_only();
+            choose_effect.description = "Choose bottom library card".to_string();
+            let effects = subject.prepend_target_prelude_if_needed(Effect::new(choose_effect));
+            ctx.last_it_choice_is_set = tag.as_str() == IT_TAG;
+            ctx.last_object_tag = Some(tag.as_str().to_string());
+            if is_sentence_helper_exiled_collection_tag(tag.as_str()) {
+                ctx.last_exiled_collection_tag = Some(tag.as_str().to_string());
+            }
+            ctx.last_player_filter = Some(chooser);
+            (effects, subject.into_choices())
+        }
         EffectAst::ChooseObjectsAcrossZones {
             filter,
             count,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1125,6 +1125,7 @@ pub(crate) enum SubjectVerbActionAst {
         allow_land: bool,
         without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
+        filter: Option<ObjectFilter>,
     },
     GrantPlayTaggedForAsLongAsYouControlSource {
         tag: TagKey,
@@ -2409,6 +2410,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                filter,
             } => f
                 .debug_struct("GrantPlayTaggedForAsLongAsExiled")
                 .field("tag", tag)
@@ -2416,6 +2418,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("allow_land", allow_land)
                 .field("without_paying_mana_cost", without_paying_mana_cost)
                 .field("allow_any_color_for_cast", allow_any_color_for_cast)
+                .field("filter", filter)
                 .finish(),
             Self::GrantPlayTaggedForAsLongAsYouControlSource {
                 tag,
@@ -3447,6 +3450,13 @@ pub(crate) enum EffectAst {
         player: PlayerAst,
         tag: TagKey,
     },
+    ChooseObjectsBottomOfLibrary {
+        filter: ObjectFilter,
+        count: ChoiceCount,
+        count_value: Option<Value>,
+        player: PlayerAst,
+        tag: TagKey,
+    },
     ChooseObjectsAcrossZones {
         filter: ObjectFilter,
         count: ChoiceCount,
@@ -4085,6 +4095,7 @@ impl EffectAst {
         allow_land: bool,
         without_paying_mana_cost: bool,
         allow_any_color_for_cast: bool,
+        filter: Option<ObjectFilter>,
     ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
@@ -4095,6 +4106,7 @@ impl EffectAst {
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                filter,
             },
         )
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/effect_ast_traversal.rs
@@ -134,6 +134,7 @@ pub(crate) fn assert_effect_ast_variant_coverage(effect: &EffectAst) {
         EffectAst::ManaRestricted { .. } => {}
         EffectAst::SelfReplacement { .. } => {}
         EffectAst::ChooseObjects { .. } => {}
+        EffectAst::ChooseObjectsBottomOfLibrary { .. } => {}
         EffectAst::ChooseObjectsAcrossZones { .. } => {}
         EffectAst::DirectionalAdjacentPlayerControl { .. } => {}
         EffectAst::MayCastMatchingSpellWithoutPayingManaCost { .. } => {}

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -991,6 +991,12 @@ fn advance_reference_frame_for_effect(
             tag,
             player,
             ..
+        }
+        | EffectAst::ChooseObjectsBottomOfLibrary {
+            filter,
+            tag,
+            player,
+            ..
         } => {
             let references_revealed_hand = filter.zone == Some(crate::zone::Zone::Hand)
                 && filter.owner.is_none()

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -687,6 +687,7 @@ fn parse_exile_top_library_then_play_bundle(
                     allow_land,
                     without_paying_mana_cost,
                     allow_any_color_for_cast,
+                    filter,
                     ..
                 },
             ..
@@ -696,6 +697,7 @@ fn parse_exile_top_library_then_play_bundle(
             allow_land,
             without_paying_mana_cost,
             allow_any_color_for_cast,
+            filter,
         ),
         _ => return Ok(None),
     };

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -66,21 +66,24 @@ const EXILE_LIBRARY_OWNER_THAT_PLAYER_PATTERN: ClauseShape<'static> = clause_sha
     prefix_any
         & [
             &["that", "player", "library"],
-            &["that", "players", "library"]
+            &["that", "players", "library"],
+            &["that", "player's", "library"]
         ]
 );
 const EXILE_LIBRARY_OWNER_TARGET_PLAYER_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [
             &["target", "player", "library"],
-            &["target", "players", "library"]
+            &["target", "players", "library"],
+            &["target", "player's", "library"]
         ]
 );
 const EXILE_LIBRARY_OWNER_TARGET_OPPONENT_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [
             &["target", "opponent", "library"],
-            &["target", "opponents", "library"]
+            &["target", "opponents", "library"],
+            &["target", "opponent's", "library"]
         ]
 );
 const EXILE_LIBRARY_OWNER_ITS_CONTROLLER_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -98,7 +101,8 @@ const EXILE_EACH_OPPONENT_LIBRARY_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [
             &["each", "opponent", "library"],
-            &["each", "opponents", "library"]
+            &["each", "opponents", "library"],
+            &["each", "opponent's", "library"]
         ]
 );
 const EXILE_THE_TOP_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["the", "top"]);
@@ -163,6 +167,11 @@ pub(crate) fn parse_exile(
         } else {
             EffectAst::subject_verb_exile_all(filter, face_down)
         });
+    }
+    if !until_source_leaves
+        && let Some(effect) = parse_exile_bottom_library_clause(tokens, subject, face_down)
+    {
+        return Ok(effect);
     }
     if !face_down
         && !until_source_leaves
@@ -587,6 +596,87 @@ pub(crate) fn parse_exile_top_library_clause(
         vec![helper_tag_for_tokens(&tokens, "exiled")],
         Vec::new(),
     ))
+}
+
+fn parse_exile_bottom_library_clause(
+    tokens: &[OwnedLexToken],
+    subject: Option<SubjectAst>,
+    face_down: bool,
+) -> Option<EffectAst> {
+    let tokens = trim_commas(tokens);
+    let words = crate::runtime_backend::token_word_refs(&tokens);
+    let prefix = ["the", "bottom"];
+    let mut start = 0usize;
+    if words.starts_with(&prefix) {
+        start = 1;
+    }
+    if !words.get(start).is_some_and(|word| *word == "bottom") {
+        return None;
+    }
+    let count_start = token_index_for_word_index(&tokens, start + 1)?;
+    let count_start_words = crate::runtime_backend::token_word_refs(&tokens[count_start..=count_start]);
+    let (count, used_after_bottom) = if count_start_words
+        .first()
+        .is_some_and(|word| EXILE_CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+    {
+        (Value::Fixed(1), 0)
+    } else {
+        parse_value(&tokens[count_start..])?
+    };
+    if count != Value::Fixed(1) {
+        return None;
+    }
+    let after_count = trim_commas(&tokens[count_start + used_after_bottom..]);
+    let after_count_words = crate::runtime_backend::token_word_refs(&after_count);
+    if !after_count_words
+        .first()
+        .is_some_and(|word| EXILE_CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+    {
+        return None;
+    }
+    let after_cards_start = token_index_for_word_index(&after_count, 1)?;
+    let after_cards = trim_commas(&after_count[after_cards_start..]);
+    let after_cards_words = crate::runtime_backend::token_word_refs(&after_cards);
+    if !after_cards_words
+        .first()
+        .is_some_and(|word| EXILE_OF_WORD_PATTERN.matches_word(word))
+    {
+        return None;
+    }
+    let owner_tokens = trim_commas(&after_cards[1..]);
+    let owner_words = crate::runtime_backend::token_word_refs(&owner_tokens);
+    let tag = helper_tag_for_tokens(&tokens, "exiled");
+    let mut filter = ObjectFilter::default();
+    filter.zone = Some(Zone::Library);
+
+    let choose_and_exile = |player: PlayerAst, tag: TagKey| {
+        vec![
+            EffectAst::ChooseObjectsBottomOfLibrary {
+                filter: filter.clone(),
+                count: crate::effect::ChoiceCount::exactly(1),
+                count_value: None,
+                player,
+                tag: tag.clone(),
+            },
+            EffectAst::subject_verb_exile(TargetAst::Tagged(tag, None), face_down),
+        ]
+    };
+
+    if EXILE_EACH_OPPONENT_LIBRARY_PATTERN.matches_words(&owner_words) {
+        return Some(EffectAst::ForEachOpponent {
+            effects: choose_and_exile(PlayerAst::That, tag),
+        });
+    }
+
+    let default_player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
+    let (player, used_words) = parse_library_owner_prefix(&owner_words, default_player)?;
+    if used_words < owner_words.len() {
+        return None;
+    }
+
+    Some(EffectAst::Sequence {
+        effects: choose_and_exile(player, tag),
+    })
 }
 
 pub(crate) fn parse_target_player_graveyard_filter(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -572,6 +572,7 @@ pub(crate) fn parse_look_at_top_then_exile_face_down_then_play_while_exiled(
                 allow_land,
                 without_paying_mana_cost,
                 allow_any_color_for_cast,
+                filter,
                 ..
             },
         ..
@@ -590,6 +591,7 @@ pub(crate) fn parse_look_at_top_then_exile_face_down_then_play_while_exiled(
             allow_land,
             without_paying_mana_cost,
             allow_any_color_for_cast,
+            filter,
         ),
     ]))
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/resource_verbs.rs
@@ -503,6 +503,7 @@ pub(crate) fn parse_look(
                 true,
                 false,
                 false,
+                None,
             ),
         );
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5488,6 +5488,59 @@ fn rewrite_lexed_permission_helpers_parse_while_exiled_you_may_spend_mana_suffix
 }
 
 #[test]
+fn rewrite_lexed_permission_helpers_parse_while_exiled_look_then_permanent_spells() {
+    let tokens = lex_line(
+        "For as long as those cards remain exiled, you may look at them, you may cast permanent spells from among them, and you may spend mana as though it were mana of any color to cast those spells",
+        0,
+    )
+    .expect("rewrite lexer should classify plural while-exiled tagged permission");
+    let inner_tokens = lex_line(
+        "For as long as those cards remain exiled, you may cast permanent spells from among them, and you may spend mana as though it were mana of any color to cast those spells",
+        0,
+    )
+    .expect("rewrite lexer should classify inner plural while-exiled permission");
+    let inner = super::permission_helpers::parse_permission_clause_spec(&inner_tokens)
+        .expect("inner plural while-exiled permission spec should parse");
+    assert!(inner.is_some(), "inner permission spec returned None");
+    let inner_debug = format!("{:?}", inner.as_ref().unwrap());
+    let inner_effect = super::permission_helpers::parse_cast_or_play_tagged_clause(&inner_tokens)
+        .expect("inner plural while-exiled permission effect should parse");
+    let inner_no_suffix_tokens = lex_line(
+        "For as long as those cards remain exiled, you may cast permanent spells from among them",
+        0,
+    )
+    .expect("rewrite lexer should classify inner no-suffix permission");
+    let inner_no_suffix_effect = super::permission_helpers::parse_cast_or_play_tagged_clause(
+        &inner_no_suffix_tokens,
+    )
+    .expect("inner no-suffix permission effect should parse");
+    let inner_no_suffix_spec = super::permission_helpers::parse_permission_clause_spec(
+        &inner_no_suffix_tokens,
+    )
+    .expect("inner no-suffix spec should parse");
+    let inner_no_suffix_debug = format!("{:?}", inner_no_suffix_spec.as_ref());
+    assert!(
+        inner_no_suffix_effect.is_some(),
+        "inner no-suffix permission effect returned None for {inner_no_suffix_debug}"
+    );
+    assert!(
+        inner_effect.is_some(),
+        "inner permission effect returned None for {inner_debug}"
+    );
+
+    let parsed = super::permission_helpers::parse_cast_or_play_tagged_clause(&tokens)
+        .expect("plural while-exiled tagged permission should parse")
+        .expect("plural while-exiled tagged permission should produce an effect");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("LookAtObjects"), "{debug}");
+    assert!(debug.contains("GrantPlayTaggedForAsLongAsExiled"), "{debug}");
+    assert!(debug.contains("allow_any_color_for_cast: true"), "{debug}");
+    assert!(debug.contains("Artifact"), "{debug}");
+    assert!(debug.contains("Planeswalker"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_parse_while_exiled_owner_prefix() {
     let tokens = lex_line(
         "For as long as that card remains exiled, its owner may cast it without paying its mana cost",
@@ -5574,6 +5627,26 @@ fn rewrite_lexed_trigger_keeps_look_exile_and_while_exiled_play_permission() {
         "{debug}"
     );
     assert!(debug.contains("allow_any_color_for_cast: true"), "{debug}");
+}
+
+#[test]
+fn rewrite_lowering_exile_bottom_card_of_each_opponent_library_face_down() -> Result<(), CardTextError>
+{
+    let def = CardDefinitionBuilder::new(CardId::new(), "Bottom Library Exile")
+        .mana_cost(super::util::parse_scryfall_mana_cost("{3}{B}").unwrap())
+        .card_types(vec![CardType::Sorcery])
+        .parse_text("Exile the bottom card of each opponent's library face down.")?;
+
+    let debug = format!("{def:#?}");
+    assert!(debug.contains("ForPlayersEffect"), "{debug}");
+    assert!(debug.contains("filter: Opponent"), "{debug}");
+    assert!(debug.contains("zone: Some(\n                                                    Library"), "{debug}");
+    assert!(debug.contains("chooser: IteratedPlayer"), "{debug}");
+    assert!(debug.contains("top_only: false"), "{debug}");
+    assert!(debug.contains("bottom_only: true"), "{debug}");
+    assert!(debug.contains("face_down: true"), "{debug}");
+
+    Ok(())
 }
 
 #[test]

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1701,6 +1701,7 @@ pub struct ChooseObjectsEffect {
     pub reveal: bool,
     pub search_mode: SearchSelectionMode,
     pub top_only: bool,
+    pub bottom_only: bool,
     pub replace_tagged_objects: bool,
 }
 
@@ -1724,6 +1725,7 @@ impl ChooseObjectsEffect {
             reveal: false,
             search_mode: SearchSelectionMode::Exact,
             top_only: false,
+            bottom_only: false,
             replace_tagged_objects: false,
         }
     }
@@ -1786,6 +1788,13 @@ impl ChooseObjectsEffect {
 
     pub fn top_only(mut self) -> Self {
         self.top_only = true;
+        self.bottom_only = false;
+        self
+    }
+
+    pub fn bottom_only(mut self) -> Self {
+        self.bottom_only = true;
+        self.top_only = false;
         self
     }
 
@@ -3817,6 +3826,7 @@ pub struct GrantPlayTaggedEffect {
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
     pub while_on_top_of_library: bool,
+    pub filter: Option<ObjectFilter>,
 }
 
 impl GrantPlayTaggedEffect {
@@ -3834,11 +3844,17 @@ impl GrantPlayTaggedEffect {
             allow_land,
             allow_any_color_for_cast,
             while_on_top_of_library: false,
+            filter: None,
         }
     }
 
     pub fn while_on_top_of_library(mut self) -> Self {
         self.while_on_top_of_library = true;
+        self
+    }
+
+    pub fn with_filter(mut self, filter: ObjectFilter) -> Self {
+        self.filter = Some(filter);
         self
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -287,6 +287,185 @@ fn hydra_omnivore_runtime_has_no_extra_damage_without_other_opponents() {
     );
 }
 
+fn arvinox_the_mind_flail_definition() -> CardDefinition {
+    let oracle = oracle_text_by_name()
+        .get("Arvinox, the Mind Flail")
+        .expect("Arvinox oracle text should be present");
+    CardDefinitionBuilder::new(CardId::new(), "Arvinox, the Mind Flail")
+        .card_types(vec![CardType::Enchantment, CardType::Creature])
+        .subtypes(vec![Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(9, 9))
+        .parse_text(oracle)
+        .expect("Arvinox should parse strictly")
+}
+
+#[test]
+fn arvinox_the_mind_flail_strict_parser_and_compiled_text_regression() {
+    let def = arvinox_the_mind_flail_definition();
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("isn't a creature unless you control three or more permanents you don't own"),
+        "expected unless static condition, got {rendered}"
+    );
+    assert!(
+        rendered.contains("exile the bottom card of each opponent's library face down"),
+        "expected bottom-card face-down exile, got {rendered}"
+    );
+    assert!(
+        rendered.contains("For as long as those cards remain exiled, you may look at them"),
+        "expected look permission for those exiled cards, got {rendered}"
+    );
+    assert!(
+        rendered.contains("you may cast permanent spells from among them"),
+        "expected permanent-spell cast permission, got {rendered}"
+    );
+    assert!(
+        rendered.contains("you may spend mana as though it were mana of any color to cast those spells"),
+        "expected any-color mana permission, got {rendered}"
+    );
+
+    let debug = format!("{def:#?}");
+    assert!(debug.contains("bottom_only: true"), "{debug}");
+    assert!(debug.contains("GrantPlayTaggedEffect"), "{debug}");
+    assert!(debug.contains("filter: Some"), "{debug}");
+}
+
+#[test]
+fn arvinox_the_mind_flail_creature_condition_counts_permanents_you_control_but_dont_own() {
+    let def = arvinox_the_mind_flail_definition();
+    let permanent = CardDefinitionBuilder::new(CardId::new(), "Borrowed Permanent")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let arvinox = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    assert!(
+        !game.current_is_creature(arvinox),
+        "Arvinox should not be a creature before Alice controls three permanents she doesn't own"
+    );
+
+    for idx in 0..2 {
+        let borrowed = game.create_object_from_definition(&permanent, bob, Zone::Battlefield);
+        game.set_current_controller(borrowed, alice);
+        assert!(
+            !game.current_is_creature(arvinox),
+            "Arvinox should still not be a creature with only {} borrowed permanents",
+            idx + 1
+        );
+    }
+
+    let third = game.create_object_from_definition(&permanent, bob, Zone::Battlefield);
+    game.set_current_controller(third, alice);
+
+    assert!(
+        game.current_is_creature(arvinox),
+        "Arvinox should become a creature once Alice controls three permanents she doesn't own"
+    );
+}
+
+#[test]
+fn arvinox_the_mind_flail_exiles_bottom_cards_and_grants_only_permanent_spell_permission() {
+    let def = arvinox_the_mind_flail_definition();
+    let permanent = CardDefinitionBuilder::new(CardId::new(), "Bottom Permanent")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let instant = CardDefinitionBuilder::new(CardId::new(), "Bottom Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let filler = CardDefinitionBuilder::new(CardId::new(), "Top Filler")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let arvinox = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let bob_bottom = game.create_object_from_definition(&permanent, bob, Zone::Library);
+    let bob_top = game.create_object_from_definition(&filler, bob, Zone::Library);
+    let charlie_bottom = game.create_object_from_definition(&instant, charlie, Zone::Library);
+    let charlie_top = game.create_object_from_definition(&filler, charlie, Zone::Library);
+    let bob_bottom_stable = game.object(bob_bottom).expect("bob bottom setup").stable_id;
+    let charlie_bottom_stable = game
+        .object(charlie_bottom)
+        .expect("charlie bottom setup")
+        .stable_id;
+    assert!(game.set_player_library_order_with_audit(
+        bob,
+        vec![bob_bottom, bob_top],
+        "Arvinox bottom-card regression setup",
+    ));
+    assert!(game.set_player_library_order_with_audit(
+        charlie,
+        vec![charlie_bottom, charlie_top],
+        "Arvinox bottom-card regression setup",
+    ));
+
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Arvinox should have an end-step triggered ability");
+    let mut ctx = crate::effects::ExecutionContext::new_default(arvinox, alice);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        arvinox,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Arvinox end-step trigger should resolve");
+
+    let bob_exiled = game
+        .find_object_by_stable_id(bob_bottom_stable)
+        .expect("bob bottom should still exist after exile");
+    let charlie_exiled = game
+        .find_object_by_stable_id(charlie_bottom_stable)
+        .expect("charlie bottom should still exist after exile");
+    assert_eq!(game.object(bob_exiled).expect("bob bottom").zone, Zone::Exile);
+    assert_eq!(game.object(bob_top).expect("bob top").zone, Zone::Library);
+    assert_eq!(
+        game.object(charlie_exiled).expect("charlie bottom").zone,
+        Zone::Exile
+    );
+    assert_eq!(
+        game.object(charlie_top).expect("charlie top").zone,
+        Zone::Library
+    );
+    assert!(game.is_face_down(bob_exiled));
+    assert!(game.is_face_down(charlie_exiled));
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            bob_exiled,
+            Zone::Exile,
+            alice,
+        ),
+        "Arvinox should grant Alice permission to cast exiled permanent spells"
+    );
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            charlie_exiled,
+            Zone::Exile,
+            alice,
+        ),
+        "Arvinox should not grant Alice permission to cast exiled nonpermanent spells"
+    );
+}
+
 #[test]
 fn clockspinning_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Clockspinning");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5436,6 +5436,16 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_reveal_top_to_hand_then_lose_mana_value_effects(effects) {
         return compact;
     }
+    if let [for_players_effect, look_effect, grant_effect] = effects
+        && let Some(for_players) =
+            for_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()
+        && let Some(look) = look_effect.downcast_ref::<crate::effects::LookAtObjectsEffect>()
+        && let Some(grant) = grant_effect.downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+        && let Some(compact) =
+            describe_for_players_bottom_library_exile_then_look_cast(for_players, look, grant)
+    {
+        return compact;
+    }
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {
         return compact;
     }
@@ -15111,6 +15121,20 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             continue;
         }
         if idx + 2 < filtered.len()
+            && let Some(for_players) =
+                filtered[idx].downcast_ref::<crate::effects::ForPlayersEffect>()
+            && let Some(look) = filtered[idx + 1]
+                .downcast_ref::<crate::effects::LookAtObjectsEffect>()
+            && let Some(grant) =
+                filtered[idx + 2].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(compact) =
+                describe_for_players_bottom_library_exile_then_look_cast(for_players, look, grant)
+        {
+            parts.push(compact);
+            idx += 3;
+            continue;
+        }
+        if idx + 2 < filtered.len()
             && let Some(look_at_top) =
                 filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
             && let Some(conditional) =
@@ -16304,6 +16328,13 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
 
     let compact = describe_effect_list(effects);
     let compact_trimmed = compact.trim();
+    if compact_trimmed.starts_with("Exile the bottom card of ")
+        && compact_trimmed.contains("For as long as those cards remain exiled")
+    {
+        return Some(cleanup_decompiled_text(&lowercase_first(
+            compact_trimmed.trim_end_matches('.'),
+        )));
+    }
     if compact_trimmed
         == "Reveal the top card of your library and put that card into your hand. You lose life equal to that card's mana value"
     {
@@ -22386,6 +22417,32 @@ fn describe_for_players_choose_then_exile(
         return None;
     }
     let choose = for_players.effects[0].downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if let Some(exile) = for_players.effects[1].downcast_ref::<crate::effects::ExileEffect>() {
+        if choose_primary_zone(choose) == Some(Zone::Library)
+            && choose.bottom_only
+            && !choose.top_only
+            && !choose.is_search
+            && choose.count.is_single()
+            && choose.chooser == PlayerFilter::IteratedPlayer
+            && choose.filter.zone == Some(Zone::Library)
+            && choose.filter.controller.is_none()
+            && choose.filter.owner.is_none()
+            && choose.filter.card_types.is_empty()
+            && choose.filter.tagged_constraints.is_empty()
+            && exile_uses_chosen_tag(&exile.spec, choose.tag.as_str())
+        {
+            let subject = match for_players.filter {
+                PlayerFilter::Any => "each player's",
+                PlayerFilter::Opponent => "each opponent's",
+                PlayerFilter::You => "your",
+                _ => return None,
+            };
+            let face_down = if exile.face_down { " face down" } else { "" };
+            return Some(format!(
+                "Exile the bottom card of {subject} library{face_down}"
+            ));
+        }
+    }
     let move_to_zone = for_players.effects[1].downcast_ref::<crate::effects::MoveToZoneEffect>()?;
     if choose_primary_zone(choose) != Some(Zone::Battlefield)
         || choose.is_search
@@ -22410,6 +22467,54 @@ fn describe_for_players_choose_then_exile(
         .replace("that player controls", "they control");
     Some(format!(
         "{subject} {choose_verb} {selection} and {exile_verb} it"
+    ))
+}
+
+fn describe_for_players_bottom_library_exile_then_look_cast(
+    for_players: &crate::effects::ForPlayersEffect,
+    look: &crate::effects::LookAtObjectsEffect,
+    grant: &crate::effects::GrantPlayTaggedEffect,
+) -> Option<String> {
+    let exile_clause = describe_for_players_choose_then_exile(for_players)?;
+    if !exile_clause.contains("the bottom card")
+        || look.viewer != PlayerFilter::You
+        || look.subject != PlayerFilter::You
+        || grant.player != PlayerFilter::You
+        || grant.duration != crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+        || grant.allow_land
+        || !grant.allow_any_color_for_cast
+    {
+        return None;
+    }
+    let look_tag = look.filter.tagged_constraints.iter().find_map(|constraint| {
+        (constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject)
+            .then_some(&constraint.tag)
+    })?;
+    if look.filter.zone != Some(Zone::Exile)
+        || look
+            .filter
+            .controller
+            .as_ref()
+            .is_some_and(|controller| *controller != PlayerFilter::You)
+        || look_tag != &grant.tag
+    {
+        return None;
+    }
+    let grant_filter = grant.filter.as_ref()?;
+    let is_permanent_spell_filter = grant_filter.card_types
+        == vec![
+            CardType::Artifact,
+            CardType::Creature,
+            CardType::Enchantment,
+            CardType::Planeswalker,
+            CardType::Battle,
+        ];
+    if !is_permanent_spell_filter {
+        return None;
+    }
+
+    Some(format!(
+        "{exile_clause}. For as long as those cards remain exiled, you may look at them, you may cast permanent spells from among them, and you may spend mana as though it were mana of any color to cast those spells"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1128,16 +1128,18 @@ where
         )));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::GrantPlayTaggedEffect>(&effect) {
-        return Ok(Effect::new(
-            crate::effects::GrantPlayTaggedEffect::new(
-                payload.tag.clone(),
-                payload.player.clone(),
-                payload.duration,
-                payload.allow_land,
-                payload.allow_any_color_for_cast,
-            )
-            .while_on_top_of_library_if(payload.while_on_top_of_library),
-        ));
+        let mut grant = crate::effects::GrantPlayTaggedEffect::new(
+            payload.tag.clone(),
+            payload.player.clone(),
+            payload.duration,
+            payload.allow_land,
+            payload.allow_any_color_for_cast,
+        )
+        .while_on_top_of_library_if(payload.while_on_top_of_library);
+        if let Some(filter) = payload.filter.clone() {
+            grant = grant.with_filter(filter);
+        }
+        return Ok(Effect::new(grant));
     }
     if let Some(payload) = M::downcast_ref::<ironsmith_core::LocalRewriteEffect<M::Effect>>(&effect)
     {

--- a/crates/ironsmith-runtime/src/effects/composition/choose_objects.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_objects.rs
@@ -53,7 +53,7 @@ pub(crate) fn top_only_selection_limit(
     effect: &ChooseObjectsEffect,
     x_value: Option<u32>,
 ) -> usize {
-    if !effect.top_only {
+    if !effect.top_only && !effect.bottom_only {
         return usize::MAX;
     }
     if effect.count.dynamic_x {

--- a/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
@@ -604,7 +604,7 @@ fn hidden_library_search_candidates(
         Box::new(player.library.iter().copied())
     };
     let mut candidates = Vec::new();
-    let limit = if effect.top_only {
+    let limit = if effect.top_only || effect.bottom_only {
         top_only_selection_limit(effect, ctx.x_value)
     } else {
         usize::MAX

--- a/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_play_tagged.rs
@@ -4,11 +4,12 @@ use crate::effect::EffectOutcome;
 use crate::effects::EffectExecutor;
 use crate::effects::helpers::resolve_player_filter;
 use crate::effects::{ExecutionContext, ExecutionError};
+use crate::filter::ObjectFilterExt as _;
 use crate::game_state::GameState;
 use crate::grant::Grantable;
 use crate::grant_registry::GrantSource;
 use crate::tag::TagKey;
-use crate::target::PlayerFilter;
+use crate::target::{ObjectFilter, PlayerFilter};
 pub use ironsmith_core::GrantPlayTaggedDuration;
 
 /// Grant temporary permission to cast or play cards tagged in the current context.
@@ -20,6 +21,7 @@ pub struct GrantPlayTaggedEffect {
     pub allow_land: bool,
     pub allow_any_color_for_cast: bool,
     pub while_on_top_of_library: bool,
+    pub filter: Option<ObjectFilter>,
 }
 
 impl GrantPlayTaggedEffect {
@@ -37,6 +39,7 @@ impl GrantPlayTaggedEffect {
             allow_land,
             allow_any_color_for_cast,
             while_on_top_of_library: false,
+            filter: None,
         }
     }
 
@@ -47,6 +50,11 @@ impl GrantPlayTaggedEffect {
 
     pub fn while_on_top_of_library_if(mut self, enabled: bool) -> Self {
         self.while_on_top_of_library = enabled;
+        self
+    }
+
+    pub fn with_filter(mut self, filter: ObjectFilter) -> Self {
+        self.filter = Some(filter);
         self
     }
 
@@ -183,6 +191,14 @@ impl EffectExecutor for GrantPlayTaggedEffect {
             let Some(object) = game.object(object_id) else {
                 continue;
             };
+            let filter_ctx = ctx.filter_context(game);
+            if self
+                .filter
+                .as_ref()
+                .is_some_and(|filter| !filter.matches(object, &filter_ctx, game))
+            {
+                continue;
+            }
             if (!self.allow_land && object.is_land()) || !seen.insert(object_id) {
                 continue;
             }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1068,6 +1068,13 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
                     _ => "as long as that player hasn't cast a spell this turn".to_string(),
                 };
             }
+            if let crate::ConditionExpr::CountComparison { display, .. } = inner.as_ref() {
+                let condition_text = display
+                    .clone()
+                    .unwrap_or_else(|| describe_static_condition(inner).replacen("as long as ", "", 1))
+                    .replace(" dont ", " don't ");
+                return format!("unless {condition_text}");
+            }
             format!("as long as not ({})", describe_static_condition(inner))
         }
         crate::ConditionExpr::PlayerCastSpellsThisTurnOrMore { player, count } => {
@@ -1162,7 +1169,7 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             display,
         } => {
             if let Some(display) = display {
-                return format!("as long as {display}");
+                return format!("as long as {}", display.replace(" dont ", " don't "));
             }
             format!(
                 "as long as there are {} {}",


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Arvinox, the Mind Flail
Initial parse error:
```
parser does not yet support line family: 'Arvinox isn't a creature unless you control three or more permanents you don't own.'; oracle-only fallback also failed: parser does not yet support line family: 'Arvinox isn't a creature unless you control three or more permanents you don't own.'
```

Current worker: i-06dc6e92479a9ef57
Branch: codex/aws-card-fix-arvinox-the-mind-flail
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
