### PR TITLE
Fix Ironsmith parse failure: Realmwright

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -151,7 +151,6 @@ use crate::zone::Zone;
 use ironsmith_core::{EffectMetric, EffectMetricSource};
 use std::sync::LazyLock;
 
-const AS_ENTERS_AURA_SUBJECTS: &[(&str, &str)] = &[("aura", "this Aura")];
 const SOURCE_CAN_BLOCK_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["this", "creature", "can", "block"]);
 const BLOCK_ADDITIONAL_DURATION_TAIL_PATTERN: ClauseShape<'static> =
@@ -4372,7 +4371,7 @@ pub(crate) fn parse_choose_basic_land_type_as_enters_line(
 ) -> Result<Option<StaticAbility>, CardTextError> {
     let words = parser_token_word_refs(tokens);
     let Some((idx, display_subject)) =
-        parse_as_enters_choice_subject_words(&words, AS_ENTERS_AURA_SUBJECTS)
+        parse_as_enters_choice_subject_words(&words, AS_ENTERS_STANDARD_SUBJECTS_WITH_AURA)
     else {
         return Ok(None);
     };
@@ -8221,6 +8220,12 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
     let added_words = &tail[..addition_idx];
     if CHOSEN_TYPE_PATTERN.matches_words(added_words) {
         let filter = parse_object_filter(subject_tokens, false)?;
+        if filter.card_types.contains(&CardType::Land) {
+            return Ok(Some(vec![StaticAbility::add_chosen_basic_land_type(
+                filter,
+                render_token_slice(tokens),
+            )]));
+        }
         return Ok(Some(vec![StaticAbility::add_chosen_creature_type(
             filter,
             render_token_slice(tokens),

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -174,6 +174,7 @@ pub enum StaticAbilityId {
     VoteAdditionalVoteWhileVoting,
     EnchantedLandIsChosenType,
     AddChosenCreatureType,
+    AddChosenBasicLandType,
     AddChosenColor,
     SetChosenColor,
     RedirectDamageToSource,
@@ -442,6 +443,7 @@ impl StaticAbilityId {
             | VoteAdditionalVoteWhileVoting
             | EnchantedLandIsChosenType
             | AddChosenCreatureType
+            | AddChosenBasicLandType
             | AddChosenColor
             | SetChosenColor
             | RedirectDamageToSource

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -282,6 +282,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         filter: ObjectFilter,
         display: String,
     },
+    AddChosenBasicLandType {
+        filter: ObjectFilter,
+        display: String,
+    },
     AddChosenColor {
         filter: ObjectFilter,
         display: String,
@@ -1054,6 +1058,9 @@ where
             }
             StaticAbilityPayload::AddChosenCreatureType { filter, display } => {
                 StaticAbilityPayload::AddChosenCreatureType { filter, display }
+            }
+            StaticAbilityPayload::AddChosenBasicLandType { filter, display } => {
+                StaticAbilityPayload::AddChosenBasicLandType { filter, display }
             }
             StaticAbilityPayload::AddChosenColor { filter, display } => {
                 StaticAbilityPayload::AddChosenColor { filter, display }
@@ -3173,6 +3180,14 @@ impl<
             id: Some(StaticAbilityId::AddChosenCreatureType),
             label: display.clone(),
             payload: StaticAbilityPayload::AddChosenCreatureType { filter, display },
+        }
+    }
+    pub fn add_chosen_basic_land_type(filter: ObjectFilter, display: impl Into<String>) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::AddChosenBasicLandType),
+            label: display.clone(),
+            payload: StaticAbilityPayload::AddChosenBasicLandType { filter, display },
         }
     }
     pub fn add_chosen_color(filter: ObjectFilter, display: impl Into<String>) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -8228,6 +8228,103 @@ fn painters_servant_definition() -> CardDefinition {
     parse_oracle_card_definition("Painter's Servant")
 }
 
+#[test]
+fn realmwright_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Realmwright");
+
+    let def = parse_oracle_card_definition("Realmwright");
+    let ids: Vec<StaticAbilityId> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(ids.contains(&StaticAbilityId::ChooseBasicLandTypeAsEnters));
+    assert!(ids.contains(&StaticAbilityId::AddChosenBasicLandType));
+    assert!(
+        !ids.contains(&StaticAbilityId::RuleFallbackText)
+            && !ids.contains(&StaticAbilityId::UnsupportedParserLine),
+        "expected strict Realmwright static abilities, got {ids:?}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("As this creature enters, choose a basic land type."),
+        "expected Realmwright choose-basic-land-type as-enters wording, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Lands you control are the chosen type in addition to their other types."),
+        "expected Realmwright chosen basic land type static wording, got {rendered}"
+    );
+}
+
+#[test]
+fn realmwright_adds_chosen_basic_land_type_to_lands_you_control_only() {
+    let def = parse_oracle_card_definition("Realmwright");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let alice_land_card = crate::card::CardBuilder::new(CardId::from_raw(2), "Alice Forest")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Forest])
+        .build();
+    let bob_land_card = crate::card::CardBuilder::new(CardId::from_raw(3), "Bob Island")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Island])
+        .build();
+    let alice_land =
+        game.create_object_from_card(&alice_land_card, alice, crate::zone::Zone::Battlefield);
+    let bob_land =
+        game.create_object_from_card(&bob_land_card, bob, crate::zone::Zone::Battlefield);
+
+    let realmwright_in_hand =
+        game.create_object_from_definition(&def, alice, crate::zone::Zone::Hand);
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let result = game
+        .move_object_with_etb_processing_with_dm(
+            realmwright_in_hand,
+            crate::zone::Zone::Battlefield,
+            &mut dm,
+        )
+        .expect("Realmwright should enter and choose a basic land type");
+    let realmwright = result.new_id;
+
+    assert_eq!(
+        game.chosen_basic_land_type(realmwright),
+        Some(Subtype::Plains),
+        "select-first decision maker should choose Plains"
+    );
+
+    let alice_land_chars = game
+        .calculated_characteristics(alice_land)
+        .expect("Alice's land should have calculated characteristics");
+    assert!(
+        alice_land_chars.subtypes.contains(&Subtype::Forest),
+        "Realmwright should preserve original land subtypes"
+    );
+    assert!(
+        alice_land_chars.subtypes.contains(&Subtype::Plains),
+        "Realmwright should add the chosen basic land type to lands Alice controls"
+    );
+
+    let bob_land_chars = game
+        .calculated_characteristics(bob_land)
+        .expect("Bob's land should have calculated characteristics");
+    assert!(
+        bob_land_chars.subtypes.contains(&Subtype::Island),
+        "opposing lands should keep their original subtype"
+    );
+    assert!(
+        !bob_land_chars.subtypes.contains(&Subtype::Plains),
+        "Realmwright should not affect lands controlled by opponents"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn painters_servant_strict_parse_and_compiled_text_regression() {

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -4199,6 +4199,50 @@ impl StaticAbilityKind for AddChosenCreatureTypeForFilter {
     }
 }
 
+/// "Objects are the chosen basic land type in addition to their other types."
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddChosenBasicLandTypeForFilter {
+    pub filter: ObjectFilter,
+    pub display: String,
+}
+
+impl AddChosenBasicLandTypeForFilter {
+    pub fn new(filter: ObjectFilter, display: String) -> Self {
+        Self { filter, display }
+    }
+}
+
+impl StaticAbilityKind for AddChosenBasicLandTypeForFilter {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::AddChosenBasicLandType
+    }
+
+    fn display(&self) -> String {
+        self.display.clone()
+    }
+
+    fn generate_effects(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+        game: &GameState,
+    ) -> Vec<ContinuousEffect> {
+        let Some(chosen_type) = game.chosen_basic_land_type(source) else {
+            return Vec::new();
+        };
+
+        vec![
+            ContinuousEffect::new(
+                source,
+                controller,
+                effect_target_for_filter(source, &self.filter),
+                Modification::AddSubtypes(vec![chosen_type]),
+            )
+            .with_source_type(EffectSourceType::StaticAbility),
+        ]
+    }
+}
+
 /// "Objects are the chosen color in addition to their other colors."
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddChosenColorForFilter {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2814,6 +2814,13 @@ impl StaticAbility {
         Self::new(AddChosenCreatureTypeForFilter::new(filter, display))
     }
 
+    pub fn add_chosen_basic_land_type(
+        filter: crate::target::ObjectFilter,
+        display: String,
+    ) -> Self {
+        Self::new(AddChosenBasicLandTypeForFilter::new(filter, display))
+    }
+
     pub fn add_chosen_color(filter: crate::target::ObjectFilter, display: String) -> Self {
         Self::new(AddChosenColorForFilter::new(filter, display))
     }

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1063,6 +1063,9 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::AddChosenCreatureType { filter, display } => {
                 StaticAbility::add_chosen_creature_type(filter.clone(), display.clone())
             }
+            ironsmith_core::StaticAbilityPayload::AddChosenBasicLandType { filter, display } => {
+                StaticAbility::add_chosen_basic_land_type(filter.clone(), display.clone())
+            }
             ironsmith_core::StaticAbilityPayload::AddChosenColor { filter, display } => {
                 StaticAbility::add_chosen_color(filter.clone(), display.clone())
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Realmwright
Initial parse error:
```
parser does not yet support line family: 'As this creature enters, choose a basic land type.'; oracle-only fallback also failed: parser does not yet support line family: 'As this creature enters, choose a basic land type.'
```

Current worker: i-099cb9451236ece95
Branch: codex/aws-card-fix-realmwright
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0013
