### PR TITLE
Fix Ironsmith parse failure: Maddening Cacophony

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -1107,7 +1107,8 @@ fn bind_relative_iterated_player_in_value_to_player_filter(
         Value::HalfLifeTotalRoundedUp(player)
         | Value::HalfLifeTotalRoundedDown(player)
         | Value::HalfStartingLifeTotalRoundedUp(player)
-        | Value::HalfStartingLifeTotalRoundedDown(player) => {
+        | Value::HalfStartingLifeTotalRoundedDown(player)
+        | Value::CardsInLibrary(player) => {
             if matches!(player, PlayerFilter::IteratedPlayer)
                 && !matches!(player_filter, PlayerFilter::IteratedPlayer)
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -37,6 +37,11 @@ const SIDED_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["sided"]
 const DIE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["die"], &["dice"]]);
 const CARD_OR_CARDS_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["card"], &["cards"]]);
+const LIBRARY_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["library"]);
+const HALF_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["half"]);
+const ROUNDED_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["rounded"]);
+const UP_OR_DOWN_WORD_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["up"], &["down"]]);
 const FOR_EACH_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["for", "each"], &["each"]]);
 const ON_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["on"]);
@@ -440,6 +445,44 @@ pub(crate) fn parse_mill(
     tokens: &[OwnedLexToken],
     subject: Option<SubjectAst>,
 ) -> Result<EffectAst, CardTextError> {
+    fn parse_half_library_count(tokens: &[OwnedLexToken]) -> Option<(Value, usize)> {
+        let words = tokens
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, token)| token.as_word().map(|word| (idx, word)))
+            .collect::<Vec<_>>();
+        let [(half_idx, half), (_, owner), (_, library), (_, rounded), (last_idx, direction)] =
+            words.as_slice()
+        else {
+            return None;
+        };
+        if *half_idx != 0
+            || !HALF_WORD_PATTERN.matches_word(half)
+            || !LIBRARY_WORD_PATTERN.matches_word(library)
+            || !ROUNDED_WORD_PATTERN.matches_word(rounded)
+            || !UP_OR_DOWN_WORD_PATTERN.matches_word(direction)
+        {
+            return None;
+        }
+
+        let player = match *owner {
+            "your" => PlayerFilter::You,
+            "their" | "that" => PlayerFilter::IteratedPlayer,
+            _ => return None,
+        };
+        let library_count = Value::CardsInLibrary(player);
+        let count = if *direction == "up" {
+            Value::HalfRoundedDown(Box::new(Value::Add(
+                Box::new(library_count),
+                Box::new(Value::Fixed(1)),
+            )))
+        } else {
+            Value::HalfRoundedDown(Box::new(library_count))
+        };
+
+        Some((count, last_idx + 1))
+    }
+
     fn parse_trailing_for_each_count(tokens: &[OwnedLexToken]) -> Option<Value> {
         let mut words = crate::runtime_backend::token_word_refs(tokens);
         if words
@@ -495,7 +538,11 @@ pub(crate) fn parse_mill(
         .is_some_and(|word| CARD_OR_CARDS_PATTERN.matches_word(word));
 
     let (mut count, used) =
-        if let Some((prefix, _)) = grammar::words_match_any_prefix(tokens, THAT_MANY_PREFIXES) {
+        if let Some((count, used)) = parse_half_library_count(tokens) {
+            (count, used)
+        } else if let Some((prefix, _)) =
+            grammar::words_match_any_prefix(tokens, THAT_MANY_PREFIXES)
+        {
             (Value::EventValue(EventValueSpec::Amount), prefix.len())
         } else if starts_with_card_keyword {
             if let Some((count, used_after_cards)) = parse_value(&tokens[1..]) {
@@ -555,7 +602,7 @@ pub(crate) fn parse_mill(
                 "missing card keyword".to_string(),
             ));
         }
-        let trailing_count_tokens = &rest[1..];
+        let trailing_count_tokens = if rest.is_empty() { rest } else { &rest[1..] };
         let trailing_words: Vec<&str> = trailing_count_tokens
             .iter()
             .filter_map(OwnedLexToken::as_word)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -61479,6 +61479,44 @@ fn parse_burst_lightning_kicker_instead_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_maddening_cacophony_strict_and_renders_kicked_mill_override() {
+    let def = parse_oracle_card_definition("Maddening Cacophony");
+
+    assert_eq!(def.name(), "Maddening Cacophony");
+    assert_eq!(def.optional_costs.len(), 1);
+    assert_eq!(def.optional_costs[0].label, "Kicker");
+
+    let program = def
+        .spell_effect
+        .as_ref()
+        .expect("Maddening Cacophony should have spell effects");
+    assert_eq!(program.segments.len(), 1);
+    assert_eq!(program.segments[0].self_replacements.len(), 1);
+
+    let debug = format!("{:#?}", program);
+    assert!(
+        debug.contains("ThisSpellWasKicked")
+            && debug.contains("MillEffect")
+            && debug.contains("CardsInLibrary")
+            && debug.contains("HalfRoundedDown"),
+        "expected Maddening Cacophony to model kicked half-library mill structurally, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Each opponent mills eight cards"),
+        "expected default mill clause in rendered text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "If this spell was kicked, each opponent mills half their library, rounded up instead"
+        ),
+        "expected kicked replacement mill clause in rendered text, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_geistblast_graveyard_copy_activation_renders_cleanly() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Geistblast")
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6187,6 +6187,21 @@ pub(super) fn strip_parenthetical_segments(text: &str) -> String {
 }
 
 pub(super) fn describe_card_count(value: &Value) -> String {
+    fn half_library_count(value: &Value) -> Option<(PlayerFilter, &'static str)> {
+        let Value::HalfRoundedDown(inner) = value else {
+            return None;
+        };
+        match inner.as_ref() {
+            Value::CardsInLibrary(player) => Some((player.clone(), "down")),
+            Value::Add(left, right) => match (left.as_ref(), right.as_ref()) {
+                (Value::CardsInLibrary(player), Value::Fixed(1))
+                | (Value::Fixed(1), Value::CardsInLibrary(player)) => Some((player.clone(), "up")),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     match value {
         Value::Fixed(1) => "a card".to_string(),
         Value::Fixed(n) => {
@@ -6201,6 +6216,10 @@ pub(super) fn describe_card_count(value: &Value) -> String {
         Value::CardTypesAmong(_) | Value::CardTypesInGraveyard(_) => {
             format!("X cards, where X is {}", describe_value(value))
         }
+        value if let Some((player, direction)) = half_library_count(value) => format!(
+            "half {} library, rounded {direction}",
+            describe_possessive_player_filter(&player)
+        ),
         value if value.has_surface_hint(ironsmith_core::ValueSurfaceHint::Difference) => {
             "cards equal to the difference".to_string()
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2737,6 +2737,10 @@ fn describe_for_players_simple_iterated_action(
     let [effect] = for_players.effects.as_slice() else {
         return None;
     };
+    let effect = effect
+        .downcast_ref::<crate::effects::TaggedEffect>()
+        .map(|tagged| tagged.effect.as_ref())
+        .unwrap_or(effect);
     let subject = describe_for_players_subject(&for_players.filter)?;
     let subject_lower = lowercase_first(subject);
     let verb = |you: &'static str, other: &'static str| {
@@ -2774,6 +2778,19 @@ fn describe_for_players_simple_iterated_action(
             "{subject} {} {}",
             verb("draw", "draws"),
             describe_card_count(&draw.count)
+        ));
+    }
+    if let Some(mill) = effect.downcast_ref::<crate::effects::MillEffect>()
+        && mill.player == PlayerFilter::IteratedPlayer
+    {
+        let count_text = if subject == "You" {
+            describe_card_count(&mill.count).replace("that player's library", "your library")
+        } else {
+            describe_card_count(&mill.count).replace("that player's library", "their library")
+        };
+        return Some(format!(
+            "{subject} {} {count_text}",
+            verb("mill", "mills")
         ));
     }
     if let Some(discard) = effect.downcast_ref::<crate::effects::DiscardEffect>()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -43374,6 +43374,54 @@ fn put_spell_contortion_on_stack(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn maddening_cacophony_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(76_307), "Maddening Cacophony")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Kicker {3}{U}\n\
+             Each opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.",
+        )
+        .expect("Maddening Cacophony should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_maddening_cacophony_library_cards(
+    game: &mut GameState,
+    owner: PlayerId,
+    prefix: &str,
+    count: usize,
+) {
+    for idx in 0..count {
+        let card = CardBuilder::new(CardId::new(), format!("{prefix} {idx}"))
+            .card_types(vec![CardType::Sorcery])
+            .build();
+        game.create_object_from_card(&card, owner, Zone::Library);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_maddening_cacophony_on_stack(
+    game: &mut GameState,
+    controller: PlayerId,
+    kicked: bool,
+) -> ObjectId {
+    let def = maddening_cacophony_definition();
+    let source = game.create_object_from_definition(&def, controller, Zone::Stack);
+    let mut entry = StackEntry::new(source, controller);
+    if kicked {
+        let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+        paid.pay_times(0, 1);
+        entry = entry.with_optional_costs_paid(paid);
+    }
+    game.push_to_stack(entry);
+    source
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn put_frightful_delusion_on_stack(
     game: &mut GameState,
     controller: PlayerId,
@@ -43585,6 +43633,84 @@ fn test_strength_of_the_tajuru_puts_x_counters_on_each_kicked_target() {
     assert_eq!(
         untargeted_counters, 0,
         "Strength of the Tajuru should affect only its chosen targets"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn maddening_cacophony_unpaid_kicker_mills_eight_from_each_opponent() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    add_maddening_cacophony_library_cards(&mut game, alice, "Alice Library", 10);
+    add_maddening_cacophony_library_cards(&mut game, bob, "Bob Library", 10);
+    add_maddening_cacophony_library_cards(&mut game, charlie, "Charlie Library", 12);
+    put_maddening_cacophony_on_stack(&mut game, alice, false);
+
+    resolve_stack_entry(&mut game).expect("Maddening Cacophony should resolve without kicker");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").library.len(),
+        10,
+        "Maddening Cacophony should not mill its controller"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob exists").graveyard.len(),
+        8,
+        "unpaid Maddening Cacophony should mill Bob eight cards"
+    );
+    assert_eq!(
+        game.player(charlie)
+            .expect("Charlie exists")
+            .graveyard
+            .len(),
+        8,
+        "unpaid Maddening Cacophony should mill Charlie eight cards"
+    );
+    assert_eq!(game.player(bob).expect("Bob exists").library.len(), 2);
+    assert_eq!(
+        game.player(charlie).expect("Charlie exists").library.len(),
+        4
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn maddening_cacophony_paid_kicker_mills_half_each_opponents_library_rounded_up() {
+    let mut game = setup_three_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    add_maddening_cacophony_library_cards(&mut game, alice, "Alice Library", 10);
+    add_maddening_cacophony_library_cards(&mut game, bob, "Bob Library", 9);
+    add_maddening_cacophony_library_cards(&mut game, charlie, "Charlie Library", 10);
+    put_maddening_cacophony_on_stack(&mut game, alice, true);
+
+    resolve_stack_entry(&mut game).expect("kicked Maddening Cacophony should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").library.len(),
+        10,
+        "kicked Maddening Cacophony should not mill its controller"
+    );
+    assert_eq!(
+        game.player(bob).expect("Bob exists").graveyard.len(),
+        5,
+        "kicked Maddening Cacophony should mill half Bob's odd library rounded up"
+    );
+    assert_eq!(
+        game.player(charlie)
+            .expect("Charlie exists")
+            .graveyard
+            .len(),
+        5,
+        "kicked Maddening Cacophony should mill half Charlie's even library"
+    );
+    assert_eq!(game.player(bob).expect("Bob exists").library.len(), 4);
+    assert_eq!(
+        game.player(charlie).expect("Charlie exists").library.len(),
+        5
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Maddening Cacophony
Initial parse error:
```
parser does not yet support line family: 'Each opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.'; oracle-only fallback also failed: parser does not yet support line family: 'Each opponent mills eight cards. If this spell was kicked, instead each opponent mills half their library, rounded up.'
```

Current worker: i-0a8705ea8fc2ed323
Branch: codex/aws-card-fix-maddening-cacophony
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0007
