### PR TITLE
Fix Ironsmith parse failure: Barrensteppe Siege

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/block_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/block_parsing.rs
@@ -79,6 +79,10 @@ pub(super) fn try_parse_modal_bullet_block(
     idx: usize,
     line: &PreprocessedLine,
 ) -> Result<Option<(RewriteLineCst, usize)>, CardTextError> {
+    if is_named_option_as_enters_choice_header(line) {
+        return Ok(None);
+    }
+
     let mut bullet_modes = Vec::new();
     let mut probe_idx = idx + 1;
     while let Some(PreprocessedItem::Line(next_line)) = preprocessed.items.get(probe_idx) {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/block_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/block_parsing.rs
@@ -79,6 +79,9 @@ pub(super) fn try_parse_modal_bullet_block(
     idx: usize,
     line: &PreprocessedLine,
 ) -> Result<Option<(RewriteLineCst, usize)>, CardTextError> {
+    if is_bullet_line(line) {
+        return Ok(None);
+    }
     if is_named_option_as_enters_choice_header(line) {
         return Ok(None);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -215,6 +215,41 @@ fn is_bullet_line(line: &PreprocessedLine) -> bool {
             .is_some_and(|token| token.kind == TokenKind::Number)
 }
 
+fn strip_choice_bullet_prefix_tokens(tokens: &[OwnedLexToken]) -> &[OwnedLexToken] {
+    if tokens
+        .first()
+        .is_some_and(|token| matches!(token.kind, TokenKind::Bullet | TokenKind::Dash))
+    {
+        tokens.get(1..).unwrap_or_default()
+    } else {
+        tokens
+    }
+}
+
+fn is_named_option_as_enters_choice_header(line: &PreprocessedLine) -> bool {
+    let words = token_word_refs(&line.tokens);
+    let Some(as_idx) = words.iter().position(|word| *word == "as") else {
+        return false;
+    };
+    let Some(enters_idx) = words
+        .iter()
+        .enumerate()
+        .skip(as_idx + 1)
+        .find_map(|(idx, word)| (*word == "enters").then_some(idx))
+    else {
+        return false;
+    };
+    let Some(choose_idx) = words
+        .iter()
+        .enumerate()
+        .skip(enters_idx + 1)
+        .find_map(|(idx, word)| (*word == "choose").then_some(idx))
+    else {
+        return false;
+    };
+    words.iter().skip(choose_idx + 1).any(|word| *word == "or")
+}
+
 fn starts_with_pawprint_modal_label(tokens: &[OwnedLexToken]) -> bool {
     let mut seen_pawprint = false;
     let mut idx = 0;
@@ -856,10 +891,12 @@ fn trigger_presentation_label_from_preprocessed_line(line: &PreprocessedLine) ->
 }
 
 fn is_nonkeyword_choice_labeled_line(line: &PreprocessedLine) -> bool {
-    split_label_prefix_lexed(&line.tokens).is_some_and(|(label, _, _)| {
+    split_label_prefix_lexed(strip_choice_bullet_prefix_tokens(&line.tokens)).is_some_and(
+        |(label, _, _)| {
         !preserve_keyword_prefix_for_parse(label.as_str())
             && !is_named_ability_label(label.as_str())
-    })
+        },
+    )
 }
 
 fn trigger_presentation_label(label: &str) -> String {
@@ -3845,8 +3882,16 @@ pub(crate) fn parse_document_cst(
                 {
                     return Err(err);
                 }
-                let dispatch =
-                    dispatch_standard_line_cst(preprocessed, idx, line, allow_unsupported)?;
+                let dispatch = if is_bullet_line(line)
+                    && split_label_prefix_lexed(strip_choice_bullet_prefix_tokens(&line.tokens))
+                        .is_some()
+                {
+                    let stripped_line =
+                        rewrite_line_tokens(line, strip_choice_bullet_prefix_tokens(&line.tokens));
+                    dispatch_standard_line_cst(preprocessed, idx, &stripped_line, allow_unsupported)?
+                } else {
+                    dispatch_standard_line_cst(preprocessed, idx, line, allow_unsupported)?
+                };
                 for cst in &dispatch.lines {
                     trace_cst_line(cst);
                 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -975,6 +975,25 @@ fn labeled_choice_block_has_peer(items: &[PreprocessedItem], idx: usize) -> bool
     false
 }
 
+fn labeled_choice_block_has_named_option_header(items: &[PreprocessedItem], idx: usize) -> bool {
+    let mut probe = idx;
+    while probe > 0 {
+        probe -= 1;
+        match items.get(probe) {
+            Some(PreprocessedItem::Line(line)) if is_named_option_as_enters_choice_header(line) => {
+                return true;
+            }
+            Some(PreprocessedItem::Line(line)) if is_nonkeyword_choice_labeled_line(line) => {
+                continue;
+            }
+            Some(PreprocessedItem::Metadata(_)) => continue,
+            Some(PreprocessedItem::Line(_)) | None => break,
+        }
+    }
+
+    false
+}
+
 fn normalize_trailing_keyword_activation_sentence_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<(Vec<OwnedLexToken>, Vec<OwnedLexToken>)> {
@@ -1674,8 +1693,8 @@ mod tests {
         normalize_named_source_trigger_for_builder, normalize_statement_parse_groups_lexed,
         normalize_trailing_keyword_activation_sentence_lexed,
         parse_colon_nonactivation_statement_fallback, parse_keyword_line_cst, parse_level_item_cst,
-        parse_statement_line_cst, parse_static_line_cst, parse_triggered_line_cst,
-        preprocess_document, probe_triggered_split, render_token_slice,
+        parse_statement_line_cst, parse_static_line_cst, parse_text_to_semantic_document,
+        parse_triggered_line_cst, preprocess_document, probe_triggered_split, render_token_slice,
         rewrite_keyword_dash_parse_tokens, rewrite_when_one_or_more_this_way_line,
         split_activation_text_parts_lexed, split_label_prefix, split_label_prefix_lexed,
         split_reveal_first_draw_line_rewrite_lexed, split_trigger_sentence_chunks_rewrite_lexed,
@@ -2460,6 +2479,73 @@ mod tests {
     }
 
     #[test]
+    fn triggered_conditional_split_accepts_creature_died_under_your_control() {
+        let line = single_preprocessed_line(
+            "At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice",
+        );
+
+        let parsed = parse_triggered_line_cst(&line)
+            .expect("Barrensteppe Siege Mardu trigger should parse");
+
+        assert_eq!(parsed.trigger_text, "the beginning of your end step");
+        assert!(
+            parsed.effect_text.contains("each opponent sacrifices a creature of their choice"),
+            "expected sacrifice-choice effect text, got {}",
+            parsed.effect_text
+        );
+        assert!(
+            matches!(
+                parsed.intervening_if,
+                Some(crate::cards::builders::PredicateAst::ValueComparison { .. })
+            ),
+            "expected controller-qualified death predicate, got {:?}",
+            parsed.intervening_if
+        );
+    }
+
+    #[test]
+    fn triggered_end_step_puts_counters_on_each_creature_you_control() {
+        let line = single_preprocessed_line(
+            "At the beginning of your end step, put a +1/+1 counter on each creature you control.",
+        );
+
+        let parsed = parse_triggered_line_cst(&line)
+            .expect("Barrensteppe Siege Abzan trigger should parse");
+
+        assert_eq!(parsed.trigger_text, "the beginning of your end step");
+        assert!(
+            parsed.effect_text.contains("put a +1/+1 counter on each creature you control"),
+            "expected counter effect text, got {}",
+            parsed.effect_text
+        );
+    }
+
+    #[test]
+    fn bullet_choice_labels_are_detected_as_choice_peers() {
+        let line = single_preprocessed_line(
+            "• Mardu — At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
+        );
+
+        assert!(
+            super::is_nonkeyword_choice_labeled_line(&line),
+            "expected bullet-prefixed option label to be detected as a choice peer"
+        );
+    }
+
+    #[test]
+    fn barrensteppe_siege_choice_block_parses_both_bullet_options() {
+        let (semantic, _) = parse_text_to_semantic_document(
+            CardDefinitionBuilder::new(CardId::new(), "Barrensteppe Siege")
+                .card_types(vec![CardType::Enchantment]),
+            "As this enchantment enters, choose Abzan or Mardu.\n• Abzan — At the beginning of your end step, put a +1/+1 counter on each creature you control.\n• Mardu — At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.".to_string(),
+            false,
+        )
+        .expect("Barrensteppe Siege choice block should parse");
+
+        assert_eq!(semantic.items.len(), 3);
+    }
+
+    #[test]
     fn triggered_presentation_label_is_derived_from_lexed_line_tokens() {
         let tokens = lex_line(
             "Mold Earth — Whenever one or more lands enter under an opponent's control without being played, draw a card.",
@@ -3188,7 +3274,8 @@ fn try_parse_labeled_line_dispatch(
     };
 
     let is_named_label = is_named_ability_label(label.as_str());
-    let preserve_as_choice_label = labeled_choice_block_has_peer(&preprocessed.items, idx);
+    let preserve_as_choice_label = labeled_choice_block_has_peer(&preprocessed.items, idx)
+        && labeled_choice_block_has_named_option_header(&preprocessed.items, idx);
     if preserve_keyword_prefix_for_parse(label.as_str()) {
         return Ok(None);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -188,6 +188,9 @@ pub(super) fn extend_triggered_line_with_result_followups(
     let mut next_idx = idx + 1;
 
     while let Some(PreprocessedItem::Line(line)) = items.get(next_idx) {
+        if super::is_nonkeyword_choice_labeled_line(line) {
+            break;
+        }
         if !is_trigger_result_followup_line(line) {
             break;
         }
@@ -218,6 +221,9 @@ pub(super) fn extend_activated_line_with_result_followups(
     let mut next_idx = idx + 1;
 
     while let Some(PreprocessedItem::Line(line)) = items.get(next_idx) {
+        if super::is_nonkeyword_choice_labeled_line(line) {
+            break;
+        }
         if !is_trigger_result_followup_line(line) {
             break;
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/conditions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/conditions.rs
@@ -349,6 +349,7 @@ pub(crate) struct ObjectDeathThisTurnConditionAst {
     pub(crate) event: ObjectDeathThisTurnEventAst,
     pub(crate) filter: ObjectFilter,
     pub(crate) comparison: Comparison,
+    pub(crate) under_controller: Option<PlayerFilter>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1677,6 +1678,35 @@ fn parse_object_died_this_turn_shape(
 ) -> Option<ObjectDeathThisTurnConditionAst> {
     let clause = LexedClause::new(tokens);
     let object_phrases: &[&[&str]] = &[&["creature"], &["creatures"]];
+    if let Some(matched) = LexPattern::new(&[
+        LexPattern::amount("amount", LexCaptureKind::UntilAnyPhrase(object_phrases)),
+        LexPattern::object("object", LexCaptureKind::OneOf(&["creature", "creatures"])),
+        LexPattern::action("action", LexCaptureKind::OneOf(&["died"])),
+        LexPattern::phrase(&["under", "your", "control"]),
+        LexPattern::phrase(&["this", "turn"]),
+    ])
+    .match_clause(clause)
+    {
+        let amount_capture = matched.capture_by_role(LexCaptureRole::Amount)?;
+        let comparison = if amount_capture.word_range.is_empty() {
+            Comparison::GreaterThanOrEqual(1)
+        } else {
+            let amount_clause = matched.capture_clause_by_role(LexCaptureRole::Amount, clause)?;
+            if clause_matches_phrase(amount_clause, &["a"]) {
+                Comparison::GreaterThanOrEqual(1)
+            } else {
+                parse_amount_capture_comparison(tokens, clause, &matched, "object-death condition")?
+            }
+        };
+
+        return Some(ObjectDeathThisTurnConditionAst {
+            event: ObjectDeathThisTurnEventAst::Died,
+            filter: ObjectFilter::creature(),
+            comparison,
+            under_controller: Some(PlayerFilter::You),
+        });
+    }
+
     let atoms = [
         LexPattern::amount("amount", LexCaptureKind::UntilAnyPhrase(object_phrases)),
         LexPattern::object("object", LexCaptureKind::OneOf(&["creature", "creatures"])),
@@ -1700,6 +1730,7 @@ fn parse_object_died_this_turn_shape(
         event: ObjectDeathThisTurnEventAst::Died,
         filter: ObjectFilter::creature(),
         comparison,
+        under_controller: None,
     })
 }
 
@@ -1728,6 +1759,7 @@ fn parse_object_put_into_your_graveyard_from_anywhere_shape(
         event: ObjectDeathThisTurnEventAst::PutIntoYourGraveyardFromAnywhere,
         filter: ObjectFilter::creature(),
         comparison: Comparison::GreaterThanOrEqual(1),
+        under_controller: None,
     })
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3537,6 +3537,13 @@ fn parse_object_death_this_turn_predicate(words: &[&str]) -> Option<PredicateAst
     match condition.event {
         crate::runtime_backend::grammar::conditions::ObjectDeathThisTurnEventAst::Died => {
             let count = comparison_to_strict_at_least_threshold(&condition.comparison)?;
+            if let Some(player) = condition.under_controller {
+                return Some(PredicateAst::ValueComparison {
+                    left: Value::CreaturesDiedThisTurnControlledBy(player),
+                    operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                    right: Value::Fixed(count as i32),
+                });
+            }
             if count <= 1 {
                 Some(PredicateAst::CreatureDiedThisTurn)
             } else {
@@ -8063,6 +8070,14 @@ mod tests {
             (
                 "If seven or more creatures died this turn",
                 PredicateAst::CreatureDiedThisTurnOrMore(7),
+            ),
+            (
+                "If a creature died under your control this turn",
+                PredicateAst::ValueComparison {
+                    left: Value::CreaturesDiedThisTurnControlledBy(PlayerFilter::You),
+                    operator: crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                    right: Value::Fixed(1),
+                },
             ),
             (
                 "If a creature card was put into your graveyard from anywhere this turn",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -41912,6 +41912,35 @@ fn parse_windcrag_siege_full_text_compiles() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_barrensteppe_siege_full_text_compiles_and_renders_choice_bullets() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Barrensteppe Siege")
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "As this enchantment enters, choose Abzan or Mardu.\n• Abzan — At the beginning of your end step, put a +1/+1 counter on each creature you control.\n• Mardu — At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
+        )
+        .expect("Barrensteppe Siege should compile strictly");
+
+    let rendered = crate::compiled_text::canonical_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("As this enchantment enters, choose abzan or mardu."),
+        "expected named-option as-enters choice text, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("• Abzan — At the beginning of your end step, put a +1/+1 counter on each creature you control."),
+        "expected Abzan bullet trigger without redundant chosen-option condition, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("• Mardu — At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice."),
+        "expected Mardu bullet trigger with compact controller-qualified death condition, got:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("chosen option"),
+        "choice bullet rendering should not repeat the structural chosen-option gate, got:\n{rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_as_long_as_its_enchanted_condition_line() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Fledgling Osprey Variant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12508,6 +12508,17 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 );
             }
             if let (
+                Value::CreaturesDiedThisTurnControlledBy(player),
+                crate::effect::ValueComparisonOperator::GreaterThanOrEqual,
+                Value::Fixed(1),
+            ) = (left, operator, right)
+            {
+                return format!(
+                    "a creature died under {} control this turn",
+                    describe_possessive_player_filter(player)
+                );
+            }
+            if let (
                 Value::LifeTotal(player),
                 crate::effect::ValueComparisonOperator::LessThanOrEqual,
                 Value::Fixed(count),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17853,6 +17853,8 @@ fn describe_triggered_inline_ability(
     } else {
         intervening_condition
     };
+    intervening_condition = intervening_condition
+        .and_then(|condition| remove_presentation_label_chosen_option(&condition, triggered));
     let mut line = describe_trigger_surface_with_frequency(triggered, trigger_frequency);
     if triggered_deals_same_damage_to_each_other_opponent(triggered) {
         line = line.replace("combat damage to a player", "combat damage to an opponent");
@@ -41339,6 +41341,53 @@ pub(super) fn split_trigger_intervening_if(
     (fold_condition_exprs(non_limit), frequency)
 }
 
+fn remove_presentation_label_chosen_option(
+    condition: &crate::ConditionExpr,
+    triggered: &crate::ability::TriggeredAbility,
+) -> Option<crate::ConditionExpr> {
+    match condition {
+        crate::ConditionExpr::SourceChosenOption(option) => {
+            if presentation_label_matches_chosen_option(triggered, option) {
+                None
+            } else {
+                Some(condition.clone())
+            }
+        }
+        crate::ConditionExpr::And(left, right) => match (
+            remove_presentation_label_chosen_option(left, triggered),
+            remove_presentation_label_chosen_option(right, triggered),
+        ) {
+            (Some(left), Some(right)) => {
+                Some(crate::ConditionExpr::And(Box::new(left), Box::new(right)))
+            }
+            (Some(only), None) | (None, Some(only)) => Some(only),
+            (None, None) => None,
+        },
+        other => Some(other.clone()),
+    }
+}
+
+fn presentation_label_matches_chosen_option(
+    triggered: &crate::ability::TriggeredAbility,
+    option: &str,
+) -> bool {
+    triggered
+        .presentation_label
+        .as_deref()
+        .is_some_and(|label| {
+            let label = label
+                .trim()
+                .trim_start_matches(|ch: char| !ch.is_alphanumeric())
+                .trim();
+            let label = label
+                .split(['—', '-'])
+                .next()
+                .unwrap_or(label)
+                .trim();
+            label.eq_ignore_ascii_case(option)
+        })
+}
+
 fn describe_zone_change_triggering_card_to_your_library(
     triggered: &crate::ability::TriggeredAbility,
 ) -> Option<String> {
@@ -41625,6 +41674,9 @@ pub(super) fn describe_ability(
             } else {
                 intervening_condition
             };
+            intervening_condition = intervening_condition.and_then(|condition| {
+                remove_presentation_label_chosen_option(&condition, triggered)
+            });
             let mut trigger_surface = apply_triggered_presentation_label(
                 triggered,
                 describe_trigger_surface_with_frequency(triggered, trigger_frequency),

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3506,6 +3506,141 @@ fn create_vanilla_creature(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn barrensteppe_siege_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(1_149_701), "Barrensteppe Siege")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "As this enchantment enters, choose Abzan or Mardu.\n\
+             • Abzan — At the beginning of your end step, put a +1/+1 counter on each creature you control.\n\
+             • Mardu — At the beginning of your end step, if a creature died under your control this turn, each opponent sacrifices a creature of their choice.",
+        )
+        .expect("Barrensteppe Siege should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_barrensteppe_end_step_triggers_on_stack(game: &mut GameState) -> usize {
+    let mut trigger_queue = TriggerQueue::new();
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfEndStepEvent::new(game.turn.active_player),
+        crate::provenance::ProvNodeId::default(),
+    );
+    for trigger in crate::triggers::check_triggers(game, &event) {
+        trigger_queue.add(trigger);
+    }
+    let count = trigger_queue.entries.len();
+    if count > 0 {
+        put_triggers_on_stack(game, &mut trigger_queue)
+            .expect("Barrensteppe Siege trigger should go on stack");
+    }
+    count
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn barrensteppe_siege_abzan_end_step_puts_counters_on_each_creature_you_control() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+
+    let siege = game.create_object_from_definition(
+        &barrensteppe_siege_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.set_chosen_named_option(siege, "abzan".to_string());
+    let first = create_vanilla_creature(&mut game, "Abzan Initiate", alice, 2, 2);
+    let second = create_vanilla_creature(&mut game, "Abzan Acolyte", alice, 1, 1);
+    let opponent = create_vanilla_creature(&mut game, "Opponent Creature", bob, 3, 3);
+
+    assert_eq!(put_barrensteppe_end_step_triggers_on_stack(&mut game), 1);
+    resolve_stack_entry(&mut game).expect("Barrensteppe Siege Abzan trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(first, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "first controlled creature should get a +1/+1 counter"
+    );
+    assert_eq!(
+        game.counter_count(second, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "second controlled creature should get a +1/+1 counter"
+    );
+    assert_eq!(
+        game.counter_count(opponent, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "opponent's creature should not get a counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn barrensteppe_siege_mardu_does_not_trigger_for_opponent_creature_death() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+
+    let siege = game.create_object_from_definition(
+        &barrensteppe_siege_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.set_chosen_named_option(siege, "mardu".to_string());
+    let bob_victim = create_vanilla_creature(&mut game, "Bob Victim", bob, 1, 1);
+    create_vanilla_creature(&mut game, "Bob Survivor", bob, 2, 2);
+
+    game.move_object_by_effect(bob_victim, Zone::Graveyard)
+        .expect("opponent creature should die");
+    let mut pending = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut pending);
+
+    assert_eq!(
+        put_barrensteppe_end_step_triggers_on_stack(&mut game),
+        0,
+        "Mardu branch should not trigger when only an opponent's creature died"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn barrensteppe_siege_mardu_sacrifices_each_opponents_chosen_creature_after_yours_died() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.active_player = alice;
+
+    let siege = game.create_object_from_definition(
+        &barrensteppe_siege_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.set_chosen_named_option(siege, "mardu".to_string());
+    let alice_victim = create_vanilla_creature(&mut game, "Alice Victim", alice, 1, 1);
+    let bob_creature = create_vanilla_creature(&mut game, "Bob Creature", bob, 2, 2);
+
+    game.move_object_by_effect(alice_victim, Zone::Graveyard)
+        .expect("your creature should die");
+    let mut pending = TriggerQueue::new();
+    drain_pending_trigger_events(&mut game, &mut pending);
+
+    assert_eq!(put_barrensteppe_end_step_triggers_on_stack(&mut game), 1);
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Barrensteppe Siege Mardu trigger should resolve");
+
+    assert!(
+        !game.battlefield.contains(&bob_creature),
+        "Mardu branch should remove the opponent's chosen creature from the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn mighty_servant_of_leuk_o_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(274_545), "Mighty Servant of Leuk-o")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -3523,6 +3523,56 @@ fn barrensteppe_siege_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+struct BarrensteppeChoiceDecisionMaker {
+    option_index: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for BarrensteppeChoiceDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if ctx
+            .options
+            .iter()
+            .any(|option| option.legal && option.index == self.option_index)
+        {
+            vec![self.option_index]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn enter_barrensteppe_siege_with_choice(
+    game: &mut GameState,
+    controller: PlayerId,
+    option_index: usize,
+    expected_option: &str,
+) -> ObjectId {
+    let hand_id = game.create_object_from_definition(
+        &barrensteppe_siege_definition(),
+        controller,
+        Zone::Hand,
+    );
+    let mut dm = BarrensteppeChoiceDecisionMaker { option_index };
+    let siege = game
+        .move_object_with_etb_processing_with_dm(hand_id, Zone::Battlefield, &mut dm)
+        .expect("Barrensteppe Siege should enter the battlefield")
+        .new_id;
+
+    assert_eq!(
+        game.chosen_named_option(siege),
+        Some(expected_option),
+        "Barrensteppe Siege should record its as-enters named option choice"
+    );
+    siege
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn put_barrensteppe_end_step_triggers_on_stack(game: &mut GameState) -> usize {
     let mut trigger_queue = TriggerQueue::new();
     let event = TriggerEvent::new_with_provenance(
@@ -3548,12 +3598,7 @@ fn barrensteppe_siege_abzan_end_step_puts_counters_on_each_creature_you_control(
     let bob = PlayerId::from_index(1);
     game.turn.active_player = alice;
 
-    let siege = game.create_object_from_definition(
-        &barrensteppe_siege_definition(),
-        alice,
-        Zone::Battlefield,
-    );
-    game.set_chosen_named_option(siege, "abzan".to_string());
+    enter_barrensteppe_siege_with_choice(&mut game, alice, 0, "abzan");
     let first = create_vanilla_creature(&mut game, "Abzan Initiate", alice, 2, 2);
     let second = create_vanilla_creature(&mut game, "Abzan Acolyte", alice, 1, 1);
     let opponent = create_vanilla_creature(&mut game, "Opponent Creature", bob, 3, 3);
@@ -3586,12 +3631,7 @@ fn barrensteppe_siege_mardu_does_not_trigger_for_opponent_creature_death() {
     let bob = PlayerId::from_index(1);
     game.turn.active_player = alice;
 
-    let siege = game.create_object_from_definition(
-        &barrensteppe_siege_definition(),
-        alice,
-        Zone::Battlefield,
-    );
-    game.set_chosen_named_option(siege, "mardu".to_string());
+    enter_barrensteppe_siege_with_choice(&mut game, alice, 1, "mardu");
     let bob_victim = create_vanilla_creature(&mut game, "Bob Victim", bob, 1, 1);
     create_vanilla_creature(&mut game, "Bob Survivor", bob, 2, 2);
 
@@ -3610,19 +3650,16 @@ fn barrensteppe_siege_mardu_does_not_trigger_for_opponent_creature_death() {
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn barrensteppe_siege_mardu_sacrifices_each_opponents_chosen_creature_after_yours_died() {
-    let mut game = setup_game();
+    let mut game = setup_three_player_game();
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
     game.turn.active_player = alice;
 
-    let siege = game.create_object_from_definition(
-        &barrensteppe_siege_definition(),
-        alice,
-        Zone::Battlefield,
-    );
-    game.set_chosen_named_option(siege, "mardu".to_string());
+    enter_barrensteppe_siege_with_choice(&mut game, alice, 1, "mardu");
     let alice_victim = create_vanilla_creature(&mut game, "Alice Victim", alice, 1, 1);
     let bob_creature = create_vanilla_creature(&mut game, "Bob Creature", bob, 2, 2);
+    let charlie_creature = create_vanilla_creature(&mut game, "Charlie Creature", charlie, 2, 2);
 
     game.move_object_by_effect(alice_victim, Zone::Graveyard)
         .expect("your creature should die");
@@ -3636,7 +3673,11 @@ fn barrensteppe_siege_mardu_sacrifices_each_opponents_chosen_creature_after_your
 
     assert!(
         !game.battlefield.contains(&bob_creature),
-        "Mardu branch should remove the opponent's chosen creature from the battlefield"
+        "Mardu branch should remove Bob's chosen creature from the battlefield"
+    );
+    assert!(
+        !game.battlefield.contains(&charlie_creature),
+        "Mardu branch should remove Charlie's chosen creature from the battlefield"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Barrensteppe Siege
Initial parse error:
```
unsupported end clause (clause: 'step put a +1/+1 counter on each creature you control'); oracle-only fallback also failed: unsupported end clause (clause: 'step put a +1/+1 counter on each creature you control')
```

Current worker: i-0c783cdfd264235d1
Branch: codex/aws-card-fix-barrensteppe-siege
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0002
