### PR TITLE
Fix Ironsmith parse failure: Rakdos, the Muscle

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -269,6 +269,10 @@ const ALLOW_ANY_COLOR_FOR_CAST_SUFFIXES: &[&[&str]] = &[
         "and", "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "them",
     ],
     &[
+        "and", "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "those",
+        "spells",
+    ],
+    &[
         "and", "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "it",
     ],
     &[

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -175,6 +175,12 @@ pub(crate) fn parse_exile(
     }
     if !face_down
         && !until_source_leaves
+        && let Some(effect) = parse_exile_dynamic_count_from_top_library_clause(tokens, subject)
+    {
+        return Ok(effect);
+    }
+    if !face_down
+        && !until_source_leaves
         && let Some(effect) = parse_exile_top_library_clause(tokens, subject)
     {
         return Ok(effect);
@@ -534,6 +540,60 @@ fn parse_library_owner_prefix(
         ));
     }
     None
+}
+
+fn parse_exile_dynamic_count_from_top_library_clause(
+    tokens: &[OwnedLexToken],
+    subject: Option<SubjectAst>,
+) -> Option<EffectAst> {
+    let tokens = trim_commas(tokens);
+    let words = crate::runtime_backend::token_word_refs(&tokens);
+    if !words
+        .first()
+        .is_some_and(|word| EXILE_CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+    {
+        return None;
+    }
+
+    let from_word_idx = find_index(&words, |word| EXILE_FROM_WORD_PATTERN.matches_word(word))?;
+    if from_word_idx <= 1 {
+        return None;
+    }
+    let count_start = token_index_for_word_index(&tokens, 1)?;
+    let from_token_idx = token_index_for_word_index(&tokens, from_word_idx)?;
+    let count_tokens = trim_commas(&tokens[count_start..from_token_idx]);
+    let count = crate::runtime_backend::grammar::values::parse_add_mana_equal_amount_value_lexed(
+        &count_tokens,
+    )?;
+
+    let after_from = &words[from_word_idx + 1..];
+    let owner_words = if after_from.len() >= 3
+        && after_from[0] == "the"
+        && EXILE_TOP_WORD_PATTERN.matches_word(after_from[1])
+        && EXILE_OF_WORD_PATTERN.matches_word(after_from[2])
+    {
+        &after_from[3..]
+    } else if after_from.len() >= 2
+        && EXILE_TOP_WORD_PATTERN.matches_word(after_from[0])
+        && EXILE_OF_WORD_PATTERN.matches_word(after_from[1])
+    {
+        &after_from[2..]
+    } else {
+        return None;
+    };
+
+    let default_player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
+    let (player, used_words) = parse_library_owner_prefix(owner_words, default_player)?;
+    if used_words < owner_words.len() {
+        return None;
+    }
+
+    Some(EffectAst::subject_verb_exile_top_of_library(
+        player,
+        count,
+        vec![helper_tag_for_tokens(&tokens, "exiled")],
+        Vec::new(),
+    ))
 }
 
 pub(crate) fn parse_exile_top_library_clause(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5450,6 +5450,24 @@ fn rewrite_lexed_permission_helpers_preserve_any_color_cast_suffix() {
 }
 
 #[test]
+fn rewrite_lexed_permission_helpers_preserve_until_next_end_step_any_color_cast_suffix() {
+    let tokens = lex_line(
+        "Until your next end step, you may play those cards, and mana of any type can be spent to cast those spells",
+        0,
+    )
+    .expect("rewrite lexer should classify plural tagged permission with mana-spend suffix");
+
+    let parsed = super::permission_helpers::parse_cast_or_play_tagged_clause(&tokens)
+        .expect("tagged permission clause should parse")
+        .expect("tagged permission clause should produce an effect");
+    let debug = format!("{parsed:?}");
+
+    assert!(debug.contains("GrantPlayTaggedUntilYourNextTurn"), "{debug}");
+    assert!(debug.contains("allow_land: true"), "{debug}");
+    assert!(debug.contains("allow_any_color_for_cast: true"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_permission_helpers_parse_while_exiled_tail_lifetime() {
     let tokens = lex_line(
         "cast that card for as long as it remains exiled and mana of any type can be spent to cast that spell",

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -62679,6 +62679,37 @@ fn parse_oracle_riveteers_charm_strict_regression() {
     );
 }
 
+#[test]
+fn parse_oracle_rakdos_the_muscle_strict_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Rakdos, the Muscle");
+    let def = parse_oracle_card_definition("Rakdos, the Muscle");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains(
+            "whenever you sacrifice another creature, exile cards equal to its mana value from the top of target player's library"
+        ),
+        "expected dynamic sacrificed-creature mana-value exile clause, got {rendered}"
+    );
+    assert!(
+        rendered_lower.contains(
+            "until your next end step, you may play those cards, and mana of any type can be spent to cast those spells"
+        ),
+        "expected next-end-step play permission with any-color mana suffix, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("ExileTopOfLibraryEffect")
+            && debug.contains("ManaValueOf")
+            && debug.contains("GrantPlayTaggedEffect")
+            && debug.contains("UntilYourNextTurnEnd")
+            && debug.contains("allow_any_color_for_cast: true"),
+        "expected Rakdos trigger to lower to dynamic top-library exile plus next-end-step any-color play grant, got {debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn planar_genesis_fallback_with_extra_tail_still_fails_loudly() {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1218,6 +1218,7 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(": as long as "))
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
     let uses_named_source_surface = lower.starts_with("this creature gets ")
+        || lower.starts_with("this creature gains ")
         || lower.starts_with("as this enters")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
@@ -1230,6 +1231,7 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(" this creature deals ")
         || lower.contains(", this creature deals ")
         || lower.contains(": this creature gets ")
+        || lower.contains(": this creature gains ")
         || lower.contains(": this creature deals ")
         || lower.contains(": whenever this creature deals combat damage to a player");
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -25538,33 +25538,46 @@ fn describe_exile_top_then_play(
     let Some(first_tag) = exile_top.moved_tags.first() else {
         return None;
     };
-    if grant_play.tag != *first_tag
-        || grant_play.duration != crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
-        || grant_play.player != exile_top.player
-    {
+    if grant_play.tag != *first_tag {
         return None;
     }
-
-    let singular_count = matches!(exile_top.count, Value::Fixed(1));
-    let exile_clause = match &exile_top.count {
-        Value::Fixed(n) if *n >= 0 => {
-            let count_u32 = *n as u32;
-            let count_text = small_number_word(count_u32).unwrap_or_else(|| n.to_string());
-            let noun = if *n == 1 { "card" } else { "cards" };
-            let owner = describe_possessive_player_filter(&exile_top.player);
-            format!("Exile the top {count_text} {noun} of {owner} library")
+    let duration_text = match grant_play.duration {
+        crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn => "Until end of turn",
+        crate::effects::GrantPlayTaggedDuration::UntilYourNextTurnEnd => {
+            "Until your next end step"
         }
-        _ => {
-            let owner = describe_possessive_player_filter(&exile_top.player);
-            let value_text = describe_value(&exile_top.count);
-            if value_text == "X"
-                || (suppress_count_where_clause
-                    && value_has_surface_hint(&exile_top.count, ValueSurfaceHint::WhereXIs))
-            {
-                format!("Exile the top X cards of {owner} library")
-            } else {
-                format!("Exile the top X cards of {owner} library, where X is {value_text}")
-            }
+        _ => return None,
+    };
+
+    let owner = describe_possessive_player_filter(&exile_top.player);
+    let dynamic_count_basis = match &exile_top.count {
+        Value::ManaValueOf(spec)
+            if matches!(spec.base(), ChooseSpec::Tagged(tag) if tag.as_str() == "triggering" || tag.as_str().starts_with("sacrificed")) =>
+        {
+            Some("its mana value")
+        }
+        _ => None,
+    };
+    let singular_count = matches!(exile_top.count, Value::Fixed(1));
+    let exile_clause = if let Some(basis) = dynamic_count_basis {
+        format!("Exile cards equal to {basis} from the top of {owner} library")
+    } else if let Value::Fixed(n) = &exile_top.count {
+        if *n < 0 {
+            return None;
+        }
+        let count_u32 = *n as u32;
+        let count_text = small_number_word(count_u32).unwrap_or_else(|| n.to_string());
+        let noun = if *n == 1 { "card" } else { "cards" };
+        format!("Exile the top {count_text} {noun} of {owner} library")
+    } else {
+        let value_text = describe_value(&exile_top.count);
+        if value_text == "X"
+            || (suppress_count_where_clause
+                && value_has_surface_hint(&exile_top.count, ValueSurfaceHint::WhereXIs))
+        {
+            format!("Exile the top X cards of {owner} library")
+        } else {
+            format!("Exile the top X cards of {owner} library, where X is {value_text}")
         }
     };
     let cards_text = if singular_count {
@@ -25577,13 +25590,44 @@ fn describe_exile_top_then_play(
     } else {
         "cast"
     };
+    let player = describe_player_filter(&grant_play.player);
+    let mana_suffix = if grant_play.allow_any_color_for_cast {
+        if grant_play.allow_land {
+            let spell_ref = if singular_count {
+                "that spell"
+            } else {
+                "those spells"
+            };
+            format!(", and mana of any type can be spent to cast {spell_ref}")
+        } else {
+            let spell_ref = if singular_count { "that spell" } else { "them" };
+            format!(", and mana of any type can be spent to cast {spell_ref}")
+        }
+    } else {
+        String::new()
+    };
+
     if !grant_play.allow_land && !singular_count {
         return Some(format!(
-            "{exile_clause}. Until end of turn, you may cast spells from among those exiled cards"
+            "{exile_clause}. {duration_text}, {player} may cast spells from among those cards{mana_suffix}"
         ));
     }
+
+    if grant_play.duration == crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+        && !grant_play.allow_any_color_for_cast
+        && grant_play.player == exile_top.player
+    {
+        return Some(format!("{exile_clause}. You may {verb} {cards_text} this turn"));
+    }
+
+    if player == "you" {
+        return Some(format!(
+            "{exile_clause}. {duration_text}, you may {verb} {cards_text}{mana_suffix}"
+        ));
+    }
+
     Some(format!(
-        "{exile_clause}. You may {verb} {cards_text} this turn"
+        "{exile_clause}. {duration_text}, {player} may {verb} {cards_text}{mana_suffix}"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30414,6 +30414,220 @@ fn riveteers_charm_mode_two_play_permission_lasts_through_next_end_step_window()
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn rakdos_the_muscle_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(90_662), "Rakdos, the Muscle")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Demon, Subtype::Mercenary])
+        .power_toughness(PowerToughness::fixed(6, 5))
+        .parse_text(
+            "Flying, trample\n\
+             Whenever you sacrifice another creature, exile cards equal to its mana value from the top of target player's library. Until your next end step, you may play those cards, and mana of any type can be spent to cast those spells.\n\
+             Sacrifice another creature: Rakdos gains indestructible until end of turn. Tap it. Activate only once each turn.",
+        )
+        .expect("Rakdos, the Muscle should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rakdos_the_muscle_trigger_exiles_mana_value_cards_and_grants_next_end_step_any_color_play() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let rakdos = rakdos_the_muscle_definition();
+    let rakdos_id = game.create_object_from_definition(&rakdos, alice, Zone::Battlefield);
+    let sacrificed = CardBuilder::new(CardId::from_raw(90_663), "Rakdos Sacrifice Fuel")
+        .card_types(vec![CardType::Creature])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let sacrificed_id = game.create_object_from_card(&sacrificed, alice, Zone::Battlefield);
+    let noncreature = CardBuilder::new(CardId::from_raw(90_664), "Rakdos Noncreature Fuel")
+        .card_types(vec![CardType::Artifact])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .build();
+    let noncreature_id = game.create_object_from_card(&noncreature, alice, Zone::Battlefield);
+
+    let exiled_land = CardBuilder::new(CardId::from_raw(90_665), "Rakdos Exiled Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let exiled_spell = CardBuilder::new(CardId::from_raw(90_666), "Rakdos Exiled Spell")
+        .card_types(vec![CardType::Sorcery])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Green]]))
+        .build();
+    let library_spare = CardBuilder::new(CardId::from_raw(90_667), "Rakdos Library Spare")
+        .card_types(vec![CardType::Instant])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .build();
+    game.create_object_from_card(&exiled_land, bob, Zone::Library);
+    game.create_object_from_card(&exiled_spell, bob, Zone::Library);
+    game.create_object_from_card(&library_spare, bob, Zone::Library);
+
+    let noncreature_event = TriggerEvent::new_with_provenance(
+        crate::events::permanents::SacrificeEvent::new(noncreature_id, Some(rakdos_id))
+            .with_snapshot(
+                game.object(noncreature_id)
+                    .map(|object| crate::snapshot::ObjectSnapshot::from_object(object, &game)),
+                Some(alice),
+            ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        crate::triggers::check_triggers(&game, &noncreature_event)
+            .into_iter()
+            .filter(|entry| entry.source == rakdos_id)
+            .count()
+            == 0,
+        "Rakdos should not trigger when you sacrifice a noncreature"
+    );
+
+    let self_event = TriggerEvent::new_with_provenance(
+        crate::events::permanents::SacrificeEvent::new(rakdos_id, Some(rakdos_id)).with_snapshot(
+            game.object(rakdos_id)
+                .map(|object| crate::snapshot::ObjectSnapshot::from_object(object, &game)),
+            Some(alice),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert!(
+        crate::triggers::check_triggers(&game, &self_event)
+            .into_iter()
+            .filter(|entry| entry.source == rakdos_id)
+            .count()
+            == 0,
+        "Rakdos should not trigger when itself is sacrificed"
+    );
+
+    let sacrifice_event = TriggerEvent::new_with_provenance(
+        crate::events::permanents::SacrificeEvent::new(sacrificed_id, Some(rakdos_id))
+            .with_snapshot(
+                game.object(sacrificed_id)
+                    .map(|object| crate::snapshot::ObjectSnapshot::from_object(object, &game)),
+                Some(alice),
+            ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let matching_triggers: Vec<_> = crate::triggers::check_triggers(&game, &sacrifice_event)
+        .into_iter()
+        .filter(|entry| entry.source == rakdos_id)
+        .collect();
+    assert_eq!(
+        matching_triggers.len(),
+        1,
+        "Rakdos should trigger exactly once when you sacrifice another creature"
+    );
+
+    let triggered = rakdos
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Rakdos should have a sacrifice trigger");
+    let mut ctx = ExecutionContext::new_default(rakdos_id, alice)
+        .with_triggering_event(sacrifice_event)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
+    for effect in triggered.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .unwrap_or_else(|err| panic!("Rakdos trigger effect should resolve: {effect:?}: {err:?}"));
+    }
+
+    assert_eq!(
+        game.exile.len(),
+        2,
+        "Rakdos should exile cards equal to the sacrificed creature's mana value"
+    );
+    let exiled_names: Vec<_> = game
+        .exile
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| (id, object.name.clone())))
+        .collect();
+    let exiled_land_id = exiled_names
+        .iter()
+        .find_map(|(id, name)| (*name == "Rakdos Exiled Land").then_some(*id))
+        .expect("Rakdos should exile the land among the two cards");
+    let exiled_spell_id = exiled_names
+        .iter()
+        .find_map(|(id, name)| (*name == "Rakdos Exiled Spell").then_some(*id))
+        .expect("Rakdos should exile the spell among the two cards");
+    assert!(
+        game.player(bob)
+            .expect("Bob exists")
+            .library
+            .iter()
+            .any(|&id| game.object(id).is_some_and(|object| object.name == "Rakdos Library Spare")),
+        "Rakdos should leave the third library card behind"
+    );
+
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            exiled_land_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Rakdos should let you play exiled lands during the window"
+    );
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            exiled_spell_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Rakdos should let you cast exiled spells during the window"
+    );
+    assert!(
+        game.can_spend_mana_as_any_color(alice, Some(exiled_spell_id)),
+        "Rakdos should allow mana of any color to cast exiled spells"
+    );
+    assert!(
+        !game.can_spend_mana_as_any_color(alice, Some(exiled_land_id)),
+        "Rakdos's any-color cast permission should not apply to exiled lands"
+    );
+
+    game.turn.turn_number = game.turn.turn_number.saturating_add(1);
+    game.turn.active_player = bob;
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            exiled_spell_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Rakdos play window should survive before your next end step"
+    );
+
+    game.turn.turn_number = game.turn.turn_number.saturating_add(2);
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            exiled_spell_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Rakdos play window should expire after your next end step"
+    );
+    assert!(
+        !game.can_spend_mana_as_any_color(alice, Some(exiled_spell_id)),
+        "Rakdos any-color cast permission should expire with the play window"
+    );
+}
+
 // === Full Game Flow Integration Test ===
 
 #[cfg(ironsmith_runtime_parser_tests)]

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30472,9 +30472,9 @@ fn rakdos_the_muscle_trigger_exiles_mana_value_cards_and_grants_next_end_step_an
         .card_types(vec![CardType::Instant])
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
         .build();
-    game.create_object_from_card(&exiled_land, bob, Zone::Library);
-    game.create_object_from_card(&exiled_spell, bob, Zone::Library);
     game.create_object_from_card(&library_spare, bob, Zone::Library);
+    game.create_object_from_card(&exiled_spell, bob, Zone::Library);
+    game.create_object_from_card(&exiled_land, bob, Zone::Library);
 
     let noncreature_event = TriggerEvent::new_with_provenance(
         crate::events::permanents::SacrificeEvent::new(noncreature_id, Some(rakdos_id))
@@ -30520,6 +30520,8 @@ fn rakdos_the_muscle_trigger_exiles_mana_value_cards_and_grants_next_end_step_an
             ),
         crate::provenance::ProvNodeId::default(),
     );
+    game.move_object_by_effect(sacrificed_id, Zone::Graveyard)
+        .expect("sacrificed creature should move to the graveyard");
     let matching_triggers: Vec<_> = crate::triggers::check_triggers(&game, &sacrifice_event)
         .into_iter()
         .filter(|entry| entry.source == rakdos_id)
@@ -30538,12 +30540,29 @@ fn rakdos_the_muscle_trigger_exiles_mana_value_cards_and_grants_next_end_step_an
             _ => None,
         })
         .expect("Rakdos should have a sacrifice trigger");
+    let effects = triggered.effects.flattened_default_effects();
+    let target_requirements = super::targeting::extract_target_requirements(
+        &game,
+        &effects,
+        alice,
+        Some(rakdos_id),
+    );
+    assert_eq!(
+        target_requirements.len(),
+        1,
+        "Rakdos trigger should require exactly one target player"
+    );
     let mut ctx = ExecutionContext::new_default(rakdos_id, alice)
         .with_triggering_event(sacrifice_event)
-        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)]);
-    for effect in triggered.effects.flattened_default_effects() {
-        crate::effects::execute_effect(&mut game, effect, &mut ctx)
-            .unwrap_or_else(|err| panic!("Rakdos trigger effect should resolve: {effect:?}: {err:?}"));
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: target_requirements[0].spec.clone(),
+            range: 0..1,
+        }]);
+    for effect in effects {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx).unwrap_or_else(|err| {
+            panic!("Rakdos trigger effect should resolve: {effect:?}: {err:?}")
+        });
     }
 
     assert_eq!(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rakdos, the Muscle
Initial parse error:
```
unsupported until-next-turn play target (clause: 'until your next end step you may play those cards and mana of any type can be spent to cast those spells'); oracle-only fallback also failed: unsupported until-next-turn play target (clause: 'until your next end step you may play those cards and mana of any type can be spent to cast those spells')
```

Current worker: i-0fa76289d0b4ac06d
Branch: codex/aws-card-fix-rakdos-the-muscle
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0003
