### PR TITLE
Fix Ironsmith parse failure: Feast of the Victorious Dead

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -1,9 +1,10 @@
 #![allow(dead_code)]
 
 use crate::cards::builders::{
-    CardTextError, EffectAst, KeywordAction, LineAst, StaticAbilityAst, TargetAst, TriggerSpec,
+    CardTextError, EffectAst, KeywordAction, LineAst, PredicateAst, StaticAbilityAst,
+    SubjectVerbActionAst, TargetAst, TriggerSpec,
 };
-use crate::effect::Value;
+use crate::effect::{EventValueSpec, Value};
 use crate::target::{ObjectFilter, PlayerFilter};
 use crate::types::CardType;
 use crate::zone::Zone;
@@ -77,6 +78,61 @@ const TWO_WORD_KEYWORD_ACTIONS: &[(&[&str], KeywordAction)] = &[
         KeywordAction::Marker("doctor companion"),
     ),
 ];
+
+fn predicate_counts_creatures_died_this_turn(predicate: &PredicateAst) -> bool {
+    matches!(
+        predicate,
+        PredicateAst::CreatureDiedThisTurn | PredicateAst::CreatureDiedThisTurnOrMore(_)
+    )
+}
+
+fn bind_event_amount_to_creatures_died_this_turn(value: &mut Value) {
+    match value {
+        Value::EventValue(EventValueSpec::Amount) | Value::EventValue(EventValueSpec::LifeAmount) => {
+            *value = Value::CreaturesDiedThisTurn;
+        }
+        Value::EventValueOffset(EventValueSpec::Amount, offset)
+        | Value::EventValueOffset(EventValueSpec::LifeAmount, offset) => {
+            *value = Value::Add(
+                Box::new(Value::CreaturesDiedThisTurn),
+                Box::new(Value::Fixed(*offset)),
+            );
+        }
+        Value::Add(left, right) | Value::Min(left, right) => {
+            bind_event_amount_to_creatures_died_this_turn(left);
+            bind_event_amount_to_creatures_died_this_turn(right);
+        }
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner)
+        | Value::SurfaceHinted { value: inner, .. } => {
+            bind_event_amount_to_creatures_died_this_turn(inner);
+        }
+        _ => {}
+    }
+}
+
+fn bind_creatures_died_condition_amounts(effects: &mut [EffectAst]) {
+    for effect in effects {
+        match effect {
+            EffectAst::SubjectVerb(subject_verb) => match &mut subject_verb.action {
+                SubjectVerbActionAst::GainLife { amount }
+                | SubjectVerbActionAst::PutCounters { count: amount, .. } => {
+                    bind_event_amount_to_creatures_died_this_turn(amount);
+                }
+                _ => {}
+            },
+            EffectAst::Conditional {
+                if_true, if_false, ..
+            } => {
+                bind_creatures_died_condition_amounts(if_true);
+                bind_creatures_died_condition_amounts(if_false);
+            }
+            _ => {}
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum AttackedPlayerFilterKind {
     Any,
@@ -976,7 +1032,10 @@ pub(crate) fn parse_triggered_line_lexed(
             spec.trigger_tokens,
             spec.effects_tokens,
         );
-        if let Ok(effects) = parse_effect_sentences_lexed(&rewritten_effects_tokens) {
+        if let Ok(mut effects) = parse_effect_sentences_lexed(&rewritten_effects_tokens) {
+            if predicate_counts_creatures_died_this_turn(&spec.predicate) {
+                bind_creatures_died_condition_amounts(&mut effects);
+            }
             return Ok(LineAst::Triggered {
                 trigger,
                 effects: vec![EffectAst::Conditional {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/combat_and_damage_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/combat_and_damage_family.rs
@@ -1011,7 +1011,7 @@ pub(crate) fn parse_distribute_counters_sentence(
     }
 
     let amount_clause = clause.from(1);
-    let (count, used) = parse_number(amount_clause.tokens()).ok_or_else(|| {
+    let (count, used) = parse_value(amount_clause.tokens()).ok_or_else(|| {
         CardTextError::ParseError(format!(
             "missing distributed counter amount (clause: '{}')",
             clause.text()
@@ -1055,7 +1055,7 @@ pub(crate) fn parse_distribute_counters_sentence(
 
     Ok(Some(EffectAst::subject_verb_put_counters(
         counter_type,
-        Value::Fixed(count as i32),
+        count,
         target,
         Some(target_count),
         true,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -192,13 +192,43 @@ fn feast_of_the_victorious_dead_strict_parser_compiled_text_and_model_regression
         put_counters.target_count.is_some(),
         "Feast should preserve the any-number distribution target count"
     );
+    let (inner_target, target_count) = match &put_counters.target {
+        ChooseSpec::WithCount(inner, count) => (inner.as_ref(), count),
+        other => panic!("expected counted distribution target, got {other:?}"),
+    };
+    assert_eq!(target_count.min, 0, "Feast should allow zero distribution targets");
+    assert_eq!(target_count.max, None, "Feast should allow any number of distribution targets");
+    assert_eq!(
+        put_counters.target_count,
+        Some(*target_count),
+        "Feast should preserve the same distribution target count on the effect"
+    );
+    let target_filter = match inner_target {
+        ChooseSpec::Object(filter) => filter,
+        other => panic!("expected object distribution target, got {other:?}"),
+    };
+    assert_eq!(
+        target_filter.zone,
+        Some(Zone::Battlefield),
+        "Feast should distribute counters only on battlefield objects"
+    );
+    assert_eq!(
+        target_filter.controller,
+        Some(PlayerFilter::You),
+        "Feast should distribute counters only among creatures you control"
+    );
+    assert!(
+        target_filter.card_types.contains(&CardType::Creature),
+        "Feast should distribute counters only among creatures, got {target_filter:?}"
+    );
 
     assert!(
         rendered.contains("At the beginning of your end step")
             && rendered.contains("creature")
             && rendered.contains("died this turn")
-            && rendered.contains("+1/+1 counters")
-            && rendered.to_ascii_lowercase().contains("distribute"),
+            && rendered.contains(
+                "you gain that much life and distribute that many +1/+1 counters among any number of creatures you control"
+            ),
         "expected Feast compiled text to preserve the end-step died-this-turn distribution, got {rendered}"
     );
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -144,6 +144,66 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn feast_of_the_victorious_dead_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Feast of the Victorious Dead");
+
+    let def = parse_oracle_card_definition("Feast of the Victorious Dead");
+    let rendered = compiled_text_lines(&def).join(" ");
+    let triggered = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Feast of the Victorious Dead should have an end-step trigger");
+
+    assert_eq!(
+        triggered.intervening_if,
+        Some(crate::effect::Condition::CreatureDiedThisTurn),
+        "Feast of the Victorious Dead should be gated by creatures dying this turn"
+    );
+
+    let effects = triggered.effects.flattened_default_effects();
+    let gain_life = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<GainLifeEffect>())
+        .expect("Feast of the Victorious Dead should gain life");
+    assert_eq!(
+        gain_life.amount,
+        Value::CreaturesDiedThisTurn,
+        "Feast life gain should count creatures that died this turn"
+    );
+
+    let put_counters = effects
+        .iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::PutCountersEffect>())
+        .expect("Feast of the Victorious Dead should distribute counters");
+    assert_eq!(
+        put_counters.amount,
+        Value::CreaturesDiedThisTurn,
+        "Feast counter distribution should count creatures that died this turn"
+    );
+    assert!(
+        put_counters.distributed,
+        "Feast should lower as a distributed counter effect"
+    );
+    assert!(
+        put_counters.target_count.is_some(),
+        "Feast should preserve the any-number distribution target count"
+    );
+
+    assert!(
+        rendered.contains("At the beginning of your end step")
+            && rendered.contains("creature")
+            && rendered.contains("died this turn")
+            && rendered.contains("+1/+1 counters")
+            && rendered.to_ascii_lowercase().contains("distribute"),
+        "expected Feast compiled text to preserve the end-step died-this-turn distribution, got {rendered}"
+    );
+}
+
+#[test]
 fn wondrous_crucible_strict_parser_compiled_text_and_model_regression() {
     assert_oracle_card_parses_strict("Wondrous Crucible");
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11700,7 +11700,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::YourFirstTurnsOfTheGameOrFewer(count) => {
             format!("it is one of your first {count} turns of the game")
         }
-        Condition::CreatureDiedThisTurn => "a creature died this turn".to_string(),
+        Condition::CreatureDiedThisTurn => "one or more creatures died this turn".to_string(),
         Condition::CreatureDiedThisTurnOrMore(count) => {
             format!("{count} or more creatures died this turn")
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -743,6 +743,49 @@ fn normalize_compile_effect_list_surface(line: &str) -> String {
     line.to_string()
 }
 
+fn describe_gain_life_then_distribute_creatures_died_counters(
+    effects: &[Effect],
+) -> Option<String> {
+    let [gain_effect, put_effect] = effects else {
+        return None;
+    };
+    let gain = gain_effect.downcast_ref::<crate::effects::GainLifeEffect>()?;
+    if !matches!(gain.amount, Value::CreaturesDiedThisTurn)
+        || !matches!(gain.player, ChooseSpec::Player(PlayerFilter::You))
+    {
+        return None;
+    }
+
+    let put = put_effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if !put.distributed
+        || !matches!(put.amount, Value::CreaturesDiedThisTurn)
+        || put.counter_type != crate::object::CounterType::PlusOnePlusOne
+    {
+        return None;
+    }
+    let ChooseSpec::WithCount(inner, count) = &put.target else {
+        return None;
+    };
+    let ChooseSpec::Object(filter) = inner.as_ref() else {
+        return None;
+    };
+    if count.min != 0
+        || count.max.is_some()
+        || put.target_count != Some(*count)
+        || filter.zone != Some(Zone::Battlefield)
+        || filter.controller != Some(PlayerFilter::You)
+        || !filter.card_types.contains(&CardType::Creature)
+    {
+        return None;
+    }
+
+    Some(format!(
+        "You gain that much life and distribute that many {} counters among {}",
+        describe_counter_type(put.counter_type),
+        describe_choose_spec(&put.target)
+    ))
+}
+
 fn is_effect_count_reference(value: &Value, effect_id: Option<crate::effect::EffectId>) -> bool {
     match value {
         Value::SurfaceHinted { value, .. } => is_effect_count_reference(value, effect_id),
@@ -5461,6 +5504,9 @@ fn describe_group_pump_then_conditional_untap(effects: &[Effect]) -> Option<Stri
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_gain_life_then_distribute_creatures_died_counters(effects) {
+        return compact;
+    }
     if let [first, second] = effects
         && let Some(tagged) = first.downcast_ref::<crate::effects::TaggedEffect>()
         && let Some(cant) = second.downcast_ref::<crate::effects::CantEffect>()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -695,6 +695,147 @@ fn put_wondrous_crucible_end_step_trigger_on_stack(game: &mut GameState) -> usiz
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn feast_of_the_victorious_dead_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(111_668), "Feast of the Victorious Dead")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among any number of creatures you control.",
+        )
+        .expect("Feast of the Victorious Dead should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_feast_end_step_trigger_on_stack(game: &mut GameState) -> usize {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::Ending;
+    game.turn.step = Some(crate::game_state::Step::End);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(game, &mut trigger_queue);
+    put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Feast end-step trigger processing should succeed");
+    game.stack.len()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseAllLegalObjects;
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseAllLegalObjects {
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .take(ctx.max.unwrap_or(usize::MAX))
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn feast_of_the_victorious_dead_does_not_trigger_without_a_creature_death() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let feast = feast_of_the_victorious_dead_definition();
+    let survivor = vanilla_creature_definition(111_669, "Feast Survivor", 2, 2);
+    let survivor_id = game.create_object_from_definition(&survivor, alice, Zone::Battlefield);
+    game.create_object_from_definition(&feast, alice, Zone::Battlefield);
+
+    assert_eq!(
+        game.turn_store
+            .turn_history
+            .total_creatures_died_this_turn(),
+        0,
+        "test setup should start with no creatures dying this turn"
+    );
+    assert_eq!(
+        put_feast_end_step_trigger_on_stack(&mut game),
+        0,
+        "Feast should not trigger unless a creature died this turn"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").life, 20);
+    assert_eq!(
+        game.counter_count(survivor_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Feast should not distribute counters when its intervening-if condition is false"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn feast_of_the_victorious_dead_gains_life_and_distributes_counters_for_creatures_died() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let feast = feast_of_the_victorious_dead_definition();
+    game.create_object_from_definition(&feast, alice, Zone::Battlefield);
+
+    let alice_doomed = vanilla_creature_definition(111_670, "Alice's Doomed Creature", 1, 1);
+    let bob_doomed = vanilla_creature_definition(111_671, "Bob's Doomed Creature", 1, 1);
+    let first_survivor = vanilla_creature_definition(111_672, "First Feast Survivor", 2, 2);
+    let second_survivor = vanilla_creature_definition(111_673, "Second Feast Survivor", 2, 2);
+    let bob_survivor = vanilla_creature_definition(111_674, "Bob's Feast Survivor", 2, 2);
+    let alice_doomed_id =
+        game.create_object_from_definition(&alice_doomed, alice, Zone::Battlefield);
+    let bob_doomed_id = game.create_object_from_definition(&bob_doomed, bob, Zone::Battlefield);
+    let first_survivor_id =
+        game.create_object_from_definition(&first_survivor, alice, Zone::Battlefield);
+    let second_survivor_id =
+        game.create_object_from_definition(&second_survivor, alice, Zone::Battlefield);
+    let bob_survivor_id = game.create_object_from_definition(&bob_survivor, bob, Zone::Battlefield);
+
+    game.move_object_by_effect(alice_doomed_id, Zone::Graveyard);
+    game.move_object_by_effect(bob_doomed_id, Zone::Graveyard);
+    assert_eq!(
+        game.turn_store
+            .turn_history
+            .total_creatures_died_this_turn(),
+        2,
+        "Feast should count all creatures that died this turn"
+    );
+
+    assert_eq!(
+        put_feast_end_step_trigger_on_stack(&mut game),
+        1,
+        "Feast should trigger at the beginning of your end step after creatures died"
+    );
+    let mut dm = ChooseAllLegalObjects;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Feast trigger should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        22,
+        "Feast should gain life equal to the number of creatures that died this turn"
+    );
+    assert_eq!(
+        game.counter_count(first_survivor_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Feast should distribute the first counter to a controlled creature"
+    );
+    assert_eq!(
+        game.counter_count(second_survivor_id, crate::object::CounterType::PlusOnePlusOne),
+        1,
+        "Feast should distribute the second counter to another controlled creature"
+    );
+    assert_eq!(
+        game.counter_count(bob_survivor_id, crate::object::CounterType::PlusOnePlusOne),
+        0,
+        "Feast should not distribute counters to creatures controlled by opponents"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn vanilla_creature_definition(
     card_id: u32,
     name: &str,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Feast of the Victorious Dead
Initial parse error:
```
missing distributed counter amount (clause: 'distribute that many +1/+1 counters among any number of creatures you control'); oracle-only fallback also failed: missing distributed counter amount (clause: 'distribute that many +1/+1 counters among any number of creatures you control')
```

Current worker: i-0a7f0fcbc3c178850
Branch: codex/aws-card-fix-feast-of-the-victorious-dead
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0007
