### PR TITLE
Fix Ironsmith parse failure: Hundred-Battle Veteran

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -3038,6 +3038,23 @@ pub(crate) fn parse_static_condition_clause(
 
         let filter_word_view = AnthemNormalizedWords::new(filter_tokens);
         let filter_words = filter_word_view.word_refs();
+        if filter_words.starts_with(&["different", "kinds", "of", "counters", "among"])
+            && let Some(among_filter_start) = filter_word_view.token_index_for_word_index(5)
+        {
+            let filter = parse_object_filter(&filter_tokens[among_filter_start..], false).map_err(
+                |_| {
+                    CardTextError::ParseError(format!(
+                        "unsupported distinct-counter-kind filter in static condition (clause: '{}')",
+                        clause_words.join(" ")
+                    ))
+                },
+            )?;
+            return Ok(crate::ConditionExpr::CountComparison {
+                count: AnthemCountExpression::DistinctCounterTypesAmong(filter),
+                comparison,
+                display: Some(clause_words.join(" ")),
+            });
+        }
         if let Some(counter_word_idx) = COUNTER_OR_COUNTERS_WORD_PATTERN.find_word(&filter_words)
             && counter_word_idx > 0
             && filter_words

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2538,6 +2538,11 @@ fn static_ability_rule_head_hints(rule_id: &'static str) -> Vec<StaticAbilityLin
             StaticAbilityLineHeadHint::Single("during"),
             StaticAbilityLineHeadHint::Pair("during", "each"),
         ],
+        "parse_play_from_permission_with_haste_this_way_line"
+        | "parse_play_from_permission_with_enter_counter_this_way_line" => vec![
+            StaticAbilityLineHeadHint::Single("you"),
+            StaticAbilityLineHeadHint::Pair("you", "may"),
+        ],
         "parse_you_may_cast_exile_counter_cards_with_mana_permission_line" => vec![
             StaticAbilityLineHeadHint::Single("you"),
             StaticAbilityLineHeadHint::Pair("you", "may"),
@@ -2949,6 +2954,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         ),
         multi_static_ability_ast_rule!(parse_surveilled_graveyard_play_life_cost_line),
         single_static_ability_ast_rule!(parse_play_from_permission_with_haste_this_way_line),
+        single_static_ability_ast_rule!(parse_play_from_permission_with_enter_counter_this_way_line),
         single_static_ability_ast_rule!(parse_you_may_static_grant_line),
         single_static_ability_ast_rule!(parse_grant_flash_to_noncreature_spells_line),
         single_static_ability_ast_rule!(parse_cast_this_spell_as_though_it_had_flash_line),
@@ -9802,6 +9808,55 @@ pub(crate) fn parse_play_from_permission_with_haste_this_way_line(
                 )
             }))
         }
+        _ => Ok(None),
+    }
+}
+
+pub(crate) fn parse_play_from_permission_with_enter_counter_this_way_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    let sentences = split_lexed_sentences(tokens);
+    let [permission_sentence, counter_sentence] = sentences.as_slice() else {
+        return Ok(None);
+    };
+
+    let counter_words = parser_token_word_refs(counter_sentence);
+    let counter_type = match counter_words.as_slice() {
+        [
+            "if",
+            "you",
+            "do",
+            "it",
+            "enters",
+            "with",
+            "a" | "an",
+            counter_word,
+            "counter",
+            "on",
+            "it",
+        ] => parse_counter_type_word(counter_word),
+        _ => None,
+    };
+    let Some(counter_type) = counter_type else {
+        return Ok(None);
+    };
+
+    match parse_permission_clause_spec(permission_sentence)? {
+        Some(crate::cards::builders::PermissionClauseSpec::GrantBySpec {
+            player,
+            spec,
+            lifetime: crate::cards::builders::PermissionLifetime::Static,
+        }) if matches!(spec.grantable, crate::grant::Grantable::PlayFrom) => Ok(
+            static_grant_beneficiary(player).map(|beneficiary| {
+                StaticAbility::grants(
+                    spec.with_beneficiary(beneficiary)
+                        .with_cast_this_way_grant(StaticAbility::enters_with_counters_value(
+                            counter_type,
+                            Value::Fixed(1),
+                        )),
+                )
+            }),
+        ),
         _ => Ok(None),
     }
 }

--- a/crates/ironsmith-core/src/anthem_model.rs
+++ b/crates/ironsmith-core/src/anthem_model.rs
@@ -10,6 +10,7 @@ pub enum AnthemCountExpression {
     AffectedAttackedThisTurn,
     CountersOnSource(CounterType),
     CountersAmong(ObjectFilter, CounterType),
+    DistinctCounterTypesAmong(ObjectFilter),
     BasicLandTypesAmong(ObjectFilter),
     CreatureTypesAmong(ObjectFilter),
     CommanderCastCount(PlayerFilter),

--- a/crates/ironsmith-core/src/grant_model.rs
+++ b/crates/ironsmith-core/src/grant_model.rs
@@ -794,6 +794,17 @@ where
                     ". If you cast {spell_text} this way, it gains haste until end of turn"
                 );
             }
+            if grants.len() == 1
+                && let Some(rest) = grants[0]
+                    .strip_prefix("Enters the battlefield with ")
+                    .or_else(|| grants[0].strip_prefix("enters the battlefield with "))
+            {
+                let spell_text = cast_this_way_spell_subject(&self.filter);
+                if self.filter == ObjectFilter::source() {
+                    return format!(". If you do, it enters with {rest}");
+                }
+                return format!(". If you cast {spell_text} this way, it enters with {rest}");
+            }
             format!(". Spells cast this way gain {}", grants.join(" and "))
         };
 
@@ -801,25 +812,37 @@ where
             && self.zone == Zone::Graveyard
             && self.filter == ObjectFilter::source()
         {
-            return format!("{may_prefix} cast this card from your graveyard");
+            return format!(
+                "{may_prefix} cast this card from your graveyard{}",
+                cast_this_way_suffix()
+            );
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Exile
             && self.filter == ObjectFilter::source()
         {
-            return format!("{may_prefix} cast this card from exile");
+            return format!(
+                "{may_prefix} cast this card from exile{}",
+                cast_this_way_suffix()
+            );
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Graveyard
             && self.filter.card_types.as_slice() == [CardType::Land]
         {
-            return format!("{may_prefix} play lands from your graveyard");
+            return format!(
+                "{may_prefix} play lands from your graveyard{}",
+                cast_this_way_suffix()
+            );
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Graveyard
             && self.filter == ObjectFilter::default()
         {
-            return format!("{may_prefix} play lands and cast spells from your graveyard");
+            return format!(
+                "{may_prefix} play lands and cast spells from your graveyard{}",
+                cast_this_way_suffix()
+            );
         }
         if matches!(self.grantable, Grantable::PlayFrom)
             && self.zone == Zone::Graveyard

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -68237,6 +68237,27 @@ fn esper_origins_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn hundred_battle_veteran_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Hundred-Battle Veteran");
+
+    let def = parse_oracle_card_definition("Hundred-Battle Veteran");
+    let rendered = crate::compiled_text::compiled_text_lines(&def).join("\n");
+    let debug = format!("{def:#?}");
+    assert_eq!(
+        rendered,
+        "As long as there are three or more different kinds of counters among creatures you control, this creature gets +2/+4.\nYou may cast this card from your graveyard. If you do, it enters with a finality counter on it.",
+        "Hundred-Battle Veteran should render its exact counter-threshold anthem and graveyard-cast finality clause"
+    );
+    assert!(
+        debug.contains("DistinctCounterTypesAmong")
+            && debug.contains("cast_this_way_grants")
+            && debug.contains("EnterWithCounters")
+            && debug.contains("Finality"),
+        "Hundred-Battle Veteran should structurally lower distinct counter kinds and cast-this-way finality counter grant, got {debug}"
+    );
+}
+
+#[test]
 fn esper_origins_graveyard_cast_condition_moves_source_with_finality_counter() {
     use crate::effects::{ExecutionContext, execute_effect};
     use crate::tests::test_helpers::setup_two_player_game;

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3402,20 +3402,21 @@ fn apply_play_from_cast_this_way_grants(
         | CastingMethod::SplitOtherHalfPlayFrom { source, zone, .. } => (*source, *zone),
         _ => return,
     };
-    let Some(source) = game.object(source_id) else {
+    let source = game.object(source_id).or_else(|| game.object(stack_id));
+    let Some(source) = source else {
         return;
     };
     let Some(mut spell_as_cast) = game.object(stack_id).cloned() else {
         return;
     };
     spell_as_cast.zone = zone;
-    let ctx = game.filter_context_for(caster, Some(source_id));
+    let ctx = game.filter_context_for(caster, Some(source.id));
     let mut granted = Vec::new();
     for ability in &source.abilities {
         let crate::ability::AbilityKind::Static(static_ability) = &ability.kind else {
             continue;
         };
-        if !static_ability.is_active(game, source_id) {
+        if !static_ability.is_active(game, source.id) {
             continue;
         }
         let Some(spec) = static_ability.grant_spec() else {
@@ -3430,7 +3431,11 @@ fn apply_play_from_cast_this_way_grants(
         }
     }
     for ability in granted {
-        game.grant_temporary_static_ability_to_object_until_end_of_turn(stack_id, ability.id());
+        game.grant_temporary_static_ability_payload_to_object_until_end_of_turn(
+            stack_id,
+            ability.id(),
+            Some(ability),
+        );
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -35870,6 +35870,187 @@ fn test_squee_the_immortal_not_castable_from_unlisted_zone() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn hundred_battle_veteran_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(72_617), "Hundred-Battle Veteran")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Zombie, Subtype::Warrior])
+        .power_toughness(PowerToughness::fixed(4, 2))
+        .parse_text(
+            "As long as there are three or more different kinds of counters among creatures you control, this creature gets +2/+4.\nYou may cast this card from your graveyard. If you do, it enters with a finality counter on it.",
+        )
+        .expect("Hundred-Battle Veteran should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hundred_battle_veteran_counter_kind_threshold_buffs_only_at_three_kinds() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let veteran = hundred_battle_veteran_definition();
+    let veteran_id = game.create_object_from_definition(&veteran, alice, Zone::Battlefield);
+    let ally = create_creature(&mut game, "Counter Ally", alice, 1, 1);
+    let other_ally = create_creature(&mut game, "Other Counter Ally", alice, 1, 1);
+
+    game.add_counters(veteran_id, crate::object::CounterType::Finality, 1);
+    game.add_counters(ally, crate::object::CounterType::PlusOnePlusOne, 1);
+    let below = game
+        .calculated_characteristics(veteran_id)
+        .expect("Veteran characteristics below threshold");
+    assert_eq!(below.power, Some(4));
+    assert_eq!(below.toughness, Some(2));
+
+    game.add_counters(other_ally, crate::object::CounterType::Stun, 1);
+    let active = game
+        .calculated_characteristics(veteran_id)
+        .expect("Veteran characteristics at threshold");
+    assert_eq!(active.power, Some(6));
+    assert_eq!(active.toughness, Some(6));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hundred_battle_veteran_graveyard_cast_enters_with_finality_counter_and_exiles_on_death() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 3);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+
+    let veteran = hundred_battle_veteran_definition();
+    let graveyard_id = game.create_object_from_definition(&veteran, alice, Zone::Graveyard);
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Graveyard,
+                    casting_method: CastingMethod::PlayFrom { use_alternative: None, .. },
+                } if *spell_id == graveyard_id
+            )
+        })
+        .expect("Hundred-Battle Veteran should be castable from graveyard");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+        &mut dm,
+    )
+    .expect("Hundred-Battle Veteran graveyard cast should complete");
+    resolve_stack_entry(&mut game).expect("Hundred-Battle Veteran should resolve");
+
+    let entered = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Hundred-Battle Veteran")
+        })
+        .expect("graveyard-cast Hundred-Battle Veteran should enter the battlefield");
+    assert_eq!(
+        game.counter_count(entered, crate::object::CounterType::Finality),
+        1,
+        "graveyard-cast Veteran should enter with one finality counter"
+    );
+
+    crate::events::processing::process_destroy(&mut game, entered, None, &mut dm);
+    assert!(
+        game.exile.iter().any(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Hundred-Battle Veteran")
+        }),
+        "a Veteran with a finality counter should be exiled instead of dying"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hundred_battle_veteran_normal_cast_does_not_get_finality_counter() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 3);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Black, 1);
+
+    let veteran = hundred_battle_veteran_definition();
+    let hand_id = game.create_object_from_definition(&veteran, alice, Zone::Hand);
+    let cast_action = compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                LegalAction::CastSpell {
+                    spell_id,
+                    from_zone: Zone::Hand,
+                    casting_method: CastingMethod::Normal,
+                } if *spell_id == hand_id
+            )
+        })
+        .expect("Hundred-Battle Veteran should be normally castable from hand");
+
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = SelectFirstDecisionMaker;
+    apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(cast_action),
+        &mut dm,
+    )
+    .expect("Hundred-Battle Veteran normal cast should complete");
+    resolve_stack_entry(&mut game).expect("Hundred-Battle Veteran should resolve");
+
+    let entered = game
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Hundred-Battle Veteran")
+        })
+        .expect("normal-cast Hundred-Battle Veteran should enter the battlefield");
+    assert_eq!(
+        game.counter_count(entered, crate::object::CounterType::Finality),
+        0,
+        "normal-cast Veteran should not enter with a finality counter"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn eelectrocute_definition() -> crate::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(72_615), "Eelectrocute")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -2972,12 +2972,27 @@ impl GameState {
         object_id: ObjectId,
         ability: crate::static_abilities::StaticAbilityId,
     ) {
+        self.grant_temporary_static_ability_payload_to_object_until_end_of_turn(
+            object_id,
+            ability,
+            None,
+        );
+    }
+
+    pub fn grant_temporary_static_ability_payload_to_object_until_end_of_turn(
+        &mut self,
+        object_id: ObjectId,
+        ability: crate::static_abilities::StaticAbilityId,
+        ability_payload: Option<crate::static_abilities::StaticAbility>,
+    ) {
         let expires_end_of_turn = self.turn.turn_number;
         let Some(object) = self.object_mut(object_id) else {
             return;
         };
         if object.temporary_static_ability_grants.iter().any(|grant| {
-            grant.ability == ability && grant.expires_end_of_turn >= expires_end_of_turn
+            grant.ability == ability
+                && grant.ability_payload == ability_payload
+                && grant.expires_end_of_turn >= expires_end_of_turn
         }) {
             return;
         }
@@ -2985,6 +3000,7 @@ impl GameState {
             .temporary_static_ability_grants
             .push(crate::object::TemporaryStaticAbilityGrant {
                 ability,
+                ability_payload,
                 expires_end_of_turn,
             });
     }

--- a/crates/ironsmith-runtime/src/object.rs
+++ b/crates/ironsmith-runtime/src/object.rs
@@ -241,9 +241,10 @@ pub struct Object {
     // - is_commander -> GameState::commanders
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TemporaryStaticAbilityGrant {
     pub ability: StaticAbilityId,
+    pub ability_payload: Option<StaticAbility>,
     pub expires_end_of_turn: u32,
 }
 
@@ -253,7 +254,9 @@ impl TemporaryStaticAbilityGrant {
     }
 
     pub fn materialize(&self) -> Option<StaticAbility> {
-        static_ability_from_id(self.ability)
+        self.ability_payload
+            .clone()
+            .or_else(|| static_ability_from_id(self.ability))
     }
 }
 

--- a/crates/ironsmith-runtime/src/replacement_ability_processor.rs
+++ b/crates/ironsmith-runtime/src/replacement_ability_processor.rs
@@ -140,6 +140,20 @@ pub fn generate_replacement_effects_from_abilities(game: &GameState) -> Vec<Repl
                     ));
                 }
             }
+
+            for grant in &object.temporary_static_ability_grants {
+                if grant.is_expired(game.turn.turn_number) {
+                    continue;
+                }
+                let Some(static_ability) = grant.materialize() else {
+                    continue;
+                };
+                if let Some(effect) =
+                    static_ability.generate_replacement_effect(object_id, controller)
+                {
+                    effects.push(effect);
+                }
+            }
         }
     }
 

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -690,6 +690,10 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
             counter_type.description(),
             pluralized_subject_text(filter)
         ),
+        AnthemCountExpression::DistinctCounterTypesAmong(filter) => format!(
+            "different kind of counter among {}",
+            pluralized_subject_text(filter)
+        ),
         AnthemCountExpression::BasicLandTypesAmong(_) => {
             "basic land type among lands you control".to_string()
         }
@@ -790,6 +794,10 @@ fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Op
         AnthemCountExpression::CountersAmong(filter, counter_type) => Some(format!(
             "{} counter among {}",
             counter_type.description(),
+            pluralized_subject_text(filter)
+        )),
+        AnthemCountExpression::DistinctCounterTypesAmong(filter) => Some(format!(
+            "different kind of counter among {}",
             pluralized_subject_text(filter)
         )),
         AnthemCountExpression::BasicLandTypesAmong(_) => {
@@ -1609,6 +1617,19 @@ pub(crate) fn resolve_anthem_count_expression(
             .filter(|obj| filter.matches_non_recursive(obj, &filter_ctx, game))
             .map(|obj| obj.counters.get(counter_type).copied().unwrap_or(0) as i32)
             .sum(),
+        AnthemCountExpression::DistinctCounterTypesAmong(filter) => {
+            use std::collections::HashSet;
+
+            let mut seen = HashSet::new();
+            for obj in all_game_object_ids(game)
+                .into_iter()
+                .filter_map(|id| game.object(id))
+                .filter(|obj| filter.matches_non_recursive(obj, &filter_ctx, game))
+            {
+                seen.extend(obj.counters.keys().copied());
+            }
+            seen.len() as i32
+        }
         AnthemCountExpression::BasicLandTypesAmong(filter) => {
             use std::collections::HashSet;
 
@@ -2023,8 +2044,14 @@ impl StaticAbilityKind for Anthem {
         };
 
         if let Some(condition) = &self.condition {
+            let condition_text = describe_static_condition(condition);
+            if self.source_only
+                && let Some(rest) = condition_text.strip_prefix("as long as ")
+            {
+                return format!("As long as {rest}, {text}");
+            }
             text.push(' ');
-            text.push_str(&describe_static_condition(condition));
+            text.push_str(&condition_text);
         }
         text
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hundred-Battle Veteran
Initial parse error:
```
parser does not yet support line family: 'You may cast this card from your graveyard. If you do, it enters with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)'; oracle-only fallback also failed: parser does not yet support line family: 'You may cast this card from your graveyard. If you do, it enters with a finality counter on it.'
```

Current worker: i-084256523040b5188
Branch: codex/aws-card-fix-hundred-battle-veteran
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0007
