### PR TITLE
Fix Ironsmith parse failure: Aspect of Wolf

### DIFF
--- a/crates/ironsmith-compiler/src/front_end/lexer.rs
+++ b/crates/ironsmith-compiler/src/front_end/lexer.rs
@@ -88,7 +88,7 @@ pub enum TokenKind {
     #[regex(r"[0-9]+", priority = 3)]
     Number,
     #[regex(
-        r"(?:\+[0-9xX]+|-[0-9xX]+|[\p{L}0-9]+)(?:(?:['’‘](?:[\p{L}0-9]+)?)|(?:[-−/](?:\+[0-9xX]+|-[0-9xX]+|[\p{L}0-9]+)))*"
+        r"(?:\+[0-9xXyY]+|-[0-9xXyY]+|[\p{L}0-9]+)(?:(?:['’‘](?:[\p{L}0-9]+)?)|(?:[-−/](?:\+[0-9xXyY]+|-[0-9xXyY]+|[\p{L}0-9]+)))*"
     )]
     Word,
 }
@@ -344,14 +344,13 @@ fn push_normalized_token_words(
             '\0'
         };
         let is_counter_char = match normalized_ch {
-            '+' | '-' => next.is_ascii_digit() || next == 'x' || next == 'X',
+            '+' | '-' => next.is_ascii_digit() || matches!(next, 'x' | 'X' | 'y' | 'Y'),
             '/' => {
-                (prev.is_ascii_digit() || prev == 'x' || prev == 'X')
+                (prev.is_ascii_digit() || matches!(prev, 'x' | 'X' | 'y' | 'Y'))
                     && (next.is_ascii_digit()
                         || next == '-'
                         || next == '+'
-                        || next == 'x'
-                        || next == 'X')
+                        || matches!(next, 'x' | 'X' | 'y' | 'Y'))
             }
             _ => false,
         };

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -3681,18 +3681,27 @@ pub(crate) fn parse_anthem_clause(
             crate::runtime_backend::token_word_refs(tokens).join(" ")
         ))
     })?;
-    let (raw_power, raw_toughness) = parse_pt_modifier_values(modifier_token).map_err(|_| {
-        CardTextError::ParseError(format!(
-            "invalid power/toughness modifier in anthem clause (clause: '{}')",
-            crate::runtime_backend::token_word_refs(tokens).join(" ")
-        ))
-    })?;
     let modifier_end = modifier_words.token_index_after_words(1).unwrap_or(1);
     let tail_tokens = trim_edge_punctuation(&modifier_tokens[modifier_end..]);
+    let mut explicit_values = None;
+    let (raw_power, raw_toughness) = match parse_pt_modifier_values(modifier_token) {
+        Ok(values) => values,
+        Err(_) => {
+            if let Some(values) = parse_dynamic_xy_anthem_values(modifier_token, &tail_tokens) {
+                explicit_values = Some(values);
+                (Value::Fixed(0), Value::Fixed(0))
+            } else {
+                return Err(CardTextError::ParseError(format!(
+                    "invalid power/toughness modifier in anthem clause (clause: '{}')",
+                    crate::runtime_backend::token_word_refs(tokens).join(" ")
+                )));
+            }
+        }
+    };
     let mut scale: Option<AnthemCountExpression> = None;
     let mut suffix_condition: Option<crate::ConditionExpr> = None;
     let mut suffix_attached_subject: Option<ObjectFilter> = None;
-    if !tail_tokens.is_empty() {
+    if explicit_values.is_none() && !tail_tokens.is_empty() {
         if token_slice_starts_with(&tail_tokens, &["for", "each"]) {
             scale = Some(parse_anthem_for_each_expression(&tail_tokens)?);
         } else if token_slice_starts_with(&tail_tokens, &["where", "x", "is"]) {
@@ -3795,9 +3804,14 @@ pub(crate) fn parse_anthem_clause(
         }
     };
 
-    let mut power = resolve_anthem_value(raw_power, scale.as_ref(), scale_fixed_components)?;
-    let mut toughness =
-        resolve_anthem_value(raw_toughness, scale.as_ref(), scale_fixed_components)?;
+    let (mut power, mut toughness) = if let Some((power, toughness)) = explicit_values {
+        (power, toughness)
+    } else {
+        (
+            resolve_anthem_value(raw_power, scale.as_ref(), scale_fixed_components)?,
+            resolve_anthem_value(raw_toughness, scale.as_ref(), scale_fixed_components)?,
+        )
+    };
 
     // When the anthem affects multiple creatures (subject is a filter rather
     // than "this creature"), any "attached to it" count expression refers to
@@ -3816,6 +3830,49 @@ pub(crate) fn parse_anthem_clause(
         toughness,
         condition,
     })
+}
+
+fn parse_dynamic_xy_anthem_values(
+    modifier_token: &str,
+    tail_tokens: &[OwnedLexToken],
+) -> Option<(AnthemValue, AnthemValue)> {
+    let (power_raw, toughness_raw) = split_pt_modifier_components(modifier_token).ok()?;
+    let power_var = pt_modifier_variable(power_raw)?;
+    let toughness_var = pt_modifier_variable(toughness_raw)?;
+    let bindings = parse_where_x_y_bindings(tail_tokens)?;
+    let value_for = |var| match var {
+        'x' => Some(AnthemValue::Dynamic(bindings.0.clone())),
+        'y' => Some(AnthemValue::Dynamic(bindings.1.clone())),
+        _ => None,
+    };
+    Some((value_for(power_var)?, value_for(toughness_var)?))
+}
+
+fn pt_modifier_variable(raw: &str) -> Option<char> {
+    let value = strip_leading_plus_char(raw).trim();
+    match value {
+        "x" | "X" => Some('x'),
+        "y" | "Y" => Some('y'),
+        _ => None,
+    }
+}
+
+fn parse_where_x_y_bindings(tokens: &[OwnedLexToken]) -> Option<(Value, Value)> {
+    let words = crate::runtime_backend::lexer::token_word_refs(tokens);
+    if words.get(0..3) != Some(&["where", "x", "is"]) {
+        return None;
+    }
+    let y_start = words
+        .windows(3)
+        .position(|window| window == ["and", "y", "is"])?;
+    if y_start <= 3 {
+        return None;
+    }
+    let x_words = &words[3..y_start];
+    let y_words = &words[y_start + 3..];
+    let (x_value, x_used) = parse_value_expr_words(x_words)?;
+    let (y_value, y_used) = parse_value_expr_words(y_words)?;
+    (x_used == x_words.len() && y_used == y_words.len()).then_some((x_value, y_value))
 }
 
 /// When an anthem targets a filter of creatures (not just the source),
@@ -6700,7 +6757,13 @@ pub(crate) fn parse_anthem_line(
     let Some(modifier_word) = tokens.get(modifier_idx).and_then(OwnedLexToken::as_word) else {
         return Ok(None);
     };
-    if parse_pt_modifier_values(modifier_word).is_err() {
+    if parse_pt_modifier_values(modifier_word).is_err()
+        && parse_dynamic_xy_anthem_values(
+            modifier_word,
+            &trim_edge_punctuation(tokens.get(modifier_idx + 1..).unwrap_or_default()),
+        )
+        .is_none()
+    {
         return Ok(None);
     }
     let clause = parse_anthem_clause(tokens, get_idx, tokens.len())?;
@@ -6741,7 +6804,13 @@ pub(crate) fn parse_multi_subject_anthem_line(
     let Some(modifier_word) = tokens.get(modifier_idx).and_then(OwnedLexToken::as_word) else {
         return Ok(None);
     };
-    if parse_pt_modifier_values(modifier_word).is_err() {
+    if parse_pt_modifier_values(modifier_word).is_err()
+        && parse_dynamic_xy_anthem_values(
+            modifier_word,
+            &trim_edge_punctuation(tokens.get(modifier_idx + 1..).unwrap_or_default()),
+        )
+        .is_none()
+    {
         return Ok(None);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/lexer.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/lexer.rs
@@ -97,7 +97,7 @@ pub(crate) enum TokenKind {
     #[regex(r"[0-9]+", priority = 3)]
     Number,
     #[regex(
-        r"(?:\+[0-9xX]+|-[0-9xX]+|[\p{L}0-9]+)(?:(?:['’‘](?:[\p{L}0-9]+)?)|(?:[-−]|/+)(?:\+[0-9xX]+|-[0-9xX]+|[\p{L}0-9]+))*"
+        r"(?:\+[0-9xXyY]+|-[0-9xXyY]+|[\p{L}0-9]+)(?:(?:['’‘](?:[\p{L}0-9]+)?)|(?:[-−]|/+)(?:\+[0-9xXyY]+|-[0-9xXyY]+|[\p{L}0-9]+))*"
     )]
     Word,
 }
@@ -362,14 +362,13 @@ fn push_normalized_token_words(
             '\0'
         };
         let is_counter_char = match normalized_ch {
-            '+' | '-' => next.is_ascii_digit() || next == 'x' || next == 'X',
+            '+' | '-' => next.is_ascii_digit() || matches!(next, 'x' | 'X' | 'y' | 'Y'),
             '/' => {
-                (prev.is_ascii_digit() || prev == 'x' || prev == 'X')
+                (prev.is_ascii_digit() || matches!(prev, 'x' | 'X' | 'y' | 'Y'))
                     && (next.is_ascii_digit()
                         || next == '-'
                         || next == '+'
-                        || next == 'x'
-                        || next == 'X')
+                        || matches!(next, 'x' | 'X' | 'y' | 'Y'))
             }
             _ => false,
         };

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2693,6 +2693,51 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         return None;
     }
 
+    if words[0] == "half" {
+        let inner_start = 1;
+        for round_idx in inner_start..words.len().saturating_sub(1) {
+            let Some(rounding) = words.get(round_idx..round_idx + 2) else {
+                continue;
+            };
+            let rounded_down = rounding == ["rounded", "down"];
+            let rounded_up = rounding == ["rounded", "up"];
+            if !rounded_down && !rounded_up {
+                continue;
+            }
+            let (base, used_inner) = parse_value_expr_term_words(&words[inner_start..round_idx])?;
+            if used_inner != round_idx.saturating_sub(inner_start) {
+                return None;
+            }
+            if rounded_down {
+                return Some((Value::HalfRoundedDown(Box::new(base)), round_idx + 2));
+            }
+            return Some((
+                Value::HalfRoundedDown(Box::new(Value::Add(
+                    Box::new(base),
+                    Box::new(Value::Fixed(1)),
+                ))),
+                round_idx + 2,
+            ));
+        }
+        let (base, used_inner) = parse_value_expr_term_words(&words[inner_start..])?;
+        let used = inner_start + used_inner;
+        match words.get(used..used + 2) {
+            Some(["rounded", "down"]) => {
+                return Some((Value::HalfRoundedDown(Box::new(base)), used + 2));
+            }
+            Some(["rounded", "up"]) => {
+                return Some((
+                    Value::HalfRoundedDown(Box::new(Value::Add(
+                        Box::new(base),
+                        Box::new(Value::Fixed(1)),
+                    ))),
+                    used + 2,
+                ));
+            }
+            _ => {}
+        }
+    }
+
     for (shape, used) in EVENT_AMOUNT_VALUE_PATTERNS {
         if shape.matches_words(words) {
             return Some((Value::EventValue(EventValueSpec::Amount), *used));

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -23,6 +23,7 @@ use super::{
     parse_text_with_annotations_lowered, parse_triggered_times_each_turn_lexed,
     parse_type_line_rewrite, split_lexed_sentences, token_word_refs,
 };
+use crate::runtime_backend::util::parse_value_expr_words;
 
 fn rewrite_line_info(text: &str) -> super::LineInfo {
     super::LineInfo {
@@ -3773,6 +3774,43 @@ fn rewrite_zone_counter_helpers_parse_half_starting_life_total_variants() {
             crate::target::PlayerFilter::target_player(),
         ))
     );
+}
+
+#[test]
+fn rewrite_value_expr_parses_half_rounded_forest_count_and_y_pt_modifier() {
+    let pt_tokens = lex_line("+X/+Y", 0).expect("rewrite lexer should classify +X/+Y");
+    assert_eq!(token_word_refs(&pt_tokens), vec!["+X/+Y"]);
+
+    let down_words = [
+        "half", "the", "number", "of", "forests", "you", "control", "rounded", "down",
+    ];
+    let up_words = [
+        "half", "the", "number", "of", "forests", "you", "control", "rounded", "up",
+    ];
+    let (down, down_used) = parse_value_expr_words(&down_words)
+        .expect("half rounded-down Forest count should parse");
+    let (up, up_used) = parse_value_expr_words(&up_words)
+        .expect("half rounded-up Forest count should parse");
+
+    assert_eq!(down_used, down_words.len());
+    assert_eq!(up_used, up_words.len());
+    assert!(matches!(down, Value::HalfRoundedDown(_)), "{down:?}");
+    assert!(
+        matches!(
+            up,
+            Value::HalfRoundedDown(ref inner) if matches!(inner.as_ref(), Value::Add(_, _))
+        ),
+        "{up:?}"
+    );
+
+    let anthem_tokens = lex_line(
+        "enchanted creature gets +x/+y, where x is half the number of forests you control, rounded down, and y is half the number of forests you control, rounded up.",
+        0,
+    )
+    .expect("Aspect-style anthem line should lex");
+    let anthem = super::keyword_static::parse_anthem_line(&anthem_tokens)
+        .expect("Aspect-style anthem line should parse without an error");
+    assert!(anthem.is_some(), "Aspect-style anthem line should match anthem parser");
 }
 
 #[test]

--- a/crates/ironsmith-core/src/anthem_model.rs
+++ b/crates/ironsmith-core/src/anthem_model.rs
@@ -1,4 +1,4 @@
-use crate::{CounterType, ManaSymbol, ObjectFilter, PlayerFilter};
+use crate::{CounterType, ManaSymbol, ObjectFilter, PlayerFilter, Value};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AnthemCountExpression {
@@ -23,6 +23,7 @@ pub enum AnthemCountExpression {
 #[derive(Debug, Clone, PartialEq)]
 pub enum AnthemValue {
     Fixed(i32),
+    Dynamic(Value),
     PerCount {
         multiplier: i32,
         count: AnthemCountExpression,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -69227,6 +69227,71 @@ fn urabrask_heretic_praetor_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[test]
+fn aspect_of_wolf_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Aspect of Wolf");
+    let def = parse_oracle_card_definition("Aspect of Wolf");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains("Enchant creature")
+            && rendered.contains(
+                "Enchanted creature gets +X/+Y, where X is half the number of Forests you control, rounded down, and Y is half the number of Forests you control, rounded up."
+            ),
+        "Aspect of Wolf compiled text should preserve enchant creature and both half-rounded Forest-count clauses, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("Dynamic")
+            && ability_debug.contains("HalfRoundedDown")
+            && ability_debug.contains("subtypes: [Forest]"),
+        "Aspect of Wolf should structurally lower to dynamic half-rounded Forest-count anthem values, got {ability_debug}"
+    );
+}
+
+#[test]
+fn aspect_of_wolf_updates_enchanted_creature_from_controller_forest_count() {
+    let aspect = parse_oracle_card_definition("Aspect of Wolf");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+
+    let creature = CardDefinitionBuilder::new(CardId::new(), "Aspect Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let forest = CardDefinitionBuilder::new(CardId::new(), "Regression Forest")
+        .card_types(vec![CardType::Land])
+        .subtypes(vec![Subtype::Forest])
+        .build();
+
+    let creature_id = game.create_object_from_definition(&creature, alice, Zone::Battlefield);
+    let aspect_id = game.create_object_from_definition(&aspect, alice, Zone::Battlefield);
+    assert!(
+        game.attach_object_to_target(
+            aspect_id,
+            crate::object::AttachmentTarget::Object(creature_id),
+        ),
+        "Aspect of Wolf should attach to the regression creature"
+    );
+
+    game.create_object_from_definition(&forest, bob, Zone::Battlefield);
+    assert_eq!(game.calculated_power(creature_id), Some(2));
+    assert_eq!(game.calculated_toughness(creature_id), Some(2));
+
+    game.create_object_from_definition(&forest, alice, Zone::Battlefield);
+    assert_eq!(game.calculated_power(creature_id), Some(2));
+    assert_eq!(game.calculated_toughness(creature_id), Some(3));
+
+    game.create_object_from_definition(&forest, alice, Zone::Battlefield);
+    assert_eq!(game.calculated_power(creature_id), Some(3));
+    assert_eq!(game.calculated_toughness(creature_id), Some(3));
+
+    game.create_object_from_definition(&forest, alice, Zone::Battlefield);
+    assert_eq!(game.calculated_power(creature_id), Some(3));
+    assert_eq!(game.calculated_toughness(creature_id), Some(4));
+}
+
 fn add_named_library_card(game: &mut crate::game_state::GameState, player: PlayerId, name: &str) {
     let card = CardDefinitionBuilder::new(CardId::new(), name)
         .card_types(vec![CardType::Instant])

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -2861,7 +2861,7 @@ fn apply_modification_to_chars(
 }
 
 /// Resolve a Value to an i32 (direct version without CalculationContext).
-fn resolve_value_direct(
+pub(crate) fn resolve_value_direct(
     value: &Value,
     objects: &ObjectMap,
     effects: &[ContinuousEffect],

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -619,6 +619,16 @@ impl AnthemValueRuntimeExt for AnthemValue {
     fn evaluate(&self, game: &GameState, source: ObjectId, controller: PlayerId) -> i32 {
         match self {
             Self::Fixed(value) => *value,
+            Self::Dynamic(value) => crate::continuous::resolve_value_direct(
+                value,
+                game.objects_map(),
+                &[],
+                &game.battlefield,
+                &game.commanders,
+                source,
+                controller,
+                game,
+            ),
             Self::PerCount { multiplier, count } => {
                 multiplier * resolve_anthem_count_expression(count, game, source, controller)
             }
@@ -1847,6 +1857,33 @@ impl StaticAbilityKind for Anthem {
                     "{subject} {verb} {}/{}",
                     signed(*power),
                     signed_toughness(*power, *toughness),
+                )
+            }
+            (AnthemValue::Dynamic(power), AnthemValue::Dynamic(toughness)) if power == toughness => {
+                format!(
+                    "{subject} {verb} +X/+X, where X is {}",
+                    crate::compiled_text::describe_value(power),
+                )
+            }
+            (AnthemValue::Dynamic(power), AnthemValue::Dynamic(toughness)) => {
+                format!(
+                    "{subject} {verb} +X/+Y, where X is {}, and Y is {}",
+                    crate::compiled_text::describe_value(power),
+                    crate::compiled_text::describe_value(toughness),
+                )
+            }
+            (AnthemValue::Dynamic(power), AnthemValue::Fixed(toughness)) => {
+                format!(
+                    "{subject} {verb} +X/{}, where X is {}",
+                    signed(*toughness),
+                    crate::compiled_text::describe_value(power),
+                )
+            }
+            (AnthemValue::Fixed(power), AnthemValue::Dynamic(toughness)) => {
+                format!(
+                    "{subject} {verb} {}/+X, where X is {}",
+                    signed(*power),
+                    crate::compiled_text::describe_value(toughness),
                 )
             }
             (


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aspect of Wolf
Initial parse error:
```
rewrite lexer encountered an unsupported token "/" on line 25 at 26..27; oracle-only fallback also failed: rewrite lexer encountered an unsupported token "/" on line 9 at 26..27
```

Current worker: i-03fa9fdb95156a20f
Branch: codex/aws-card-fix-aspect-of-wolf
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0013
