### PR TITLE
Fix Ironsmith parse failure: Gaea's Revenge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -525,6 +525,93 @@ fn simple_negated_object_restriction(
     })
 }
 
+fn source_filtered_target_restriction(
+    tokens: &[OwnedLexToken],
+    words: &[&str],
+    target_filter: &ObjectFilter,
+) -> Result<Option<crate::effect::Restriction>, CardTextError> {
+    if words.len() < 8 || !words.starts_with(&["be", "the", "target", "of"]) {
+        return Ok(None);
+    }
+
+    let Some(source_marker_start) = words[4..]
+        .windows(4)
+        .position(|window| window == ["spells", "or", "abilities", "from"])
+        .map(|idx| idx + 4)
+    else {
+        return Ok(None);
+    };
+    let source_words_start = source_marker_start + 4;
+    if source_words_start >= words.len() {
+        return Ok(None);
+    }
+
+    let source_words_end = if words
+        .last()
+        .is_some_and(|word| matches!(*word, "source" | "sources"))
+    {
+        words.len() - 1
+    } else {
+        words.len()
+    };
+    if source_words_start >= source_words_end {
+        return Ok(None);
+    }
+
+    let word_view = ActivationRestrictionCompatWords::new(tokens);
+    let spell_filter = if source_marker_start > 4 {
+        let spell_token_start = word_view.token_index_after_words(4).unwrap_or(tokens.len());
+        let spell_token_end = word_view
+            .token_index_after_words(source_marker_start)
+            .unwrap_or(tokens.len());
+        let spell_tokens = trim_commas(&tokens[spell_token_start..spell_token_end]);
+        Some(
+            match parse_object_filter(&spell_tokens, false).ok() {
+                Some(filter) => Some(filter),
+                None => parse_subject_object_filter(&spell_tokens)?,
+            }
+            .ok_or_else(|| {
+                CardTextError::ParseError(format!(
+                    "unsupported source-filtered target restriction tail (clause: '{}')",
+                    crate::runtime_backend::token_word_refs(tokens).join(" ")
+                ))
+            })?,
+        )
+    } else {
+        None
+    };
+    let source_token_start = word_view
+        .token_index_after_words(source_words_start)
+        .unwrap_or(tokens.len());
+    let source_token_end = word_view
+        .token_index_after_words(source_words_end)
+        .unwrap_or(tokens.len());
+    let source_tokens = trim_commas(&tokens[source_token_start..source_token_end]);
+
+    let source_filter = match parse_object_filter(&source_tokens, false).ok() {
+        Some(filter) => Some(filter),
+        None => parse_subject_object_filter(&source_tokens)?,
+    }
+    .ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "unsupported source-filtered target restriction tail (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        ))
+    })?;
+
+    if spell_filter.as_ref().is_some_and(|filter| filter != &source_filter) {
+        return Err(CardTextError::ParseError(format!(
+            "unsupported source-filtered target restriction tail (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        )));
+    }
+
+    Ok(Some(crate::effect::Restriction::be_targeted_from(
+        target_filter.clone(),
+        source_filter,
+    )))
+}
+
 fn player_negated_restriction_from_tail(
     words: &[&str],
     player: PlayerFilter,
@@ -1757,6 +1844,14 @@ pub(crate) fn parse_negated_object_restriction_clause(
         }));
     }
     if let Some(restriction) = simple_negated_object_restriction(&remainder_words, &filter) {
+        return Ok(Some(ParsedCantRestriction {
+            restriction,
+            target,
+        }));
+    }
+    if let Some(restriction) =
+        source_filtered_target_restriction(&remainder_tokens, &remainder_words, &filter)?
+    {
         return Ok(Some(ParsedCantRestriction {
             restriction,
             target,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_helpers.rs
@@ -542,6 +542,10 @@ pub(crate) fn resolve_restriction_it_tag(
             Restriction::have_counters_placed(resolve_it_tag(filter, refs)?)
         }
         Restriction::BeTargeted(filter) => Restriction::be_targeted(resolve_it_tag(filter, refs)?),
+        Restriction::BeTargetedFrom(filter, source_filter) => Restriction::be_targeted_from(
+            resolve_it_tag(filter, refs)?,
+            resolve_it_tag(source_filter, refs)?,
+        ),
         Restriction::BeTargetedPlayer(player) => {
             Restriction::BeTargetedPlayer(resolve_contextual_player_filter(player, refs)?)
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -14832,6 +14832,41 @@ fn absolute_virtue_player_protection_from_opponents_parses_as_targeting_restrict
 }
 
 #[test]
+fn gaeas_revenge_source_filtered_targeting_restriction_parses_strictly() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Gaea's Revenge")
+        .card_types(vec![CardType::Creature])
+        .parse_text(
+            "This spell can't be countered.\n\
+             Haste\n\
+             This creature can't be the target of nongreen spells or abilities from nongreen sources.",
+        )
+        .expect("Gaea's Revenge text should parse");
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("BeCountered")
+            && debug.contains("Haste")
+            && debug.contains("BeTargetedFrom")
+            && debug.contains("excluded_colors"),
+        "expected uncounterable, haste, and nongreen source targeting restriction, got {debug}"
+    );
+}
+
+#[test]
+fn source_filtered_targeting_restriction_rejects_mismatched_spell_and_source_filters() {
+    let err = parse_error_message(
+        CardDefinitionBuilder::new(CardId::new(), "Mismatched Target Restriction")
+            .card_types(vec![CardType::Creature])
+            .parse_text(
+                "This creature can't be the target of nongreen spells or abilities from nonblue sources.",
+            ),
+    );
+    assert!(
+        err.contains("unsupported source-filtered target restriction tail"),
+        "expected mismatched spell/source qualifiers to remain unsupported, got {err}"
+    );
+}
+
+#[test]
 fn maddening_hex_damage_equal_to_die_result_binds_prior_roll() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Maddening Hex Variant")
         .parse_text(

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -310,6 +310,7 @@ pub enum Restriction {
     BeSacrificed(ObjectFilter),
     HaveCountersPlaced(ObjectFilter),
     BeTargeted(ObjectFilter),
+    BeTargetedFrom(ObjectFilter, ObjectFilter),
     BeTargetedPlayer(PlayerFilter),
     BeTargetedPlayerFrom(PlayerFilter, ObjectFilter),
     BeCountered(ObjectFilter),
@@ -594,6 +595,10 @@ impl Restriction {
 
     pub fn be_targeted(filter: ObjectFilter) -> Self {
         Self::BeTargeted(filter)
+    }
+
+    pub fn be_targeted_from(filter: ObjectFilter, source_filter: ObjectFilter) -> Self {
+        Self::BeTargetedFrom(filter, source_filter)
     }
 
     pub fn be_targeted_player(filter: PlayerFilter) -> Self {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10679,6 +10679,13 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
         crate::effect::Restriction::BeTargeted(filter) => {
             format!("{} can't be targeted", filter.description())
         }
+        crate::effect::Restriction::BeTargetedFrom(filter, source_filter) => {
+            format!(
+                "{} can't be targeted by {} sources",
+                filter.description(),
+                describe_hexproof_from_filter(source_filter)
+            )
+        }
         crate::effect::Restriction::BeTargetedPlayer(filter) => {
             format!("{} can't be targeted", describe_player_set_filter(filter))
         }

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -1215,6 +1215,21 @@ impl RestrictionExt for Restriction {
                     }
                 }
             }
+            Restriction::BeTargetedFrom(filter, source_filter) => {
+                for &obj_id in &game.battlefield {
+                    if let Some(obj) = game.object(obj_id)
+                        && filter.matches(obj, &ctx, game)
+                    {
+                        tracker.cant_be_targeted_from.push(
+                            crate::game_state::ObjectCantBeTargetedFrom {
+                                object: obj_id,
+                                source_filter: source_filter.clone(),
+                                controller,
+                            },
+                        );
+                    }
+                }
+            }
             Restriction::BeTargetedPlayer(filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -50019,6 +50019,158 @@ fn giant_solifuge_keywords_apply_to_targeting_haste_and_trample() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn gaeas_revenge_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(193_669), "Gaea's Revenge")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Green],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elemental])
+        .power_toughness(PowerToughness::fixed(8, 5))
+        .parse_text(
+            "This spell can't be countered.\n\
+             Haste\n\
+             This creature can't be the target of nongreen spells or abilities from nongreen sources.",
+        )
+        .expect("Gaea's Revenge should parse strictly for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn colored_instant_definition(
+    name: &str,
+    colors: crate::color::ColorSet,
+) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Instant])
+        .color_indicator(colors)
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn colored_creature_definition(
+    name: &str,
+    colors: crate::color::ColorSet,
+) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .color_indicator(colors)
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gaeas_revenge_strict_parser_and_compiled_text_regression() {
+    let def = gaeas_revenge_definition();
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("This spell can't be countered."),
+        "Gaea's Revenge should render its uncounterable spell restriction, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Haste"),
+        "Gaea's Revenge should render haste, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "This creature can't be the target of nongreen spells or abilities from nongreen sources."
+        ),
+        "Gaea's Revenge should render its nongreen source targeting restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gaeas_revenge_static_abilities_apply_to_countering_haste_and_targeting() {
+    use crate::target::{ChooseSpec, ObjectFilter};
+    use crate::targeting::{
+        TargetingInvalidReason, TargetingResult, can_target_object, compute_legal_targets,
+    };
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let revenge = gaeas_revenge_definition();
+
+    let revenge_spell = game.create_object_from_definition(&revenge, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(revenge_spell, alice));
+    game.update_cant_effects();
+    assert!(
+        !game.can_be_countered(revenge_spell),
+        "Gaea's Revenge should be uncounterable while it is a spell on the stack"
+    );
+
+    let revenge_id = game.create_object_from_definition(&revenge, alice, Zone::Battlefield);
+    game.set_summoning_sick(revenge_id);
+    game.refresh_continuous_state();
+    assert!(
+        crate::rules::combat::can_attack(
+            game.object(revenge_id).expect("Gaea's Revenge exists"),
+            &game,
+        ),
+        "haste should let Gaea's Revenge attack despite summoning sickness"
+    );
+
+    let red_spell =
+        colored_instant_definition("Nongreen Targeting Spell", crate::color::ColorSet::RED);
+    let red_spell_id = game.create_object_from_definition(&red_spell, bob, Zone::Stack);
+    assert!(
+        matches!(
+            can_target_object(&game, revenge_id, red_spell_id, bob),
+            TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted)
+        ),
+        "an opponent's nongreen spell should not be able to target Gaea's Revenge"
+    );
+
+    let friendly_red_source = colored_creature_definition(
+        "Friendly Nongreen Ability Source",
+        crate::color::ColorSet::RED,
+    );
+    let friendly_red_source_id =
+        game.create_object_from_definition(&friendly_red_source, alice, Zone::Battlefield);
+    assert!(
+        matches!(
+            can_target_object(&game, revenge_id, friendly_red_source_id, alice),
+            TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted)
+        ),
+        "Gaea's Revenge should also reject its controller's nongreen ability sources"
+    );
+
+    let green_spell =
+        colored_instant_definition("Green Targeting Spell", crate::color::ColorSet::GREEN);
+    let green_spell_id = game.create_object_from_definition(&green_spell, bob, Zone::Stack);
+    assert!(
+        can_target_object(&game, revenge_id, green_spell_id, bob).is_legal(),
+        "a green spell should be able to target Gaea's Revenge"
+    );
+
+    let legal_targets_from_red = compute_legal_targets(
+        &game,
+        &ChooseSpec::Target(Box::new(ChooseSpec::Object(ObjectFilter::creature()))),
+        bob,
+        Some(red_spell_id),
+    );
+    assert!(
+        !legal_targets_from_red.contains(&Target::Object(revenge_id)),
+        "Gaea's Revenge should not appear in legal target lists for nongreen sources"
+    );
+
+    let legal_targets_from_green = compute_legal_targets(
+        &game,
+        &ChooseSpec::Target(Box::new(ChooseSpec::Object(ObjectFilter::creature()))),
+        bob,
+        Some(green_spell_id),
+    );
+    assert!(
+        legal_targets_from_green.contains(&Target::Object(revenge_id)),
+        "Gaea's Revenge should appear in legal target lists for green sources"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn cultivator_colossus_etb_only_asks_may_once_per_land_put() {
     use crate::cards::definitions::{basic_forest, grizzly_bears};

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -671,6 +671,9 @@ pub struct CantEffectTracker {
     /// "can't be the target of spells or abilities"
     pub cant_be_targeted: HashSet<ObjectId>,
 
+    /// Permanents that can't be targeted by sources matching a filter.
+    pub cant_be_targeted_from: Vec<ObjectCantBeTargetedFrom>,
+
     /// Players that can't be targeted.
     pub cant_target_players: HashSet<PlayerId>,
 
@@ -693,6 +696,13 @@ pub struct CantEffectTracker {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlayerCantBeTargetedFrom {
     pub player: PlayerId,
+    pub source_filter: crate::target::ObjectFilter,
+    pub controller: PlayerId,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectCantBeTargetedFrom {
+    pub object: ObjectId,
     pub source_filter: crate::target::ObjectFilter,
     pub controller: PlayerId,
 }
@@ -919,6 +929,8 @@ impl CantEffectTracker {
         self.cant_win_game.extend(other.cant_win_game);
         self.cant_become_monarch.extend(other.cant_become_monarch);
         self.cant_be_targeted.extend(other.cant_be_targeted);
+        self.cant_be_targeted_from
+            .extend(other.cant_be_targeted_from.clone());
         self.cant_target_players.extend(other.cant_target_players);
         self.cant_target_players_from
             .extend(other.cant_target_players_from.clone());
@@ -964,6 +976,7 @@ impl CantEffectTracker {
         self.cant_win_game.clear();
         self.cant_become_monarch.clear();
         self.cant_be_targeted.clear();
+        self.cant_be_targeted_from.clear();
         self.cant_target_players.clear();
         self.cant_target_players_from.clear();
         self.cant_be_countered.clear();
@@ -1267,6 +1280,25 @@ impl CantEffectTracker {
     /// Check if a permanent is untargetable by the rules tracker.
     pub fn is_untargetable(&self, permanent: ObjectId) -> bool {
         self.cant_be_targeted.contains(&permanent)
+    }
+
+    pub fn can_target_object_from_source(
+        &self,
+        game: &GameState,
+        object: ObjectId,
+        source_id: ObjectId,
+    ) -> bool {
+        let Some(source) = game.object(source_id) else {
+            return true;
+        };
+
+        !self.cant_be_targeted_from.iter().any(|restriction| {
+            if restriction.object != object {
+                return false;
+            }
+            let filter_ctx = game.filter_context_for(restriction.controller, Some(source_id));
+            restriction.source_filter.matches(source, &filter_ctx, game)
+        })
     }
 
     /// Check if a player can be targeted.
@@ -3497,6 +3529,12 @@ impl GameState {
     /// Is this permanent untargetable (by shroud/hexproof-style effects)?
     pub fn is_untargetable(&self, permanent: ObjectId) -> bool {
         self.effect_store.cant_effects.is_untargetable(permanent)
+    }
+
+    pub fn can_target_object_from_source(&self, object: ObjectId, source_id: ObjectId) -> bool {
+        self.effect_store
+            .cant_effects
+            .can_target_object_from_source(self, object, source_id)
     }
 
     /// Can this player be targeted?

--- a/crates/ironsmith-runtime/src/targeting/computation.rs
+++ b/crates/ironsmith-runtime/src/targeting/computation.rs
@@ -118,6 +118,9 @@ pub(crate) fn can_target_object_with_view_and_source_snapshot(
     if game.is_untargetable(target_id) && game.controller_of(target) != caster {
         return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
     }
+    if !game.can_target_object_from_source(target_id, source_id) {
+        return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
+    }
 
     TargetingResult::legal()
 }
@@ -165,6 +168,20 @@ fn can_target_object_from_source_snapshot_with_view(
 
     if game.is_untargetable(target_id) && game.controller_of(target) != caster {
         return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
+    }
+
+    for restriction in &game.effect_store.cant_effects.cant_be_targeted_from {
+        if restriction.object != target_id {
+            continue;
+        }
+        let filter_ctx =
+            game.filter_context_for(restriction.controller, Some(source_snapshot.object_id));
+        if restriction
+            .source_filter
+            .matches_snapshot(source_snapshot, &filter_ctx, game)
+        {
+            return TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted);
+        }
     }
 
     TargetingResult::legal()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gaea's Revenge
Initial parse error:
```
unsupported negated restriction tail (clause: 'this creature can't be the target of nongreen spells or abilities from nongreen sources'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'this creature can't be the target of nongreen spells or abilities from nongreen sources')
```

Current worker: i-05be33181cab78e9c
Branch: codex/aws-card-fix-gaea-s-revenge
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
