### PR TITLE
Fix Ironsmith parse failure: Gloomshrieker

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2102,6 +2102,30 @@ fn simple_would_die_exile_player_filter(words: &[&str]) -> Option<PlayerFilter> 
         .find_map(|(phrase, player)| (*phrase == words).then(|| player.clone()))
 }
 
+fn simple_source_would_die_exile_filter(words: &[&str]) -> Option<ObjectFilter> {
+    let source_type = match words {
+        ["if", "this", "creature", "would", "die", "exile", "it", "instead"] => {
+            Some(CardType::Creature)
+        }
+        ["if", "this", "artifact", "would", "die", "exile", "it", "instead"] => {
+            Some(CardType::Artifact)
+        }
+        ["if", "this", "enchantment", "would", "die", "exile", "it", "instead"] => {
+            Some(CardType::Enchantment)
+        }
+        ["if", "this", "permanent", "would", "die", "exile", "it", "instead"]
+        | ["if", "this", "object", "would", "die", "exile", "it", "instead"]
+        | ["if", "this", "would", "die", "exile", "it", "instead"] => None,
+        _ => return None,
+    };
+
+    let filter = match source_type {
+        Some(card_type) => ObjectFilter::source().with_type(card_type),
+        None => ObjectFilter::source(),
+    };
+    Some(filter)
+}
+
 fn max_hand_size_subject_prefix(words: &[&str]) -> Option<(PlayerFilter, usize)> {
     if MAX_HAND_SIZE_YOU_SUBJECT_PATTERN.matches_words(words) {
         Some((PlayerFilter::You, 1))
@@ -10881,6 +10905,10 @@ pub(crate) fn parse_exile_would_die_instead_line(
                 StaticAbility::exile_would_die_instead_with_damage_source(victim, Some(damaged_by)),
             ));
         }
+    }
+
+    if let Some(filter) = simple_source_would_die_exile_filter(&words) {
+        return Ok(Some(StaticAbility::exile_would_die_instead(filter)));
     }
 
     let Some(player) = simple_would_die_exile_player_filter(&words) else {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -11198,6 +11198,19 @@ fn rewrite_rayami_nontoken_creature_would_die_with_blood_counter_static_replacem
 }
 
 #[test]
+fn rewrite_this_creature_would_die_static_replacement() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Self-Exiling Creature Variant")
+        .card_types(vec![CardType::Creature])
+        .parse_text("If this creature would die, exile it instead.")
+        .expect("self death replacement should parse");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(debug.contains("ExileWouldDieInstead"), "{debug}");
+    assert!(debug.contains("source: true"), "{debug}");
+    assert!(debug.contains("Creature"), "{debug}");
+}
+
+#[test]
 fn rewrite_exile_counter_cast_permission_with_mana_permission_static_line() {
     let line = "You may cast spells from among cards in exile your opponents own with ice counters on them, and you may spend mana from snow sources as though it were mana of any color to cast those spells.";
     let tokens = lex_line(line, 0).expect("permission line should lex");

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -24649,6 +24649,185 @@ fn burn_the_accursed_regression_uses_oracle_like_damage_and_die_replacement_text
 }
 
 #[test]
+fn gloomshrieker_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Gloomshrieker");
+    let def = parse_oracle_card_definition("Gloomshrieker");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        lower.contains("menace"),
+        "expected Gloomshrieker menace text, got {rendered}"
+    );
+    assert!(
+        lower.contains(
+            "when this creature enters, return target permanent card from your graveyard to your hand"
+        ),
+        "expected Gloomshrieker ETB return text, got {rendered}"
+    );
+    assert!(
+        lower.contains("if this creature would die, exile it instead"),
+        "expected self death replacement text, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("ExileWouldDieInstead")
+            && abilities_debug.contains("source: true")
+            && abilities_debug.contains("Creature"),
+        "expected source-scoped creature death replacement, got {abilities_debug}"
+    );
+}
+
+#[test]
+fn gloomshrieker_enters_returns_target_permanent_card_from_your_graveyard_to_hand() {
+    let def = parse_oracle_card_definition("Gloomshrieker");
+    let nonpermanent = CardDefinitionBuilder::new(CardId::new(), "Gloomshrieker Test Instant")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let permanent = CardDefinitionBuilder::new(CardId::new(), "Gloomshrieker Test Artifact")
+        .card_types(vec![CardType::Artifact])
+        .build();
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    game.create_object_from_definition(&nonpermanent, alice, Zone::Graveyard);
+    game.create_object_from_definition(&permanent, alice, Zone::Graveyard);
+    let gloom_in_hand = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let gloom_snapshot =
+        crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(
+            game.object(gloom_in_hand)
+                .expect("Gloomshrieker should be in hand before entering"),
+            &game,
+        );
+    let gloom = game
+        .move_object_with_etb_processing(gloom_in_hand, Zone::Battlefield)
+        .expect("Gloomshrieker should enter")
+        .new_id;
+
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::ZoneChangeEvent::with_results(
+            gloom,
+            vec![gloom],
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(gloom_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let triggered = crate::triggers::check_triggers(&game, &event);
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for entry in triggered.into_iter().filter(|entry| entry.source == gloom) {
+        trigger_queue.add(entry);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Gloomshrieker should trigger once when it enters"
+    );
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    crate::game_loop::put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Gloomshrieker trigger should go on the stack with a legal target");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Gloomshrieker trigger should resolve");
+
+    let hand_names: Vec<String> = game
+        .objects_in_zone(Zone::Hand)
+        .into_iter()
+        .filter_map(|id| game.object(id).map(|object| object.name.clone()))
+        .collect();
+    let graveyard_names: Vec<String> = game
+        .objects_in_zone(Zone::Graveyard)
+        .into_iter()
+        .filter_map(|id| game.object(id).map(|object| object.name.clone()))
+        .collect();
+
+    assert!(
+        hand_names.iter().any(|name| name == "Gloomshrieker Test Artifact"),
+        "the permanent card target should move to hand, hand={hand_names:?}"
+    );
+    assert!(
+        graveyard_names
+            .iter()
+            .any(|name| name == "Gloomshrieker Test Instant"),
+        "the nonpermanent card should not be a legal target, graveyard={graveyard_names:?}"
+    );
+}
+
+#[test]
+fn gloomshrieker_death_replacement_exiles_only_gloomshrieker() {
+    let def = parse_oracle_card_definition("Gloomshrieker");
+    let decoy_def = CardDefinitionBuilder::new(CardId::new(), "Gloomshrieker Test Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let gloom = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let decoy = game.create_object_from_definition(&decoy_def, alice, Zone::Battlefield);
+    game.update_replacement_effects();
+
+    let decoy_destination = crate::events::processing::process_zone_change_with_event(
+        &mut game,
+        decoy,
+        Zone::Battlefield,
+        Zone::Graveyard,
+        crate::events::cause::EventCause::from_sba(),
+    )
+    .expect("decoy death should not be prevented");
+    assert_eq!(
+        decoy_destination,
+        Zone::Graveyard,
+        "Gloomshrieker's replacement must not affect other creatures"
+    );
+    game.move_object_by_sba(decoy, decoy_destination)
+        .expect("decoy should move to graveyard");
+
+    let gloom_destination = crate::events::processing::process_zone_change_with_event(
+        &mut game,
+        gloom,
+        Zone::Battlefield,
+        Zone::Graveyard,
+        crate::events::cause::EventCause::from_sba(),
+    )
+    .expect("Gloomshrieker death should not be prevented");
+    assert_eq!(
+        gloom_destination,
+        Zone::Exile,
+        "Gloomshrieker should be exiled instead of going to the graveyard"
+    );
+    game.move_object_by_sba(gloom, gloom_destination)
+        .expect("Gloomshrieker should move to exile");
+
+    let exile_names: Vec<String> = game
+        .objects_in_zone(Zone::Exile)
+        .into_iter()
+        .filter_map(|id| game.object(id).map(|object| object.name.clone()))
+        .collect();
+    let graveyard_names: Vec<String> = game
+        .objects_in_zone(Zone::Graveyard)
+        .into_iter()
+        .filter_map(|id| game.object(id).map(|object| object.name.clone()))
+        .collect();
+
+    assert!(
+        exile_names.iter().any(|name| name == "Gloomshrieker"),
+        "Gloomshrieker should end in exile, exile={exile_names:?}"
+    );
+    assert!(
+        graveyard_names
+            .iter()
+            .any(|name| name == "Gloomshrieker Test Bear"),
+        "the decoy creature should end in the graveyard, graveyard={graveyard_names:?}"
+    );
+    assert!(
+        !graveyard_names.iter().any(|name| name == "Gloomshrieker"),
+        "Gloomshrieker should not be in the graveyard, graveyard={graveyard_names:?}"
+    );
+}
+
+#[test]
 fn moira_and_teshar_regression_keeps_leave_battlefield_instead_marker() {
     let def = parse_oracle_card_definition("Moira and Teshar");
     let rendered = unprocessed_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -5086,6 +5086,16 @@ impl ExileWouldDieInstead {
     }
 }
 
+fn is_simple_source_would_die_filter(filter: &ObjectFilter) -> bool {
+    if !filter.source || filter.card_types.len() > 1 {
+        return false;
+    }
+
+    let mut filter_without_type = filter.clone();
+    filter_without_type.card_types.clear();
+    filter_without_type == ObjectFilter::source()
+}
+
 impl StaticAbilityKind for ExileWouldDieInstead {
     fn id(&self) -> StaticAbilityId {
         StaticAbilityId::ExileWouldDieInstead
@@ -5138,6 +5148,13 @@ impl StaticAbilityKind for ExileWouldDieInstead {
                     effects: self.follow_up_effects.clone(),
                 },
             ));
+        }
+
+        if is_simple_source_would_die_filter(&self.filter)
+            && self.exile_with_counters.is_empty()
+            && self.follow_up_effects.is_empty()
+        {
+            return Some(ReplacementEffect::exile_instead_of_dying(source, controller));
         }
 
         Some(ReplacementEffect::with_matcher(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gloomshrieker
Initial parse error:
```
unsupported predicate (predicate: 'this creature would die'); oracle-only fallback also failed: unsupported predicate (predicate: 'this creature would die')
```

Current worker: i-0767ae4772c41ea2a
Branch: codex/aws-card-fix-gloomshrieker
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0001
