### PR TITLE
Fix Ironsmith parse failure: Alhammarret, High Arbiter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2703,6 +2703,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_pregame_choose_color_line),
         single_static_ability_ast_rule!(parse_activated_abilities_cost_increase_line),
         single_static_ability_ast_rule!(parse_choose_basic_land_type_as_enters_line),
+        single_static_ability_ast_rule!(parse_revealed_hand_choose_nonland_card_name_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_card_name_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_creature_type_as_enters_line),
         single_static_ability_ast_rule!(parse_choose_named_options_as_enters_line),
@@ -4391,6 +4392,40 @@ pub(crate) fn parse_choose_card_name_as_enters_line(
 
     Ok(Some(StaticAbility::choose_card_name_as_enters(format!(
         "As {display_subject} enters, choose a card name."
+    ))))
+}
+
+pub(crate) fn parse_revealed_hand_choose_nonland_card_name_as_enters_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let sentences = split_lexed_sentences(tokens);
+    if sentences.len() != 2 {
+        return Ok(None);
+    }
+
+    let first_words = parser_token_word_refs(sentences[0]);
+    let Some((idx, display_subject)) =
+        parse_as_enters_choice_subject_words(&first_words, AS_ENTERS_STANDARD_SUBJECTS_WITH_AURA)
+    else {
+        return Ok(None);
+    };
+    if first_words.get(idx..) != Some(&["each", "opponent", "reveals", "their", "hand"][..])
+    {
+        return Ok(None);
+    }
+
+    let second_words = parser_token_word_refs(sentences[1]);
+    if second_words
+        != [
+            "you", "choose", "the", "name", "of", "a", "nonland", "card", "revealed",
+            "this", "way",
+        ]
+    {
+        return Ok(None);
+    }
+
+    Ok(Some(StaticAbility::choose_revealed_hand_nonland_card_name_as_enters(format!(
+        "As {display_subject} enters, each opponent reveals their hand. You choose the name of a nonland card revealed this way."
     ))))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8261,6 +8261,36 @@ fn rewrite_keyword_static_as_enters_choice_parsers_share_subject_tables() {
 }
 
 #[test]
+fn rewrite_keyword_static_as_enters_revealed_hand_card_name_choice() {
+    let tokens = lex_line(
+        "as this creature enters, each opponent reveals their hand. you choose the name of a nonland card revealed this way.",
+        0,
+    )
+    .expect("rewrite lexer should classify revealed-hand card-name choice");
+
+    let ability = super::keyword_static::parse_revealed_hand_choose_nonland_card_name_as_enters_line(
+        &tokens,
+    )
+    .expect("revealed-hand card-name choice should parse");
+
+    assert!(matches!(
+        ability,
+        Some(ability)
+            if ability.id() == crate::static_abilities::StaticAbilityId::ChooseCardNameAsEnters
+                && ability.display().contains("each opponent reveals their hand")
+                && ability.display().contains("nonland card revealed this way")
+                && matches!(
+                    &ability.payload,
+                    crate::static_abilities::StaticAbilityPayload::ChooseCardNameAsEnters {
+                        reveal_opponents_hands: true,
+                        require_nonland_from_revealed_opponents: true,
+                        ..
+                    }
+                )
+    ));
+}
+
+#[test]
 fn rewrite_grammar_exile_to_countered_exile_instead_of_graveyard_splitter_matches_static_shape() {
     let tokens = lex_line(
         "If a creature would be put into an opponent's graveyard from anywhere, exile it instead with a stun counter on it.",

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -393,7 +393,11 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     },
     ChoosePlayerAsEnters(String),
     NoteLifeTotalAsEnters(String),
-    ChooseCardNameAsEnters(String),
+    ChooseCardNameAsEnters {
+        display: String,
+        reveal_opponents_hands: bool,
+        require_nonland_from_revealed_opponents: bool,
+    },
     ChooseCreatureTypeAsEnters(String),
     ChooseNamedOptionAsEnters {
         options: Vec<String>,
@@ -1218,9 +1222,15 @@ where
             StaticAbilityPayload::NoteLifeTotalAsEnters(display) => {
                 StaticAbilityPayload::NoteLifeTotalAsEnters(display)
             }
-            StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
-                StaticAbilityPayload::ChooseCardNameAsEnters(display)
-            }
+            StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                reveal_opponents_hands,
+                require_nonland_from_revealed_opponents,
+            } => StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                reveal_opponents_hands,
+                require_nonland_from_revealed_opponents,
+            },
             StaticAbilityPayload::ChooseCreatureTypeAsEnters(display) => {
                 StaticAbilityPayload::ChooseCreatureTypeAsEnters(display)
             }
@@ -3290,7 +3300,23 @@ impl<
         Self {
             id: Some(StaticAbilityId::ChooseCardNameAsEnters),
             label: display.clone(),
-            payload: StaticAbilityPayload::ChooseCardNameAsEnters(display),
+            payload: StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                reveal_opponents_hands: false,
+                require_nonland_from_revealed_opponents: false,
+            },
+        }
+    }
+    pub fn choose_revealed_hand_nonland_card_name_as_enters(display: impl Into<String>) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::ChooseCardNameAsEnters),
+            label: display.clone(),
+            payload: StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                reveal_opponents_hands: true,
+                require_nonland_from_revealed_opponents: true,
+            },
         }
     }
     pub fn redirect_damage_from_you_and_other_permanents_to_source() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -43835,6 +43835,53 @@ fn academic_probation_strict_parser_text_and_structure_regression() {
 }
 
 #[test]
+fn alhammarret_high_arbiter_strict_parser_text_and_structure_regression() {
+    assert_oracle_card_parses_strict("Alhammarret, High Arbiter");
+
+    let def = parse_oracle_card_definition("Alhammarret, High Arbiter");
+    let abilities_debug = format!("{:#?}", def.abilities);
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join("\n");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    let oracle = oracle_text_by_name()
+        .get("Alhammarret, High Arbiter")
+        .expect("Alhammarret oracle text");
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            oracle,
+            &compiled,
+            Some(crate::semantic_compare::EmbeddingConfig {
+                dims: 384,
+                mismatch_threshold: 0.99,
+            }),
+        );
+
+    assert!(
+        abilities_debug.contains("ChooseCardNameAsEnters")
+            && abilities_debug.contains("reveal_opponents_hands: true")
+            && abilities_debug.contains("require_nonland_from_revealed_opponents: true")
+            && abilities_debug.contains("RuleRestriction")
+            && abilities_debug.contains("CastSpellsMatching")
+            && abilities_debug.contains("{chosen name}"),
+        "Alhammarret should lower to an as-enters card-name choice and chosen-name cast restriction, got {abilities_debug}"
+    );
+    assert!(
+        def.spell_effect.is_none(),
+        "Alhammarret's as-enters choice should not lower into a resolving spell effect"
+    );
+    assert!(
+        rendered_lower.contains("each opponent reveals their hand")
+            && rendered_lower.contains("you choose the name of a nonland card revealed this way")
+            && rendered_lower.contains("opponents can't cast spells with the chosen name"),
+        "Alhammarret compiled text should preserve reveal-hand and chosen-name restriction clauses, got {rendered}"
+    );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Alhammarret semantic comparison to clear target, score={similarity}, mismatch={mismatch}, compiled={compiled:?}"
+    );
+}
+
+#[test]
 fn archon_of_valors_reach_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Archon of Valor's Reach");
     let abilities_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1218,6 +1218,7 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(": as long as "))
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
     let uses_named_source_surface = lower.starts_with("this creature gets ")
+        || lower.starts_with("as this enters")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
         || lower.contains("if this creature has one or more ")
@@ -1244,6 +1245,14 @@ pub(super) fn substitute_legendary_source_reference(
         .strip_prefix("Whenever this or another ")
         .map(|rest| format!("Whenever {source_name} or another {rest}"))
         .unwrap_or_else(|| line.to_string());
+
+    let line = if let Some(rest) = line.strip_prefix("As this enters") {
+        format!("As {source_name} enters{rest}")
+    } else if let Some(rest) = line.strip_prefix("as this enters") {
+        format!("As {source_name} enters{rest}")
+    } else {
+        line
+    };
 
     let substituted = [
         ("This creature", source_name),

--- a/crates/ironsmith-runtime/src/effect.rs
+++ b/crates/ironsmith-runtime/src/effect.rs
@@ -894,19 +894,20 @@ impl RestrictionExt for Restriction {
             Restriction::CastSpellsMatching(filter, spell_filter) => {
                 for player in &game.players {
                     if player.is_in_game() && player_matches_restriction_filter(player.id, filter) {
-                        if spell_filter.name.as_deref() == Some("{chosen name}")
-                            && let Some(source) = source
-                            && let Some(chosen_names) = game.chosen_named_option(source)
-                        {
-                            for chosen_name in chosen_names.lines().map(str::trim) {
-                                if !chosen_name.is_empty() {
-                                    let mut resolved_filter = spell_filter.clone();
-                                    resolved_filter.name = Some(chosen_name.to_string());
-                                    tracker.add_cant_cast_filter_from_source(
-                                        player.id,
-                                        resolved_filter,
-                                        Some(source),
-                                    );
+                        if spell_filter.name.as_deref() == Some("{chosen name}") {
+                            if let Some(source) = source
+                                && let Some(chosen_names) = game.chosen_named_option(source)
+                            {
+                                for chosen_name in chosen_names.lines().map(str::trim) {
+                                    if !chosen_name.is_empty() {
+                                        let mut resolved_filter = spell_filter.clone();
+                                        resolved_filter.name = Some(chosen_name.to_string());
+                                        tracker.add_cant_cast_filter_from_source(
+                                            player.id,
+                                            resolved_filter,
+                                            Some(source),
+                                        );
+                                    }
                                 }
                             }
                         } else {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -7768,6 +7768,220 @@ impl DecisionMaker for CaptureRevealDecisionMaker {
     }
 }
 
+struct AlhammarretChoiceDecisionMaker {
+    name: &'static str,
+    view_calls: Vec<(PlayerId, PlayerId, Zone, bool, Vec<ObjectId>)>,
+}
+
+impl AlhammarretChoiceDecisionMaker {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            view_calls: Vec::new(),
+        }
+    }
+}
+
+impl DecisionMaker for AlhammarretChoiceDecisionMaker {
+    fn decide_text(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::TextInputContext,
+    ) -> String {
+        self.name.to_string()
+    }
+
+    fn view_cards(
+        &mut self,
+        _game: &GameState,
+        viewer: PlayerId,
+        cards: &[ObjectId],
+        ctx: &crate::decisions::context::ViewCardsContext,
+    ) {
+        self.view_calls
+            .push((viewer, ctx.subject, ctx.zone, ctx.public, cards.to_vec()));
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn alhammarret_high_arbiter_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(91_201), "Alhammarret, High Arbiter")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(5)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Sphinx])
+        .power_toughness(PowerToughness::fixed(5, 5))
+        .parse_text(
+            "Flying\nAs Alhammarret enters, each opponent reveals their hand. You choose the name of a nonland card revealed this way.\nYour opponents can't cast spells with the chosen name (as long as this creature is on the battlefield).",
+        )
+        .expect("Alhammarret should parse for runtime regression")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn named_spell_definition(card_id: u32, name: &str) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(card_id), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .card_types(vec![CardType::Instant])
+        .with_spell_effect(vec![Effect::draw(1)])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn named_land_definition(card_id: u32, name: &str) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(card_id), name)
+        .card_types(vec![CardType::Land])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn alhammarret_high_arbiter_reveals_opponents_hand_and_blocks_chosen_nonland_name() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let alhammarret = alhammarret_high_arbiter_definition();
+    let lightning = named_spell_definition(91_202, "Lightning Bolt");
+    let giant_growth = named_spell_definition(91_203, "Giant Growth");
+    let forest = named_land_definition(91_204, "Forest");
+
+    let alhammarret_hand = game.create_object_from_definition(&alhammarret, alice, Zone::Hand);
+    let bob_lightning = game.create_object_from_definition(&lightning, bob, Zone::Hand);
+    let bob_other = game.create_object_from_definition(&giant_growth, bob, Zone::Hand);
+    let bob_forest = game.create_object_from_definition(&forest, bob, Zone::Hand);
+    let alice_lightning = game.create_object_from_definition(&lightning, alice, Zone::Hand);
+
+    let mut dm = AlhammarretChoiceDecisionMaker::new("Lightning Bolt");
+    let result = game
+        .move_object_with_etb_processing_with_dm(alhammarret_hand, Zone::Battlefield, &mut dm)
+        .expect("Alhammarret should enter the battlefield");
+    game.update_cant_effects();
+
+    assert_eq!(
+        game.chosen_named_option(result.new_id).map(str::to_string),
+        Some("Lightning Bolt".to_string()),
+        "Alhammarret should store the nonland name chosen from an opponent's revealed hand"
+    );
+    assert_eq!(dm.view_calls.len(), 2, "Bob's hand should be revealed to both players");
+    assert!(dm.view_calls.iter().all(|(_, subject, zone, public, cards)| {
+        *subject == bob
+            && *zone == Zone::Hand
+            && *public
+            && cards == &vec![bob_lightning, bob_other, bob_forest]
+    }));
+
+    let bob_filter_debug = format!(
+        "{:?}",
+        game.effect_store
+            .cant_effects
+            .cast_filters_for_player(bob)
+    );
+    let alice_filter_debug = format!(
+        "{:?}",
+        game.effect_store
+            .cant_effects
+            .cast_filters_for_player(alice)
+    );
+    assert!(
+        bob_filter_debug.contains("Lightning Bolt") && !bob_filter_debug.contains("Giant Growth"),
+        "Alhammarret should add only a Bob-side cast prohibition for the chosen nonland name, got {bob_filter_debug}"
+    );
+    assert!(
+        alice_filter_debug == "None",
+        "Alhammarret should not restrict its controller, got {alice_filter_debug}"
+    );
+    game.move_object_by_effect(result.new_id, Zone::Graveyard)
+        .expect("Alhammarret should be movable off the battlefield");
+    game.update_cant_effects();
+    assert!(
+        game.effect_store
+            .cant_effects
+            .cast_filters_for_player(bob)
+            .is_none(),
+        "Alhammarret's chosen-name restriction should end when it leaves the battlefield"
+    );
+    assert!(
+        game.object(bob_lightning).is_some()
+            && game.object(bob_other).is_some()
+            && game.object(alice_lightning).is_some(),
+        "test spells should remain in hand while checking cast restrictions"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn alhammarret_high_arbiter_rejects_revealed_land_name_choice() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let alhammarret = alhammarret_high_arbiter_definition();
+    let lightning = named_spell_definition(91_205, "Lightning Bolt");
+    let forest = named_land_definition(91_206, "Forest");
+
+    let alhammarret_hand = game.create_object_from_definition(&alhammarret, alice, Zone::Hand);
+    let bob_lightning = game.create_object_from_definition(&lightning, bob, Zone::Hand);
+    game.create_object_from_definition(&forest, bob, Zone::Hand);
+
+    let mut dm = AlhammarretChoiceDecisionMaker::new("Forest");
+    let result = game
+        .move_object_with_etb_processing_with_dm(alhammarret_hand, Zone::Battlefield, &mut dm)
+        .expect("Alhammarret should enter the battlefield");
+    game.update_cant_effects();
+
+    assert!(
+        game.chosen_named_option(result.new_id).is_none(),
+        "Alhammarret should reject land names even when revealed"
+    );
+    assert!(
+        game.effect_store
+            .cant_effects
+            .cast_filters_for_player(bob)
+            .is_none(),
+        "without a valid nonland revealed choice, Alhammarret should not add a cast prohibition"
+    );
+    assert!(
+        game.object(bob_lightning).is_some(),
+        "Bob's Lightning Bolt should remain available in hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn alhammarret_high_arbiter_rejects_unrevealed_nonland_name_choice() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let alhammarret = alhammarret_high_arbiter_definition();
+    let lightning = named_spell_definition(91_207, "Lightning Bolt");
+
+    let alhammarret_hand = game.create_object_from_definition(&alhammarret, alice, Zone::Hand);
+    let bob_lightning = game.create_object_from_definition(&lightning, bob, Zone::Hand);
+
+    let mut dm = AlhammarretChoiceDecisionMaker::new("Giant Growth");
+    let result = game
+        .move_object_with_etb_processing_with_dm(alhammarret_hand, Zone::Battlefield, &mut dm)
+        .expect("Alhammarret should enter the battlefield");
+    game.update_cant_effects();
+
+    assert!(
+        game.chosen_named_option(result.new_id).is_none(),
+        "Alhammarret should reject nonland names that were not revealed from an opponent's hand"
+    );
+    assert!(
+        game.effect_store
+            .cant_effects
+            .cast_filters_for_player(bob)
+            .is_none(),
+        "without a revealed nonland choice, Alhammarret should not add a cast prohibition"
+    );
+    assert!(
+        game.object(bob_lightning).is_some(),
+        "Bob's Lightning Bolt should remain available in hand"
+    );
+}
+
 #[test]
 fn test_generate_damage_triggers_emits_life_loss_for_player_damage() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -4779,7 +4779,32 @@ impl GameState {
                             self.set_chosen_player(new_id, options[chosen_idx]);
                         }
                     }
-                    if static_ability.card_name_choice_as_enters().is_some() {
+                    if let Some(spec) = static_ability.card_name_choice_as_enters() {
+                        if spec.reveal_opponents_hands {
+                            let opponent_ids = self
+                                .players
+                                .iter()
+                                .filter(|player| player.is_in_game() && player.id != controller)
+                                .map(|player| player.id)
+                                .collect::<Vec<_>>();
+                            for opponent_id in opponent_ids {
+                                let cards = self
+                                    .player(opponent_id)
+                                    .map(|player| player.hand.clone())
+                                    .unwrap_or_default();
+                                for viewer_idx in 0..self.players.len() {
+                                    let viewer = crate::ids::PlayerId::from_index(viewer_idx as u8);
+                                    let mut view_ctx = crate::decisions::context::ViewCardsContext::look_at_hand(
+                                        viewer,
+                                        opponent_id,
+                                        Some(new_id),
+                                    );
+                                    view_ctx.description = "Reveal that player's hand".to_string();
+                                    view_ctx.public = true;
+                                    decision_maker.view_cards(self, viewer, &cards, &view_ctx);
+                                }
+                            }
+                        }
                         let choice_ctx = crate::decisions::context::TextInputContext::new(
                             controller,
                             Some(new_id),
@@ -4801,6 +4826,20 @@ impl GameState {
                             .get(chosen_name)
                             .map(|definition| definition.name().to_string())
                             .unwrap_or_else(|| chosen_name.to_string());
+                        if spec.require_nonland_from_revealed_opponents
+                            && !self
+                                .players
+                                .iter()
+                                .filter(|player| player.is_in_game() && player.id != controller)
+                                .flat_map(|player| player.hand.iter().copied())
+                                .filter_map(|object_id| self.object(object_id))
+                                .any(|object| {
+                                    !object.is_land()
+                                        && object.name.eq_ignore_ascii_case(&canonical_name)
+                                })
+                        {
+                            continue;
+                        }
                         self.set_chosen_named_option(new_id, canonical_name);
                     }
                     if let Some(spec) = static_ability.named_option_choice_as_enters() {

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1631,11 +1631,22 @@ impl StaticAbilityKind for NoteLifeTotalAsEnters {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChooseCardNameAsEnters {
     pub display: String,
+    pub reveal_opponents_hands: bool,
+    pub require_nonland_from_revealed_opponents: bool,
 }
 
 impl ChooseCardNameAsEnters {
     pub fn new(display: String) -> Self {
-        Self { display }
+        Self::with_spec(display, ChooseCardNameAsEntersSpec::default())
+    }
+
+    pub fn with_spec(display: String, spec: ChooseCardNameAsEntersSpec) -> Self {
+        Self {
+            display,
+            reveal_opponents_hands: spec.reveal_opponents_hands,
+            require_nonland_from_revealed_opponents: spec
+                .require_nonland_from_revealed_opponents,
+        }
     }
 }
 
@@ -1649,7 +1660,10 @@ impl StaticAbilityKind for ChooseCardNameAsEnters {
     }
 
     fn card_name_choice_as_enters(&self) -> Option<ChooseCardNameAsEntersSpec> {
-        Some(ChooseCardNameAsEntersSpec)
+        Some(ChooseCardNameAsEntersSpec {
+            reveal_opponents_hands: self.reveal_opponents_hands,
+            require_nonland_from_revealed_opponents: self.require_nonland_from_revealed_opponents,
+        })
     }
 }
 

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -981,7 +981,10 @@ pub struct NoteLifeTotalAsEntersSpec;
 
 /// Spec for "as this enters, choose a card name" abilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ChooseCardNameAsEntersSpec;
+pub struct ChooseCardNameAsEntersSpec {
+    pub reveal_opponents_hands: bool,
+    pub require_nonland_from_revealed_opponents: bool,
+}
 
 /// Spec for "as this enters, choose a basic land type" abilities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -2722,6 +2725,23 @@ impl StaticAbility {
 
     pub fn choose_card_name_as_enters(display: String) -> Self {
         Self::new(ChooseCardNameAsEnters::new(display))
+    }
+
+    pub fn choose_card_name_as_enters_with_spec(
+        display: String,
+        spec: ChooseCardNameAsEntersSpec,
+    ) -> Self {
+        Self::new(ChooseCardNameAsEnters::with_spec(display, spec))
+    }
+
+    pub fn choose_revealed_hand_nonland_card_name_as_enters(display: String) -> Self {
+        Self::choose_card_name_as_enters_with_spec(
+            display,
+            ChooseCardNameAsEntersSpec {
+                reveal_opponents_hands: true,
+                require_nonland_from_revealed_opponents: true,
+            },
+        )
     }
 
     pub fn choose_basic_land_type_as_enters(display: String) -> Self {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1200,9 +1200,17 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::NoteLifeTotalAsEnters(display) => {
                 StaticAbility::note_life_total_as_enters(display.clone())
             }
-            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters(display) => {
-                StaticAbility::choose_card_name_as_enters(display.clone())
-            }
+            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters {
+                display,
+                reveal_opponents_hands,
+                require_nonland_from_revealed_opponents,
+            } => StaticAbility::choose_card_name_as_enters_with_spec(
+                display.clone(),
+                super::ChooseCardNameAsEntersSpec {
+                    reveal_opponents_hands: *reveal_opponents_hands,
+                    require_nonland_from_revealed_opponents: *require_nonland_from_revealed_opponents,
+                },
+            ),
             ironsmith_core::StaticAbilityPayload::ChooseCreatureTypeAsEnters(display) => {
                 StaticAbility::choose_creature_type_as_enters(display.clone())
             }
@@ -1926,11 +1934,18 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
     }
 
     fn card_name_choice_as_enters(&self) -> Option<super::ChooseCardNameAsEntersSpec> {
-        matches!(
-            self.payload(),
-            ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters(_)
-        )
-        .then_some(super::ChooseCardNameAsEntersSpec)
+        let ironsmith_core::StaticAbilityPayload::ChooseCardNameAsEnters {
+            reveal_opponents_hands,
+            require_nonland_from_revealed_opponents,
+            ..
+        } = self.payload()
+        else {
+            return None;
+        };
+        Some(super::ChooseCardNameAsEntersSpec {
+            reveal_opponents_hands: *reveal_opponents_hands,
+            require_nonland_from_revealed_opponents: *require_nonland_from_revealed_opponents,
+        })
     }
 
     fn basic_land_type_choice_as_enters(&self) -> Option<super::ChooseBasicLandTypeAsEntersSpec> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Alhammarret, High Arbiter
Initial parse error:
```
compiled text dropped required semantic marker: reveals-hand
```

Current worker: i-0d9ec7f90f4ad1c82
Branch: codex/aws-card-fix-alhammarret-high-arbiter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
