### PR TITLE
Fix Ironsmith parse failure: Wondrous Crucible

### DIFF
--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,65 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn wondrous_crucible_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Wondrous Crucible");
+
+    let def = parse_oracle_card_definition("Wondrous Crucible");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = compiled_text_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("GrantAbility")
+            && ability_debug.contains("Ward")
+            && ability_debug.contains("Generic(2)"),
+        "Wondrous Crucible should grant ward {{2}} to permanents you control, got {ability_debug}"
+    );
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Wondrous Crucible should have an end-step triggered ability");
+    let effects = triggered.effects.flattened_default_effects();
+    let exile = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<MoveToZoneEffect>())
+        .expect("Wondrous Crucible should exile a card from the graveyard");
+    let ChooseSpec::Object(filter) = exile.target.base() else {
+        panic!(
+            "Wondrous Crucible exile target should be a graveyard object filter, got {:?}",
+            exile.target
+        );
+    };
+
+    assert_eq!(exile.zone, Zone::Exile);
+    assert!(
+        exile.target.count().is_random(),
+        "Wondrous Crucible should structurally mark the graveyard exile choice as random"
+    );
+    assert_eq!(filter.zone, Some(Zone::Graveyard));
+    assert_eq!(filter.owner, Some(PlayerFilter::You));
+    assert!(filter.excluded_card_types.contains(&CardType::Land));
+    assert!(
+        ability_debug.contains("CopySpellEffect")
+            && ability_debug.contains("CastTaggedEffect")
+            && ability_debug.contains("as_copy: true")
+            && ability_debug.contains("without_paying_mana_cost: true"),
+        "Wondrous Crucible should copy the exiled card and allow casting that copy for free, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("Exile a nonland card at random from your graveyard"),
+        "compiled text should preserve the at-random exile clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Copy it. You may cast the copy without paying its mana cost"),
+        "compiled text should compact the copy/cast-copy sequence, got {rendered}"
+    );
+}
+
+#[test]
 fn consulate_surveillance_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Consulate Surveillance");
     let def = parse_oracle_card_definition("Consulate Surveillance");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -621,6 +621,44 @@ fn wrapped_effect_tag(effect: &Effect) -> Option<&crate::TagKey> {
     None
 }
 
+fn describe_copy_tagged_then_may_cast_copy(effects: &[Effect]) -> Option<String> {
+    let [copy_effect, may_effect] = effects else {
+        return None;
+    };
+
+    let copy_spell = unwrap_basic_tag_wrappers(copy_effect)
+        .downcast_ref::<crate::effects::CopySpellEffect>()?;
+    if copy_spell.count != Value::Fixed(1) || !copy_spell.removed_supertypes.is_empty() {
+        return None;
+    }
+    let ChooseSpec::Tagged(copy_tag) = &copy_spell.target else {
+        return None;
+    };
+
+    let may = may_effect.downcast_ref::<crate::effects::MayEffect>()?;
+    let [cast_effect] = may.effects.as_slice() else {
+        return None;
+    };
+    let cast_tagged = unwrap_basic_tag_wrappers(cast_effect)
+        .downcast_ref::<crate::effects::CastTaggedEffect>()?;
+    if !cast_tagged.as_copy || &cast_tagged.tag != copy_tag {
+        return None;
+    }
+
+    let verb = if cast_tagged.allow_land { "play" } else { "cast" };
+    let mut text = format!("Copy it. You may {verb} the copy");
+    if cast_tagged.without_paying_mana_cost {
+        text.push_str(" without paying its mana cost");
+    }
+    if let Some(reduction) = cast_tagged.cost_reduction.as_ref() {
+        text.push_str(&format!(
+            ". That copy costs {} less to cast",
+            reduction.to_oracle()
+        ));
+    }
+    Some(text)
+}
+
 fn describe_spell_mastery_reanimation_effects(effects: &[&Effect]) -> Option<String> {
     let [move_effect, conditional_effect] = effects else {
         return None;
@@ -5435,6 +5473,19 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     }
     if let Some(compact) = describe_reveal_top_to_hand_then_lose_mana_value_effects(effects) {
         return compact;
+    }
+    if let Some(compact) = describe_copy_tagged_then_may_cast_copy(effects) {
+        return compact;
+    }
+    if effects.len() > 2
+        && let Some(compact_tail) =
+            describe_copy_tagged_then_may_cast_copy(&effects[effects.len() - 2..])
+    {
+        let prefix = describe_effect_list(&effects[..effects.len() - 2]);
+        if prefix.trim().is_empty() {
+            return compact_tail;
+        }
+        return format!("{}. {compact_tail}", prefix.trim_end_matches('.'));
     }
     if let [for_players_effect, look_effect, grant_effect] = effects
         && let Some(for_players) =
@@ -32048,8 +32099,13 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         return match move_to_zone.zone {
             Zone::Exile => {
                 if let Some(owner) = graveyard_owner_from_spec(&move_to_zone.target) {
-                    let target_text =
+                    let mut target_text =
                         describe_choose_spec_without_graveyard_zone(&move_to_zone.target);
+                    if move_to_zone.target.count().is_random()
+                        && !target_text.to_ascii_lowercase().contains(" at random")
+                    {
+                        target_text.push_str(" at random");
+                    }
                     let from_text = match owner {
                         Some(owner) => {
                             format!("{} graveyard", describe_possessive_player_filter(&owner))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -649,6 +649,52 @@ fn colfenors_urn_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn wondrous_crucible_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(696_480), "Wondrous Crucible")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(7)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "Permanents you control have ward {2}.\n\
+             At the beginning of your end step, mill two cards, then exile a nonland card at random from your graveyard. Copy it. You may cast the copy without paying its mana cost.",
+        )
+        .expect("Wondrous Crucible should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn wondrous_crucible_spell_definition(
+    card_id: u32,
+    name: &str,
+) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(card_id), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Instant])
+        .parse_text("Draw a card.")
+        .expect("Wondrous Crucible test spell should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn wondrous_crucible_land_card(card_id: u32, name: &str) -> crate::card::Card {
+    CardBuilder::new(CardId::from_raw(card_id), name)
+        .card_types(vec![CardType::Land])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_wondrous_crucible_end_step_trigger_on_stack(game: &mut GameState) -> usize {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(game, &mut trigger_queue);
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Wondrous Crucible end-step trigger processing should succeed");
+    game.stack.len()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn vanilla_creature_definition(
     card_id: u32,
     name: &str,
@@ -693,6 +739,170 @@ fn activated_ability_count(game: &GameState, object_id: ObjectId) -> usize {
         .iter()
         .filter(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
         .count()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wondrous_crucible_grants_ward_two_to_permanents_you_control_runtime() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let crucible = wondrous_crucible_definition();
+    game.create_object_from_definition(&crucible, alice, Zone::Battlefield);
+    let protected = game.create_object_from_card(
+        &CardBuilder::new(CardId::from_raw(696_481), "Protected Relic")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let opponent_ward = crate::targeting::collect_ward_costs(&game, &[protected], bob);
+    assert_eq!(opponent_ward.len(), 1, "opponent targeting should see ward");
+    assert_eq!(opponent_ward[0].target, protected);
+    assert_eq!(opponent_ward[0].ward_controller, alice);
+    assert_eq!(opponent_ward[0].cost.display(), "{2}");
+    assert!(
+        crate::targeting::collect_ward_costs(&game, &[protected], alice).is_empty(),
+        "ward should not tax the controller's own targeting"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wondrous_crucible_end_step_randomly_exiles_nonland_and_declining_cast_leaves_it_exiled() {
+    struct DeclineMay;
+
+    impl DecisionMaker for DeclineMay {
+        fn decide_boolean(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            false
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let crucible = wondrous_crucible_definition();
+    game.create_object_from_definition(&crucible, alice, Zone::Battlefield);
+    let spark = wondrous_crucible_spell_definition(696_482, "Crucible Spark");
+    game.create_object_from_definition(&spark, alice, Zone::Library);
+    let land = wondrous_crucible_land_card(696_483, "Milled Plains");
+    game.create_object_from_card(&land, alice, Zone::Library);
+    let random_before = game.irreversible_random_count();
+
+    assert_eq!(
+        put_wondrous_crucible_end_step_trigger_on_stack(&mut game),
+        1,
+        "Wondrous Crucible should trigger at the beginning of your end step"
+    );
+    let mut dm = DeclineMay;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Wondrous Crucible trigger should resolve");
+
+    assert_eq!(
+        game.irreversible_random_count(),
+        random_before + 1,
+        "the at-random graveyard selection should consume match randomness"
+    );
+    assert_eq!(count_named_objects_in_zone(&game, Zone::Graveyard, "Milled Plains"), 1);
+    assert_eq!(count_named_objects_in_zone(&game, Zone::Exile, "Crucible Spark"), 1);
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Stack, "Crucible Spark"),
+        0,
+        "declining the may-cast branch should not put a copy on the stack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wondrous_crucible_end_step_accepting_may_casts_copy_without_paying_mana() {
+    struct AcceptMay;
+
+    impl DecisionMaker for AcceptMay {
+        fn decide_boolean(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let crucible = wondrous_crucible_definition();
+    game.create_object_from_definition(&crucible, alice, Zone::Battlefield);
+    let spark = wondrous_crucible_spell_definition(696_484, "Crucible Spark");
+    game.create_object_from_definition(&spark, alice, Zone::Library);
+    let land = wondrous_crucible_land_card(696_485, "Milled Island");
+    game.create_object_from_card(&land, alice, Zone::Library);
+
+    assert_eq!(put_wondrous_crucible_end_step_trigger_on_stack(&mut game), 1);
+    let mut dm = AcceptMay;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Wondrous Crucible trigger should resolve");
+
+    assert_eq!(count_named_objects_in_zone(&game, Zone::Exile, "Crucible Spark"), 1);
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Stack, "Crucible Spark"),
+        1,
+        "accepting the may-cast branch should cast a stack copy"
+    );
+    let copy_id = game
+        .stack
+        .last()
+        .expect("the copied spell should be on the stack")
+        .object_id;
+    let copy = game.object(copy_id).expect("stack copy object exists");
+    assert_eq!(copy.name, "Crucible Spark");
+    assert_eq!(copy.zone, Zone::Stack);
+    assert_eq!(
+        game.player(alice).expect("Alice exists").mana_pool.total(),
+        0,
+        "the copied spell should be cast without paying its {{3}} mana cost"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn wondrous_crucible_end_step_with_no_nonland_graveyard_card_mills_but_casts_no_copy() {
+    struct AcceptMay;
+
+    impl DecisionMaker for AcceptMay {
+        fn decide_boolean(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let crucible = wondrous_crucible_definition();
+    game.create_object_from_definition(&crucible, alice, Zone::Battlefield);
+    let plains = wondrous_crucible_land_card(696_486, "Only Plains");
+    let island = wondrous_crucible_land_card(696_487, "Only Island");
+    game.create_object_from_card(&plains, alice, Zone::Library);
+    game.create_object_from_card(&island, alice, Zone::Library);
+
+    assert_eq!(put_wondrous_crucible_end_step_trigger_on_stack(&mut game), 1);
+    let mut dm = AcceptMay;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Wondrous Crucible trigger should resolve");
+
+    assert_eq!(count_named_objects_in_zone(&game, Zone::Graveyard, "Only Plains"), 1);
+    assert_eq!(count_named_objects_in_zone(&game, Zone::Graveyard, "Only Island"), 1);
+    assert_eq!(
+        game.objects_in_zone(Zone::Exile).len(),
+        0,
+        "without a nonland graveyard card, Wondrous Crucible should exile nothing"
+    );
+    assert!(
+        game.stack.is_empty(),
+        "without an exiled nonland card, the copy/may-cast branch should put nothing on the stack"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Wondrous Crucible
Initial parse error:
```
compiled text dropped required semantic marker: at-random
```

Current worker: i-0cd73f7cb8e9bc12e
Branch: codex/aws-card-fix-wondrous-crucible
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0003
