### PR TITLE
Fix Ironsmith parse failure: Nightscape Battlemage

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -470,6 +470,13 @@ pub(super) fn lower_kicker(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
 ) -> Result<LineAst, CardTextError> {
+    if let Some(label) = line.text.strip_prefix("__split_kicker_label:") {
+        let cost = require_keyword_parse(line, "kicker", parse_kicker_line_lexed(tokens)?)?;
+        return Ok(LineAst::OptionalCost(
+            crate::cost::OptionalCost::custom(label, cost.cost).into(),
+        ));
+    }
+
     Ok(LineAst::OptionalCost(
         require_keyword_parse(line, "kicker", parse_kicker_line_lexed(tokens)?)?.into(),
     ))

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1189,9 +1189,79 @@ pub(super) fn run_freerunning_line_family(
 pub(super) fn run_keyword_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
+    if let Some(split_lines) = split_same_line_and_or_kicker_keywords(ctx.line)? {
+        return Ok(Some(LineDispatchResult {
+            lines: split_lines,
+            next_idx: ctx.idx + 1,
+        }));
+    }
+
     Ok(parse_keyword_line_cst(ctx.line)?.map(|keyword_line| {
         LineDispatchResult::single(RewriteLineCst::Keyword(keyword_line), ctx.idx + 1)
     }))
+}
+
+fn split_same_line_and_or_kicker_keywords(
+    line: &PreprocessedLine,
+) -> Result<Option<Vec<RewriteLineCst>>, CardTextError> {
+    if !token_slice_first_is(&line.tokens, "kicker") {
+        return Ok(None);
+    }
+
+    let mut tail = line.tokens.get(1..).unwrap_or_default();
+    if matches!(
+        tail.first().map(|token| token.kind),
+        Some(TokenKind::Dash | TokenKind::EmDash)
+    ) {
+        tail = tail.get(1..).unwrap_or_default();
+    }
+
+    let reminder_start = tail
+        .windows(3)
+        .position(|window| token_slice_starts_with(window, &["you", "may", "pay"]))
+        .or_else(|| {
+            tail.windows(2)
+                .position(|window| token_slice_starts_with(window, &["you", "may"]))
+        })
+        .unwrap_or(tail.len());
+    let sentence_end = find_token_kind(tail, TokenKind::Period).unwrap_or(tail.len());
+    let paren_start = find_token_kind(tail, TokenKind::LParen).unwrap_or(tail.len());
+    let end = reminder_start.min(sentence_end).min(paren_start);
+    let cost_tokens = trim_lexed_commas(&tail[..end]);
+    let Some(and_or_idx) = cost_tokens.iter().position(|token| token.is_word("and/or")) else {
+        return Ok(None);
+    };
+
+    let branches = [
+        trim_lexed_commas(&cost_tokens[..and_or_idx]),
+        trim_lexed_commas(&cost_tokens[and_or_idx + 1..]),
+    ];
+    if branches.iter().any(|branch| branch.is_empty()) {
+        return Ok(None);
+    }
+
+    let mut lines = Vec::new();
+    for branch in branches {
+        let parsed_cost = parse_activation_cost_tokens_rewrite(branch)?;
+        let lowered_cost = lower_activation_cost_cst(&parsed_cost)?;
+        let cost_text = lowered_cost
+            .mana_cost()
+            .map(|cost| cost.to_oracle())
+            .unwrap_or_else(|| lowered_cost.display());
+        let label = format!("Kicker {cost_text}");
+        let raw = label.clone();
+        let tokens = lex_line(&raw, line.info.line_index)?;
+        let rewritten = rewrite_line_tokens(line, &tokens);
+        let mut keyword = parse_keyword_line_cst(&rewritten)?.ok_or_else(|| {
+            CardTextError::ParseError(format!(
+                "parser could not split same-line kicker cost '{raw}'"
+            ))
+        })?;
+        keyword.text = format!("__split_kicker_label:{label}");
+        lines.push(RewriteLineCst::Keyword(keyword));
+    }
+
+    Ok(Some(lines))
 }
 
 pub(super) fn run_additional_combat_after_this_phase_line_family(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1,4 +1,5 @@
 use super::super::super::lex_patterns::{LexCaptureKind, LexCaptureRole, LexPattern};
+use super::super::super::leaf::{lower_activation_cost_cst, parse_activation_cost_tokens_rewrite};
 use super::super::super::lexer::{LexedClause, OwnedLexToken, render_token_slice};
 use super::*;
 use crate::runtime_backend::sentences::effect_sentences::clause_pattern_helpers::{
@@ -4126,7 +4127,8 @@ fn parse_no_spells_cast_last_turn_shape(tokens: &[OwnedLexToken]) -> Option<Pred
 }
 
 fn parse_this_spell_paid_named_label_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
-    parse_this_spell_was_kicked_shape(tokens)
+    parse_this_spell_was_kicked_with_cost_shape(tokens)
+        .or_else(|| parse_this_spell_was_kicked_shape(tokens))
         .or_else(|| parse_this_spell_was_bargained_shape(tokens))
         .or_else(|| {
             parse_named_spell_label_action_shape(tokens, "Gift", &["was", "promised"], false)
@@ -4147,6 +4149,44 @@ fn parse_this_spell_paid_named_label_shape(tokens: &[OwnedLexToken]) -> Option<P
             parse_named_spell_label_action_shape(tokens, "Tribute", &["was", "not", "paid"], true)
         })
         .or_else(|| parse_behold_spell_label_shape(tokens))
+}
+
+fn parse_this_spell_was_kicked_with_cost_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
+    let was_idx = tokens.iter().position(|token| token.is_word("was"))?;
+    if !tokens.get(was_idx + 1).is_some_and(|token| token.is_word("kicked"))
+        || !tokens.get(was_idx + 2).is_some_and(|token| token.is_word("with"))
+    {
+        return None;
+    }
+
+    if !is_kicked_source_clause(LexedClause::new(&tokens[..was_idx])) {
+        return None;
+    }
+
+    let mut cost_start = was_idx + 3;
+    if tokens
+        .get(cost_start)
+        .is_some_and(|token| token.is_word("its") || token.is_word("their"))
+    {
+        cost_start += 1;
+    }
+    let kicker_idx = tokens
+        .iter()
+        .enumerate()
+        .skip(cost_start)
+        .find_map(|(idx, token)| token.is_word("kicker").then_some(idx))?;
+    if kicker_idx + 1 != tokens.len() || cost_start >= kicker_idx {
+        return None;
+    }
+
+    let parsed_cost = parse_activation_cost_tokens_rewrite(&tokens[cost_start..kicker_idx]).ok()?;
+    let lowered_cost = lower_activation_cost_cst(&parsed_cost).ok()?;
+    let cost_text = lowered_cost
+        .mana_cost()
+        .map(|cost| cost.to_oracle())
+        .unwrap_or_else(|| lowered_cost.display());
+    (!cost_text.is_empty())
+        .then(|| PredicateAst::ThisSpellPaidLabel(format!("Kicker {cost_text}")))
 }
 
 fn parse_this_spell_was_kicked_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {

--- a/crates/ironsmith-core/src/cost_model.rs
+++ b/crates/ironsmith-core/src/cost_model.rs
@@ -852,6 +852,8 @@ pub struct OptionalCostsPaid {
 impl OptionalCostsPaid {
     fn label_matches_query(stored: &str, query: &str) -> bool {
         stored == query
+            || (query.eq_ignore_ascii_case("Kicker")
+                && stored.to_ascii_lowercase().starts_with("kicker "))
             || (query.eq_ignore_ascii_case("Gift")
                 && stored.to_ascii_lowercase().starts_with("gift "))
             || (query.eq_ignore_ascii_case("Conspire")

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -11988,6 +11988,214 @@ fn test_parse_kicker_keyword_line_with_reminder_text_strips_reminder_tail() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn nightscape_battlemage_strict_parser_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Nightscape Battlemage");
+
+    assert_eq!(def.optional_costs.len(), 2);
+    assert_eq!(def.optional_costs[0].label, "Kicker {2}{U}");
+    assert_eq!(def.optional_costs[1].label, "Kicker {2}{R}");
+    assert_eq!(
+        def.optional_costs[0]
+            .cost
+            .mana_cost()
+            .expect("blue kicker should be a mana cost")
+            .to_oracle(),
+        "{2}{U}"
+    );
+    assert_eq!(
+        def.optional_costs[1]
+            .cost
+            .mana_cost()
+            .expect("red kicker should be a mana cost")
+            .to_oracle(),
+        "{2}{R}"
+    );
+
+    let rendered = compiled_text_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Kicker {2}{U} and/or {2}{R}"),
+        "expected split kicker costs to render as one and/or keyword line, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "When this creature enters, if it was kicked with its {2}{U} kicker, return up to two target nonblack creatures to their owners' hands."
+        ),
+        "expected blue kicker ETB clause in compiled text, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "When this creature enters, if it was kicked with its {2}{R} kicker, destroy target land."
+        ),
+        "expected red kicker ETB clause in compiled text, got {rendered}"
+    );
+
+    let conditions: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => triggered.intervening_if.as_ref(),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        conditions.contains(&&crate::effect::Condition::ThisSpellPaidLabel(
+            "Kicker {2}{U}".to_string()
+        )),
+        "expected blue kicker paid-label condition, got {conditions:?}"
+    );
+    assert!(
+        conditions.contains(&&crate::effect::Condition::ThisSpellPaidLabel(
+            "Kicker {2}{R}".to_string()
+        )),
+        "expected red kicker paid-label condition, got {conditions:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn nightscape_battlemage_runtime_branches_use_matching_kicker_labels() {
+    fn trigger_effects_for_label(
+        def: &CardDefinition,
+        label: &str,
+    ) -> crate::resolution::ResolutionProgram {
+        def.abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered)
+                    if triggered.intervening_if.as_ref()
+                        == Some(&crate::effect::Condition::ThisSpellPaidLabel(label.to_string())) =>
+                {
+                    Some(triggered.effects.clone())
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("missing Nightscape Battlemage trigger for {label}"))
+    }
+
+    fn paid(def: &CardDefinition, index: usize) -> crate::cost::OptionalCostsPaid {
+        let mut paid = crate::cost::OptionalCostsPaid::from_costs(&def.optional_costs);
+        paid.pay(index);
+        paid
+    }
+
+    let def = parse_oracle_card_definition("Nightscape Battlemage");
+    let blue_effects = trigger_effects_for_label(&def, "Kicker {2}{U}");
+    let red_effects = trigger_effects_for_label(&def, "Kicker {2}{R}");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let etb_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::EnterBattlefieldEvent::new(source, Zone::Stack),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let nonblack_def = CardDefinitionBuilder::new(CardId::new(), "Nonblack Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let other_nonblack_def = CardDefinitionBuilder::new(CardId::new(), "Other Nonblack Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let land_def = CardDefinitionBuilder::new(CardId::new(), "Target Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let first_creature = game.create_object_from_definition(&nonblack_def, bob, Zone::Battlefield);
+    let second_creature =
+        game.create_object_from_definition(&other_nonblack_def, bob, Zone::Battlefield);
+    let land = game.create_object_from_definition(&land_def, bob, Zone::Battlefield);
+
+    game.push_to_stack(
+        crate::game_state::StackEntry::ability(source, alice, blue_effects.clone())
+            .with_targets(vec![
+                crate::game_state::Target::Object(first_creature),
+                crate::game_state::Target::Object(second_creature),
+            ])
+            .with_optional_costs_paid(paid(&def, 0))
+            .with_intervening_if(crate::effect::Condition::ThisSpellPaidLabel(
+                "Kicker {2}{U}".to_string(),
+            )),
+    );
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("blue Nightscape Battlemage trigger should resolve");
+    assert!(
+        !game.battlefield.contains(&first_creature) && !game.battlefield.contains(&second_creature),
+        "blue kicker trigger should remove both nonblack creatures from the battlefield"
+    );
+    let bob_hand_names: Vec<_> = game
+        .player(bob)
+        .expect("Bob exists")
+        .hand
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .map(|object| object.name.as_str())
+        .collect();
+    assert!(
+        bob_hand_names.contains(&"Nonblack Target")
+            && bob_hand_names.contains(&"Other Nonblack Target"),
+        "blue kicker trigger should return both nonblack creatures to hand, got {bob_hand_names:?}"
+    );
+
+    assert!(
+        !crate::triggers::verify_intervening_if(
+            &game,
+            &crate::effect::Condition::ThisSpellPaidLabel("Kicker {2}{R}".to_string()),
+            alice,
+            &etb_event,
+            source,
+            None,
+            Some(&paid(&def, 0)),
+        ),
+        "red kicker intervening-if must be false when only the blue kicker was paid"
+    );
+    assert!(
+        game.battlefield.contains(&land),
+        "checking the unpaid red branch must not move the target land"
+    );
+
+    assert!(
+        crate::triggers::verify_intervening_if(
+            &game,
+            &crate::effect::Condition::ThisSpellPaidLabel("Kicker {2}{R}".to_string()),
+            alice,
+            &etb_event,
+            source,
+            None,
+            Some(&paid(&def, 1)),
+        ),
+        "red kicker intervening-if should be true when the red kicker was paid"
+    );
+
+    game.push_to_stack(
+        crate::game_state::StackEntry::ability(source, alice, red_effects)
+            .with_targets(vec![crate::game_state::Target::Object(land)])
+            .with_optional_costs_paid(paid(&def, 1))
+            .with_intervening_if(crate::effect::Condition::ThisSpellPaidLabel(
+                "Kicker {2}{R}".to_string(),
+            )),
+    );
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("red Nightscape Battlemage trigger should resolve when red kicker was paid");
+    assert!(
+        !game.battlefield.contains(&land),
+        "red kicker trigger should destroy the target land"
+    );
+    let bob_graveyard_names: Vec<_> = game
+        .player(bob)
+        .expect("Bob exists")
+        .graveyard
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .map(|object| object.name.as_str())
+        .collect();
+    assert!(
+        bob_graveyard_names.contains(&"Target Land"),
+        "destroyed land should move to its owner's graveyard, got {bob_graveyard_names:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_dash_kicker_with_typed_discard_cost_compiles_to_optional_cost() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Dash Kicker Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -77,6 +77,23 @@ fn merge_adjacent_keyword_surface_lines(lines: Vec<String>) -> Vec<String> {
             }
         }
 
+        if let Some(cost) = split_kicker_cost_line(&lines[idx]) {
+            let mut costs = vec![cost.to_string()];
+            let mut consumed = 1usize;
+            while let Some(next) = lines.get(idx + consumed) {
+                let Some(next_cost) = split_kicker_cost_line(next) else {
+                    break;
+                };
+                costs.push(next_cost.to_string());
+                consumed += 1;
+            }
+            if consumed > 1 {
+                out.push(format!("Kicker {}", costs.join(" and/or ")));
+                idx += consumed;
+                continue;
+            }
+        }
+
         if let Some(keyword) = split_bare_keyword_line(&lines[idx]) {
             let mut keywords = vec![keyword.to_string()];
             let mut consumed = 1usize;
@@ -150,6 +167,12 @@ fn merge_adjacent_keyword_surface_lines(lines: Vec<String>) -> Vec<String> {
         idx += 1;
     }
     out
+}
+
+fn split_kicker_cost_line(line: &str) -> Option<&str> {
+    let trimmed = line.trim().trim_end_matches('.');
+    let cost = trimmed.strip_prefix("Kicker ")?.trim();
+    (!cost.is_empty()).then_some(cost)
 }
 
 fn split_keyword_ability_line(line: &str) -> Option<(&str, &str)> {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11829,6 +11829,9 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             if label.eq_ignore_ascii_case("bargain") {
                 return "this spell was bargained".to_string();
             }
+            if let Some(cost) = label.strip_prefix("Kicker ") {
+                return format!("it was kicked with its {cost} kicker");
+            }
             if label.eq_ignore_ascii_case("tribute") {
                 return "tribute was paid".to_string();
             }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -42996,6 +42996,13 @@ pub(super) fn describe_optional_cost_line(cost: &crate::cost::OptionalCost) -> S
     if label.to_ascii_lowercase().starts_with("gift ") {
         return label.trim().to_string();
     }
+    if label.to_ascii_lowercase().starts_with("kicker ") {
+        return if cost_text.trim().is_empty() {
+            "Kicker".to_string()
+        } else {
+            format!("Kicker {cost_text}")
+        };
+    }
     if label == "Conspire" || label.starts_with("Conspire ") {
         let reminder_cost = cost_text
             .trim()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nightscape Battlemage
Initial parse error:
```
unsupported activation cost segment (clause: '{2}{u} and/or {2}{r}'): rewrite activation-cost segment parser does not yet support '{2}{u} and/or {2}{r}'; oracle-only fallback also failed: unsupported activation cost segment (clause: '{2}{u} and/or {2}{r}'): rewrite activation-cost segment parser does not yet support '{2}{u} and/or {2}{r}'
```

Current worker: i-0cb02ee92015b3954
Branch: codex/aws-card-fix-nightscape-battlemage
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0010
