### PR TITLE
Fix Ironsmith parse failure: Kodama of the Center Tree

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -301,6 +301,7 @@ impl CardDefinitionBuilder {
             KeywordAction::Riot => self.riot(),
             KeywordAction::Soulbond => self.soulbond(),
             KeywordAction::Soulshift(amount) => self.soulshift(amount),
+            KeywordAction::SoulshiftValue(value) => self.soulshift_value(value),
             KeywordAction::Recover(cost) => self.recover(cost),
             KeywordAction::Outlast(cost) => self.outlast(cost),
             KeywordAction::Scavenge(cost) => self.scavenge(cost),
@@ -1198,15 +1199,39 @@ impl CardDefinitionBuilder {
     }
 
     pub fn soulshift(self, amount: u32) -> Self {
+        self.with_ability(Self::soulshift_triggered_ability(
+            crate::filter::Comparison::LessThanOrEqual(amount as i32),
+            None,
+        ))
+    }
+
+    pub fn soulshift_value(self, amount: Value) -> Self {
+        self.with_ability(Self::soulshift_triggered_ability(
+            crate::filter::Comparison::LessThanOrEqualExpr(Box::new(amount)),
+            Some("keyword:soulshift X".to_string()),
+        ))
+    }
+
+    pub(crate) fn soulshift_triggered_ability_from_value(amount: Value) -> crate::ability::Ability {
+        Self::soulshift_triggered_ability(
+            crate::filter::Comparison::LessThanOrEqualExpr(Box::new(amount)),
+            Some("keyword:soulshift X".to_string()),
+        )
+    }
+
+    fn soulshift_triggered_ability(
+        mana_value: crate::filter::Comparison,
+        presentation_label: Option<String>,
+    ) -> crate::ability::Ability {
         let filter = crate::target::ObjectFilter::default()
             .with_subtype(Subtype::Spirit)
             .owned_by(crate::target::PlayerFilter::You)
             .in_zone(crate::zone::Zone::Graveyard)
-            .with_mana_value(crate::filter::Comparison::LessThanOrEqual(amount as i32));
+            .with_mana_value(mana_value);
         let target = crate::target::ChooseSpec::target(crate::target::ChooseSpec::Object(filter))
             .with_count(ChoiceCount::up_to(1));
 
-        self.with_ability(crate::ability::Ability {
+        crate::ability::Ability {
             kind: crate::ability::AbilityKind::Triggered(crate::ability::TriggeredAbility {
                 trigger: crate::triggers::Trigger::this_dies(),
                 effects: crate::resolution::ResolutionProgram::from_effects(vec![
@@ -1214,10 +1239,10 @@ impl CardDefinitionBuilder {
                 ]),
                 choices: vec![target],
                 intervening_if: None,
-                presentation_label: None,
+                presentation_label,
             }),
             functional_zones: vec![crate::zone::Zone::Battlefield],
-        })
+        }
     }
 
     pub fn recover(self, cost: ManaCost) -> Self {

--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -1,6 +1,7 @@
 use crate::ability::ActivationTiming;
 use crate::color::ColorSet;
 use crate::cost::TotalCost;
+use crate::effect::Value;
 use crate::filter::ObjectFilter;
 use crate::mana::ManaCost;
 use crate::static_abilities::LandwalkKind;
@@ -59,6 +60,7 @@ pub enum KeywordAction {
     Graft(u32),
     Soulbond,
     Soulshift(u32),
+    SoulshiftValue(Value),
     Recover(ManaCost),
     Outlast(ManaCost),
     Scavenge(ManaCost),
@@ -163,6 +165,17 @@ pub enum KeywordAction {
     MarkerText(String),
 }
 
+pub(crate) fn describe_soulshift_value(value: &Value) -> String {
+    if let Value::Count(filter) = value
+        && filter.zone == Some(crate::zone::Zone::Battlefield)
+        && filter.controller == Some(crate::target::PlayerFilter::You)
+        && filter.subtypes.contains(&Subtype::Spirit)
+    {
+        return "the number of Spirits you control".to_string();
+    }
+    "that value".to_string()
+}
+
 impl KeywordAction {
     pub fn lowers_to_static_ability(&self) -> bool {
         matches!(
@@ -215,6 +228,7 @@ impl KeywordAction {
                 | Self::Graft(_)
                 | Self::Soulbond
                 | Self::Soulshift(_)
+                | Self::SoulshiftValue(_)
                 | Self::Outlast(_)
                 | Self::Unearth(_)
                 | Self::Eternalize(_)
@@ -332,6 +346,10 @@ impl KeywordAction {
             Self::Graft(amount) => format!("Graft {amount}"),
             Self::Soulbond => "Soulbond".to_string(),
             Self::Soulshift(amount) => format!("Soulshift {amount}"),
+            Self::SoulshiftValue(value) => format!(
+                "Soulshift X, where X is {}",
+                describe_soulshift_value(value)
+            ),
             Self::Recover(cost) => format!("Recover {}", cost.to_oracle()),
             Self::Outlast(cost) => format!("Outlast {}", cost.to_oracle()),
             Self::Scavenge(cost) => format!("Scavenge {}", cost.to_oracle()),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -946,6 +946,36 @@ where
     Some(KeywordAction::Marker(keyword))
 }
 
+pub(crate) fn parse_dynamic_soulshift_keyword_action(words: &[&str]) -> Option<KeywordAction> {
+    if !matches!(
+        words,
+        [
+            "soulshift",
+            "x",
+            "where",
+            "x",
+            "is",
+            "the",
+            "number",
+            "of",
+            spirit_word,
+            "you",
+            "control",
+            ..
+        ] if matches!(*spirit_word, "spirit" | "spirits")
+    ) {
+        return None;
+    }
+
+    let count_filter = ObjectFilter::default()
+        .with_subtype(crate::types::Subtype::Spirit)
+        .you_control()
+        .in_zone(crate::zone::Zone::Battlefield);
+    Some(KeywordAction::SoulshiftValue(crate::effect::Value::Count(
+        count_filter,
+    )))
+}
+
 pub(crate) enum KeywordCostFallback {
     MarkerOnly,
     MarkerOrText,
@@ -1321,6 +1351,9 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
     if let Some(action) =
         parse_numeric_keyword_action(&words, "soulshift", KeywordAction::Soulshift)
     {
+        return Some(action);
+    }
+    if let Some(action) = parse_dynamic_soulshift_keyword_action(&words) {
         return Some(action);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/mod.rs
@@ -119,8 +119,9 @@ pub(crate) use choice_object_clauses::{
 };
 use keyword_action_costs::*;
 pub(crate) use keyword_action_costs::{
-    normalize_cant_words, parse_ability_phrase, parse_payment_clause_as_total_cost,
-    parse_single_word_keyword_action, target_ast_to_object_filter,
+    normalize_cant_words, parse_ability_phrase, parse_dynamic_soulshift_keyword_action,
+    parse_payment_clause_as_total_cost, parse_single_word_keyword_action,
+    target_ast_to_object_filter,
 };
 use keyword_activated_lines::*;
 pub(crate) use keyword_activated_lines::{

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -503,6 +503,10 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
         if let Some(action) = parse_count_keyword("soulshift", KeywordAction::Soulshift) {
             return Some(action);
         }
+        if let Some(action) = super::activation_and_restrictions::keyword_action_costs::parse_dynamic_soulshift_keyword_action(&words)
+        {
+            return Some(action);
+        }
         if let Some(action) = parse_count_keyword("modular", KeywordAction::Modular) {
             return Some(action);
         }
@@ -752,6 +756,12 @@ pub(crate) fn parse_ability_line_lexed(tokens: &[OwnedLexToken]) -> Option<Vec<K
     }
     if let Some(actions) = parse_splice_keyword_line_lexed(tokens) {
         return Some(actions);
+    }
+    let words = TokenWordView::new(tokens).word_refs();
+    if let Some(action) =
+        super::activation_and_restrictions::keyword_action_costs::parse_dynamic_soulshift_keyword_action(&words)
+    {
+        return Some(vec![action]);
     }
 
     let segments = split_on_lexed_comma_or_semicolon(tokens);

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -5561,6 +5561,24 @@ fn nonstatic_keyword_action_as_granted_object_ability(
     action: KeywordAction,
 ) -> Option<(ParsedAbility, String)> {
     match action {
+        KeywordAction::Soulshift(amount) => {
+            let ability = crate::CardDefinitionBuilder::new(crate::CardId::from_raw(0), "Soulshift")
+                .soulshift(amount)
+                .build()
+                .abilities
+                .into_iter()
+                .next()?;
+            Some((parsed_ability_from_ability(ability), format!("Soulshift {amount}")))
+        }
+        KeywordAction::SoulshiftValue(value) => Some((
+            parsed_ability_from_ability(
+                crate::CardDefinitionBuilder::soulshift_triggered_ability_from_value(value.clone()),
+            ),
+            format!(
+                "Soulshift X, where X is {}",
+                crate::payload::describe_soulshift_value(&value)
+            ),
+        )),
         KeywordAction::Casualty(power) => {
             let mut creature_filter = ObjectFilter::creature().you_control();
             creature_filter.power = Some(crate::filter::Comparison::GreaterThanOrEqual(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/keyword_lines.rs
@@ -19,6 +19,12 @@ pub(crate) fn parse_ability_line(tokens: &[OwnedLexToken]) -> Option<Vec<Keyword
     if let Some(actions) = parse_flashback_keyword_line(tokens) {
         return Some(actions);
     }
+    let words = crate::runtime_backend::lexer::TokenWordView::new(tokens).word_refs();
+    if let Some(action) =
+        super::activation_and_restrictions::parse_dynamic_soulshift_keyword_action(&words)
+    {
+        return Some(vec![action]);
+    }
 
     let segments = split_lexed_slices_on_commas_or_semicolons(tokens);
     let mut actions = Vec::new();

--- a/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/static_ability_helpers.rs
@@ -87,6 +87,10 @@ pub(crate) fn static_ability_for_keyword_action(action: KeywordAction) -> Option
         KeywordAction::Soulshift(amount) => {
             Some(StaticAbility::keyword_marker(format!("soulshift {amount}")))
         }
+        KeywordAction::SoulshiftValue(value) => Some(StaticAbility::keyword_marker(format!(
+            "soulshift X, where X is {}",
+            crate::payload::describe_soulshift_value(&value)
+        ))),
         KeywordAction::Outlast(cost) => Some(StaticAbility::keyword_marker(format!(
             "outlast {}",
             cost.to_oracle()

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -8,14 +8,18 @@ use crate::runtime_backend::grammar::structure::{
     StatementLineFamily, classify_statement_line_family_lexed,
 };
 use crate::runtime_backend::lexer::parser_token_word_refs;
+use crate::runtime_backend::util::is_source_reference_words;
 use crate::runtime_backend::sentences::effect_sentences::clause_pattern_helpers::{
     ClauseShape, clause_shape,
 };
+use crate::KeywordAction;
 
 const DRAFT_RULE_LINE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["draft", "this", "card", "face", "up"]);
 const THIS_CREATURE_SOURCE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["this", "creature"]);
+const HAS_OR_HAVE_WORD_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["has"], &["have"]]);
 const PARTNER_KEYWORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["partner"]);
 const DRAFT_RULE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
@@ -1654,6 +1658,9 @@ fn lower_rewrite_static_to_chunk_impl(
             chosen_option_label,
         );
     }
+    if let Some(actions) = parse_source_has_keyword_actions(&lexed) {
+        return Ok(LineAst::Abilities(actions));
+    }
     if !should_skip_keyword_action_static_probe_tokens(parse_tokens)
         && let Some(actions) = parse_ability_line_lexed(&lexed)
     {
@@ -1701,6 +1708,20 @@ fn lower_rewrite_static_to_chunk_impl(
         "rewrite static lowering could not reconstitute static line '{}'",
         line.info.raw_line
     )))
+}
+
+fn parse_source_has_keyword_actions(lexed: &[OwnedLexToken]) -> Option<Vec<KeywordAction>> {
+    let words = crate::runtime_backend::lexer::token_word_refs(lexed);
+    let has_word_idx = words
+        .iter()
+        .position(|word| HAS_OR_HAVE_WORD_PATTERN.matches_word(word))?;
+    if has_word_idx == 0 || !is_source_reference_words(&words[..has_word_idx]) {
+        return None;
+    }
+
+    let has_token_idx = token_index_for_word_index(lexed, has_word_idx)?;
+    let tail = trim_commas(&lexed[has_token_idx + 1..]);
+    parse_ability_line_lexed(&tail)
 }
 
 fn looks_like_ability_word_marker_tokens(parse_tokens: &[OwnedLexToken]) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -1010,6 +1010,10 @@ pub(crate) fn rewrite_static_ability_for_keyword_action(
         KeywordAction::Soulshift(amount) => {
             Some(StaticAbility::keyword_marker(format!("soulshift {amount}")))
         }
+        KeywordAction::SoulshiftValue(value) => Some(StaticAbility::keyword_marker(format!(
+            "soulshift X, where X is {}",
+            crate::payload::describe_soulshift_value(&value)
+        ))),
         KeywordAction::Outlast(cost) => Some(StaticAbility::keyword_marker(format!(
             "outlast {}",
             cost.to_oracle()

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -512,6 +512,7 @@ pub(crate) enum KeywordAction {
     Graft(u32),
     Soulbond,
     Soulshift(u32),
+    SoulshiftValue(Value),
     Recover(ManaCost),
     Outlast(ManaCost),
     Scavenge(ManaCost),
@@ -618,6 +619,18 @@ pub(crate) enum KeywordAction {
 }
 
 #[cfg(any(test, ironsmith_runtime_parser_tests))]
+fn describe_soulshift_value(value: &Value) -> String {
+    if let Value::Count(filter) = value
+        && filter.zone == Some(Zone::Battlefield)
+        && filter.controller == Some(PlayerFilter::You)
+        && filter.subtypes.contains(&Subtype::Spirit)
+    {
+        return "the number of Spirits you control".to_string();
+    }
+    "that value".to_string()
+}
+
+#[cfg(any(test, ironsmith_runtime_parser_tests))]
 impl KeywordAction {
     pub(crate) fn lowers_to_static_ability(&self) -> bool {
         matches!(
@@ -668,6 +681,7 @@ impl KeywordAction {
                 | Self::Graft(_)
                 | Self::Soulbond
                 | Self::Soulshift(_)
+                | Self::SoulshiftValue(_)
                 | Self::Outlast(_)
                 | Self::Unearth(_)
                 | Self::Eternalize(_)
@@ -784,6 +798,10 @@ impl KeywordAction {
             Self::Graft(amount) => format!("Graft {amount}"),
             Self::Soulbond => "Soulbond".to_string(),
             Self::Soulshift(amount) => format!("Soulshift {amount}"),
+            Self::SoulshiftValue(value) => format!(
+                "Soulshift X, where X is {}",
+                describe_soulshift_value(value)
+            ),
             Self::Recover(cost) => format!("Recover {}", cost.to_oracle()),
             Self::Outlast(cost) => format!("Outlast {}", cost.to_oracle()),
             Self::Scavenge(cost) => format!("Scavenge {}", cost.to_oracle()),
@@ -1679,6 +1697,7 @@ impl CardDefinitionBuilder {
             KeywordAction::Graft(amount) => self.graft(amount),
             KeywordAction::Soulbond => self.soulbond(),
             KeywordAction::Soulshift(amount) => self.soulshift(amount),
+            KeywordAction::SoulshiftValue(value) => self.soulshift_value(value),
             KeywordAction::Recover(cost) => self.recover(cost),
             KeywordAction::Outlast(cost) => self.outlast(cost),
             KeywordAction::Scavenge(cost) => self.scavenge(cost),
@@ -2576,15 +2595,33 @@ impl CardDefinitionBuilder {
     /// Soulshift means "When this creature dies, you may return target Spirit card
     /// with mana value N or less from your graveyard to your hand."
     pub fn soulshift(self, amount: u32) -> Self {
+        self.with_ability(Self::soulshift_triggered_ability(
+            crate::filter::Comparison::LessThanOrEqual(amount as i32),
+            None,
+        ))
+    }
+
+    /// Add soulshift X, where X is a dynamic value.
+    pub fn soulshift_value(self, amount: Value) -> Self {
+        self.with_ability(Self::soulshift_triggered_ability(
+            crate::filter::Comparison::LessThanOrEqualExpr(Box::new(amount)),
+            Some("keyword:soulshift X".to_string()),
+        ))
+    }
+
+    fn soulshift_triggered_ability(
+        mana_value: crate::filter::Comparison,
+        presentation_label: Option<String>,
+    ) -> Ability {
         let filter = ObjectFilter::default()
             .with_subtype(Subtype::Spirit)
             .owned_by(PlayerFilter::You)
             .in_zone(Zone::Graveyard)
-            .with_mana_value(crate::filter::Comparison::LessThanOrEqual(amount as i32));
+            .with_mana_value(mana_value);
         let target =
             ChooseSpec::target(ChooseSpec::Object(filter)).with_count(ChoiceCount::up_to(1));
 
-        self.with_ability(Ability {
+        Ability {
             kind: AbilityKind::Triggered(TriggeredAbility {
                 trigger: Trigger::this_dies(),
                 effects: crate::resolution::ResolutionProgram::from_effects(vec![
@@ -2592,10 +2629,10 @@ impl CardDefinitionBuilder {
                 ]),
                 choices: vec![target],
                 intervening_if: None,
-                presentation_label: None,
+                presentation_label,
             }),
             functional_zones: vec![Zone::Battlefield],
-        })
+        }
     }
 
     /// Add recover with a mana cost.

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5969,6 +5969,55 @@ fn test_parse_soulshift_keyword_line_compiles_keyword_text() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn kodama_of_the_center_tree_parses_dynamic_soulshift_and_renders_oracle_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(74086), "Kodama of the Center Tree")
+        .mana_cost(ManaCost::from_symbols(vec![
+            ManaSymbol::Generic(4),
+            ManaSymbol::Green,
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::new(PtValue::Star, PtValue::Star))
+        .parse_text(
+            "Kodama of the Center Tree's power and toughness are each equal to the number of Spirits you control.\n\
+             Kodama of the Center Tree has soulshift X, where X is the number of Spirits you control. (When this creature dies, you may return target Spirit card with mana value X or less from your graveyard to your hand.)",
+        )
+        .expect("Kodama of the Center Tree should parse strict oracle text");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains(
+            "Kodama of the Center Tree's power and toughness are each equal to the number of Spirits you control."
+        ),
+        "expected named CDA surface, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Kodama of the Center Tree has soulshift X, where X is the number of Spirits you control."
+        ),
+        "expected named dynamic soulshift surface, got {rendered}"
+    );
+
+    let soulshift = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Kodama should have a real soulshift triggered ability");
+    let debug = format!("{soulshift:?}");
+    assert!(
+        debug.contains("LessThanOrEqualExpr")
+            && debug.contains("Count(ObjectFilter")
+            && debug.contains("subtypes: [Spirit]"),
+        "expected soulshift target cap to count Spirits you control, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_outlast_keyword_line_compiles_keyword_text() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Outlast Parse Test")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1218,6 +1218,7 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(": as long as "))
         && (lower.contains(", this creature has ") || lower.contains(" this creature has "));
     let uses_named_source_surface = lower.starts_with("this creature gets ")
+        || lower.starts_with("this creature's power and toughness ")
         || lower.starts_with("as this enters")
         || conditional_static_self_surface
         || lower.contains("if this land has ")
@@ -1232,6 +1233,12 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(": this creature gets ")
         || lower.contains(": this creature deals ")
         || lower.contains(": whenever this creature deals combat damage to a player");
+    if card.supertypes.contains(&Supertype::Legendary) && lower.starts_with("soulshift ") {
+        let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
+        if !source_name.is_empty() {
+            return format!("{source_name} has {}", lowercase_first(line));
+        }
+    }
     if !card.supertypes.contains(&Supertype::Legendary) || !uses_named_source_surface {
         return line.to_string();
     }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -40537,14 +40537,14 @@ fn describe_structural_soulshift_keyword(
         return None;
     }
 
-    let amount = soulshift_target_amount(&return_effect.target)?;
-    if soulshift_target_amount(&triggered.choices[0]) != Some(amount) {
+    let amount = soulshift_target_amount_text(&return_effect.target)?;
+    if soulshift_target_amount_text(&triggered.choices[0]) != Some(amount.clone()) {
         return None;
     }
     Some(format!("Soulshift {amount}"))
 }
 
-fn soulshift_target_amount(spec: &ChooseSpec) -> Option<i32> {
+fn soulshift_target_amount_text(spec: &ChooseSpec) -> Option<String> {
     let ChooseSpec::WithCount(inner, count) = spec else {
         return None;
     };
@@ -40563,8 +40563,12 @@ fn soulshift_target_amount(spec: &ChooseSpec) -> Option<i32> {
     {
         return None;
     }
-    match filter.mana_value {
-        Some(crate::filter::Comparison::LessThanOrEqual(amount)) if amount >= 0 => Some(amount),
+    match &filter.mana_value {
+        Some(crate::filter::Comparison::LessThanOrEqual(amount)) if *amount >= 0 => {
+            Some(amount.to_string())
+        }
+        Some(crate::filter::Comparison::LessThanOrEqualExpr(value)) => describe_where_x_basis(value)
+            .map(|basis| format!("X, where X is {basis}")),
         _ => None,
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
+++ b/crates/ironsmith-runtime/src/game_loop/sba_triggers.rs
@@ -834,7 +834,7 @@ fn target_requirements_from_explicit_choices(
                 &resolved_target_spec,
                 trigger.controller,
                 Some(trigger.source),
-                None,
+                entry.source_snapshot.as_ref(),
                 tagged_objects_ref,
                 entry.defending_player,
                 attacking_player,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12581,6 +12581,154 @@ fn test_card_with_mana_value(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn kodama_of_the_center_tree_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_086), "Kodama of the Center Tree")
+        .mana_cost(ManaCost::from_symbols(vec![
+            ManaSymbol::Generic(4),
+            ManaSymbol::Green,
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::new(PtValue::Star, PtValue::Star))
+        .parse_text(
+            "Kodama of the Center Tree's power and toughness are each equal to the number of Spirits you control.\n\
+             Kodama of the Center Tree has soulshift X, where X is the number of Spirits you control. (When this creature dies, you may return target Spirit card with mana value X or less from your graveyard to your hand.)",
+        )
+        .expect("Kodama of the Center Tree should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn spirit_card_with_mana_value(name: &str, mana_value: u8) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Generic(mana_value)]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Spirit])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn kodama_soulshift_effect(def: &crate::cards::CardDefinition) -> &Effect {
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Kodama should have soulshift as a triggered ability");
+
+    triggered
+        .effects
+        .segments
+        .first()
+        .and_then(|segment| segment.default_effects.first())
+        .expect("Kodama soulshift should return a graveyard target")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn player_zone_contains_named(game: &GameState, player: PlayerId, zone: Zone, name: &str) -> bool {
+    let object_ids = match zone {
+        Zone::Hand => &game.player(player).expect("player exists").hand,
+        Zone::Graveyard => &game.player(player).expect("player exists").graveyard,
+        _ => panic!("unsupported zone check {zone:?}"),
+    };
+    object_ids.iter().any(|id| {
+        game.object(*id)
+            .is_some_and(|object| object.name == name && object.zone == zone)
+    })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kodama_of_the_center_tree_soulshift_returns_spirit_with_mana_value_at_most_spirits_controlled() {
+    let def = kodama_of_the_center_tree_definition();
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let kodama = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    game.create_object_from_card(
+        &spirit_card_with_mana_value("Battlefield Spirit One", 1),
+        alice,
+        Zone::Battlefield,
+    );
+    game.create_object_from_card(
+        &spirit_card_with_mana_value("Battlefield Spirit Two", 1),
+        alice,
+        Zone::Battlefield,
+    );
+    let target = game.create_object_from_card(
+        &spirit_card_with_mana_value("Returned Spirit", 2),
+        alice,
+        Zone::Graveyard,
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(kodama, alice).with_targets(vec![
+        crate::effects::ResolvedTarget::Object(target),
+    ]);
+    let outcome = crate::effects::execute_effect(
+        &mut game,
+        kodama_soulshift_effect(&def),
+        &mut ctx,
+    )
+    .expect("Kodama soulshift effect should execute");
+
+    assert!(outcome.status.is_success(), "expected success, got {outcome:?}");
+    assert!(
+        player_zone_contains_named(&game, alice, Zone::Hand, "Returned Spirit"),
+        "soulshift should move the legal Spirit card to hand"
+    );
+    assert!(
+        !player_zone_contains_named(&game, alice, Zone::Graveyard, "Returned Spirit"),
+        "returned Spirit should no longer be in the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kodama_of_the_center_tree_soulshift_rejects_spirit_above_dynamic_mana_value_cap() {
+    let def = kodama_of_the_center_tree_definition();
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let kodama = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    game.create_object_from_card(
+        &spirit_card_with_mana_value("Battlefield Spirit One", 1),
+        alice,
+        Zone::Battlefield,
+    );
+    game.create_object_from_card(
+        &spirit_card_with_mana_value("Battlefield Spirit Two", 1),
+        alice,
+        Zone::Battlefield,
+    );
+    let target = game.create_object_from_card(
+        &spirit_card_with_mana_value("Too Large Spirit", 3),
+        alice,
+        Zone::Graveyard,
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(kodama, alice).with_targets(vec![
+        crate::effects::ResolvedTarget::Object(target),
+    ]);
+    let outcome = crate::effects::execute_effect(
+        &mut game,
+        kodama_soulshift_effect(&def),
+        &mut ctx,
+    )
+    .expect("Kodama soulshift effect should execute");
+
+    assert_eq!(outcome.status, crate::effect::OutcomeStatus::TargetInvalid);
+    assert!(
+        player_zone_contains_named(&game, alice, Zone::Graveyard, "Too Large Spirit"),
+        "over-cap Spirit should stay in the graveyard"
+    );
+    assert!(
+        !player_zone_contains_named(&game, alice, Zone::Hand, "Too Large Spirit"),
+        "over-cap Spirit should not move to hand"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn infernal_kirin_discards_only_cards_matching_triggering_spell_mana_value() {
     struct ChooseBobAndAllDiscardCards {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -12609,25 +12609,6 @@ fn spirit_card_with_mana_value(name: &str, mana_value: u8) -> crate::card::Card 
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
-fn kodama_soulshift_effect(def: &crate::cards::CardDefinition) -> &Effect {
-    let triggered = def
-        .abilities
-        .iter()
-        .find_map(|ability| match &ability.kind {
-            AbilityKind::Triggered(triggered) => Some(triggered),
-            _ => None,
-        })
-        .expect("Kodama should have soulshift as a triggered ability");
-
-    triggered
-        .effects
-        .segments
-        .first()
-        .and_then(|segment| segment.default_effects.first())
-        .expect("Kodama soulshift should return a graveyard target")
-}
-
-#[cfg(ironsmith_runtime_parser_tests)]
 fn player_zone_contains_named(game: &GameState, player: PlayerId, zone: Zone, name: &str) -> bool {
     let object_ids = match zone {
         Zone::Hand => &game.player(player).expect("player exists").hand,
@@ -12642,17 +12623,19 @@ fn player_zone_contains_named(game: &GameState, player: PlayerId, zone: Zone, na
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn kodama_of_the_center_tree_soulshift_returns_spirit_with_mana_value_at_most_spirits_controlled() {
+fn kodama_of_the_center_tree_dynamic_soulshift_counts_itself_when_dying() {
     let def = kodama_of_the_center_tree_definition();
     let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
     let alice = PlayerId::from_index(0);
-    let kodama = game.create_object_from_definition(&def, alice, Zone::Graveyard);
-    game.create_object_from_card(
+    let kodama = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let other_spirit_one = game.create_object_from_card(
         &spirit_card_with_mana_value("Battlefield Spirit One", 1),
         alice,
         Zone::Battlefield,
     );
-    game.create_object_from_card(
+    let other_spirit_two = game.create_object_from_card(
         &spirit_card_with_mana_value("Battlefield Spirit Two", 1),
         alice,
         Zone::Battlefield,
@@ -12663,20 +12646,27 @@ fn kodama_of_the_center_tree_soulshift_returns_spirit_with_mana_value_at_most_sp
         Zone::Graveyard,
     );
 
-    let mut ctx = crate::effects::ExecutionContext::new_default(kodama, alice).with_targets(vec![
-        crate::effects::ResolvedTarget::Object(target),
-    ]);
-    let outcome = crate::effects::execute_effect(
-        &mut game,
-        kodama_soulshift_effect(&def),
-        &mut ctx,
-    )
-    .expect("Kodama soulshift effect should execute");
+    game.mark_damage(kodama, 99);
+    check_and_apply_sbas(&mut game, &mut trigger_queue)
+        .expect("lethal damage should put Kodama into the graveyard and queue soulshift");
+    assert_eq!(trigger_queue.entries.len(), 1, "Kodama should trigger once");
 
-    assert!(outcome.status.is_success(), "expected success, got {outcome:?}");
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Kodama soulshift should go on the stack");
+    let entry = game.stack.last().expect("soulshift should be on the stack");
+    assert!(
+        entry.targets.contains(&Target::Object(target)),
+        "two other Spirits plus dying Kodama should make a mana value 3 Spirit a legal soulshift target"
+    );
+
+    game.move_object_by_effect(other_spirit_one, Zone::Graveyard);
+    game.move_object_by_effect(other_spirit_two, Zone::Graveyard);
+
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Kodama soulshift should resolve");
+
     assert!(
         player_zone_contains_named(&game, alice, Zone::Hand, "Returned Spirit"),
-        "soulshift should move the legal Spirit card to hand"
+        "soulshift should use the pre-death value instead of drifting with later battlefield changes"
     );
     assert!(
         !player_zone_contains_named(&game, alice, Zone::Graveyard, "Returned Spirit"),
@@ -12686,18 +12676,15 @@ fn kodama_of_the_center_tree_soulshift_returns_spirit_with_mana_value_at_most_sp
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
-fn kodama_of_the_center_tree_soulshift_rejects_spirit_above_dynamic_mana_value_cap() {
+fn kodama_of_the_center_tree_dynamic_soulshift_rejects_above_predeath_count() {
     let def = kodama_of_the_center_tree_definition();
     let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
     let alice = PlayerId::from_index(0);
-    let kodama = game.create_object_from_definition(&def, alice, Zone::Graveyard);
+    let kodama = game.create_object_from_definition(&def, alice, Zone::Battlefield);
     game.create_object_from_card(
-        &spirit_card_with_mana_value("Battlefield Spirit One", 1),
-        alice,
-        Zone::Battlefield,
-    );
-    game.create_object_from_card(
-        &spirit_card_with_mana_value("Battlefield Spirit Two", 1),
+        &spirit_card_with_mana_value("Battlefield Spirit", 1),
         alice,
         Zone::Battlefield,
     );
@@ -12707,17 +12694,18 @@ fn kodama_of_the_center_tree_soulshift_rejects_spirit_above_dynamic_mana_value_c
         Zone::Graveyard,
     );
 
-    let mut ctx = crate::effects::ExecutionContext::new_default(kodama, alice).with_targets(vec![
-        crate::effects::ResolvedTarget::Object(target),
-    ]);
-    let outcome = crate::effects::execute_effect(
-        &mut game,
-        kodama_soulshift_effect(&def),
-        &mut ctx,
-    )
-    .expect("Kodama soulshift effect should execute");
+    game.mark_damage(kodama, 99);
+    check_and_apply_sbas(&mut game, &mut trigger_queue)
+        .expect("lethal damage should put Kodama into the graveyard and queue soulshift");
+    assert_eq!(trigger_queue.entries.len(), 1, "Kodama should trigger once");
 
-    assert_eq!(outcome.status, crate::effect::OutcomeStatus::TargetInvalid);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Kodama soulshift should go on the stack even when choosing no target");
+    let entry = game.stack.last().expect("soulshift should be on the stack");
+    assert!(
+        !entry.targets.contains(&Target::Object(target)),
+        "one other Spirit plus dying Kodama should cap soulshift at mana value 2"
+    );
     assert!(
         player_zone_contains_named(&game, alice, Zone::Graveyard, "Too Large Spirit"),
         "over-cap Spirit should stay in the graveyard"

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -11,7 +11,8 @@ use std::rc::Rc;
 use crate::Effect;
 use crate::ability::{AbilityKind, TriggeredAbility};
 use crate::continuous::ContinuousEffect;
-use crate::filter::ObjectFilter;
+use crate::effect::Value;
+use crate::filter::{Comparison, ObjectFilter};
 use crate::filter::ObjectRef;
 use crate::game_state::{GameState, Phase, Step};
 use crate::ids::{ObjectId, PlayerId, StableId};
@@ -41,6 +42,200 @@ fn trigger_entry_x_value(trigger_event: &TriggerEvent, fallback: Option<u32>) ->
         .downcast::<crate::events::other::BecameMonstrousEvent>()
         .map(|event| event.n)
         .or(fallback)
+}
+
+fn is_dynamic_soulshift_trigger(trigger_ability: &TriggeredAbility) -> bool {
+    trigger_ability.presentation_label.as_deref() == Some("keyword:soulshift X")
+}
+
+fn soulshift_value_from_choose_spec(spec: &ChooseSpec) -> Option<&Value> {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::Target(spec)
+        | ChooseSpec::WithCount(spec, _)
+        | ChooseSpec::WithCountValue(spec, _, _) => soulshift_value_from_choose_spec(spec),
+        ChooseSpec::Object(filter) => match filter.mana_value.as_ref()? {
+            Comparison::LessThanOrEqualExpr(value) => Some(value.as_ref()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn count_filter_from_trigger_lki(
+    game: &GameState,
+    trigger_event: &TriggerEvent,
+    controller: PlayerId,
+    source: ObjectId,
+    filter: &ObjectFilter,
+) -> i32 {
+    let filter_ctx = game.filter_context_for(controller, Some(source));
+    let mut seen = HashSet::new();
+    let mut count = 0i32;
+
+    for object in game.objects_in_deterministic_order() {
+        if filter.matches(object, &filter_ctx, game) {
+            seen.insert(object.stable_id);
+            count += 1;
+        }
+    }
+
+    if let Some(zone_change) = trigger_event.downcast::<crate::events::zones::ZoneChangeEvent>() {
+        for snapshot in zone_change.snapshots() {
+            if !seen.insert(snapshot.stable_id) {
+                continue;
+            }
+            if filter.matches_snapshot(snapshot, &filter_ctx, game) {
+                count += 1;
+            }
+        }
+    } else if let Some(snapshot) = trigger_event.snapshot()
+        && seen.insert(snapshot.stable_id)
+        && filter.matches_snapshot(snapshot, &filter_ctx, game)
+    {
+        count += 1;
+    }
+
+    count
+}
+
+fn resolve_soulshift_trigger_lki_value(
+    game: &GameState,
+    trigger_event: &TriggerEvent,
+    controller: PlayerId,
+    source: ObjectId,
+    value: &Value,
+) -> Option<i32> {
+    match value {
+        Value::SurfaceHinted { value, .. } => {
+            resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, value)
+        }
+        Value::Fixed(value) => Some(*value),
+        Value::Add(left, right) => Some(
+            resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, left)?
+                + resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, right)?,
+        ),
+        Value::Scaled(value, multiplier) => {
+            resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, value)
+                .map(|value| value * *multiplier)
+        }
+        Value::DividedRoundedDown(value, divisor) if *divisor != 0 => {
+            resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, value)
+                .map(|value| value.div_euclid(*divisor))
+        }
+        Value::Min(left, right) => Some(
+            resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, left)?.min(
+                resolve_soulshift_trigger_lki_value(game, trigger_event, controller, source, right)?,
+            ),
+        ),
+        Value::Count(filter) => Some(count_filter_from_trigger_lki(
+            game,
+            trigger_event,
+            controller,
+            source,
+            filter,
+        )),
+        Value::CountScaled(filter, multiplier) => Some(
+            count_filter_from_trigger_lki(game, trigger_event, controller, source, filter)
+                * *multiplier,
+        ),
+        _ => None,
+    }
+}
+
+fn captured_dynamic_soulshift_x_value(
+    game: &GameState,
+    trigger_event: &TriggerEvent,
+    controller: PlayerId,
+    source: ObjectId,
+    trigger_ability: &TriggeredAbility,
+) -> Option<u32> {
+    if !is_dynamic_soulshift_trigger(trigger_ability) {
+        return None;
+    }
+
+    let value = trigger_ability
+        .choices
+        .iter()
+        .find_map(soulshift_value_from_choose_spec)?;
+    let resolved = resolve_soulshift_trigger_lki_value(
+        game,
+        trigger_event,
+        controller,
+        source,
+        value,
+    )?;
+    u32::try_from(resolved.max(0)).ok()
+}
+
+fn freeze_soulshift_object_filter(mut filter: ObjectFilter, x_value: u32) -> ObjectFilter {
+    if matches!(filter.mana_value, Some(Comparison::LessThanOrEqualExpr(_))) {
+        filter.mana_value = Some(Comparison::LessThanOrEqual(x_value as i32));
+    }
+    filter
+}
+
+fn freeze_soulshift_choose_spec(spec: &ChooseSpec, x_value: u32) -> ChooseSpec {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, hints } => ChooseSpec::SurfaceHinted {
+            spec: Box::new(freeze_soulshift_choose_spec(spec, x_value)),
+            hints: hints.clone(),
+        },
+        ChooseSpec::Target(spec) => {
+            ChooseSpec::Target(Box::new(freeze_soulshift_choose_spec(spec, x_value)))
+        }
+        ChooseSpec::WithCount(spec, count) => ChooseSpec::WithCount(
+            Box::new(freeze_soulshift_choose_spec(spec, x_value)),
+            count.clone(),
+        ),
+        ChooseSpec::WithCountValue(spec, count, value) => ChooseSpec::WithCountValue(
+            Box::new(freeze_soulshift_choose_spec(spec, x_value)),
+            count.clone(),
+            value.clone(),
+        ),
+        ChooseSpec::Object(filter) => {
+            ChooseSpec::Object(freeze_soulshift_object_filter(filter.clone(), x_value))
+        }
+        _ => spec.clone(),
+    }
+}
+
+fn freeze_soulshift_effect(effect: Effect, x_value: u32) -> Effect {
+    if let Some(return_effect) = effect.downcast_ref::<crate::effects::ReturnFromGraveyardToHandEffect>() {
+        let mut return_effect = return_effect.clone();
+        return_effect.target = freeze_soulshift_choose_spec(&return_effect.target, x_value);
+        return Effect::new(return_effect);
+    }
+    effect
+}
+
+fn queued_triggered_ability(
+    trigger_ability: &TriggeredAbility,
+    dynamic_soulshift_x: Option<u32>,
+) -> TriggeredAbility {
+    let (effects, choices) = if let Some(x_value) = dynamic_soulshift_x {
+        let effects = trigger_ability
+            .effects
+            .clone()
+            .try_map_effects(|effect| Ok::<Effect, ()>(freeze_soulshift_effect(effect, x_value)))
+            .expect("freezing soulshift effects should be infallible");
+        let choices = trigger_ability
+            .choices
+            .iter()
+            .map(|choice| freeze_soulshift_choose_spec(choice, x_value))
+            .collect();
+        (effects, choices)
+    } else {
+        (trigger_ability.effects.clone(), trigger_ability.choices.clone())
+    };
+
+    TriggeredAbility {
+        trigger: trigger_ability.trigger.clone(),
+        effects,
+        choices,
+        intervening_if: trigger_ability.intervening_if.clone(),
+        presentation_label: None,
+    }
 }
 
 /// Stable, structural identity for a trigger definition.
@@ -1054,18 +1249,20 @@ pub(crate) fn check_triggers_with_view(
                         continue;
                     }
 
+                    let dynamic_soulshift_x = captured_dynamic_soulshift_x_value(
+                        game,
+                        trigger_event,
+                        snapshot.controller,
+                        snapshot.object_id,
+                        trigger_ability,
+                    );
                     let entry = TriggeredAbilityEntry {
                         source: snapshot.object_id,
                         controller: snapshot.controller,
-                        x_value: trigger_entry_x_value(trigger_event, snapshot.x_value),
+                        x_value: dynamic_soulshift_x
+                            .or_else(|| trigger_entry_x_value(trigger_event, snapshot.x_value)),
                         event_value_amount,
-                        ability: TriggeredAbility {
-                            trigger: trigger_ability.trigger.clone(),
-                            effects: trigger_ability.effects.clone(),
-                            choices: trigger_ability.choices.clone(),
-                            intervening_if: trigger_ability.intervening_if.clone(),
-                            presentation_label: None,
-                        },
+                        ability: queued_triggered_ability(trigger_ability, dynamic_soulshift_x),
                         triggering_event: trigger_event.clone(),
                         source_stable_id: snapshot.stable_id,
                         source_name: snapshot.name.clone(),
@@ -1126,18 +1323,20 @@ pub(crate) fn check_triggers_with_view(
                     continue;
                 }
 
+                let dynamic_soulshift_x = captured_dynamic_soulshift_x_value(
+                    game,
+                    trigger_event,
+                    snapshot.controller,
+                    snapshot.object_id,
+                    trigger_ability,
+                );
                 let entry = TriggeredAbilityEntry {
                     source: snapshot.object_id,
                     controller: snapshot.controller,
-                    x_value: trigger_entry_x_value(trigger_event, snapshot.x_value),
+                    x_value: dynamic_soulshift_x
+                        .or_else(|| trigger_entry_x_value(trigger_event, snapshot.x_value)),
                     event_value_amount,
-                    ability: TriggeredAbility {
-                        trigger: trigger_ability.trigger.clone(),
-                        effects: trigger_ability.effects.clone(),
-                        choices: trigger_ability.choices.clone(),
-                        intervening_if: trigger_ability.intervening_if.clone(),
-                        presentation_label: None,
-                    },
+                    ability: queued_triggered_ability(trigger_ability, dynamic_soulshift_x),
                     triggering_event: trigger_event.clone(),
                     source_stable_id: snapshot.stable_id,
                     source_name: snapshot.name.clone(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kodama of the Center Tree
Initial parse error:
```
parser does not yet support line family: 'Kodama of the Center Tree has soulshift X, where X is the number of Spirits you control. (When this creature dies, you may return target Spirit card with mana value X or less from your graveyard to your hand.)'; oracle-only fallback also failed: parser does not yet support line family: 'Kodama of the Center Tree has soulshift X, where X is the number of Spirits you control.'
```

Current worker: i-072996f93c9f8447a
Branch: codex/aws-card-fix-kodama-of-the-center-tree
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0003
