### PR TITLE
Fix Ironsmith parse failure: Thassa's Intervention

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/zone_move_verbs.rs
@@ -694,19 +694,28 @@ fn counter_unless_payment_total_cost(
     mana: Vec<ManaSymbol>,
     life: Option<Value>,
     additional_generic: Option<Value>,
+    mana_multiplier: Option<Value>,
     x_value: Option<Value>,
     display_hint: ironsmith_core::DynamicManaDisplayHint,
 ) -> crate::cost::TotalCost {
     let mut components = Vec::new();
     let mana_cost = crate::mana::ManaCost::from_symbols(mana);
-    if !mana_cost.is_empty() || additional_generic.is_some() || x_value.is_some() {
-        if mana_cost.has_x() || additional_generic.is_some() || x_value.is_some() {
+    if !mana_cost.is_empty()
+        || additional_generic.is_some()
+        || mana_multiplier.is_some()
+        || x_value.is_some()
+    {
+        if mana_cost.has_x()
+            || additional_generic.is_some()
+            || mana_multiplier.is_some()
+            || x_value.is_some()
+        {
             components.push(crate::costs::Cost::dynamic_mana(
                 ironsmith_core::DynamicManaCost::new(
                     mana_cost,
                     x_value,
                     additional_generic,
-                    None,
+                    mana_multiplier,
                     display_hint,
                 ),
             ));
@@ -842,6 +851,7 @@ pub(crate) fn parse_counter(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardT
 
         let mut life = None;
         let mut additional_generic = None;
+        let mut mana_multiplier = None;
         let mut x_value = None;
         let mut dynamic_display_hint = ironsmith_core::DynamicManaDisplayHint::Default;
         if mana.is_empty() {
@@ -856,6 +866,10 @@ pub(crate) fn parse_counter(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardT
             {
                 additional_generic = Some(value);
                 dynamic_display_hint = ironsmith_core::DynamicManaDisplayHint::ManaEqualTo;
+                trailing_start = None;
+            } else if has_x_mana_payment && payment_words.as_slice() == ["twice"] {
+                mana.push(ManaSymbol::X);
+                mana_multiplier = Some(Value::Fixed(2));
                 trailing_start = None;
             } else {
                 return Err(CardTextError::ParseError(format!(
@@ -957,7 +971,12 @@ pub(crate) fn parse_counter(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardT
             }
         }
 
-        if mana.is_empty() && life.is_none() && additional_generic.is_none() && x_value.is_none() {
+        if mana.is_empty()
+            && life.is_none()
+            && additional_generic.is_none()
+            && mana_multiplier.is_none()
+            && x_value.is_none()
+        {
             return Err(CardTextError::ParseError(format!(
                 "missing mana cost (clause: '{}')",
                 crate::runtime_backend::token_word_refs(tokens).join(" ")
@@ -997,6 +1016,7 @@ pub(crate) fn parse_counter(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardT
                 mana,
                 life,
                 additional_generic,
+                mana_multiplier,
                 x_value,
                 dynamic_display_hint,
             ),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18275,6 +18275,30 @@ fn frightful_delusion_strict_parser_and_compiled_text_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn thassas_intervention_strict_parser_and_twice_x_counter_text_regression() {
+    assert_oracle_card_parses_strict("Thassa's Intervention");
+
+    let def = parse_oracle_card_definition("Thassa's Intervention");
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    let spell_compact_debug = format!("{:?}", def.spell_effect);
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+
+    assert!(
+        spell_debug.contains("ChooseModeEffect")
+            && spell_debug.contains("UnlessPaysEffect")
+            && spell_debug.contains("CounterEffect")
+            && spell_compact_debug.contains("multiplier: Some(Fixed(2))"),
+        "expected Thassa's Intervention to lower twice-X counter mode structurally, got {spell_debug}"
+    );
+    assert!(
+        rendered.contains("Look at the top X cards of your library")
+            && rendered.contains("Counter target spell unless its controller pays twice {X}"),
+        "expected Thassa's Intervention compiled text to preserve both modes and twice-X payment, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_counter_unless_pays_and_life_rendering() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Mundungu Probe")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -21288,6 +21288,13 @@ fn describe_dynamic_mana_cost(dynamic: &ironsmith_core::DynamicManaCost) -> Stri
         dynamic.base.to_oracle()
     };
     if let Some(multiplier) = dynamic.multiplier.as_ref() {
+        if dynamic.base.to_oracle() == "{X}"
+            && dynamic.x_value.is_none()
+            && dynamic.additional_generic.is_none()
+            && matches!(multiplier, Value::Fixed(2))
+        {
+            return "twice {X}".to_string();
+        }
         let each = describe_payment_each_value(multiplier);
         if text.is_empty() {
             text = format!("{{1}} for each {each}");

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -44180,6 +44180,23 @@ fn frightful_delusion_definition() -> crate::cards::CardDefinition {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn thassas_intervention_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(76_304), "Thassa's Intervention")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Instant])
+        .parse_text(
+            "Choose one —\n\
+             • Look at the top X cards of your library. Put up to two of them into your hand and the rest on the bottom of your library in a random order.\n\
+             • Counter target spell unless its controller pays twice {X}.",
+        )
+        .expect("Thassa's Intervention should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn stack_spell_probe_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(76_302), "Stack Spell Probe")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))
@@ -44217,6 +44234,27 @@ fn put_frightful_delusion_on_stack(
     let source = game.create_object_from_definition(&def, controller, Zone::Stack);
     game.push_to_stack(
         StackEntry::new(source, controller).with_targets(vec![Target::Object(target_spell)]),
+    );
+    source
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_thassas_intervention_counter_mode_on_stack(
+    game: &mut GameState,
+    controller: PlayerId,
+    target_spell: ObjectId,
+    x_value: u32,
+) -> ObjectId {
+    let def = thassas_intervention_definition();
+    let source = game.create_object_from_definition(&def, controller, Zone::Stack);
+    if let Some(spell) = game.object_mut(source) {
+        spell.x_value = Some(x_value);
+    }
+    game.push_to_stack(
+        StackEntry::new(source, controller)
+            .with_x(x_value)
+            .with_chosen_modes(Some(vec![1]))
+            .with_targets(vec![Target::Object(target_spell)]),
     );
     source
 }
@@ -44668,6 +44706,93 @@ fn spell_contortion_two_kicks_draws_two_cards_when_target_controller_pays() {
         game.player(alice).expect("alice exists").hand.len(),
         alice_hand_before + 2,
         "Spell Contortion kicked twice should draw two cards"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thassas_intervention_counter_mode_counters_when_target_controller_cannot_pay_twice_x() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let thassas_intervention =
+        put_thassas_intervention_counter_mode_on_stack(&mut game, alice, target_spell, 2);
+
+    resolve_stack_entry(&mut game).expect("Thassa's Intervention should resolve");
+
+    let countered_target = game
+        .current_object_id_after_zone_change(target_spell)
+        .expect("target spell should still be tracked after zone change");
+    assert_eq!(
+        game.object(countered_target)
+            .expect("target spell exists")
+            .zone,
+        Zone::Graveyard,
+        "the target spell should be countered when its controller cannot pay twice X"
+    );
+    assert!(
+        !game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == thassas_intervention)
+            && game.objects_in_zone(Zone::Graveyard).iter().any(|id| {
+                game.object(*id)
+                    .is_some_and(|obj| obj.name == "Thassa's Intervention")
+            }),
+        "Thassa's Intervention should leave the stack and go to its owner's graveyard after resolving"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn thassas_intervention_counter_mode_does_not_counter_when_target_controller_pays_twice_x() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.player_mut(bob)
+        .expect("bob exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 4);
+
+    let target_def = stack_spell_probe_definition();
+    let target_spell = game.create_object_from_definition(&target_def, bob, Zone::Stack);
+    game.push_to_stack(StackEntry::new(target_spell, bob));
+    let thassas_intervention =
+        put_thassas_intervention_counter_mode_on_stack(&mut game, alice, target_spell, 2);
+
+    let mut dm = SelectFirstDecisionMaker;
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Thassa's Intervention should resolve");
+
+    assert_eq!(
+        game.object(target_spell).expect("target spell exists").zone,
+        Zone::Stack,
+        "the target spell should remain on the stack when its controller pays twice X"
+    );
+    assert!(
+        game.stack
+            .iter()
+            .any(|entry| entry.object_id == target_spell),
+        "the paid-for target spell should still have a stack entry"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").mana_pool.total(),
+        0,
+        "the target spell's controller should spend four mana when X is 2"
+    );
+    assert!(
+        !game
+            .stack
+            .iter()
+            .any(|entry| entry.object_id == thassas_intervention)
+            && game.objects_in_zone(Zone::Graveyard).iter().any(|id| {
+                game.object(*id)
+                    .is_some_and(|obj| obj.name == "Thassa's Intervention")
+            }),
+        "Thassa's Intervention should leave the stack and go to its owner's graveyard after resolving"
     );
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Thassa's Intervention
Initial parse error:
```
missing mana cost (clause: 'target spell unless its controller pays twice'); oracle-only fallback also failed: missing mana cost (clause: 'target spell unless its controller pays twice')
```

Current worker: i-0e43c11c4ee148550
Branch: codex/aws-card-fix-thassa-s-intervention
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0013
