### PR TITLE
Fix Ironsmith parse failure: Nicol Bolas, Dragon-God

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -744,7 +744,9 @@ const HAS_ALL_ACTIVATED_ABILITIES_OF_PATTERN: ClauseShape<'static> = clause_shap
     prefix_any
         & [
             &["has", "all", "activated", "abilities", "of"],
-            &["have", "all", "activated", "abilities", "of"]
+            &["have", "all", "activated", "abilities", "of"],
+            &["has", "all", "loyalty", "abilities", "of"],
+            &["have", "all", "loyalty", "abilities", "of"]
         ]
 );
 const SAME_NAME_AS_SOURCE_CREATURE_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -11160,6 +11162,9 @@ pub(crate) fn parse_copy_activated_abilities_line(
     let Some(has_idx) = has_idx else {
         return Ok(None);
     };
+    let only_loyalty = clause_words
+        .get(has_idx + 2)
+        .is_some_and(|word| *word == "loyalty");
     let Some(has_token_idx) = token_index_for_word_index(tokens, has_idx) else {
         return Ok(None);
     };
@@ -11229,6 +11234,9 @@ pub(crate) fn parse_copy_activated_abilities_line(
         .with_display(display);
     if let Some(counter) = counter {
         ability = ability.with_counter(counter);
+    }
+    if only_loyalty {
+        ability = ability.with_only_loyalty();
     }
     if force_once_each_turn {
         ability = ability.with_once_each_turn();

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -55,7 +55,10 @@ use super::subject_verb_primitives::{
 use super::verb_dispatch::parse_effect_with_verb;
 use super::verb_handlers::parse_control_duration;
 use super::zone_counter_helpers::{parse_half_starting_life_total_value, parse_put_counters};
-use super::zone_handlers::{collapse_leading_signed_pt_modifier_tokens, parse_sacrifice};
+use super::zone_handlers::{
+    collapse_leading_signed_pt_modifier_tokens,
+    parse_each_opponent_exiles_card_from_their_hand_or_permanent_they_control, parse_sacrifice,
+};
 use super::{
     Verb, bind_implicit_player_context, find_verb, parse_effect_chain_with_subject_verb_primitives,
     parse_simple_gain_ability_clause, parse_simple_lose_ability_clause, parse_subtype_word,
@@ -1192,6 +1195,12 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
             [effect] => effect.clone(),
             _ => EffectAst::Sequence { effects },
         });
+    }
+
+    if let Some(effect) =
+        parse_each_opponent_exiles_card_from_their_hand_or_permanent_they_control(tokens)
+    {
+        return Ok(effect);
     }
 
     if let Some(effect) = run_clause_primitives(tokens)? {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/conditionals.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/conditionals.rs
@@ -100,6 +100,9 @@ pub(crate) fn parse_for_each_opponent_doesnt(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if let Some(effect) = parse_for_each_doesnt_control_lose_game(tokens, true)? {
+        return Ok(Some(effect));
+    }
     let Some(split) = split_for_each_opponent_doesnt_clause_lexed(tokens) else {
         return Ok(None);
     };
@@ -122,6 +125,9 @@ pub(crate) fn parse_for_each_player_doesnt(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
+    if let Some(effect) = parse_for_each_doesnt_control_lose_game(tokens, false)? {
+        return Ok(Some(effect));
+    }
     let Some(split) = split_for_each_player_doesnt_clause_lexed(tokens) else {
         return Ok(None);
     };
@@ -135,6 +141,76 @@ pub(crate) fn parse_for_each_player_doesnt(
     let effects = parse_effect_chain_inner(split.effect_tokens)?;
     let predicate = parse_negated_who_this_way_predicate(split.inner_tokens)?;
     Ok(Some(EffectAst::ForEachPlayerDoesNot { effects, predicate }))
+}
+
+fn parse_for_each_doesnt_control_lose_game(
+    tokens: &[OwnedLexToken],
+    opponent: bool,
+) -> Result<Option<EffectAst>, CardTextError> {
+    let split = if opponent {
+        split_for_each_opponent_doesnt_clause_lexed(tokens)
+    } else {
+        split_for_each_player_doesnt_clause_lexed(tokens)
+    };
+    let Some(split) = split else {
+        return Ok(None);
+    };
+
+    let inner_words = crate::runtime_backend::token_word_refs(split.inner_tokens);
+    let verb_idx = split.negation_idx + split.negation_len;
+    if !inner_words
+        .get(verb_idx)
+        .is_some_and(|word| *word == "control")
+    {
+        return Ok(None);
+    }
+
+    let Some(lose_idx) = inner_words
+        .windows(3)
+        .enumerate()
+        .find_map(|(idx, window)| {
+            ((window[0] == "loses" || window[0] == "lose")
+                && window[1] == "the"
+                && window[2] == "game")
+                .then_some(idx)
+        })
+    else {
+        return Ok(None);
+    };
+    if lose_idx <= verb_idx + 1 {
+        return Ok(None);
+    }
+
+    let Some(filter_start) = token_index_for_word_index(split.inner_tokens, verb_idx + 1) else {
+        return Ok(None);
+    };
+    let Some(filter_end) = token_index_for_word_index(split.inner_tokens, lose_idx) else {
+        return Ok(None);
+    };
+    let filter_tokens = trim_commas(&split.inner_tokens[filter_start..filter_end]);
+    if filter_tokens.is_empty() {
+        return Ok(None);
+    }
+    let filter = parse_object_filter(&filter_tokens, false)?;
+
+    let effect = EffectAst::Conditional {
+        predicate: PredicateAst::PlayerControlsNo {
+            player: PlayerAst::That,
+            filter,
+        },
+        if_true: vec![EffectAst::subject_verb_lose_game(PlayerAst::That)],
+        if_false: Vec::new(),
+    };
+
+    Ok(Some(if opponent {
+        EffectAst::ForEachOpponent {
+            effects: vec![effect],
+        }
+    } else {
+        EffectAst::ForEachPlayer {
+            effects: vec![effect],
+        }
+    }))
 }
 
 pub(crate) fn negated_action_word_index(words: &[&str]) -> Option<(usize, usize)> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -108,6 +108,56 @@ const EXILE_EACH_OPPONENT_LIBRARY_PATTERN: ClauseShape<'static> = clause_shape!(
 const EXILE_THE_TOP_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(prefix & ["the", "top"]);
 const EXILE_WITH_THAT_NAME_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["with", "that", "name"]]);
+const EXILE_CARD_FROM_THEIR_HAND_OR_PERMANENT_THEY_CONTROL_PATTERN: ClauseShape<'static> =
+    clause_shape!(
+        exact_any
+            & [
+                &[
+                    "a",
+                    "card",
+                    "from",
+                    "their",
+                    "hand",
+                    "or",
+                    "a",
+                    "permanent",
+                    "they",
+                    "control",
+                ],
+                &[
+                    "a",
+                    "card",
+                    "from",
+                    "their",
+                    "hand",
+                    "or",
+                    "permanent",
+                    "they",
+                    "control",
+                ],
+                &[
+                    "card",
+                    "from",
+                    "their",
+                    "hand",
+                    "or",
+                    "a",
+                    "permanent",
+                    "they",
+                    "control",
+                ],
+                &[
+                    "card",
+                    "from",
+                    "their",
+                    "hand",
+                    "or",
+                    "permanent",
+                    "they",
+                    "control",
+                ],
+            ]
+    );
 
 pub(crate) fn parse_exile(
     tokens: &[OwnedLexToken],
@@ -203,6 +253,14 @@ pub(crate) fn parse_exile(
     if let Some(effect) = parse_attached_object_exile_bundle(tokens, face_down)? {
         return Ok(effect);
     }
+    if !face_down
+        && !until_source_leaves
+        && let Some(effect) = parse_exile_card_from_their_hand_or_permanent_they_control(
+            tokens, subject,
+        )
+    {
+        return Ok(effect);
+    }
     let has_same_name_token_bundle = grammar::contains_word(tokens, "and")
         && grammar::contains_word(tokens, "tokens")
         && grammar::contains_word(tokens, "same")
@@ -263,6 +321,67 @@ pub(crate) fn parse_exile(
         EffectAst::subject_verb_exile_until_source_leaves(target, face_down)
     } else {
         EffectAst::subject_verb_exile(target, face_down)
+    })
+}
+
+pub(crate) fn parse_each_opponent_exiles_card_from_their_hand_or_permanent_they_control(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if words.len() < 4
+        || words[0] != "each"
+        || !matches!(words[1], "opponent" | "opponents")
+        || !matches!(words[2], "exile" | "exiles")
+    {
+        return None;
+    }
+    let target_start = token_index_for_word_index(tokens, 3)?;
+    parse_exile_card_from_their_hand_or_permanent_they_control(
+        &tokens[target_start..],
+        Some(SubjectAst::Player(PlayerAst::Opponent)),
+    )
+}
+
+fn parse_exile_card_from_their_hand_or_permanent_they_control(
+    tokens: &[OwnedLexToken],
+    subject: Option<SubjectAst>,
+) -> Option<EffectAst> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    if !EXILE_CARD_FROM_THEIR_HAND_OR_PERMANENT_THEY_CONTROL_PATTERN.matches_words(&words) {
+        return None;
+    }
+
+    let wrap_for_each_opponent = matches!(subject, Some(SubjectAst::Player(PlayerAst::Opponent)));
+    let chooser = match subject {
+        Some(SubjectAst::Player(PlayerAst::That | PlayerAst::Opponent)) => PlayerAst::That,
+        _ => return None,
+    };
+
+    let mut hand_card = ObjectFilter::default().in_zone(Zone::Hand);
+    hand_card.owner = Some(PlayerFilter::IteratedPlayer);
+    let mut permanent = ObjectFilter::permanent_card().in_zone(Zone::Battlefield);
+    permanent.controller = Some(PlayerFilter::IteratedPlayer);
+
+    let mut filter = ObjectFilter::default();
+    filter.any_of = vec![hand_card, permanent];
+    let tag = helper_tag_for_tokens(tokens, "exiled");
+    let effects = vec![
+        EffectAst::ChooseObjectsAcrossZones {
+            filter,
+            count: crate::effect::ChoiceCount::exactly(1),
+            count_value: None,
+            player: chooser,
+            tag: tag.clone(),
+            zones: vec![Zone::Hand, Zone::Battlefield],
+            search_mode: None,
+        },
+        EffectAst::subject_verb_exile(TargetAst::Tagged(tag, None), false),
+    ];
+
+    Some(if wrap_for_each_opponent {
+        EffectAst::ForEachOpponent { effects }
+    } else {
+        EffectAst::Sequence { effects }
     })
 }
 

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -4324,6 +4324,7 @@ impl<T, E, C, Cond> GrantObjectAbilityForFilter<T, E, C, Cond> {
 pub struct CopyActivatedAbilities {
     pub filter: ObjectFilter,
     pub counter: Option<CounterType>,
+    pub only_loyalty: bool,
     pub exclude_source_name: bool,
     pub exclude_source_id: bool,
     pub force_once_each_turn: bool,
@@ -4335,6 +4336,7 @@ impl CopyActivatedAbilities {
         Self {
             filter,
             counter: None,
+            only_loyalty: false,
             exclude_source_name: false,
             exclude_source_id: true,
             force_once_each_turn: false,
@@ -4355,6 +4357,10 @@ impl CopyActivatedAbilities {
     }
     pub fn with_counter(mut self, counter: CounterType) -> Self {
         self.counter = Some(counter);
+        self
+    }
+    pub fn with_only_loyalty(mut self) -> Self {
+        self.only_loyalty = true;
         self
     }
     pub fn with_once_each_turn(mut self) -> Self {

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -418,6 +418,7 @@ pub enum Subtype {
     // Planeswalker types
     Ajani,
     Ashiok,
+    Bolas,
     Chandra,
     Elspeth,
     Garruk,
@@ -726,6 +727,7 @@ impl Subtype {
         &[
             Subtype::Ajani,
             Subtype::Ashiok,
+            Subtype::Bolas,
             Subtype::Chandra,
             Subtype::Elspeth,
             Subtype::Garruk,
@@ -1065,6 +1067,7 @@ impl Subtype {
             self,
             Subtype::Ajani
                 | Subtype::Ashiok
+                | Subtype::Bolas
                 | Subtype::Chandra
                 | Subtype::Elspeth
                 | Subtype::Garruk

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1206,6 +1206,206 @@ fn ichormoon_gauntlet_grants_two_loyalty_abilities_to_planeswalkers_you_control(
 }
 
 #[test]
+fn nicol_bolas_dragon_god_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Nicol Bolas, Dragon-God");
+
+    let def = parse_oracle_card_definition("Nicol Bolas, Dragon-God");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("CopyActivatedAbilities")
+            && ability_debug.contains("only_loyalty: true")
+            && ability_debug.contains("exclude_source_id: true"),
+        "Nicol Bolas should structurally copy only loyalty abilities from other planeswalkers, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("ChooseObjectsEffect")
+            && ability_debug.contains("zone: Some")
+            && ability_debug.contains("Hand")
+            && ability_debug.contains("additional_zones")
+            && ability_debug.contains("Battlefield"),
+        "Nicol Bolas +1 should structurally choose from hand or battlefield, got {ability_debug}"
+    );
+    assert!(
+        ability_debug.contains("Not(")
+            && ability_debug.contains("PlayerControls")
+            && ability_debug.contains("LoseTheGameEffect"),
+        "Nicol Bolas -8 should structurally require opponents without legendary creature/planeswalker to lose, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains(
+            "has all loyalty abilities of all other planeswalkers on the battlefield"
+        ),
+        "expected compiled text to preserve loyalty-copy clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "+1: You draw a card. Each opponent exiles a card from their hand or a permanent they control"
+        ) || rendered.contains(
+            "+1: Draw a card. Each opponent exiles a card from their hand or a permanent they control"
+        ),
+        "expected compiled text to preserve draw plus hand-or-permanent exile clauses, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "−8: Each opponent who doesn't control a legendary creature or planeswalker loses the game"
+        ),
+        "expected compiled text to preserve -8 conditional losing-game clause, got {rendered}"
+    );
+    assert!(
+        !crate::cards::generated_definition_has_unimplemented_content(&def),
+        "Nicol Bolas should compile without unsupported runtime markers: {ability_debug}"
+    );
+}
+
+fn nicol_bolas_test_planeswalker_with_loyalty_and_nonloyalty_abilities() -> CardDefinition {
+    let mut loyalty_gain_life = crate::ability::Ability::activated(
+        crate::cost::TotalCost::free(),
+        vec![crate::effect::Effect::gain_life(3)],
+    );
+    if let AbilityKind::Activated(activated) = &mut loyalty_gain_life.kind {
+        activated.is_loyalty_ability = true;
+    }
+
+    CardDefinitionBuilder::new(CardId::new(), "Bolas Test Planeswalker")
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(3)
+        .with_ability(loyalty_gain_life)
+        .with_ability(crate::ability::Ability::activated(
+            crate::cost::TotalCost::free(),
+            vec![crate::effect::Effect::draw(2)],
+        ))
+        .build()
+}
+
+#[test]
+fn nicol_bolas_dragon_god_copies_only_other_planeswalkers_loyalty_abilities() {
+    let nicol = parse_oracle_card_definition("Nicol Bolas, Dragon-God");
+    let other_planeswalker = nicol_bolas_test_planeswalker_with_loyalty_and_nonloyalty_abilities();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let nicol_id = game.create_object_from_definition(&nicol, alice, Zone::Battlefield);
+    game.create_object_from_definition(&other_planeswalker, bob, Zone::Battlefield);
+
+    let activated = game
+        .current_abilities(nicol_id)
+        .expect("Nicol Bolas should have current abilities")
+        .into_iter()
+        .filter_map(|ability| match ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let loyalty_count = activated
+        .iter()
+        .filter(|ability| ability.is_loyalty_ability())
+        .count();
+    assert_eq!(
+        loyalty_count, 4,
+        "Nicol Bolas should have his three printed loyalty abilities plus one copied loyalty ability, got {activated:#?}"
+    );
+    assert!(
+        activated.iter().any(|ability| ability
+            .effects
+            .flattened_default_effects()
+            .into_iter()
+            .any(|effect| effect
+                .downcast_ref::<crate::effects::GainLifeEffect>()
+                .is_some())),
+        "Nicol Bolas should copy the other planeswalker's loyalty ability, got {activated:#?}"
+    );
+    assert!(
+        !activated.iter().any(|ability| ability
+            .effects
+            .flattened_default_effects()
+            .into_iter()
+            .any(|effect| effect
+                .downcast_ref::<crate::effects::DrawCardsEffect>()
+                .is_some_and(|draw| draw.count == Value::Fixed(2)))),
+        "Nicol Bolas must not copy non-loyalty activated abilities, got {activated:#?}"
+    );
+}
+
+fn nicol_bolas_minus_eight_effects(def: &CardDefinition) -> Vec<Effect> {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.is_loyalty_ability()
+                    && activated
+                        .effects
+                        .flattened_default_effects()
+                        .into_iter()
+                        .any(|effect| {
+                            format!("{effect:#?}").contains("LoseTheGameEffect")
+                        }) => Some(
+                activated
+                    .effects
+                    .flattened_default_effects()
+                    .into_iter()
+                    .cloned()
+                    .collect(),
+            ),
+            _ => None,
+        })
+        .expect("Nicol Bolas should have a -8 lose-the-game loyalty ability")
+}
+
+#[test]
+fn nicol_bolas_dragon_god_minus_eight_respects_legendary_creature_or_planeswalker_branch() {
+    let nicol = parse_oracle_card_definition("Nicol Bolas, Dragon-God");
+    let minus_eight_effects = nicol_bolas_minus_eight_effects(&nicol);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let mut unprotected_game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let unprotected_source =
+        unprotected_game.create_object_from_definition(&nicol, alice, Zone::Battlefield);
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(unprotected_source, alice, &mut dm);
+    for effect in &minus_eight_effects {
+        crate::effects::execute_effect(&mut unprotected_game, effect, &mut ctx)
+            .expect("Nicol Bolas -8 should resolve");
+    }
+    assert!(
+        unprotected_game.player(bob).expect("bob exists").has_lost,
+        "opponent without a legendary creature or planeswalker should lose the game"
+    );
+    assert!(
+        !unprotected_game
+            .player(alice)
+            .expect("alice exists")
+            .has_lost,
+        "Nicol Bolas -8 should affect opponents only"
+    );
+
+    let legendary_creature = CardDefinitionBuilder::new(CardId::new(), "Bolas Test Legend")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let mut protected_game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let protected_source =
+        protected_game.create_object_from_definition(&nicol, alice, Zone::Battlefield);
+    protected_game.create_object_from_definition(&legendary_creature, bob, Zone::Battlefield);
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(protected_source, alice, &mut dm);
+    for effect in &minus_eight_effects {
+        crate::effects::execute_effect(&mut protected_game, effect, &mut ctx)
+            .expect("Nicol Bolas -8 should resolve");
+    }
+    assert!(
+        !protected_game.player(bob).expect("bob exists").has_lost,
+        "opponent with a legendary creature should not lose the game"
+    );
+}
+
+#[test]
 fn ichormoon_gauntlet_trigger_adds_selected_existing_counter_kind() {
     struct ChooseFirstCounterKind;
     impl crate::decision::DecisionMaker for ChooseFirstCounterKind {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1329,6 +1329,186 @@ fn nicol_bolas_dragon_god_copies_only_other_planeswalkers_loyalty_abilities() {
     );
 }
 
+fn nicol_bolas_plus_one_effects(def: &CardDefinition) -> Vec<Effect> {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.is_loyalty_ability() && {
+                    let debug = format!("{:?}", activated.effects);
+                    debug.contains("ChooseObjectsEffect")
+                        && debug.contains("zone: Some(Hand)")
+                        && debug.contains("additional_zones: [Battlefield]")
+                        && debug.contains("MoveToZoneEffect")
+                        && debug.contains("zone: Exile")
+                } =>
+            {
+                Some(
+                    activated
+                        .effects
+                        .flattened_default_effects()
+                        .into_iter()
+                        .cloned()
+                        .collect(),
+                )
+            }
+            _ => None,
+        })
+        .expect("Nicol Bolas should have a +1 draw and each-opponent exile loyalty ability")
+}
+
+fn nicol_bolas_test_card(name: &str, card_types: Vec<CardType>) -> CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .build()
+}
+
+fn nicol_bolas_has_object_named_in_zone(
+    game: &crate::game_state::GameState,
+    name: &str,
+    zone: Zone,
+) -> bool {
+    game.objects_in_zone(zone).into_iter().any(|id| {
+        game.object(id)
+            .is_some_and(|object| object.name == name)
+    })
+}
+
+#[test]
+fn nicol_bolas_dragon_god_plus_one_each_opponent_exiles_own_hand_card_or_permanent() {
+    struct ChooseExpectedOpponentObjects {
+        bob_choice: ObjectId,
+        charlie_choice: ObjectId,
+        prompts: Vec<PlayerId>,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseExpectedOpponentObjects {
+        fn decide_objects(
+            &mut self,
+            game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            let choice = match ctx.player.index() {
+                1 => self.bob_choice,
+                2 => self.charlie_choice,
+                _ => panic!("Nicol Bolas +1 should prompt only opponents, got {ctx:?}"),
+            };
+
+            assert_eq!(ctx.min, 1, "each opponent should choose exactly one object");
+            assert_eq!(ctx.max, Some(1), "each opponent should choose exactly one object");
+            for candidate in &ctx.candidates {
+                assert!(candidate.legal, "all surfaced candidates should be legal");
+                let object = game
+                    .object(candidate.id)
+                    .expect("choice candidate should exist");
+                assert!(
+                    (object.zone == Zone::Hand && object.owner == ctx.player)
+                        || (object.zone == Zone::Battlefield
+                            && game.controller_of(object) == ctx.player),
+                    "Nicol Bolas +1 candidates must be from the chooser's hand or permanents they control, got {object:#?} for {ctx:?}"
+                );
+            }
+            assert!(
+                ctx.candidates.iter().any(|candidate| candidate.id == choice),
+                "expected chosen object to be among candidates for {ctx:?}"
+            );
+            self.prompts.push(ctx.player);
+            vec![choice]
+        }
+    }
+
+    let nicol = parse_oracle_card_definition("Nicol Bolas, Dragon-God");
+    let plus_one_effects = nicol_bolas_plus_one_effects(&nicol);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let source = game.create_object_from_definition(&nicol, alice, Zone::Battlefield);
+    let alice_hand = game.create_object_from_definition(
+        &nicol_bolas_test_card("Alice Hand Card", vec![CardType::Sorcery]),
+        alice,
+        Zone::Hand,
+    );
+    let alice_permanent = game.create_object_from_definition(
+        &nicol_bolas_test_card("Alice Permanent", vec![CardType::Artifact]),
+        alice,
+        Zone::Battlefield,
+    );
+    game.create_object_from_definition(
+        &nicol_bolas_test_card("Alice Draw Card", vec![CardType::Instant]),
+        alice,
+        Zone::Library,
+    );
+    let bob_hand = game.create_object_from_definition(
+        &nicol_bolas_test_card("Bob Hand Card", vec![CardType::Sorcery]),
+        bob,
+        Zone::Hand,
+    );
+    let bob_permanent = game.create_object_from_definition(
+        &nicol_bolas_test_card("Bob Permanent", vec![CardType::Artifact]),
+        bob,
+        Zone::Battlefield,
+    );
+    let charlie_hand = game.create_object_from_definition(
+        &nicol_bolas_test_card("Charlie Hand Card", vec![CardType::Sorcery]),
+        charlie,
+        Zone::Hand,
+    );
+    let charlie_permanent = game.create_object_from_definition(
+        &nicol_bolas_test_card("Charlie Permanent", vec![CardType::Artifact]),
+        charlie,
+        Zone::Battlefield,
+    );
+
+    let mut dm = ChooseExpectedOpponentObjects {
+        bob_choice: bob_hand,
+        charlie_choice: charlie_permanent,
+        prompts: Vec::new(),
+    };
+    {
+        let mut ctx = crate::effects::ExecutionContext::new(source, alice, &mut dm);
+        for effect in &plus_one_effects {
+            crate::effects::execute_effect(&mut game, effect, &mut ctx)
+                .expect("Nicol Bolas +1 should resolve");
+        }
+    }
+
+    assert_eq!(dm.prompts, vec![bob, charlie]);
+    assert!(
+        nicol_bolas_has_object_named_in_zone(&game, "Bob Hand Card", Zone::Exile),
+        "Bob's chosen hand card should move to exile"
+    );
+    assert!(
+        nicol_bolas_has_object_named_in_zone(&game, "Charlie Permanent", Zone::Exile),
+        "Charlie's chosen permanent should move to exile"
+    );
+    assert_eq!(
+        game.object(bob_permanent).expect("bob permanent").zone,
+        Zone::Battlefield,
+        "Bob should exile exactly one object"
+    );
+    assert_eq!(
+        game.object(charlie_hand).expect("charlie hand card").zone,
+        Zone::Hand,
+        "Charlie should exile exactly one object"
+    );
+    assert_eq!(
+        game.object(alice_hand).expect("alice hand card").zone,
+        Zone::Hand,
+        "Nicol Bolas's controller should not choose or exile a card"
+    );
+    assert_eq!(
+        game.object(alice_permanent)
+            .expect("alice permanent")
+            .zone,
+        Zone::Battlefield,
+        "Nicol Bolas's controller should not choose or exile a permanent"
+    );
+}
+
 fn nicol_bolas_minus_eight_effects(def: &CardDefinition) -> Vec<Effect> {
     def.abilities
         .iter()
@@ -1402,6 +1582,34 @@ fn nicol_bolas_dragon_god_minus_eight_respects_legendary_creature_or_planeswalke
     assert!(
         !protected_game.player(bob).expect("bob exists").has_lost,
         "opponent with a legendary creature should not lose the game"
+    );
+
+    let legendary_planeswalker = CardDefinitionBuilder::new(CardId::new(), "Bolas Test Legendwalker")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(3)
+        .build();
+    let mut planeswalker_protected_game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let planeswalker_protected_source =
+        planeswalker_protected_game.create_object_from_definition(&nicol, alice, Zone::Battlefield);
+    planeswalker_protected_game.create_object_from_definition(
+        &legendary_planeswalker,
+        bob,
+        Zone::Battlefield,
+    );
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new(planeswalker_protected_source, alice, &mut dm);
+    for effect in &minus_eight_effects {
+        crate::effects::execute_effect(&mut planeswalker_protected_game, effect, &mut ctx)
+            .expect("Nicol Bolas -8 should resolve");
+    }
+    assert!(
+        !planeswalker_protected_game
+            .player(bob)
+            .expect("bob exists")
+            .has_lost,
+        "opponent with a legendary planeswalker should not lose the game"
     );
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1235,7 +1235,7 @@ fn nicol_bolas_dragon_god_strict_parser_compiled_text_and_model_regression() {
     );
     assert!(
         rendered.contains(
-            "has all loyalty abilities of all other planeswalkers on the battlefield"
+            "Nicol Bolas has all loyalty abilities of all other planeswalkers on the battlefield"
         ),
         "expected compiled text to preserve loyalty-copy clause, got {rendered}"
     );

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1233,7 +1233,8 @@ pub(super) fn substitute_legendary_source_reference(
         || lower.contains(", this creature deals ")
         || lower.contains(": this creature gets ")
         || lower.contains(": this creature deals ")
-        || lower.contains(": whenever this creature deals combat damage to a player");
+        || lower.contains(": whenever this creature deals combat damage to a player")
+        || lower.starts_with("this planeswalker has ");
     if card.supertypes.contains(&Supertype::Legendary) && lower.starts_with("soulshift ") {
         let source_name = card.name.split(',').next().unwrap_or(&card.name).trim();
         if !source_name.is_empty() {
@@ -1269,6 +1270,8 @@ pub(super) fn substitute_legendary_source_reference(
         ("this land", source_name),
         ("This artifact", source_name),
         ("this artifact", source_name),
+        ("This planeswalker", source_name),
+        ("this planeswalker", source_name),
     ]
     .into_iter()
     .fold(line, |line, (from, to)| {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -2343,6 +2343,50 @@ fn is_nonland_permanent_filter_in_zone(filter: &ObjectFilter, zone: Zone) -> boo
         })
 }
 
+fn is_permanent_filter_in_zone(filter: &ObjectFilter, zone: Zone) -> bool {
+    filter.zone == Some(zone)
+        && filter.excluded_card_types.is_empty()
+        && (filter.card_types.is_empty()
+            || [
+                CardType::Artifact,
+                CardType::Creature,
+                CardType::Enchantment,
+                CardType::Land,
+                CardType::Planeswalker,
+                CardType::Battle,
+            ]
+            .iter()
+            .all(|card_type| filter.card_types.contains(card_type)))
+}
+
+fn choose_filter_is_iterated_hand_card_or_permanent(choose: &crate::effects::ChooseObjectsEffect) -> bool {
+    if choose.filter.any_of.len() != 2 {
+        return false;
+    }
+    let mut has_hand_card = false;
+    let mut has_permanent = false;
+    for branch in &choose.filter.any_of {
+        if branch.zone == Some(Zone::Hand)
+            && branch.card_types.is_empty()
+            && branch.any_of.is_empty()
+            && matches!(branch.owner, None | Some(PlayerFilter::IteratedPlayer))
+            && matches!(branch.controller, None | Some(PlayerFilter::IteratedPlayer))
+        {
+            has_hand_card = true;
+            continue;
+        }
+        if is_permanent_filter_in_zone(branch, Zone::Battlefield)
+            && branch.any_of.is_empty()
+            && matches!(branch.controller, None | Some(PlayerFilter::IteratedPlayer))
+        {
+            has_permanent = true;
+            continue;
+        }
+        return false;
+    }
+    has_hand_card && has_permanent
+}
+
 fn describe_tagged_condition_card_selection(condition: &Condition, tag: &str) -> Option<String> {
     match condition {
         Condition::TaggedObjectMatches(condition_tag, filter) if condition_tag.as_str() == tag => {
@@ -3848,6 +3892,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
 
     let refs = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_player_protection_from_everything_pair(&refs) {
+        return Some(compact);
+    }
+
+    if let Some(compact) = describe_draw_then_for_players_choose_exile(effects) {
         return Some(compact);
     }
 
@@ -5562,7 +5610,23 @@ fn describe_group_pump_then_conditional_untap(effects: &[Effect]) -> Option<Stri
     ))
 }
 
+fn describe_draw_then_for_players_choose_exile(effects: &[Effect]) -> Option<String> {
+    let [draw_effect, for_players_effect] = effects else {
+        return None;
+    };
+    let draw = draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    if draw.player != PlayerFilter::You || draw.count != Value::Fixed(1) {
+        return None;
+    }
+    let for_players = for_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()?;
+    let exile_clause = describe_for_players_choose_then_exile(for_players)?;
+    Some(format!("You draw a card. {exile_clause}"))
+}
+
 pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
+    if let Some(compact) = describe_draw_then_for_players_choose_exile(effects) {
+        return compact;
+    }
     if let [first, second] = effects
         && let Some(tagged) = first.downcast_ref::<crate::effects::TaggedEffect>()
         && let Some(cant) = second.downcast_ref::<crate::effects::CantEffect>()
@@ -22629,6 +22693,23 @@ fn describe_for_players_choose_then_exile(
         }
     }
     let move_to_zone = for_players.effects[1].downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if choose_primary_zone(choose) == Some(Zone::Hand)
+        && choose.additional_zones.contains(&Zone::Battlefield)
+        && !choose.is_search
+        && choose.count.is_single()
+        && choose.chooser == PlayerFilter::IteratedPlayer
+        && choose_filter_is_iterated_hand_card_or_permanent(choose)
+        && move_to_exile_uses_chosen_tag(move_to_zone, choose.tag.as_str())
+    {
+        let (subject, object) = match for_players.filter {
+            PlayerFilter::Any => ("Each player", "a card from their hand or a permanent they control"),
+            PlayerFilter::Opponent => ("Each opponent", "a card from their hand or a permanent they control"),
+            PlayerFilter::You => ("You", "a card from your hand or a permanent you control"),
+            _ => return None,
+        };
+        let verb = if subject == "You" { "exile" } else { "exiles" };
+        return Some(format!("{subject} {verb} {object}"));
+    }
     if choose_primary_zone(choose) != Some(Zone::Battlefield)
         || choose.is_search
         || !choose.count.is_single()
@@ -22653,6 +22734,44 @@ fn describe_for_players_choose_then_exile(
     Some(format!(
         "{subject} {choose_verb} {selection} and {exile_verb} it"
     ))
+}
+
+fn describe_for_players_controls_no_lose_game(
+    for_players: &crate::effects::ForPlayersEffect,
+) -> Option<String> {
+    if for_players.effects.len() != 1 {
+        return None;
+    }
+    let conditional = for_players.effects[0].downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+        return None;
+    }
+    let lose_game = conditional.if_true[0].downcast_ref::<crate::effects::LoseTheGameEffect>()?;
+    if lose_game.player != PlayerFilter::IteratedPlayer {
+        return None;
+    }
+    let Condition::Not(inner) = &conditional.condition else {
+        return None;
+    };
+    let Condition::PlayerControls { player, filter } = inner.as_ref() else {
+        return None;
+    };
+    if player != &PlayerFilter::IteratedPlayer
+        || !filter.supertypes.contains(&Supertype::Legendary)
+        || !filter.card_types.contains(&CardType::Creature)
+        || !filter.card_types.contains(&CardType::Planeswalker)
+    {
+        return None;
+    }
+    match for_players.filter {
+        PlayerFilter::Opponent => {
+            Some("Each opponent who doesn't control a legendary creature or planeswalker loses the game".to_string())
+        }
+        PlayerFilter::Any => {
+            Some("Each player who doesn't control a legendary creature or planeswalker loses the game".to_string())
+        }
+        _ => None,
+    }
 }
 
 fn describe_for_players_bottom_library_exile_then_look_cast(
@@ -31993,6 +32112,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_for_players_choose_then_exile(for_players) {
+            return compact;
+        }
+        if let Some(compact) = describe_for_players_controls_no_lose_game(for_players) {
             return compact;
         }
         if let Some(compact) = describe_for_players_may_choose_then_move_to_battlefield(for_players)

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -370,6 +370,7 @@ pub enum Modification {
         filter: ObjectFilter,
         counter: Option<crate::object::CounterType>,
         include_mana: bool,
+        only_loyalty: bool,
         exclude_source_name: bool,
         exclude_source_id: bool,
         force_once_each_turn: bool,
@@ -2514,6 +2515,7 @@ fn apply_modification_to_chars(
             filter,
             counter,
             include_mana,
+            only_loyalty,
             exclude_source_name,
             exclude_source_id,
             force_once_each_turn,
@@ -2567,7 +2569,10 @@ fn apply_modification_to_chars(
                 }
 
                 for ability in &candidate_chars.abilities {
-                    if !matches!(ability.kind, AbilityKind::Activated(_)) {
+                    let AbilityKind::Activated(activated) = &ability.kind else {
+                        continue;
+                    };
+                    if *only_loyalty && !activated.is_loyalty_ability() {
                         continue;
                     }
                     if ability_is_mana_for_object(ability, game, candidate) && !*include_mana {
@@ -3367,6 +3372,7 @@ fn calculate_with_layers(object: &Object, ctx: &CalculationContext) -> Calculate
                     filter,
                     counter,
                     include_mana,
+                    only_loyalty,
                     exclude_source_name,
                     exclude_source_id,
                     force_once_each_turn,
@@ -3417,7 +3423,10 @@ fn calculate_with_layers(object: &Object, ctx: &CalculationContext) -> Calculate
                         }
 
                         for ability in &candidate_chars.abilities {
-                            if !matches!(ability.kind, AbilityKind::Activated(_)) {
+                            let AbilityKind::Activated(activated) = &ability.kind else {
+                                continue;
+                            };
+                            if *only_loyalty && !activated.is_loyalty_ability() {
                                 continue;
                             }
                             if ability_is_mana_for_object(ability, ctx.game, candidate)

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -381,6 +381,7 @@ fn effect_output_changed(
         filter,
         counter,
         include_mana,
+        only_loyalty,
         exclude_source_name,
         exclude_source_id,
         ..
@@ -390,6 +391,7 @@ fn effect_output_changed(
             filter,
             *counter,
             *include_mana,
+            *only_loyalty,
             *exclude_source_name,
             *exclude_source_id,
             a,
@@ -402,6 +404,7 @@ fn effect_output_changed(
             filter,
             *counter,
             *include_mana,
+            *only_loyalty,
             *exclude_source_name,
             *exclude_source_id,
             a,
@@ -993,6 +996,7 @@ fn collect_activated_ability_signatures(
     filter: &ObjectFilter,
     counter: Option<crate::object::CounterType>,
     include_mana: bool,
+    only_loyalty: bool,
     exclude_source_name: bool,
     exclude_source_id: bool,
     effect: &ContinuousEffect,
@@ -1027,7 +1031,10 @@ fn collect_activated_ability_signatures(
             continue;
         }
         for ability in &chars.abilities {
-            if !matches!(ability.kind, AbilityKind::Activated(_)) {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                continue;
+            };
+            if only_loyalty && !activated.is_loyalty_ability() {
                 continue;
             }
             if ability_is_mana_for_object(ability, game, obj) && !include_mana {
@@ -2364,6 +2371,7 @@ mod tests {
                 filter: ObjectFilter::land(),
                 counter: None,
                 include_mana: true,
+                only_loyalty: false,
                 exclude_source_name: false,
                 exclude_source_id: false,
                 force_once_each_turn: false,
@@ -2473,6 +2481,7 @@ mod tests {
                 filter: ObjectFilter::land(),
                 counter: None,
                 include_mana: true,
+                only_loyalty: false,
                 exclude_source_name: false,
                 exclude_source_id: false,
                 force_once_each_turn: false,

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -2699,6 +2699,7 @@ pub struct CopyActivatedAbilities {
     pub filter: ObjectFilter,
     pub counter: Option<CounterType>,
     pub include_mana: bool,
+    pub only_loyalty: bool,
     pub exclude_source_name: bool,
     pub exclude_source_id: bool,
     pub force_once_each_turn: bool,
@@ -2712,6 +2713,7 @@ impl CopyActivatedAbilities {
             filter,
             counter: None,
             include_mana: true,
+            only_loyalty: false,
             exclude_source_name: false,
             exclude_source_id: true,
             force_once_each_turn: false,
@@ -2722,6 +2724,11 @@ impl CopyActivatedAbilities {
 
     pub fn with_counter(mut self, counter: CounterType) -> Self {
         self.counter = Some(counter);
+        self
+    }
+
+    pub fn with_only_loyalty(mut self) -> Self {
+        self.only_loyalty = true;
         self
     }
 
@@ -2779,6 +2786,7 @@ impl StaticAbilityKind for CopyActivatedAbilities {
                     filter: self.filter.clone(),
                     counter: self.counter,
                     include_mana: self.include_mana,
+                    only_loyalty: self.only_loyalty,
                     exclude_source_name: self.exclude_source_name,
                     exclude_source_id: self.exclude_source_id,
                     force_once_each_turn: self.force_once_each_turn,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -916,6 +916,9 @@ impl StaticAbilityModelInterpreter {
                 if let Some(counter) = copy.counter {
                     converted = converted.with_counter(counter);
                 }
+                if copy.only_loyalty {
+                    converted = converted.with_only_loyalty();
+                }
                 if copy.force_once_each_turn {
                     converted = converted.with_once_each_turn();
                 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Nicol Bolas, Dragon-God
Initial parse error:
```
parser does not yet support line family: 'Nicol Bolas has all loyalty abilities of all other planeswalkers on the battlefield.'; oracle-only fallback also failed: parser does not yet support line family: 'Nicol Bolas has all loyalty abilities of all other planeswalkers on the battlefield.'
```

Current worker: i-00b5bd144abe6476a
Branch: codex/aws-card-fix-nicol-bolas-dragon-god
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0013
