### PR TITLE
Fix Ironsmith parse failure: Bartel Runeaxe

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/activation_restriction_clauses.rs
@@ -530,7 +530,7 @@ fn source_filtered_target_restriction(
     words: &[&str],
     target_filter: &ObjectFilter,
 ) -> Result<Option<crate::effect::Restriction>, CardTextError> {
-    if words.len() < 8 || !words.starts_with(&["be", "the", "target", "of"]) {
+    if words.len() < 6 || !words.starts_with(&["be", "the", "target", "of"]) {
         return Ok(None);
     }
 
@@ -539,7 +539,7 @@ fn source_filtered_target_restriction(
         .position(|window| window == ["spells", "or", "abilities", "from"])
         .map(|idx| idx + 4)
     else {
-        return Ok(None);
+        return source_only_target_restriction(tokens, words, target_filter);
     };
     let source_words_start = source_marker_start + 4;
     if source_words_start >= words.len() {
@@ -605,6 +605,48 @@ fn source_filtered_target_restriction(
             crate::runtime_backend::token_word_refs(tokens).join(" ")
         )));
     }
+
+    Ok(Some(crate::effect::Restriction::be_targeted_from(
+        target_filter.clone(),
+        source_filter,
+    )))
+}
+
+fn source_only_target_restriction(
+    tokens: &[OwnedLexToken],
+    words: &[&str],
+    target_filter: &ObjectFilter,
+) -> Result<Option<crate::effect::Restriction>, CardTextError> {
+    if !words
+        .last()
+        .is_some_and(|word| matches!(*word, "spell" | "spells"))
+    {
+        return Ok(None);
+    }
+
+    let word_view = ActivationRestrictionCompatWords::new(tokens);
+    let source_token_start = word_view.token_index_after_words(4).unwrap_or(tokens.len());
+    let source_tokens = trim_commas(&tokens[source_token_start..]);
+    let descriptor_tokens = source_tokens
+        .get(..source_tokens.len().saturating_sub(1))
+        .unwrap_or_default();
+    let mut source_filter = match parse_object_filter(&source_tokens, false).ok() {
+        Some(filter) => Some(filter),
+        None => parse_subject_object_filter(&source_tokens)?,
+    }
+    .or_else(|| match parse_object_filter(descriptor_tokens, false).ok() {
+        Some(filter) => Some(filter),
+        None => parse_subject_object_filter(descriptor_tokens).ok().flatten(),
+    })
+    .ok_or_else(|| {
+        CardTextError::ParseError(format!(
+            "unsupported source-filtered target restriction tail (clause: '{}')",
+            crate::runtime_backend::token_word_refs(tokens).join(" ")
+        ))
+    })?;
+
+    source_filter.zone = Some(crate::zone::Zone::Stack);
+    source_filter.stack_kind = Some(crate::filter::StackObjectKind::Spell);
 
     Ok(Some(crate::effect::Restriction::be_targeted_from(
         target_filter.clone(),
@@ -691,6 +733,10 @@ pub(crate) fn format_negated_restriction_display(tokens: &[OwnedLexToken]) -> St
             ("non", Some("phyrexian")) => {
                 out.push("non-phyrexian".to_string());
                 idx += 2;
+            }
+            ("aura", _) => {
+                out.push("Aura".to_string());
+                idx += 1;
             }
             _ => {
                 out.push(words[idx].to_string());

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -15008,6 +15008,24 @@ fn gaeas_revenge_source_filtered_targeting_restriction_parses_strictly() {
 }
 
 #[test]
+fn bartel_runeaxe_aura_spell_targeting_restriction_parses_strictly() {
+    let def = CardDefinitionBuilder::new(CardId::new(), "Bartel Runeaxe")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Giant, Subtype::Warrior])
+        .parse_text("Vigilance\nBartel Runeaxe can't be the target of Aura spells.")
+        .expect("Bartel Runeaxe text should parse");
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("Vigilance")
+            && debug.contains("BeTargetedFrom")
+            && debug.contains("stack_kind: Some(Spell)")
+            && debug.contains("subtypes: [Aura]"),
+        "expected vigilance and an Aura spell targeting restriction, got {debug}"
+    );
+}
+
+#[test]
 fn source_filtered_targeting_restriction_rejects_mismatched_spell_and_source_filters() {
     let err = parse_error_message(
         CardDefinitionBuilder::new(CardId::new(), "Mismatched Target Restriction")

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1228,6 +1228,7 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.starts_with("whenever this creature deals combat damage to a player")
         || lower.starts_with("whenever this creature or another ")
         || lower.starts_with("whenever this or another ")
+        || lower.starts_with("this creature can't be the target ")
         || lower.contains(" this creature deals ")
         || lower.contains(", this creature deals ")
         || lower.contains(": this creature gets ")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10695,6 +10695,13 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             format!("{} can't be targeted", filter.description())
         }
         crate::effect::Restriction::BeTargetedFrom(filter, source_filter) => {
+            if let Some(source_description) = describe_spell_targeting_source_filter(source_filter) {
+                return format!(
+                    "{} can't be the target of {}",
+                    filter.description(),
+                    source_description
+                );
+            }
             let source_description = describe_hexproof_from_filter(source_filter);
             format!(
                 "{} can't be the target of {} spells or abilities from {} sources",
@@ -10733,6 +10740,33 @@ pub(super) fn describe_restriction(restriction: &crate::effect::Restriction) -> 
             format!("{} can't attack or block alone", filter.description())
         }
     }
+}
+
+fn describe_spell_targeting_source_filter(source_filter: &ObjectFilter) -> Option<String> {
+    if source_filter.zone != Some(Zone::Stack)
+        || source_filter.stack_kind != Some(StackObjectKind::Spell)
+    {
+        return None;
+    }
+
+    let mut rest = source_filter.clone();
+    rest.zone = None;
+    rest.stack_kind = None;
+    if rest.subtypes == [crate::types::Subtype::Aura]
+        && (rest.card_types.is_empty()
+            || rest.card_types == [crate::types::CardType::Enchantment])
+    {
+        rest.subtypes.clear();
+        rest.card_types.clear();
+        if rest == ObjectFilter::default() {
+            return Some("Aura spells".to_string());
+        }
+    }
+
+    let description = source_filter.description();
+    description
+        .strip_suffix(" spell")
+        .map(|description| format!("{description} spells"))
 }
 
 fn describe_hexproof_from_filter(filter: &ObjectFilter) -> String {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -50982,6 +50982,23 @@ fn gaeas_revenge_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn bartel_runeaxe_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(1_648), "Bartel Runeaxe")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Green],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Giant, Subtype::Warrior])
+        .power_toughness(PowerToughness::fixed(6, 5))
+        .parse_text("Vigilance\nBartel Runeaxe can't be the target of Aura spells.")
+        .expect("Bartel Runeaxe should parse strictly for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn colored_instant_definition(
     name: &str,
     colors: crate::color::ColorSet,
@@ -51111,6 +51128,116 @@ fn gaeas_revenge_static_abilities_apply_to_countering_haste_and_targeting() {
     assert!(
         legal_targets_from_green.contains(&Target::Object(revenge_id)),
         "Gaea's Revenge should appear in legal target lists for green sources"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bartel_runeaxe_strict_parser_and_compiled_text_regression() {
+    let def = bartel_runeaxe_definition();
+    let rendered = crate::compiled_text::unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains("Vigilance"),
+        "Bartel Runeaxe should render vigilance, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Bartel Runeaxe can't be the target of Aura spells."),
+        "Bartel Runeaxe should render its Aura-spell targeting restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn bartel_runeaxe_blocks_aura_spell_targets_but_not_other_spells_and_has_vigilance() {
+    use crate::target::{ChooseSpec, ObjectFilter};
+    use crate::targeting::{
+        TargetingInvalidReason, TargetingResult, can_target_object, compute_legal_targets,
+    };
+
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let bartel = bartel_runeaxe_definition();
+    let bartel_id = game.create_object_from_definition(&bartel, alice, Zone::Battlefield);
+    game.update_cant_effects();
+
+    let aura_spell = CardDefinitionBuilder::new(CardId::new(), "Targeting Aura")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Aura])
+        .build();
+    let aura_spell_id = game.create_object_from_definition(&aura_spell, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(aura_spell_id, bob));
+    assert!(
+        matches!(
+            can_target_object(&game, bartel_id, aura_spell_id, bob),
+            TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted)
+        ),
+        "an opponent's Aura spell should not be able to target Bartel Runeaxe"
+    );
+
+    let friendly_aura_spell_id =
+        game.create_object_from_definition(&aura_spell, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(friendly_aura_spell_id, alice));
+    assert!(
+        matches!(
+            can_target_object(&game, bartel_id, friendly_aura_spell_id, alice),
+            TargetingResult::Invalid(TargetingInvalidReason::CantBeTargeted)
+        ),
+        "Bartel Runeaxe's Aura-spell restriction should not depend on controller"
+    );
+
+    let non_aura_spell = CardDefinitionBuilder::new(CardId::new(), "Targeting Enchantment")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let non_aura_spell_id = game.create_object_from_definition(&non_aura_spell, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(non_aura_spell_id, bob));
+    assert!(
+        can_target_object(&game, bartel_id, non_aura_spell_id, bob).is_legal(),
+        "a non-Aura spell should be able to target Bartel Runeaxe"
+    );
+
+    let legal_targets_from_aura = compute_legal_targets(
+        &game,
+        &ChooseSpec::Target(Box::new(ChooseSpec::Object(ObjectFilter::creature()))),
+        bob,
+        Some(aura_spell_id),
+    );
+    assert!(
+        !legal_targets_from_aura.contains(&Target::Object(bartel_id)),
+        "Bartel Runeaxe should not appear in legal target lists for Aura spells"
+    );
+
+    let legal_targets_from_non_aura = compute_legal_targets(
+        &game,
+        &ChooseSpec::Target(Box::new(ChooseSpec::Object(ObjectFilter::creature()))),
+        bob,
+        Some(non_aura_spell_id),
+    );
+    assert!(
+        legal_targets_from_non_aura.contains(&Target::Object(bartel_id)),
+        "Bartel Runeaxe should appear in legal target lists for non-Aura spells"
+    );
+
+    game.remove_summoning_sickness(bartel_id);
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(crate::game_state::Step::DeclareAttackers);
+    let mut combat = CombatState::default();
+    let mut trigger_queue = TriggerQueue::new();
+    apply_attacker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[AttackerDeclaration {
+            creature: bartel_id,
+            target: AttackTarget::Player(bob),
+        }],
+    )
+    .expect("Bartel Runeaxe should be able to attack");
+    assert!(
+        !game.is_tapped(bartel_id),
+        "vigilance should keep Bartel Runeaxe untapped as it attacks"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Bartel Runeaxe
Initial parse error:
```
unsupported negated restriction tail (clause: 'this can't be the target of aura spells'); oracle-only fallback also failed: unsupported negated restriction tail (clause: 'this can't be the target of aura spells')
```

Current worker: i-08a775a0b7ec07ebc
Branch: codex/aws-card-fix-bartel-runeaxe
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0011
