### PR TITLE
Fix Ironsmith parse failure: Staff of the Storyteller

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -161,6 +161,8 @@ const THIS_BECOMES_MONSTROUS_TRIGGER_PATTERN: ClauseShape<'static> = clause_shap
             &["becomes", "monstrous"],
         ]
 );
+const CREATE_OR_CREATES_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["create"], &["creates"]]);
 const THIS_MUTATES_TRIGGER_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -1908,6 +1910,28 @@ pub(crate) fn parse_trigger_clause_lexed(
             if GIFT_TAIL_PATTERN.matches_words(&gifted_words) {
                 return Ok(TriggerSpec::PlayerGivesGift(player));
             }
+        }
+    }
+
+    if let Some(create_idx) = find_token_shape(tokens, &CREATE_OR_CREATES_PATTERN) {
+        let subject_tokens = &tokens[..create_idx];
+        let subject_word_view = ActivationRestrictionCompatWords::new(subject_tokens);
+        let subject_words = subject_word_view.to_word_refs();
+        if let Some(player) = parse_trigger_subject_player_filter(&subject_words) {
+            let object_tokens = trim_commas(&tokens[create_idx + 1..]);
+            let one_or_more = has_leading_one_or_more(&object_tokens);
+            let object_tokens = strip_leading_one_or_more_lexed(&object_tokens);
+            let filter = parse_object_filter_lexed(object_tokens, false).map_err(|_| {
+                CardTextError::ParseError(format!(
+                    "unsupported token-created trigger filter (clause: '{}')",
+                    words.join(" ")
+                ))
+            })?;
+            return Ok(TriggerSpec::TokensCreated {
+                player,
+                filter,
+                one_or_more,
+            });
         }
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -199,6 +199,11 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::PlayerSacrifices { player, filter } => {
             Trigger::player_sacrifices(player, filter)
         }
+        TriggerSpec::TokensCreated {
+            player,
+            filter,
+            one_or_more,
+        } => Trigger::tokens_created(player, filter, one_or_more),
         TriggerSpec::LeavesBattlefield(filter) => Trigger::leaves_battlefield(filter),
         TriggerSpec::Dies(filter) => Trigger::dies(filter),
         TriggerSpec::DiesOneOrMore(filter) => Trigger::new(
@@ -506,6 +511,7 @@ fn trigger_binds_iterated_player(trigger: &TriggerSpec) -> bool {
         | TriggerSpec::PlayerTapsForMana { .. }
         | TriggerSpec::PlayerRollsResult { .. }
         | TriggerSpec::PlayerSacrifices { .. }
+        | TriggerSpec::TokensCreated { .. }
         | TriggerSpec::ThisDealsDamageToPlayer { .. }
         | TriggerSpec::DealsDamageToPlayer { .. }
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
@@ -581,6 +587,13 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         TriggerSpec::PlayerRollsResult { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::AbilityActivated { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::PlayerSacrifices { .. } => Some(PlayerFilter::IteratedPlayer),
+        TriggerSpec::TokensCreated { player, .. } => {
+            if *player == PlayerFilter::Any {
+                Some(PlayerFilter::IteratedPlayer)
+            } else {
+                Some(player.clone())
+            }
+        }
         TriggerSpec::ThisDealsDamageToPlayer { .. }
         | TriggerSpec::DealsDamageToPlayer { .. }
         | TriggerSpec::DealsNoncombatDamageToPlayer { .. }
@@ -675,6 +688,7 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             | TriggerSpec::KeywordActionTaggedObject { .. }
             | TriggerSpec::KeywordActionFromSource { .. }
             | TriggerSpec::CounterPutOn { .. }
+            | TriggerSpec::TokensCreated { .. }
             | TriggerSpec::EntersBattlefieldOneOrMore { .. } => true,
             TriggerSpec::StateBased { .. } => false,
             TriggerSpec::Either(left, right) => {

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -250,6 +250,11 @@ pub(crate) enum TriggerSpec {
         player: PlayerFilter,
         filter: ObjectFilter,
     },
+    TokensCreated {
+        player: PlayerFilter,
+        filter: ObjectFilter,
+        one_or_more: bool,
+    },
     LeavesBattlefield(ObjectFilter),
     Dies(ObjectFilter),
     DiesOneOrMore(ObjectFilter),

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -15066,6 +15066,29 @@ fn parse_trigger_clause_supports_one_or_more_energy_player_gain() {
 }
 
 #[test]
+fn parse_trigger_clause_supports_one_or_more_creature_tokens_created_by_you() {
+    let tokens = lex_line("you create one or more creature tokens", 0)
+        .expect("rewrite lexer should tokenize one-or-more token-created trigger clause");
+    let parsed =
+        super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
+            &tokens,
+        );
+    let Ok(crate::cards::builders::TriggerSpec::TokensCreated {
+        player,
+        filter,
+        one_or_more,
+    }) = parsed
+    else {
+        panic!("expected token-created trigger, got {parsed:?}");
+    };
+
+    assert_eq!(player, crate::target::PlayerFilter::You);
+    assert!(one_or_more, "expected one-or-more count mode");
+    assert!(filter.token, "expected creature tokens to keep token filter");
+    assert_eq!(filter.card_types, vec![crate::types::CardType::Creature]);
+}
+
+#[test]
 fn clown_car_parses_roll_x_six_sided_dice_with_odd_even_result_clauses() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Clown Car")
         .parse_text(

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -232,6 +232,11 @@ pub enum TriggerKind {
         player: PlayerFilter,
         filter: ObjectFilter,
     },
+    TokensCreated {
+        player: PlayerFilter,
+        filter: ObjectFilter,
+        one_or_more: bool,
+    },
     Dies {
         filter: ObjectFilter,
     },
@@ -854,6 +859,16 @@ impl Trigger {
         Self::typed(
             "player_sacrifices",
             TriggerKind::PlayerSacrifices { player, filter },
+        )
+    }
+    pub fn tokens_created(player: PlayerFilter, filter: ObjectFilter, one_or_more: bool) -> Self {
+        Self::typed(
+            "tokens_created",
+            TriggerKind::TokensCreated {
+                player,
+                filter,
+                one_or_more,
+            },
         )
     }
     pub fn dies(filter: ObjectFilter) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -337,6 +337,267 @@ fn consulate_surveillance_prevents_damage_from_chosen_source_only() {
 }
 
 #[test]
+fn staff_of_the_storyteller_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Staff of the Storyteller");
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let compiled = unprocessed_compiled_lines(&def);
+    let rendered = compiled.join("\n");
+    let oracle = oracle_text_by_name()
+        .get("Staff of the Storyteller")
+        .expect("Staff of the Storyteller oracle text")
+        .clone();
+    let (_oracle_cov, _compiled_cov, similarity, _delta, mismatch) =
+        crate::semantic_compare::compare_semantics_scored(
+            &oracle,
+            &compiled,
+            crate::semantic_compare::report_embedding_config(),
+        );
+
+    assert!(
+        ability_debug.contains("TokensCreated")
+            && ability_debug.contains("PutCountersEffect")
+            && ability_debug.contains("story")
+            && ability_debug.contains("RemoveCountersEffect")
+            && ability_debug.contains("DrawCardsEffect"),
+        "Staff should structurally keep token-created trigger, story counter, and draw activation, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "Whenever you create one or more creature tokens, put a story counter on this artifact."
+        ) && rendered.contains("{W}, {T}, Remove a story counter from this artifact: Draw a card."),
+        "expected Staff compiled text to preserve token-created trigger and activation, got {rendered}"
+    );
+    assert!(
+        similarity >= 0.99 && !mismatch,
+        "expected Staff semantic comparison to clear target, score={similarity}, mismatch={mismatch}, compiled={compiled:?}"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_enters_token_adds_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let enters = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            staff,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, staff, &enters),
+        1,
+        "Staff should trigger once when it enters"
+    );
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    let staff_token_triggers = trigger_queue
+        .entries
+        .iter()
+        .filter(|entry| entry.source == staff)
+        .count();
+    assert_eq!(
+        staff_token_triggers, 1,
+        "Staff should trigger once from the Spirit creature token it created"
+    );
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Staff token-created trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Staff token-created trigger should resolve");
+
+    let spirit_tokens = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id))
+        .filter(|object| {
+            matches!(object.kind, crate::object::ObjectKind::Token)
+                && object.subtypes.contains(&Subtype::Spirit)
+                && game.controller_of(object) == alice
+        })
+        .count();
+    assert_eq!(spirit_tokens, 1, "Staff should create one Spirit token");
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        1,
+        "Staff should get a story counter from creating a creature token"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_noncreature_token_does_not_add_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let clue = CardDefinitionBuilder::new(CardId::new(), "Clue")
+        .token()
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let effect = crate::effect::Effect::new(CreateTokenEffect::you(clue, 1));
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice);
+
+    crate::effects::execute_effect(&mut game, &effect, &mut ctx)
+        .expect("creating a Clue token should resolve");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+
+    assert!(
+        trigger_queue.entries.iter().all(|entry| entry.source != staff),
+        "Staff should not trigger from creating a noncreature token"
+    );
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        0,
+        "noncreature tokens should not add story counters"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_multiple_creature_tokens_add_one_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let soldier = CardDefinitionBuilder::new(CardId::new(), "Soldier")
+        .token()
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Soldier])
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let effect = crate::effect::Effect::new(CreateTokenEffect::you(soldier, 2));
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice);
+
+    crate::effects::execute_effect(&mut game, &effect, &mut ctx)
+        .expect("creating two Soldier tokens should resolve");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    let staff_trigger_count = trigger_queue
+        .entries
+        .iter()
+        .filter(|entry| entry.source == staff)
+        .count();
+    assert_eq!(
+        staff_trigger_count, 1,
+        "one-or-more token-created trigger should fire once for a batch of creature tokens"
+    );
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Staff token-created trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Staff token-created trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        1,
+        "creating multiple creature tokens in one event should add one story counter"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_opponent_creature_token_does_not_add_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let soldier = CardDefinitionBuilder::new(CardId::new(), "Soldier")
+        .token()
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Soldier])
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let effect = crate::effect::Effect::new(CreateTokenEffect::new(
+        soldier,
+        1,
+        PlayerFilter::Opponent,
+    ));
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice);
+
+    crate::effects::execute_effect(&mut game, &effect, &mut ctx)
+        .expect("creating an opponent Soldier token should resolve");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+
+    assert!(
+        trigger_queue.entries.iter().all(|entry| entry.source != staff),
+        "Staff should not trigger from creature tokens created by an opponent"
+    );
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        0,
+        "opponent-created creature tokens should not add story counters"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_activation_removes_story_counter_and_draws() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Staff should have a draw activated ability");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let top_card = CardDefinitionBuilder::new(CardId::new(), "Staff Drawn Card")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+    game.create_object_from_definition(&top_card, alice, Zone::Library);
+    game.remove_summoning_sickness(staff);
+
+    assert!(
+        crate::cost::can_pay_cost(&game, staff, alice, &activated.mana_cost).is_err(),
+        "Staff activation should not be payable without a story counter"
+    );
+    game.add_counters(staff, CounterType::Named("story"), 1)
+        .expect("Staff should accept a story counter");
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::White, 1);
+    crate::cost::can_pay_cost(&game, staff, alice, &activated.mana_cost)
+        .expect("Staff activation should be payable with white mana, tap, and a story counter");
+    let mut dm = crate::decision::AutoPassDecisionMaker::default();
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        staff,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("Staff activation cost should be paid");
+
+    assert!(game.is_tapped(staff), "activation cost should tap Staff");
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        0,
+        "activation cost should remove the story counter"
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Staff draw effect should resolve");
+    }
+
+    let hand_cards = game
+        .objects_in_zone(Zone::Hand)
+        .into_iter()
+        .filter_map(|id| game.object(id))
+        .filter(|object| object.name == "Staff Drawn Card")
+        .count();
+    assert_eq!(hand_cards, 1, "Staff activation should draw one card");
+}
+
+#[test]
 fn hydra_omnivore_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Hydra Omnivore");
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -669,6 +669,10 @@ fn staff_of_the_storyteller_activation_removes_story_counter_and_draws() {
     );
     game.add_counters(staff, CounterType::Named("story"), 1)
         .expect("Staff should accept a story counter");
+    assert!(
+        crate::cost::can_pay_cost(&game, staff, alice, &activated.mana_cost).is_err(),
+        "Staff activation should not be payable without white mana even with a story counter"
+    );
     game.player_mut(alice)
         .expect("Alice should exist")
         .mana_pool

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -7,8 +7,8 @@ use crate::compiled_text::{
 };
 use crate::effects::{
     AddManaEffect, ChooseModeEffect, ChooseObjectsEffect, ConsultTopOfLibraryEffect,
-    CreateTokenEffect, DestroyEffect, DoubleCountersEffect, DrawCardsEffect, EffectExecutor,
-    GainLifeEffect, IfEffect, MoveToZoneEffect, ReturnFromGraveyardToHandEffect,
+    CreateTokenCopyEffect, CreateTokenEffect, DestroyEffect, DoubleCountersEffect, DrawCardsEffect,
+    EffectExecutor, GainLifeEffect, IfEffect, MoveToZoneEffect, ReturnFromGraveyardToHandEffect,
     TagTriggeringObjectEffect, TaggedEffect, TargetOnlyEffect, UntapEffect, WithIdEffect,
 };
 use crate::filter::ObjectFilterExt;
@@ -496,6 +496,116 @@ fn staff_of_the_storyteller_multiple_creature_tokens_add_one_story_counter() {
         game.counter_count(staff, CounterType::Named("story")),
         1,
         "creating multiple creature tokens in one event should add one story counter"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_creature_token_copies_add_one_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Story Bear")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let effect = CreateTokenCopyEffect::new(ChooseSpec::creature(), 2, PlayerFilter::You);
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)]);
+
+    effect
+        .execute(&mut game, &mut ctx)
+        .expect("creating two creature token copies should resolve");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+    let staff_trigger_count = trigger_queue
+        .entries
+        .iter()
+        .filter(|entry| entry.source == staff)
+        .count();
+    assert_eq!(
+        staff_trigger_count, 1,
+        "one-or-more token-created trigger should fire once for a batch of creature token copies"
+    );
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Staff token-copy-created trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Staff token-copy-created trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        1,
+        "creating multiple creature token copies in one event should add one story counter"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_noncreature_token_copy_does_not_add_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let artifact = CardDefinitionBuilder::new(CardId::new(), "Story Rock")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target = game.create_object_from_definition(&artifact, alice, Zone::Battlefield);
+    let effect = CreateTokenCopyEffect::new(
+        ChooseSpec::Object(crate::target::ObjectFilter::artifact()),
+        1,
+        PlayerFilter::You,
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)]);
+
+    effect
+        .execute(&mut game, &mut ctx)
+        .expect("creating a noncreature token copy should resolve");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+
+    assert!(
+        trigger_queue.entries.iter().all(|entry| entry.source != staff),
+        "Staff should not trigger from creating a noncreature token copy"
+    );
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        0,
+        "noncreature token copies should not add story counters"
+    );
+}
+
+#[test]
+fn staff_of_the_storyteller_opponent_creature_token_copy_does_not_add_story_counter() {
+    let def = parse_oracle_card_definition("Staff of the Storyteller");
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Opponent Story Bear")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Bear])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let staff = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let target = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let effect = CreateTokenCopyEffect::new(ChooseSpec::creature(), 1, PlayerFilter::Opponent);
+    let mut ctx = crate::effects::ExecutionContext::new_default(staff, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target)]);
+
+    effect
+        .execute(&mut game, &mut ctx)
+        .expect("creating an opponent creature token copy should resolve");
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    crate::game_loop::drain_pending_trigger_events(&mut game, &mut trigger_queue);
+
+    assert!(
+        trigger_queue.entries.iter().all(|entry| entry.source != staff),
+        "Staff should not trigger from creature token copies created by an opponent"
+    );
+    assert_eq!(
+        game.counter_count(staff, CounterType::Named("story")),
+        0,
+        "opponent-created creature token copies should not add story counters"
     );
 }
 

--- a/crates/ironsmith-runtime/src/effects/tokens/create_token.rs
+++ b/crates/ironsmith-runtime/src/effects/tokens/create_token.rs
@@ -77,7 +77,7 @@ impl EffectExecutor for CreateTokenEffect {
             game,
             controller_id,
             base_count,
-            Some(token_preview),
+            Some(token_preview.clone()),
             ctx.cause.clone(),
             &mut ctx.decision_maker,
         );
@@ -142,6 +142,22 @@ impl EffectExecutor for CreateTokenEffect {
 
                 schedule_token_cleanup(game, ctx, entered_id, controller_id, cleanup_options)?;
             }
+        }
+
+        let primary_created_count = created_ids.len() as u32;
+        if primary_created_count > 0 {
+            game.queue_trigger_event(
+                ctx.provenance,
+                crate::triggers::TriggerEvent::new_with_provenance(
+                    crate::events::CreateTokensEvent::with_token_cause(
+                        controller_id,
+                        primary_created_count,
+                        token_preview,
+                        ctx.cause.clone(),
+                    ),
+                    ctx.provenance,
+                ),
+            );
         }
 
         let additional_ids = create_replacement_additional_tokens(

--- a/crates/ironsmith-runtime/src/effects/tokens/create_token_copy.rs
+++ b/crates/ironsmith-runtime/src/effects/tokens/create_token_copy.rs
@@ -275,7 +275,7 @@ impl EffectExecutor for CreateTokenCopyEffect {
             game,
             controller_id,
             base_count,
-            Some(token_preview),
+            Some(token_preview.clone()),
             ctx.cause.clone(),
             &mut ctx.decision_maker,
         );
@@ -349,6 +349,22 @@ impl EffectExecutor for CreateTokenCopyEffect {
 
                 schedule_token_cleanup(game, ctx, entered_id, controller_id, cleanup_options)?;
             }
+        }
+
+        let primary_created_count = created_ids.len() as u32;
+        if primary_created_count > 0 {
+            game.queue_trigger_event(
+                ctx.provenance,
+                crate::triggers::TriggerEvent::new_with_provenance(
+                    crate::events::CreateTokensEvent::with_token_cause(
+                        controller_id,
+                        primary_created_count,
+                        token_preview,
+                        ctx.cause.clone(),
+                    ),
+                    ctx.provenance,
+                ),
+            );
         }
 
         let additional_ids = create_replacement_additional_tokens(

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -55,6 +55,7 @@ pub mod other;
 pub mod phase_step;
 pub mod special;
 pub mod spell_ability;
+pub mod tokens;
 pub mod zone_changes;
 
 // Re-export core types
@@ -78,6 +79,7 @@ pub use other::*;
 pub use phase_step::*;
 pub use special::*;
 pub use spell_ability::*;
+pub use tokens::*;
 pub use zone_changes::*;
 
 use crate::events::EventKind;
@@ -982,6 +984,11 @@ impl Trigger {
     /// Create a "when a player sacrifices [filter]" trigger.
     pub fn player_sacrifices(player: PlayerFilter, filter: ObjectFilter) -> Self {
         Self::new(PlayerSacrificesTrigger::new(player, filter))
+    }
+
+    /// Create a "whenever [player] creates [tokens]" trigger.
+    pub fn tokens_created(player: PlayerFilter, filter: ObjectFilter, one_or_more: bool) -> Self {
+        Self::new(TokensCreatedTrigger::new(player, filter, one_or_more))
     }
 
     /// Create a "at the beginning of each player's turn" trigger.

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -326,6 +326,11 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::PlayerSacrifices { player, filter } => {
             crate::triggers::Trigger::player_sacrifices(player, filter)
         }
+        TriggerKind::TokensCreated {
+            player,
+            filter,
+            one_or_more,
+        } => crate::triggers::Trigger::tokens_created(player, filter, one_or_more),
         TriggerKind::Dies { filter } => crate::triggers::Trigger::dies(filter),
         TriggerKind::PutIntoGraveyard { filter } => {
             crate::triggers::Trigger::put_into_graveyard(filter)

--- a/crates/ironsmith-runtime/src/triggers/tokens/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/tokens/mod.rs
@@ -1,0 +1,5 @@
+//! Token-creation triggers.
+
+mod tokens_created;
+
+pub use tokens_created::TokensCreatedTrigger;

--- a/crates/ironsmith-runtime/src/triggers/tokens/tokens_created.rs
+++ b/crates/ironsmith-runtime/src/triggers/tokens/tokens_created.rs
@@ -1,0 +1,135 @@
+//! "Whenever [player] creates [tokens]" trigger.
+
+use crate::events::{CreateTokensEvent, EventKind};
+use crate::filter::{ObjectFilterExt as _, PlayerFilterExt as _};
+use crate::target::{ObjectFilter, PlayerFilter};
+use crate::triggers::TriggerEvent;
+use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TokensCreatedTrigger {
+    pub player: PlayerFilter,
+    pub filter: ObjectFilter,
+    pub one_or_more: bool,
+}
+
+impl TokensCreatedTrigger {
+    pub fn new(player: PlayerFilter, filter: ObjectFilter, one_or_more: bool) -> Self {
+        Self {
+            player,
+            filter,
+            one_or_more,
+        }
+    }
+}
+
+impl TriggerMatcher for TokensCreatedTrigger {
+    fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
+        if event.kind() != EventKind::CreateTokens {
+            return false;
+        }
+        let Some(created) = event.downcast::<CreateTokensEvent>() else {
+            return false;
+        };
+        if created.count == 0
+            || !self
+                .player
+                .matches_player(created.controller, &ctx.filter_ctx)
+        {
+            return false;
+        }
+        let Some(token) = &created.token else {
+            return self.filter == ObjectFilter::default();
+        };
+        self.filter.matches(token, &ctx.filter_ctx, ctx.game)
+    }
+
+    fn trigger_count(&self, event: &TriggerEvent) -> u32 {
+        if self.one_or_more {
+            return 1;
+        }
+        event
+            .downcast::<CreateTokensEvent>()
+            .map_or(1, |created| created.count.max(1))
+    }
+
+    fn display(&self) -> String {
+        let subject = match &self.player {
+            PlayerFilter::You => "you".to_string(),
+            PlayerFilter::Opponent => "an opponent".to_string(),
+            PlayerFilter::Any => "a player".to_string(),
+            other => other.description(),
+        };
+        let verb = if self.player == PlayerFilter::You {
+            "create"
+        } else {
+            "creates"
+        };
+        let token = self.filter.description();
+        let object_phrase = if self.one_or_more {
+            format!("one or more {token}s")
+        } else {
+            format!("a {token}")
+        };
+        format!("Whenever {subject} {verb} {object_phrase}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cards::CardDefinitionBuilder;
+    use crate::events::cause::EventCause;
+    use crate::ids::{ObjectId, PlayerId};
+    use crate::object::Object;
+    use crate::provenance::ProvNodeId;
+    use crate::types::{CardType, Subtype};
+
+    #[test]
+    fn matches_creature_token_created_by_controller_once_for_one_or_more() {
+        let game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let soldier = CardDefinitionBuilder::new(crate::CardId::new(), "Soldier")
+            .token()
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Soldier])
+            .build();
+        let token = Object::from_token_definition(ObjectId::from_raw(100), &soldier, alice);
+        let event = TriggerEvent::new_with_provenance(
+            CreateTokensEvent::with_token_cause(alice, 3, token, EventCause::effect()),
+            ProvNodeId::default(),
+        );
+        let trigger = TokensCreatedTrigger::new(
+            PlayerFilter::You,
+            ObjectFilter::creature().token(),
+            true,
+        );
+        let ctx = TriggerContext::for_source(ObjectId::from_raw(1), alice, &game);
+
+        assert!(trigger.matches(&event, &ctx));
+        assert_eq!(trigger.trigger_count(&event), 1);
+    }
+
+    #[test]
+    fn rejects_noncreature_token_for_creature_token_filter() {
+        let game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let clue = CardDefinitionBuilder::new(crate::CardId::new(), "Clue")
+            .token()
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let token = Object::from_token_definition(ObjectId::from_raw(100), &clue, alice);
+        let event = TriggerEvent::new_with_provenance(
+            CreateTokensEvent::with_token_cause(alice, 1, token, EventCause::effect()),
+            ProvNodeId::default(),
+        );
+        let trigger = TokensCreatedTrigger::new(
+            PlayerFilter::You,
+            ObjectFilter::creature().token(),
+            true,
+        );
+        let ctx = TriggerContext::for_source(ObjectId::from_raw(1), alice, &game);
+
+        assert!(!trigger.matches(&event, &ctx));
+    }
+}


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Staff of the Storyteller
Initial parse error:
```
unsupported triggered line: 'Whenever you create one or more creature tokens, put a story counter on this artifact.'; oracle-only fallback also failed: unsupported triggered line: 'Whenever you create one or more creature tokens, put a story counter on this artifact.'
```

Current worker: i-04ea6f70f3422cc31
Branch: codex/aws-card-fix-staff-of-the-storyteller
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0003
