### PR TITLE
Fix Ironsmith parse failure: Invasive Surgery

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects.rs
@@ -1626,20 +1626,21 @@ pub(crate) fn parse_search_library_sentence_with_grammar_entrypoint_lexed(
     }
 
     if has_trailing_that_player_shuffle(tokens) {
-        let mut rewrote_existing_shuffle = false;
+        let mut has_existing_shuffle = false;
         for effect in &mut effects {
             if let EffectAst::SubjectVerb(subject_verb) = effect
                 && matches!(subject_verb.action, SubjectVerbActionAst::ShuffleLibrary)
-                && matches!(
+            {
+                has_existing_shuffle = true;
+                if matches!(
                     subject_verb.subject.player,
                     PlayerAst::You | PlayerAst::Implicit
-                )
-            {
-                subject_verb.subject.player = PlayerAst::That;
-                rewrote_existing_shuffle = true;
+                ) {
+                    subject_verb.subject.player = PlayerAst::That;
+                }
             }
         }
-        if !rewrote_existing_shuffle {
+        if !has_existing_shuffle {
             effects.push(EffectAst::subject_verb(
                 SubjectVerbRoleAst::LibraryOwner,
                 PlayerAst::That,

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/search_library.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/effects/search_library.rs
@@ -85,6 +85,58 @@ const CONTROLLER_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN: ClauseShape<'static>
             ],
         ]
 );
+const CONTROLLER_SUFFIX_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(
+        prefix_any
+            & [
+                &[
+                    "the",
+                    "graveyard",
+                    "hand",
+                    "and",
+                    "library",
+                    "of",
+                    "that",
+                    "spells",
+                    "controller",
+                    "for"
+                ],
+                &[
+                    "graveyard",
+                    "hand",
+                    "and",
+                    "library",
+                    "of",
+                    "that",
+                    "spells",
+                    "controller",
+                    "for"
+                ],
+                &[
+                    "the",
+                    "graveyard",
+                    "hand",
+                    "and",
+                    "library",
+                    "of",
+                    "that",
+                    "objects",
+                    "controller",
+                    "for"
+                ],
+                &[
+                    "graveyard",
+                    "hand",
+                    "and",
+                    "library",
+                    "of",
+                    "that",
+                    "objects",
+                    "controller",
+                    "for"
+                ],
+            ]
+    );
 const OWNER_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix_any
         & [
@@ -932,6 +984,8 @@ pub(crate) fn derive_search_library_subject_routing_lexed(
     } else if YOUR_OR_THEIR_LIBRARY_FOR_PREFIX_PATTERN.matches_words(search_body_words) {
         // Keep player from parsed subject/default context.
     } else if CONTROLLER_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN.matches_words(search_body_words)
+        || CONTROLLER_SUFFIX_GRAVEYARD_HAND_LIBRARY_FOR_PREFIX_PATTERN
+            .matches_words(search_body_words)
     {
         player = PlayerAst::ItsController;
         forced_library_owner = Some(PlayerFilter::ControllerOf(crate::filter::ObjectRef::Target));

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/structure.rs
@@ -1555,6 +1555,18 @@ pub(crate) fn split_if_clause_lexed(
                     effects,
                 });
             }
+            if effect_tokens
+                .first()
+                .is_some_and(|token| token.is_word("search") || token.is_word("searches"))
+                && let Ok(effects) =
+                    parse_effects_with_leading_instead(effect_tokens, &mut parse_effects)
+                && !effects.is_empty()
+            {
+                return Ok(IfClauseSplitSpec {
+                    predicate: IfClausePredicateSpec::Conditional(predicate),
+                    effects,
+                });
+            }
             let comma_fragment_looks_like_effect = if comma_indices.len() > 1 {
                 let fragment_tokens = &tokens[first_comma_idx + 1..comma_indices[1]];
                 parse_effects_with_leading_instead(fragment_tokens, &mut parse_effects)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -31778,6 +31778,38 @@ fn parse_search_its_controller_graveyard_hand_and_library_exiles_same_name_cards
 }
 
 #[test]
+fn parse_invasive_surgery_oracle_strict_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Invasive Surgery");
+
+    let rendered = compiled_text_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Counter target sorcery spell")
+            && rendered.contains("Delirium — If there are four or more card types among cards in your graveyard")
+            && rendered.contains("search the graveyard, hand, and library of that spell's controller")
+            && rendered.contains("for any number of cards with the same name as that spell")
+            && rendered.contains("exile those cards, then that player shuffles"),
+        "expected Invasive Surgery compiled text to preserve counter, delirium, optional same-name multi-zone search, and shuffle, got {rendered}"
+    );
+    assert!(
+        !rendered.to_ascii_lowercase().contains("unsupported")
+            && !rendered.contains("sorcery spell spell")
+            && !rendered.contains("for all cards with the same name"),
+        "Invasive Surgery should parse strictly without fallback or over-broad all-cards wording, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.spell_effect).to_ascii_lowercase();
+    assert!(
+        debug.contains("conditionaleffect")
+            && debug.contains("playerhascardtypesingraveyardormore")
+            && debug.contains("samenameastagged")
+            && debug.contains("controllerof")
+            && debug.contains("additional_zones: [hand, library]")
+            && debug.matches("shufflelibraryeffect").count() == 1,
+        "expected Invasive Surgery to lower to one delirium-gated controller same-name search/exile/shuffle, got {debug}"
+    );
+}
+
+#[test]
 fn parse_oracle_reap_intellect_regression() {
     let def = parse_oracle_card_definition("Reap Intellect");
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -5857,6 +5857,8 @@ pub(super) fn normalize_common_semantic_phrasing(line: &str) -> String {
             "Counter target instant or sorcery spell",
         )
         .replace("Counter target sorcery", "Counter target sorcery spell")
+        .replace("Counter target instant spell spell", "Counter target instant spell")
+        .replace("Counter target sorcery spell spell", "Counter target sorcery spell")
         .replace(
             "Counter target enchantment or instant or sorcery",
             "Counter target enchantment, instant, or sorcery spell",

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -29523,6 +29523,92 @@ pub(super) fn describe_search_origin_zones(
     Some(zone_text)
 }
 
+fn describe_delirium_countered_spell_same_name_search(
+    conditional: &crate::effects::ConditionalEffect,
+) -> Option<String> {
+    let crate::effect::Condition::PlayerHasCardTypesInGraveyardOrMore { player, count } =
+        &conditional.condition
+    else {
+        return None;
+    };
+    if *player != PlayerFilter::You || *count != 4 || !conditional.if_false.is_empty() {
+        return None;
+    }
+
+    let [choose_effect, for_each_effect, shuffle_effect] = conditional.if_true.as_slice() else {
+        return None;
+    };
+    let choose = choose_effect.downcast_ref::<crate::effects::ChooseObjectsEffect>()?;
+    if !choose.is_search
+        || choose.chooser != PlayerFilter::You
+        || choose.count.min != 0
+        || choose.count.max.is_some()
+        || choose.search_mode != SearchSelectionMode::Optional
+        || choose.reveal
+    {
+        return None;
+    }
+    let zones = choose_search_zones(choose)?;
+    if zones.len() != 3
+        || !zones.contains(&Zone::Graveyard)
+        || !zones.contains(&Zone::Hand)
+        || !zones.contains(&Zone::Library)
+    {
+        return None;
+    }
+    if !matches!(
+        choose.filter.owner.as_ref(),
+        Some(PlayerFilter::ControllerOf(crate::filter::ObjectRef::Target))
+    ) {
+        return None;
+    }
+    if !choose.filter.tagged_constraints.iter().any(|constraint| {
+        constraint.relation == crate::filter::TaggedOpbjectRelation::SameNameAsTagged
+            && constraint.tag.as_str().starts_with("countered_")
+    }) {
+        return None;
+    }
+    let mut unqualified_filter = choose.filter.clone();
+    unqualified_filter.owner = None;
+    unqualified_filter.tagged_constraints.clear();
+    if unqualified_filter != ObjectFilter::default() {
+        return None;
+    }
+
+    let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachTaggedEffect>()?;
+    if for_each.tag != choose.tag || for_each.effects.len() != 1 {
+        return None;
+    }
+    let move_effect = if let Some(tagged) =
+        for_each.effects[0].downcast_ref::<crate::effects::TaggedEffect>()
+    {
+        tagged.effect.as_ref()
+    } else {
+        &for_each.effects[0]
+    };
+    let move_to_zone = move_effect.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Exile
+        || move_to_zone.to_top
+        || !matches!(&move_to_zone.target, ChooseSpec::Tagged(tag) if tag == &choose.tag)
+    {
+        return None;
+    }
+
+    let shuffle = shuffle_effect.downcast_ref::<crate::effects::ShuffleLibraryEffect>()?;
+    if shuffle.player != PlayerFilter::ControllerOf(crate::filter::ObjectRef::Target) {
+        return None;
+    }
+
+    Some(
+        concat!(
+            "Delirium — If there are four or more card types among cards in your graveyard, ",
+            "search the graveyard, hand, and library of that spell's controller for any number ",
+            "of cards with the same name as that spell, exile those cards, then that player shuffles"
+        )
+        .to_string(),
+    )
+}
+
 pub(super) fn describe_search_choose_for_each(
     choose: &crate::effects::ChooseObjectsEffect,
     for_each: &crate::effects::ForEachTaggedEffect,
@@ -29653,7 +29739,9 @@ pub(super) fn describe_search_choose_for_each(
     } else {
         let mut count_text = describe_choice_count(&choose.count);
         if count_text == "any number" {
-            count_text = if is_same_name_search(&choose.filter) {
+            count_text = if is_same_name_search(&choose.filter)
+                && choose.search_mode == crate::effect::SearchSelectionMode::AllMatching
+            {
                 "all".to_string()
             } else {
                 "any number of".to_string()
@@ -32846,7 +32934,10 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         if let Some(target_text) = describe_counter_all_stack_abilities(&counter_spell.target) {
             return format!("Counter {target_text}");
         }
-        return format!("Counter {}", describe_choose_spec(&counter_spell.target));
+        let target_text = describe_choose_spec(&counter_spell.target)
+            .replace("instant spell spell", "instant spell")
+            .replace("sorcery spell spell", "sorcery spell");
+        return format!("Counter {target_text}");
     }
     if let Some(unless_pays) = effect.downcast_ref::<crate::effects::UnlessPaysEffect>() {
         let payer = match unless_pays.player {
@@ -34854,6 +34945,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_no_more_counters_move_then_each_player_return(conditional) {
+            return compact;
+        }
+        if let Some(compact) = describe_delirium_countered_spell_same_name_search(conditional) {
             return compact;
         }
         if conditional.if_false.is_empty()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -45041,6 +45041,178 @@ fn test_force_of_negation_exiles_nexus_of_fate_instead_of_shuffling_it() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn invasive_surgery_test_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Invasive Surgery")
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Blue]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Counter target sorcery spell.\nDelirium — If there are four or more card types among cards in your graveyard, search the graveyard, hand, and library of that spell's controller for any number of cards with the same name as that spell, exile those cards, then that player shuffles.",
+        )
+        .expect("Invasive Surgery should parse strictly for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn invasive_surgery_target_sorcery(name: &str) -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_symbols(vec![ManaSymbol::Black]))
+        .card_types(vec![CardType::Sorcery])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_invasive_surgery_delirium_cards(game: &mut GameState, controller: PlayerId, count: usize) {
+    let type_sets = [
+        ("Delirium Artifact", vec![CardType::Artifact]),
+        ("Delirium Creature", vec![CardType::Creature]),
+        ("Delirium Enchantment", vec![CardType::Enchantment]),
+        ("Delirium Land", vec![CardType::Land]),
+    ];
+    for (name, card_types) in type_sets.into_iter().take(count) {
+        let def = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(card_types)
+            .build();
+        game.create_object_from_definition(&def, controller, Zone::Graveyard);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[derive(Default)]
+struct InvasiveSurgeryDecisionMaker {
+    object_selection_calls: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for InvasiveSurgeryDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        self.object_selection_calls += 1;
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_invasive_surgery_with_delirium_exiles_same_name_cards_from_controller_zones() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    put_invasive_surgery_delirium_cards(&mut game, alice, 4);
+
+    let target_def = invasive_surgery_target_sorcery("Duplicated Sorcery");
+    let stack_copy = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(stack_copy, bob));
+    game.create_object_from_definition(&target_def, bob, Zone::Graveyard);
+    game.create_object_from_definition(&target_def, bob, Zone::Hand);
+    game.create_object_from_definition(&target_def, bob, Zone::Library);
+    let other_def = invasive_surgery_target_sorcery("Different Sorcery");
+    game.create_object_from_definition(&other_def, bob, Zone::Library);
+
+    let invasive_surgery = invasive_surgery_test_definition();
+    let invasive_id = game.create_object_from_definition(&invasive_surgery, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(invasive_id, alice).with_targets(vec![Target::Object(
+        stack_copy,
+    )]));
+
+    let mut decisions = InvasiveSurgeryDecisionMaker::default();
+    resolve_stack_entry_with(&mut game, &mut decisions).expect("Invasive Surgery should resolve");
+
+    assert_eq!(
+        decisions.object_selection_calls, 1,
+        "delirium branch should perform one same-name multi-zone search"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Duplicated Sorcery"),
+        4,
+        "delirium branch should exile the countered spell and same-name cards from graveyard, hand, and library"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Graveyard, "Duplicated Sorcery"),
+        0,
+        "same-name graveyard cards should be exiled after the counter resolves"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Hand, "Duplicated Sorcery"),
+        0,
+        "same-name hand cards should be exiled"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Library, "Duplicated Sorcery"),
+        0,
+        "same-name library cards should be exiled"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Library, "Different Sorcery"),
+        1,
+        "cards with a different name should remain in the searched player's library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn test_invasive_surgery_without_delirium_only_counters_target_sorcery() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    put_invasive_surgery_delirium_cards(&mut game, alice, 3);
+
+    let target_def = invasive_surgery_target_sorcery("Duplicated Sorcery");
+    let stack_copy = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(stack_copy, bob));
+    game.create_object_from_definition(&target_def, bob, Zone::Graveyard);
+    game.create_object_from_definition(&target_def, bob, Zone::Hand);
+    game.create_object_from_definition(&target_def, bob, Zone::Library);
+
+    let invasive_surgery = invasive_surgery_test_definition();
+    let invasive_id = game.create_object_from_definition(&invasive_surgery, alice, Zone::Stack);
+    game.push_to_stack(StackEntry::new(invasive_id, alice).with_targets(vec![Target::Object(
+        stack_copy,
+    )]));
+
+    let mut decisions = InvasiveSurgeryDecisionMaker::default();
+    resolve_stack_entry_with(&mut game, &mut decisions).expect("Invasive Surgery should resolve");
+
+    assert_eq!(
+        decisions.object_selection_calls, 0,
+        "non-delirium branch should not perform the same-name search"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Exile, "Duplicated Sorcery"),
+        0,
+        "without delirium, Invasive Surgery should not exile same-name cards"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Graveyard, "Duplicated Sorcery"),
+        2,
+        "without delirium, only the target sorcery should be countered into the graveyard alongside the existing copy"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Hand, "Duplicated Sorcery"),
+        1,
+        "same-name hand card should remain when delirium is not satisfied"
+    );
+    assert_eq!(
+        count_named_objects_in_zone(&game, Zone::Library, "Duplicated Sorcery"),
+        1,
+        "same-name library card should remain when delirium is not satisfied"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_force_of_will_alternative_cost_not_available_with_only_nonblue_card() {
     use crate::cards::definitions::force_of_will;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Invasive Surgery
Initial parse error:
```
unsupported predicate (predicate: 'there are four or more card types among cards in your graveyard search graveyard hand and library of that spells controller for any number of cards with same name as that spell exile those cards'); oracle-only fallback also failed: unsupported predicate (predicate: 'there are four or more card types among cards in your graveyard search graveyard hand and library of that spells controller for any number of cards with same name as that spell exile those cards')
```

Current worker: i-0de80fb76133c5d7a
Branch: codex/aws-card-fix-invasive-surgery
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0011
