### PR TITLE
Fix Ironsmith parse failure: Aberrant Return

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -3617,7 +3617,33 @@ pub(crate) fn parse_target_count_range_prefix(
     let (first, first_used) = parse_number(tokens)?;
     let or_idx = first_used;
     if !token_slice_at_is(tokens, or_idx, "or") {
-        return None;
+        if !tokens.get(or_idx).is_some_and(OwnedLexToken::is_comma) {
+            return None;
+        }
+        let (second, second_used) = parse_number(tokens.get(or_idx + 1..)?)?;
+        let second_end = or_idx + 1 + second_used;
+        let or_idx = if tokens.get(second_end).is_some_and(OwnedLexToken::is_comma) {
+            second_end + 1
+        } else {
+            second_end
+        };
+        if !token_slice_at_is(tokens, or_idx, "or") {
+            return None;
+        }
+        let (third, third_used) = parse_number(tokens.get(or_idx + 1..)?)?;
+        if second <= first || third < second {
+            return None;
+        }
+        return Some((
+            ChoiceCount {
+                min: first as usize,
+                max: Some(third as usize),
+                dynamic_x: false,
+                up_to_x: false,
+                random: false,
+            },
+            or_idx + 1 + third_used,
+        ));
     }
     let (second, second_used) = parse_number(&tokens[or_idx + 1..])?;
     if second < first {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/counter_marker_family.rs
@@ -93,6 +93,8 @@ pub(crate) const IF_ENTERS_WITH_ADDITIONAL_COUNTER_PATTERN_ATOMS: &[LexPatternAt
     ),
 ];
 const TAGGED_ENTERS_WITH_ADDITIONAL_COUNTER_PREFIXES: &[&[&str]] = &[
+    &["each", "of", "them", "enters", "with"],
+    &["all", "of", "them", "enter", "with"],
     &["that", "card", "enters", "with"],
     &["that", "creature", "enters", "with"],
     &["that", "object", "enters", "with"],
@@ -1210,7 +1212,7 @@ pub(crate) fn parse_if_enters_with_additional_counter_sentence_matched(
     };
 
     let Some((count, counter_type)) =
-        parse_additional_counter_descriptor_on_target(counter_clause, &[&["it"]])?
+        parse_additional_counter_descriptor_on_target(counter_clause, &[&["it"], &["them"]])?
     else {
         return Ok(None);
     };

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/mechanic_marker_family.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/subject_verb_primitives/mechanic_marker_family.rs
@@ -594,6 +594,8 @@ pub(crate) const PRE_CONDITIONAL_SUBJECT_VERB_PRIMITIVES: &[SubjectVerbPrimitive
         52,
         PreDiagnostic,
         &[
+            LexRuleHeadHint::Single("all"),
+            LexRuleHeadHint::Single("each"),
             LexRuleHeadHint::Single("it"),
             LexRuleHeadHint::Single("that"),
         ],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -27899,6 +27899,198 @@ fn parse_teferis_time_twist_text_parses_typed_counter_followup() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_aberrant_return_oracle_parses_and_renders_enters_with_counters() {
+    assert_oracle_card_parses_strict("Aberrant Return");
+    let def = parse_oracle_card_definition("Aberrant Return");
+
+    let debug = format!("{:?}", def.spell_effect);
+    assert!(
+        debug.contains("MoveToZoneEffect")
+            && debug.contains("WithCount")
+            && debug.contains("min: 1")
+            && debug.contains("max: Some(3)")
+            && debug.contains("PutCountersEffect")
+            && debug.contains("MinusOneMinusOne"),
+        "Aberrant Return should lower to one-to-three targeted graveyard returns plus -1/-1 counters, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert_eq!(
+        rendered,
+        "Put one, two, or three target creature cards from graveyards onto the battlefield under your control. Each of them enters with an additional -1/-1 counter on it.",
+        "Aberrant Return compiled text should preserve target count and enter-with-counter wording"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_aberrant_return_graveyard_permanent(
+    game: &mut crate::game_state::GameState,
+    name: &str,
+    owner: PlayerId,
+    card_types: Vec<CardType>,
+) -> ObjectId {
+    let is_creature = card_types.contains(&CardType::Creature);
+    let mut builder = crate::card::CardBuilder::new(CardId::new(), name).card_types(card_types);
+    if is_creature {
+        builder = builder.power_toughness(PowerToughness::fixed(2, 2));
+    }
+    game.create_object_from_card(&builder.build(), owner, Zone::Graveyard)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn battlefield_object_named(
+    game: &crate::game_state::GameState,
+    name: &str,
+) -> Option<ObjectId> {
+    game.battlefield.iter().copied().find(|id| {
+        game.object(*id)
+            .is_some_and(|object| object.name == name && object.zone == Zone::Battlefield)
+    })
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn replay_aberrant_return_returns_three_target_creatures_with_minus_counters() {
+    let def = parse_oracle_card_definition("Aberrant Return");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_creature = create_aberrant_return_graveyard_permanent(
+        &mut game,
+        "Alice Aberrant Bear",
+        alice,
+        vec![CardType::Creature],
+    );
+    let bob_creature = create_aberrant_return_graveyard_permanent(
+        &mut game,
+        "Bob Aberrant Bear",
+        bob,
+        vec![CardType::Creature],
+    );
+    let second_bob_creature = create_aberrant_return_graveyard_permanent(
+        &mut game,
+        "Bob Aberrant Soldier",
+        bob,
+        vec![CardType::Creature],
+    );
+    create_aberrant_return_graveyard_permanent(
+        &mut game,
+        "Ignored Aberrant Relic",
+        bob,
+        vec![CardType::Artifact],
+    );
+
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    game.push_to_stack(
+        crate::game_state::StackEntry::new(spell_id, alice).with_targets(vec![
+            crate::game_state::Target::Object(alice_creature),
+            crate::game_state::Target::Object(bob_creature),
+            crate::game_state::Target::Object(second_bob_creature),
+        ]),
+    );
+
+    crate::game_loop::resolve_stack_entry_with(
+        &mut game,
+        &mut crate::decision::SelectFirstDecisionMaker,
+    )
+    .expect("Aberrant Return should resolve with three legal creature-card targets");
+
+    for name in [
+        "Alice Aberrant Bear",
+        "Bob Aberrant Bear",
+        "Bob Aberrant Soldier",
+    ] {
+        let returned = battlefield_object_named(&game, name)
+            .unwrap_or_else(|| panic!("{name} should be returned to the battlefield"));
+        let object = game.object(returned).expect("returned object exists");
+        assert_eq!(
+            game.controller_of(object),
+            alice,
+            "Aberrant Return should put {name} onto the battlefield under its caster's control"
+        );
+        assert_eq!(
+            game.counter_count(returned, crate::object::CounterType::MinusOneMinusOne),
+            1,
+            "{name} should enter with exactly one -1/-1 counter"
+        );
+    }
+
+    assert!(
+        battlefield_object_named(&game, "Ignored Aberrant Relic").is_none(),
+        "noncreature graveyard cards should not be returned by Aberrant Return"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aberrant_return_target_requirements_reject_noncreatures_and_cap_at_three() {
+    let def = parse_oracle_card_definition("Aberrant Return");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+
+    let creature_targets = (0..4)
+        .map(|idx| {
+            create_aberrant_return_graveyard_permanent(
+                &mut game,
+                &format!("Aberrant Extra Target {idx}"),
+                alice,
+                vec![CardType::Creature],
+            )
+        })
+        .collect::<Vec<_>>();
+    let artifact = create_aberrant_return_graveyard_permanent(
+        &mut game,
+        "Aberrant Illegal Relic",
+        alice,
+        vec![CardType::Artifact],
+    );
+
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let requirements = crate::game_loop::extract_target_requirements_from_program_with_modes(
+        &game,
+        def.spell_effect
+            .as_ref()
+            .expect("Aberrant Return should have spell effects"),
+        alice,
+        Some(spell_id),
+        None,
+    );
+
+    assert_eq!(
+        requirements.len(),
+        1,
+        "Aberrant Return should have one target group"
+    );
+    assert_eq!(
+        requirements[0].min_targets, 1,
+        "Aberrant Return requires at least one target"
+    );
+    assert_eq!(
+        requirements[0].max_targets,
+        Some(3),
+        "Aberrant Return allows at most three targets"
+    );
+    for creature in creature_targets {
+        assert!(
+            requirements[0]
+                .legal_targets
+                .contains(&crate::game_state::Target::Object(creature)),
+            "creature cards in graveyards should be legal Aberrant Return targets"
+        );
+    }
+    assert!(
+        !requirements[0]
+            .legal_targets
+            .contains(&crate::game_state::Target::Object(artifact)),
+        "noncreature graveyard cards should not be legal Aberrant Return targets"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_named_enters_tapped_and_doesnt_untap_fails_strictly() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Grimgrin Variant")
         .parse_text("Grimgrin enters tapped and doesn't untap during your untap step.")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -7401,11 +7401,14 @@ pub(super) fn describe_choose_spec_without_graveyard_zone(spec: &ChooseSpec) -> 
                         if filter.single_graveyard {
                             " in single graveyard".to_string()
                         } else {
-                            " in graveyard".to_string()
+                            " in a graveyard".to_string()
                         }
                     }
                 };
-                if let Some(stripped) = text.strip_suffix(&suffix) {
+                if let Some(stripped) = text
+                    .strip_suffix(&suffix)
+                    .or_else(|| text.strip_suffix(" in graveyard"))
+                {
                     return ensure_indefinite_article(&render_artifact_non_aura_enchantment_text(
                         filter, stripped,
                     ));
@@ -7438,11 +7441,14 @@ pub(super) fn describe_choose_spec_without_graveyard_zone(spec: &ChooseSpec) -> 
                         if filter.single_graveyard {
                             " in single graveyard".to_string()
                         } else {
-                            " in graveyard".to_string()
+                            " in a graveyard".to_string()
                         }
                     }
                 };
-                if let Some(stripped) = text.strip_suffix(&suffix) {
+                if let Some(stripped) = text
+                    .strip_suffix(&suffix)
+                    .or_else(|| text.strip_suffix(" in graveyard"))
+                {
                     let stripped = strip_leading_article(stripped);
                     return format!("all {}", pluralize_relative_object_phrase(stripped));
                 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -16419,6 +16419,9 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
     if let Some(compact) = describe_choose_color_then_chosen_color_mana(&effect_refs) {
         return Some(compact);
     }
+    if let Some(compact) = describe_move_to_battlefield_with_additional_counters(effects) {
+        return Some(compact);
+    }
 
     if effects.len() >= 2
         && let Some(first) = describe_target_then_look_at_tagged_object(&effect_refs[..2])
@@ -25158,6 +25161,67 @@ fn describe_each_player_return_all_from_their_graveyard_with_counters(
         .unwrap_or(target_text);
     Some(format!(
         "Each player returns {target_text} from their graveyard to the battlefield with an additional {} counter on it",
+        describe_counter_type(put_counters.counter_type),
+    ))
+}
+
+fn describe_move_to_battlefield_with_additional_counters(effects: &[Effect]) -> Option<String> {
+    let [move_effect, counter_effect] = effects else {
+        return None;
+    };
+    let moved_tag = structural_effect_tag(move_effect)?;
+    let move_to_zone = unwrap_structural_effect_tag(move_effect)
+        .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Battlefield
+        || move_to_zone.enters_tapped
+        || move_to_zone.enters_attacking
+        || move_to_zone.enters_face_down
+    {
+        return None;
+    }
+
+    let put_counters = tagged_put_counters_effect(counter_effect)?;
+    if put_counters.distributed
+        || put_counters.target_count.is_some()
+        || !matches!(put_counters.amount, Value::Fixed(1))
+        || !matches!(
+            &put_counters.target,
+            ChooseSpec::Tagged(tag) if tag == moved_tag
+        )
+    {
+        return None;
+    }
+
+    let target_text = if let Some(owner) = graveyard_owner_from_spec(&move_to_zone.target) {
+        let target_text = describe_choose_spec_without_graveyard_zone(&move_to_zone.target);
+        let from_text = match owner {
+            Some(owner) => format!("{} graveyard", describe_possessive_player_filter(&owner)),
+            None if choose_spec_allows_multiple(&move_to_zone.target) => "graveyards".to_string(),
+            None => "a graveyard".to_string(),
+        };
+        format!("{target_text} from {from_text}")
+    } else {
+        describe_choose_spec(&move_to_zone.target)
+    };
+    let controller_suffix = match move_to_zone.battlefield_controller {
+        crate::effects::BattlefieldController::Preserve => "",
+        crate::effects::BattlefieldController::Owner => {
+            if choose_spec_allows_multiple(&move_to_zone.target) {
+                " under their owners' control"
+            } else {
+                " under its owner's control"
+            }
+        }
+        crate::effects::BattlefieldController::You => " under your control",
+    };
+    let entering_subject = if choose_spec_allows_multiple(&move_to_zone.target) {
+        "Each of them enters"
+    } else {
+        "It enters"
+    };
+
+    Some(format!(
+        "Put {target_text} onto the battlefield{controller_suffix}. {entering_subject} with an additional {} counter on it",
         describe_counter_type(put_counters.counter_type),
     ))
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aberrant Return
Initial parse error:
```
could not find verb in effect clause (clause: 'each of them enters with an additional -1/-1 counter on it'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end); oracle-only fallback also failed: could not find verb in effect clause (clause: 'each of them enters with an additional -1/-1 counter on it'; known verbs: add, move, deal, draw, counter, destroy, exile, untap, scry, discard, transform, convert, regenerate, mill, get, reveal, look, lose, gain, put, sacrifice, create, investigate, attach, remove, return, exchange, become, switch, skip, surveil, shuffle, reorder, pay, detain, goad, suspect, end)
```

Current worker: i-02e7fd2bf1ef997e8
Branch: codex/aws-card-fix-aberrant-return
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0008
