### PR TITLE
Fix Ironsmith parse failure: Myrkul's Edict

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1570,9 +1570,14 @@ pub(super) fn run_statement_probe_line_family(
         && !is_draw_replacement_reveal_top_static_line(&ctx.line.tokens)
         && let Some(statement_line) = parse_statement_line_cst(ctx.line)?
     {
+        let (statement_line, next_idx) = extend_statement_line_with_result_followups(
+            &ctx.preprocessed.items,
+            ctx.idx,
+            statement_line,
+        );
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Statement(statement_line),
-            ctx.idx + 1,
+            next_idx,
         )));
     }
     Ok(None)
@@ -1621,7 +1626,12 @@ pub(super) fn run_statement_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
     Ok(parse_statement_line_cst(ctx.line)?.map(|statement_line| {
-        LineDispatchResult::single(RewriteLineCst::Statement(statement_line), ctx.idx + 1)
+        let (statement_line, next_idx) = extend_statement_line_with_result_followups(
+            &ctx.preprocessed.items,
+            ctx.idx,
+            statement_line,
+        );
+        LineDispatchResult::single(RewriteLineCst::Statement(statement_line), next_idx)
     }))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -160,8 +160,9 @@ use line_dispatch::{LineDispatchResult, dispatch_standard_line_cst};
 use statement_cst_support::looks_like_statement_line;
 use statement_cst_support::{
     extend_activated_line_with_result_followups, extend_triggered_line_with_result_followups,
-    looks_like_statement_line_lexed, normalize_statement_parse_groups_lexed,
-    parse_colon_nonactivation_statement_fallback, parse_statement_line_cst,
+    extend_statement_line_with_result_followups, looks_like_statement_line_lexed,
+    normalize_statement_parse_groups_lexed, parse_colon_nonactivation_statement_fallback,
+    parse_statement_line_cst,
 };
 use unsupported::diagnose_known_unsupported_rewrite_line;
 
@@ -3415,9 +3416,11 @@ fn try_parse_labeled_line_dispatch(
     if should_prefer_statement_before_static_for_nonpermanent_spell(preprocessed, &body_line.tokens)
         && let Some(statement_line) = parse_statement_line_cst(&body_line)?
     {
+        let (statement_line, next_idx) =
+            extend_statement_line_with_result_followups(&preprocessed.items, idx, statement_line);
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Statement(statement_line),
-            idx + 1,
+            next_idx,
         )));
     }
 
@@ -3499,9 +3502,11 @@ fn try_parse_labeled_line_dispatch(
     }
 
     if let Some(statement_line) = parse_statement_line_cst(&body_line)? {
+        let (statement_line, next_idx) =
+            extend_statement_line_with_result_followups(&preprocessed.items, idx, statement_line);
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Statement(statement_line),
-            idx + 1,
+            next_idx,
         )));
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/statement_cst_support.rs
@@ -258,6 +258,39 @@ pub(super) fn extend_activated_line_with_result_followups(
     (activated, next_idx)
 }
 
+pub(super) fn extend_statement_line_with_result_followups(
+    items: &[PreprocessedItem],
+    idx: usize,
+    mut statement: StatementLineCst,
+) -> (StatementLineCst, usize) {
+    let mut next_idx = idx + 1;
+
+    while let Some(PreprocessedItem::Line(line)) = items.get(next_idx) {
+        if super::is_nonkeyword_choice_labeled_line(line) {
+            break;
+        }
+        if !is_trigger_result_followup_line(line) {
+            break;
+        }
+
+        let followup_text = render_token_slice(&line.tokens).trim().to_string();
+        if !statement.text.is_empty() {
+            statement.text.push('\n');
+        }
+        statement.text.push_str(followup_text.as_str());
+        append_joined_line_tokens(&mut statement.parse_tokens, &line.tokens);
+        if let Some(parse_group) = statement.parse_groups.last_mut() {
+            append_joined_line_tokens(parse_group, &line.tokens);
+        } else {
+            statement.parse_groups.push(line.tokens.clone());
+        }
+
+        next_idx += 1;
+    }
+
+    (statement, next_idx)
+}
+
 fn looks_like_statement_line_tokens(tokens: &[OwnedLexToken]) -> bool {
     if matches!(
         structure::classify_static_line_family_lexed(tokens),

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1388,12 +1388,10 @@ fn split_leading_numeric_result_prefix_lexed<'a>(
     tokens: &'a [OwnedLexToken],
 ) -> Option<(IfResultPredicate, &'a [OwnedLexToken])> {
     let first = tokens.first()?;
-    let second = tokens.get(1)?;
-    let third = tokens.get(2)?;
     let pipe_idx = tokens
         .iter()
         .position(|token| token.kind == TokenKind::Pipe)?;
-    if pipe_idx < 3 {
+    if pipe_idx != 1 && pipe_idx < 3 {
         return None;
     }
 
@@ -1401,26 +1399,30 @@ fn split_leading_numeric_result_prefix_lexed<'a>(
         TokenKind::Number => first.parser_text().parse::<i32>().ok()?,
         _ => return None,
     };
-    if !matches!(second.kind, TokenKind::Dash | TokenKind::EmDash) {
-        return None;
-    }
-    let max = match third.kind {
-        TokenKind::Number => third.parser_text().parse::<i32>().ok()?,
-        _ => return None,
+    let predicate = if pipe_idx == 1 {
+        IfResultPredicate::Value(Comparison::Equal(min))
+    } else {
+        let second = tokens.get(1)?;
+        let third = tokens.get(2)?;
+        if !matches!(second.kind, TokenKind::Dash | TokenKind::EmDash) {
+            return None;
+        }
+        let max = match third.kind {
+            TokenKind::Number => third.parser_text().parse::<i32>().ok()?,
+            _ => return None,
+        };
+        if min > max {
+            return None;
+        }
+        IfResultPredicate::Value(Comparison::BetweenInclusive(min, max))
     };
-    if min > max {
-        return None;
-    }
 
     let trailing_tokens = trim_lexed_commas(&tokens[pipe_idx + 1..]);
     if trailing_tokens.is_empty() {
         return None;
     }
 
-    Some((
-        IfResultPredicate::Value(Comparison::BetweenInclusive(min, max)),
-        trailing_tokens,
-    ))
+    Some((predicate, trailing_tokens))
 }
 
 pub(crate) fn split_trailing_if_clause_lexed<'a>(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -18,6 +18,7 @@ use super::super::effect_ast_traversal::{
 };
 use super::super::grammar::filters::parse_spell_filter_with_grammar_entrypoint_lexed as parse_spell_filter_lexed;
 use super::super::grammar::primitives::{self as grammar, TokenWordView};
+use super::super::grammar::structure::split_leading_result_prefix_lexed;
 use super::super::keyword_static::parse_value_binding_clause;
 use super::super::lexer::{
     LexStream, LexedClause, OwnedLexToken, TokenKind, contains_token_word_sequence, lex_line,
@@ -928,6 +929,44 @@ fn try_merge_otherwise_into_previous_conditional(
     true
 }
 
+fn try_append_to_previous_numeric_result_branch(
+    effects: &mut [EffectAst],
+    sentence_effects: &[EffectAst],
+    sentence_tokens: &[OwnedLexToken],
+    result_branch_line: Option<usize>,
+) -> bool {
+    if sentence_effects.is_empty()
+        || split_leading_result_prefix_lexed(sentence_tokens).is_some()
+        || result_branch_line != sentence_tokens.first().map(|token| token.span.line)
+    {
+        return false;
+    }
+    let Some(EffectAst::IfResult {
+        predicate: IfResultPredicate::Value(_),
+        effects: branch_effects,
+    }) = effects.last_mut() else {
+        return false;
+    };
+    branch_effects.extend(sentence_effects.iter().cloned());
+    true
+}
+
+fn numeric_result_branch_line(
+    sentence_effects: &[EffectAst],
+    sentence_tokens: &[OwnedLexToken],
+) -> Option<usize> {
+    if split_leading_result_prefix_lexed(sentence_tokens).is_none() {
+        return None;
+    }
+    match sentence_effects {
+        [EffectAst::IfResult {
+            predicate: IfResultPredicate::Value(_),
+            ..
+        }] => sentence_tokens.first().map(|token| token.span.line),
+        _ => None,
+    }
+}
+
 fn maybe_append_trailing_that_much_life_loss(
     sentence_effects: &mut Vec<EffectAst>,
     sentence_tokens: &[OwnedLexToken],
@@ -1117,6 +1156,7 @@ fn parse_effect_sentences_from_sentence_inputs(
     let mut sentence_idx = 0usize;
     let mut carried_context: Option<CarryContext> = None;
     let mut carried_where_x: Option<Value> = None;
+    let mut last_numeric_result_branch_line: Option<usize> = None;
 
     while sentence_idx < sentences.len() {
         let sentence = sentences[sentence_idx].lowered();
@@ -1345,7 +1385,19 @@ fn parse_effect_sentences_from_sentence_inputs(
             continue;
         }
 
+        if try_append_to_previous_numeric_result_branch(
+            &mut effects,
+            &sentence_effects,
+            &sentence_tokens,
+            last_numeric_result_branch_line,
+        ) {
+            sentence_idx += parse_plan.consumed_sentences;
+            continue;
+        }
+
         parse_trace::event(format!("effects: {}", summarize_effects(&sentence_effects)));
+        last_numeric_result_branch_line =
+            numeric_result_branch_line(&sentence_effects, &sentence_tokens);
         if let Some(where_value) = sentence_where_x {
             carried_where_x = Some(where_value);
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -42,6 +42,9 @@ const GREATEST_MANA_VALUE_AMONG_WORDS: &[&str] =
     &["with", "the", "greatest", "mana", "value", "among"];
 const GREATEST_MANA_VALUE_AMONG_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & GREATEST_MANA_VALUE_AMONG_WORDS);
+const GREATEST_POWER_AMONG_WORDS: &[&str] = &["with", "the", "greatest", "power", "among"];
+const GREATEST_POWER_AMONG_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & GREATEST_POWER_AMONG_WORDS);
 const CHOICE_SUFFIX_THREE_WORD_PATTERNS: &[&[&str]] = &[
     &["of", "their", "choice"],
     &["of", "your", "choice"],
@@ -188,11 +191,29 @@ fn parse_unless_mana_spent_to_cast_predicate(tokens: &[OwnedLexToken]) -> Option
 fn split_greatest_mana_value_among_clause(
     tokens: &[OwnedLexToken],
 ) -> Option<(&[OwnedLexToken], &[OwnedLexToken])> {
+    split_aggregate_among_clause(
+        tokens,
+        GREATEST_MANA_VALUE_AMONG_WORDS,
+        GREATEST_MANA_VALUE_AMONG_PATTERN,
+    )
+}
+
+fn split_greatest_power_among_clause(
+    tokens: &[OwnedLexToken],
+) -> Option<(&[OwnedLexToken], &[OwnedLexToken])> {
+    split_aggregate_among_clause(tokens, GREATEST_POWER_AMONG_WORDS, GREATEST_POWER_AMONG_PATTERN)
+}
+
+fn split_aggregate_among_clause<'a>(
+    tokens: &'a [OwnedLexToken],
+    marker_words: &[&str],
+    marker_pattern: ClauseShape<'static>,
+) -> Option<(&'a [OwnedLexToken], &'a [OwnedLexToken])> {
     let words = crate::runtime_backend::token_word_refs(tokens);
     let marker_start = words
-        .windows(GREATEST_MANA_VALUE_AMONG_WORDS.len())
-        .position(|window| GREATEST_MANA_VALUE_AMONG_PATTERN.matches_words(window))?;
-    let marker_end = marker_start + GREATEST_MANA_VALUE_AMONG_WORDS.len();
+        .windows(marker_words.len())
+        .position(|window| marker_pattern.matches_words(window))?;
+    let marker_end = marker_start + marker_words.len();
     let before_idx = token_index_for_word_index(tokens, marker_start)?;
     let after_idx = token_index_for_word_index(tokens, marker_end)?;
     Some((&tokens[..before_idx], &tokens[after_idx..]))
@@ -323,6 +344,7 @@ pub(crate) fn parse_sacrifice(
     // Split off a trailing "for each ..." suffix before parsing the filter.
     let remaining_tokens = &tokens[idx..];
     let mut greatest_mana_value_reference_filter = None;
+    let mut greatest_power_reference_filter = None;
     let object_clause_tokens = if let Some((base_object_tokens, among_tokens)) =
         split_greatest_mana_value_among_clause(remaining_tokens)
     {
@@ -334,6 +356,18 @@ pub(crate) fn parse_sacrifice(
         }
         let among_filter = parse_object_filter_lexed(among_tokens, false)?;
         greatest_mana_value_reference_filter = Some(among_filter);
+        base_object_tokens
+    } else if let Some((base_object_tokens, among_tokens)) =
+        split_greatest_power_among_clause(remaining_tokens)
+    {
+        if among_tokens.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing object set after greatest power among (clause: '{}')",
+                normalized_words.join(" ")
+            )));
+        }
+        let among_filter = parse_object_filter_lexed(among_tokens, false)?;
+        greatest_power_reference_filter = Some(among_filter);
         base_object_tokens
     } else {
         remaining_tokens
@@ -403,6 +437,11 @@ pub(crate) fn parse_sacrifice(
     if let Some(among_filter) = greatest_mana_value_reference_filter {
         filter.mana_value = Some(crate::filter::Comparison::EqualExpr(Box::new(
             Value::GreatestManaValue(among_filter),
+        )));
+    }
+    if let Some(among_filter) = greatest_power_reference_filter {
+        filter.power = Some(crate::filter::Comparison::EqualExpr(Box::new(
+            Value::GreatestPower(among_filter),
         )));
     }
     if filter.source && count != 1 {

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -9111,6 +9111,40 @@ If a card would be put into your graveyard from anywhere this turn, exile that c
 
     #[cfg(ironsmith_runtime_parser_tests)]
     #[test]
+    fn parse_myrkuls_edict_strict_d20_table_and_greatest_power_branch() {
+        let def = CardDefinitionBuilder::new(CardId::new(), "Myrkul's Edict")
+            .card_types(vec![CardType::Sorcery])
+            .parse_text(
+                "Roll a d20.\n\
+                 1—9 | Choose an opponent. That player sacrifices a creature of their choice.\n\
+                 10—19 | Each opponent sacrifices a creature of their choice.\n\
+                 20 | Each opponent sacrifices a creature with the greatest power among creatures that player controls.",
+            )
+            .expect("Myrkul's Edict should parse strictly");
+
+        let rendered = unprocessed_compiled_lines(&def).join("\n");
+        assert!(
+            rendered.contains("Roll a d20"),
+            "expected Myrkul's Edict to render the d20 roll, got {rendered}"
+        );
+        assert!(
+            rendered.contains("1—9 |") && rendered.contains("10—19 |") && rendered.contains("20 |"),
+            "expected Myrkul's Edict to render all d20 result rows, got {rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "Each opponent sacrifices a creature with the greatest power among creatures that player controls"
+            ),
+            "expected Myrkul's Edict to preserve the greatest-power sacrifice branch, got {rendered}"
+        );
+        assert!(
+            !rendered.contains("effect #") && !rendered.contains("dynamic value"),
+            "Myrkul's Edict should not expose raw effect ids or dynamic-value wording, got {rendered}"
+        );
+    }
+
+    #[cfg(ironsmith_runtime_parser_tests)]
+    #[test]
     fn parse_unless_controller_pays_life_keeps_unless_branch() {
         let def = CardDefinitionBuilder::new(CardId::new(), "Unless Life Variant")
             .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -22542,6 +22542,10 @@ pub(super) fn describe_for_players_choose_then_sacrifice(
     {
         chosen = rest.to_string();
     }
+    if let Some(chosen) = describe_greatest_power_choice_filter(&choose.filter) {
+        let chosen = with_indefinite_article(&chosen);
+        return Some(format!("{subject} {verb} {chosen}"));
+    }
     let chosen = with_indefinite_article(&chosen);
     Some(format!("{subject} {verb} {chosen} of {possessive} choice"))
 }
@@ -22994,6 +22998,12 @@ pub(super) fn describe_choose_then_sacrifice(
         if refers_to_created_token {
             return Some(format!("{player} {verb} that token"));
         }
+        if let Some(chosen) = describe_greatest_power_choice_filter(&choose.filter) {
+            return Some(format!(
+                "{player} {verb} {}",
+                with_indefinite_article(&chosen)
+            ));
+        }
         if let Some(rest) = chosen.strip_prefix(&format!("{player}'s ")) {
             let chosen_kind = with_indefinite_article(rest);
             return Some(format!("{player} {verb} {chosen_kind} of their choice"));
@@ -23006,6 +23016,34 @@ pub(super) fn describe_choose_then_sacrifice(
         let chosen = pluralize_noun_phrase(&chosen);
         Some(format!("{player} {verb} {count_text} {chosen}"))
     }
+}
+
+fn describe_greatest_power_choice_filter(filter: &ObjectFilter) -> Option<String> {
+    let Some(crate::filter::Comparison::EqualExpr(value)) = filter.power.as_ref() else {
+        return None;
+    };
+    let Value::GreatestPower(among_filter) = value.as_ref() else {
+        return None;
+    };
+    if filter.card_types != [CardType::Creature]
+        || among_filter.card_types != [CardType::Creature]
+        || filter.controller != among_filter.controller
+    {
+        return None;
+    }
+    let among = match filter.controller.as_ref() {
+        Some(PlayerFilter::You) => "among creatures you control".to_string(),
+        Some(PlayerFilter::Opponent) => "among creatures an opponent controls".to_string(),
+        Some(PlayerFilter::NotYou) => "among creatures your opponents control".to_string(),
+        Some(PlayerFilter::IteratedPlayer) => "among creatures that player controls".to_string(),
+        Some(PlayerFilter::TaggedPlayer(_)) => "among creatures that player controls".to_string(),
+        Some(controller) => format!(
+            "among creatures {} controls",
+            describe_player_filter(controller)
+        ),
+        None => "among creatures on the battlefield".to_string(),
+    };
+    Some(format!("creature with the greatest power {among}"))
 }
 
 fn describe_sacrifice_effect(sacrifice: SacrificeView<'_>) -> String {
@@ -23037,6 +23075,9 @@ fn describe_sacrifice_effect(sacrifice: SacrificeView<'_>) -> String {
         let description = sacrifice.filter.description();
         if sacrifice.filter.token && filter_is_tagged_it(sacrifice.filter) {
             return format!("{player} {verb} that token");
+        }
+        if let Some(chosen) = describe_greatest_power_choice_filter(sacrifice.filter) {
+            return format!("{player} {verb} {}", with_indefinite_article(&chosen));
         }
         if matches!(
             sacrifice.player,

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -958,6 +958,12 @@ fn resolve_filter_comparison_rhs_value(
             }
             Some(seen.len() as i32)
         }
+        Value::GreatestPower(filter) => game
+            .objects_in_deterministic_order()
+            .into_iter()
+            .filter(|object| filter.matches(object, ctx, game))
+            .filter_map(|object| game.calculated_power(object.id).or_else(|| object.power()))
+            .max(),
         Value::CountersOnSource(counter_type) => {
             let source = game.object(ctx.source?)?;
             Some(source.counters.get(counter_type).copied().unwrap_or(0) as i32)

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -194,6 +194,139 @@ fn component_pouch_d20_branches_put_one_or_two_component_counters_runtime() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn myrkuls_edict_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(563_018), "Myrkul's Edict")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(1)],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Roll a d20.\n\
+             1—9 | Choose an opponent. That player sacrifices a creature of their choice.\n\
+             10—19 | Each opponent sacrifices a creature of their choice.\n\
+             20 | Each opponent sacrifices a creature with the greatest power among creatures that player controls.",
+        )
+        .expect("Myrkul's Edict should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_myrkul_edict_creature(
+    game: &mut GameState,
+    name: &str,
+    controller: PlayerId,
+    power: i32,
+) -> ObjectId {
+    let card = CardBuilder::new(CardId::new(), name)
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(power, power))
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_myrkuls_edict(game: &mut GameState, roll: u32) {
+    let def = myrkuls_edict_definition();
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    game.force_next_die_roll(roll);
+
+    let mut dm = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_decision_maker(&mut dm);
+    for effect in def
+        .spell_effect
+        .as_ref()
+        .expect("Myrkul's Edict should have spell effects")
+        .flattened_default_effects()
+    {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Myrkul's Edict effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn myrkul_edict_zone_contains(game: &GameState, zone: Zone, name: &str) -> bool {
+    game.objects_in_zone(zone)
+        .iter()
+        .filter_map(|id| game.object(*id))
+        .any(|object| object.name == name)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn myrkuls_edict_low_roll_only_chosen_opponent_sacrifices() {
+    let mut game = setup_three_player_game();
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    create_myrkul_edict_creature(&mut game, "Bob Bear", bob, 2);
+    create_myrkul_edict_creature(&mut game, "Charlie Bear", charlie, 2);
+
+    resolve_myrkuls_edict(&mut game, 7);
+
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Graveyard, "Bob Bear"),
+        "1-9 should make the chosen opponent sacrifice a creature"
+    );
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Battlefield, "Charlie Bear"),
+        "1-9 should not make each opponent sacrifice"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn myrkuls_edict_middle_roll_each_opponent_sacrifices_one_creature() {
+    let mut game = setup_three_player_game();
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    create_myrkul_edict_creature(&mut game, "Bob Bear", bob, 2);
+    create_myrkul_edict_creature(&mut game, "Charlie Bear", charlie, 2);
+
+    resolve_myrkuls_edict(&mut game, 15);
+
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Graveyard, "Bob Bear"),
+        "10-19 should make Bob sacrifice a creature"
+    );
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Graveyard, "Charlie Bear"),
+        "10-19 should make Charlie sacrifice a creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn myrkuls_edict_twenty_sacrifices_only_each_opponents_greatest_power_creature() {
+    let mut game = setup_three_player_game();
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    create_myrkul_edict_creature(&mut game, "Bob Small", bob, 1);
+    create_myrkul_edict_creature(&mut game, "Bob Large", bob, 5);
+    create_myrkul_edict_creature(&mut game, "Charlie Small", charlie, 2);
+    create_myrkul_edict_creature(&mut game, "Charlie Large", charlie, 4);
+
+    resolve_myrkuls_edict(&mut game, 20);
+
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Graveyard, "Bob Large"),
+        "20 should make Bob sacrifice a greatest-power creature"
+    );
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Graveyard, "Charlie Large"),
+        "20 should make Charlie sacrifice a greatest-power creature"
+    );
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Battlefield, "Bob Small"),
+        "20 should not allow Bob to sacrifice a lower-power creature"
+    );
+    assert!(
+        myrkul_edict_zone_contains(&game, Zone::Battlefield, "Charlie Small"),
+        "20 should not allow Charlie to sacrifice a lower-power creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn reprocess_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(646_813), "Reprocess")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Myrkul's Edict
Initial parse error:
```
missing prior effect for if clause; oracle-only fallback also failed: missing prior effect for if clause
```

Current worker: i-02ce2c90552f000fd
Branch: codex/aws-card-fix-myrkul-s-edict
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0011
