### PR TITLE
Fix Ironsmith parse failure: Charging Tuskodon

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -305,6 +305,8 @@ const DAMAGE_DOUBLING_TO_TARGET_PATTERN: ClauseShape<'static> = clause_shape!(
 );
 const WOULD_DEAL_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["would", "deal", "damage", "to"]);
+const WOULD_DEAL_COMBAT_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact & ["would", "deal", "combat", "damage", "to"]);
 const WOULD_DEAL_DAMAGE_TO_YOU_PHRASE_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["would", "deal", "damage", "to", "you"]);
 const IT_DEALS_MULTIPLE_THAT_DAMAGE_TO_PHRASE_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -5068,30 +5070,25 @@ pub(crate) fn parse_double_damage_amount_replacement_line(
         return Ok(None);
     }
 
-    let Some(would_idx) = find_window_by(&words, 4, |window| {
-        WOULD_DEAL_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
-    }) else {
+    let Some((would_idx, damage_phrase_len, combat_only)) =
+        find_damage_multiplier_would_deal_phrase(&words)
+    else {
         return Ok(None);
     };
-    let Some(source_idx) = SOURCE_WORD_PATTERN.find_word(&words[..would_idx]) else {
-        return Ok(None);
-    };
-    if source_idx <= 1 {
-        return Ok(None);
-    }
 
-    let Some(tail_idx) = find_window_by(&words[would_idx + 4..], 6, |window| {
+    let damage_tail_start = would_idx + damage_phrase_len;
+    let Some(tail_idx) = find_window_by(&words[damage_tail_start..], 6, |window| {
         IT_DEALS_MULTIPLE_THAT_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
     }) else {
         return Ok(None);
     };
-    let replacement_start = would_idx + 4 + tail_idx;
+    let replacement_start = damage_tail_start + tail_idx;
     let factor = match words.get(replacement_start + 2).copied() {
         Some("double") => 2,
         Some("triple") => 3,
         _ => return Ok(None),
     };
-    let damaged_words = &words[would_idx + 4..replacement_start];
+    let damaged_words = &words[damage_tail_start..replacement_start];
     let replacement_target_words = &words[replacement_start + 6..];
     if damaged_words.is_empty()
         || replacement_target_words.len() < 2
@@ -5107,28 +5104,10 @@ pub(crate) fn parse_double_damage_amount_replacement_line(
         return Ok(None);
     }
 
-    let source_tokens = trim_lexed_commas(
-        LexedClause::new(&tokens)
-            .between_word_range(1, source_idx)
-            .unwrap_or_else(|| LexedClause::new(&tokens).between(tokens.len(), tokens.len()))
-            .tokens(),
-    );
-    let source_words = parser_token_word_refs(source_tokens);
-    let mut source_filter =
-        if source_tokens.is_empty() || ARTICLE_WORD_PATTERN.matches_words(&source_words) {
-            ObjectFilter::default()
-        } else {
-            parse_object_filter_lexed(source_tokens, false)?
-        };
-
-    match &words[source_idx + 1..would_idx] {
-        ["you", "control"] => source_filter = source_filter.you_control(),
-        ["an", "opponent", "controls"] | ["opponent", "controls"] => {
-            source_filter = source_filter.controlled_by(PlayerFilter::Opponent);
-        }
-        [] => {}
-        _ => return Ok(None),
-    }
+    let Some(source_filter) = parse_damage_replacement_source_filter(&tokens, &words, would_idx)?
+    else {
+        return Ok(None);
+    };
 
     let mut display = render_token_slice(&tokens).trim().to_string();
     if !display.ends_with('.') {
@@ -5140,8 +5119,72 @@ pub(crate) fn parse_double_damage_amount_replacement_line(
         target_player_filter,
         target_object_filter,
         factor,
+        combat_only,
         display,
     )))
+}
+
+fn find_damage_multiplier_would_deal_phrase(words: &[&str]) -> Option<(usize, usize, bool)> {
+    find_window_by(words, 5, |window| {
+        WOULD_DEAL_COMBAT_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
+    })
+    .map(|idx| (idx, 5, true))
+    .or_else(|| {
+        find_window_by(words, 4, |window| {
+            WOULD_DEAL_DAMAGE_TO_PHRASE_PATTERN.matches_words(window)
+        })
+        .map(|idx| (idx, 4, false))
+    })
+}
+
+fn parse_damage_replacement_source_filter(
+    tokens: &[OwnedLexToken],
+    words: &[&str],
+    would_idx: usize,
+) -> Result<Option<ObjectFilter>, CardTextError> {
+    if would_idx <= 1 {
+        return Ok(None);
+    }
+
+    if let Some(source_idx) = SOURCE_WORD_PATTERN.find_word(&words[..would_idx]) {
+        if source_idx <= 1 {
+            return Ok(None);
+        }
+        let source_tokens = trim_lexed_commas(
+            LexedClause::new(tokens)
+                .between_word_range(1, source_idx)
+                .unwrap_or_else(|| LexedClause::new(tokens).between(tokens.len(), tokens.len()))
+                .tokens(),
+        );
+        let source_words = parser_token_word_refs(source_tokens);
+        let mut source_filter =
+            if source_tokens.is_empty() || ARTICLE_WORD_PATTERN.matches_words(&source_words) {
+                ObjectFilter::default()
+            } else {
+                parse_object_filter_lexed(source_tokens, false)?
+            };
+
+        match &words[source_idx + 1..would_idx] {
+            ["you", "control"] => source_filter = source_filter.you_control(),
+            ["an", "opponent", "controls"] | ["opponent", "controls"] => {
+                source_filter = source_filter.controlled_by(PlayerFilter::Opponent);
+            }
+            [] => {}
+            _ => return Ok(None),
+        }
+        return Ok(Some(source_filter));
+    }
+
+    let source_tokens = trim_lexed_commas(
+        LexedClause::new(tokens)
+            .between_word_range(1, would_idx)
+            .unwrap_or_else(|| LexedClause::new(tokens).between(tokens.len(), tokens.len()))
+            .tokens(),
+    );
+    if source_tokens.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(parse_object_filter_lexed(source_tokens, false)?))
 }
 
 fn parse_damage_amount_replacement_target_filters(

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -466,6 +466,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         target_player_filter: Option<PlayerFilter>,
         target_object_filter: Option<ObjectFilter>,
         factor: u32,
+        combat_only: bool,
         display: String,
     },
     DoubleCountersReplacement {
@@ -1405,12 +1406,14 @@ where
                 target_player_filter,
                 target_object_filter,
                 factor,
+                combat_only,
                 display,
             } => StaticAbilityPayload::DoubleDamageAmountReplacement {
                 source_filter,
                 target_player_filter,
                 target_object_filter,
                 factor,
+                combat_only,
                 display,
             },
             StaticAbilityPayload::DoubleCountersReplacement {
@@ -3910,6 +3913,7 @@ impl<
             target_player_filter,
             target_object_filter,
             2,
+            false,
             display,
         )
     }
@@ -3919,6 +3923,7 @@ impl<
         target_player_filter: Option<PlayerFilter>,
         target_object_filter: Option<ObjectFilter>,
         factor: u32,
+        combat_only: bool,
         display: impl Into<String>,
     ) -> Self {
         let display = display.into();
@@ -3930,6 +3935,7 @@ impl<
                 target_player_filter,
                 target_object_filter,
                 factor,
+                combat_only,
                 display,
             },
         }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -54167,6 +54167,103 @@ fn calamity_bearer_runtime_ignores_non_giant_and_opposing_giant_sources() {
 }
 
 #[test]
+fn charging_tuskodon_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Charging Tuskodon");
+    let def = parse_oracle_card_definition("Charging Tuskodon");
+    let rendered_lines = canonical_compiled_lines(&def);
+
+    assert!(
+        rendered_lines.iter().any(|line| line == "Trample"),
+        "Charging Tuskodon should render trample, got {rendered_lines:?}"
+    );
+    assert!(
+        rendered_lines.iter().any(|line| line
+            == "If this creature would deal combat damage to a player, it deals double that damage to that player instead."),
+        "Charging Tuskodon should render its combat-damage replacement clause, got {rendered_lines:?}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("DoubleDamageAmountReplacement")
+            && debug.contains("factor: 2")
+            && debug.contains("combat_only: true")
+            && debug.contains("target_player_filter: Some")
+            && debug.contains("target_object_filter: None"),
+        "Charging Tuskodon should compile to a combat-only player damage multiplier, got {debug}"
+    );
+}
+
+#[test]
+fn charging_tuskodon_runtime_doubles_only_its_combat_damage_to_players() {
+    let def = parse_oracle_card_definition("Charging Tuskodon");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let tuskodon = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let other_creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_305), "Other Attacker")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let target_permanent = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::from_raw(91_306), "Bob Permanent")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        bob,
+        Zone::Battlefield,
+    );
+
+    let combat_to_player = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        tuskodon,
+        crate::events::DamageTarget::Player(bob),
+        4,
+        true,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(combat_to_player.assignments.len(), 1);
+    assert_eq!(combat_to_player.assignments[0].amount, 8);
+
+    let noncombat_to_player = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        tuskodon,
+        crate::events::DamageTarget::Player(bob),
+        4,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(noncombat_to_player.assignments.len(), 1);
+    assert_eq!(noncombat_to_player.assignments[0].amount, 4);
+
+    let combat_to_permanent = crate::events::processing::process_damage_assignments_with_event(
+        &mut game,
+        tuskodon,
+        crate::events::DamageTarget::Object(target_permanent),
+        4,
+        true,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(combat_to_permanent.assignments.len(), 1);
+    assert_eq!(combat_to_permanent.assignments[0].amount, 4);
+
+    let other_source_combat_to_player =
+        crate::events::processing::process_damage_assignments_with_event(
+            &mut game,
+            other_creature,
+            crate::events::DamageTarget::Player(bob),
+            4,
+            true,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(other_source_combat_to_player.assignments.len(), 1);
+    assert_eq!(other_source_combat_to_player.assignments[0].amount, 4);
+}
+
+#[test]
 fn rebbec_architect_of_ascension_strict_parser_and_text_regression() {
     let def = parse_oracle_card_definition("Rebbec, Architect of Ascension");
 

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3326,6 +3326,7 @@ impl StaticAbilityKind for RedirectDamageToSourceController {
                 target_player_filter: Some(self.target_player_filter.clone()),
                 target_object_filter: None,
                 condition: None,
+                combat_only: false,
                 noncombat_only: false,
                 amount_less_than: None,
             },
@@ -3407,6 +3408,7 @@ struct DamageAmountReplacementMatcher {
     target_player_filter: Option<PlayerFilter>,
     target_object_filter: Option<ObjectFilter>,
     condition: Option<crate::ConditionExpr>,
+    combat_only: bool,
     noncombat_only: bool,
     amount_less_than: Option<Value>,
 }
@@ -3491,6 +3493,9 @@ impl DamageAmountReplacementMatcher {
         damage: &DamageEvent,
         ctx: &crate::events::context::EventContext<'_>,
     ) -> bool {
+        if self.combat_only && !damage.is_combat {
+            return false;
+        }
         if self.noncombat_only && damage.is_combat {
             return false;
         }
@@ -3587,6 +3592,7 @@ impl StaticAbilityKind for ModifyDamageAmountReplacement {
                 target_player_filter: self.target_player_filter.clone(),
                 target_object_filter: self.target_object_filter.clone(),
                 condition: self.condition.clone(),
+                combat_only: false,
                 noncombat_only: false,
                 amount_less_than: None,
             },
@@ -3617,6 +3623,7 @@ impl StaticAbilityKind for MinimumDamageAmountReplacement {
                 target_player_filter: self.target_player_filter.clone(),
                 target_object_filter: self.target_object_filter.clone(),
                 condition: None,
+                combat_only: false,
                 noncombat_only: self.noncombat_only,
                 amount_less_than: Some(self.floor.clone()),
             },
@@ -3631,6 +3638,7 @@ pub struct DoubleDamageAmountReplacement {
     pub target_player_filter: Option<PlayerFilter>,
     pub target_object_filter: Option<ObjectFilter>,
     pub factor: u32,
+    pub combat_only: bool,
     pub display: String,
 }
 
@@ -3640,6 +3648,7 @@ impl DoubleDamageAmountReplacement {
         target_player_filter: Option<PlayerFilter>,
         target_object_filter: Option<ObjectFilter>,
         factor: u32,
+        combat_only: bool,
         display: impl Into<String>,
     ) -> Self {
         Self {
@@ -3647,6 +3656,7 @@ impl DoubleDamageAmountReplacement {
             target_player_filter,
             target_object_filter,
             factor,
+            combat_only,
             display: display.into(),
         }
     }
@@ -3674,6 +3684,7 @@ impl StaticAbilityKind for DoubleDamageAmountReplacement {
                 target_player_filter: self.target_player_filter.clone(),
                 target_object_filter: self.target_object_filter.clone(),
                 condition: None,
+                combat_only: self.combat_only,
                 noncombat_only: false,
                 amount_less_than: None,
             },

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2964,6 +2964,7 @@ impl StaticAbility {
             target_player_filter,
             target_object_filter,
             2,
+            false,
             display,
         )
     }
@@ -2973,6 +2974,7 @@ impl StaticAbility {
         target_player_filter: Option<crate::target::PlayerFilter>,
         target_object_filter: Option<crate::target::ObjectFilter>,
         factor: u32,
+        combat_only: bool,
         display: String,
     ) -> Self {
         Self::new(DoubleDamageAmountReplacement::new(
@@ -2980,6 +2982,7 @@ impl StaticAbility {
             target_player_filter,
             target_object_filter,
             factor,
+            combat_only,
             display,
         ))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1373,12 +1373,14 @@ impl StaticAbilityModelInterpreter {
                 target_player_filter,
                 target_object_filter,
                 factor,
+                combat_only,
                 display,
             } => StaticAbility::multiply_damage_amount_replacement(
                 source_filter.clone(),
                 target_player_filter.clone(),
                 target_object_filter.clone(),
                 *factor,
+                *combat_only,
                 display.clone(),
             ),
             ironsmith_core::StaticAbilityPayload::DoubleCountersReplacement {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Charging Tuskodon
Initial parse error:
```
missing damage amount (clause: 'double that damage to that player instead'); oracle-only fallback also failed: missing damage amount (clause: 'double that damage to that player instead')
```

Current worker: i-0e034eab4852f6e94
Branch: codex/aws-card-fix-charging-tuskodon
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0011
