### PR TITLE
Fix Ironsmith parse failure: Gloomwidow's Feast

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -4413,6 +4413,7 @@ fn parse_tagged_state_predicate(words: &[&str]) -> Option<PredicateAst> {
     parse_tagged_controlled_permanent_shape(&tokens)
         .or_else(|| parse_tagged_entered_under_your_control_shape(&tokens))
         .or_else(|| parse_tagged_wasnt_blocking_shape(&tokens))
+        .or_else(|| parse_tagged_historical_identity_shape(&tokens))
         .or_else(|| parse_it_soulbond_paired_shape(&tokens))
         .or_else(|| parse_tagged_creature_filter_shape(&tokens))
 }
@@ -4493,6 +4494,50 @@ fn parse_tagged_wasnt_blocking_shape(tokens: &[OwnedLexToken]) -> Option<Predica
         ));
     }
     None
+}
+
+fn parse_tagged_historical_identity_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
+    let clause = LexedClause::new(tokens);
+    let action_phrases: &[&[&str]] = &[&["was"], &["were"]];
+    let atoms = [
+        LexPattern::subject("subject", LexCaptureKind::UntilAnyPhrase(action_phrases)),
+        LexPattern::action("action", LexCaptureKind::WordCount(1)),
+        LexPattern::object("descriptor", LexCaptureKind::Rest),
+    ];
+    let matched = LexPattern::new(&atoms).match_clause(clause)?;
+    let subject_clause = matched.capture_clause_by_role(LexCaptureRole::Subject, clause)?;
+    if !is_tagged_identity_subject_clause(subject_clause) {
+        return None;
+    }
+    let descriptor_clause = matched.capture_clause_by_role(LexCaptureRole::Object, clause)?;
+    let (negative, descriptor_clause) = parse_source_identity_descriptor_clause(descriptor_clause)?;
+    if negative
+        || descriptor_clause.tokens().is_empty()
+        || source_identity_descriptor_contains_ignored_state(descriptor_clause)
+    {
+        return None;
+    }
+    let descriptor_words = descriptor_clause.word_refs();
+    let filter = parse_object_filter(descriptor_clause.tokens(), false)
+        .ok()
+        .or_else(|| parse_color_only_object_filter_words(&descriptor_words))
+        .or_else(|| parse_identity_descriptor_filter_words(&descriptor_words))?;
+    if !object_filter_has_identity(&filter) {
+        return None;
+    }
+    Some(PredicateAst::TaggedMatches(TagKey::from(IT_TAG), filter))
+}
+
+fn is_tagged_identity_subject_clause(clause: LexedClause<'_>) -> bool {
+    clause_matches_any_phrase(
+        clause,
+        &[
+            &["it"],
+            &["that", "card"],
+            &["that", "creature"],
+            &["that", "permanent"],
+        ],
+    )
 }
 
 fn parse_it_soulbond_paired_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
@@ -7592,6 +7637,16 @@ mod tests {
                     TagKey::from(IT_TAG),
                     ObjectFilter {
                         nonblocking: true,
+                        ..Default::default()
+                    },
+                ),
+            ),
+            (
+                "If that creature was blue or black",
+                PredicateAst::TaggedMatches(
+                    TagKey::from(IT_TAG),
+                    ObjectFilter {
+                        colors: Some(ColorSet::BLUE.union(ColorSet::BLACK)),
                         ..Default::default()
                     },
                 ),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -69967,3 +69967,53 @@ fn captain_america_throw_unattaches_equipment_and_deals_its_mana_value_divided_d
         "Throw should not be payable without an Equipment attached to Captain America"
     );
 }
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn gloomwidows_feast_definition() -> crate::cards::CardDefinition {
+    parse_oracle_card_definition("Gloomwidow's Feast")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gloomwidows_feast_parses_strictly() {
+    assert_oracle_card_parses_strict("Gloomwidow's Feast");
+
+    let def = gloomwidows_feast_definition();
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        !rendered.contains("unsupported predicate")
+            && !rendered.contains("unsupported effect")
+            && !rendered.contains("unsupported parser line fallback"),
+        "Gloomwidow's Feast should parse without unsupported fallback markers, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("DestroyEffect")
+            && debug.contains("TaggedObjectMatches")
+            && debug.contains("CreateTokenEffect")
+            && debug.contains("Spider"),
+        "Gloomwidow's Feast should lower to destroy, tagged color condition, and Spider token creation, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gloomwidows_feast_compiled_text_preserves_blue_or_black_was_clause() {
+    let def = gloomwidows_feast_definition();
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Destroy target creature with flying"),
+        "Gloomwidow's Feast should render the flying target restriction, got {rendered}"
+    );
+    assert!(
+        rendered.contains("If that creature was blue or black"),
+        "Gloomwidow's Feast should render the historical blue-or-black condition, got {rendered}"
+    );
+    assert!(
+        rendered.contains("create a 1/2 green Spider creature token with reach"),
+        "Gloomwidow's Feast should render the conditional Spider token, got {rendered}"
+    );
+}

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5562,7 +5562,103 @@ fn describe_group_pump_then_conditional_untap(effects: &[Effect]) -> Option<Stri
     ))
 }
 
+fn describe_destroy_then_color_conditional(
+    destroy_effect: &Effect,
+    conditional_effect: &Effect,
+) -> Option<String> {
+    let tagged_destroy = destroy_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let destroy = tagged_destroy
+        .effect
+        .downcast_ref::<crate::effects::DestroyEffect>()?;
+    let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() {
+        return None;
+    }
+    let crate::effect::Condition::TaggedObjectMatches(condition_tag, filter) = &conditional.condition
+    else {
+        return None;
+    };
+    if condition_tag != &tagged_destroy.tag {
+        return None;
+    }
+    let colors = filter.colors?;
+    let mut color_only = filter.clone();
+    color_only.colors = None;
+    if color_only != crate::target::ObjectFilter::default() {
+        return None;
+    }
+    let color_text = describe_filter_color_alternatives(colors);
+    if color_text.is_empty() {
+        return None;
+    }
+    let noun = destroyed_target_reference_noun(&destroy.spec)?;
+    let true_branch = lowercase_first(
+        describe_effect_list(&conditional.if_true)
+            .trim()
+            .trim_end_matches('.'),
+    );
+    if true_branch.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}. If that {noun} was {color_text}, {true_branch}",
+        describe_effect(destroy_effect).trim_end_matches('.')
+    ))
+}
+
+fn describe_filter_color_alternatives(colors: crate::color::ColorSet) -> String {
+    let mut names = Vec::new();
+    if colors.contains(crate::color::Color::White) {
+        names.push("white".to_string());
+    }
+    if colors.contains(crate::color::Color::Blue) {
+        names.push("blue".to_string());
+    }
+    if colors.contains(crate::color::Color::Black) {
+        names.push("black".to_string());
+    }
+    if colors.contains(crate::color::Color::Red) {
+        names.push("red".to_string());
+    }
+    if colors.contains(crate::color::Color::Green) {
+        names.push("green".to_string());
+    }
+    join_with_or(&names)
+}
+
+fn destroyed_target_reference_noun(spec: &ChooseSpec) -> Option<&'static str> {
+    let target = match spec.unhinted() {
+        ChooseSpec::Target(inner) => inner.unhinted(),
+        ChooseSpec::WithCount(inner, count) if count.is_single() => match inner.unhinted() {
+            ChooseSpec::Target(target) => target.unhinted(),
+            other => other,
+        },
+        _ => return None,
+    };
+    let ChooseSpec::Object(filter) = target else {
+        return None;
+    };
+    if filter.card_types.contains(&crate::types::CardType::Creature) {
+        Some("creature")
+    } else if filter.card_types.contains(&crate::types::CardType::Artifact) {
+        Some("artifact")
+    } else if filter.card_types.contains(&crate::types::CardType::Enchantment) {
+        Some("enchantment")
+    } else if filter.card_types.contains(&crate::types::CardType::Land) {
+        Some("land")
+    } else if filter.card_types.contains(&crate::types::CardType::Planeswalker) {
+        Some("planeswalker")
+    } else {
+        Some("permanent")
+    }
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let [first, second] = effects
+        && let Some(compact) = describe_destroy_then_color_conditional(first, second)
+    {
+        return compact;
+    }
     if let [first, second] = effects
         && let Some(tagged) = first.downcast_ref::<crate::effects::TaggedEffect>()
         && let Some(cant) = second.downcast_ref::<crate::effects::CantEffect>()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -54565,3 +54565,203 @@ fn trove_tracker_only_triggers_on_battlefield_to_graveyard_moves() {
         "moving Trove Tracker from hand to graveyard should not count as dying"
     );
 }
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn gloomwidows_feast_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(154_394), "Gloomwidow's Feast")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Green],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Destroy target creature with flying. If that creature was blue or black, create a 1/2 green Spider creature token with reach.",
+        )
+        .expect("Gloomwidow's Feast should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_gloomwidows_feast_target(
+    game: &mut GameState,
+    controller: PlayerId,
+    name: &str,
+    colors: crate::color::ColorSet,
+) -> ObjectId {
+    let def = CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .color_indicator(colors)
+        .flying()
+        .build();
+    game.create_object_from_definition(&def, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_gloomwidows_feast_at(game: &mut GameState, controller: PlayerId, target: ObjectId) {
+    let def = gloomwidows_feast_definition();
+    let spell_id = game.create_object_from_definition(&def, controller, Zone::Stack);
+    game.push_to_stack(
+        StackEntry::new(spell_id, controller).with_targets(vec![Target::Object(target)]),
+    );
+    resolve_stack_entry(game).expect("Gloomwidow's Feast should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn gloomwidow_spider_tokens_controlled_by(game: &GameState, player: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|&id| {
+            game.object(id).is_some_and(|object| {
+                game.controller_of(object) == player
+                    && object.kind == ObjectKind::Token
+                    && object.name == "Spider"
+                    && object.card_types.contains(&CardType::Creature)
+                    && object.subtypes.contains(&Subtype::Spider)
+                    && game.current_power(id) == Some(1)
+                    && game.current_toughness(id) == Some(2)
+                    && game.current_colors(id) == Some(crate::color::ColorSet::GREEN)
+                    && game.object_has_static_ability_id(
+                        id,
+                        crate::static_abilities::StaticAbilityId::Reach,
+                    )
+            })
+        })
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gloomwidows_feast_targets_only_creatures_with_flying() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let def = gloomwidows_feast_definition();
+    let effects = def
+        .spell_effect
+        .as_ref()
+        .expect("Gloomwidow's Feast should have spell effects");
+    let flying_creature = create_gloomwidows_feast_target(
+        &mut game,
+        bob,
+        "Gloomwidow Legal Flying Target",
+        crate::color::ColorSet::BLUE,
+    );
+    let nonflying_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Gloomwidow Nonflying Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .color_indicator(crate::color::ColorSet::BLUE)
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+    let flying_artifact = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Gloomwidow Flying Artifact")
+            .card_types(vec![CardType::Artifact])
+            .flying()
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let requirements = extract_target_requirements(&game, effects, alice, None);
+    assert_eq!(
+        requirements.len(),
+        1,
+        "Gloomwidow's Feast should require exactly one target"
+    );
+    let legal_targets = &requirements[0].legal_targets;
+    assert!(
+        legal_targets.contains(&Target::Object(flying_creature)),
+        "flying creatures should be legal Gloomwidow's Feast targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(nonflying_creature)),
+        "nonflying creatures should not be legal Gloomwidow's Feast targets, got {legal_targets:?}"
+    );
+    assert!(
+        !legal_targets.contains(&Target::Object(flying_artifact)),
+        "noncreature permanents with flying should not be legal Gloomwidow's Feast targets, got {legal_targets:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gloomwidows_feast_destroys_blue_flying_target_and_creates_spider() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_gloomwidows_feast_target(
+        &mut game,
+        bob,
+        "Gloomwidow Blue Target",
+        crate::color::ColorSet::BLUE,
+    );
+
+    resolve_gloomwidows_feast_at(&mut game, alice, target);
+
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Graveyard, "Gloomwidow Blue Target"),
+        1,
+        "Gloomwidow's Feast should destroy its flying creature target"
+    );
+    assert_eq!(
+        gloomwidow_spider_tokens_controlled_by(&game, alice).len(),
+        1,
+        "Gloomwidow's Feast should create the Spider when the destroyed target was blue"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gloomwidows_feast_destroys_black_flying_target_and_creates_spider() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_gloomwidows_feast_target(
+        &mut game,
+        bob,
+        "Gloomwidow Black Target",
+        crate::color::ColorSet::BLACK,
+    );
+
+    resolve_gloomwidows_feast_at(&mut game, alice, target);
+
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Graveyard, "Gloomwidow Black Target"),
+        1,
+        "Gloomwidow's Feast should destroy its black flying creature target"
+    );
+    assert_eq!(
+        gloomwidow_spider_tokens_controlled_by(&game, alice).len(),
+        1,
+        "Gloomwidow's Feast should create the Spider when the destroyed target was black"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gloomwidows_feast_destroys_green_flying_target_without_creating_spider() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let target = create_gloomwidows_feast_target(
+        &mut game,
+        bob,
+        "Gloomwidow Green Target",
+        crate::color::ColorSet::GREEN,
+    );
+
+    resolve_gloomwidows_feast_at(&mut game, alice, target);
+
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Graveyard, "Gloomwidow Green Target"),
+        1,
+        "Gloomwidow's Feast should still destroy a non-blue, non-black flying target"
+    );
+    assert!(
+        gloomwidow_spider_tokens_controlled_by(&game, alice).is_empty(),
+        "Gloomwidow's Feast should not create a Spider when the destroyed target was neither blue nor black"
+    );
+}


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gloomwidow's Feast
Initial parse error:
```
unsupported predicate (predicate: 'that creature was blue or black'); oracle-only fallback also failed: unsupported predicate (predicate: 'that creature was blue or black')
```

Current worker: i-0a05963548fadb426
Branch: codex/aws-card-fix-gloomwidow-s-feast
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0009
