### PR TITLE
Fix Ironsmith parse failure: Mark of Asylum

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -39,6 +39,7 @@ use super::grammar::abilities::{
     is_prevent_all_combat_damage_to_source_line_lexed,
     is_prevent_all_damage_dealt_to_creatures_line_lexed,
     is_prevent_all_damage_to_source_by_creatures_line_lexed,
+    is_prevent_all_noncombat_damage_to_matching_permanents_line_lexed,
     is_prevent_all_noncombat_damage_to_other_creatures_you_control_line_lexed,
     is_prevent_damage_to_other_creature_you_control_put_counters_line_lexed,
     is_protection_mana_value_marker_line_lexed, is_remove_snow_line_lexed,
@@ -2933,6 +2934,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         ),
         single_static_ability_ast_rule!(
             parse_prevent_all_noncombat_damage_to_other_creatures_you_control_line
+        ),
+        single_static_ability_ast_rule!(
+            parse_prevent_all_noncombat_damage_to_matching_permanents_line
         ),
         single_static_ability_ast_rule!(parse_prevent_all_damage_to_source_by_creatures_line),
         single_static_ability_ast_rule!(
@@ -9069,6 +9073,42 @@ pub(crate) fn parse_prevent_all_noncombat_damage_to_other_creatures_you_control_
     }
 
     Ok(None)
+}
+
+pub(crate) fn parse_prevent_all_noncombat_damage_to_matching_permanents_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if !is_prevent_all_noncombat_damage_to_matching_permanents_line_lexed(tokens) {
+        return Ok(None);
+    }
+
+    let Some((_phrase_idx, phrase_end)) = find_token_word_sequence_span(
+        tokens,
+        &[
+            "prevent",
+            "all",
+            "noncombat",
+            "damage",
+            "that",
+            "would",
+            "be",
+            "dealt",
+            "to",
+        ],
+    ) else {
+        return Ok(None);
+    };
+    let target_tokens = trim_commas(&tokens[phrase_end..]);
+    if target_tokens.is_empty() {
+        return Err(CardTextError::ParseError(format!(
+            "missing prevent-all noncombat damage target filter: {}",
+            render_token_slice(tokens)
+        )));
+    }
+    let filter = parse_object_filter_lexed(&target_tokens, false)?;
+    Ok(Some(
+        StaticAbility::prevent_all_noncombat_damage_to_permanents_matching(filter),
+    ))
 }
 
 pub(crate) fn parse_prevent_all_damage_to_source_by_creatures_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -3117,6 +3117,39 @@ pub(crate) fn is_prevent_all_noncombat_damage_to_other_creatures_you_control_lin
     )
 }
 
+pub(crate) fn is_prevent_all_noncombat_damage_to_matching_permanents_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    const PREVENT_ALL_NONCOMBAT_DAMAGE_TO_PREFIX: &[&str] = &[
+        "prevent",
+        "all",
+        "noncombat",
+        "damage",
+        "that",
+        "would",
+        "be",
+        "dealt",
+        "to",
+    ];
+    const PREVENT_ALL_NONCOMBAT_DAMAGE_TO_PATTERN: LexPattern<'static> = LexPattern::new(&[
+        LexPattern::phrase(PREVENT_ALL_NONCOMBAT_DAMAGE_TO_PREFIX),
+        LexPattern::object("object", LexCaptureKind::OneOrMoreWords),
+    ]);
+
+    let clause = LexedClause::new(tokens);
+    let Some(matched) = PREVENT_ALL_NONCOMBAT_DAMAGE_TO_PATTERN.match_clause(clause) else {
+        return false;
+    };
+    let Some(object) = matched.capture_clause_by_role(LexCaptureRole::Object, clause) else {
+        return false;
+    };
+    let object_words = object.word_refs();
+    !matches!(
+        object_words.as_slice(),
+        ["this", "creature"] | ["this", "permanent"] | ["it"]
+    ) && !object_words.iter().any(|word| *word == "turn")
+}
+
 pub(crate) fn is_prevent_all_combat_damage_to_matching_permanents_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8950,6 +8950,12 @@ fn rewrite_grammar_prevention_static_line_probes_match_keyword_static_shapes() {
             crate::static_abilities::StaticAbilityId::PreventAllNoncombatDamageToOtherCreaturesYouControl,
         ),
         (
+            "Prevent all noncombat damage that would be dealt to creatures you control.",
+            super::grammar::abilities::is_prevent_all_noncombat_damage_to_matching_permanents_line_lexed as Probe,
+            super::keyword_static::parse_prevent_all_noncombat_damage_to_matching_permanents_line as Parser,
+            crate::static_abilities::StaticAbilityId::PreventAllNoncombatDamageToPermanentsMatching,
+        ),
+        (
             "Prevent all damage that would be dealt to this permanent by creatures.",
             super::grammar::abilities::is_prevent_all_damage_to_source_by_creatures_line_lexed as Probe,
             super::keyword_static::parse_prevent_all_damage_to_source_by_creatures_line as Parser,

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -183,6 +183,7 @@ pub enum StaticAbilityId {
     PreventAllDamageToSelf,
     PreventAllCombatDamageToSelf,
     PreventAllCombatDamageToPermanentsMatching,
+    PreventAllNoncombatDamageToPermanentsMatching,
     PreventAllDamageToSelfByCreatures,
     PreventDamageToYouFromSourceFilter,
     PreventDamageToSelfRemoveCounter,
@@ -449,6 +450,7 @@ impl StaticAbilityId {
             | PreventAllDamageToSelf
             | PreventAllCombatDamageToSelf
             | PreventAllCombatDamageToPermanentsMatching
+            | PreventAllNoncombatDamageToPermanentsMatching
             | PreventAllDamageToSelfByCreatures
             | PreventDamageToYouFromSourceFilter
             | PreventDamageToSelfRemoveCounter

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -216,6 +216,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     HexproofFrom(ObjectFilter),
     Protection(ProtectionFrom),
     PreventAllCombatDamageToPermanentsMatching(ObjectFilter),
+    PreventAllNoncombatDamageToPermanentsMatching(ObjectFilter),
     RuleRestriction {
         restriction: Restriction,
         display: String,
@@ -929,6 +930,9 @@ where
             StaticAbilityPayload::Protection(from) => StaticAbilityPayload::Protection(from),
             StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(filter) => {
                 StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(filter)
+            }
+            StaticAbilityPayload::PreventAllNoncombatDamageToPermanentsMatching(filter) => {
+                StaticAbilityPayload::PreventAllNoncombatDamageToPermanentsMatching(filter)
             }
             StaticAbilityPayload::RuleRestriction {
                 restriction,
@@ -3448,6 +3452,13 @@ impl<
             id: Some(StaticAbilityId::PreventAllCombatDamageToPermanentsMatching),
             label: "prevent all combat damage to permanents matching filter".into(),
             payload: StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(filter),
+        }
+    }
+    pub fn prevent_all_noncombat_damage_to_permanents_matching(filter: ObjectFilter) -> Self {
+        Self {
+            id: Some(StaticAbilityId::PreventAllNoncombatDamageToPermanentsMatching),
+            label: "prevent all noncombat damage to permanents matching filter".into(),
+            payload: StaticAbilityPayload::PreventAllNoncombatDamageToPermanentsMatching(filter),
         }
     }
     pub fn prevent_all_damage_to_self() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1078,6 +1078,130 @@ fn templar_knight_deck_construction_rule_has_no_game_runtime_effects() {
 }
 
 #[test]
+fn mark_of_asylum_strict_parser_compiled_text_and_runtime_prevention_regression() {
+    assert_oracle_card_parses_strict("Mark of Asylum");
+
+    let def = parse_oracle_card_definition("Mark of Asylum");
+    let rendered = unprocessed_compiled_lines(&def);
+    assert_eq!(
+        rendered,
+        vec![
+            "Prevent all noncombat damage that would be dealt to creatures you control."
+                .to_string(),
+        ],
+        "Mark of Asylum should render its noncombat prevention clause exactly"
+    );
+
+    let static_ability = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Static(static_ability) = &ability.kind else {
+                return None;
+            };
+            let is_mark_prevention = static_ability.id()
+                == StaticAbilityId::PreventAllNoncombatDamageToPermanentsMatching;
+            is_mark_prevention.then_some(static_ability)
+        })
+        .expect("Mark of Asylum should lower to filtered noncombat damage prevention");
+    assert_eq!(
+        static_ability.display(),
+        "Prevent all noncombat damage that would be dealt to creatures you control."
+    );
+
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let _mark = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+    let damage_source = CardBuilder::new(CardId::new(), "Damage Source")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let source_id = game.create_object_from_card(&damage_source, bob, Zone::Battlefield);
+
+    let protected = CardBuilder::new(CardId::new(), "Protected Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let protected_id = game.create_object_from_card(&protected, alice, Zone::Battlefield);
+
+    let controlled_noncreature = CardBuilder::new(CardId::new(), "Controlled Noncreature")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let controlled_noncreature_id =
+        game.create_object_from_card(&controlled_noncreature, alice, Zone::Battlefield);
+
+    let opponent_creature = CardBuilder::new(CardId::new(), "Opponent Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let opponent_creature_id =
+        game.create_object_from_card(&opponent_creature, bob, Zone::Battlefield);
+
+    let (noncombat_damage, noncombat_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            source_id,
+            crate::events::DamageTarget::Object(protected_id),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        noncombat_damage, 0,
+        "Mark of Asylum should prevent noncombat damage to creatures you control"
+    );
+    assert!(noncombat_prevented);
+
+    let (combat_damage, combat_prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        source_id,
+        crate::events::DamageTarget::Object(protected_id),
+        3,
+        true,
+        crate::events::cause::EventCause::from_combat_damage(source_id, bob),
+    );
+    assert_eq!(
+        combat_damage, 3,
+        "Mark of Asylum should not prevent combat damage"
+    );
+    assert!(!combat_prevented);
+
+    let (controlled_noncreature_damage, controlled_noncreature_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            source_id,
+            crate::events::DamageTarget::Object(controlled_noncreature_id),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        controlled_noncreature_damage, 3,
+        "Mark of Asylum should not prevent damage to noncreature permanents you control"
+    );
+    assert!(!controlled_noncreature_prevented);
+
+    let (opponent_damage, opponent_prevented) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            source_id,
+            crate::events::DamageTarget::Object(opponent_creature_id),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        opponent_damage, 3,
+        "Mark of Asylum should not prevent damage to creatures you do not control"
+    );
+    assert!(!opponent_prevented);
+}
+
+#[test]
 fn templar_knight_activation_cost_filter_requires_untapped_attacking_named_creatures_you_control() {
     let def = parse_oracle_card_definition("Templar Knight");
     let activated = def

--- a/crates/ironsmith-runtime/src/events/damage/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/damage/matchers.rs
@@ -230,6 +230,53 @@ impl ReplacementMatcher for PreventableCombatDamageToObjectMatcher {
     }
 }
 
+/// Matches preventable noncombat damage events dealt to an object matching a filter.
+#[derive(Debug, Clone)]
+pub struct PreventableNoncombatDamageToObjectMatcher {
+    pub filter: ObjectFilter,
+}
+
+impl PreventableNoncombatDamageToObjectMatcher {
+    pub fn new(filter: ObjectFilter) -> Self {
+        Self { filter }
+    }
+}
+
+impl ReplacementMatcher for PreventableNoncombatDamageToObjectMatcher {
+    fn matches_event(&self, event: &dyn GameEventType, ctx: &EventContext) -> bool {
+        if event.event_kind() != EventKind::Damage {
+            return false;
+        }
+
+        let Some(damage) = downcast_event::<DamageEvent>(event) else {
+            return false;
+        };
+
+        if damage.is_unpreventable || damage.is_combat {
+            return false;
+        }
+
+        let DamageTarget::Object(object_id) = damage.target else {
+            return false;
+        };
+
+        ctx.game
+            .object(object_id)
+            .is_some_and(|object| self.filter.matches(object, &ctx.filter_ctx, ctx.game))
+    }
+
+    fn priority(&self) -> ReplacementPriority {
+        ReplacementPriority::Other
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "When preventable noncombat damage would be dealt to {}",
+            self.filter.description()
+        )
+    }
+}
+
 /// Matches noncombat damage events.
 #[derive(Debug, Clone)]
 pub struct NoncombatDamageMatcher;

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -166,6 +166,12 @@ impl StaticAbility {
                         .to_string(),
                 });
             }
+            Some(StaticAbilityId::PreventAllNoncombatDamageToPermanentsMatching) => {
+                return Err(StaticAbilityModelConversionError {
+                    detail: "filtered noncombat-damage prevention needs its object-filter payload"
+                        .to_string(),
+                });
+            }
             Some(StaticAbilityId::PreventAllDamageToSelfByCreatures) => {
                 Self::prevent_all_damage_to_self_by_creatures()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -29,6 +29,7 @@ use crate::events::damage::matchers::{
     DamageFromSourceToPlayerMatcher, DamageToObjectMatcher, DamageToOtherCreatureYouControlMatcher,
     DamageToPlayerOrObjectMatcher, DamageToSelfCombatMatcher, DamageToSelfConstraintMatcher,
     DamageToSelfFromSourceFilterMatcher, PreventableCombatDamageToObjectMatcher,
+    PreventableNoncombatDamageToObjectMatcher,
 };
 use crate::events::permanents::matchers::AttachedPermanentWouldBeDestroyedMatcher;
 use crate::events::traits::{
@@ -2014,6 +2015,44 @@ impl StaticAbilityKind for PreventAllCombatDamageToPermanentsMatching {
             source,
             controller,
             PreventableCombatDamageToObjectMatcher::new(self.filter.clone()),
+            ReplacementAction::Prevent,
+        ))
+    }
+}
+
+/// "Prevent all noncombat damage that would be dealt to [matching permanents]."
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreventAllNoncombatDamageToPermanentsMatching {
+    pub filter: ObjectFilter,
+}
+
+impl PreventAllNoncombatDamageToPermanentsMatching {
+    pub fn new(filter: ObjectFilter) -> Self {
+        Self { filter }
+    }
+}
+
+impl StaticAbilityKind for PreventAllNoncombatDamageToPermanentsMatching {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::PreventAllNoncombatDamageToPermanentsMatching
+    }
+
+    fn display(&self) -> String {
+        format!(
+            "Prevent all noncombat damage that would be dealt to {}.",
+            pluralize_filter_description(&self.filter.description())
+        )
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            PreventableNoncombatDamageToObjectMatcher::new(self.filter.clone()),
             ReplacementAction::Prevent,
         ))
     }
@@ -6998,6 +7037,84 @@ mod tests {
             crate::events::cause::EventCause::effect(),
         );
         assert!(!matcher.matches_event(&noncreature_damage, &ctx));
+    }
+
+    #[test]
+    fn test_prevent_all_noncombat_damage_to_permanents_matching_generates_replacement() {
+        let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let source = CardBuilder::new(CardId::new(), "Mark of Asylum Probe")
+            .card_types(vec![CardType::Enchantment])
+            .build();
+        let source_id = game.create_object_from_card(&source, alice, Zone::Battlefield);
+
+        let protected = CardBuilder::new(CardId::new(), "Protected Creature")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let protected_id = game.create_object_from_card(&protected, alice, Zone::Battlefield);
+
+        let opponent = CardBuilder::new(CardId::new(), "Opponent Creature")
+            .card_types(vec![CardType::Creature])
+            .build();
+        let opponent_id = game.create_object_from_card(&opponent, bob, Zone::Battlefield);
+
+        let damage_source = CardBuilder::new(CardId::new(), "Damage Source")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let damage_source_id =
+            game.create_object_from_card(&damage_source, bob, Zone::Battlefield);
+
+        let mut filter = ObjectFilter::creature();
+        filter.controller = Some(PlayerFilter::You);
+        let ability = PreventAllNoncombatDamageToPermanentsMatching::new(filter);
+        let replacement = ability
+            .generate_replacement_effect(source_id, alice)
+            .expect("should generate replacement effect");
+        assert_eq!(replacement.replacement, ReplacementAction::Prevent);
+
+        let matcher = replacement
+            .matcher
+            .as_ref()
+            .expect("replacement must have a matcher");
+        let ctx = EventContext::for_replacement_effect(alice, source_id, &game);
+
+        let noncombat_to_controlled_creature = DamageEvent::with_cause(
+            damage_source_id,
+            DamageTarget::Object(protected_id),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(matcher.matches_event(&noncombat_to_controlled_creature, &ctx));
+
+        let combat_to_controlled_creature = DamageEvent::with_cause(
+            damage_source_id,
+            DamageTarget::Object(protected_id),
+            2,
+            true,
+            crate::events::cause::EventCause::combat_damage(damage_source_id),
+        );
+        assert!(!matcher.matches_event(&combat_to_controlled_creature, &ctx));
+
+        let noncombat_to_opponent_creature = DamageEvent::with_cause(
+            damage_source_id,
+            DamageTarget::Object(opponent_id),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(!matcher.matches_event(&noncombat_to_opponent_creature, &ctx));
+
+        let unpreventable = DamageEvent::unpreventable_with_cause(
+            damage_source_id,
+            DamageTarget::Object(protected_id),
+            2,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+        assert!(!matcher.matches_event(&unpreventable, &ctx));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2452,6 +2452,12 @@ impl StaticAbility {
         Self::new(PreventAllCombatDamageToPermanentsMatching::new(filter))
     }
 
+    pub fn prevent_all_noncombat_damage_to_permanents_matching(
+        filter: crate::target::ObjectFilter,
+    ) -> Self {
+        Self::new(PreventAllNoncombatDamageToPermanentsMatching::new(filter))
+    }
+
     pub fn prevent_all_damage_to_self() -> Self {
         Self::new(PreventAllDamageToSelf)
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -944,6 +944,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::PreventAllCombatDamageToPermanentsMatching(
                 filter,
             ) => StaticAbility::prevent_all_combat_damage_to_permanents_matching(filter.clone()),
+            ironsmith_core::StaticAbilityPayload::PreventAllNoncombatDamageToPermanentsMatching(
+                filter,
+            ) => StaticAbility::prevent_all_noncombat_damage_to_permanents_matching(filter.clone()),
             ironsmith_core::StaticAbilityPayload::HexproofFrom(filter) => {
                 StaticAbility::hexproof_from(filter.clone())
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mark of Asylum
Initial parse error:
```
parser does not yet support line family: 'Prevent all noncombat damage that would be dealt to creatures you control.'; oracle-only fallback also failed: parser does not yet support line family: 'Prevent all noncombat damage that would be dealt to creatures you control.'
```

Current worker: i-045b376ade6777d67
Branch: codex/aws-card-fix-mark-of-asylum
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
