### PR TITLE
Fix Ironsmith parse failure: Night Shift of the Living Dead

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -4,6 +4,15 @@ use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseSha
 
 const REVEAL_THIS_CARD_FROM_HAND_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["reveal", "this", "card", "from", "your", "hand"]);
+const DIE_ROLL_RESULT_ADJUSTMENT_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix & ["after", "you", "roll", "a", "die"];
+    contains_phrases & [
+        &["you", "may", "pay"],
+        &["if", "you", "do"],
+        &["increase", "or", "decrease", "the", "result", "by"],
+        &["do", "this", "only", "once", "each", "turn"],
+    ]
+);
 
 fn join_statement_parse_sentence_group(sentences: &[Vec<OwnedLexToken>]) -> Vec<OwnedLexToken> {
     let mut joined = Vec::new();
@@ -28,6 +37,14 @@ pub(super) fn parse_statement_line_cst(
     let normalized = line.info.normalized.normalized.as_str();
     if looks_like_day_night_starts_day_as_enters_static_line(&line.tokens) {
         return Ok(None);
+    }
+    if DIE_ROLL_RESULT_ADJUSTMENT_PATTERN.matches_words(&token_word_refs(&line.tokens)) {
+        return Ok(Some(StatementLineCst {
+            info: line.info.clone(),
+            text: normalized.to_string(),
+            parse_tokens: line.tokens.clone(),
+            parse_groups: vec![line.tokens.clone()],
+        }));
     }
     let line_family = structure::classify_statement_line_family_lexed(&line.tokens);
     let force_statement = matches!(line_family, Some(structure::StatementLineFamily::Divvy))

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -495,6 +495,13 @@ pub(crate) fn classify_statement_line_family_lexed(
         return Some(StatementLineFamily::Generic);
     }
 
+    if primitives::parse_prefix(tokens, primitives::phrase(&["after", "you", "roll", "a", "die"])).is_some()
+        && primitives::contains_phrase(tokens, &["you", "may", "pay"])
+        && primitives::contains_phrase(tokens, &["increase", "or", "decrease", "the", "result"])
+    {
+        return Some(StatementLineFamily::Generic);
+    }
+
     let sentence_words_match = |sentence_tokens: &[OwnedLexToken], expected: &[&str]| {
         let words = TokenWordView::new(sentence_tokens);
         words.len() == expected.len() && words.slice_eq(0, expected)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -204,6 +204,15 @@ const TARGETED_TEMPORARY_MODIFIER_PATTERN: ClauseShape<'static> = clause_shape!(
     contains_any_words & [&["get", "gets", "gain", "gains"]]
 );
 const IF_INSTEAD_PATTERN: ClauseShape<'static> = clause_shape!(contains_words & ["if", "instead"]);
+const DIE_ROLL_RESULT_ADJUSTMENT_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix & ["after", "you", "roll", "a", "die"];
+    contains_phrases & [
+        &["you", "may", "pay"],
+        &["if", "you", "do"],
+        &["increase", "or", "decrease", "the", "result", "by"],
+        &["do", "this", "only", "once", "each", "turn"],
+    ]
+);
 const CANT_CAST_PHRASES: &[&[&str]] = &[&["cant", "cast"], &["can't", "cast"]];
 const CANT_CAST_NEXT_TURN_PATTERN: ClauseShape<'static> = ClauseShape::new()
     .contains_any_phrases(&[CANT_CAST_PHRASES])
@@ -460,6 +469,9 @@ fn lower_rewrite_statement_to_chunks_impl(
     parse_tokens: &[OwnedLexToken],
     parse_groups: &[Vec<OwnedLexToken>],
 ) -> Result<Vec<LineAst>, CardTextError> {
+    if let Some(chunk) = parse_die_roll_result_adjustment_static_chunk(parse_tokens) {
+        return Ok(vec![chunk]);
+    }
     if !parse_groups.is_empty() {
         if parse_groups.len() > 1
             && sentences_have_token_creation_followup_after_first(parse_groups)
@@ -478,6 +490,8 @@ fn lower_rewrite_statement_to_chunks_impl(
         let mut chunks = Vec::with_capacity(parse_groups.len());
         for group_tokens in parse_groups {
             if let Some(chunk) = parse_day_night_starts_day_static_chunk(group_tokens) {
+                chunks.push(chunk);
+            } else if let Some(chunk) = parse_die_roll_result_adjustment_static_chunk(group_tokens) {
                 chunks.push(chunk);
             } else if let Some(chunk) = parse_self_enters_with_x_counters_static_chunk(group_tokens)
             {
@@ -518,6 +532,8 @@ fn lower_rewrite_statement_to_chunks_impl(
             for sentence in sentence_tokens {
                 if let Some(chunk) = parse_self_enters_with_x_counters_static_chunk(&sentence) {
                     chunks.push(chunk);
+                } else if let Some(chunk) = parse_die_roll_result_adjustment_static_chunk(&sentence) {
+                    chunks.push(chunk);
                 } else if let Some(chunk) = parse_day_night_starts_day_static_chunk(&sentence) {
                     chunks.push(chunk);
                 } else if let Some(abilities) = parse_static_ability_ast_line_lexed(&sentence)? {
@@ -535,6 +551,8 @@ fn lower_rewrite_statement_to_chunks_impl(
             let mut chunks = Vec::with_capacity(grouped_tokens.len());
             for group_tokens in grouped_tokens {
                 if let Some(chunk) = parse_day_night_starts_day_static_chunk(&group_tokens) {
+                    chunks.push(chunk);
+                } else if let Some(chunk) = parse_die_roll_result_adjustment_static_chunk(&group_tokens) {
                     chunks.push(chunk);
                 } else if let Some(chunk) =
                     parse_self_enters_with_x_counters_static_chunk(&group_tokens)
@@ -560,6 +578,43 @@ fn lower_rewrite_statement_to_chunks_impl(
         "rewrite statement lowering expected prepared parse tokens for '{}'",
         line.info.raw_line
     )))
+}
+
+fn parse_die_roll_result_adjustment_static_chunk(tokens: &[OwnedLexToken]) -> Option<LineAst> {
+    let words = token_word_refs(tokens);
+    if !DIE_ROLL_RESULT_ADJUSTMENT_PATTERN.matches_words(&words) {
+        return None;
+    }
+    let life_cost = words
+        .windows(3)
+        .find_map(|window| {
+            (window[0] == "pay" && window[2] == "life")
+                .then(|| window[1].parse::<u32>().ok())
+                .flatten()
+        })
+        .unwrap_or(1);
+    let amount = words
+        .windows(2)
+        .find_map(|window| {
+            (window[0] == "by")
+                .then(|| window[1].parse::<u32>().ok())
+                .flatten()
+        })
+        .unwrap_or(1);
+    let display = format!(
+        "After you roll a die, you may pay {life_cost} life. If you do, increase or decrease the result by {amount}. Do this only once each turn."
+    );
+    Some(LineAst::StaticAbilities(vec![
+        crate::cards::builders::StaticAbilityAst::Static(
+            StaticAbility::die_roll_result_adjustment(
+                PlayerFilter::You,
+                life_cost,
+                amount,
+                true,
+                display,
+            ),
+        ),
+    ]))
 }
 
 fn sentences_have_token_copy_followup_after_first<S: AsRef<[OwnedLexToken]>>(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -13766,6 +13766,40 @@ fn hordewing_skaab_parses_and_keeps_if_you_do_discard_followup() -> Result<(), C
 }
 
 #[test]
+fn night_shift_parses_die_adjustment_and_zombie_employee_token() -> Result<(), CardTextError> {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Night Shift of the Living Dead")
+        .card_types(vec![CardType::Enchantment]);
+    let text = "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.\nWhenever you roll a 6, create a 2/2 black Zombie Employee creature token.";
+    let (definition, _) = parse_text_with_annotations_lowered(builder, text.to_string(), false)?;
+
+    let debug = format!("{definition:#?}");
+    assert!(
+        debug.contains("DieRollResultAdjustment"),
+        "expected lowered die-roll result adjustment static ability: {debug}"
+    );
+    assert!(
+        debug.contains("PlayerRollsResult") && debug.contains("CreateTokenEffect"),
+        "expected die-roll trigger to create a token: {debug}"
+    );
+    assert!(
+        debug.contains("Zombie") && debug.contains("Employee"),
+        "expected created token to keep both creature subtypes: {debug}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn token_definition_keeps_multiple_creature_subtypes() {
+    let token = super::compile_support::token_definition_for(
+        "2/2 black Zombie Employee creature token",
+    )
+    .expect("Zombie Employee token should be recognized");
+
+    assert_eq!(token.card.subtypes, vec![Subtype::Zombie, Subtype::Employee]);
+}
+
+#[test]
 fn rewrite_lowering_conditional_antecedent_prelude_carries_target_spec() -> Result<(), CardTextError>
 {
     let def = CardDefinitionBuilder::new(CardId::new(), "Conditional Fight Variant")

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -154,6 +154,7 @@ pub enum StaticAbilityId {
     PlayersSkipUpkeep,
     DamageNotRemovedDuringCleanup,
     BlackManaMayBePaidWithLife,
+    DieRollResultAdjustment,
     MinimumSpellTotalMana,
     CantPayLifeOrSacrificeNonlandForCastOrActivate,
     ChooseColorAsEnters,
@@ -420,6 +421,7 @@ impl StaticAbilityId {
             | PlayersSkipUpkeep
             | DamageNotRemovedDuringCleanup
             | BlackManaMayBePaidWithLife
+            | DieRollResultAdjustment
             | MinimumSpellTotalMana
             | CantPayLifeOrSacrificeNonlandForCastOrActivate
             | ChooseColorAsEnters

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -212,6 +212,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         maximum: Value,
         display: String,
     },
+    DieRollResultAdjustment(DieRollResultAdjustment),
     LevelAbility(Box<LevelAbilityModel<T, E, C, Cond>>),
     HexproofFrom(ObjectFilter),
     Protection(ProtectionFrom),
@@ -565,6 +566,15 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     },
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DieRollResultAdjustment {
+    pub player: PlayerFilter,
+    pub life_cost: u32,
+    pub amount: u32,
+    pub once_each_turn: bool,
+    pub display: String,
+}
+
 impl<T, E, C, Cond> StaticAbility<T, E, C, Cond>
 where
     C: Clone,
@@ -906,6 +916,9 @@ where
             }
             StaticAbilityPayload::ThisSpellXMaximum { maximum, display } => {
                 StaticAbilityPayload::ThisSpellXMaximum { maximum, display }
+            }
+            StaticAbilityPayload::DieRollResultAdjustment(spec) => {
+                StaticAbilityPayload::DieRollResultAdjustment(spec)
             }
             StaticAbilityPayload::LevelAbility(level) => {
                 let level = *level;
@@ -1769,6 +1782,27 @@ impl<
             id: Some(StaticAbilityId::ThisSpellXMaximum),
             label: display.clone(),
             payload: StaticAbilityPayload::ThisSpellXMaximum { maximum, display },
+        }
+    }
+
+    pub fn die_roll_result_adjustment(
+        player: PlayerFilter,
+        life_cost: u32,
+        amount: u32,
+        once_each_turn: bool,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::DieRollResultAdjustment),
+            label: display.clone(),
+            payload: StaticAbilityPayload::DieRollResultAdjustment(DieRollResultAdjustment {
+                player,
+                life_cost,
+                amount,
+                once_each_turn,
+                display,
+            }),
         }
     }
 

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -213,6 +213,7 @@ pub enum Subtype {
     Elephant,
     Elk,
     Elf,
+    Employee,
     Eye,
     Faerie,
     Fish,
@@ -510,6 +511,7 @@ impl Subtype {
             Subtype::Elephant,
             Subtype::Elk,
             Subtype::Elf,
+            Subtype::Employee,
             Subtype::Eye,
             Subtype::Faerie,
             Subtype::Fish,
@@ -847,6 +849,7 @@ impl Subtype {
                 | Subtype::Elephant
                 | Subtype::Elk
                 | Subtype::Elf
+                | Subtype::Employee
                 | Subtype::Eye
                 | Subtype::Faerie
                 | Subtype::Fish

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -1257,6 +1257,37 @@ mod tests {
     }
 
     #[test]
+    fn create_token_text_preserves_multiple_creature_subtypes() {
+        let token = crate::CardDefinitionBuilder::new(crate::ids::CardId::new(), "Zombie")
+            .token()
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Zombie, Subtype::Employee])
+            .color_indicator(crate::color::ColorSet::BLACK)
+            .power_toughness(crate::card::PowerToughness::fixed(2, 2))
+            .build();
+
+        assert_eq!(
+            compile_effect_list(&[Effect::create_tokens(token, Value::Fixed(1))]),
+            "Create a 2/2 black Zombie Employee creature token"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn night_shift_compiled_text_preserves_die_adjustment_and_zombie_employee_token() {
+        let text = "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.\nWhenever you roll a 6, create a 2/2 black Zombie Employee creature token.";
+        let definition = crate::CardDefinitionBuilder::new(
+            crate::ids::CardId::new(),
+            "Night Shift of the Living Dead",
+        )
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(text)
+            .expect("Night Shift should compile");
+
+        assert_eq!(compiled_text_lines(&definition).join("\n"), text);
+    }
+
+    #[test]
     fn conditional_enters_with_counter_uses_adamant_prefix_surface() {
         assert_eq!(
             finalize_ast_surface_line(

--- a/crates/ironsmith-runtime/src/effects/player/roll_die.rs
+++ b/crates/ironsmith-runtime/src/effects/player/roll_die.rs
@@ -1,9 +1,20 @@
 use crate::effect::{EffectOutcome, ExecutionFact};
+use crate::decision::FallbackStrategy;
+use crate::decisions::{ask_choose_one, ask_may_choice};
 use crate::effects::{EffectExecutor, helpers::resolve_player_filter};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::other::DieRolledEvent;
+use crate::filter::PlayerFilterExt as _;
 use crate::game_state::GameState;
+use crate::static_abilities::DieRollResultAdjustmentSpec;
 use crate::target::PlayerFilter;
+
+#[derive(Debug, Clone)]
+struct AvailableDieRollAdjustment {
+    source: crate::ids::ObjectId,
+    controller: crate::ids::PlayerId,
+    spec: DieRollResultAdjustmentSpec,
+}
 
 /// Roll a die for a player using the game's deterministic RNG.
 #[derive(Debug, Clone, PartialEq)]
@@ -42,37 +53,178 @@ impl EffectExecutor for RollDieEffect {
             return Ok(EffectOutcome::count(0));
         }
         if let Some(forced) = game.take_forced_die_roll() {
-            let clamped = forced.clamp(1, self.sides);
-            game.turn_store
-                .turn_history
-                .record_die_roll(player, clamped);
-            return Ok(EffectOutcome::count(clamped as i32)
+            let result = forced.clamp(1, self.sides);
+            let adjusted = apply_die_roll_result_adjustments(game, ctx, player, result);
+            game.turn_store.turn_history.record_die_roll(player, adjusted);
+            return Ok(EffectOutcome::count(adjusted as i32)
                 .with_event(crate::triggers::TriggerEvent::new_with_provenance(
-                    DieRolledEvent::new(player, ctx.source, clamped, self.sides),
+                    DieRolledEvent::new(player, ctx.source, adjusted, self.sides),
                     ctx.provenance,
                 ))
-                .with_execution_fact(ExecutionFact::ChosenNumber(clamped)));
+                .with_execution_fact(ExecutionFact::ChosenNumber(adjusted)));
         }
 
         let mut faces: Vec<u32> = (1..=self.sides).collect();
         game.shuffle_slice(&mut faces);
         let result = faces[0];
-        game.turn_store.turn_history.record_die_roll(player, result);
-        Ok(EffectOutcome::count(result as i32)
+        let adjusted = apply_die_roll_result_adjustments(game, ctx, player, result);
+        game.turn_store.turn_history.record_die_roll(player, adjusted);
+        Ok(EffectOutcome::count(adjusted as i32)
             .with_event(crate::triggers::TriggerEvent::new_with_provenance(
-                DieRolledEvent::new(player, ctx.source, result, self.sides),
+                DieRolledEvent::new(player, ctx.source, adjusted, self.sides),
                 ctx.provenance,
             ))
-            .with_execution_fact(ExecutionFact::ChosenNumber(result)))
+            .with_execution_fact(ExecutionFact::ChosenNumber(adjusted)))
     }
+}
+
+fn available_die_roll_adjustments(
+    game: &GameState,
+    player: crate::ids::PlayerId,
+) -> Vec<AvailableDieRollAdjustment> {
+    game.battlefield
+        .iter()
+        .filter_map(|source| {
+            let object = game.object(*source)?;
+            let controller = game.controller_of(object);
+            let filter_context = game.filter_context_for(controller, Some(*source));
+            object.abilities.iter().find_map(|ability| {
+                let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
+                    return None;
+                };
+                let spec = static_ability.die_roll_result_adjustment_spec()?;
+                if spec.once_each_turn
+                    && game
+                        .turn_store
+                        .turn_history
+                        .die_roll_result_adjusted_this_turn(*source)
+                {
+                    return None;
+                }
+                if !spec.player.matches_player(player, &filter_context) {
+                    return None;
+                }
+                if !game.can_pay_life(controller, spec.life_cost) {
+                    return None;
+                }
+                Some(AvailableDieRollAdjustment {
+                    source: *source,
+                    controller,
+                    spec,
+                })
+            })
+        })
+        .collect()
+}
+
+fn apply_die_roll_result_adjustments(
+    game: &mut GameState,
+    ctx: &mut ExecutionContext,
+    player: crate::ids::PlayerId,
+    result: u32,
+) -> u32 {
+    let mut adjusted = result;
+    for adjustment in available_die_roll_adjustments(game, player) {
+        let description = format!(
+            "pay {} life to increase or decrease the die result by {}",
+            adjustment.spec.life_cost, adjustment.spec.amount
+        );
+        if !ask_may_choice(
+            game,
+            &mut ctx.decision_maker,
+            adjustment.controller,
+            adjustment.source,
+            description,
+            FallbackStrategy::Decline,
+        ) {
+            continue;
+        }
+        if !game.pay_life(adjustment.controller, adjustment.spec.life_cost) {
+            continue;
+        }
+        let options = [
+            ("Increase".to_string(), adjustment.spec.amount as i32),
+            ("Decrease".to_string(), -(adjustment.spec.amount as i32)),
+        ];
+        let delta = ask_choose_one(
+            game,
+            &mut ctx.decision_maker,
+            adjustment.controller,
+            adjustment.source,
+            &options,
+        )
+        .unwrap_or(adjustment.spec.amount as i32);
+        adjusted = if delta.is_negative() {
+            adjusted.saturating_sub(delta.unsigned_abs())
+        } else {
+            adjusted.saturating_add(delta as u32)
+        };
+        if adjustment.spec.once_each_turn {
+            game.turn_store
+                .turn_history
+                .record_die_roll_result_adjustment(adjustment.source);
+        }
+    }
+    adjusted
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ability::Ability;
+    use crate::decision::DecisionMaker;
+    use crate::decisions::context::{BooleanContext, SelectOptionsContext};
     use crate::effect::{Comparison, Effect, EffectId, EffectPredicate};
     use crate::effects::{ExecutionContext, execute_effect};
-    use crate::ids::PlayerId;
+    use crate::ids::{CardId, ObjectId, PlayerId};
+    use crate::static_abilities::StaticAbility;
+    use crate::types::CardType;
+    use crate::zone::Zone;
+
+    struct DieAdjustmentDecisionMaker {
+        accept: bool,
+        option: usize,
+    }
+
+    impl DecisionMaker for DieAdjustmentDecisionMaker {
+        fn decide_boolean(&mut self, _game: &GameState, _ctx: &BooleanContext) -> bool {
+            self.accept
+        }
+
+        fn decide_options(&mut self, _game: &GameState, _ctx: &SelectOptionsContext) -> Vec<usize> {
+            vec![self.option]
+        }
+    }
+
+    fn add_die_adjustment_source(game: &mut GameState, controller: PlayerId) -> ObjectId {
+        let card =
+            crate::CardDefinitionBuilder::new(CardId::from_raw(91_001), "Die Adjustment Source")
+                .card_types(vec![CardType::Creature])
+                .with_ability(Ability::static_ability(
+                    StaticAbility::die_roll_result_adjustment(
+                        PlayerFilter::You,
+                        1,
+                        1,
+                        true,
+                        "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.",
+                    ),
+                ))
+                .build();
+        game.create_object_from_definition(&card, controller, Zone::Battlefield)
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    fn add_compiled_night_shift_source(game: &mut GameState, controller: PlayerId) -> ObjectId {
+        let text = "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.\nWhenever you roll a 6, create a 2/2 black Zombie Employee creature token.";
+        let card = crate::CardDefinitionBuilder::new(
+            CardId::from_raw(91_002),
+            "Night Shift of the Living Dead",
+        )
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(text)
+        .expect("Night Shift should compile");
+        game.create_object_from_definition(&card, controller, Zone::Battlefield)
+    }
 
     #[test]
     fn roll_die_is_deterministic_for_a_seed_and_consumes_randomness() {
@@ -131,6 +283,192 @@ mod tests {
             before,
             "forced die rolls should not consume RNG state"
         );
+    }
+
+    #[test]
+    fn roll_die_adjustment_declined_leaves_result_and_life_unchanged() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = add_die_adjustment_source(&mut game, alice);
+        game.force_next_die_roll(5);
+
+        let mut dm = DieAdjustmentDecisionMaker {
+            accept: false,
+            option: 0,
+        };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+        let outcome = execute_effect(
+            &mut game,
+            &Effect::roll_die(6, PlayerFilter::You),
+            &mut ctx,
+        )
+        .expect("die roll should resolve");
+
+        assert_eq!(outcome.as_count(), Some(5));
+        assert_eq!(game.player(alice).unwrap().life, 20);
+        assert!(
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(alice, 5)
+        );
+        assert!(
+            !game
+                .turn_store
+                .turn_history
+                .die_roll_result_adjusted_this_turn(source)
+        );
+    }
+
+    #[test]
+    fn roll_die_adjustment_can_increase_or_decrease_recorded_result() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = add_die_adjustment_source(&mut game, alice);
+        game.force_next_die_roll(5);
+
+        let mut increase_dm = DieAdjustmentDecisionMaker {
+            accept: true,
+            option: 0,
+        };
+        let mut ctx =
+            ExecutionContext::new_default(source, alice).with_decision_maker(&mut increase_dm);
+        let outcome = execute_effect(
+            &mut game,
+            &Effect::roll_die(6, PlayerFilter::You),
+            &mut ctx,
+        )
+        .expect("die roll should resolve");
+
+        assert_eq!(outcome.as_count(), Some(6));
+        assert_eq!(game.player(alice).unwrap().life, 19);
+        assert!(
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(alice, 6)
+        );
+
+        game.turn_store.turn_history.clear_for_new_turn();
+        game.force_next_die_roll(6);
+        let mut decrease_dm = DieAdjustmentDecisionMaker {
+            accept: true,
+            option: 1,
+        };
+        let mut ctx =
+            ExecutionContext::new_default(source, alice).with_decision_maker(&mut decrease_dm);
+        let outcome = execute_effect(
+            &mut game,
+            &Effect::roll_die(6, PlayerFilter::You),
+            &mut ctx,
+        )
+        .expect("die roll should resolve");
+
+        assert_eq!(outcome.as_count(), Some(5));
+        assert_eq!(game.player(alice).unwrap().life, 18);
+        assert!(
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(alice, 5)
+        );
+    }
+
+    #[test]
+    fn roll_die_adjustment_can_increase_above_the_die_face_count() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = add_die_adjustment_source(&mut game, alice);
+        game.force_next_die_roll(6);
+
+        let mut dm = DieAdjustmentDecisionMaker {
+            accept: true,
+            option: 0,
+        };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+        let outcome = execute_effect(
+            &mut game,
+            &Effect::roll_die(6, PlayerFilter::You),
+            &mut ctx,
+        )
+        .expect("die roll should resolve");
+
+        let die_event = outcome
+            .events
+            .first()
+            .and_then(|event| event.downcast::<DieRolledEvent>())
+            .expect("roll should emit a die-rolled event");
+        assert_eq!(outcome.as_count(), Some(7));
+        assert_eq!(die_event.result, 7);
+        assert!(
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(alice, 7)
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
+    fn night_shift_adjusted_roll_emits_six_for_result_based_triggers() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = add_compiled_night_shift_source(&mut game, alice);
+        game.force_next_die_roll(5);
+
+        let mut dm = DieAdjustmentDecisionMaker {
+            accept: true,
+            option: 0,
+        };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+        let outcome = execute_effect(
+            &mut game,
+            &Effect::roll_die(6, PlayerFilter::You),
+            &mut ctx,
+        )
+        .expect("die roll should resolve");
+
+        let die_event = outcome
+            .events
+            .first()
+            .and_then(|event| event.downcast::<DieRolledEvent>())
+            .expect("roll should emit a die-rolled event");
+        assert_eq!(outcome.as_count(), Some(6));
+        assert_eq!(die_event.result, 6);
+        assert!(
+            game.turn_store
+                .turn_history
+                .player_rolled_result_this_turn(alice, 6),
+            "adjusted result should be recorded for result-based die-roll triggers"
+        );
+    }
+
+    #[test]
+    fn roll_die_adjustment_applies_only_once_each_turn() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = add_die_adjustment_source(&mut game, alice);
+
+        let mut dm = DieAdjustmentDecisionMaker {
+            accept: true,
+            option: 0,
+        };
+        let mut ctx = ExecutionContext::new_default(source, alice).with_decision_maker(&mut dm);
+
+        game.force_next_die_roll(4);
+        let first = execute_effect(&mut game, &Effect::roll_die(6, PlayerFilter::You), &mut ctx)
+            .expect("first die roll should resolve");
+        game.force_next_die_roll(4);
+        let second = execute_effect(&mut game, &Effect::roll_die(6, PlayerFilter::You), &mut ctx)
+            .expect("second die roll should resolve");
+
+        assert_eq!(first.as_count(), Some(5));
+        assert_eq!(second.as_count(), Some(4));
+        assert_eq!(game.player(alice).unwrap().life, 19);
+
+        game.turn_store.turn_history.clear_for_new_turn();
+        game.force_next_die_roll(4);
+        let third = execute_effect(&mut game, &Effect::roll_die(6, PlayerFilter::You), &mut ctx)
+            .expect("next-turn die roll should resolve");
+
+        assert_eq!(third.as_count(), Some(5));
+        assert_eq!(game.player(alice).unwrap().life, 18);
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -5,7 +5,7 @@
 use super::{
     ChooseBasicLandTypeAsEntersSpec, ChooseCardNameAsEntersSpec, ChooseColorAsBecomesAttachedSpec,
     ChooseColorAsEntersSpec, ChooseCreatureTypeAsEntersSpec, ChooseLandTypeAsEntersSpec,
-    ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec,
+    ChooseNamedOptionAsEntersSpec, ChoosePlayerAsEntersSpec, DieRollResultAdjustmentSpec,
     ChoosePowerToughnessAsEntersOrTurnsFaceUpSpec, ConditionalSpellKeywordKind,
     ConditionalSpellKeywordSpec, CountAsCardNamedForSpellEffectSpec, EnterAsCopyAsEntersSpec,
     GraveyardCountMetric, NoteLifeTotalAsEntersSpec, PowerToughnessChoiceOption, StaticAbility,
@@ -174,6 +174,52 @@ fn describe_redirect_zone_phrase(zone: Zone) -> &'static str {
 /// Daybound keyword static ability.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Daybound;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DieRollResultAdjustment {
+    player: PlayerFilter,
+    life_cost: u32,
+    amount: u32,
+    once_each_turn: bool,
+    display: String,
+}
+
+impl DieRollResultAdjustment {
+    pub fn new(
+        player: PlayerFilter,
+        life_cost: u32,
+        amount: u32,
+        once_each_turn: bool,
+        display: impl Into<String>,
+    ) -> Self {
+        Self {
+            player,
+            life_cost,
+            amount,
+            once_each_turn,
+            display: display.into(),
+        }
+    }
+}
+
+impl StaticAbilityKind for DieRollResultAdjustment {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::DieRollResultAdjustment
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn die_roll_result_adjustment_spec(&self) -> Option<DieRollResultAdjustmentSpec> {
+        Some(DieRollResultAdjustmentSpec {
+            player: self.player.clone(),
+            life_cost: self.life_cost,
+            amount: self.amount,
+            once_each_turn: self.once_each_turn,
+        })
+    }
+}
 
 impl StaticAbilityKind for Daybound {
     fn id(&self) -> StaticAbilityId {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -959,6 +959,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
     ) -> Option<CountAsCardNamedForSpellEffectSpec> {
         None
     }
+
+    /// Return a die-roll result adjustment descriptor, if any.
+    fn die_roll_result_adjustment_spec(&self) -> Option<DieRollResultAdjustmentSpec> {
+        None
+    }
 }
 
 /// Spec for "as this enters, choose a color" abilities.
@@ -1087,6 +1092,15 @@ pub struct CountAsCardNamedForSpellEffectSpec {
     pub counted_name: String,
 }
 
+/// Spec for abilities that can change a die-roll result as it is rolled.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DieRollResultAdjustmentSpec {
+    pub player: crate::target::PlayerFilter,
+    pub life_cost: u32,
+    pub amount: u32,
+    pub once_each_turn: bool,
+}
+
 // Implement Clone for Box<dyn StaticAbilityKind>
 impl Clone for Box<dyn StaticAbilityKind> {
     fn clone(&self) -> Self {
@@ -1211,6 +1225,10 @@ impl StaticAbility {
         &self,
     ) -> Option<CountAsCardNamedForSpellEffectSpec> {
         self.0.count_as_card_named_for_spell_effect_spec()
+    }
+
+    pub fn die_roll_result_adjustment_spec(&self) -> Option<DieRollResultAdjustmentSpec> {
+        self.0.die_roll_result_adjustment_spec()
     }
 
     /// Get the display text for this ability.
@@ -3216,6 +3234,22 @@ impl StaticAbility {
     /// you may pay 2 life. If you don't, it enters the battlefield tapped."
     pub fn pay_life_or_enter_tapped(life_cost: u32) -> Self {
         Self::new(PayLifeOrEnterTappedReplacement::new(life_cost))
+    }
+
+    pub fn die_roll_result_adjustment(
+        player: crate::target::PlayerFilter,
+        life_cost: u32,
+        amount: u32,
+        once_each_turn: bool,
+        display: impl Into<String>,
+    ) -> Self {
+        Self::new(DieRollResultAdjustment::new(
+            player,
+            life_cost,
+            amount,
+            once_each_turn,
+            display,
+        ))
     }
 
     pub fn keyword_fallback_text(text: impl Into<String>) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -113,6 +113,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ThisSpellXMaximum { maximum, display } => {
                 format!("ThisSpellXMaximum {{ maximum: {maximum:?}, display: {display:?} }}")
             }
+            ironsmith_core::StaticAbilityPayload::DieRollResultAdjustment(spec) => {
+                format!("DieRollResultAdjustment {{ spec: {spec:?} }}")
+            }
             payload => format!("{payload:?}"),
         }
     }
@@ -1191,6 +1194,15 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::ThisSpellXMaximum { maximum, display } => {
                 StaticAbility::this_spell_x_maximum(maximum.clone(), display.clone())
             }
+            ironsmith_core::StaticAbilityPayload::DieRollResultAdjustment(spec) => {
+                StaticAbility::die_roll_result_adjustment(
+                    spec.player.clone(),
+                    spec.life_cost,
+                    spec.amount,
+                    spec.once_each_turn,
+                    spec.display.clone(),
+                )
+            }
             ironsmith_core::StaticAbilityPayload::MinimumSpellTotalMana(amount) => {
                 StaticAbility::minimum_spell_total_mana(*amount)
             }
@@ -2031,6 +2043,20 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
                 spell_name: spell_name.clone(),
                 counted_name: counted_name.clone(),
             }),
+            _ => None,
+        }
+    }
+
+    fn die_roll_result_adjustment_spec(&self) -> Option<super::DieRollResultAdjustmentSpec> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::DieRollResultAdjustment(spec) => {
+                Some(super::DieRollResultAdjustmentSpec {
+                    player: spec.player.clone(),
+                    life_cost: spec.life_cost,
+                    amount: spec.amount,
+                    once_each_turn: spec.once_each_turn,
+                })
+            }
             _ => None,
         }
     }

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -42,6 +42,7 @@ pub struct TurnHistory {
     pub players_attacked_this_turn: HashSet<PlayerId>,
     pub players_tapped_land_for_mana_this_turn: HashSet<PlayerId>,
     pub die_rolls_this_turn: HashMap<PlayerId, Vec<u32>>,
+    pub die_roll_result_adjustments_this_turn: HashSet<ObjectId>,
     pub creatures_attacked_this_turn: HashSet<ObjectId>,
     pub creature_attack_counts_this_turn: HashMap<ObjectId, u32>,
     pub crewed_this_turn: HashMap<ObjectId, Vec<ObjectId>>,
@@ -65,6 +66,7 @@ impl TurnHistory {
         self.players_attacked_this_turn.clear();
         self.players_tapped_land_for_mana_this_turn.clear();
         self.die_rolls_this_turn.clear();
+        self.die_roll_result_adjustments_this_turn.clear();
         self.creatures_attacked_this_turn.clear();
         self.creature_attack_counts_this_turn.clear();
         self.crewed_this_turn.clear();
@@ -749,6 +751,14 @@ impl TurnHistory {
             .entry(player)
             .or_default()
             .push(result);
+    }
+
+    pub fn record_die_roll_result_adjustment(&mut self, source: ObjectId) {
+        self.die_roll_result_adjustments_this_turn.insert(source);
+    }
+
+    pub fn die_roll_result_adjusted_this_turn(&self, source: ObjectId) -> bool {
+        self.die_roll_result_adjustments_this_turn.contains(&source)
     }
 
     pub fn player_rolled_result_this_turn(&self, player: PlayerId, result: u32) -> bool {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Night Shift of the Living Dead
Initial parse error:
```
parser does not yet support line family: 'After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.'; oracle-only fallback also failed: parser does not yet support line family: 'After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.'
```

Current worker: i-03050f971a467d906
Branch: codex/aws-card-fix-night-shift-of-the-living-dead
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
