### PR TITLE
Fix Ironsmith parse failure: Kitsune's Technique

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -95,6 +95,64 @@ fn subject_verb_player_effect(
     })
 }
 
+fn player_filter_for_library_count(player: PlayerAst) -> Option<PlayerFilter> {
+    let filter = match player {
+        PlayerAst::You | PlayerAst::Implicit => PlayerFilter::You,
+        PlayerAst::Opponent => PlayerFilter::Opponent,
+        PlayerAst::NotYou => PlayerFilter::NotYou,
+        PlayerAst::Any => PlayerFilter::Any,
+        PlayerAst::Target => PlayerFilter::target_player(),
+        PlayerAst::TargetOpponent => PlayerFilter::target_opponent(),
+        PlayerAst::That => PlayerFilter::IteratedPlayer,
+        PlayerAst::ThatPlayerOrTargetController => PlayerFilter::target_player(),
+        PlayerAst::Defending => PlayerFilter::Defending,
+        PlayerAst::Attacking => PlayerFilter::Attacking,
+        PlayerAst::Chosen => PlayerFilter::ChosenPlayer,
+        PlayerAst::MostCardsInHand => PlayerFilter::MostCardsInHand,
+        PlayerAst::MostLifeTied => PlayerFilter::MostLifeTied,
+        PlayerAst::LowestLifeTied => PlayerFilter::LowestLifeTied,
+        PlayerAst::ItsController | PlayerAst::ItsOwner => return None,
+    };
+    Some(filter)
+}
+
+fn parse_half_library_count_value(
+    words: &[&str],
+    subject_player: PlayerAst,
+) -> Option<(Value, usize)> {
+    if words.first().copied() != Some("half") {
+        return None;
+    }
+
+    let (player, library_idx) = match words.get(1..4) {
+        Some(["their", "library", _]) => (player_filter_for_library_count(subject_player)?, 2),
+        Some(["your", "library", _]) => (PlayerFilter::You, 2),
+        Some(["target", "player", "library"]) | Some(["target", "players", "library"]) => {
+            (PlayerFilter::target_player(), 3)
+        }
+        Some(["target", "opponent", "library"])
+        | Some(["target", "opponents", "library"]) => (PlayerFilter::target_opponent(), 3),
+        Some(["that", "player", "library"]) | Some(["that", "players", "library"]) => {
+            (player_filter_for_library_count(subject_player)?, 3)
+        }
+        _ => return None,
+    };
+
+    let round_words = words.get(library_idx + 1..library_idx + 3)?;
+    let base = Value::CardsInLibrary(player);
+    match round_words {
+        ["rounded", "down"] => Some((Value::HalfRoundedDown(Box::new(base)), library_idx + 3)),
+        ["rounded", "up"] => Some((
+            Value::HalfRoundedDown(Box::new(Value::Add(
+                Box::new(base),
+                Box::new(Value::Fixed(1)),
+            ))),
+            library_idx + 3,
+        )),
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_become(
     tokens: &[OwnedLexToken],
     subject: Option<SubjectAst>,
@@ -494,28 +552,43 @@ pub(crate) fn parse_mill(
         .and_then(OwnedLexToken::as_word)
         .is_some_and(|word| CARD_OR_CARDS_PATTERN.matches_word(word));
 
-    let (mut count, used) =
+    let subject_player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
+    let (mut count, used, count_includes_library_noun) =
         if let Some((prefix, _)) = grammar::words_match_any_prefix(tokens, THAT_MANY_PREFIXES) {
-            (Value::EventValue(EventValueSpec::Amount), prefix.len())
+            (Value::EventValue(EventValueSpec::Amount), prefix.len(), false)
         } else if starts_with_card_keyword {
             if let Some((count, used_after_cards)) = parse_value(&tokens[1..]) {
-                (count, 1 + used_after_cards)
+                (count, 1 + used_after_cards, false)
+            } else if let Some((count, used_after_cards)) =
+                parse_half_library_count_value(&clause_words[1..], subject_player)
+            {
+                let used_words = 1 + used_after_cards;
+                let used = crate::runtime_backend::token_index_for_word_index(tokens, used_words)
+                    .unwrap_or(tokens.len());
+                (count, used, true)
             } else if let Some(count) = parse_add_mana_equal_amount_value(&tokens[1..]) {
                 // Mill clauses like "cards equal to its toughness" place the amount after "cards".
-                (count, tokens.len())
+                (count, tokens.len(), false)
             } else {
                 return Err(CardTextError::ParseError(format!(
                     "missing mill count (clause: '{}')",
                     clause_words.join(" ")
                 )));
             }
+        } else if let Some((count, used)) =
+            parse_half_library_count_value(&clause_words, subject_player)
+        {
+            let used = crate::runtime_backend::token_index_for_word_index(tokens, used)
+                .unwrap_or(tokens.len());
+            (count, used, true)
         } else {
-            parse_value(tokens).ok_or_else(|| {
+            let (count, used) = parse_value(tokens).ok_or_else(|| {
                 CardTextError::ParseError(format!(
                     "missing mill count (clause: '{}')",
                     clause_words.join(" ")
                 ))
-            })?
+            })?;
+            (count, used, false)
         };
 
     let rest = &tokens[used..];
@@ -546,6 +619,11 @@ pub(crate) fn parse_mill(
             }
         }
     } else {
+        if rest.is_empty() && !count_includes_library_noun {
+            return Err(CardTextError::ParseError(
+                "missing card keyword".to_string(),
+            ));
+        }
         if rest
             .first()
             .and_then(OwnedLexToken::as_word)
@@ -555,7 +633,11 @@ pub(crate) fn parse_mill(
                 "missing card keyword".to_string(),
             ));
         }
-        let trailing_count_tokens = &rest[1..];
+        let trailing_count_tokens = if rest.is_empty() {
+            rest
+        } else {
+            &rest[1..]
+        };
         let trailing_words: Vec<&str> = trailing_count_tokens
             .iter()
             .filter_map(OwnedLexToken::as_word)
@@ -574,11 +656,9 @@ pub(crate) fn parse_mill(
         }
     }
 
-    let player = extract_subject_player(subject).unwrap_or(PlayerAst::Implicit);
-
     Ok(subject_verb_player_effect(
         SubjectVerbRoleAst::AffectedPlayer,
-        player,
+        subject_player,
         SubjectVerbActionAst::Mill { count },
     ))
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -24798,6 +24798,51 @@ fn splinters_technique_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn kitsunes_technique_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Kitsune's Technique");
+
+    let sneak = def
+        .alternative_casts
+        .iter()
+        .find(|method| method.name().eq_ignore_ascii_case("Sneak"))
+        .expect("Kitsune's Technique should compile with a sneak alternative cost");
+    assert_eq!(
+        sneak.mana_cost().map(|cost| cost.to_oracle()),
+        Some("{1}{U}".to_string()),
+        "Kitsune's Technique should preserve its printed Sneak cost"
+    );
+    assert!(
+        sneak.non_mana_costs().iter().any(|cost| {
+            cost.effect_ref().is_some_and(|effect| {
+                effect
+                    .downcast_ref::<crate::effects::SneakCostEffect>()
+                    .is_some()
+            })
+        }),
+        "Kitsune's Technique Sneak should require returning an unblocked attacker as a real cost"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Sneak {1}{U}"),
+        "compiled text should preserve the Kitsune's Technique sneak keyword cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Target opponent mills half their library, rounded up"),
+        "compiled text should render the rounded-up half-library mill clause, got {rendered}"
+    );
+
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        spell_debug.contains("MillEffect")
+            && spell_debug.contains("HalfRoundedDown")
+            && spell_debug.contains("CardsInLibrary"),
+        "Kitsune's Technique should lower to a dynamic half-library MillEffect, got {spell_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn permanent_sneak_form_stays_unsupported_until_tapped_attacking_is_modeled() {
     let err = CardDefinitionBuilder::new(CardId::from_raw(80_491), "Permanent Sneak Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8247,6 +8247,17 @@ pub(crate) fn describe_value(value: &Value) -> String {
                         describe_count_filter_value_subject(filter)
                     );
                 }
+                let library_filter = match (left.as_ref(), right.as_ref()) {
+                    (Value::CardsInLibrary(filter), Value::Fixed(1))
+                    | (Value::Fixed(1), Value::CardsInLibrary(filter)) => Some(filter),
+                    _ => None,
+                };
+                if let Some(filter) = library_filter {
+                    return format!(
+                        "half the number of cards in {} library, rounded up",
+                        describe_possessive_player_filter(filter)
+                    );
+                }
             }
             format!("half {}, rounded down", describe_value(value))
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -27680,10 +27680,41 @@ pub(super) fn describe_mill_then_may_return(
     let mill_clause = format!(
         "{player} {} {}",
         player_verb(&player, "mill", "mills"),
-        describe_card_count(&mill.count)
+        describe_mill_count_for_player(&mill.count, &mill.player)
     );
     let return_clause = lowercase_first(&describe_effect(return_effect));
     Some(format!("{mill_clause}, then {player} may {return_clause}"))
+}
+
+fn describe_mill_count_for_player(count: &Value, player: &PlayerFilter) -> String {
+    fn half_library_count(count: &Value) -> Option<(&PlayerFilter, bool)> {
+        let Value::HalfRoundedDown(inner) = count else {
+            return None;
+        };
+        match inner.as_ref() {
+            Value::CardsInLibrary(filter) => Some((filter, false)),
+            Value::Add(left, right) => match (left.as_ref(), right.as_ref()) {
+                (Value::CardsInLibrary(filter), Value::Fixed(1))
+                | (Value::Fixed(1), Value::CardsInLibrary(filter)) => Some((filter, true)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    if let Some((library_player, rounded_up)) = half_library_count(count)
+        && library_player == player
+    {
+        let possessive = if matches!(player, PlayerFilter::You) {
+            "your"
+        } else {
+            "their"
+        };
+        let rounding = if rounded_up { "up" } else { "down" };
+        return format!("half {possessive} library, rounded {rounding}");
+    }
+
+    describe_card_count(count)
 }
 
 fn describe_choose_filter_from_tagged_cards(
@@ -27742,13 +27773,16 @@ fn describe_choose_filter_from_tagged_cards(
 
 fn describe_tagged_mill_clause(mill: &crate::effects::MillEffect) -> String {
     if matches!(mill.player, PlayerFilter::You) {
-        format!("Mill {}", describe_card_count(&mill.count))
+        format!(
+            "Mill {}",
+            describe_mill_count_for_player(&mill.count, &mill.player)
+        )
     } else {
         let player = describe_player_filter(&mill.player);
         format!(
             "{player} {} {}",
             player_verb(&player, "mill", "mills"),
-            describe_card_count(&mill.count)
+            describe_mill_count_for_player(&mill.count, &mill.player)
         )
     }
 }
@@ -33884,7 +33918,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             {
                 return format!("Mill X cards, where X is {where_x}");
             }
-            let count_text = describe_card_count(&mill.count);
+            let count_text = describe_mill_count_for_player(&mill.count, &mill.player);
             if let Some(rest) = count_text.strip_prefix("the number of ") {
                 let basis = singularize_for_each_basis(rest.strip_suffix(" cards").unwrap_or(rest));
                 return format!("Mill a card for each {basis}");
@@ -33908,7 +33942,7 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 player_verb(&player, "mill", "mills")
             );
         }
-        let count_text = describe_card_count(&mill.count);
+        let count_text = describe_mill_count_for_player(&mill.count, &mill.player);
         if let Some(rest) = count_text.strip_prefix("the number of ") {
             let basis = singularize_for_each_basis(rest.strip_suffix(" cards").unwrap_or(rest));
             return format!(

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -51923,6 +51923,231 @@ fn splinters_technique_sneak_cast_returns_attacker_and_searches_library() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn kitsunes_technique_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(80_492), "Kitsune's Technique")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Sneak {1}{U} (You may cast this spell for {1}{U} if you also return an unblocked attacker you control to hand during the declare blockers step.)\n\
+             Target opponent mills half their library, rounded up.",
+        )
+        .expect("Kitsune's Technique should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn set_up_kitsunes_technique_sneak_game(
+    step: Step,
+    include_unblocked_attacker: bool,
+) -> (GameState, PlayerId, PlayerId, ObjectId, Option<ObjectId>) {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::Combat;
+    game.turn.step = Some(step);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Blue, 2);
+
+    let spell_id =
+        game.create_object_from_definition(&kitsunes_technique_definition(), alice, Zone::Hand);
+    let attacker_id = if include_unblocked_attacker {
+        let attacker = CardBuilder::new(CardId::from_raw(80_493), "Kitsune Sneak Attacker")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build();
+        let attacker_id = game.create_object_from_card(&attacker, alice, Zone::Battlefield);
+        game.combat = Some(crate::combat_state::CombatState {
+            attackers: vec![crate::combat_state::AttackerInfo {
+                creature: attacker_id,
+                target: AttackTarget::Player(bob),
+            }],
+            ..Default::default()
+        });
+        Some(attacker_id)
+    } else {
+        game.combat = Some(Default::default());
+        None
+    };
+
+    (game, alice, bob, spell_id, attacker_id)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_kitsune_library_cards(game: &mut GameState, owner: PlayerId, count: u32) {
+    for index in 0..count {
+        let card = CardBuilder::new(
+            CardId::from_raw(80_500 + index),
+            &format!("Kitsune Library Card {index}"),
+        )
+        .card_types(vec![CardType::Sorcery])
+        .build();
+        game.create_object_from_card(&card, owner, Zone::Library);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_kitsunes_technique_targeting_bob(
+    game: &mut GameState,
+    alice: PlayerId,
+    bob: PlayerId,
+    spell_id: ObjectId,
+    spell_effect: &crate::resolution::ResolutionProgram,
+) {
+    let mut ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: ChooseSpec::target_opponent(),
+            range: 0..1,
+        }]);
+    for effect in spell_effect.flattened_default_effects() {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Kitsune's Technique effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kitsunes_technique_sneak_cast_is_legal_only_with_unblocked_attacker_during_declare_blockers() {
+    use crate::alternative_cast::CastingMethod;
+    use crate::decision::{LegalAction, compute_legal_actions};
+
+    let (game, alice, _, spell_id, _) =
+        set_up_kitsunes_technique_sneak_game(Step::DeclareBlockers, true);
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: candidate,
+                from_zone: Zone::Hand,
+                casting_method: CastingMethod::Alternative(0),
+            } if *candidate == spell_id
+        )),
+        "Kitsune's Technique should be sneak-castable during declare blockers with an unblocked attacker"
+    );
+
+    let (game, alice, _, spell_id, _) =
+        set_up_kitsunes_technique_sneak_game(Step::DeclareBlockers, false);
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: candidate,
+                casting_method: CastingMethod::Alternative(0),
+                ..
+            } if *candidate == spell_id
+        )),
+        "Kitsune's Technique should not be sneak-castable without an unblocked attacker"
+    );
+
+    let (game, alice, _, spell_id, _) =
+        set_up_kitsunes_technique_sneak_game(Step::CombatDamage, true);
+    let actions = compute_legal_actions(&game, alice);
+    assert!(
+        !actions.iter().any(|action| matches!(
+            action,
+            LegalAction::CastSpell {
+                spell_id: candidate,
+                casting_method: CastingMethod::Alternative(0),
+                ..
+            } if *candidate == spell_id
+        )),
+        "Kitsune's Technique sneak timing should end after the declare blockers step"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kitsunes_technique_sneak_cost_returns_attacker_and_mills_odd_library_rounded_up() {
+    let (mut game, alice, bob, spell_id, attacker_id) =
+        set_up_kitsunes_technique_sneak_game(Step::DeclareBlockers, true);
+    let attacker_id = attacker_id.expect("attacker should exist");
+    add_kitsune_library_cards(&mut game, bob, 5);
+
+    let total_cost = game
+        .object(spell_id)
+        .and_then(|object| object.alternative_casts[0].total_cost().cloned())
+        .expect("Kitsune's Technique should have a sneak total cost");
+    let spell_effect = game
+        .object(spell_id)
+        .and_then(|object| object.spell_effect.clone())
+        .expect("Kitsune's Technique should have a spell effect");
+    let mut decision_maker = SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(spell_id, alice, &mut decision_maker);
+    crate::special_actions::pay_total_cost_with_choice_in_context(
+        &mut game,
+        alice,
+        spell_id,
+        &total_cost,
+        crate::costs::PaymentReason::CastSpell,
+        &mut ctx,
+    )
+    .expect("paying Kitsune's Technique sneak cost should succeed");
+
+    assert!(
+        game.player(alice)
+            .expect("alice exists")
+            .hand
+            .iter()
+            .any(|id| game
+                .object(*id)
+                .is_some_and(|object| object.name == "Kitsune Sneak Attacker")),
+        "paying sneak should return the unblocked attacker to hand"
+    );
+    assert!(
+        !game.battlefield.contains(&attacker_id),
+        "paying sneak should remove the attacker from the battlefield"
+    );
+
+    resolve_kitsunes_technique_targeting_bob(&mut game, alice, bob, spell_id, &spell_effect);
+    assert_eq!(
+        game.player(bob).expect("bob exists").graveyard.len(),
+        3,
+        "five-card library should mill three cards when rounded up"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").library.len(),
+        2,
+        "Kitsune's Technique should leave the un-milled half in Bob's library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn kitsunes_technique_even_library_does_not_round_past_half() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let def = kitsunes_technique_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    add_kitsune_library_cards(&mut game, bob, 4);
+    let spell_effect = def
+        .spell_effect
+        .as_ref()
+        .expect("Kitsune's Technique should have a spell effect");
+
+    resolve_kitsunes_technique_targeting_bob(&mut game, alice, bob, spell_id, spell_effect);
+    assert_eq!(
+        game.player(bob).expect("bob exists").graveyard.len(),
+        2,
+        "four-card library should mill exactly two cards"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").library.len(),
+        2,
+        "rounded-up half should not mill an extra card for an even library size"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn quandrix_apprentice_magecraft_puts_only_a_looked_land_into_hand() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Kitsune's Technique
Initial parse error:
```
missing mill count (clause: 'half their library rounded up'); oracle-only fallback also failed: missing mill count (clause: 'half their library rounded up')
```

Current worker: i-0e089207a45ebfbe8
Branch: codex/aws-card-fix-kitsune-s-technique
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0011
