### PR TITLE
Fix Ironsmith parse failure: Last Rites

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/choice_object_clauses.rs
@@ -20,6 +20,8 @@ const SECOND_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["second
 const THIRD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["third"]);
 const CHOOSE_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["choose"], &["chooses"]]);
+const FOR_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["for"]);
+const EACH_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["each"]);
 const CHOICE_CONNECTOR_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["or"], &["and"]]);
 const CREATURE_TYPE_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["creature", "type"]);
@@ -78,6 +80,13 @@ const OF_TAGGED_REFERENCE_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["of", "them"], &["of", "those"]]);
 const OF_TAGGED_CARDS_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["of", "those", "card"], &["of", "those", "cards"]]);
+const FOR_EACH_CARD_DISCARDED_THIS_WAY_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["for", "each", "card", "discarded", "this", "way"],
+            &["for", "each", "cards", "discarded", "this", "way"]
+        ]
+);
 const CARD_OR_CARDS_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["card"], &["cards"]]);
 const CONTROLLER_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -209,6 +218,15 @@ fn expand_graveyard_or_hand_disjunction_filter(
     filter
 }
 
+fn parse_choose_objects_for_each_count_value(tokens: &[OwnedLexToken]) -> Option<Value> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if FOR_EACH_CARD_DISCARDED_THIS_WAY_PATTERN.matches_words(&words) {
+        Some(Value::Count(ObjectFilter::tagged(TagKey::from(IT_TAG))))
+    } else {
+        None
+    }
+}
+
 pub(crate) fn parse_target_player_choose_objects_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<(PlayerAst, ObjectFilter, ChoiceCount)>, CardTextError> {
@@ -307,6 +325,14 @@ pub(crate) fn parse_target_player_choose_objects_clause(
 pub(crate) fn parse_you_choose_objects_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<(PlayerAst, ObjectFilter, ChoiceCount)>, CardTextError> {
+    Ok(parse_you_choose_objects_clause_with_count_value(tokens)?.map(
+        |(chooser, filter, count, _count_value)| (chooser, filter, count),
+    ))
+}
+
+pub(crate) fn parse_you_choose_objects_clause_with_count_value(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<(PlayerAst, ObjectFilter, ChoiceCount, Option<Value>)>, CardTextError> {
     let trimmed_tokens = trim_edge_punctuation(tokens);
     let tokens = trimmed_tokens.as_slice();
     let clause_words = crate::runtime_backend::lexer::parser_token_word_refs(tokens);
@@ -339,6 +365,19 @@ pub(crate) fn parse_you_choose_objects_clause(
             "missing chosen object after choose clause (clause: '{}')",
             clause_words.join(" ")
         )));
+    }
+
+    let mut count_value = None;
+    let for_each_idx = (0..choose_object_tokens.len().saturating_sub(1)).find(|idx| {
+        FOR_WORD_PATTERN.matches_token(&choose_object_tokens[*idx])
+            && EACH_WORD_PATTERN.matches_token(&choose_object_tokens[*idx + 1])
+    });
+    if let Some(for_each_idx) = for_each_idx {
+        let count_tokens = trim_commas(&choose_object_tokens[for_each_idx..]);
+        if let Some(value) = parse_choose_objects_for_each_count_value(&count_tokens) {
+            count_value = Some(value);
+            choose_object_tokens.truncate(for_each_idx);
+        }
     }
 
     let mut references_it = false;
@@ -399,6 +438,9 @@ pub(crate) fn parse_you_choose_objects_clause(
             continue;
         }
         idx += 1;
+    }
+    if count_value.is_some() {
+        count = ChoiceCount::dynamic_x();
     }
 
     if choose_words.is_empty() {
@@ -496,7 +538,7 @@ pub(crate) fn parse_you_choose_objects_clause(
         choose_filter.controller = Some(PlayerFilter::You);
     }
 
-    Ok(Some((chooser, choose_filter, count)))
+    Ok(Some((chooser, choose_filter, count, count_value)))
 }
 
 pub(crate) fn parse_you_choose_player_clause(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/mod.rs
@@ -115,7 +115,8 @@ pub(crate) use choice_object_clauses::{
     parse_sentence_target_player_chooses_then_puts_on_top_of_library,
     parse_sentence_target_player_chooses_then_you_put_it_onto_battlefield,
     parse_target_player_choose_objects_clause, parse_target_player_chooses_then_other_cant_block,
-    parse_you_choose_objects_clause, parse_you_choose_player_clause,
+    parse_you_choose_objects_clause, parse_you_choose_objects_clause_with_count_value,
+    parse_you_choose_player_clause,
 };
 use keyword_action_costs::*;
 pub(crate) use keyword_action_costs::{

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
@@ -203,6 +203,10 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
             let followup_player = choose_followup_player_filter(&resolved_filter, &chooser)
                 .unwrap_or_else(|| chooser.clone());
             let chooses_tagged_pool = chooses_tagged_object_pool(&resolved_filter);
+            let count_value = count_value
+                .as_ref()
+                .map(|value| resolve_value_it_tag(value, &current_reference_env(ctx)))
+                .transpose()?;
             let (mut effects, choices) = if let Some(zones) = cross_zone_choices {
                 compile_choose_objects_across_zones_with_subject(
                     subject,
@@ -327,6 +331,10 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
             let chooses_tagged_pool = chooses_tagged_object_pool(&resolved_filter);
             let default_search =
                 slice_contains(zones.as_slice(), &Zone::Library) && !chooses_tagged_pool;
+            let count_value = count_value
+                .as_ref()
+                .map(|value| resolve_value_it_tag(value, &current_reference_env(ctx)))
+                .transpose()?;
             let (effects, choices) = compile_choose_objects_across_zones_with_subject(
                 subject,
                 resolved_filter,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -2,7 +2,7 @@ use winnow::Parser as _;
 
 use super::super::activation_and_restrictions::choice_object_clauses::{
     parse_choose_card_type_phrase_words, parse_target_player_choose_objects_clause,
-    parse_you_choose_objects_clause,
+    parse_you_choose_objects_clause, parse_you_choose_objects_clause_with_count_value,
 };
 use super::super::lexer::{
     OwnedLexToken, TokenKind, parser_token_word_refs, split_lexed_sentences,
@@ -36,6 +36,18 @@ use crate::zone::Zone;
 const CHOSEN_TYPE_REFERENCE_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_any_words &[&["that", "chosen"]]; contains_words & ["type"]);
 const YOU_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["you"]);
+const THEN_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["then"]);
+const DISCARD_ANY_NUMBER_OF_CARDS_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["discard", "any", "number", "of", "cards"]);
+const TARGET_PLAYER_REVEALS_HAND_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["target", "player", "reveals", "their", "hand"],
+            &["target", "opponent", "reveals", "their", "hand"]
+        ]
+);
+const THAT_PLAYER_DISCARDS_THOSE_CARDS_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["that", "player", "discards", "those", "cards"]);
 const PROLIFERATE_CHOOSE_COUNTERED_PERMANENTS_PATTERN: ClauseShape<'static> = clause_shape!(
     exact
         & [
@@ -1246,6 +1258,66 @@ fn parse_choose_objects_then_for_each_of_those_bundle(
     Ok(Some(combined))
 }
 
+fn parse_discard_reveal_choose_discard_chosen_bundle(
+    sentences: &[&[OwnedLexToken]],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let [first, second, third] = sentences else {
+        return Ok(None);
+    };
+    if !DISCARD_ANY_NUMBER_OF_CARDS_PATTERN.matches_words(&parser_token_word_refs(first)) {
+        return Ok(None);
+    }
+    if !THAT_PLAYER_DISCARDS_THOSE_CARDS_PATTERN.matches_words(&parser_token_word_refs(third)) {
+        return Ok(None);
+    }
+
+    let Some(then_idx) = find_index(second, |token| THEN_WORD_PATTERN.matches_token(token)) else {
+        return Ok(None);
+    };
+    let reveal_tokens = trim_commas(&second[..then_idx]);
+    if !TARGET_PLAYER_REVEALS_HAND_PATTERN.matches_words(&parser_token_word_refs(&reveal_tokens)) {
+        return Ok(None);
+    }
+    let choose_tokens = trim_commas(&second[then_idx + 1..]);
+    let Some((chooser, choose_filter, choose_count, count_value)) =
+        parse_you_choose_objects_clause_with_count_value(&choose_tokens)?
+    else {
+        return Ok(None);
+    };
+    let discarded_tag = TagKey::from("discarded_this_way");
+    let count_value = count_value.map(|_| Value::Count(ObjectFilter::tagged(discarded_tag.clone())));
+
+    let mut discarded_filter = ObjectFilter::tagged(TagKey::from(IT_TAG));
+    discarded_filter.zone = Some(Zone::Hand);
+
+    Ok(Some(vec![
+        EffectAst::subject_verb_discard(
+            PlayerAst::Implicit,
+            Value::Fixed(0),
+            false,
+            true,
+            None,
+            Some(discarded_tag),
+        ),
+        EffectAst::subject_verb_reveal_hand(PlayerAst::Target),
+        EffectAst::ChooseObjects {
+            filter: choose_filter,
+            count: choose_count,
+            count_value,
+            player: chooser,
+            tag: TagKey::from(IT_TAG),
+        },
+        EffectAst::subject_verb_discard(
+            PlayerAst::That,
+            Value::Count(discarded_filter.clone()),
+            false,
+            false,
+            Some(discarded_filter),
+            None,
+        ),
+    ]))
+}
+
 fn choose_counter_target(
     first: &[OwnedLexToken],
     first_words: &[&str],
@@ -2288,6 +2360,11 @@ pub(crate) fn parse_exact_card_effect_bundle_lexed(
             sentences[0],
             sentences[1],
         )
+    {
+        return Some(effects);
+    }
+    if sentences.len() == 3
+        && let Ok(Some(effects)) = parse_discard_reveal_choose_discard_chosen_bundle(&sentences)
     {
         return Some(effects);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/bundle_rules.rs
@@ -1275,9 +1275,15 @@ fn parse_discard_reveal_choose_discard_chosen_bundle(
         return Ok(None);
     };
     let reveal_tokens = trim_commas(&second[..then_idx]);
-    if !TARGET_PLAYER_REVEALS_HAND_PATTERN.matches_words(&parser_token_word_refs(&reveal_tokens)) {
+    let reveal_words = parser_token_word_refs(&reveal_tokens);
+    if !TARGET_PLAYER_REVEALS_HAND_PATTERN.matches_words(&reveal_words) {
         return Ok(None);
     }
+    let revealed_player = match reveal_words.as_slice() {
+        ["target", "player", "reveals", "their", "hand"] => PlayerAst::Target,
+        ["target", "opponent", "reveals", "their", "hand"] => PlayerAst::TargetOpponent,
+        _ => return Ok(None),
+    };
     let choose_tokens = trim_commas(&second[then_idx + 1..]);
     let Some((chooser, choose_filter, choose_count, count_value)) =
         parse_you_choose_objects_clause_with_count_value(&choose_tokens)?
@@ -1299,7 +1305,7 @@ fn parse_discard_reveal_choose_discard_chosen_bundle(
             None,
             Some(discarded_tag),
         ),
-        EffectAst::subject_verb_reveal_hand(PlayerAst::Target),
+        EffectAst::subject_verb_reveal_hand(revealed_player),
         EffectAst::ChooseObjects {
             filter: choose_filter,
             count: choose_count,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -11,7 +11,8 @@ use super::super::activation_and_restrictions::{
     parse_choose_creature_type_phrase_words, parse_choose_player_phrase_words,
     parse_may_cast_it_sentence, parse_single_word_keyword_action,
     parse_target_player_choose_objects_clause, parse_you_choose_objects_clause,
-    parse_you_choose_player_clause, starts_with_target_indicator,
+    parse_you_choose_objects_clause_with_count_value, parse_you_choose_player_clause,
+    starts_with_target_indicator,
 };
 use super::super::grammar::primitives::{self as grammar, TokenWordView};
 use super::super::grammar::structure::split_trailing_if_clause_lexed;
@@ -1332,11 +1333,13 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         });
     }
 
-    if let Some((chooser, choose_filter, choose_count)) = parse_you_choose_objects_clause(tokens)? {
+    if let Some((chooser, choose_filter, choose_count, count_value)) =
+        parse_you_choose_objects_clause_with_count_value(tokens)?
+    {
         return Ok(EffectAst::ChooseObjects {
             filter: choose_filter,
             count: choose_count,
-            count_value: None,
+            count_value,
             player: chooser,
             tag: TagKey::from(IT_TAG),
         });

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -12,6 +12,7 @@ use self::subject_verb_followups::{
 use super::super::activation_and_restrictions::{
     parse_choose_card_type_phrase_words, parse_mana_usage_restriction_sentence_lexed,
     parse_target_player_choose_objects_clause, parse_you_choose_objects_clause,
+    parse_you_choose_objects_clause_with_count_value,
 };
 use super::super::effect_ast_traversal::{
     for_each_nested_effects, for_each_nested_effects_mut, try_for_each_nested_effects_mut,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/lex_chain_helpers.rs
@@ -1266,6 +1266,20 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     && grammar::words_match_any_prefix(after_then, PUT_BACK_PREFIXES).is_some()
                     && grammar::contains_word(after_then, "any")
                     && grammar::contains_word(after_then, "order");
+                let allow_choose_backref_followup = has_back_ref
+                    && matches!(
+                        after_words.as_slice(),
+                        ["choose" | "chooses", ..]
+                            | ["you", "choose" | "chooses", ..]
+                            | ["that", "player" | "players", "choose" | "chooses", ..]
+                            | ["the", "voter", "choose" | "chooses", ..]
+                            | [
+                                "target",
+                                "player" | "players" | "opponent" | "opponents",
+                                "choose" | "chooses",
+                                ..
+                            ]
+                    );
                 let allow_clash_followup = starts_with_clash;
                 if has_effect_head && (!has_back_ref || allow_backref_split)
                     || has_effect_head && allow_clash_followup
@@ -1279,6 +1293,7 @@ pub(crate) fn split_segments_on_comma_then_lexed(
                     || has_effect_head && allow_put_battlefield_with_counter_followup
                     || has_effect_head && allow_put_into_hand_followup
                     || has_effect_head && allow_put_back_in_any_order_followup
+                    || has_effect_head && allow_choose_backref_followup
                 {
                     split_point = Some(i);
                     break;

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1067,6 +1067,47 @@ fn last_rites_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn discard_reveal_choose_discard_bundle_preserves_target_opponent() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Opponent Last Rites Variant")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Discard any number of cards. Target opponent reveals their hand, then you choose a nonland card from it for each card discarded this way. That player discards those cards.",
+        )
+        .expect("target-opponent discard/reveal/choose/discard bundle should parse");
+    let rendered = compiled_text_lines(&def).join("\n");
+    assert_eq!(
+        rendered,
+        "Discard any number of cards. Target opponent reveals their hand, then you choose a nonland card from it for each card discarded this way. That player discards those cards."
+    );
+
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("variant should have spell effects")
+        .flattened_default_effects();
+    let [discard_cost_effect, reveal_effect, choose_effect, discard_chosen_effect] = effects else {
+        panic!("variant should lower to discard/reveal/choose/discard effects, got {effects:#?}");
+    };
+    let discard_cost = discard_cost_effect
+        .downcast_ref::<crate::effects::DiscardEffect>()
+        .expect("variant should start by discarding any number of your cards");
+    let reveal = reveal_effect
+        .downcast_ref::<crate::effects::LookAtHandEffect>()
+        .expect("variant should reveal the target opponent's hand");
+    let choose = choose_effect
+        .downcast_ref::<crate::effects::ChooseObjectsEffect>()
+        .expect("variant should choose cards from the revealed hand");
+    let discard_chosen = discard_chosen_effect
+        .downcast_ref::<crate::effects::DiscardEffect>()
+        .expect("variant should discard the chosen cards");
+
+    assert_eq!(discard_cost.player, PlayerFilter::You);
+    assert_eq!(reveal.target, ChooseSpec::target_opponent());
+    assert_eq!(choose.filter.owner, Some(PlayerFilter::target_opponent()));
+    assert_eq!(discard_chosen.player, PlayerFilter::target_opponent());
+}
+
+#[test]
 fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Boss's Chauffeur");
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -998,6 +998,75 @@ fn reprocess_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn last_rites_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Last Rites");
+
+    let def = parse_oracle_card_definition("Last Rites");
+    let rendered = compiled_text_lines(&def).join("\n");
+
+    assert_eq!(def.name(), "Last Rites");
+    assert_eq!(def.card.card_types, vec![CardType::Sorcery]);
+    assert_eq!(
+        rendered,
+        "Discard any number of cards. Target player reveals their hand, then you choose a nonland card from it for each card discarded this way. That player discards those cards."
+    );
+
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Last Rites should have spell effects")
+        .flattened_default_effects();
+    let [discard_cost_effect, reveal_effect, choose_effect, discard_chosen_effect] = effects else {
+        panic!("Last Rites should lower to discard/reveal/choose/discard effects, got {effects:#?}");
+    };
+    let discard_cost = discard_cost_effect
+        .downcast_ref::<crate::effects::DiscardEffect>()
+        .expect("Last Rites should start by discarding any number of your cards");
+    let reveal = reveal_effect
+        .downcast_ref::<crate::effects::LookAtHandEffect>()
+        .expect("Last Rites should reveal the target player's hand");
+    let choose = choose_effect
+        .downcast_ref::<crate::effects::ChooseObjectsEffect>()
+        .expect("Last Rites should choose cards from the revealed hand");
+    let discard_chosen = discard_chosen_effect
+        .downcast_ref::<crate::effects::DiscardEffect>()
+        .expect("Last Rites should discard the chosen cards");
+
+    assert_eq!(discard_cost.player, PlayerFilter::You);
+    assert!(discard_cost.any_number);
+    assert_eq!(discard_cost.tag.as_ref().map(|tag| tag.as_str()), Some("discarded_this_way"));
+    assert_eq!(reveal.target, ChooseSpec::target_player());
+    assert!(reveal.reveal);
+    assert_eq!(choose.chooser, PlayerFilter::You);
+    assert_eq!(choose.filter.zone, Some(Zone::Hand));
+    assert_eq!(choose.filter.owner, Some(PlayerFilter::target_player()));
+    assert_eq!(choose.filter.excluded_card_types, vec![CardType::Land]);
+    assert!(choose.count.dynamic_x);
+    assert!(matches!(
+        choose.count_value.as_ref(),
+        Some(Value::Count(filter)) if filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag.as_str() == "discarded_this_way"
+                && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+        })
+    ));
+    assert_eq!(discard_chosen.player, PlayerFilter::target_player());
+    assert!(matches!(
+        &discard_chosen.count,
+        Value::Count(filter) if filter.tagged_constraints.iter().any(|constraint| {
+            constraint.tag == choose.tag
+                && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+        })
+    ));
+    assert!(discard_chosen.card_filter.as_ref().is_some_and(|filter| {
+        filter.owner == Some(PlayerFilter::target_player())
+            && filter.tagged_constraints.iter().any(|constraint| {
+                constraint.tag == choose.tag
+                    && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            })
+    }));
+}
+
+#[test]
 fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Boss's Chauffeur");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -1188,6 +1188,108 @@ fn choose_primary_zone(choose: &crate::effects::ChooseObjectsEffect) -> Option<Z
     choose.filter.zone.or(choose.zone)
 }
 
+fn object_filter_has_tag(filter: &ObjectFilter, tag: &crate::tag::TagKey) -> bool {
+    filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            && constraint.tag == *tag
+    })
+}
+
+fn choose_spec_player_filter(spec: &ChooseSpec) -> Option<PlayerFilter> {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. } => choose_spec_player_filter(spec),
+        ChooseSpec::Target(inner) => {
+            Some(PlayerFilter::Target(Box::new(choose_spec_player_filter(inner)?)))
+        }
+        ChooseSpec::Player(filter) => Some(filter.clone()),
+        _ => None,
+    }
+}
+
+fn hand_choice_selection_from_it(choose: &crate::effects::ChooseObjectsEffect) -> String {
+    let mut filter = choose.filter.clone();
+    filter.zone = None;
+    filter.owner = None;
+    filter.controller = None;
+    filter.tagged_constraints.clear();
+    let mut selection = if choose_primary_zone(choose) == Some(Zone::Hand)
+        && choose.filter.card_types.is_empty()
+        && choose.filter.excluded_card_types == vec![CardType::Land]
+    {
+        "nonland card".to_string()
+    } else if choose_primary_zone(choose) == Some(Zone::Hand)
+        && choose.filter.card_types.is_empty()
+        && choose.filter.excluded_card_types.is_empty()
+        && choose.filter.subtypes.is_empty()
+        && choose.filter.colors.is_none()
+        && choose.filter.mana_value.is_none()
+    {
+        "card".to_string()
+    } else {
+        filter.description()
+    };
+    if !selection.contains("card") {
+        selection.push_str(" card");
+    }
+    with_indefinite_article(&selection)
+}
+
+fn describe_discard_reveal_hand_choose_discard_chosen(effects: &[&Effect]) -> Option<String> {
+    let [discard_cost_effect, look_effect, choose_effect, discard_chosen_effect] = effects else {
+        return None;
+    };
+    let discard_cost = discard_cost_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+    let discarded_tag = discard_cost.tag.as_ref()?;
+    if discard_cost.player != PlayerFilter::You
+        || discard_cost.count != Value::Fixed(0)
+        || !discard_cost.any_number
+        || discard_cost.random
+        || discard_cost.card_filter.is_some()
+    {
+        return None;
+    }
+
+    let look = look_effect.downcast_ref::<crate::effects::LookAtHandEffect>()?;
+    if !look.reveal {
+        return None;
+    }
+    let look_player = choose_spec_player_filter(&look.target)?;
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if choose.chooser != PlayerFilter::You
+        || !choose.count.is_dynamic_x()
+        || choose_primary_zone(choose) != Some(Zone::Hand)
+        || choose.filter.owner.as_ref() != Some(&look_player)
+        || !matches!(
+            choose.count_value.as_ref(),
+            Some(Value::Count(filter)) if object_filter_has_tag(filter, discarded_tag)
+        )
+    {
+        return None;
+    }
+
+    let discard_chosen = discard_chosen_effect.downcast_ref::<crate::effects::DiscardEffect>()?;
+    if discard_chosen.random
+        || discard_chosen.any_number
+        || discard_chosen.player != look_player
+        || !matches!(&discard_chosen.count, Value::Count(filter) if object_filter_has_tag(filter, &choose.tag))
+        || !discard_chosen
+            .card_filter
+            .as_ref()
+            .is_some_and(|filter| object_filter_has_tag(filter, &choose.tag))
+    {
+        return None;
+    }
+
+    let revealer = describe_choose_spec(&look.target);
+    let reveal_verb = player_verb(&revealer, "reveal", "reveals");
+    let selection = hand_choice_selection_from_it(choose);
+    Some(format!(
+        "Discard any number of cards. {} {} their hand, then you choose {selection} from it for each card discarded this way. That player discards those cards",
+        capitalize_first(&revealer),
+        reveal_verb
+    ))
+}
+
 fn describe_reveal_hand_subset_choose_then_discard(effects: &[&Effect]) -> Option<String> {
     let [reveal_effect, choose_effect, discard_effect] = effects else {
         return None;
@@ -6685,32 +6787,8 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             .downcast_ref::<crate::effects::MoveToLibraryNthFromTopEffect>()
     }
 
-    fn hand_choice_selection_from_it(choose: &crate::effects::ChooseObjectsEffect) -> String {
-        let mut filter = choose.filter.clone();
-        filter.zone = None;
-        filter.owner = None;
-        filter.controller = None;
-        filter.tagged_constraints.clear();
-        let mut selection = if choose_primary_zone(choose) == Some(Zone::Hand)
-            && choose.filter.card_types.is_empty()
-            && choose.filter.excluded_card_types == vec![CardType::Land]
-        {
-            "nonland card".to_string()
-        } else if choose_primary_zone(choose) == Some(Zone::Hand)
-            && choose.filter.card_types.is_empty()
-            && choose.filter.excluded_card_types.is_empty()
-            && choose.filter.subtypes.is_empty()
-            && choose.filter.colors.is_none()
-            && choose.filter.mana_value.is_none()
-        {
-            "card".to_string()
-        } else {
-            filter.description()
-        };
-        if !selection.contains("card") {
-            selection.push_str(" card");
-        }
-        with_indefinite_article(&selection)
+    if let Some(compact) = describe_discard_reveal_hand_choose_discard_chosen(&raw_effects) {
+        return compact;
     }
 
     fn library_top_position_text(position: &crate::effect::Value) -> String {
@@ -7042,6 +7120,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
+    if let Some(compact) = describe_discard_reveal_hand_choose_discard_chosen(&filtered) {
+        return compact;
+    }
     if let Some(compact) = describe_reveal_hand_choose_move(&filtered) {
         return compact;
     }
@@ -16279,6 +16360,9 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
     }
 
     let effect_refs = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_discard_reveal_hand_choose_discard_chosen(&effect_refs) {
+        return Some(compact);
+    }
     if let Some(compact) = describe_player_protection_from_everything_pair(&effect_refs) {
         return Some(compact);
     }

--- a/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
+++ b/crates/ironsmith-runtime/src/effects/composition/choose_objects_runtime.rs
@@ -1068,11 +1068,6 @@ pub(crate) fn run_choose_objects(
                 || (effect.is_search && effect.search_mode == SearchSelectionMode::Optional);
             if optional_dynamic_choice {
                 (0, x.min(candidates.len()))
-            } else if x > candidates.len() && !effect.is_search {
-                return Err(ExecutionError::Impossible(format!(
-                    "Not enough candidates to choose dynamic-count objects ({x}, {} available)",
-                    candidates.len()
-                )));
             } else {
                 let bounded = x.min(candidates.len());
                 (bounded, bounded)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12722,6 +12722,190 @@ fn infernal_kirin_discards_only_cards_matching_triggering_spell_mana_value() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn last_rites_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(27_376), "Last Rites")
+        .mana_cost(ManaCost::from_symbols(vec![
+            ManaSymbol::Generic(2),
+            ManaSymbol::Black,
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Discard any number of cards. Target player reveals their hand, then you choose a nonland card from it for each card discarded this way. That player discards those cards.",
+        )
+        .expect("Last Rites should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn test_card_for_last_rites(name: &str, card_types: Vec<CardType>) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn last_rites_discards_chosen_nonlands_from_revealed_target_hand() {
+    fn stable_id_of(game: &GameState, id: ObjectId) -> crate::ids::StableId {
+        game.object(id).expect("object should exist").stable_id
+    }
+
+    fn current_id_of(
+        game: &GameState,
+        stable_id: crate::ids::StableId,
+        label: &str,
+    ) -> ObjectId {
+        game.find_object_by_stable_id(stable_id)
+            .unwrap_or_else(|| panic!("{label} should still exist"))
+    }
+
+    struct LastRitesDecisionMaker {
+        target: PlayerId,
+        discard_from_hand: Vec<ObjectId>,
+        choose_from_target: Vec<ObjectId>,
+        reveal_calls: Vec<(PlayerId, PlayerId, bool, Vec<ObjectId>)>,
+    }
+
+    impl DecisionMaker for LastRitesDecisionMaker {
+        fn decide_targets(
+            &mut self,
+            _game: &GameState,
+            _ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<Target> {
+            vec![Target::Player(self.target)]
+        }
+
+        fn decide_objects(
+            &mut self,
+            _game: &GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            let legal_ids = ctx
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .collect::<Vec<_>>();
+            let scripted = if self
+                .discard_from_hand
+                .iter()
+                .any(|id| legal_ids.contains(id))
+            {
+                &self.discard_from_hand
+            } else {
+                &self.choose_from_target
+            };
+            scripted
+                .iter()
+                .copied()
+                .filter(|id| legal_ids.contains(id))
+                .collect()
+        }
+
+        fn view_cards(
+            &mut self,
+            _game: &GameState,
+            viewer: PlayerId,
+            cards: &[ObjectId],
+            ctx: &crate::decisions::context::ViewCardsContext,
+        ) {
+            self.reveal_calls
+                .push((viewer, ctx.subject, ctx.public, cards.to_vec()));
+        }
+    }
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_discard_one = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Discard One", vec![CardType::Instant]),
+        alice,
+        Zone::Hand,
+    );
+    let alice_discard_two = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Discard Two", vec![CardType::Creature]),
+        alice,
+        Zone::Hand,
+    );
+    let alice_keeps = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Keeps", vec![CardType::Sorcery]),
+        alice,
+        Zone::Hand,
+    );
+    let bob_nonland_one = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Nonland One", vec![CardType::Instant]),
+        bob,
+        Zone::Hand,
+    );
+    let bob_nonland_two = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Nonland Two", vec![CardType::Creature]),
+        bob,
+        Zone::Hand,
+    );
+    let bob_land = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Land", vec![CardType::Land]),
+        bob,
+        Zone::Hand,
+    );
+    let alice_discard_one_stable = stable_id_of(&game, alice_discard_one);
+    let alice_discard_two_stable = stable_id_of(&game, alice_discard_two);
+    let alice_keeps_stable = stable_id_of(&game, alice_keeps);
+    let bob_nonland_one_stable = stable_id_of(&game, bob_nonland_one);
+    let bob_nonland_two_stable = stable_id_of(&game, bob_nonland_two);
+    let bob_land_stable = stable_id_of(&game, bob_land);
+
+    let last_rites = last_rites_definition();
+    let spell_id = game.create_object_from_definition(&last_rites, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_targets(vec![Target::Player(bob)]));
+
+    let mut dm = LastRitesDecisionMaker {
+        target: bob,
+        discard_from_hand: vec![alice_discard_one, alice_discard_two],
+        choose_from_target: vec![bob_nonland_one, bob_nonland_two],
+        reveal_calls: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Last Rites should resolve");
+
+    assert_eq!(
+        dm.reveal_calls.len(),
+        game.players.len(),
+        "Last Rites should reveal the target player's hand publicly"
+    );
+    for (_viewer, subject, public, cards) in &dm.reveal_calls {
+        assert_eq!(*subject, bob);
+        assert!(*public);
+        assert!(cards.contains(&bob_nonland_one));
+        assert!(cards.contains(&bob_nonland_two));
+        assert!(cards.contains(&bob_land));
+    }
+
+    let alice_discard_one = current_id_of(&game, alice_discard_one_stable, "Alice Discard One");
+    let alice_discard_two = current_id_of(&game, alice_discard_two_stable, "Alice Discard Two");
+    let alice_keeps = current_id_of(&game, alice_keeps_stable, "Alice Keeps");
+    let bob_nonland_one = current_id_of(&game, bob_nonland_one_stable, "Bob Nonland One");
+    let bob_nonland_two = current_id_of(&game, bob_nonland_two_stable, "Bob Nonland Two");
+    let bob_land = current_id_of(&game, bob_land_stable, "Bob Land");
+
+    let alice_hand = &game.player(alice).expect("alice exists").hand;
+    assert!(!alice_hand.contains(&alice_discard_one));
+    assert!(!alice_hand.contains(&alice_discard_two));
+    assert!(alice_hand.contains(&alice_keeps));
+
+    let bob_hand = &game.player(bob).expect("bob exists").hand;
+    assert!(!bob_hand.contains(&bob_nonland_one));
+    assert!(!bob_hand.contains(&bob_nonland_two));
+    assert!(bob_hand.contains(&bob_land));
+
+    let alice_graveyard = &game.player(alice).expect("alice exists").graveyard;
+    assert!(alice_graveyard.contains(&alice_discard_one));
+    assert!(alice_graveyard.contains(&alice_discard_two));
+    let bob_graveyard = &game.player(bob).expect("bob exists").graveyard;
+    assert!(bob_graveyard.contains(&bob_nonland_one));
+    assert!(bob_graveyard.contains(&bob_nonland_two));
+    assert!(!bob_graveyard.contains(&bob_land));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn infernal_kirin_triggers_for_arcane_spell() {
     let mut game = setup_game();

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12743,76 +12743,80 @@ fn test_card_for_last_rites(name: &str, card_types: Vec<CardType>) -> crate::car
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn last_rites_stable_id_of(game: &GameState, id: ObjectId) -> crate::ids::StableId {
+    game.object(id).expect("object should exist").stable_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn last_rites_current_id_of(
+    game: &GameState,
+    stable_id: crate::ids::StableId,
+    label: &str,
+) -> ObjectId {
+    game.find_object_by_stable_id(stable_id)
+        .unwrap_or_else(|| panic!("{label} should still exist"))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct LastRitesDecisionMaker {
+    target: PlayerId,
+    discard_from_hand: Vec<ObjectId>,
+    choose_from_target: Vec<ObjectId>,
+    reveal_calls: Vec<(PlayerId, PlayerId, bool, Vec<ObjectId>)>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for LastRitesDecisionMaker {
+    fn decide_targets(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::TargetsContext,
+    ) -> Vec<Target> {
+        vec![Target::Player(self.target)]
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        let legal_ids = ctx
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .collect::<Vec<_>>();
+        let scripted = if self
+            .discard_from_hand
+            .iter()
+            .any(|id| legal_ids.contains(id))
+        {
+            &self.discard_from_hand
+        } else {
+            &self.choose_from_target
+        };
+        scripted
+            .iter()
+            .copied()
+            .filter(|id| legal_ids.contains(id))
+            .collect()
+    }
+
+    fn view_cards(
+        &mut self,
+        _game: &GameState,
+        viewer: PlayerId,
+        cards: &[ObjectId],
+        ctx: &crate::decisions::context::ViewCardsContext,
+    ) {
+        self.reveal_calls
+            .push((viewer, ctx.subject, ctx.public, cards.to_vec()));
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn last_rites_discards_chosen_nonlands_from_revealed_target_hand() {
-    fn stable_id_of(game: &GameState, id: ObjectId) -> crate::ids::StableId {
-        game.object(id).expect("object should exist").stable_id
-    }
-
-    fn current_id_of(
-        game: &GameState,
-        stable_id: crate::ids::StableId,
-        label: &str,
-    ) -> ObjectId {
-        game.find_object_by_stable_id(stable_id)
-            .unwrap_or_else(|| panic!("{label} should still exist"))
-    }
-
-    struct LastRitesDecisionMaker {
-        target: PlayerId,
-        discard_from_hand: Vec<ObjectId>,
-        choose_from_target: Vec<ObjectId>,
-        reveal_calls: Vec<(PlayerId, PlayerId, bool, Vec<ObjectId>)>,
-    }
-
-    impl DecisionMaker for LastRitesDecisionMaker {
-        fn decide_targets(
-            &mut self,
-            _game: &GameState,
-            _ctx: &crate::decisions::context::TargetsContext,
-        ) -> Vec<Target> {
-            vec![Target::Player(self.target)]
-        }
-
-        fn decide_objects(
-            &mut self,
-            _game: &GameState,
-            ctx: &crate::decisions::context::SelectObjectsContext,
-        ) -> Vec<ObjectId> {
-            let legal_ids = ctx
-                .candidates
-                .iter()
-                .filter(|candidate| candidate.legal)
-                .map(|candidate| candidate.id)
-                .collect::<Vec<_>>();
-            let scripted = if self
-                .discard_from_hand
-                .iter()
-                .any(|id| legal_ids.contains(id))
-            {
-                &self.discard_from_hand
-            } else {
-                &self.choose_from_target
-            };
-            scripted
-                .iter()
-                .copied()
-                .filter(|id| legal_ids.contains(id))
-                .collect()
-        }
-
-        fn view_cards(
-            &mut self,
-            _game: &GameState,
-            viewer: PlayerId,
-            cards: &[ObjectId],
-            ctx: &crate::decisions::context::ViewCardsContext,
-        ) {
-            self.reveal_calls
-                .push((viewer, ctx.subject, ctx.public, cards.to_vec()));
-        }
-    }
-
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);
     let bob = PlayerId::from_index(1);
@@ -12847,12 +12851,12 @@ fn last_rites_discards_chosen_nonlands_from_revealed_target_hand() {
         bob,
         Zone::Hand,
     );
-    let alice_discard_one_stable = stable_id_of(&game, alice_discard_one);
-    let alice_discard_two_stable = stable_id_of(&game, alice_discard_two);
-    let alice_keeps_stable = stable_id_of(&game, alice_keeps);
-    let bob_nonland_one_stable = stable_id_of(&game, bob_nonland_one);
-    let bob_nonland_two_stable = stable_id_of(&game, bob_nonland_two);
-    let bob_land_stable = stable_id_of(&game, bob_land);
+    let alice_discard_one_stable = last_rites_stable_id_of(&game, alice_discard_one);
+    let alice_discard_two_stable = last_rites_stable_id_of(&game, alice_discard_two);
+    let alice_keeps_stable = last_rites_stable_id_of(&game, alice_keeps);
+    let bob_nonland_one_stable = last_rites_stable_id_of(&game, bob_nonland_one);
+    let bob_nonland_two_stable = last_rites_stable_id_of(&game, bob_nonland_two);
+    let bob_land_stable = last_rites_stable_id_of(&game, bob_land);
 
     let last_rites = last_rites_definition();
     let spell_id = game.create_object_from_definition(&last_rites, alice, Zone::Stack);
@@ -12879,12 +12883,16 @@ fn last_rites_discards_chosen_nonlands_from_revealed_target_hand() {
         assert!(cards.contains(&bob_land));
     }
 
-    let alice_discard_one = current_id_of(&game, alice_discard_one_stable, "Alice Discard One");
-    let alice_discard_two = current_id_of(&game, alice_discard_two_stable, "Alice Discard Two");
-    let alice_keeps = current_id_of(&game, alice_keeps_stable, "Alice Keeps");
-    let bob_nonland_one = current_id_of(&game, bob_nonland_one_stable, "Bob Nonland One");
-    let bob_nonland_two = current_id_of(&game, bob_nonland_two_stable, "Bob Nonland Two");
-    let bob_land = current_id_of(&game, bob_land_stable, "Bob Land");
+    let alice_discard_one =
+        last_rites_current_id_of(&game, alice_discard_one_stable, "Alice Discard One");
+    let alice_discard_two =
+        last_rites_current_id_of(&game, alice_discard_two_stable, "Alice Discard Two");
+    let alice_keeps = last_rites_current_id_of(&game, alice_keeps_stable, "Alice Keeps");
+    let bob_nonland_one =
+        last_rites_current_id_of(&game, bob_nonland_one_stable, "Bob Nonland One");
+    let bob_nonland_two =
+        last_rites_current_id_of(&game, bob_nonland_two_stable, "Bob Nonland Two");
+    let bob_land = last_rites_current_id_of(&game, bob_land_stable, "Bob Land");
 
     let alice_hand = &game.player(alice).expect("alice exists").hand;
     assert!(!alice_hand.contains(&alice_discard_one));
@@ -12903,6 +12911,140 @@ fn last_rites_discards_chosen_nonlands_from_revealed_target_hand() {
     assert!(bob_graveyard.contains(&bob_nonland_one));
     assert!(bob_graveyard.contains(&bob_nonland_two));
     assert!(!bob_graveyard.contains(&bob_land));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn last_rites_discards_available_nonlands_when_more_cards_were_discarded() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_discard_one = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Discard One", vec![CardType::Instant]),
+        alice,
+        Zone::Hand,
+    );
+    let alice_discard_two = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Discard Two", vec![CardType::Creature]),
+        alice,
+        Zone::Hand,
+    );
+    let alice_discard_three = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Discard Three", vec![CardType::Sorcery]),
+        alice,
+        Zone::Hand,
+    );
+    let bob_nonland = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Only Nonland", vec![CardType::Instant]),
+        bob,
+        Zone::Hand,
+    );
+    let bob_land = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Land", vec![CardType::Land]),
+        bob,
+        Zone::Hand,
+    );
+    let bob_nonland_stable = last_rites_stable_id_of(&game, bob_nonland);
+    let bob_land_stable = last_rites_stable_id_of(&game, bob_land);
+
+    let last_rites = last_rites_definition();
+    let spell_id = game.create_object_from_definition(&last_rites, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_targets(vec![Target::Player(bob)]));
+
+    let mut dm = LastRitesDecisionMaker {
+        target: bob,
+        discard_from_hand: vec![alice_discard_one, alice_discard_two, alice_discard_three],
+        choose_from_target: vec![bob_nonland],
+        reveal_calls: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Last Rites should resolve even when fewer nonlands are available");
+
+    let bob_nonland = last_rites_current_id_of(&game, bob_nonland_stable, "Bob Only Nonland");
+    let bob_land = last_rites_current_id_of(&game, bob_land_stable, "Bob Land");
+    let bob_hand = &game.player(bob).expect("bob exists").hand;
+    assert!(!bob_hand.contains(&bob_nonland));
+    assert!(bob_hand.contains(&bob_land));
+    let bob_graveyard = &game.player(bob).expect("bob exists").graveyard;
+    assert!(bob_graveyard.contains(&bob_nonland));
+    assert!(!bob_graveyard.contains(&bob_land));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn last_rites_zero_discard_leaves_target_hand_intact() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_card = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Keeps", vec![CardType::Instant]),
+        alice,
+        Zone::Hand,
+    );
+    let bob_nonland = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Nonland", vec![CardType::Instant]),
+        bob,
+        Zone::Hand,
+    );
+    let alice_card_stable = last_rites_stable_id_of(&game, alice_card);
+    let bob_nonland_stable = last_rites_stable_id_of(&game, bob_nonland);
+
+    let last_rites = last_rites_definition();
+    let spell_id = game.create_object_from_definition(&last_rites, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_targets(vec![Target::Player(bob)]));
+
+    let mut dm = LastRitesDecisionMaker {
+        target: bob,
+        discard_from_hand: Vec::new(),
+        choose_from_target: vec![bob_nonland],
+        reveal_calls: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Last Rites should resolve");
+
+    let alice_card = last_rites_current_id_of(&game, alice_card_stable, "Alice Keeps");
+    let bob_nonland = last_rites_current_id_of(&game, bob_nonland_stable, "Bob Nonland");
+    assert!(game.player(alice).expect("alice exists").hand.contains(&alice_card));
+    assert!(game.player(bob).expect("bob exists").hand.contains(&bob_nonland));
+    assert!(game.player(bob).expect("bob exists").graveyard.is_empty());
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn last_rites_no_target_nonlands_discards_none_from_target() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_discard = game.create_object_from_card(
+        &test_card_for_last_rites("Alice Discard", vec![CardType::Instant]),
+        alice,
+        Zone::Hand,
+    );
+    let bob_land = game.create_object_from_card(
+        &test_card_for_last_rites("Bob Land", vec![CardType::Land]),
+        bob,
+        Zone::Hand,
+    );
+    let bob_land_stable = last_rites_stable_id_of(&game, bob_land);
+
+    let last_rites = last_rites_definition();
+    let spell_id = game.create_object_from_definition(&last_rites, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, alice).with_targets(vec![Target::Player(bob)]));
+
+    let mut dm = LastRitesDecisionMaker {
+        target: bob,
+        discard_from_hand: vec![alice_discard],
+        choose_from_target: Vec::new(),
+        reveal_calls: Vec::new(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm)
+        .expect("Last Rites should resolve with no target nonlands");
+
+    let bob_land = last_rites_current_id_of(&game, bob_land_stable, "Bob Land");
+    assert!(game.player(bob).expect("bob exists").hand.contains(&bob_land));
+    assert!(game.player(bob).expect("bob exists").graveyard.is_empty());
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Last Rites
Initial parse error:
```
spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Count(ObjectFilter { zone: Some(Hand), controller: None, cast_by: None, cast_this_turn: false, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, chosen_card_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, dealt_damage_to_player_this_turn: None, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [TaggedObjectConstraint { tag: TagKey("__it__"), relation: IsTaggedObject }], specific: None, any_of: [], source: false }), player: IteratedPlayer, random: false, any_number: false, card_filter: Some(ObjectFilter { zone: Some(Hand), controller: None, cast_by: None, cast_this_turn: false, first_spell_cast_each_turn: false, owner: Some(IteratedPlayer), single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, chosen_card_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, dealt_damage_to_player_this_turn: None, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [TaggedObjectConstraint { tag: TagKey("discarded_0"), relation: IsTaggedObject }], specific: None, any_of: [], source: false }), tag: Some(TagKey("discarded_1")) }); oracle-only fallback also failed: spell text effects references PlayerFilter::IteratedPlayer without a trigger or loop that binds "that player": Effect(DiscardEffect { count: Count(ObjectFilter { zone: Some(Hand), controller: None, cast_by: None, cast_this_turn: false, first_spell_cast_each_turn: false, owner: None, single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, chosen_card_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, dealt_damage_to_player_this_turn: None, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [TaggedObjectConstraint { tag: TagKey("__it__"), relation: IsTaggedObject }], specific: None, any_of: [], source: false }), player: IteratedPlayer, random: false, any_number: false, card_filter: Some(ObjectFilter { zone: Some(Hand), controller: None, cast_by: None, cast_this_turn: false, first_spell_cast_each_turn: false, owner: Some(IteratedPlayer), single_graveyard: false, targets_player: None, targets_object: None, targets_any_of: false, stack_kind: None, target_count: None, targets_only_player: None, targets_only_object: None, targets_only_any_of: false, could_be_targeted_by: None, card_types: [], all_card_types: [], excluded_card_types: [], subtypes: [], type_or_subtype_union: false, excluded_subtypes: [], supertypes: [], excluded_supertypes: [], colors: None, chosen_color: false, chosen_creature_type: false, chosen_card_type: false, excluded_chosen_creature_type: false, excluded_colors: ColorSet(0), colorless: false, multicolored: false, monocolored: false, all_colors: None, exactly_two_colors: None, color_count: None, historic: false, nonhistoric: false, modified: false, token: false, nontoken: false, face_down: None, other: false, tapped: false, untapped: false, attacking: false, attacked_this_turn: false, attacking_player_or_planeswalker_controlled_by: None, attached_to_player: None, nonattacking: false, enlist_eligible: false, blocking: false, nonblocking: false, blocked: false, blocked_by: None, unblocked: false, in_combat_with_source: false, entered_since_your_last_turn_ended: false, entered_battlefield_this_turn: false, entered_battlefield_controller: None, entered_graveyard_this_turn: false, entered_graveyard_from_battlefield_this_turn: false, surveilled_this_turn: false, was_dealt_damage_this_turn: false, dealt_damage_to_player_this_turn: None, drawn_this_turn: false, power: None, power_parity: None, power_reference: Effective, power_relative_to_source: None, power_greater_than_base_power: false, toughness: None, toughness_reference: Effective, total_power_toughness: None, mana_value: None, mana_value_parity: None, mana_value_eq_counters_on_source: None, has_mana_cost: false, has_tap_activated_ability: false, no_abilities: false, no_x_in_cost: false, has_x_in_cost: false, with_counter: None, without_counter: None, total_counters_parity: None, name: None, excluded_name: None, distinct_names: false, distinct_powers: false, distinct_creature_types: false, alternative_cast: None, static_abilities: [], excluded_static_abilities: [], ability_markers: [], excluded_ability_markers: [], is_commander: false, noncommander: false, tagged_constraints: [TaggedObjectConstraint { tag: TagKey("discarded_0"), relation: IsTaggedObject }], specific: None, any_of: [], source: false }), tag: Some(TagKey("discarded_1")) })
```

Current worker: i-01d2160076de77f4f
Branch: codex/aws-card-fix-last-rites
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0003
