### PR TITLE
Fix Ironsmith parse failure: Necromancer's Covenant

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -2559,6 +2559,11 @@ pub(crate) fn maybe_apply_carried_player_with_clause_lexed(
     clause_tokens: &[OwnedLexToken],
 ) {
     let clause_words = clause_words_for_carry_lexed(clause_tokens);
+    if clause_words.first().is_some_and(|word| *word == "create")
+        && normalize_imperative_create_player(effect)
+    {
+        return;
+    }
     let should_skip = match carried_context {
         CarryContext::Player(_) => {
             matches!(
@@ -2598,6 +2603,25 @@ pub(crate) fn maybe_apply_carried_player_with_clause_lexed(
         return;
     }
     maybe_apply_carried_player(effect, carried_context);
+}
+
+fn normalize_imperative_create_player(effect: &mut EffectAst) -> bool {
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action: SubjectVerbActionAst::CreateTokenWithMods { player, .. },
+        ..
+    }) = effect
+    else {
+        return false;
+    };
+
+    if matches!(
+        player,
+        PlayerAst::Implicit | PlayerAst::Target | PlayerAst::TargetOpponent | PlayerAst::That
+    ) {
+        *player = PlayerAst::You;
+        return true;
+    }
+    false
 }
 
 pub(crate) fn bind_implicit_player_context(effect: &mut EffectAst, player: PlayerAst) {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -1400,6 +1400,30 @@ pub(crate) fn parse_create_for_each_dynamic_count(tokens: &[OwnedLexToken]) -> O
     if grammar::words_match_any_prefix(
         tokens,
         &[
+            &["card", "exiled", "this", "way"],
+            &["cards", "exiled", "this", "way"],
+            &["creature", "card", "exiled", "this", "way"],
+            &["creature", "cards", "exiled", "this", "way"],
+            &["object", "exiled", "this", "way"],
+            &["objects", "exiled", "this", "way"],
+            &["permanent", "exiled", "this", "way"],
+            &["permanents", "exiled", "this", "way"],
+        ],
+    )
+    .is_some()
+    {
+        return Some(
+            Value::PendingEffectMetric {
+                source: ironsmith_core::EffectMetricSource::AffectedObjects,
+                metric: ironsmith_core::EffectMetric::Count,
+            }
+            .with_surface_hint(ValueSurfaceHint::ForEach),
+        );
+    }
+
+    if grammar::words_match_any_prefix(
+        tokens,
+        &[
             &["card", "put", "into", "a", "graveyard", "this", "way"],
             &["cards", "put", "into", "a", "graveyard", "this", "way"],
             &["object", "put", "into", "a", "graveyard", "this", "way"],

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1355,6 +1355,57 @@ fn reprocess_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn necromancers_covenant_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Necromancer's Covenant");
+
+    let def = parse_oracle_card_definition("Necromancer's Covenant");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(def.name(), "Necromancer's Covenant");
+    assert_eq!(def.card.card_types, vec![CardType::Enchantment]);
+    assert!(
+        rendered.contains(
+            "When this enchantment enters, exile all creature cards from target player's graveyard, then create a 2/2 black Zombie creature token for each card exiled this way."
+        ),
+        "Necromancer's Covenant should render its exiled-this-way token count, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("target player creates"),
+        "bare create after target-player graveyard exile should be controlled by you, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Zombies you control have Lifelink"),
+        "Necromancer's Covenant should render the Zombie lifelink grant, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("ExileEffect")
+            && ability_debug.contains("CreateTokenEffect")
+            && ability_debug.contains("EffectMetric")
+            && ability_debug.contains("AffectedObjects")
+            && ability_debug.contains("GrantAbility")
+            && ability_debug.contains("Lifelink"),
+        "Necromancer's Covenant should structurally exile, count affected cards, create Zombies, and grant lifelink, got {ability_debug}"
+    );
+}
+
+#[test]
+fn explicit_target_player_create_after_exile_keeps_target_controller() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(405_318), "Explicit Target Create")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Exile all creature cards from target player's graveyard, then target player creates a 2/2 black Zombie creature token for each card exiled this way.",
+        )
+        .expect("explicit target-player create should parse");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("target player creates"),
+        "explicit target-player token creation should not be rewritten to you, got {rendered}"
+    );
+}
+
+#[test]
 fn boss_s_chauffeur_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Boss's Chauffeur");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -10009,6 +10009,41 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         None
     }
 
+    fn describe_prior_effect_count_create_token_bundle(filtered: &[&Effect]) -> Option<String> {
+        let [prior_effect, create_effect] = filtered else {
+            return None;
+        };
+        let with_id = prior_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+        let create = downcast_create_token(create_effect)?;
+        if prior_effect_count_metric(&create.count) != Some(with_id.id)
+            || !matches!(create.controller, PlayerFilter::You)
+            || create.controller_target.is_some()
+            || create.enters_tapped
+            || create.enters_attacking
+            || create.exile_at_end_of_combat
+            || create.sacrifice_at_end_of_combat
+            || create.sacrifice_at_next_end_step
+            || create.exile_at_next_end_step
+        {
+            return None;
+        }
+        let (subject, action) = prior_effect_count_subject(&with_id.effect)?;
+        let subject = if action == "exiled" && subject.contains(" card") {
+            "card".to_string()
+        } else {
+            subject
+        };
+        let prior_text = describe_effect(prior_effect)
+            .replace(" in target player's graveyard", " from target player's graveyard")
+            .replace(" in your graveyard", " from your graveyard")
+            .trim_end_matches('.')
+            .to_string();
+        Some(format!(
+            "{prior_text}, then create a {} for each {subject} {action} this way",
+            describe_token_blueprint(&create.token)
+        ))
+    }
+
     fn describe_prior_effect_dynamic_count_token_bundle(filtered: &[&Effect]) -> Option<String> {
         let [prior_effect, create_effect, set_pt_effect] = filtered else {
             return None;
@@ -14183,6 +14218,14 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         {
             parts.push(rendered);
             idx += 3;
+            continue;
+        }
+        if idx + 1 < filtered.len()
+            && let Some(rendered) =
+                describe_prior_effect_count_create_token_bundle(&filtered[idx..idx + 2])
+        {
+            parts.push(rendered);
+            idx += 2;
             continue;
         }
         if idx + 2 < filtered.len()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -364,6 +364,187 @@ fn reprocess_can_choose_zero_and_draws_no_cards() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn necromancers_covenant_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(405_317), "Necromancer's Covenant")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::White],
+            vec![ManaSymbol::Black],
+            vec![ManaSymbol::Black],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "When this enchantment enters, exile all creature cards from target player's graveyard, then create a 2/2 black Zombie creature token for each card exiled this way.\n\
+             Zombies you control have lifelink.",
+        )
+        .expect("Necromancer's Covenant should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_necromancers_covenant_graveyard_card(
+    game: &mut GameState,
+    name: &str,
+    owner: PlayerId,
+    card_types: Vec<CardType>,
+) -> ObjectId {
+    let mut builder = CardBuilder::new(CardId::new(), name).card_types(card_types.clone());
+    if card_types.contains(&CardType::Creature) {
+        builder = builder.power_toughness(PowerToughness::fixed(2, 2));
+    }
+    let card = builder.build();
+    game.create_object_from_card(&card, owner, Zone::Graveyard)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_necromancers_covenant_etb(
+    game: &mut GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    target_player: PlayerId,
+) {
+    let covenant = necromancers_covenant_definition();
+    let triggered = covenant
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Necromancer's Covenant should have an enters trigger");
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(target_player)]);
+    for effect in triggered.effects.flattened_default_effects() {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Necromancer's Covenant ETB effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn necromancers_covenant_zombie_tokens(game: &GameState, controller: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|id| {
+            game.object(*id).is_some_and(|object| {
+                object.kind == ObjectKind::Token
+                    && game.controller_of(object) == controller
+                    && object.card_types.contains(&CardType::Creature)
+                    && object.subtypes.contains(&Subtype::Zombie)
+            })
+        })
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necromancers_covenant_exiles_target_graveyard_creatures_and_creates_that_many_zombies() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let covenant = necromancers_covenant_definition();
+    let source = game.create_object_from_definition(&covenant, alice, Zone::Battlefield);
+
+    create_necromancers_covenant_graveyard_card(
+        &mut game,
+        "Bob Graveyard Creature One",
+        bob,
+        vec![CardType::Creature],
+    );
+    create_necromancers_covenant_graveyard_card(
+        &mut game,
+        "Bob Graveyard Creature Two",
+        bob,
+        vec![CardType::Creature],
+    );
+    let bob_noncreature = create_necromancers_covenant_graveyard_card(
+        &mut game,
+        "Bob Graveyard Artifact",
+        bob,
+        vec![CardType::Artifact],
+    );
+    let alice_creature = create_necromancers_covenant_graveyard_card(
+        &mut game,
+        "Alice Graveyard Creature",
+        alice,
+        vec![CardType::Creature],
+    );
+
+    resolve_necromancers_covenant_etb(&mut game, source, alice, bob);
+
+    let exiled_names = game
+        .objects_in_zone(Zone::Exile)
+        .iter()
+        .filter_map(|id| game.object(*id).map(|object| object.name.clone()))
+        .collect::<Vec<_>>();
+    assert!(
+        exiled_names.iter().any(|name| name == "Bob Graveyard Creature One")
+            && exiled_names.iter().any(|name| name == "Bob Graveyard Creature Two"),
+        "target player's creature cards should be exiled, got {exiled_names:?}"
+    );
+    assert_eq!(
+        game.object(bob_noncreature).expect("Bob artifact").zone,
+        Zone::Graveyard,
+        "noncreature cards in the target graveyard should stay in the graveyard"
+    );
+    assert_eq!(
+        game.object(alice_creature).expect("Alice creature").zone,
+        Zone::Graveyard,
+        "creature cards in non-target graveyards should stay in the graveyard"
+    );
+
+    let zombies = necromancers_covenant_zombie_tokens(&game, alice);
+    assert_eq!(
+        zombies.len(),
+        2,
+        "controller should create one Zombie for each card exiled this way"
+    );
+    for zombie in zombies {
+        let object = game.object(zombie).expect("Zombie token should exist");
+        assert_eq!(object.power(), Some(2));
+        assert_eq!(object.toughness(), Some(2));
+        assert!(
+            game.current_has_static_ability_id(
+                zombie,
+                crate::static_abilities::StaticAbilityId::Lifelink,
+            ),
+            "Necromancer's Covenant should grant lifelink to Zombies you control"
+        );
+    }
+    assert!(
+        necromancers_covenant_zombie_tokens(&game, bob).is_empty(),
+        "target player should not create the Zombies"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn necromancers_covenant_creates_no_zombies_when_target_graveyard_has_no_creature_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let covenant = necromancers_covenant_definition();
+    let source = game.create_object_from_definition(&covenant, alice, Zone::Battlefield);
+    let bob_artifact = create_necromancers_covenant_graveyard_card(
+        &mut game,
+        "Bob Graveyard Artifact",
+        bob,
+        vec![CardType::Artifact],
+    );
+
+    resolve_necromancers_covenant_etb(&mut game, source, alice, bob);
+
+    assert_eq!(
+        game.object(bob_artifact).expect("Bob artifact").zone,
+        Zone::Graveyard,
+        "noncreature cards should not be exiled"
+    );
+    assert!(
+        necromancers_covenant_zombie_tokens(&game, alice).is_empty(),
+        "no cards exiled this way should create no Zombie tokens"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn tide_of_war_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(78_606), "Tide of War")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Necromancer's Covenant
Initial parse error:
```
unsupported this-way create count (clause: 'a 2/2 black zombie creature token for each card exiled this way'); oracle-only fallback also failed: unsupported this-way create count (clause: 'a 2/2 black zombie creature token for each card exiled this way')
```

Current worker: i-0d185c49e1857f17f
Branch: codex/aws-card-fix-necromancer-s-covenant
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0011
