### PR TITLE
Fix Ironsmith parse failure: Mindstorm Crown

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3097,6 +3097,82 @@ fn parse_player_cards_in_hand_predicate(words: &[&str]) -> Option<PredicateAst> 
     }
 }
 
+fn parse_player_cards_in_hand_at_turn_start_predicate(words: &[&str]) -> Option<PredicateAst> {
+    let Some(words) = strip_at_beginning_this_turn_suffix(words) else {
+        let had_idx = words.iter().position(|word| *word == "had")?;
+        return parse_player_had_card_in_hand_at_turn_start_without_amount(words, had_idx);
+    };
+    let had_idx = words.iter().position(|word| *word == "had")?;
+    let mut present_words = words.to_vec();
+    present_words[had_idx] = "have";
+    let tokens = crate::runtime_backend::lexer::synthetic_word_tokens(&present_words);
+    let Some(condition) =
+        crate::runtime_backend::grammar::conditions::parse_player_cards_in_hand_condition(&tokens)
+    else {
+        return parse_player_had_card_in_hand_at_turn_start_without_amount(words, had_idx);
+    };
+    let player = player_ast_from_status_player_filter(condition.player.clone())?;
+    match condition.comparison {
+        crate::effect::Comparison::GreaterThanOrEqual(count) if count >= 0 => {
+            Some(PredicateAst::PlayerCardsInHandAtTurnStartOrMore {
+                player,
+                count: count as u32,
+            })
+        }
+        crate::effect::Comparison::GreaterThan(count) if count >= -1 => {
+            Some(PredicateAst::PlayerCardsInHandAtTurnStartOrMore {
+                player,
+                count: (count + 1) as u32,
+            })
+        }
+        crate::effect::Comparison::LessThanOrEqual(count) if count >= 0 => {
+            Some(PredicateAst::PlayerCardsInHandAtTurnStartOrFewer {
+                player,
+                count: count as u32,
+            })
+        }
+        crate::effect::Comparison::LessThan(count) if count > 0 => {
+            Some(PredicateAst::PlayerCardsInHandAtTurnStartOrFewer {
+                player,
+                count: (count - 1) as u32,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_player_had_card_in_hand_at_turn_start_without_amount(
+    words: &[&str],
+    had_idx: usize,
+) -> Option<PredicateAst> {
+    let subject = match &words[..had_idx] {
+        ["you"] => PlayerAst::You,
+        ["that", "player"] | ["that"] => PlayerAst::That,
+        _ => return None,
+    };
+    match &words[had_idx + 1..] {
+        ["card", "in", "hand"] | ["cards", "in", "hand"] => {
+            Some(PredicateAst::PlayerCardsInHandAtTurnStartOrMore {
+                player: subject,
+                count: 1,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn strip_at_beginning_this_turn_suffix<'a>(words: &'a [&'a str]) -> Option<&'a [&'a str]> {
+    for suffix in [
+        ["at", "the", "beginning", "of", "this", "turn"].as_slice(),
+        ["at", "beginning", "of", "this", "turn"].as_slice(),
+    ] {
+        if words.len() > suffix.len() && words[words.len() - suffix.len()..] == *suffix {
+            return Some(&words[..words.len() - suffix.len()]);
+        }
+    }
+    None
+}
+
 fn parse_player_life_total_predicate(words: &[&str]) -> Option<PredicateAst> {
     let tokens = crate::runtime_backend::lexer::synthetic_word_tokens(words);
     let condition =
@@ -5839,6 +5915,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_player_cards_in_hand_relation_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_player_cards_in_hand_at_turn_start_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -493,6 +493,20 @@ pub(crate) fn compile_condition_from_predicate_ast(
                 count: *count as i32,
             }
         }
+        PredicateAst::PlayerCardsInHandAtTurnStartOrMore { player, count } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::PlayerCardsInHandAtTurnStartOrMore {
+                player,
+                count: *count as i32,
+            }
+        }
+        PredicateAst::PlayerCardsInHandAtTurnStartOrFewer { player, count } => {
+            let player = resolve_non_target_player_filter(*player, &refs)?;
+            Condition::PlayerCardsInHandAtTurnStartOrFewer {
+                player,
+                count: *count as i32,
+            }
+        }
         PredicateAst::PlayerHasMoreCardsInHandThanYou { player } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerHasMoreCardsInHandThanYou { player }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -518,6 +518,14 @@ pub(crate) enum PredicateAst {
         player: PlayerAst,
         count: u32,
     },
+    PlayerCardsInHandAtTurnStartOrMore {
+        player: PlayerAst,
+        count: u32,
+    },
+    PlayerCardsInHandAtTurnStartOrFewer {
+        player: PlayerAst,
+        count: u32,
+    },
     PlayerHasMoreCardsInHandThanYou {
         player: PlayerAst,
     },

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -726,6 +726,14 @@ pub enum Condition {
         player: PlayerFilter,
         count: i32,
     },
+    PlayerCardsInHandAtTurnStartOrMore {
+        player: PlayerFilter,
+        count: i32,
+    },
+    PlayerCardsInHandAtTurnStartOrFewer {
+        player: PlayerFilter,
+        count: i32,
+    },
     PlayerHasMoreCardsInHandThanYou {
         player: PlayerFilter,
     },

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40647,6 +40647,140 @@ fn blitz_leech_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[test]
+fn mindstorm_crown_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Mindstorm Crown");
+
+    let def = parse_oracle_card_definition("Mindstorm Crown");
+    let rendered = unprocessed_compiled_lines(&def);
+    let expected = concat!(
+        "At the beginning of your upkeep, draw a card if you had no cards in hand at the beginning of this turn. ",
+        "If you had a card in hand, this artifact deals 1 damage to you."
+    );
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(def.name(), "Mindstorm Crown");
+    assert_eq!(rendered, vec![expected.to_string()]);
+    assert!(
+        ability_debug.contains("PlayerCardsInHandAtTurnStartOrFewer")
+            && ability_debug.contains("PlayerCardsInHandAtTurnStartOrMore")
+            && ability_debug.contains("DrawCardsEffect")
+            && ability_debug.contains("DealDamageEffect"),
+        "Mindstorm Crown should structurally model both turn-start hand branches, got {ability_debug}"
+    );
+}
+
+fn mindstorm_crown_triggered_ability(
+    def: &CardDefinition,
+) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Mindstorm Crown should have an upkeep triggered ability")
+}
+
+fn create_mindstorm_crown_test_card(
+    game: &mut crate::game_state::GameState,
+    id: u32,
+    owner: PlayerId,
+    zone: Zone,
+) -> ObjectId {
+    game.create_object_from_card(
+        &crate::card::CardBuilder::new(CardId::from_raw(id), &format!("Mindstorm Test Card {id}"))
+            .card_types(vec![CardType::Creature])
+            .build(),
+        owner,
+        zone,
+    )
+}
+
+#[test]
+fn mindstorm_crown_draws_when_hand_was_empty_at_turn_start() {
+    let def = parse_oracle_card_definition("Mindstorm Crown");
+    let triggered = mindstorm_crown_triggered_ability(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let crown_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    create_mindstorm_crown_test_card(&mut game, 91_001, alice, Zone::Library);
+
+    game.record_turn_start_hand_sizes();
+    create_mindstorm_crown_test_card(&mut game, 91_002, alice, Zone::Hand);
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(crown_id, alice);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        crown_id,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Mindstorm Crown trigger should resolve");
+
+    assert_eq!(
+        game.life_total(alice),
+        20,
+        "empty turn-start hand should not deal damage"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        2,
+        "empty turn-start hand should draw even if Alice had a card by resolution"
+    );
+}
+
+#[test]
+fn mindstorm_crown_deals_damage_when_hand_had_card_at_turn_start() {
+    let def = parse_oracle_card_definition("Mindstorm Crown");
+    let triggered = mindstorm_crown_triggered_ability(&def);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let crown_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    create_mindstorm_crown_test_card(&mut game, 91_101, alice, Zone::Library);
+    let hand_card = create_mindstorm_crown_test_card(&mut game, 91_102, alice, Zone::Hand);
+
+    game.record_turn_start_hand_sizes();
+    game.move_object(
+        hand_card,
+        Zone::Graveyard,
+        crate::events::cause::EventCause::from_game_rule(),
+    )
+    .expect("setup should move hand card out of hand");
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(crown_id, alice);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        crown_id,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Mindstorm Crown trigger should resolve");
+
+    assert_eq!(
+        game.life_total(alice),
+        19,
+        "nonempty turn-start hand should deal 1 damage"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        0,
+        "nonempty turn-start hand should not draw even if Alice's hand is empty by resolution"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn fear_of_immobility_keeps_tap_target_and_conditional_stun_counter() {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11670,6 +11670,34 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
                 count_text
             )
         }
+        Condition::PlayerCardsInHandAtTurnStartOrMore { player, count } => {
+            let subject = describe_player_filter(player);
+            if *count == 1 {
+                return format!(
+                    "{} had a card in hand at the beginning of this turn",
+                    subject
+                );
+            }
+            let count_text = number_word(*count).unwrap_or_else(|| count.to_string());
+            format!(
+                "{} had {} or more cards in hand at the beginning of this turn",
+                subject, count_text
+            )
+        }
+        Condition::PlayerCardsInHandAtTurnStartOrFewer { player, count } => {
+            let subject = describe_player_filter(player);
+            if *count == 0 {
+                return format!(
+                    "{} had no cards in hand at the beginning of this turn",
+                    subject
+                );
+            }
+            let count_text = number_word(*count).unwrap_or_else(|| count.to_string());
+            format!(
+                "{} had {} or fewer cards in hand at the beginning of this turn",
+                subject, count_text
+            )
+        }
         Condition::PlayerHasMoreCardsInHandThanYou { player } => {
             format!(
                 "{} has more cards in hand than you",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5563,6 +5563,9 @@ fn describe_group_pump_then_conditional_untap(effects: &[Effect]) -> Option<Stri
 }
 
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_turn_start_hand_condition_effects(effects) {
+        return compact;
+    }
     if let [first, second] = effects
         && let Some(tagged) = first.downcast_ref::<crate::effects::TaggedEffect>()
         && let Some(cant) = second.downcast_ref::<crate::effects::CantEffect>()
@@ -16350,6 +16353,47 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     cleanup_decompiled_text(&text)
+}
+
+fn describe_turn_start_hand_condition_effects(effects: &[Effect]) -> Option<String> {
+    let [first_effect, second_effect] = effects else {
+        return None;
+    };
+    let first = first_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    let second = second_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !first.if_false.is_empty()
+        || !second.if_false.is_empty()
+        || first.if_true.len() != 1
+        || second.if_true.len() != 1
+    {
+        return None;
+    }
+    let Condition::PlayerCardsInHandAtTurnStartOrFewer {
+        player: first_player,
+        count: 0,
+    } = &first.condition
+    else {
+        return None;
+    };
+    let Condition::PlayerCardsInHandAtTurnStartOrMore {
+        player: second_player,
+        count: 1,
+    } = &second.condition
+    else {
+        return None;
+    };
+    if first_player != second_player {
+        return None;
+    }
+
+    let first_text = lowercase_first(describe_effect(&first.if_true[0]).trim_end_matches('.'));
+    let first_condition = lowercase_first(&describe_condition(&first.condition));
+    let second_condition = lowercase_first(&describe_condition(&second.condition))
+        .replace(" at the beginning of this turn", "");
+    let second_text = lowercase_first(describe_effect(&second.if_true[0]).trim_end_matches('.'));
+    Some(format!(
+        "{first_text} if {first_condition}. If {second_condition}, {second_text}"
+    ))
 }
 
 fn describe_vote_with_received_vote_followups(effects: &[Effect]) -> Option<String> {

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -944,6 +944,14 @@ fn triggering_object_had_to_attack_this_combat(
         })
 }
 
+fn player_hand_count_at_turn_start(game: &GameState, player_id: PlayerId) -> Option<i32> {
+    game.turn_store
+        .hand_sizes_at_turn_start
+        .get(&player_id)
+        .copied()
+        .map(|count| count as i32)
+}
+
 fn evaluate_condition_shared_core(
     game: &GameState,
     condition: &Condition,
@@ -1313,6 +1321,8 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::ValueComparison { .. } => {}
         Condition::PlayerCardsInHandOrMore { .. } => {}
         Condition::PlayerCardsInHandOrFewer { .. } => {}
+        Condition::PlayerCardsInHandAtTurnStartOrMore { .. } => {}
+        Condition::PlayerCardsInHandAtTurnStartOrFewer { .. } => {}
         Condition::PlayerControlsBasicLandTypesAmongLandsOrMore { .. } => {}
         Condition::PlayerHasCardTypesInGraveyardOrMore { .. } => {}
         Condition::PlayerHasLessLifeThanYou { .. } => {}
@@ -1532,6 +1542,22 @@ pub fn evaluate_condition_external(
             };
             game.player(player_id)
                 .map(|p| p.hand.len() as i32 <= *count)
+                .unwrap_or(false)
+        }
+        Condition::PlayerCardsInHandAtTurnStartOrMore { player, count } => {
+            let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
+                return false;
+            };
+            player_hand_count_at_turn_start(game, player_id)
+                .map(|hand_count| hand_count >= *count)
+                .unwrap_or(false)
+        }
+        Condition::PlayerCardsInHandAtTurnStartOrFewer { player, count } => {
+            let Some(player_id) = resolve_condition_player_external(game, ctx, player) else {
+                return false;
+            };
+            player_hand_count_at_turn_start(game, player_id)
+                .map(|hand_count| hand_count <= *count)
                 .unwrap_or(false)
         }
         Condition::PlayerHasLessLifeThanYou { player } => {
@@ -2708,6 +2734,22 @@ fn evaluate_condition_simple(
             let hand = game.player(player_id).map(|p| p.hand.len()).unwrap_or(0);
             hand <= *count as usize
         }
+        Condition::PlayerCardsInHandAtTurnStartOrMore { player, count } => {
+            let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
+                return false;
+            };
+            player_hand_count_at_turn_start(game, player_id)
+                .map(|hand_count| hand_count >= *count)
+                .unwrap_or(false)
+        }
+        Condition::PlayerCardsInHandAtTurnStartOrFewer { player, count } => {
+            let Some(player_id) = resolve_condition_player_simple(game, controller, player) else {
+                return false;
+            };
+            player_hand_count_at_turn_start(game, player_id)
+                .map(|hand_count| hand_count <= *count)
+                .unwrap_or(false)
+        }
         Condition::PlayerHasMoreCardsInHandThanYou { player } => {
             let your_hand = game.player(controller).map(|p| p.hand.len()).unwrap_or(0);
             matching_condition_players_simple(game, controller, player)
@@ -3387,6 +3429,18 @@ fn evaluate_condition(
             let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
             let hand_count = game.player(player_id).map(|p| p.hand.len()).unwrap_or(0);
             Ok(hand_count <= *count as usize)
+        }
+        Condition::PlayerCardsInHandAtTurnStartOrMore { player, count } => {
+            let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
+            Ok(player_hand_count_at_turn_start(game, player_id)
+                .map(|hand_count| hand_count >= *count)
+                .unwrap_or(false))
+        }
+        Condition::PlayerCardsInHandAtTurnStartOrFewer { player, count } => {
+            let player_id = crate::effects::helpers::resolve_player_filter(game, player, ctx)?;
+            Ok(player_hand_count_at_turn_start(game, player_id)
+                .map(|hand_count| hand_count <= *count)
+                .unwrap_or(false))
         }
         Condition::PlayerHasMoreCardsInHandThanYou { player } => {
             let your_hand = game

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -260,6 +260,8 @@ pub struct TurnStore {
     pub skip_current_turn_main_phases: HashSet<PlayerId>,
     /// Unified owner for per-turn event and action history.
     pub turn_history: TurnHistory,
+    /// Hand sizes captured as the current turn began, before the untap step.
+    pub hand_sizes_at_turn_start: HashMap<PlayerId, usize>,
     /// Total number of spells cast during the immediately previous turn.
     /// Updated when turn advances.
     pub spells_cast_last_turn_total: u32,
@@ -7487,6 +7489,16 @@ impl GameState {
         if let Some(player) = self.player_mut(next_player) {
             player.begin_turn();
         }
+        self.record_turn_start_hand_sizes();
+    }
+
+    pub fn record_turn_start_hand_sizes(&mut self) {
+        self.turn_store.hand_sizes_at_turn_start = self
+            .players
+            .iter()
+            .filter(|player| player.is_in_game())
+            .map(|player| (player.id, player.hand.len()))
+            .collect();
     }
 
     pub fn mark_combat_phase_started(&mut self) {

--- a/crates/ironsmith-runtime/src/turn_runner.rs
+++ b/crates/ironsmith-runtime/src/turn_runner.rs
@@ -315,6 +315,7 @@ impl TurnRunner {
             // Beginning Phase
             // ================================================================
             TurnState::BeginTurn => {
+                game.record_turn_start_hand_sizes();
                 game.activate_pending_player_control(game.turn.active_player);
 
                 // Untap step — no priority


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Mindstorm Crown
Initial parse error:
```
missing condition after trailing if clause; oracle-only fallback also failed: missing condition after trailing if clause
```

Current worker: i-0158726f5b7eb5dd8
Branch: codex/aws-card-fix-mindstorm-crown
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0008
